### PR TITLE
docs: README refresh; spec/tasks — agent selection and interactive input requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,14 @@ discuss before investing significant effort.
 ## Development
 
 The daemon and TUI are written in Go (see the spec for the architecture).
-Until Phase 0 lands there is no code to build; afterwards:
+Build targets run via [mage](https://magefile.org/) with zero install
+(list all targets with `go run mage.go -l`):
 
 ```sh
-make build   # build the vincent binary
-make test    # run all tests
-make lint    # golangci-lint
+go run mage.go build     # build the vincent binary into bin/
+go run mage.go test      # run all tests
+go run mage.go testrace  # run all tests with the race detector
+go run mage.go lint      # golangci-lint (pinned via go.mod tool directive)
 ```
 
 ## Pull request checklist

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![CI](https://github.com/lezli01/vincent/actions/workflows/ci.yml/badge.svg)](https://github.com/lezli01/vincent/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Local-first orchestrator for AI coding-agent workloads — monitor and manage
+**VINCENT** — **v**endor-**in**dependent **c**ontrol plane for **e**xecuting
+**n**ative agent **t**ooling.
+
+A local-first orchestrator for AI coding-agent workloads: monitor and manage
 many agent tasks on your machine from one central place.
 
 A background daemon owns all state and execution: register local git
@@ -13,10 +16,23 @@ Agent steps drive locally installed agent CLIs (Claude Code and Codex first)
 headlessly. A TUI — and later a web UI — is a thin client over the daemon's
 API, so work keeps running when no client is attached.
 
+## Why "vincent"?
+
+The name is an acronym, and every part of it maps to the system:
+
+- **Vendor-independent** — supports multiple agent providers and CLIs.
+- **Control plane** — the daemon owns state, workflows, scheduling, and
+  execution.
+- **Executing** — vincent runs workloads rather than merely observing them.
+- **Native agent tooling** — it invokes locally installed tools such as
+  Claude Code and Codex.
+
 ## Status
 
-**Design phase.** The v0 specification is complete; implementation follows the
-task breakdown.
+**Implementation in progress.** The v0 specification is complete and work
+follows the task breakdown: phase 0 (scaffolding — Go module, CLI stubs, dev
+tooling, cross-platform CI) is done, and phase 1 (the daemon spine — config,
+SQLite store, daemon + API, first end-to-end task run) is underway.
 
 - [v0 specification](docs/versions/v0/spec.md)
 - [v0 task breakdown & progress](docs/versions/v0/tasks.md)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
-# vincent
+<h1 align="center">vincent</h1>
 
-[![CI](https://github.com/lezli01/vincent/actions/workflows/ci.yml/badge.svg)](https://github.com/lezli01/vincent/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+<p align="center">
+  <strong>Vendor-independent control plane for executing native agent tooling.</strong>
+</p>
 
-**VINCENT** — **v**endor-**in**dependent **c**ontrol plane for **e**xecuting
-**n**ative agent **t**ooling.
+<p align="center">
+  A local-first orchestrator for AI coding-agent workloads — monitor and manage<br>
+  many agent tasks on your machine from one central place.
+</p>
 
-A local-first orchestrator for AI coding-agent workloads: monitor and manage
-many agent tasks on your machine from one central place.
+<p align="center">
+  <a href="https://github.com/lezli01/vincent/actions/workflows/ci.yml"><img src="https://github.com/lezli01/vincent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://www.buymeacoffee.com/lezli01"><img src="https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buymeacoffee&logoColor=black" alt="Buy Me a Coffee"></a>
+</p>
 
-A background daemon owns all state and execution: register local git
-repositories, author reusable workflows (agent prompts, shell commands, manual
-gates), and run any number of tasks, each isolated in its own git worktree.
-Agent steps drive locally installed agent CLIs (Claude Code and Codex first)
-headlessly. A TUI — and later a web UI — is a thin client over the daemon's
-API, so work keeps running when no client is attached.
+<p align="center">
+  <a href="#why-vincent">Why</a> &bull;
+  <a href="#what-it-does">What It Does</a> &bull;
+  <a href="#project-status">Status</a> &bull;
+  <a href="#contributing">Contributing</a> &bull;
+  <a href="docs/versions/v0/spec.md">Spec</a>
+</p>
 
-## Why "vincent"?
+---
+
+## Why vincent?
+
+Coding agents are easy to start and hard to supervise: kick off a handful of
+CLI runs across a few repositories and you are soon juggling terminals, losing
+transcripts, and hand-managing branches. vincent turns that into a managed
+workload — one place to register repositories, author workflows, launch tasks,
+and see what every agent is doing, with work continuing when no client is
+attached.
 
 The name is an acronym, and every part of it maps to the system:
 
@@ -27,22 +43,56 @@ The name is an acronym, and every part of it maps to the system:
 - **Native agent tooling** — it invokes locally installed tools such as
   Claude Code and Codex.
 
-## Status
+It is released under the [MIT License](LICENSE) and created by `lezli01` at
+[lezli01.is-a.dev](https://lezli01.is-a.dev). Contributions are welcome — see
+[Contributing](#contributing).
+
+## What It Does
+
+A background daemon owns all state and execution: register local git
+repositories, author reusable workflows (agent prompts, shell commands, manual
+gates), and run any number of tasks, each isolated in its own git worktree.
+Agent steps drive locally installed agent CLIs (Claude Code and Codex first)
+headlessly. A TUI — and later a web UI — is a thin client over the daemon's
+API, so work keeps running when no client is attached.
+
+## Project Status
 
 **Implementation in progress.** The v0 specification is complete and work
 follows the task breakdown: phase 0 (scaffolding — Go module, CLI stubs, dev
 tooling, cross-platform CI) is done, and phase 1 (the daemon spine — config,
 SQLite store, daemon + API, first end-to-end task run) is underway.
 
-- [v0 specification](docs/versions/v0/spec.md)
-- [v0 task breakdown & progress](docs/versions/v0/tasks.md)
+See [docs/versions/v0/spec.md](docs/versions/v0/spec.md) for the product and
+implementation spec, and
+[docs/versions/v0/tasks.md](docs/versions/v0/tasks.md) for the task breakdown
+and progress.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). In short: all changes land via pull
-request to `master`, merged with merge commits (no squashing), using
-[Conventional Commits](https://www.conventionalcommits.org/).
+Contributions of every size are welcome — bug reports, docs, test cases, and
+features. Start here:
+
+- Read the [Contributing guide](CONTRIBUTING.md) for development setup, build
+  and test commands, and the commit-message convention.
+- Be a good neighbor: this project follows a
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+- Found a bug or want a feature? Open an
+  [issue](https://github.com/lezli01/vincent/issues/new/choose).
+
+All changes land via pull request to `master`, merged with merge commits (no
+squashing), using [Conventional Commits](https://www.conventionalcommits.org/).
+Details are in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Security
+
+vincent executes AI agents in full-auto mode by default — a documented design
+decision (see [the spec](docs/versions/v0/spec.md), §16), not a vulnerability —
+but security reports are taken seriously. Please report vulnerabilities
+privately via GitHub's
+[security advisories](https://github.com/lezli01/vincent/security/advisories/new)
+rather than a public issue. See [SECURITY.md](SECURITY.md) for details.
 
 ## License
 
-[MIT](LICENSE)
+vincent is released under the [MIT License](LICENSE). © 2026 lezli01.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,10 @@
 Please **do not** open a public issue for security vulnerabilities.
 
 Use GitHub's private vulnerability reporting: go to the repository's
-**Security** tab → **Report a vulnerability**. Reports are acknowledged on a
-best-effort basis.
+**Security** tab → **Report a vulnerability**, or use this direct link:
+<https://github.com/lezli01/vincent/security/advisories/new>. Reports submitted
+this way are private and visible only to the maintainers, and are acknowledged
+on a best-effort basis.
 
 ## Scope notes
 

--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -35,6 +35,8 @@ steps.
 - Unlimited projects, workflows, and tasks; every task isolated in its own worktree.
 - Workflow-defined delivery: agent, command, and manual-gate step types; linear execution.
 - Two agent adapters — Claude Code and Codex — behind one interface.
+- Agent, model, and effort selectable per workflow, per step, and per task at
+  creation; selectable options discovered ad hoc from the installed CLIs (§9.6).
 - Unattended operation by default (agents run full-auto), with per-workflow/step overrides.
 - Monitoring: live task board, per-task live output tail, per-step duration/token/cost metrics, durable transcripts.
 - Crash-safe: daemon restart recovers and resumes interrupted work automatically.
@@ -75,6 +77,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 18 | Daemon lifecycle | TUI auto-starts daemon; `vincent daemon start/stop/status`; optional OS service install; interrupted steps re-run on restart |
 | 19 | Name | `vincent` |
 | 20 | v1 scope | Everything above, both agent adapters |
+| 21 | Agent/model/effort selection | Adapter-native values; per-step resolution `step > task override > workflow defaults > adapter default` with agent-scoped inheritance; options probed ad hoc from the installed CLIs, merged with a curated catalog, free text always allowed (§8.6, §9.6) |
 
 ## 4. Architecture
 
@@ -167,6 +170,7 @@ A unit of work delivered by running a workflow against a project.
 | `branch_name` | `vincent/{id}-{slug}` (slug: lowercase title, `[a-z0-9-]`, max 40 chars) |
 | `worktree_path` | assigned when the worktree is created |
 | `priority` | integer, default 0; higher runs first |
+| `agent_override` / `model_override` / `effort_override` | optional, chosen at creation (§13.2); replace the workflow's `defaults` but never an explicit step field (§8.6) |
 | `state` | §6 |
 | `current_step` | index into the snapshot's step list |
 
@@ -176,7 +180,7 @@ One attempt at executing one step of one task. Every attempt (including retries 
 re-runs after interruption) is a distinct StepRun row — history is append-only.
 
 Records: step id/index/type, attempt number, state (`running`, `succeeded`, `failed`,
-`interrupted`, `approved`, `rejected`, `skipped`), timestamps, agent used, exit code,
+`interrupted`, `approved`, `rejected`, `skipped`), timestamps, agent/model/effort used (as resolved per §8.6), exit code,
 check exit code, failure reason, transcript file path, input/output tokens, cost (USD,
 nullable — not all agents report cost).
 
@@ -296,7 +300,8 @@ description: Implement, test, review, then push and open a PR.
 
 defaults:                             # optional; per-step values override
   agent: claude                       # claude | codex
-  model: ""                           # passed through to the adapter if set
+  model: ""                           # adapter-native id/alias (e.g. sonnet); options via GET /v1/agents (§9.6)
+  effort: ""                          # adapter-native effort (claude: low…max; codex: minimal…high) (§8.6)
   permission_mode: full-auto          # full-auto | restricted   (§9.4)
   max_retries: 1
   timeout: 60m
@@ -321,7 +326,8 @@ steps:
 
   - id: self-review
     type: agent
-    agent: codex                      # per-step agent override
+    agent: codex                      # per-step agent override — defaults.model/effort
+    effort: high                      # don't follow across the agent switch (§8.6)
     prompt: |
       Review the diff of this branch against {{.Task.BaseBranch}} for bugs and
       missed requirements. The implementation summary was:
@@ -347,7 +353,7 @@ Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
 
 | Type | Required | Optional |
 |---|---|---|
-| `agent` | `prompt` | `agent`, `model`, `permission_mode`, `check`, `check_timeout` |
+| `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `check`, `check_timeout` |
 | `command` | `run` | `shell`, `env` (map), `check`, `check_timeout` |
 | `manual` | `instructions` | — |
 
@@ -355,6 +361,11 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
 
 - `steps` non-empty; step ids unique; templates must parse; `type` known; durations
   parse as Go durations; unknown keys are errors (strict decoding) to catch typos.
+- `agent` values must name a known adapter. Each step's resolved
+  (agent, model, effort) triple (§8.6) is checked against that adapter's option
+  catalog (§9.6): a known-invalid value (e.g. a claude-only effort reaching a
+  codex step) is a validation error; values the catalog doesn't know (free-text
+  models) pass with a warning — the CLI stays the final authority at run time.
 
 ### 8.3 Command steps and shells
 
@@ -403,6 +414,26 @@ VINCENT_WORKTREE, VINCENT_BRANCH, VINCENT_BASE_BRANCH, VINCENT_STEP_ID,
 VINCENT_STEP_ATTEMPT, VINCENT_WORKFLOW
 ```
 
+### 8.6 Agent, model, and effort resolution
+
+For each `agent` step, the effective agent, model, and effort resolve in this
+order (first hit wins):
+
+1. explicit step field (`agent` / `model` / `effort`)
+2. task-level override chosen at creation (§13.2) — replaces workflow
+   `defaults`, never an explicit step field
+3. workflow `defaults`
+4. adapter default (empty = the CLI's own default)
+
+**Agent-scoped inheritance:** `model` and `effort` only inherit from a level
+whose resolved agent matches the step's resolved agent. When a step (or a task
+override) switches agent without setting them, they reset to the new adapter's
+default rather than leaking across — a claude alias like `sonnet` must never
+reach codex.
+
+The resolved triple is recorded on every StepRun (§5.4, §14) and passed to the
+adapter via `RunSpec` (§9.1).
+
 ## 9. Agent adapters
 
 ### 9.1 Interface
@@ -411,13 +442,15 @@ VINCENT_STEP_ATTEMPT, VINCENT_WORKFLOW
 type AgentAdapter interface {
     Name() string                                   // "claude", "codex"
     Detect(ctx context.Context) (Availability, error) // found on PATH? version? logged in (best effort)?
+    Options(ctx context.Context) (AgentOptions, error) // selectable models/efforts, probed ad hoc (§9.6)
     Start(ctx context.Context, spec RunSpec) (RunHandle, error)
 }
 
 type RunSpec struct {
     Prompt         string
     WorkDir        string            // the task worktree
-    Model          string            // optional passthrough
+    Model          string            // resolved per §8.6; "" = CLI default
+    Effort         string            // resolved per §8.6; adapter-native; "" = CLI default
     PermissionMode PermissionMode    // FullAuto | Restricted
     Env            []string
 }
@@ -435,6 +468,18 @@ type RunResult struct {
     OutputTokens int64
     CostUSD      *float64 // nil if unreported (e.g. codex)
 }
+
+type AgentOptions struct {
+    Models        []Option // known model ids/aliases; never exhaustive — free text is always accepted
+    Efforts       []Option // adapter-native effort levels
+    DefaultModel  string   // "" = the CLI decides
+    DefaultEffort string   // "" = the CLI decides
+}
+
+type Option struct {
+    Value  string
+    Source string // "cli" (probed from the installed binary) | "curated" (catalog shipped with vincent)
+}
 ```
 
 The daemon consumes only this interface; adding an agent (Gemini CLI, etc.) is one new
@@ -451,12 +496,20 @@ adapter with zero core changes.
   result event.
 - Restricted mode maps to Claude's allowlist flags (`--allowedTools` with an
   edit/read/git/test set).
+- Model and effort pass through as `--model` / `--effort`.
+- `Options()` probes `claude --help` ad hoc: the `--effort` enum (`low, medium,
+  high, xhigh, max` as of 2.1.x) and the documented model aliases are parsed
+  from the help text (source `cli`) and merged with the curated catalog (§9.6).
 
 ### 9.3 Codex adapter
 
 - Invocation: `codex exec --json` with full-access sandbox flags in full-auto mode,
   cwd = worktree, prompt via stdin.
 - Normalizes Codex's JSONL events; token usage parsed when present; `CostUSD` is nil.
+- Model and effort pass through as `-c model=…` / `-c model_reasoning_effort=…`.
+- The CLI enumerates nothing (`--help` documents only `-c key=value`), so
+  `Options()` returns the curated catalog (source `curated`; efforts
+  `minimal, low, medium, high`).
 
 ### 9.4 Permission modes
 
@@ -474,6 +527,32 @@ Set at workflow `defaults` or per step; there is no daemon-global hardcoded poli
 `GET /v1/info` reports, per adapter: found/not-found, path, version. The TUI surfaces
 missing agents at task-creation time (a workflow whose steps need an unavailable agent
 is flagged).
+
+### 9.6 Option discovery (`GET /v1/agents`)
+
+`GET /v1/agents` returns, per adapter, the availability data of §9.5 plus the
+selectable options — models and efforts with provenance, and the adapter
+defaults:
+
+```json
+{ "agents": [ {
+    "name": "claude", "available": true, "path": "…", "version": "2.1.224",
+    "models":  [ { "value": "sonnet", "source": "cli" }, { "value": "opus", "source": "cli" } ],
+    "efforts": [ { "value": "low", "source": "cli" }, { "value": "max", "source": "cli" } ],
+    "default_model": "", "default_effort": "",
+    "probed_at": "2026-08-07T10:00:00Z", "probe_error": null } ] }
+```
+
+- **Always dynamic, never slow:** probes run on demand and results are cached
+  keyed by *binary identity* (resolved path + mtime + version). Help output is
+  a pure function of the installed binary, so the cache is never stale by
+  construction: updating the CLI invalidates it and the next request re-probes.
+  `?refresh=true` forces a re-probe.
+- **Probe failure degrades, never blocks:** if the CLI is missing or its help
+  output can't be parsed, the endpoint serves the curated catalog with
+  `probe_error` set; free-text entry is unaffected.
+- Catalogs are advisory: pickers (§15) always accept free text, and validation
+  treats catalog membership per §8.2.
 
 ## 10. Worktree management
 
@@ -601,6 +680,8 @@ edited via `PATCH /v1/projects/{id}`.
 GET    /v1/health                       liveness (also unauthenticated) → { status, version }
 GET    /v1/info                         daemon version, uptime, agent availability, caps in effect
 GET    /v1/config                       effective global config (read-only)
+GET    /v1/agents                       per-adapter availability + model/effort options (§9.6);
+                                        ?refresh=true forces a re-probe
 
 GET    /v1/projects                     list
 POST   /v1/projects                     { path, name?, default_branch?, default_workflow?, max_parallel_tasks? }
@@ -614,7 +695,9 @@ POST   /v1/workflows/validate           { yaml } → { valid, errors[] }
 
 GET    /v1/tasks?project_id=&state=&limit=&offset=
 POST   /v1/tasks                        { project_id, workflow, title, description?, fields?,
-                                          base_branch?, priority? } → task (state=queued)
+                                          base_branch?, priority?, agent?, model?, effort? }
+                                        → task (state=queued); agent/model/effort form the
+                                        task-level override (§8.6), validated per §8.2
 GET    /v1/tasks/{id}                   full task incl. step runs summary
 PATCH  /v1/tasks/{id}                   { priority }               (queued/paused only)
 POST   /v1/tasks/{id}/cancel
@@ -679,6 +762,9 @@ CREATE TABLE tasks (
   branch_name         TEXT NOT NULL,
   worktree_path       TEXT,
   priority            INTEGER NOT NULL DEFAULT 0,
+  agent_override      TEXT,                   -- task-level selection (§8.6); NULL = none
+  model_override      TEXT,
+  effort_override     TEXT,
   state               TEXT NOT NULL,          -- §6
   current_step        INTEGER NOT NULL DEFAULT 0,
   block_reason        TEXT,                   -- set while state='blocked'
@@ -700,6 +786,8 @@ CREATE TABLE step_runs (
   state               TEXT NOT NULL,          -- running | succeeded | failed | interrupted
                                               -- | approved | rejected | skipped
   agent               TEXT,                   -- adapter name, agent steps only
+  model               TEXT,                   -- resolved model as passed to the adapter (§8.6)
+  effort              TEXT,                   -- resolved effort as passed to the adapter (§8.6)
   pid                 INTEGER,                -- while running
   proc_started_at     TEXT,
   exit_code           INTEGER,
@@ -753,7 +841,9 @@ stream for the live tail.
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
    `$EDITOR`) → custom fields (key/value) → base branch (default prefilled) →
-   priority → create.
+   priority → optional agent/model/effort override (pickers fed by
+   `GET /v1/agents` with provenance-tagged options and free-text entry;
+   replaces workflow defaults, never explicit step fields, §8.6) → create.
 4. **Projects.** List/add/edit/remove; per-project cap and defaults.
 5. **Workflows.** Merged registry with scope badges and validation status; `e` opens
    the file in `$EDITOR`; live reload reflects saves immediately.
@@ -798,6 +888,8 @@ stream for the live tail.
 | Workflow file edited mid-task | Irrelevant — execution uses the task's snapshot |
 | Workflow deleted before task creation | Creation fails: `workflow_not_found` |
 | Agent CLI missing at step start | Step fails (retry policy applies) with a `agent_unavailable` reason; typically → blocked |
+| Option probe fails (help unparseable) | `GET /v1/agents` serves the curated catalog with `probe_error` set; selection and free text keep working (§9.6) |
+| Model/effort unknown to the catalog | Validation warning only; the CLI is the final authority — a rejected value fails the step with the CLI's error (retry policy applies) |
 | Base branch doesn't exist | Task creation fails fast |
 | Branch `vincent/{id}-{slug}` already exists | Task blocked with clear reason (never reuse) |
 | Worktree dir manually deleted | Next step fails → blocked with `worktree_missing`; retry recreates the worktree from the branch if it survives |
@@ -812,8 +904,8 @@ stream for the live tail.
 
 | Milestone | Contents | Acceptance |
 |---|---|---|
-| **M1 — Spine** | Daemon skeleton, SQLite + migrations, config, token auth, projects CRUD, task creation with worktree, Claude adapter, single hardcoded-format one-step run, transcripts, health/info | `curl` can register a repo, create a 1-step agent task, watch it finish, and see the branch/diff |
-| **M2 — Workflow engine** | YAML registry (global+project, watch/validate/snapshot), all three step types, templates, checks, retry/blocked flow, gates, scheduler with both caps, pause/cancel/skip/edit+retry, SSE, crash recovery, Codex adapter | Multi-step workflow incl. gate + command publish step runs unattended to the gate; kill -9 of the daemon mid-step recovers correctly; caps honored under load |
+| **M1 — Spine** | Daemon skeleton, SQLite + migrations, config, token auth, projects CRUD, task creation with worktree (incl. optional agent/model/effort override), Claude adapter (model/effort passthrough + options probe), single hardcoded-format one-step run, transcripts, health/info | `curl` can register a repo, create a 1-step agent task, watch it finish, and see the branch/diff |
+| **M2 — Workflow engine** | YAML registry (global+project, watch/validate/snapshot), all three step types, templates, checks, retry/blocked flow, gates, scheduler with both caps, pause/cancel/skip/edit+retry, SSE, crash recovery, Codex adapter, agent option catalog (`GET /v1/agents`) + §8.6 resolution/validation | Multi-step workflow incl. gate + command publish step runs unattended to the gate; kill -9 of the daemon mid-step recovers correctly; caps honored under load |
 | **M3 — TUI** | All six views, live tail, diff view, all actions, `$EDITOR` integration, daemon auto-start | The full loop (register → author workflow → run 3 parallel tasks → approve gate → archive) is doable without leaving the TUI |
 | **M4 — Polish** | `service install` for all 3 OSes, CLI subcommands, retention pruning, docs, first-run experience, packaged releases (signed binaries) | Fresh-machine install to first completed task in under 10 minutes on each OS |
 

--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -19,7 +19,8 @@ steps sequentially inside a dedicated **git worktree**, so parallel tasks never
 collide. Agent steps run locally installed agent CLIs (Claude Code and Codex in v1)
 headlessly. The daemon schedules tasks under configurable global and per-project
 concurrency caps, records full transcripts and run metrics, streams live progress over
-SSE, and pauses for human input when a step fails or a manual gate is reached.
+SSE, and pauses for human input when a step fails, a manual gate is reached, or a
+running agent asks a structured question (§7.4).
 
 **Nothing about delivery is hardcoded.** Whether a finished task pushes a branch,
 opens a PR, or just leaves a diff for review is entirely determined by the workflow's
@@ -39,6 +40,7 @@ steps.
   creation; selectable options discovered ad hoc from the installed CLIs (§9.6).
 - Unattended operation by default (agents run full-auto), with per-workflow/step overrides.
 - Monitoring: live task board, per-task live output tail, per-step duration/token/cost metrics, durable transcripts.
+- Human-in-the-loop when needed: gates, blocked tasks, and mid-run agent questions alert in the client; a question is answered into the still-live agent session (§7.4).
 - Crash-safe: daemon restart recovers and resumes interrupted work automatically.
 
 ### Non-goals (v1) — explicitly deferred
@@ -78,6 +80,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 19 | Name | `vincent` |
 | 20 | v1 scope | Everything above, both agent adapters |
 | 21 | Agent/model/effort selection | Adapter-native values; per-step resolution `step > task override > workflow defaults > adapter default` with agent-scoped inheritance; options probed ad hoc from the installed CLIs, merged with a curated catalog, free text always allowed (§8.6, §9.6) |
+| 22 | Agent input requests | Structured requests only (`question`/`permission`); new `awaiting_input` state that keeps its slot; step clock pauses, bounded by `input_timeout` (default 24h); normalized schema + raw passthrough; `POST /v1/tasks/{id}/answer`; per-adapter capability (claude yes, codex no); `on_input: wait\|deny` opt-out; TUI-level alerts only (§6, §7.4, §13.2, §15) |
 
 ## 4. Architecture
 
@@ -173,6 +176,7 @@ A unit of work delivered by running a workflow against a project.
 | `agent_override` / `model_override` / `effort_override` | optional, chosen at creation (§13.2); replace the workflow's `defaults` but never an explicit step field (§8.6) |
 | `state` | §6 |
 | `current_step` | index into the snapshot's step list |
+| `pending_input` | normalized InputRequest (§7.4) while state is `awaiting_input`; cleared on answer, timeout, or process exit |
 
 ### 5.4 StepRun
 
@@ -182,7 +186,8 @@ re-runs after interruption) is a distinct StepRun row — history is append-only
 Records: step id/index/type, attempt number, state (`running`, `succeeded`, `failed`,
 `interrupted`, `approved`, `rejected`, `skipped`), timestamps, agent/model/effort used (as resolved per §8.6), exit code,
 check exit code, failure reason, transcript file path, input/output tokens, cost (USD,
-nullable — not all agents report cost).
+nullable — not all agents report cost), input wait time (ms spent in `awaiting_input`,
+§7.4 — excluded from duration metrics).
 
 ## 6. Task lifecycle
 
@@ -190,26 +195,29 @@ nullable — not all agents report cost).
                  create
                    │
                    ▼
-              ┌────────┐   slot free    ┌─────────┐
-   ┌─────────►│ queued ├───────────────►│ running │◄────────────┐
-   │          └────────┘  (scheduler)   └──┬──┬──┬┘             │
-   │   approve ▲   ▲ retry/skip            │  │  │              │
-   │           │   │                       │  │  │ all steps    │
-   │      ┌────┴───┴─┐   manual step       │  │  │ succeeded    │
-   │      │          │◄────────────────────┘  │  ▼              │
-   │      │ awaiting │                        │ ┌──────┐        │
-   │      │  _gate   │      step failed,      │ │ done │        │
-   │      └────┬─────┘      retries exhausted ▼ └──┬───┘        │
-   │           │ reject   ┌─────────┐              │            │
-   │           └─────────►│ blocked │              │            │
-   │                      └──┬──────┘              │            │
-   │ resume                  │ abort               │ archive    │
-┌──┴─────┐  pause            ▼                     ▼            │
-│ paused │◄───────┐      ┌─────────┐          ┌──────────┐      │
-└────────┘ (from  │      │ aborted ├─────────►│ archived │      │
-           queued/│      └─────────┘  archive └──────────┘      │
-           running┘                                             │
-                          interrupted step re-run on restart ───┘
+              ┌────────┐   slot free    ┌─────────┐  input request  ┌────────────────┐
+   ┌─────────►│ queued ├───────────────►│ running │◄───────────────►│ awaiting_input │
+   │          └────────┘  (scheduler)   └──┬──┬──┬┘    answer*      └────────────────┘
+   │   approve ▲   ▲ retry/skip            │  │  │
+   │           │   │                       │  │  │ all steps
+   │      ┌────┴───┴─┐   manual step       │  │  │ succeeded
+   │      │          │◄────────────────────┘  │  ▼
+   │      │ awaiting │                        │ ┌──────┐
+   │      │  _gate   │      step failed,      │ │ done │
+   │      └────┬─────┘      retries exhausted ▼ └──┬───┘
+   │           │ reject   ┌─────────┐              │
+   │           └─────────►│ blocked │              │
+   │                      └──┬──────┘              │
+   │ resume                  │ abort               │ archive
+┌──┴─────┐  pause            ▼                     ▼
+│ paused │◄───────┐      ┌─────────┐          ┌──────────┐
+└────────┘ (from  │      │ aborted ├─────────►│ archived │
+           queued/│      └─────────┘  archive └──────────┘
+           running┘
+
+* answer resumes the step in place; input_timeout fails the attempt (normal
+  retry/blocked policy §7.2). On daemon restart, an interrupted step re-runs
+  as a fresh attempt and the task is re-queued (§12.4).
 ```
 
 ### States
@@ -219,6 +227,7 @@ nullable — not all agents report cost).
 | `queued` | Ready to run; waiting for scheduler admission | no |
 | `running` | A step process is executing (or about to) | **yes** |
 | `awaiting_gate` | Paused at a `manual` step, waiting for approval | no |
+| `awaiting_input` | The running agent emitted a structured input request (§7.4); its live process is idle, waiting for the answer | **yes** |
 | `blocked` | A step failed and retries are exhausted; waiting for a human decision | no |
 | `paused` | Engineer-requested soft pause (takes effect at the next step boundary) | no |
 | `done` | All steps succeeded; worktree/branch retained for inspection | no |
@@ -229,12 +238,13 @@ nullable — not all agents report cost).
 
 | Action | Valid from | Effect |
 |---|---|---|
-| `cancel` (abort) | queued, running, awaiting_gate, blocked, paused | Kills any running process (graceful term, then kill after 10 s; `taskkill /T /F` on Windows); → `aborted` |
+| `cancel` (abort) | queued, running, awaiting_input, awaiting_gate, blocked, paused | Kills any running process (graceful term, then kill after 10 s; `taskkill /T /F` on Windows); → `aborted` |
 | `pause` | queued, running | `running`: finishes the current step, then holds; → `paused` |
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step (fresh attempt, retry counter reset); → `queued` |
 | `edit + retry` | blocked | Overrides the step's prompt/command **in this task's snapshot only**, then retries; the override is recorded on the StepRun |
 | `skip` | blocked, awaiting_gate | Marks the step `skipped`, advances to the next step; → `queued` |
+| `answer` | awaiting_input | Delivers the answer to the pending input request into the live agent session (§7.4); → `running` (step clock resumes) |
 | `approve` | awaiting_gate | Gate step → `approved`; advances; → `queued` |
 | `reject` | awaiting_gate | Gate step → `rejected`; → `blocked` (from which: retry earlier via edit, skip, or abort) |
 | `set priority` | queued, paused | Reorders scheduler admission |
@@ -287,6 +297,56 @@ between steps or attempts. Durable state flows between steps through:
 This keeps steps individually re-runnable, keeps context windows small, and avoids
 coupling to any one agent's session semantics.
 
+### 7.4 Interactive input requests
+
+While an `agent` step runs, an input-capable adapter (§9.1, §9.5) may surface a
+structured **input request** from the agent:
+
+- **`question`** — the agent asks the user something (e.g. Claude Code's
+  AskUserQuestion tool): one or more questions, each optionally with predefined
+  options and multi-select; free-text answers are always accepted.
+- **`permission`** — in `restricted` mode, the agent requests approval for a
+  denied action (tool/command summary included).
+
+Only machine-readable requests from the agent's event stream qualify; vincent never
+infers "the agent seems to be asking something" from output text.
+
+Behavior with `on_input: wait` (the default):
+
+1. The task moves `running` → `awaiting_input`, **keeping its concurrency slot**
+   (the agent process is alive mid-step, idle on its stdin — killing or re-queuing
+   it would lose the very session the answer belongs to). The normalized request
+   (§9.1 `InputRequest`; the adapter-native payload is preserved in `raw`) is
+   stored on the task as `pending_input` and a durable `task.awaiting_input`
+   event is emitted (§13.3) — this is the alert clients key off.
+2. The step `timeout` clock **pauses** — it measures agent work, not human
+   latency. A separate `input_timeout` (global default 24h, §12.3; overridable in
+   workflow `defaults` and per step) bounds the wait: on expiry the process is
+   killed and the attempt fails with reason `input_timeout` (normal retry/blocked
+   policy, §7.2), freeing the slot.
+3. The engineer answers via `POST /v1/tasks/{id}/answer` or the TUI answer form
+   (§15). The adapter translates the answer back to its native protocol and
+   writes it to the live process; the task returns to `running` and the step
+   clock resumes. Requests are serial — an agent blocks on its pending request,
+   so at most one `pending_input` exists per task.
+
+`on_input: deny` (workflow `defaults` or per step) keeps runs strictly unattended:
+the adapter immediately auto-responds — questions get a canned "no user is
+available; decide with your best judgment" answer, permission requests are denied
+— and the task never leaves `running`.
+
+Adapters without mid-run input support (`supports_input: false`, §9.5 — codex in
+v1) never produce input requests; their steps behave exactly as today. Requests
+and answers are appended to the step transcript as namespaced `vincent.*` lines;
+time spent waiting is recorded per StepRun (`input_wait_ms`) and excluded from
+duration metrics (§17). Crash recovery treats `awaiting_input` like `running`: on
+restart the attempt is `interrupted` and re-runs as a fresh session (§12.4) — the
+pending request is discarded and the fresh run may re-ask.
+
+Full-auto note: in `full-auto`, permission prompts are bypassed at the CLI level,
+so `permission` requests should not occur; `question` requests can occur in any
+permission mode.
+
 ## 8. Workflow definition (YAML)
 
 ### 8.1 File format
@@ -303,6 +363,8 @@ defaults:                             # optional; per-step values override
   model: ""                           # adapter-native id/alias (e.g. sonnet); options via GET /v1/agents (§9.6)
   effort: ""                          # adapter-native effort (claude: low…max; codex: minimal…high) (§8.6)
   permission_mode: full-auto          # full-auto | restricted   (§9.4)
+  on_input: wait                      # wait | deny — agent input requests (§7.4)
+  input_timeout: 24h                  # max wait in awaiting_input (§7.4)
   max_retries: 1
   timeout: 60m
 
@@ -353,14 +415,15 @@ Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
 
 | Type | Required | Optional |
 |---|---|---|
-| `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `check`, `check_timeout` |
+| `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `on_input`, `input_timeout`, `check`, `check_timeout` |
 | `command` | `run` | `shell`, `env` (map), `check`, `check_timeout` |
 | `manual` | `instructions` | — |
 
 Constraints (validated on load and via `POST /v1/workflows/validate`):
 
 - `steps` non-empty; step ids unique; templates must parse; `type` known; durations
-  parse as Go durations; unknown keys are errors (strict decoding) to catch typos.
+  parse as Go durations; `on_input` is `wait` or `deny`; unknown keys are errors
+  (strict decoding) to catch typos.
 - `agent` values must name a known adapter. Each step's resolved
   (agent, model, effort) triple (§8.6) is checked against that adapter's option
   catalog (§9.6): a known-invalid value (e.g. a claude-only effort reaching a
@@ -441,7 +504,7 @@ adapter via `RunSpec` (§9.1).
 ```go
 type AgentAdapter interface {
     Name() string                                   // "claude", "codex"
-    Detect(ctx context.Context) (Availability, error) // found on PATH? version? logged in (best effort)?
+    Detect(ctx context.Context) (Availability, error) // found on PATH? version? logged in (best effort)? supports mid-run input (§7.4)?
     Options(ctx context.Context) (AgentOptions, error) // selectable models/efforts, probed ad hoc (§9.6)
     Start(ctx context.Context, spec RunSpec) (RunHandle, error)
 }
@@ -452,13 +515,34 @@ type RunSpec struct {
     Model          string            // resolved per §8.6; "" = CLI default
     Effort         string            // resolved per §8.6; adapter-native; "" = CLI default
     PermissionMode PermissionMode    // FullAuto | Restricted
+    OnInput        InputPolicy       // Wait | Deny (§7.4); ignored when the adapter lacks input support
     Env            []string
 }
 
 type RunHandle interface {
-    Events() <-chan AgentEvent  // normalized stream: Output, ToolUse, Usage, Result, Error
+    Events() <-chan AgentEvent  // normalized stream: Output, ToolUse, Usage, InputRequest, Result, Error
+    Respond(resp InputResponse) error // answer the pending InputRequest (§7.4); error if none pending
     Wait() (RunResult, error)   // blocks until process exit
     Kill() error
+}
+
+type InputRequest struct {          // §7.4; at most one pending per run
+    Kind       string           // "question" | "permission"
+    Questions  []Question       // kind=question: one or more structured questions
+    Permission *PermissionReq   // kind=permission: tool name + action summary
+    Raw        json.RawMessage  // adapter-native payload, passed through to clients untranslated
+}
+
+type Question struct {
+    Text        string
+    Header      string
+    Options     []string // may be empty; free-text answers are always accepted
+    MultiSelect bool
+}
+
+type InputResponse struct {
+    Answers map[string][]string // question text → selected/typed answer(s)
+    Allow   *bool               // kind=permission: approve or deny
 }
 
 type RunResult struct {
@@ -500,6 +584,15 @@ adapter with zero core changes.
 - `Options()` probes `claude --help` ad hoc: the `--effort` enum (`low, medium,
   high, xhigh, max` as of 2.1.x) and the documented model aliases are parsed
   from the help text (source `cli`) and merged with the curated catalog (§9.6).
+- **Mid-run input (§7.4):** the process is additionally started with
+  `--input-format stream-json` and stdin kept open. Question/permission control
+  messages arriving on the stream are normalized to `InputRequest`; `Respond()`
+  translates the answer back to the control protocol and writes it to stdin. The
+  control-message wire format is not publicly documented — like the flags above
+  it is pinned against the detected CLI version at implementation time and
+  guarded by fixture tests; if the protocol can't be verified for an installed
+  version, the adapter reports `supports_input: false` and steps degrade
+  gracefully (no `awaiting_input`, §7.4).
 
 ### 9.3 Codex adapter
 
@@ -510,6 +603,9 @@ adapter with zero core changes.
 - The CLI enumerates nothing (`--help` documents only `-c key=value`), so
   `Options()` returns the curated catalog (source `curated`; efforts
   `minimal, low, medium, high`).
+- `codex exec` is strictly non-interactive once started — no mid-run input
+  channel exists. `supports_input: false`; codex steps never enter
+  `awaiting_input`, and `on_input` has no effect on them (§7.4).
 
 ### 9.4 Permission modes
 
@@ -517,14 +613,16 @@ adapter with zero core changes.
   unattended orchestration; the worktree is disposable and every change is
   inspectable before the engineer merges anything. **This is a real risk surface
   (agents can run arbitrary commands as the user) and is documented prominently.**
-- `restricted`: adapter-specific allowlists; steps may stall or fail on denied
-  actions. For sensitive projects.
+- `restricted`: adapter-specific allowlists. On input-capable adapters, denied
+  actions surface as `permission` input requests (§7.4, subject to `on_input`);
+  on others, steps may stall or fail on denied actions. For sensitive projects.
 
 Set at workflow `defaults` or per step; there is no daemon-global hardcoded policy.
 
 ### 9.5 Detection
 
-`GET /v1/info` reports, per adapter: found/not-found, path, version. The TUI surfaces
+`GET /v1/info` reports, per adapter: found/not-found, path, version,
+`supports_input` (§7.4). The TUI surfaces
 missing agents at task-creation time (a workflow whose steps need an unavailable agent
 is flagged).
 
@@ -537,6 +635,7 @@ defaults:
 ```json
 { "agents": [ {
     "name": "claude", "available": true, "path": "…", "version": "2.1.224",
+    "supports_input": true,
     "models":  [ { "value": "sonnet", "source": "cli" }, { "value": "opus", "source": "cli" } ],
     "efforts": [ { "value": "low", "source": "cli" }, { "value": "max", "source": "cli" } ],
     "default_model": "", "default_effort": "",
@@ -638,6 +737,7 @@ max_parallel_tasks: 3        # global cap
 defaults:
   agent_timeout: 60m
   command_timeout: 15m
+  input_timeout: 24h           # max wait in awaiting_input (§7.4)
 transcript_retention_days: 90   # transcripts of *archived* tasks older than this are pruned
 log_level: info
 ```
@@ -653,7 +753,9 @@ edited via `PATCH /v1/projects/{id}`.
 - On startup: any StepRun still marked `running` is finalized as `interrupted`; if its
   recorded PID still exists *and* its start time matches, the process is killed
   (orphan). The owning task returns to `queued` and the interrupted step re-runs as a
-  fresh attempt that does **not** consume a retry.
+  fresh attempt that does **not** consume a retry. Tasks found in `awaiting_input`
+  are treated identically — the pending request is discarded with the process, and
+  the fresh session may re-ask (§7.4).
 - Graceful shutdown (`daemon stop`, SIGTERM, Windows service stop): stop admitting new
   steps, give running processes 15 s to exit after a termination signal, then kill;
   mark those runs `interrupted` (same resume path as a crash).
@@ -698,7 +800,7 @@ POST   /v1/tasks                        { project_id, workflow, title, descripti
                                           base_branch?, priority?, agent?, model?, effort? }
                                         → task (state=queued); agent/model/effort form the
                                         task-level override (§8.6), validated per §8.2
-GET    /v1/tasks/{id}                   full task incl. step runs summary
+GET    /v1/tasks/{id}                   full task incl. step runs summary and pending_input (§7.4)
 PATCH  /v1/tasks/{id}                   { priority }               (queued/paused only)
 POST   /v1/tasks/{id}/cancel
 POST   /v1/tasks/{id}/pause
@@ -707,6 +809,7 @@ POST   /v1/tasks/{id}/retry            { prompt_override?, run_override? }   (bl
 POST   /v1/tasks/{id}/skip             (blocked/awaiting_gate only)
 POST   /v1/tasks/{id}/approve          (awaiting_gate only)
 POST   /v1/tasks/{id}/reject           (awaiting_gate only)
+POST   /v1/tasks/{id}/answer           { answers?, allow? }        (awaiting_input only, §7.4)
 POST   /v1/tasks/{id}/archive          { force? }                  (done/aborted only)
 
 GET    /v1/tasks/{id}/steps             all StepRuns (every attempt)
@@ -726,9 +829,11 @@ Two kinds of streams:
    emitted as SSE with `id:` set, so clients reconnect with `Last-Event-ID` and miss
    nothing. Types:
    `task.created`, `task.state_changed`, `task.archived`, `step.started`,
-   `step.finished`, `step.retrying`, `gate.waiting`, `project.*`,
-   `workflow.registry_changed`, `daemon.shutting_down`.
-   Payloads carry ids + the new state, not full objects (clients re-fetch as needed).
+   `step.finished`, `step.retrying`, `gate.waiting`, `task.awaiting_input`,
+   `project.*`, `workflow.registry_changed`, `daemon.shutting_down`.
+   Payloads carry ids + the new state, not full objects (clients re-fetch as needed);
+   `task.awaiting_input` additionally carries the request kind and a one-line summary
+   — the full request comes from `GET /v1/tasks/{id}` (§7.4).
    `/v1/events` supports `?types=` and `?project_id=` filters.
 
 2. **Live output** — ephemeral, high-volume. `agent.output`, `agent.tool_use`,
@@ -768,6 +873,7 @@ CREATE TABLE tasks (
   state               TEXT NOT NULL,          -- §6
   current_step        INTEGER NOT NULL DEFAULT 0,
   block_reason        TEXT,                   -- set while state='blocked'
+  pending_input_json  TEXT,                   -- normalized InputRequest while state='awaiting_input' (§7.4)
   created_at          TEXT NOT NULL,
   updated_at          TEXT NOT NULL,
   started_at          TEXT,
@@ -798,6 +904,7 @@ CREATE TABLE step_runs (
   input_tokens        INTEGER,
   output_tokens       INTEGER,
   cost_usd            REAL,                   -- NULL when the agent doesn't report cost
+  input_wait_ms       INTEGER NOT NULL DEFAULT 0, -- time spent awaiting_input (§7.4); excluded from durations
   started_at          TEXT NOT NULL,
   finished_at         TEXT
 );
@@ -831,13 +938,20 @@ stream for the live tail.
 1. **Board (home).** Table of tasks: id, project, title, state (color-coded), current
    step `k/n` + step name, elapsed, cost-so-far. Filter by project/state; sort
    respects scheduler order for queued tasks. Header shows daemon status, agent
-   availability, running/cap counts.
+   availability, running/cap counts, and a needs-attention count. Tasks waiting on
+   a human (`awaiting_input`, `awaiting_gate`, `blocked`) are pinned to the top
+   with a distinct badge, and the TUI rings the terminal bell on
+   `task.awaiting_input` — most terminals flash/badge the window even unfocused
+   (§7.4). OS desktop notifications remain out of v1 (§20).
 2. **Task detail.** Step timeline (every attempt, with durations, tokens, cost);
    live output tail of the running step (follow mode); scrollback into full
    transcripts of past steps; **diff tab** (`GET …/diff`, syntax-highlighted); action
    bar for exactly the actions valid in the current state (§6), including gate
    approve/reject with the rendered gate instructions, and edit+retry which opens
-   `$EDITOR` on the failing step's prompt/command.
+   `$EDITOR` on the failing step's prompt/command. When the task is
+   `awaiting_input`, the pending question or permission request is rendered in
+   place (options, multi-select, free-text entry) above the live tail, and
+   submitting the answer resumes the run in the same session (§7.4).
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
    `$EDITOR`) → custom fields (key/value) → base branch (default prefilled) →
@@ -872,8 +986,10 @@ stream for the live tail.
 
 ## 17. Observability
 
-- **Per step:** duration, exit codes, tokens in/out, cost (when reported), full JSONL
-  transcript on disk (agent events, command output, check output).
+- **Per step:** duration (active time — time spent `awaiting_input` is tracked
+  separately as input wait, §7.4), exit codes, tokens in/out, cost (when reported),
+  full JSONL transcript on disk (agent events, command output, check output,
+  input requests and answers).
 - **Per task:** aggregate duration/tokens/cost across attempts (rolled up from
   step_runs; shown on board and detail views).
 - **Daemon log:** structured (slog), rotated; scheduler decisions at debug level.
@@ -898,6 +1014,10 @@ stream for the live tail.
 | DB corruption | Startup fails loudly, points at the file, never auto-deletes |
 | Agent emits gigabytes of output | Transcript writes are streamed to disk; SSE output chunks are rate-limited/coalesced (~10 Hz); per-run transcript size cap (default 512 MB) fails the step past the cap |
 | Template references missing field | Step fails at render time (before any process starts) with the template error |
+| `answer` posted when task isn't `awaiting_input` | `409` with the current state (standard invalid-transition handling) |
+| Agent process dies while `awaiting_input` | Attempt fails with its exit code (retry policy applies); `pending_input` cleared |
+| `input_timeout` expires | Process killed; attempt fails with reason `input_timeout`; normal retry/blocked policy (§7.2) |
+| Unparseable/unknown control request from an agent | Transcripted verbatim; attempt fails with `input_protocol_error` (retry policy applies) — vincent never waits on a request it can't render |
 | Clock skew / DST | All timestamps stored UTC RFC3339 |
 
 ## 19. Milestones
@@ -905,14 +1025,14 @@ stream for the live tail.
 | Milestone | Contents | Acceptance |
 |---|---|---|
 | **M1 — Spine** | Daemon skeleton, SQLite + migrations, config, token auth, projects CRUD, task creation with worktree (incl. optional agent/model/effort override), Claude adapter (model/effort passthrough + options probe), single hardcoded-format one-step run, transcripts, health/info | `curl` can register a repo, create a 1-step agent task, watch it finish, and see the branch/diff |
-| **M2 — Workflow engine** | YAML registry (global+project, watch/validate/snapshot), all three step types, templates, checks, retry/blocked flow, gates, scheduler with both caps, pause/cancel/skip/edit+retry, SSE, crash recovery, Codex adapter, agent option catalog (`GET /v1/agents`) + §8.6 resolution/validation | Multi-step workflow incl. gate + command publish step runs unattended to the gate; kill -9 of the daemon mid-step recovers correctly; caps honored under load |
-| **M3 — TUI** | All six views, live tail, diff view, all actions, `$EDITOR` integration, daemon auto-start | The full loop (register → author workflow → run 3 parallel tasks → approve gate → archive) is doable without leaving the TUI |
+| **M2 — Workflow engine** | YAML registry (global+project, watch/validate/snapshot), all three step types, templates, checks, retry/blocked flow, gates, scheduler with both caps, pause/cancel/skip/edit+retry, SSE, crash recovery, Codex adapter, agent option catalog (`GET /v1/agents`) + §8.6 resolution/validation, agent input requests (`awaiting_input`, answer endpoint, `input_timeout`, `on_input`, §7.4) | Multi-step workflow incl. gate + command publish step runs unattended to the gate; an agent question round-trips awaiting_input → answer → resume; kill -9 of the daemon mid-step recovers correctly; caps honored under load |
+| **M3 — TUI** | All six views, live tail, diff view, all actions, input-request alerts + answer form, `$EDITOR` integration, daemon auto-start | The full loop (register → author workflow → run 3 parallel tasks → answer an agent question → approve gate → archive) is doable without leaving the TUI |
 | **M4 — Polish** | `service install` for all 3 OSes, CLI subcommands, retention pruning, docs, first-run experience, packaged releases (signed binaries) | Fresh-machine install to first completed task in under 10 minutes on each OS |
 
 ## 20. Future work (explicitly out of v1)
 
 - Web UI on the same API; auth story for non-loopback exposure.
-- OS desktop notifications (blocked / gate / done) — natural M4+1.
+- OS desktop notifications (blocked / gate / awaiting input / done) — natural M4+1.
 - More adapters (Gemini CLI, opencode, …); adapter capability flags.
 - Workflow branching/conditionals, parallel steps, and step fan-out.
 - LLM-as-judge verification as an optional third success layer.

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -18,10 +18,10 @@ implementation progress; the executing agent updates it in place as work proceed
 |---|---|---|---|
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 2/9 | 🔨 in progress |
-| 2 — Workflow engine (M2) | 10 tasks | 0/10 | ⬜ not started |
+| 2 — Workflow engine (M2) | 11 tasks | 0/11 | ⬜ not started |
 | 3 — TUI (M3) | 8 tasks | 0/8 | ⬜ not started |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **6/37** | |
+| **Total** | | **6/38** | |
 
 ---
 
@@ -77,6 +77,15 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
 - *Diff endpoint:* `git -C {worktree} diff <merge-base(base, HEAD)>` — committed + staged + unstaged tracked changes; untracked files excluded (documented limitation).
 - *M1 gate:* `scripts/m1-gate.sh` (bash + curl + jq) run in CI on all 3 OSes (Git Bash on Windows): build vincent+fakeagent → temp dirs via env overrides → start daemon → register temp repo → create task → poll to done → assert branch/diff/transcript → stop daemon.
 
+**Agent/model/effort selection decisions (grill session, 2026-08-07; spec §8.6, §9.6):**
+
+- *Discovery:* adapter `Options()` probes the installed CLI ad hoc — claude: `--help` parse yields the `--effort` enum + model aliases (verified against 2.1.224); codex: `--help` enumerates nothing (only `-c key=value`, verified against 0.142.5) — merged with a curated per-adapter catalog; every option provenance-tagged `cli`/`curated`; free text always accepted.
+- *Effort scale:* adapter-native strings, no normalized vincent scale (claude `low…max`, codex `minimal…high`). Known-invalid (agent, model/effort) pairs are validation errors; values unknown to the catalog warn and pass through — the CLI is the final authority at run time.
+- *Selection surfaces & precedence:* workflow `defaults` + per-step fields (existing) + new optional task-level override on `POST /v1/tasks`; resolution `step > task override > defaults > adapter default` — explicit step pins always win (cross-agent workflows stay intact).
+- *Inheritance:* agent-scoped — `model`/`effort` never leak across an agent switch; they reset to the new adapter's default unless set alongside.
+- *Freshness:* `GET /v1/agents` cache keyed by binary identity (resolved path + mtime + version) — never stale by construction since help output is a pure function of the binary; `?refresh=true` re-probes.
+- *Phasing:* interfaces shaped final in phase 1 (T1.7: `RunSpec.Effort`, `--model`/`--effort`, `Options()` probe; T1.8: override params + `*_override`/StepRun columns); catalog endpoint + resolution/validation engine as new T2.11; codex probe in T2.9; TUI pickers in T3.5. M1 gate unchanged — the override is optional.
+
 - [x] **T1.1 — Config & platform dirs.** Platform-native config/data dir resolution (§12.2); `config.yaml` load with defaults + strict validation (§12.3); hot-reload via fsnotify. ✓ 2026-08-07
   *Done when:* unit tests cover defaults, overrides, invalid config rejection, and live reload. *(Verified: 28 unit tests — defaults, partial/full overrides, 13 invalid-config rejections, live reload incl. invalid-edit keep-last-good, per-OS data-dir table, generated default file loads back to `Default()`.)*
 - [x] **T1.2 — SQLite store & migrations.** Pure-Go driver; WAL + busy_timeout; embedded migrations applying schema §14; typed store layer (CRUD + scheduler query) for projects, tasks, step_runs, events. ✓ 2026-08-07
@@ -89,10 +98,10 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
   *Done when:* endpoint tests against temp git repos cover happy path + each validation failure.
 - [ ] **T1.6 — Worktree manager.** Create worktree + branch `vincent/{id}-{slug}` from base (§10); slug rules (§5.3); remove + prune on archive with dirty detection and `force`; error taxonomy for missing base branch, pre-existing branch, missing project path (§18).
   *Done when:* integration tests with temp repos cover create/remove/dirty/each error case.
-- [ ] **T1.7 — AgentAdapter + Claude Code adapter.** Interface per §9.1; Claude implementation: prompt via stdin, `stream-json` event parsing, full-auto flag, usage/cost extraction, kill support; `Detect()` wired into `/v1/info`. Include a **fake agent** test binary emitting scripted stream-json so CI never calls a real API.
-  *Done when:* adapter unit tests against the fake binary cover success, error event, nonzero exit, kill, and usage parsing.
-- [ ] **T1.8 — Minimal task run.** `POST /v1/tasks` (validation, snapshot placeholder, immediate queue) with a hardcoded single-agent-step execution path: worktree create → adapter run → StepRun + transcript file → `done`/`blocked`; `GET /v1/tasks[,/{id}]`, `/steps`, `/steps/{run_id}/transcript`, `/diff` (§13.2). Depends: T1.2, T1.5–T1.7.
-  *Done when:* end-to-end test with fake agent produces correct DB rows, transcript file, diff output.
+- [ ] **T1.7 — AgentAdapter + Claude Code adapter.** Interface per §9.1 (incl. `Options()` and `RunSpec.Model`/`Effort`); Claude implementation: prompt via stdin, `stream-json` event parsing, full-auto flag, `--model`/`--effort` passthrough, usage/cost extraction, kill support; `Options()` help-probe (effort enum + model aliases parsed from `--help`, merged with the curated catalog, §9.6); `Detect()` wired into `/v1/info`. Include a **fake agent** test binary emitting scripted stream-json so CI never calls a real API.
+  *Done when:* adapter unit tests against the fake binary cover success, error event, nonzero exit, kill, and usage parsing; options probe parses a captured `--help` fixture and falls back to curated-only on an unparseable one.
+- [ ] **T1.8 — Minimal task run.** `POST /v1/tasks` (validation, snapshot placeholder, immediate queue, optional `agent`/`model`/`effort` task-level override persisted to the `*_override` columns via a new migration) with a hardcoded single-agent-step execution path: worktree create → adapter run (agent/model/effort resolved per §8.6, recorded on the StepRun) → StepRun + transcript file → `done`/`blocked`; `GET /v1/tasks[,/{id}]`, `/steps`, `/steps/{run_id}/transcript`, `/diff` (§13.2). Depends: T1.2, T1.5–T1.7.
+  *Done when:* end-to-end test with fake agent produces correct DB rows, transcript file, diff output; an override round-trips into StepRun `model`/`effort`.
 - [ ] **T1.9 — Phase gate (M1 acceptance).** Scripted curl flow per §19 M1 against the fake agent in CI; run once manually with real `claude` on Windows and record the result here.
   *Done when:* script committed and green in CI; manual run noted.
 
@@ -106,7 +115,7 @@ Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) r
   *Done when:* unit tests cover every context variable, missing-field failure, and the retry block.
 - [ ] **T2.3 — Task state machine.** Full FSM §6 with persisted transitions, guarded invalid transitions (409), workflow snapshot at creation replacing T1.8's placeholder, `block_reason`, timestamps.
   *Done when:* exhaustive transition-table test (every state × every action) passes.
-- [ ] **T2.4 — Step executors.** Agent step (any adapter), command step (platform shell selection + `shell:` pin, §8.3), manual gate, `check` execution, per-step timeouts with kill, retry loop honoring `max_retries`, transcript capture for all output. (§7)
+- [ ] **T2.4 — Step executors.** Agent step (any adapter; agent/model/effort resolved per §8.6 via T2.11), command step (platform shell selection + `shell:` pin, §8.3), manual gate, `check` execution, per-step timeouts with kill, retry loop honoring `max_retries`, transcript capture for all output. (§7)
   *Done when:* integration tests cover each step type, check pass/fail, timeout kill, retry-then-blocked, and Windows + POSIX shells in CI.
 - [ ] **T2.5 — Scheduler.** Global + per-project caps counting only `running`; admission by priority DESC, created_at ASC; re-evaluation on every state change and config reload (§11).
   *Done when:* concurrency tests prove both caps and ordering under simultaneous task load.
@@ -116,8 +125,10 @@ Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) r
   *Done when:* reconnect-resume test misses zero state events; output streaming test shows coalescing.
 - [ ] **T2.8 — Crash recovery.** PID + start-time journaling before spawn; startup orphan detection/kill; `interrupted` runs re-queued without consuming retries; graceful shutdown (admission stop, 15 s term-then-kill) (§12.4).
   *Done when:* test kills the daemon hard mid-step and asserts full recovery; graceful path tested.
-- [ ] **T2.9 — Codex adapter.** Per §9.3, behind the same interface; nil cost handling; fake-binary tests mirroring T1.7. Depends: T1.7 (interface only — can run parallel to T2.1+).
+- [ ] **T2.9 — Codex adapter.** Per §9.3, behind the same interface; model/effort via `-c model=` / `-c model_reasoning_effort=`; `Options()` serves the curated catalog (the CLI enumerates nothing); nil cost handling; fake-binary tests mirroring T1.7. Depends: T1.7 (interface only — can run parallel to T2.1+).
   *Done when:* same test matrix as the Claude adapter passes.
+- [ ] **T2.11 — Agent option catalog & selection resolution.** `GET /v1/agents` (§9.6): per-adapter availability + provenance-tagged model/effort options; cache keyed by binary identity (resolved path + mtime + version) with `?refresh=true`; probe-failure fallback to curated with `probe_error`. §8.6 resolution engine (step > task > defaults > adapter default, agent-scoped inheritance) consumed by T2.4; catalog validation wired into T2.1 workflow checks and `POST /v1/tasks` (§8.2: known-invalid = error, unknown = warning). Depends: T1.7, T2.9.
+  *Done when:* resolution table-tests cover every precedence and inheritance case incl. agent-switch resets; cache test proves invalidation on binary swap and a hit otherwise; known-invalid pair rejected while a free-text model passes with a warning.
 - [ ] **T2.10 — Phase gate (M2 acceptance).** Automated: multi-step workflow (agent → command → gate → command publish to a local bare remote) with fake agents; kill -9 recovery; cap stress test. Manual: one real-workflow run with real `claude`, result recorded here.
   *Done when:* acceptance script green in CI; manual run noted.
 
@@ -133,8 +144,8 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
   *Done when:* a running fake-agent task shows live tail; historical attempts browsable.
 - [ ] **T3.4 — Task detail: diff & actions.** Diff tab (syntax highlighted); action bar offering exactly the state-valid actions; gate approve/reject with rendered instructions; edit+retry through `$EDITOR` (§6, §15).
   *Done when:* every action reachable and functional from the detail view; invalid actions never shown.
-- [ ] **T3.5 — New-task flow.** Project picker → workflow picker (description, step list, unavailable-agent flags) → title → description (inline or `$EDITOR`) → fields → base branch → priority (§15).
-  *Done when:* task created through the flow runs end-to-end; unavailable agent visibly flagged.
+- [ ] **T3.5 — New-task flow.** Project picker → workflow picker (description, step list, unavailable-agent flags) → title → description (inline or `$EDITOR`) → fields → base branch → priority → optional agent/model/effort pickers fed by `GET /v1/agents` (provenance-tagged options, free-text entry, note that step pins are not overridden) (§15, §8.6).
+  *Done when:* task created through the flow runs end-to-end; unavailable agent visibly flagged; override pickers populate from a live probe and accept free text.
 - [ ] **T3.6 — Projects & Workflows views.** Project list/add/edit/remove with per-project cap; workflow registry with scope badges + validation status, `e` opens `$EDITOR`, live reload visible (§15).
   *Done when:* editing a workflow file externally or via `e` updates the view without restart.
 - [ ] **T3.7 — Daemon view & first-run warning.** Version/uptime/config/adapters/log tail; one-time full-auto risk notice on first run (§16); quit reminder with running-task count.

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -18,10 +18,10 @@ implementation progress; the executing agent updates it in place as work proceed
 |---|---|---|---|
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 2/9 | 🔨 in progress |
-| 2 — Workflow engine (M2) | 11 tasks | 0/11 | ⬜ not started |
+| 2 — Workflow engine (M2) | 12 tasks | 0/12 | ⬜ not started |
 | 3 — TUI (M3) | 8 tasks | 0/8 | ⬜ not started |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **6/38** | |
+| **Total** | | **6/39** | |
 
 ---
 
@@ -86,6 +86,18 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
 - *Freshness:* `GET /v1/agents` cache keyed by binary identity (resolved path + mtime + version) — never stale by construction since help output is a pure function of the binary; `?refresh=true` re-probes.
 - *Phasing:* interfaces shaped final in phase 1 (T1.7: `RunSpec.Effort`, `--model`/`--effort`, `Options()` probe; T1.8: override params + `*_override`/StepRun columns); catalog endpoint + resolution/validation engine as new T2.11; codex probe in T2.9; TUI pickers in T3.5. M1 gate unchanged — the override is optional.
 
+**Agent input-request decisions (grill session, 2026-08-07; spec §7.4):**
+
+- *Trigger:* structured, machine-readable requests only — `question` (AskUserQuestion-style, options/multi-select/free text) and `permission` (restricted-mode prompt); nothing inferred from output text.
+- *State:* new `awaiting_input`, **holds** its concurrency slot (live agent process idle mid-step); `answer` human action returns it to `running` in place; `cancel` valid from it.
+- *Clocks:* step `timeout` pauses while waiting; new `input_timeout` (global default 24h in config `defaults`, overridable in workflow `defaults`/per step); expiry kills the process and fails the attempt (`input_timeout`) under normal retry/blocked policy.
+- *API:* normalized `InputRequest` (kind, questions/options/multiSelect, adapter-native payload in `raw`) stored as task `pending_input`; durable `task.awaiting_input` event (kind + summary; full request via task GET); `POST /v1/tasks/{id}/answer` (409 outside `awaiting_input`).
+- *Opt-out:* `on_input: wait | deny` (workflow `defaults` + per step, default `wait`); `deny` = adapter auto-answers ("no user available — best judgment" / permission denied) so unattended workflows never stall.
+- *Capability:* per-adapter `supports_input` — claude yes via bidirectional stream-json (`--input-format stream-json`, stdin kept open; control-message wire format is undocumented → pinned per detected CLI version, fixture-tested, degrades to `supports_input: false` if unverifiable); codex `exec` is strictly non-interactive → never enters `awaiting_input`. Unparseable control request = attempt fails `input_protocol_error`, never hangs.
+- *Alerts:* TUI-level only (board pins needs-attention tasks + badge, header attention count, terminal bell on `task.awaiting_input`); OS desktop notifications stay post-v1.
+- *Recovery/metrics:* crash while `awaiting_input` = `interrupted` (request discarded, fresh re-run may re-ask); request+answer transcripted as `vincent.*` lines; wait time in new `input_wait_ms` StepRun column, excluded from durations.
+- *Phasing:* interface shape final in T1.7 (`InputRequest`/`InputResponse` types, `Respond()` on RunHandle, `RunSpec.OnInput`, `supports_input` in Detect — claude may report `false` until the engine lands); full engine as new T2.12 (incl. `pending_input_json`/`input_wait_ms` migration); TUI in T3.2/T3.4; fake agent grows an ask-question scenario.
+
 - [x] **T1.1 — Config & platform dirs.** Platform-native config/data dir resolution (§12.2); `config.yaml` load with defaults + strict validation (§12.3); hot-reload via fsnotify. ✓ 2026-08-07
   *Done when:* unit tests cover defaults, overrides, invalid config rejection, and live reload. *(Verified: 28 unit tests — defaults, partial/full overrides, 13 invalid-config rejections, live reload incl. invalid-edit keep-last-good, per-OS data-dir table, generated default file loads back to `Default()`.)*
 - [x] **T1.2 — SQLite store & migrations.** Pure-Go driver; WAL + busy_timeout; embedded migrations applying schema §14; typed store layer (CRUD + scheduler query) for projects, tasks, step_runs, events. ✓ 2026-08-07
@@ -98,8 +110,8 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
   *Done when:* endpoint tests against temp git repos cover happy path + each validation failure.
 - [ ] **T1.6 — Worktree manager.** Create worktree + branch `vincent/{id}-{slug}` from base (§10); slug rules (§5.3); remove + prune on archive with dirty detection and `force`; error taxonomy for missing base branch, pre-existing branch, missing project path (§18).
   *Done when:* integration tests with temp repos cover create/remove/dirty/each error case.
-- [ ] **T1.7 — AgentAdapter + Claude Code adapter.** Interface per §9.1 (incl. `Options()` and `RunSpec.Model`/`Effort`); Claude implementation: prompt via stdin, `stream-json` event parsing, full-auto flag, `--model`/`--effort` passthrough, usage/cost extraction, kill support; `Options()` help-probe (effort enum + model aliases parsed from `--help`, merged with the curated catalog, §9.6); `Detect()` wired into `/v1/info`. Include a **fake agent** test binary emitting scripted stream-json so CI never calls a real API.
-  *Done when:* adapter unit tests against the fake binary cover success, error event, nonzero exit, kill, and usage parsing; options probe parses a captured `--help` fixture and falls back to curated-only on an unparseable one.
+- [ ] **T1.7 — AgentAdapter + Claude Code adapter.** Interface per §9.1 (incl. `Options()`, `RunSpec.Model`/`Effort`, and the §7.4 input-request surface shaped final: `InputRequest`/`InputResponse` types, `Respond()` on RunHandle, `RunSpec.OnInput`, `supports_input` in `Detect()` — claude may report `false` until T2.12 lands the engine); Claude implementation: prompt via stdin, `stream-json` event parsing, full-auto flag, `--model`/`--effort` passthrough, usage/cost extraction, kill support; `Options()` help-probe (effort enum + model aliases parsed from `--help`, merged with the curated catalog, §9.6); `Detect()` wired into `/v1/info`. Include a **fake agent** test binary emitting scripted stream-json so CI never calls a real API.
+  *Done when:* adapter unit tests against the fake binary cover success, error event, nonzero exit, kill, and usage parsing; options probe parses a captured `--help` fixture and falls back to curated-only on an unparseable one; the input-request interface compiles and is stubbed (behavior exercised in T2.12).
 - [ ] **T1.8 — Minimal task run.** `POST /v1/tasks` (validation, snapshot placeholder, immediate queue, optional `agent`/`model`/`effort` task-level override persisted to the `*_override` columns via a new migration) with a hardcoded single-agent-step execution path: worktree create → adapter run (agent/model/effort resolved per §8.6, recorded on the StepRun) → StepRun + transcript file → `done`/`blocked`; `GET /v1/tasks[,/{id}]`, `/steps`, `/steps/{run_id}/transcript`, `/diff` (§13.2). Depends: T1.2, T1.5–T1.7.
   *Done when:* end-to-end test with fake agent produces correct DB rows, transcript file, diff output; an override round-trips into StepRun `model`/`effort`.
 - [ ] **T1.9 — Phase gate (M1 acceptance).** Scripted curl flow per §19 M1 against the fake agent in CI; run once manually with real `claude` on Windows and record the result here.
@@ -107,14 +119,14 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
 
 ## Phase 2 — Workflow engine (M2)
 
-Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) runs unattended to the gate; `kill -9` mid-step recovers correctly; caps honored under load.
+Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) runs unattended to the gate; an agent question round-trips awaiting_input → answer → resume; `kill -9` mid-step recovers correctly; caps honored under load.
 
 - [ ] **T2.1 — Workflow registry.** Strict YAML decode with unknown-key rejection (§8.1–8.2); validation with file/line errors; global + project scopes with shadowing (§5.2); fsnotify reload keeping valid entries when one file is broken; `GET /v1/workflows`, `POST /v1/workflows/validate`.
   *Done when:* table-driven validation tests + scope-shadowing and broken-file-isolation tests pass.
 - [ ] **T2.2 — Template engine.** Context assembly per §8.4 (`.Task`, `.Project`, `.Workflow`, `.Step`, `.Steps`, `.Worktree`, `.LastFailure`); render-fails-before-spawn; command/check env vars (§8.5); retry failure block appending (§8.4).
   *Done when:* unit tests cover every context variable, missing-field failure, and the retry block.
-- [ ] **T2.3 — Task state machine.** Full FSM §6 with persisted transitions, guarded invalid transitions (409), workflow snapshot at creation replacing T1.8's placeholder, `block_reason`, timestamps.
-  *Done when:* exhaustive transition-table test (every state × every action) passes.
+- [ ] **T2.3 — Task state machine.** Full FSM §6 with persisted transitions (incl. `awaiting_input`, §7.4), guarded invalid transitions (409), workflow snapshot at creation replacing T1.8's placeholder, `block_reason`, timestamps.
+  *Done when:* exhaustive transition-table test (every state × every action, incl. `answer`) passes.
 - [ ] **T2.4 — Step executors.** Agent step (any adapter; agent/model/effort resolved per §8.6 via T2.11), command step (platform shell selection + `shell:` pin, §8.3), manual gate, `check` execution, per-step timeouts with kill, retry loop honoring `max_retries`, transcript capture for all output. (§7)
   *Done when:* integration tests cover each step type, check pass/fail, timeout kill, retry-then-blocked, and Windows + POSIX shells in CI.
 - [ ] **T2.5 — Scheduler.** Global + per-project caps counting only `running`; admission by priority DESC, created_at ASC; re-evaluation on every state change and config reload (§11).
@@ -129,7 +141,9 @@ Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) r
   *Done when:* same test matrix as the Claude adapter passes.
 - [ ] **T2.11 — Agent option catalog & selection resolution.** `GET /v1/agents` (§9.6): per-adapter availability + provenance-tagged model/effort options; cache keyed by binary identity (resolved path + mtime + version) with `?refresh=true`; probe-failure fallback to curated with `probe_error`. §8.6 resolution engine (step > task > defaults > adapter default, agent-scoped inheritance) consumed by T2.4; catalog validation wired into T2.1 workflow checks and `POST /v1/tasks` (§8.2: known-invalid = error, unknown = warning). Depends: T1.7, T2.9.
   *Done when:* resolution table-tests cover every precedence and inheritance case incl. agent-switch resets; cache test proves invalidation on binary swap and a hit otherwise; known-invalid pair rejected while a free-text model passes with a warning.
-- [ ] **T2.10 — Phase gate (M2 acceptance).** Automated: multi-step workflow (agent → command → gate → command publish to a local bare remote) with fake agents; kill -9 recovery; cap stress test. Manual: one real-workflow run with real `claude`, result recorded here.
+- [ ] **T2.12 — Interactive input requests (§7.4).** Claude adapter bidirectional stream-json input (stdin kept open, `--input-format stream-json`; question/permission control messages normalized to `InputRequest`; `Respond()` translation back; wire protocol pinned against the detected CLI version with fixtures, degrading to `supports_input: false` when unverifiable); `awaiting_input` FSM wiring (slot retained, step clock paused, `input_wait_ms` accounting); `input_timeout` enforcement; `on_input: wait|deny` resolution (deny = adapter auto-answer, no state change); migration adding `pending_input_json` + `input_wait_ms`; `POST /v1/tasks/{id}/answer`; durable `task.awaiting_input` event; request/answer transcript lines; fake-agent ask-question scenario (blocks until answered on stdin). Depends: T1.7, T2.3, T2.4, T2.6, T2.7.
+  *Done when:* fake-agent test drives request → `awaiting_input` (slot held, clock paused) → answer → resume → done; `input_timeout` expiry fails the attempt with the right reason; deny mode auto-answers with no state change; unparseable control request fails `input_protocol_error`; answer in wrong state returns 409.
+- [ ] **T2.10 — Phase gate (M2 acceptance).** Automated: multi-step workflow (agent → command → gate → command publish to a local bare remote) with fake agents, incl. an input-request round-trip (§7.4); kill -9 recovery; cap stress test. Manual: one real-workflow run with real `claude`, result recorded here.
   *Done when:* acceptance script green in CI; manual run noted.
 
 ## Phase 3 — TUI (M3)
@@ -138,12 +152,12 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
 
 - [ ] **T3.1 — TUI foundation.** Bubble Tea shell; API client (token + `daemon.json` discovery); daemon auto-start when unreachable (§12.1); `/v1/events` subscription driving re-render; view routing, global keys, help overlay (§15).
   *Done when:* TUI connects, auto-starts a stopped daemon, and reflects an externally-made state change live.
-- [ ] **T3.2 — Board view.** Task table (id, project, title, state color-coded, step k/n, elapsed, cost), filters, scheduler-order sort; header with daemon status, agent availability, running/cap counts.
-  *Done when:* board renders live updates from SSE without polling; filters work.
+- [ ] **T3.2 — Board view.** Task table (id, project, title, state color-coded, step k/n, elapsed, cost), filters, scheduler-order sort; header with daemon status, agent availability, running/cap counts, needs-attention count; needs-attention tasks (`awaiting_input`/`awaiting_gate`/`blocked`) pinned on top with a distinct badge; terminal bell on `task.awaiting_input` (§7.4, §15).
+  *Done when:* board renders live updates from SSE without polling; filters work; an awaiting-input fake-agent task visibly alerts (pin + badge + bell).
 - [ ] **T3.3 — Task detail: timeline & tail.** Step timeline with attempts/durations/tokens/cost; live output tail with follow mode; scrollback into past transcripts via ranged transcript endpoint.
   *Done when:* a running fake-agent task shows live tail; historical attempts browsable.
-- [ ] **T3.4 — Task detail: diff & actions.** Diff tab (syntax highlighted); action bar offering exactly the state-valid actions; gate approve/reject with rendered instructions; edit+retry through `$EDITOR` (§6, §15).
-  *Done when:* every action reachable and functional from the detail view; invalid actions never shown.
+- [ ] **T3.4 — Task detail: diff & actions.** Diff tab (syntax highlighted); action bar offering exactly the state-valid actions; gate approve/reject with rendered instructions; answer form for `awaiting_input` (question/permission rendered with options, multi-select, free-text entry; submits `POST /answer` and the run resumes in place, §7.4); edit+retry through `$EDITOR` (§6, §15).
+  *Done when:* every action reachable and functional from the detail view; invalid actions never shown; a fake-agent question is answerable from the detail view and the run resumes live.
 - [ ] **T3.5 — New-task flow.** Project picker → workflow picker (description, step list, unavailable-agent flags) → title → description (inline or `$EDITOR`) → fields → base branch → priority → optional agent/model/effort pickers fed by `GET /v1/agents` (provenance-tagged options, free-text entry, note that step pins are not overridden) (§15, §8.6).
   *Done when:* task created through the flow runs end-to-end; unavailable agent visibly flagged; override pickers populate from a live probe and accept free text.
 - [ ] **T3.6 — Projects & Workflows views.** Project list/add/edit/remove with per-project cap; workflow registry with scope badges + validation status, `e` opens `$EDITOR`, live reload visible (§15).


### PR DESCRIPTION
## Summary

Documentation-only branch, three strands (grew beyond the original README scope):

### README & community files

Brings vincent in line with the README/community-file styling shared by hotrulez, markpad, lintforge, and gcbad_dart:

- **README restyled to house style**: centered header + bold tagline, centered badge row (CI, MIT, Buy Me a Coffee), anchor nav row, `## Why vincent?` opener, then `What It Does` / `Project Status` / `Contributing` / `Security` / `License` sections matching the shared template.
- **Naming rationale kept**: the `Why vincent?` section carries the VINCENT acronym — vendor-independent control plane for executing native agent tooling — with each part mapped to the system.
- **Status refreshed**: "Design phase" → implementation in progress (phase 0 done, phase 1 spine underway), with spec/tasks links.
- **CONTRIBUTING.md**: replaced the stale pre-Phase-0 `make` targets with the actual zero-install mage targets (`go run mage.go build|test|testrace|lint`).
- **SECURITY.md**: added the direct private-advisory link, matching the other repos' reporting sections.
- Deliberately *not* copied from the other repos: the squash-merge/release-please convention — vincent keeps merge commits (no squashing) per its CONTRIBUTING.md.

### Agent/model/effort selection (spec §8.6, §9.6 — grill session 2026-08-07)

Adapter-native values; `step > task override > workflow defaults > adapter default` resolution with agent-scoped inheritance; options probed ad hoc from the installed CLIs merged with a curated catalog, free text always allowed. Tasks: T1.7/T1.8 interface shaping, new T2.11 catalog + resolution engine, T3.5 pickers.

### Interactive input requests (new spec §7.4 — grill session 2026-08-07)

Agents that emit structured questions (AskUserQuestion-style) or restricted-mode permission requests flip the task to a new `awaiting_input` state: slot held, step clock paused with an `input_timeout` (default 24h) backstop, durable `task.awaiting_input` alert event, and the answer delivered into the still-live session via `POST /v1/tasks/{id}/answer`. Per-adapter `supports_input` capability (claude via bidirectional stream-json pinned per detected CLI version; codex none) and an `on_input: wait|deny` opt-out keep unattended workflows intact. Tasks: new T2.12 engine; T1.7/T2.3/T2.10/T3.2/T3.4 scoped up; dashboard now 39 tasks.

## Review notes

- The §6 lifecycle diagram was redrawn: `awaiting_input` sits beside `running`; the restart-loop arrow became a footnote (matches §12.4's "task returns to queued" more accurately).
- Claude's mid-run control-message wire format is not publicly documented — the spec hedges the same way §9.2 already does for flags: pinned per detected CLI version, fixture-tested, degrading to `supports_input: false`.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)