### PR TITLE
Daemon lifecycle and HTTP API foundation (T1.3, T1.4)

### DIFF
--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -784,6 +784,8 @@ GET    /v1/info                         daemon version, uptime, agent availabili
 GET    /v1/config                       effective global config (read-only)
 GET    /v1/agents                       per-adapter availability + model/effort options (§9.6);
                                         ?refresh=true forces a re-probe
+POST   /v1/daemon/stop                  graceful shutdown (§12.4); 202, then the daemon exits.
+                                        `vincent daemon stop` calls this and waits for exit
 
 GET    /v1/projects                     list
 POST   /v1/projects                     { path, name?, default_branch?, default_workflow?, max_parallel_tasks? }

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -17,11 +17,11 @@ implementation progress; the executing agent updates it in place as work proceed
 | Phase | Scope | Done | Status |
 |---|---|---|---|
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
-| 1 — Spine (M1) | 9 tasks | 2/9 | 🔨 in progress |
+| 1 — Spine (M1) | 9 tasks | 4/9 | 🔨 in progress |
 | 2 — Workflow engine (M2) | 12 tasks | 0/12 | ⬜ not started |
 | 3 — TUI (M3) | 8 tasks | 0/8 | ⬜ not started |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **6/39** | |
+| **Total** | | **8/39** | |
 
 ---
 
@@ -115,10 +115,10 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
 - *`/v1/config`:* effective config as snake_case JSON mirroring `config.yaml`; durations rendered as Go duration strings.
 - *Token:* 32 bytes `crypto/rand` as hex, written atomically (temp+rename) 0600 at first start, reused unchanged on later starts.
 
-- [~] **T1.3 — Daemon lifecycle.** `vincent daemon` (foreground); `daemon start/stop/status` (detached start, graceful stop, status via `daemon.json`); single-instance lock file; bearer token generated 0600 at first start; structured logging with rotation. (§12.1, §12.2, §13.1)
-  *Done when:* start/status/stop cycle works on all 3 OSes; second daemon refuses to start; token/`daemon.json` created with correct permissions.
-- [~] **T1.4 — API foundation.** `net/http` server bound `127.0.0.1`; bearer-auth middleware (health exempt); JSON error envelope with stable codes; `GET /v1/health`, `/v1/info` (agent availability wired later), `/v1/config`. (§13.1–13.2)
-  *Done when:* auth rejection, health-without-auth, and error-shape tests pass.
+- [x] **T1.3 — Daemon lifecycle.** `vincent daemon` (foreground); `daemon start/stop/status` (detached start, graceful stop, status via `daemon.json`); single-instance lock file; bearer token generated 0600 at first start; structured logging with rotation. (§12.1, §12.2, §13.1) ✓ 2026-08-07
+  *Done when:* start/status/stop cycle works on all 3 OSes; second daemon refuses to start; token/`daemon.json` created with correct permissions. *(Verified: PR #10 matrix green on ubuntu/macos/windows — binary e2e drives the full start/status/stop cycle incl. idempotency and exit codes; in-process tests cover second-instance refusal, API stop, context cancel, fatal invalid config; token 0600 asserted on POSIX, existence on Windows.)*
+- [x] **T1.4 — API foundation.** `net/http` server bound `127.0.0.1`; bearer-auth middleware (health exempt); JSON error envelope with stable codes; `GET /v1/health`, `/v1/info` (agent availability wired later), `/v1/config`. (§13.1–13.2) ✓ 2026-08-07
+  *Done when:* auth rejection, health-without-auth, and error-shape tests pass. *(Verified: PR #10 — httptest suite covers auth rejection (missing/wrong token), health without auth, 404/405/401/500 envelope shapes incl. Allow header, panic recovery, and the stop endpoint with and without auth.)*
 - [ ] **T1.5 — Projects API.** `GET/POST /v1/projects`, `GET/PATCH/DELETE /v1/projects/{id}`; registration validation (path exists, is git repo); `default_branch` auto-detection with fallback (§5.1); delete guarded by non-archived tasks.
   *Done when:* endpoint tests against temp git repos cover happy path + each validation failure.
 - [ ] **T1.6 — Worktree manager.** Create worktree + branch `vincent/{id}-{slug}` from base (§10); slug rules (§5.3); remove + prune on archive with dirty detection and `force`; error taxonomy for missing base branch, pre-existing branch, missing project path (§18).

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -102,9 +102,22 @@ Milestone acceptance (§19 M1): via `curl` alone — register a repo, create a o
   *Done when:* unit tests cover defaults, overrides, invalid config rejection, and live reload. *(Verified: 28 unit tests — defaults, partial/full overrides, 13 invalid-config rejections, live reload incl. invalid-edit keep-last-good, per-OS data-dir table, generated default file loads back to `Default()`.)*
 - [x] **T1.2 — SQLite store & migrations.** Pure-Go driver; WAL + busy_timeout; embedded migrations applying schema §14; typed store layer (CRUD + scheduler query) for projects, tasks, step_runs, events. ✓ 2026-08-07
   *Done when:* migration idempotence test + CRUD round-trip tests pass on all 3 OSes in CI. *(Verified: PR #7 matrix green on ubuntu/macos/windows — idempotence via re-migrate + reopen, pragma checks, CRUD round-trips incl. nullable columns, scheduler ordering, FK enforcement.)*
-- [ ] **T1.3 — Daemon lifecycle.** `vincent daemon` (foreground); `daemon start/stop/status` (detached start, graceful stop, status via `daemon.json`); single-instance lock file; bearer token generated 0600 at first start; structured logging with rotation. (§12.1, §12.2, §13.1)
+**T1.3/T1.4 decisions (grill session, 2026-08-07):**
+
+- *Start handshake:* `daemon start` first probes for a healthy daemon (already running = success), then spawns the detached child and polls `daemon.json` + `GET /v1/health` for ~10 s; on failure it prints the tail of `daemon.log` and exits non-zero. No pipe IPC.
+- *Status truth:* try-acquire `daemon.lock` — acquirable means no daemon (a leftover `daemon.json` is reported as stale); held means alive, then `/v1/health` decides responsiveness. Exit codes: 0 healthy · 1 not running · 2 alive-but-unresponsive. Human-readable output; `--json` deferred to T4.2.
+- *Idempotency:* desired-state semantics — `start` on a running daemon and `stop` with none running both print what happened and exit 0.
+- *Stop flow:* `daemon stop` POSTs `/v1/daemon/stop` (202; response completes before shutdown begins), then waits for the lock to become acquirable (~20 s, longer than the daemon's own kill grace); `--force` falls back to killing the recorded PID.
+- *Foreground = daemon:* `vincent daemon` is the real daemon in both modes — always takes the lock, writes token/`daemon.json`, always logs to the rotating file; foreground additionally mirrors logs to stderr. Log level rides a `slog.LevelVar` so `log_level` applies on hot-reload; a `listen` change is warned and the effective value kept.
+- *Middleware order:* recover outermost → request log → auth → handler (panics always logged and enveloped as 500; unauthorized requests still logged). `/v1/health` is auth-exempt and logged at debug so poll loops don't spam the log.
+- *Error vocabulary (initial):* `unauthorized`, `not_found`, `method_not_allowed`, `invalid_json`, `validation_failed`, `invalid_state`, `internal`; ServeMux fallback 404/405 wrapped so every error body is the §13.1 envelope (405 carries `Allow`).
+- *`/v1/info` (initial):* version/commit/built, pid, `started_at`, uptime, effective listen address, `max_parallel_tasks`; agent availability joins in T1.7 (additive).
+- *`/v1/config`:* effective config as snake_case JSON mirroring `config.yaml`; durations rendered as Go duration strings.
+- *Token:* 32 bytes `crypto/rand` as hex, written atomically (temp+rename) 0600 at first start, reused unchanged on later starts.
+
+- [~] **T1.3 — Daemon lifecycle.** `vincent daemon` (foreground); `daemon start/stop/status` (detached start, graceful stop, status via `daemon.json`); single-instance lock file; bearer token generated 0600 at first start; structured logging with rotation. (§12.1, §12.2, §13.1)
   *Done when:* start/status/stop cycle works on all 3 OSes; second daemon refuses to start; token/`daemon.json` created with correct permissions.
-- [ ] **T1.4 — API foundation.** `net/http` server bound `127.0.0.1`; bearer-auth middleware (health exempt); JSON error envelope with stable codes; `GET /v1/health`, `/v1/info` (agent availability wired later), `/v1/config`. (§13.1–13.2)
+- [~] **T1.4 — API foundation.** `net/http` server bound `127.0.0.1`; bearer-auth middleware (health exempt); JSON error envelope with stable codes; `GET /v1/health`, `/v1/info` (agent availability wired later), `/v1/config`. (§13.1–13.2)
   *Done when:* auth rejection, health-without-auth, and error-shape tests pass.
 - [ ] **T1.5 — Projects API.** `GET/POST /v1/projects`, `GET/PATCH/DELETE /v1/projects/{id}`; registration validation (path exists, is git repo); `default_branch` auto-detection with fallback (§5.1); delete guarded by non-archived tasks.
   *Done when:* endpoint tests against temp git repos cover happy path + each validation failure.

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.26
 require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/goccy/go-yaml v1.19.2
+	github.com/gofrs/flock v0.13.0
 	github.com/magefile/mage v1.17.2
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	modernc.org/sqlite v1.56.0
 )
 
@@ -87,7 +89,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202 // indirect

--- a/go.sum
+++ b/go.sum
@@ -959,6 +959,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,4 +1,5 @@
-// Package api will serve the localhost HTTP API: bearer-auth middleware,
-// JSON error envelope, REST endpoints, and SSE event streams
-// (spec §13; T1.4–T1.5, T2.6–T2.7).
+// Package api serves the localhost HTTP API (spec §13): bearer-auth
+// middleware with a health exemption, request logging, panic recovery, and
+// the JSON error envelope with stable snake_case codes. Domain endpoints
+// (projects, tasks) and SSE streams land with T1.5+ and T2.7.
 package api

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Stable error codes (spec §13.1). The vocabulary grows additively as
+// endpoints land; codes never change meaning.
+const (
+	CodeUnauthorized     = "unauthorized"
+	CodeNotFound         = "not_found"
+	CodeMethodNotAllowed = "method_not_allowed"
+	CodeInvalidJSON      = "invalid_json"
+	CodeValidationFailed = "validation_failed"
+	CodeInvalidState     = "invalid_state"
+	CodeInternal         = "internal"
+)
+
+// errorBody is the §13.1 error envelope: {"error": {"code", "message"}}.
+type errorBody struct {
+	Error errorDetail `json:"error"`
+}
+
+type errorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// writeJSON writes v as the JSON response body with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	// Encoding a value we constructed can only fail on a broken connection;
+	// there is no useful recovery at this point.
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes the error envelope with the given status and stable code.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, errorBody{Error: errorDetail{Code: code, Message: message}})
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// healthPath is exempt from auth (spec §13.1) and logged at debug so status
+// poll loops don't flood the log (phase 1 decision).
+const healthPath = "/v1/health"
+
+// authMiddleware enforces the bearer token with a constant-time comparison.
+func (s *Server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == healthPath {
+			next.ServeHTTP(w, r)
+			return
+		}
+		const prefix = "Bearer "
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, prefix) ||
+			subtle.ConstantTimeCompare([]byte(auth[len(prefix):]), []byte(s.deps.Token)) != 1 {
+			writeError(w, http.StatusUnauthorized, CodeUnauthorized, "missing or invalid bearer token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// logMiddleware records one line per request with method, path, status, and
+// duration.
+func (s *Server) logMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(sw, r)
+		level := slog.LevelInfo
+		if r.URL.Path == healthPath {
+			level = slog.LevelDebug
+		}
+		s.deps.Logger.Log(r.Context(), level, "http request",
+			"method", r.Method, "path", r.URL.Path,
+			"status", sw.status, "duration_ms", time.Since(start).Milliseconds())
+	})
+}
+
+// recoverMiddleware is outermost (phase 1 decision): a handler panic is
+// logged with its stack and answered with the internal error envelope.
+func (s *Server) recoverMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			v := recover()
+			if v == nil {
+				return
+			}
+			if v == http.ErrAbortHandler { //nolint:errorlint // sentinel by identity, per net/http docs
+				panic(v)
+			}
+			s.deps.Logger.Error("panic in handler",
+				"method", r.Method, "path", r.URL.Path,
+				"panic", v, "stack", string(debug.Stack()))
+			writeError(w, http.StatusInternalServerError, CodeInternal, "internal server error")
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// statusWriter captures the response status for logging.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/version"
+)
+
+// Deps are the daemon facilities the API serves from.
+type Deps struct {
+	// Token is the bearer token every non-health request must present.
+	Token string
+	// Config returns the current effective configuration (hot-reloaded).
+	Config func() config.Config
+	// StartedAt is the daemon start time, for uptime reporting.
+	StartedAt time.Time
+	// ListenAddr is the effective bound address.
+	ListenAddr string
+	// RequestStop triggers a graceful daemon shutdown; it must not block.
+	RequestStop func()
+	// Logger receives request and panic logs.
+	Logger *slog.Logger
+}
+
+// Server is the vincent HTTP API server.
+type Server struct {
+	deps    Deps
+	handler http.Handler
+	httpSrv *http.Server
+}
+
+// New assembles the server: routes wrapped in recover → log → auth
+// middleware (outermost first; phase 1 decision).
+func New(deps Deps) *Server {
+	s := &Server{deps: deps}
+	s.handler = s.buildHandler()
+	s.httpSrv = &http.Server{
+		Handler:           s.handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return s
+}
+
+// Handler exposes the fully-wrapped handler for tests.
+func (s *Server) Handler() http.Handler { return s.handler }
+
+// Serve serves on ln until Shutdown; it returns http.ErrServerClosed then.
+func (s *Server) Serve(ln net.Listener) error {
+	if err := s.httpSrv.Serve(ln); err != nil {
+		return fmt.Errorf("serve http: %w", err)
+	}
+	return nil
+}
+
+// Shutdown gracefully drains in-flight requests.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if err := s.httpSrv.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutdown http: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) buildHandler() http.Handler {
+	mux := http.NewServeMux()
+	rt := &router{mux: mux, allowed: map[string][]string{}}
+	rt.handle(http.MethodGet, "/v1/health", s.handleHealth)
+	rt.handle(http.MethodGet, "/v1/info", s.handleInfo)
+	rt.handle(http.MethodGet, "/v1/config", s.handleConfig)
+	rt.handle(http.MethodPost, "/v1/daemon/stop", s.handleStop)
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		writeError(w, http.StatusNotFound, CodeNotFound, "no such endpoint")
+	})
+	var h http.Handler = mux
+	h = s.authMiddleware(h)
+	h = s.logMiddleware(h)
+	h = s.recoverMiddleware(h)
+	return h
+}
+
+// router registers method-qualified patterns plus one path-level fallback per
+// path, so requests with a wrong method get the §13.1 envelope (with Allow)
+// instead of ServeMux's plain-text 405.
+type router struct {
+	mux     *http.ServeMux
+	allowed map[string][]string
+}
+
+func (rt *router) handle(method, path string, h http.HandlerFunc) {
+	if len(rt.allowed[path]) == 0 {
+		rt.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			allow := strings.Join(rt.allowed[path], ", ")
+			w.Header().Set("Allow", allow)
+			writeError(w, http.StatusMethodNotAllowed, CodeMethodNotAllowed,
+				fmt.Sprintf("%s is not allowed on %s (allowed: %s)", r.Method, path, allow))
+		})
+	}
+	rt.allowed[path] = append(rt.allowed[path], method)
+	rt.mux.HandleFunc(method+" "+path, h)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":  "ok",
+		"version": version.Version(),
+	})
+}
+
+// infoResponse is the GET /v1/info body (initial shape, phase 1 decision);
+// agent availability joins in T1.7 additively.
+type infoResponse struct {
+	Version          string `json:"version"`
+	Commit           string `json:"commit"`
+	Built            string `json:"built"`
+	PID              int    `json:"pid"`
+	StartedAt        string `json:"started_at"`
+	UptimeSeconds    int64  `json:"uptime_seconds"`
+	Listen           string `json:"listen"`
+	MaxParallelTasks int    `json:"max_parallel_tasks"`
+}
+
+func (s *Server) handleInfo(w http.ResponseWriter, _ *http.Request) {
+	cfg := s.deps.Config()
+	writeJSON(w, http.StatusOK, infoResponse{
+		Version:          version.Version(),
+		Commit:           version.Commit(),
+		Built:            version.Date(),
+		PID:              os.Getpid(),
+		StartedAt:        s.deps.StartedAt.UTC().Format(time.RFC3339),
+		UptimeSeconds:    int64(time.Since(s.deps.StartedAt).Seconds()),
+		Listen:           s.deps.ListenAddr,
+		MaxParallelTasks: cfg.MaxParallelTasks,
+	})
+}
+
+// configResponse mirrors config.yaml as snake_case JSON; durations render as
+// Go duration strings (phase 1 decision).
+type configResponse struct {
+	Listen                  string               `json:"listen"`
+	MaxParallelTasks        int                  `json:"max_parallel_tasks"`
+	Defaults                configDefaults       `json:"defaults"`
+	TranscriptRetentionDays int                  `json:"transcript_retention_days"`
+	LogLevel                string               `json:"log_level"`
+	Agents                  map[string]agentPath `json:"agents"`
+}
+
+type configDefaults struct {
+	AgentTimeout   string `json:"agent_timeout"`
+	CommandTimeout string `json:"command_timeout"`
+}
+
+type agentPath struct {
+	Path string `json:"path"`
+}
+
+func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
+	cfg := s.deps.Config()
+	writeJSON(w, http.StatusOK, configResponse{
+		Listen:           cfg.Listen,
+		MaxParallelTasks: cfg.MaxParallelTasks,
+		Defaults: configDefaults{
+			AgentTimeout:   cfg.Defaults.AgentTimeout.String(),
+			CommandTimeout: cfg.Defaults.CommandTimeout.String(),
+		},
+		TranscriptRetentionDays: cfg.TranscriptRetentionDays,
+		LogLevel:                cfg.LogLevel,
+		Agents: map[string]agentPath{
+			"claude": {Path: cfg.Agents.Claude.Path},
+			"codex":  {Path: cfg.Agents.Codex.Path},
+		},
+	})
+}
+
+func (s *Server) handleStop(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusAccepted, map[string]bool{"stopping": true})
+	s.deps.RequestStop()
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+const testToken = "test-token-0123456789abcdef"
+
+// newTestServer returns a running test server and a channel receiving one
+// element per RequestStop call (a channel, not a counter, so the assertion
+// synchronizes with the handler goroutine). cfg lets tests inject a
+// panicking Config dependency.
+func newTestServer(t *testing.T, cfg func() config.Config) (*httptest.Server, chan struct{}) {
+	t.Helper()
+	if cfg == nil {
+		cfg = config.Default
+	}
+	stops := make(chan struct{}, 8)
+	s := New(Deps{
+		Token:       testToken,
+		Config:      cfg,
+		StartedAt:   time.Now().Add(-time.Minute),
+		ListenAddr:  "127.0.0.1:12345",
+		RequestStop: func() { stops <- struct{}{} },
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return ts, stops
+}
+
+func doRequest(t *testing.T, ts *httptest.Server, method, path, token string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, ts.URL+path, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, body
+}
+
+// wantError asserts the §13.1 envelope shape and code.
+func wantError(t *testing.T, resp *http.Response, body []byte, status int, code string) {
+	t.Helper()
+	if resp.StatusCode != status {
+		t.Fatalf("status = %d, want %d (body %s)", resp.StatusCode, status, body)
+	}
+	var e errorBody
+	if err := json.Unmarshal(body, &e); err != nil {
+		t.Fatalf("error body is not JSON: %v (%s)", err, body)
+	}
+	if e.Error.Code != code {
+		t.Errorf("error code = %q, want %q", e.Error.Code, code)
+	}
+	if e.Error.Message == "" {
+		t.Error("error message is empty")
+	}
+}
+
+func TestHealthWithoutAuth(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/health", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var h struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(body, &h); err != nil {
+		t.Fatalf("parse health: %v", err)
+	}
+	if h.Status != "ok" || h.Version == "" {
+		t.Errorf("health = %+v, want status ok and non-empty version", h)
+	}
+}
+
+func TestAuthRejection(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	for name, token := range map[string]string{
+		"missing header": "",
+		"wrong token":    "not-the-token",
+	} {
+		resp, body := doRequest(t, ts, http.MethodGet, "/v1/info", token)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s: status = %d, want 401", name, resp.StatusCode)
+		}
+		wantError(t, resp, body, http.StatusUnauthorized, CodeUnauthorized)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/info", testToken)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	var info infoResponse
+	if err := json.Unmarshal(body, &info); err != nil {
+		t.Fatalf("parse info: %v", err)
+	}
+	if info.Version == "" {
+		t.Error("version is empty")
+	}
+	if info.PID <= 0 {
+		t.Errorf("pid = %d, want > 0", info.PID)
+	}
+	if info.UptimeSeconds < 0 {
+		t.Errorf("uptime_seconds = %d, want >= 0", info.UptimeSeconds)
+	}
+	if info.Listen != "127.0.0.1:12345" {
+		t.Errorf("listen = %q", info.Listen)
+	}
+	if info.MaxParallelTasks != config.Default().MaxParallelTasks {
+		t.Errorf("max_parallel_tasks = %d", info.MaxParallelTasks)
+	}
+}
+
+func TestConfigView(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/config", testToken)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	var cfg configResponse
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	want := config.Default()
+	if cfg.Listen != want.Listen || cfg.LogLevel != want.LogLevel ||
+		cfg.MaxParallelTasks != want.MaxParallelTasks ||
+		cfg.TranscriptRetentionDays != want.TranscriptRetentionDays {
+		t.Errorf("config = %+v, want defaults %+v", cfg, want)
+	}
+	if cfg.Defaults.AgentTimeout != want.Defaults.AgentTimeout.String() {
+		t.Errorf("agent_timeout = %q, want %q", cfg.Defaults.AgentTimeout, want.Defaults.AgentTimeout)
+	}
+	if _, ok := cfg.Agents["claude"]; !ok {
+		t.Error("agents.claude missing")
+	}
+	if !strings.Contains(string(body), "max_parallel_tasks") {
+		t.Error("response keys are not snake_case")
+	}
+}
+
+func TestNotFoundEnvelope(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/definitely-not-a-thing", testToken)
+	wantError(t, resp, body, http.StatusNotFound, CodeNotFound)
+}
+
+func TestMethodNotAllowedEnvelope(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/daemon/stop", testToken)
+	wantError(t, resp, body, http.StatusMethodNotAllowed, CodeMethodNotAllowed)
+	if allow := resp.Header.Get("Allow"); allow != http.MethodPost {
+		t.Errorf("Allow = %q, want POST", allow)
+	}
+}
+
+func TestStopEndpoint(t *testing.T) {
+	ts, stops := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodPost, "/v1/daemon/stop", testToken)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (body %s)", resp.StatusCode, body)
+	}
+	select {
+	case <-stops:
+	case <-time.After(2 * time.Second):
+		t.Error("RequestStop was not called")
+	}
+}
+
+func TestStopRequiresAuth(t *testing.T) {
+	ts, stops := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodPost, "/v1/daemon/stop", "")
+	wantError(t, resp, body, http.StatusUnauthorized, CodeUnauthorized)
+	select {
+	case <-stops:
+		t.Error("RequestStop was called despite the auth rejection")
+	default:
+	}
+}
+
+func TestPanicRecovery(t *testing.T) {
+	ts, _ := newTestServer(t, func() config.Config { panic("boom") })
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/info", testToken)
+	wantError(t, resp, body, http.StatusInternalServerError, CodeInternal)
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,19 +3,27 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lezli01/vincent/internal/version"
 )
 
-// Execute runs the root command and returns the process exit code.
+// Execute runs the root command and returns the process exit code. Errors
+// are printed here (not by cobra) so exitError can exit silently with its
+// specific code after the command already reported the situation.
 func Execute() int {
-	if err := newRootCmd().Execute(); err != nil {
-		return 1
+	root := newRootCmd()
+	root.SilenceErrors = true
+	err := root.Execute()
+	var ee exitError
+	if err != nil && !errors.As(err, &ee) {
+		fmt.Fprintln(os.Stderr, "Error:", err)
 	}
-	return 0
+	return asExitCode(err)
 }
 
 func newRootCmd() *cobra.Command {
@@ -30,17 +38,6 @@ func newRootCmd() *cobra.Command {
 	}
 	root.AddCommand(newDaemonCmd(), newVersionCmd())
 	return root
-}
-
-func newDaemonCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "daemon",
-		Short: "Run the vincent daemon in the foreground",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), "The vincent daemon is not implemented yet (Phase 1).")
-			return err
-		},
-	}
 }
 
 func newVersionCmd() *cobra.Command {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+const (
+	// startTimeout bounds the `daemon start` health poll (phase 1 decision).
+	startTimeout = 10 * time.Second
+	// stopTimeout exceeds the daemon's own shutdown grace so a graceful stop
+	// is never reported as a failure prematurely.
+	stopTimeout = 20 * time.Second
+	// pollInterval paces lifecycle polling loops.
+	pollInterval = 100 * time.Millisecond
+)
+
+func newDaemonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "daemon",
+		Short: "Run the vincent daemon in the foreground",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return daemon.Run(cmd.Context(), daemon.Options{Foreground: true})
+		},
+	}
+	cmd.AddCommand(newDaemonStartCmd(), newDaemonStopCmd(), newDaemonStatusCmd())
+	return cmd
+}
+
+func newDaemonStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the daemon in the background",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return err
+			}
+			// Desired-state semantics: an already-healthy daemon is success.
+			if running, err := daemon.ProbeRunning(dirs.Data); err != nil {
+				return err
+			} else if running {
+				ri, err := daemon.ReadRuntimeInfo(dirs.Data)
+				if err == nil {
+					_, _ = fmt.Fprintf(out, "daemon already running (pid %d, port %d)\n", ri.PID, ri.Port)
+				} else {
+					_, _ = fmt.Fprintln(out, "daemon already running")
+				}
+				return nil
+			}
+			pid, err := daemon.StartDetached()
+			if err != nil {
+				return err
+			}
+			deadline := time.Now().Add(startTimeout)
+			for time.Now().Before(deadline) {
+				// Match the child pid so a stale daemon.json from a previous
+				// crash can't be mistaken for the daemon we just spawned.
+				ri, err := daemon.ReadRuntimeInfo(dirs.Data)
+				if err == nil && ri.PID == pid {
+					if _, err := daemon.CheckHealth(cmd.Context(), ri.Port); err == nil {
+						_, _ = fmt.Fprintf(out, "daemon started (pid %d, port %d)\n", ri.PID, ri.Port)
+						return nil
+					}
+				}
+				time.Sleep(pollInterval)
+			}
+			return fmt.Errorf("daemon did not become healthy within %s\n--- daemon.log tail ---\n%s",
+				startTimeout, daemon.LogTail(dirs.Data, 20))
+		},
+	}
+}
+
+func newDaemonStopCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the daemon gracefully",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return err
+			}
+			running, err := daemon.ProbeRunning(dirs.Data)
+			if err != nil {
+				return err
+			}
+			if !running {
+				_, _ = fmt.Fprintln(out, "daemon is not running")
+				return nil
+			}
+			ri, err := daemon.ReadRuntimeInfo(dirs.Data)
+			if err != nil {
+				return fmt.Errorf("daemon is running but its daemon.json is unreadable: %w", err)
+			}
+			stopErr := requestGracefulStop(cmd.Context(), dirs.Data, ri.Port)
+			if stopErr == nil {
+				if waitStopped(dirs.Data, stopTimeout) {
+					_, _ = fmt.Fprintln(out, "daemon stopped")
+					return nil
+				}
+				stopErr = fmt.Errorf("daemon did not exit within %s", stopTimeout)
+			}
+			if !force {
+				return fmt.Errorf("%w (use --force to kill pid %d)", stopErr, ri.PID)
+			}
+			if err := daemon.KillPID(ri.PID); err != nil {
+				return err
+			}
+			if !waitStopped(dirs.Data, stopTimeout) {
+				return fmt.Errorf("killed pid %d but the daemon lock is still held", ri.PID)
+			}
+			_, _ = fmt.Fprintf(out, "daemon killed (pid %d)\n", ri.PID)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "kill the daemon process if graceful stop fails")
+	return cmd
+}
+
+func requestGracefulStop(ctx context.Context, dataDir string, port int) error {
+	token, err := daemon.ReadToken(dataDir)
+	if err != nil {
+		return err
+	}
+	return daemon.RequestStop(ctx, port, token)
+}
+
+// waitStopped polls until no daemon holds the lock or the timeout elapses.
+func waitStopped(dataDir string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if running, err := daemon.ProbeRunning(dataDir); err == nil && !running {
+			return true
+		}
+		time.Sleep(pollInterval)
+	}
+	return false
+}
+
+func newDaemonStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Report whether the daemon is running (exit 0 healthy, 1 not running, 2 unresponsive)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return err
+			}
+			running, err := daemon.ProbeRunning(dirs.Data)
+			if err != nil {
+				return err
+			}
+			if !running {
+				if _, err := daemon.ReadRuntimeInfo(dirs.Data); err == nil {
+					_, _ = fmt.Fprintln(out, "daemon is not running (stale daemon.json from an unclean shutdown)")
+				} else {
+					_, _ = fmt.Fprintln(out, "daemon is not running")
+				}
+				return exitError{code: 1}
+			}
+			ri, err := daemon.ReadRuntimeInfo(dirs.Data)
+			if err != nil {
+				_, _ = fmt.Fprintln(out, "daemon is running but its daemon.json is unreadable")
+				return exitError{code: 2}
+			}
+			h, err := daemon.CheckHealth(cmd.Context(), ri.Port)
+			if err != nil {
+				_, _ = fmt.Fprintf(out, "daemon process is alive (pid %d) but not responding on port %d\n", ri.PID, ri.Port)
+				return exitError{code: 2}
+			}
+			_, _ = fmt.Fprintf(out, "daemon is running (pid %d, port %d, version %s, started %s)\n",
+				ri.PID, ri.Port, h.Version, ri.StartedAt.Local().Format(time.RFC3339))
+			return nil
+		},
+	}
+}
+
+// exitError carries a specific process exit code out of a RunE without
+// printing anything: the command has already written its report.
+type exitError struct{ code int }
+
+func (e exitError) Error() string { return fmt.Sprintf("exit code %d", e.code) }
+
+// asExitCode extracts a specific exit code, defaulting to 1 for plain errors.
+func asExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee exitError
+	if errors.As(err, &ee) {
+		return ee.code
+	}
+	return 1
+}

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+// vincentBin is the real binary under test, built once in TestMain. The
+// detached self-exec in `daemon start` (spec §12.1) can only be exercised
+// through the actual executable, not in-process.
+var vincentBin string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "vincent-e2e-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "e2e setup:", err)
+		os.Exit(1)
+	}
+	vincentBin = filepath.Join(tmp, "vincent")
+	if runtime.GOOS == "windows" {
+		vincentBin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", vincentBin, "github.com/lezli01/vincent/cmd/vincent")
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e setup: build vincent: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+// runVincent runs the built binary with isolated config/data dirs and
+// returns its combined output and exit code.
+func runVincent(t *testing.T, dataDir, cfgDir string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(vincentBin, args...)
+	cmd.Env = append(os.Environ(),
+		config.EnvDataDir+"="+dataDir,
+		config.EnvConfigDir+"="+cfgDir,
+	)
+	out, err := cmd.CombinedOutput()
+	code := cmd.ProcessState.ExitCode()
+	if err != nil && code < 0 {
+		t.Fatalf("vincent %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), code
+}
+
+// TestDaemonStartStatusStopCycle is the T1.3 acceptance: the full lifecycle
+// through the real binary, including detached start, idempotent start/stop,
+// status exit codes, and token/daemon.json creation.
+func TestDaemonStartStatusStopCycle(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	t.Cleanup(func() {
+		// Never leak a detached daemon, even when an assertion fails.
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = append(os.Environ(),
+			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
+		_, _ = cmd.CombinedOutput()
+	})
+
+	out, code := runVincent(t, dataDir, cfgDir, "daemon", "status")
+	if code != 1 || !strings.Contains(out, "not running") {
+		t.Fatalf("status before start: code %d, out %q; want 1, 'not running'", code, out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "stop")
+	if code != 0 || !strings.Contains(out, "not running") {
+		t.Fatalf("stop before start: code %d, out %q; want 0, 'not running'", code, out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "start")
+	if code != 0 || !strings.Contains(out, "daemon started") {
+		t.Fatalf("start: code %d, out %q; want 0, 'daemon started'", code, out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "status")
+	if code != 0 || !strings.Contains(out, "daemon is running") {
+		t.Fatalf("status while running: code %d, out %q; want 0, 'daemon is running'", code, out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "start")
+	if code != 0 || !strings.Contains(out, "already running") {
+		t.Fatalf("second start: code %d, out %q; want 0, 'already running'", code, out)
+	}
+
+	// Token and daemon.json exist with the promised properties (§12.2, §13.1).
+	fi, err := os.Stat(daemon.TokenPath(dataDir))
+	if err != nil {
+		t.Fatalf("token file: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("token permissions = %o, want 600", perm)
+		}
+	}
+	raw, err := os.ReadFile(daemon.RuntimePath(dataDir))
+	if err != nil {
+		t.Fatalf("daemon.json: %v", err)
+	}
+	var ri daemon.RuntimeInfo
+	if err := json.Unmarshal(raw, &ri); err != nil {
+		t.Fatalf("daemon.json parse: %v (%s)", err, raw)
+	}
+	if ri.Port <= 0 || ri.PID <= 0 || ri.StartedAt.IsZero() {
+		t.Errorf("daemon.json = %+v; want positive port/pid and a start time", ri)
+	}
+	// A generated default config.yaml appears on first start (§12.3).
+	if _, err := os.Stat(filepath.Join(cfgDir, config.FileName)); err != nil {
+		t.Errorf("default config.yaml not generated: %v", err)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "stop")
+	if code != 0 || !strings.Contains(out, "daemon stopped") {
+		t.Fatalf("stop: code %d, out %q; want 0, 'daemon stopped'", code, out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "status")
+	if code != 1 || !strings.Contains(out, "not running") {
+		t.Fatalf("status after stop: code %d, out %q; want 1, 'not running'", code, out)
+	}
+	if strings.Contains(out, "stale") {
+		t.Errorf("graceful stop left a stale daemon.json: %q", out)
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "stop")
+	if code != 0 || !strings.Contains(out, "not running") {
+		t.Fatalf("second stop: code %d, out %q; want 0, 'not running'", code, out)
+	}
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// HealthInfo is the /v1/health response body.
+type HealthInfo struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+// httpClient keeps lifecycle requests snappy: everything here talks to
+// loopback, so a slow response means a wedged daemon, not a slow network.
+var httpClient = &http.Client{Timeout: 2 * time.Second}
+
+// CheckHealth calls the daemon's unauthenticated health endpoint.
+func CheckHealth(ctx context.Context, port int) (HealthInfo, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/v1/health", port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return HealthInfo{}, fmt.Errorf("build health request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return HealthInfo{}, fmt.Errorf("health check: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return HealthInfo{}, fmt.Errorf("health check: unexpected status %s", resp.Status)
+	}
+	var h HealthInfo
+	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
+		return HealthInfo{}, fmt.Errorf("decode health response: %w", err)
+	}
+	return h, nil
+}
+
+// RequestStop asks the daemon to shut down gracefully via
+// POST /v1/daemon/stop (phase 1 spec addition). It returns once the daemon
+// has accepted the request; the caller waits for the lock to release.
+func RequestStop(ctx context.Context, port int, token string) error {
+	url := fmt.Sprintf("http://127.0.0.1:%d/v1/daemon/stop", port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("build stop request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("stop request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("stop request: unexpected status %s: %s", resp.Status, body)
+	}
+	return nil
+}
+
+// KillPID force-kills a daemon process, the `daemon stop --force` fallback.
+func KillPID(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	if err := p.Kill(); err != nil {
+		return fmt.Errorf("kill process %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,165 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/gofrs/flock"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/version"
+)
+
+// ErrAlreadyRunning is returned when another daemon holds the single-instance
+// lock (spec §12.1).
+var ErrAlreadyRunning = errors.New("another vincent daemon is already running")
+
+// shutdownTimeout bounds the HTTP server drain on graceful shutdown.
+const shutdownTimeout = 5 * time.Second
+
+// Options configures Run.
+type Options struct {
+	// Foreground mirrors logs to stderr in addition to the log file.
+	Foreground bool
+}
+
+// Run runs the daemon until the context is canceled, a termination signal
+// arrives, or a stop is requested via POST /v1/daemon/stop. Startup order:
+// dirs → lock → config (invalid = fatal) → store/migrations → token →
+// listener → daemon.json; teardown reverses it, removing daemon.json only on
+// this graceful path (spec §12.2, §12.4).
+func Run(ctx context.Context, opts Options) error {
+	dirs, err := config.ResolveDirs()
+	if err != nil {
+		return err
+	}
+	logsDir := filepath.Join(dirs.Data, "logs")
+	if err := os.MkdirAll(logsDir, 0o700); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	logger, level, closeLog := newLogger(logsDir, opts.Foreground)
+	defer func() { _ = closeLog() }()
+
+	lock := flock.New(LockPath(dirs.Data))
+	locked, err := lock.TryLock()
+	if err != nil {
+		return fmt.Errorf("acquire daemon lock: %w", err)
+	}
+	if !locked {
+		if ri, err := ReadRuntimeInfo(dirs.Data); err == nil {
+			return fmt.Errorf("%w (pid %d, port %d)", ErrAlreadyRunning, ri.PID, ri.Port)
+		}
+		return ErrAlreadyRunning
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	if _, err := config.EnsureDefaultFile(dirs.Config); err != nil {
+		logger.Error("startup failed", "error", err)
+		return err
+	}
+	cfg, err := config.Load(filepath.Join(dirs.Config, config.FileName))
+	if err != nil {
+		logger.Error("startup failed: invalid config", "error", err)
+		return err
+	}
+	if lvl, err := parseLevel(cfg.LogLevel); err == nil {
+		level.Set(lvl)
+	}
+	logger.Info("starting vincent daemon",
+		"version", version.Version(), "pid", os.Getpid(), "data_dir", dirs.Data)
+
+	st, err := store.Open(filepath.Join(dirs.Data, "vincent.db"))
+	if err != nil {
+		logger.Error("startup failed: store", "error", err)
+		return err
+	}
+	defer func() { _ = st.Close() }()
+
+	token, err := EnsureToken(dirs.Data)
+	if err != nil {
+		logger.Error("startup failed: token", "error", err)
+		return err
+	}
+
+	ln, err := net.Listen("tcp", cfg.Listen)
+	if err != nil {
+		logger.Error("startup failed: listen", "addr", cfg.Listen, "error", err)
+		return fmt.Errorf("listen on %s: %w", cfg.Listen, err)
+	}
+
+	// current is the effective configuration, swapped whole on hot-reload.
+	var current atomic.Pointer[config.Config]
+	current.Store(&cfg)
+
+	ctx, stopSignals := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+	stopRequested := make(chan struct{})
+	var stopOnce sync.Once
+	requestStop := func() { stopOnce.Do(func() { close(stopRequested) }) }
+
+	startedAt := time.Now()
+	srv := api.New(api.Deps{
+		Token:       token,
+		Config:      func() config.Config { return *current.Load() },
+		StartedAt:   startedAt,
+		ListenAddr:  ln.Addr().String(),
+		RequestStop: requestStop,
+		Logger:      logger,
+	})
+
+	if err := config.Watch(ctx, logger, dirs.Config, func(next config.Config) {
+		prev := current.Load()
+		if next.Listen != prev.Listen {
+			logger.Warn("listen change ignored until restart",
+				"effective", prev.Listen, "requested", next.Listen)
+			next.Listen = prev.Listen
+		}
+		if lvl, err := parseLevel(next.LogLevel); err == nil {
+			level.Set(lvl)
+		}
+		current.Store(&next)
+	}); err != nil {
+		logger.Warn("config hot-reload unavailable", "error", err)
+	}
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	ri := RuntimeInfo{Port: port, PID: os.Getpid(), StartedAt: startedAt}
+	if err := WriteRuntimeInfo(dirs.Data, ri); err != nil {
+		logger.Error("startup failed: daemon.json", "error", err)
+		return err
+	}
+	defer func() { _ = RemoveRuntimeInfo(dirs.Data) }()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+	logger.Info("daemon ready", "addr", ln.Addr().String())
+
+	select {
+	case <-ctx.Done():
+		logger.Info("shutting down: signal or parent context")
+	case <-stopRequested:
+		logger.Info("shutting down: stop requested via API")
+	case err := <-serveErr:
+		logger.Error("http server failed", "error", err)
+		return fmt.Errorf("http server: %w", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Warn("http shutdown incomplete", "error", err)
+	}
+	logger.Info("daemon stopped")
+	return nil
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+func TestEnsureTokenCreatesAndReuses(t *testing.T) {
+	dir := t.TempDir()
+	tok, err := EnsureToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+	if len(tok) != 64 {
+		t.Fatalf("token length = %d, want 64 hex chars", len(tok))
+	}
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(TokenPath(dir))
+		if err != nil {
+			t.Fatalf("stat token: %v", err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Errorf("token permissions = %o, want 600", perm)
+		}
+	} else if _, err := os.Stat(TokenPath(dir)); err != nil {
+		t.Fatalf("token file missing: %v", err)
+	}
+	again, err := EnsureToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureToken (second): %v", err)
+	}
+	if again != tok {
+		t.Error("second EnsureToken generated a new token; want reuse")
+	}
+	read, err := ReadToken(dir)
+	if err != nil || read != tok {
+		t.Errorf("ReadToken = %q, %v; want the ensured token", read, err)
+	}
+}
+
+func TestEnsureTokenRegeneratesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(TokenPath(dir), []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tok, err := EnsureToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+	if len(tok) != 64 {
+		t.Errorf("token length = %d, want 64", len(tok))
+	}
+}
+
+func TestRuntimeInfoRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := ReadRuntimeInfo(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("read missing daemon.json: err = %v, want ErrNotExist", err)
+	}
+	want := RuntimeInfo{Port: 4242, PID: 999, StartedAt: time.Now().UTC().Truncate(time.Second)}
+	if err := WriteRuntimeInfo(dir, want); err != nil {
+		t.Fatalf("WriteRuntimeInfo: %v", err)
+	}
+	got, err := ReadRuntimeInfo(dir)
+	if err != nil {
+		t.Fatalf("ReadRuntimeInfo: %v", err)
+	}
+	if got.Port != want.Port || got.PID != want.PID || !got.StartedAt.Equal(want.StartedAt) {
+		t.Errorf("round-trip = %+v, want %+v", got, want)
+	}
+	if err := RemoveRuntimeInfo(dir); err != nil {
+		t.Fatalf("RemoveRuntimeInfo: %v", err)
+	}
+	if err := RemoveRuntimeInfo(dir); err != nil {
+		t.Errorf("RemoveRuntimeInfo (already gone): %v, want nil", err)
+	}
+}
+
+func TestProbeRunningNoDaemon(t *testing.T) {
+	running, err := ProbeRunning(t.TempDir())
+	if err != nil || running {
+		t.Errorf("ProbeRunning = %v, %v; want false, nil", running, err)
+	}
+	running, err = ProbeRunning(filepath.Join(t.TempDir(), "does", "not", "exist"))
+	if err != nil || running {
+		t.Errorf("ProbeRunning (missing dir) = %v, %v; want false, nil", running, err)
+	}
+}
+
+func TestLogTail(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "logs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	for i := 1; i <= 30; i++ {
+		b.WriteString("line ")
+		b.WriteString(string(rune('0' + i%10)))
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "logs", "daemon.log"), []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tail := LogTail(dir, 5)
+	if got := strings.Count(tail, "\n") + 1; got != 5 {
+		t.Errorf("tail has %d lines, want 5", got)
+	}
+}
+
+// startTestDaemon runs Run in-process against temp dirs and returns the
+// discovered runtime info plus the Run result channel.
+func startTestDaemon(ctx context.Context, t *testing.T) (dataDir string, ri RuntimeInfo, done <-chan error) {
+	t.Helper()
+	dataDir = t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+	ch := make(chan error, 1)
+	go func() { ch <- Run(ctx, Options{}) }()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		if ri, err = ReadRuntimeInfo(dataDir); err == nil {
+			if _, err := CheckHealth(ctx, ri.Port); err == nil {
+				return dataDir, ri, ch
+			}
+		}
+		select {
+		case err := <-ch:
+			t.Fatalf("daemon exited during startup: %v", err)
+		default:
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("daemon did not become healthy within 15s")
+	return "", RuntimeInfo{}, nil
+}
+
+func waitDone(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(15 * time.Second):
+		t.Fatal("daemon did not exit within 15s")
+		return nil
+	}
+}
+
+func TestRunLifecycleStopViaAPI(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dataDir, ri, done := startTestDaemon(ctx, t)
+
+	if ri.PID != os.Getpid() {
+		t.Errorf("daemon.json pid = %d, want %d", ri.PID, os.Getpid())
+	}
+	if running, err := ProbeRunning(dataDir); err != nil || !running {
+		t.Errorf("ProbeRunning = %v, %v; want true, nil", running, err)
+	}
+	token, err := ReadToken(dataDir)
+	if err != nil {
+		t.Fatalf("ReadToken: %v", err)
+	}
+
+	// A second instance must refuse to start while the lock is held.
+	if err := Run(ctx, Options{}); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("second Run: err = %v, want ErrAlreadyRunning", err)
+	}
+
+	// A stop request with a bad token must be rejected.
+	if err := RequestStop(ctx, ri.Port, "wrong-token"); err == nil {
+		t.Error("RequestStop with wrong token succeeded; want rejection")
+	}
+
+	if err := RequestStop(ctx, ri.Port, token); err != nil {
+		t.Fatalf("RequestStop: %v", err)
+	}
+	if err := waitDone(t, done); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, err := ReadRuntimeInfo(dataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("daemon.json still present after graceful stop: %v", err)
+	}
+	if running, _ := ProbeRunning(dataDir); running {
+		t.Error("lock still held after graceful stop")
+	}
+}
+
+func TestRunContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dataDir, _, done := startTestDaemon(ctx, t)
+	cancel()
+	if err := waitDone(t, done); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if _, err := ReadRuntimeInfo(dataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Error("daemon.json still present after context cancel")
+	}
+}
+
+func TestRunFatalOnInvalidConfig(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, t.TempDir())
+	t.Setenv(config.EnvConfigDir, cfgDir)
+	bad := "log_level: bogus\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := Run(context.Background(), Options{})
+	if err == nil || !strings.Contains(err.Error(), "log_level") {
+		t.Fatalf("Run with invalid config: err = %v, want log_level validation error", err)
+	}
+}

--- a/internal/daemon/doc.go
+++ b/internal/daemon/doc.go
@@ -1,4 +1,5 @@
-// Package daemon will own the daemon lifecycle: foreground/detached start,
-// graceful stop, single-instance locking, token bootstrap, structured
-// logging, and crash recovery (spec §12; T1.3, T2.8).
+// Package daemon owns the daemon lifecycle (spec §12): foreground and
+// detached start, graceful stop, single-instance locking, token bootstrap,
+// runtime discovery via daemon.json, and structured logging with rotation.
+// Crash recovery of step runs arrives with T2.8.
 package daemon

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gofrs/flock"
+)
+
+const lockFile = "daemon.lock"
+
+// LockPath returns the single-instance lock file path inside dataDir.
+func LockPath(dataDir string) string { return filepath.Join(dataDir, lockFile) }
+
+// ProbeRunning reports whether a daemon currently holds the single-instance
+// lock. It is the authoritative liveness check: flock releases on process
+// death, so a crashed daemon never reads as running. A missing data dir means
+// no daemon ever started there.
+func ProbeRunning(dataDir string) (bool, error) {
+	l := flock.New(LockPath(dataDir))
+	ok, err := l.TryLock()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("probe daemon lock: %w", err)
+	}
+	if ok {
+		_ = l.Unlock()
+		return false, nil
+	}
+	return true, nil
+}

--- a/internal/daemon/logging.go
+++ b/internal/daemon/logging.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// newLogger builds the daemon logger (phase 1 decision): slog TextHandler
+// over a size-rotated {data_dir}/logs/daemon.log, mirrored to stderr in
+// foreground mode. The returned LevelVar starts at info and is re-set from
+// config at startup and on every hot-reload. close flushes the log file.
+func newLogger(logsDir string, foreground bool) (log *slog.Logger, level *slog.LevelVar, closeLog func() error) {
+	lj := &lumberjack.Logger{
+		Filename:   filepath.Join(logsDir, "daemon.log"),
+		MaxSize:    10, // MB
+		MaxBackups: 3,
+	}
+	var w io.Writer = lj
+	if foreground {
+		w = io.MultiWriter(os.Stderr, lj)
+	}
+	level = new(slog.LevelVar)
+	h := slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})
+	return slog.New(h), level, lj.Close
+}
+
+// parseLevel maps a validated config log_level to its slog level.
+func parseLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q", s)
+	}
+}
+
+// LogTail returns up to n trailing lines of the daemon log, for surfacing
+// startup failures from `daemon start`.
+func LogTail(dataDir string, n int) string {
+	b, err := os.ReadFile(filepath.Join(dataDir, "logs", "daemon.log"))
+	if err != nil {
+		return fmt.Sprintf("(no daemon log: %v)", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/daemon/runtime.go
+++ b/internal/daemon/runtime.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const runtimeFile = "daemon.json"
+
+// RuntimeInfo is the client-discovery record published as daemon.json
+// (spec §12.2). It is written after the listener is bound and removed on
+// graceful shutdown; a crash leaves it behind, which `daemon status` reports
+// as stale (the lock, not this file, is the liveness authority).
+type RuntimeInfo struct {
+	Port      int       `json:"port"`
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// RuntimePath returns the daemon.json path inside dataDir.
+func RuntimePath(dataDir string) string { return filepath.Join(dataDir, runtimeFile) }
+
+// WriteRuntimeInfo atomically publishes ri as daemon.json.
+func WriteRuntimeInfo(dataDir string, ri RuntimeInfo) error {
+	b, err := json.MarshalIndent(ri, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal daemon.json: %w", err)
+	}
+	if err := writeFileAtomic(RuntimePath(dataDir), append(b, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write daemon.json: %w", err)
+	}
+	return nil
+}
+
+// ReadRuntimeInfo reads daemon.json. A missing file yields os.ErrNotExist.
+func ReadRuntimeInfo(dataDir string) (RuntimeInfo, error) {
+	b, err := os.ReadFile(RuntimePath(dataDir))
+	if err != nil {
+		return RuntimeInfo{}, fmt.Errorf("read daemon.json: %w", err)
+	}
+	var ri RuntimeInfo
+	if err := json.Unmarshal(b, &ri); err != nil {
+		return RuntimeInfo{}, fmt.Errorf("parse daemon.json: %w", err)
+	}
+	return ri, nil
+}
+
+// RemoveRuntimeInfo deletes daemon.json; a missing file is not an error.
+func RemoveRuntimeInfo(dataDir string) error {
+	if err := os.Remove(RuntimePath(dataDir)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove daemon.json: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// StartDetached spawns `vincent daemon` as a detached background process
+// (phase 1 decision: self-exec with platform SysProcAttr) and returns its
+// pid. Stdio is discarded; the child logs to the rotating daemon log. The
+// caller polls daemon.json + /v1/health to confirm startup.
+func StartDetached() (pid int, err error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("resolve own executable: %w", err)
+	}
+	cmd := exec.Command(exe, "daemon")
+	cmd.SysProcAttr = detachSysProcAttr()
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("spawn detached daemon: %w", err)
+	}
+	pid = cmd.Process.Pid
+	if err := cmd.Process.Release(); err != nil {
+		return 0, fmt.Errorf("release detached daemon: %w", err)
+	}
+	return pid, nil
+}

--- a/internal/daemon/spawn_unix.go
+++ b/internal/daemon/spawn_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package daemon
+
+import "syscall"
+
+// detachSysProcAttr puts the child in its own session so it survives the CLI
+// process exiting and is not signaled with the parent's terminal group.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/daemon/spawn_windows.go
+++ b/internal/daemon/spawn_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package daemon
+
+import "syscall"
+
+// detachedProcess starts the child without a console; syscall exports
+// CREATE_NEW_PROCESS_GROUP but not this flag.
+const detachedProcess = 0x00000008
+
+// detachSysProcAttr detaches the child from the parent's console and control
+// signals so it survives the CLI process and terminal closing.
+func detachSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: detachedProcess | syscall.CREATE_NEW_PROCESS_GROUP,
+		HideWindow:    true,
+	}
+}

--- a/internal/daemon/token.go
+++ b/internal/daemon/token.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const tokenFile = "token"
+
+// TokenPath returns the API bearer token file path inside dataDir.
+func TokenPath(dataDir string) string { return filepath.Join(dataDir, tokenFile) }
+
+// ReadToken reads the API bearer token created by a previous daemon start.
+func ReadToken(dataDir string) (string, error) {
+	b, err := os.ReadFile(TokenPath(dataDir))
+	if err != nil {
+		return "", fmt.Errorf("read token: %w", err)
+	}
+	tok := strings.TrimSpace(string(b))
+	if tok == "" {
+		return "", errors.New("read token: file is empty")
+	}
+	return tok, nil
+}
+
+// EnsureToken returns the existing bearer token or generates one on first
+// start: 32 bytes of crypto/rand as hex, written atomically with 0600
+// permissions (spec §13.1). An existing token is reused unchanged; on POSIX
+// its permissions are re-tightened to 0600.
+func EnsureToken(dataDir string) (string, error) {
+	path := TokenPath(dataDir)
+	b, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("read token: %w", err)
+	}
+	if tok := strings.TrimSpace(string(b)); err == nil && tok != "" {
+		if runtime.GOOS != "windows" {
+			if err := os.Chmod(path, 0o600); err != nil {
+				return "", fmt.Errorf("tighten token permissions: %w", err)
+			}
+		}
+		return tok, nil
+	}
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	tok := hex.EncodeToString(buf)
+	if err := writeFileAtomic(path, []byte(tok+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("write token: %w", err)
+	}
+	return tok, nil
+}
+
+// writeFileAtomic writes data to a temp file in path's directory and renames
+// it into place, so readers never observe a partial file.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".tmp*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmp := f.Name()
+	cleanup := func() { _ = f.Close(); _ = os.Remove(tmp) }
+	if err := f.Chmod(perm); err != nil && runtime.GOOS != "windows" {
+		cleanup()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename into place: %w", err)
+	}
+	return nil
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,10 +14,31 @@ var (
 	date    = ""
 )
 
+// Version returns the version string, "dev" when not injected.
+func Version() string { return version }
+
+// Commit returns the abbreviated VCS revision, "unknown" when unavailable.
+func Commit() string {
+	c, _ := vcsFallback()
+	return c
+}
+
+// Date returns the build date, "unknown" when unavailable.
+func Date() string {
+	_, d := vcsFallback()
+	return d
+}
+
 // String renders one-line build info, e.g.
 // "vincent version dev (commit 9ad1de4, built 2026-08-06)".
 func String() string {
-	v, c, d := version, commit, date
+	return fmt.Sprintf("vincent version %s (commit %s, built %s)", Version(), Commit(), Date())
+}
+
+// vcsFallback fills commit/date from debug.ReadBuildInfo when the ldflags
+// injection is absent (plain `go build`).
+func vcsFallback() (c, d string) {
+	c, d = commit, date
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, s := range info.Settings {
 			switch s.Key {
@@ -41,5 +62,5 @@ func String() string {
 	if d == "" {
 		d = "unknown"
 	}
-	return fmt.Sprintf("vincent version %s (commit %s, built %s)", v, c, d)
+	return c, d
 }


### PR DESCRIPTION
PR 2 of the phase 1 delivery plan (T1.3 + T1.4), per the decisions recorded in [tasks.md](docs/versions/v0/tasks.md).

## T1.3 — Daemon lifecycle
- Single-instance enforcement via `gofrs/flock` on `daemon.lock`; a second daemon exits with a pointer to the running one.
- Bearer token: 32 bytes crypto/rand hex, written atomically 0600 at first start, reused thereafter.
- `daemon.json` published atomically after the listener binds; removed only on graceful shutdown (stale files reported by `status`).
- Logging: slog TextHandler over lumberjack rotation; foreground mirrors to stderr; `log_level` hot-reloads via `LevelVar`; `listen` changes warn and keep the effective value.
- `daemon start`: detached self-exec (`DETACHED_PROCESS` / `setsid`), then polls `daemon.json` + `/v1/health` (~10 s); failure prints the daemon.log tail.
- `daemon status`: lock probe (authoritative) + health; exit 0 healthy / 1 not running / 2 unresponsive.
- `daemon stop [--force]`: POST `/v1/daemon/stop`, wait for lock release (~20 s), `--force` kills the recorded PID. `start`/`stop` are idempotent (desired-state semantics).

## T1.4 — API foundation
- stdlib `net/http` ServeMux with Go 1.22+ method patterns; middleware recover → log → auth (constant-time compare; `/v1/health` exempt and logged at debug).
- §13.1 JSON error envelope with stable snake_case codes; ServeMux 404/405 wrapped so every error is enveloped (405 sets `Allow`).
- `GET /v1/health`, `GET /v1/info`, `GET /v1/config`, `POST /v1/daemon/stop` (spec §13.2 addition, committed here).

## Tests
- httptest: auth rejection, health-without-auth, error shapes (404/405/401/500), panic recovery, stop endpoint w/ and w/o auth.
- In-process daemon lifecycle: startup → health → second-instance refusal → API stop → clean teardown; context-cancel path; fatal invalid config; token/daemon.json/lock unit tests.
- Binary e2e (T1.3 done-criterion): full `start`/`status`/`stop` cycle through the real executable on all three OSes, asserting exit codes, idempotency, token perms (POSIX), and daemon.json shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)