### PR TITLE
feat(engine): task FSM + step executors (T2.3, T2.4)

### DIFF
--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -18,10 +18,10 @@ implementation progress; the executing agent updates it in place as work proceed
 |---|---|---|---|
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
-| 2 — Workflow engine (M2) | 12 tasks | 2/12 | 🟡 in progress |
+| 2 — Workflow engine (M2) | 12 tasks | 4/12 | 🟡 in progress |
 | 3 — TUI (M3) | 8 tasks | 0/8 | ⬜ not started |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **15/39** | |
+| **Total** | | **17/39** | |
 
 ---
 
@@ -184,10 +184,11 @@ Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) r
   *Done when:* table-driven validation tests + scope-shadowing and broken-file-isolation tests pass. *(Verified: 23-case validation table incl. per-type field rejection and located line numbers, scope shadowing across builtin/global/project, broken- and unparsable-file isolation, duplicate-name-in-scope, project re-point and removal, live-reload tests covering create/edit/break/delete, a directory created after startup, a project registered after startup, and non-YAML files not churning the registry. Spec additions recorded: built-in scope in §5.2, entry shape in §13.2.)*
 - [x] **T2.2 — Template engine.** Context assembly per §8.4 (`.Task`, `.Project`, `.Workflow`, `.Step`, `.Steps`, `.Worktree`, `.LastFailure`); render-fails-before-spawn; command/check env vars (§8.5); retry failure block appending (§8.4). ✓ 2026-08-07
   *Done when:* unit tests cover every context variable, missing-field failure, and the retry block. *(Verified: every §8.4 variable asserted individually, strict-render failures for struct-field typo / map-key typo / unknown root, the defensive `index` idiom, all ten §8.5 env vars, and the failure block incl. 200-line truncation. Spec §8.1/§8.4 updated: `missingkey=error` means an optional field reads `{{ with index .Task.Fields "ticket" }}`.)*
-- [ ] **T2.3 — Task state machine.** Full FSM §6 with persisted transitions (incl. `awaiting_input`, §7.4), guarded invalid transitions (409), workflow snapshot at creation replacing T1.8's placeholder, `block_reason`, timestamps.
-  *Done when:* exhaustive transition-table test (every state × every action, incl. `answer`) passes.
-- [ ] **T2.4 — Step executors.** Agent step (any adapter; agent/model/effort resolved per §8.6 via T2.11), command step (platform shell selection + `shell:` pin, §8.3), manual gate, `check` execution, per-step timeouts with kill, retry loop honoring `max_retries`, transcript capture for all output. (§7)
-  *Done when:* integration tests cover each step type, check pass/fail, timeout kill, retry-then-blocked, and Windows + POSIX shells in CI.
+- [x] **T2.3 — Task state machine.** Full FSM §6 with persisted transitions (incl. `awaiting_input`, §7.4), guarded invalid transitions (409), workflow snapshot at creation replacing T1.8's placeholder, `block_reason`, timestamps. ✓ 2026-08-07
+  *Done when:* exhaustive transition-table test (every state × every action, incl. `answer`) passes. *(Verified: `internal/taskstate` holds the table; the test restates §6 independently and walks all 9 states × 16 actions, plus slot/terminal/human-action classification. Persistence is `store.TransitionTask` — compare-and-swap on the from-state with the `task.state_changed` event written in the same transaction; a conflicted transition writes neither row. Task creation now snapshots the registry entry. The 409 surface itself arrives with T2.6's action endpoints — `StateConflictError` already carries the current state for it.)*
+- [x] **T2.4 — Step executors.** Agent step (any adapter; agent/model/effort resolved per §8.6 via T2.11), command step (platform shell selection + `shell:` pin, §8.3), manual gate, `check` execution, per-step timeouts with kill, retry loop honoring `max_retries`, transcript capture for all output. (§7) ✓ 2026-08-07
+  *Done when:* integration tests cover each step type, check pass/fail, timeout kill, retry-then-blocked, and Windows + POSIX shells in CI. *(Verified: engine integration tests drive the real runner against real repos and the fake agent — multi-step agent→command run with §8.5 env, manual gate parking (row at entry, actor exits), retry-then-blocked with per-attempt transcripts, check failure recording `check_exit_code`, timeout tree-kill, template error failing before spawn, `.Steps` results flowing into a later step, and the §8.4 failure block reaching the retry prompt. Scripts are written per platform so the same tests exercise sh and pwsh in CI. §8.6 resolution has its own precedence/inheritance table test; T2.11 moves it into `internal/agent` and adds catalog validation.)*
+  *Carried forward:* the retry budget currently counts every failed attempt of a step; `store.CountStepAttempts` takes a `since` cursor so T2.6's human `retry` can reset it. In-process interruptions now re-queue the task (§12.4), but the startup sweep is still T1.8's blocking one until T2.8.
 - [ ] **T2.5 — Scheduler.** Global + per-project caps counting only `running`; admission by priority DESC, created_at ASC; re-evaluation on every state change and config reload (§11).
   *Done when:* concurrency tests prove both caps and ordering under simultaneous task load.
 - [ ] **T2.6 — Human actions API.** `cancel` (process kill incl. Windows tree-kill), `pause` (step-boundary), `resume`, `retry` with prompt/run overrides recorded, `skip`, `approve`, `reject`, `archive` (+dirty `force`), `PATCH` priority (§6, §13.2).

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -11,9 +11,27 @@ import (
 	"time"
 
 	"github.com/lezli01/vincent/internal/store"
-	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/workflow"
 	"github.com/lezli01/vincent/internal/worktree"
 )
+
+// firstNonBlank returns the first value that is not empty after trimming.
+func firstNonBlank(values ...string) string {
+	for _, v := range values {
+		if t := strings.TrimSpace(v); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// ptrValue dereferences an optional string field, treating nil as empty.
+func ptrValue(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
 
 // taskResponse is the JSON shape of a task (spec §5.3). Optional fields
 // render as null.
@@ -131,10 +149,11 @@ type taskCreateRequest struct {
 	Effort      *string           `json:"effort"`
 }
 
-// handleTaskCreate implements POST /v1/tasks (spec §13.2). M1 accepts only
-// the synthesized adhoc workflow; the optional agent/model/effort override
-// is validated per the T1.7–T1.9 decision: the agent must name a registered
-// adapter, model/effort are free text until T2.11's catalog validation.
+// handleTaskCreate implements POST /v1/tasks (spec §13.2). The workflow is
+// resolved through the registry and snapshotted onto the task (§5.3); the
+// optional agent/model/effort override is validated per the T1.7–T1.9
+// decision: the agent must name a registered adapter, model/effort are free
+// text until T2.11's catalog validation.
 func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	var req taskCreateRequest
 	if !decodeJSON(w, r, &req) {
@@ -156,13 +175,19 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, "title is required")
 		return
 	}
-	workflow := "adhoc"
-	if req.Workflow != nil && *req.Workflow != "" {
-		workflow = *req.Workflow
-	}
-	if workflow != "adhoc" {
+	// Workflow resolution (§5.3): the named workflow, else the project's
+	// default, else the built-in adhoc. The entry's source becomes the
+	// task's snapshot, so later edits to the file never touch this task.
+	workflowName := firstNonBlank(ptrValue(req.Workflow), project.DefaultWorkflow, workflow.AdhocName)
+	entry, ok := s.deps.Workflows.Lookup(project.ID, workflowName)
+	if !ok {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
-			fmt.Sprintf("workflow %q not found: the workflow registry arrives in M2; only the built-in \"adhoc\" workflow exists", workflow))
+			fmt.Sprintf("workflow %q not found for project %d", workflowName, project.ID))
+		return
+	}
+	if !entry.Valid() {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("workflow %q is invalid: %s", workflowName, entry.Errors.Error()))
 		return
 	}
 	baseBranch := project.DefaultBranch
@@ -190,8 +215,8 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	t := store.Task{
 		ProjectID:        project.ID,
 		Title:            title,
-		WorkflowName:     workflow,
-		WorkflowSnapshot: taskrun.AdhocSnapshot,
+		WorkflowName:     entry.Name,
+		WorkflowSnapshot: entry.Source,
 		BaseBranch:       baseBranch,
 		Fields:           req.Fields,
 		AgentOverride:    agentOverride,

--- a/internal/api/tasks_test.go
+++ b/internal/api/tasks_test.go
@@ -319,8 +319,10 @@ func TestRunnerStopInterrupts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
-	if got.State != store.TaskBlocked || got.BlockReason != "interrupted" {
-		t.Errorf("after stop: %s/%q, want blocked/interrupted", got.State, got.BlockReason)
+	// An interruption is not a failure (§7.2, §12.4): the task returns to
+	// queued and the attempt re-runs on the next admission.
+	if got.State != store.TaskQueued || got.BlockReason != "" {
+		t.Errorf("after stop: %s/%q, want queued with no block reason", got.State, got.BlockReason)
 	}
 	runs, err := h.store.ListStepRuns(t.Context(), created.ID)
 	if err != nil || len(runs) != 1 {
@@ -340,7 +342,7 @@ func TestTaskCreateValidation(t *testing.T) {
 	}{
 		{"missing title", map[string]any{}, "title is required"},
 		{"unknown project", map[string]any{"project_id": int64(9999), "title": "x"}, "project 9999 not found"},
-		{"unknown workflow", map[string]any{"title": "x", "workflow": "feature-pr"}, "only the built-in"},
+		{"unknown workflow", map[string]any{"title": "x", "workflow": "feature-pr"}, "not found for project"},
 		{"unknown agent", map[string]any{"title": "x", "agent": "gemini"}, "available: claude"},
 		{"missing base branch", map[string]any{"title": "x", "base_branch": "nope"}, "does not resolve"},
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -154,12 +154,20 @@ func Run(ctx context.Context, opts Options) error {
 		logger.Warn("workflow hot-reload unavailable", "error", err)
 	}
 
+	// The command-step shell is probed once and logged; a step's `shell:`
+	// pin is resolved per use and fails the step when missing (§8.3).
+	shells := taskrun.NewShells(logger)
+	if _, err := shells.Default(); err != nil {
+		logger.Warn("command steps will fail until a shell is available", "error", err)
+	}
+
 	worktrees := worktree.NewManager(git, dirs.Data)
 	runner := taskrun.New(taskrun.Deps{
 		Store:     st,
 		Config:    currentConfig,
 		Worktrees: worktrees,
 		Agents:    agents,
+		Shells:    shells,
 		DataDir:   dirs.Data,
 		Logger:    logger,
 	})

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -1,0 +1,283 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EventTaskStateChanged is the durable event every transition writes
+// (spec §13.3).
+const EventTaskStateChanged = "task.state_changed"
+
+// StateConflictError reports that a task was not in the expected state when
+// a transition was attempted — the API answers 409 with the current state
+// (spec §13.1).
+type StateConflictError struct {
+	TaskID int64
+	Want   TaskState
+	Got    TaskState
+}
+
+func (e *StateConflictError) Error() string {
+	return fmt.Sprintf("task %d is %s, not %s", e.TaskID, e.Got, e.Want)
+}
+
+// AsStateConflict extracts a *StateConflictError from err, if that is what
+// it is.
+func AsStateConflict(err error) (*StateConflictError, bool) {
+	var conflict *StateConflictError
+	ok := errors.As(err, &conflict)
+	return conflict, ok
+}
+
+// TaskChange are optional field writes applied atomically with a transition.
+// A nil field is left unchanged.
+type TaskChange struct {
+	// BlockReason is recorded when moving to blocked; leaving blocked always
+	// clears it, whatever this holds.
+	BlockReason *string
+	// CurrentStep moves the step cursor (advance, or rewind on retry).
+	CurrentStep *int
+	// WorktreePath records the worktree once created (§10).
+	WorktreePath *string
+	// Snapshot replaces the workflow snapshot — edit+retry, which overrides
+	// a step in this task's snapshot only (§6).
+	Snapshot *string
+	// EventPayload carries extra fields into the state-change event, merged
+	// with from/to. Reserved keys (from, to) are overwritten.
+	EventPayload map[string]any
+}
+
+// TransitionTask moves a task from one state to another, writing the state
+// change and its durable event in a single transaction (phase 2 decision):
+// an event never exists without the state change that produced it, and the
+// event id is the SSE cursor a client can resume from.
+//
+// The update is a compare-and-swap on `from`: if the task moved in the
+// meantime the transaction rolls back and a *StateConflictError is returned
+// carrying the state actually found. Callers should validate the action
+// against taskstate first; this is the race guard, not the rulebook.
+//
+// Timestamps follow §6 by convention: started_at is stamped the first time a
+// task runs, finished_at when it reaches done or aborted, archived_at on
+// archive.
+func (s *Store) TransitionTask(
+	ctx context.Context, id int64, from, to TaskState, ch TaskChange,
+) (*Task, *Event, error) {
+	var (
+		task *Task
+		ev   *Event
+	)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `SELECT `+taskColumns+` FROM tasks WHERE id = ?`, id)
+		t, err := scanTask(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("task %d: %w", id, ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get task %d: %w", id, err)
+		}
+		if t.State != from {
+			return &StateConflictError{TaskID: id, Want: from, Got: t.State}
+		}
+
+		now := time.Now()
+		t.State = to
+		t.UpdatedAt = now
+		applyChange(t, ch)
+		switch to {
+		case TaskRunning:
+			if t.StartedAt == nil {
+				t.StartedAt = &now
+			}
+		case TaskDone, TaskAborted:
+			t.FinishedAt = &now
+		case TaskArchived:
+			t.ArchivedAt = &now
+		case TaskQueued, TaskAwaitingGate, TaskBlocked, TaskPaused:
+			// No timestamp of their own; updated_at covers them.
+		}
+		if to != TaskBlocked {
+			t.BlockReason = ""
+		}
+
+		res, err := tx.ExecContext(ctx, `
+			UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
+				workflow_snapshot = ?, updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
+			WHERE id = ? AND state = ?`,
+			string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
+			t.WorkflowSnapshot, formatTime(t.UpdatedAt),
+			formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt),
+			id, string(from))
+		if err != nil {
+			return fmt.Errorf("transition task %d: %w", id, err)
+		}
+		if err := oneRowAffected(res, fmt.Sprintf("task %d", id)); err != nil {
+			return err
+		}
+
+		payload, err := statePayload(from, to, t, ch.EventPayload)
+		if err != nil {
+			return err
+		}
+		e := &Event{
+			TS:        now,
+			Type:      EventTaskStateChanged,
+			TaskID:    &t.ID,
+			ProjectID: &t.ProjectID,
+			Payload:   payload,
+		}
+		if err := appendEventTx(ctx, tx, e); err != nil {
+			return err
+		}
+		task, ev = t, e
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return task, ev, nil
+}
+
+// SetTaskProgress writes the step cursor and worktree path without changing
+// state — the engine advancing through steps, and recording the worktree it
+// created (§10). Nil fields are left unchanged.
+func (s *Store) SetTaskProgress(ctx context.Context, id int64, currentStep *int, worktreePath *string) error {
+	if currentStep == nil && worktreePath == nil {
+		return nil
+	}
+	sets := []string{"updated_at = ?"}
+	args := []any{formatTime(time.Now())}
+	if currentStep != nil {
+		sets = append(sets, "current_step = ?")
+		args = append(args, *currentStep)
+	}
+	if worktreePath != nil {
+		sets = append(sets, "worktree_path = ?")
+		args = append(args, nullString(*worktreePath))
+	}
+	args = append(args, id)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET `+strings.Join(sets, ", ")+` WHERE id = ?`, args...)
+	if err != nil {
+		return fmt.Errorf("set task %d progress: %w", id, err)
+	}
+	return oneRowAffected(res, fmt.Sprintf("task %d", id))
+}
+
+// StepAttempts summarizes the attempts recorded for one step of one task.
+type StepAttempts struct {
+	// Last is the highest attempt number written so far; the next attempt is
+	// Last+1. Attempt numbers are monotonic per (task, step) so history stays
+	// append-only and transcript files never collide (phase 2 decision).
+	Last int
+	// Failed counts attempts that failed. Interrupted attempts are excluded:
+	// an interruption is not a failure and consumes no retry (§7.2).
+	Failed int
+}
+
+// CountStepAttempts summarizes attempts for one step. `since` bounds the
+// count to attempts started after a point in time — the hook a human retry
+// uses to reset the retry budget (§6); the zero time counts all attempts.
+func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex int, since time.Time) (StepAttempts, error) {
+	var (
+		out      StepAttempts
+		last     sql.NullInt64
+		failed   sql.NullInt64
+		sinceArg any
+	)
+	q := `SELECT MAX(attempt), SUM(CASE WHEN state = ? THEN 1 ELSE 0 END)
+		FROM step_runs WHERE task_id = ? AND step_index = ?`
+	args := []any{string(StepFailed), taskID, stepIndex}
+	if !since.IsZero() {
+		q += ` AND started_at > ?`
+		sinceArg = formatTime(since)
+		args = append(args, sinceArg)
+	}
+	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&last, &failed); err != nil {
+		return out, fmt.Errorf("count step attempts: %w", err)
+	}
+	out.Last = int(last.Int64)
+	out.Failed = int(failed.Int64)
+	return out, nil
+}
+
+func applyChange(t *Task, ch TaskChange) {
+	if ch.CurrentStep != nil {
+		t.CurrentStep = *ch.CurrentStep
+	}
+	if ch.WorktreePath != nil {
+		t.WorktreePath = *ch.WorktreePath
+	}
+	if ch.Snapshot != nil {
+		t.WorkflowSnapshot = *ch.Snapshot
+	}
+	if ch.BlockReason != nil {
+		t.BlockReason = *ch.BlockReason
+	}
+}
+
+// statePayload builds the state-change event body: ids plus the new state,
+// not the full object — clients re-fetch what they need (§13.3).
+func statePayload(from, to TaskState, t *Task, extra map[string]any) (json.RawMessage, error) {
+	payload := map[string]any{}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	payload["from"] = string(from)
+	payload["to"] = string(to)
+	payload["current_step"] = t.CurrentStep
+	if t.BlockReason != "" {
+		payload["block_reason"] = t.BlockReason
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal state event: %w", err)
+	}
+	return b, nil
+}
+
+// appendEventTx inserts an event inside an open transaction, assigning its
+// id — the same insert AppendEvent performs standalone.
+func appendEventTx(ctx context.Context, tx *sql.Tx, e *Event) error {
+	if e.TS.IsZero() {
+		e.TS = time.Now()
+	}
+	if len(e.Payload) == 0 {
+		e.Payload = json.RawMessage("{}")
+	}
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO events (ts, type, task_id, project_id, payload_json) VALUES (?, ?, ?, ?, ?)`,
+		formatTime(e.TS), e.Type, e.TaskID, e.ProjectID, string(e.Payload))
+	if err != nil {
+		return fmt.Errorf("insert event: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("insert event: %w", err)
+	}
+	e.ID = id
+	return nil
+}
+
+// withTx runs fn in a transaction, committing on success and rolling back on
+// any error or panic.
+func (s *Store) withTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+	return nil
+}

--- a/internal/store/transitions_test.go
+++ b/internal/store/transitions_test.go
@@ -1,0 +1,187 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestTransitionTaskWritesStateAndEventTogether(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "work", TaskQueued)
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	got, ev, err := s.TransitionTask(ctx, task.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("TransitionTask: %v", err)
+	}
+	if got.State != TaskRunning {
+		t.Errorf("state = %s, want running", got.State)
+	}
+	if got.StartedAt == nil {
+		t.Error("started_at was not stamped on the first run")
+	}
+	if ev == nil || ev.ID == 0 || ev.Type != EventTaskStateChanged {
+		t.Fatalf("event = %+v, want a persisted task.state_changed", ev)
+	}
+	if ev.TaskID == nil || *ev.TaskID != task.ID || ev.ProjectID == nil || *ev.ProjectID != p.ID {
+		t.Errorf("event ids = %+v, want task %d project %d", ev, task.ID, p.ID)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("payload not JSON: %v", err)
+	}
+	if payload["from"] != "queued" || payload["to"] != "running" {
+		t.Errorf("payload = %v, want from queued to running", payload)
+	}
+
+	// The event is in the table, readable by an SSE catch-up query.
+	events, err := s.ListEvents(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != ev.ID {
+		t.Fatalf("events = %+v, want exactly the one just written", events)
+	}
+
+	// Reloading confirms the state was committed, not just returned.
+	reloaded, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if reloaded.State != TaskRunning {
+		t.Errorf("reloaded state = %s, want running", reloaded.State)
+	}
+}
+
+func TestTransitionTaskConflictLeavesNothingBehind(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "work", TaskRunning)
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	_, _, err := s.TransitionTask(ctx, task.ID, TaskQueued, TaskRunning, TaskChange{})
+	conflict, ok := AsStateConflict(err)
+	if !ok {
+		t.Fatalf("err = %v, want a StateConflictError", err)
+	}
+	if conflict.Got != TaskRunning || conflict.Want != TaskQueued || conflict.TaskID != task.ID {
+		t.Errorf("conflict = %+v, want task %d want=queued got=running", conflict, task.ID)
+	}
+
+	// A failed transition writes no event: the rollback covers both writes.
+	events, err := s.ListEvents(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %+v, want none after a conflicted transition", events)
+	}
+}
+
+func TestTransitionTaskMissingTask(t *testing.T) {
+	s := openTest(t)
+	_, _, err := s.TransitionTask(t.Context(), 9999, TaskQueued, TaskRunning, TaskChange{})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestTransitionTaskAppliesChanges(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "work", TaskRunning)
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	reason := "nonzero_exit"
+	step := 2
+	worktree := "/data/worktrees/1"
+	snapshot := "name: edited\nsteps: []\n"
+	got, ev, err := s.TransitionTask(ctx, task.ID, TaskRunning, TaskBlocked, TaskChange{
+		BlockReason:  &reason,
+		CurrentStep:  &step,
+		WorktreePath: &worktree,
+		Snapshot:     &snapshot,
+		EventPayload: map[string]any{"step_id": "implement"},
+	})
+	if err != nil {
+		t.Fatalf("TransitionTask: %v", err)
+	}
+	if got.BlockReason != reason || got.CurrentStep != step ||
+		got.WorktreePath != worktree || got.WorkflowSnapshot != snapshot {
+		t.Errorf("task = %+v, want the change applied", got)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		t.Fatalf("payload not JSON: %v", err)
+	}
+	if payload["block_reason"] != reason || payload["step_id"] != "implement" {
+		t.Errorf("payload = %v, want block_reason and the extra field", payload)
+	}
+
+	// Leaving blocked clears the reason without the caller asking.
+	got, _, err = s.TransitionTask(ctx, task.ID, TaskBlocked, TaskQueued, TaskChange{})
+	if err != nil {
+		t.Fatalf("TransitionTask(retry): %v", err)
+	}
+	if got.BlockReason != "" {
+		t.Errorf("block_reason = %q after leaving blocked, want empty", got.BlockReason)
+	}
+}
+
+func TestTransitionTaskTimestamps(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	task := newTask(p.ID, "work", TaskQueued)
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	running, _, err := s.TransitionTask(ctx, task.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	firstStart := running.StartedAt
+
+	// An interrupted task is re-queued and re-admitted; started_at keeps the
+	// original first-run stamp (§6 timestamps are about the task, not the
+	// attempt).
+	if _, _, err := s.TransitionTask(ctx, task.ID, TaskRunning, TaskQueued, TaskChange{}); err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	running, _, err = s.TransitionTask(ctx, task.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("re-admit: %v", err)
+	}
+	if running.StartedAt == nil || !running.StartedAt.Equal(*firstStart) {
+		t.Errorf("started_at = %v, want the first run's %v", running.StartedAt, firstStart)
+	}
+
+	done, _, err := s.TransitionTask(ctx, task.ID, TaskRunning, TaskDone, TaskChange{})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if done.FinishedAt == nil {
+		t.Error("finished_at was not stamped on done")
+	}
+	archived, _, err := s.TransitionTask(ctx, task.ID, TaskDone, TaskArchived, TaskChange{})
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if archived.ArchivedAt == nil {
+		t.Error("archived_at was not stamped on archive")
+	}
+}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -1,0 +1,421 @@
+package taskrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// Failure and block reasons produced by the run path. They share one
+// vocabulary with worktree.Reason* so a block_reason means the same thing
+// wherever it came from (T1.5/T1.6 decision).
+const (
+	ReasonTimeout          = "timeout"
+	ReasonInterrupted      = "interrupted"
+	ReasonNonzeroExit      = "nonzero_exit"
+	ReasonAgentError       = "agent_error"
+	ReasonAgentUnavailable = "agent_unavailable"
+	ReasonCheckFailed      = "check_failed"
+	ReasonTemplateError    = "template_error"
+	ReasonInvalidSnapshot  = "invalid_snapshot"
+	ReasonRejected         = "rejected"
+	ReasonInternalError    = "internal_error"
+)
+
+// Durable event types the engine emits (spec §13.3). State changes emit
+// task.state_changed from inside the transition itself.
+const (
+	eventStepStarted  = "step.started"
+	eventStepFinished = "step.finished"
+	eventStepRetrying = "step.retrying"
+	eventGateWaiting  = "gate.waiting"
+)
+
+// resultSummaryLimit caps result_summary rows; the full text lives in the
+// transcript.
+const resultSummaryLimit = 4096
+
+// outputTailLines is how much command output feeds `.Steps[…].Result` and
+// the §8.4 retry failure block.
+const outputTailLines = 200
+
+// stepEnv is everything one step needs to run.
+type stepEnv struct {
+	task    *store.Task
+	project *store.Project
+	wf      *workflow.Workflow
+	step    workflow.Step
+	index   int
+	log     *slog.Logger
+}
+
+// stepOutcome is the result of one attempt.
+type stepOutcome struct {
+	state         store.StepRunState
+	reason        string
+	result        string
+	output        string // tail of the attempt's output, for the retry block
+	exitCode      *int
+	checkExitCode *int
+}
+
+// execute runs one admission of a task: it walks the snapshot's steps from
+// the task's current step until the task finishes, parks, or fails. The
+// goroutine is the sole writer of this task's state, and it exits whenever
+// the task stops holding its concurrency slot (phase 2 decision).
+func (r *Runner) execute(ctx context.Context, task *store.Task) {
+	log := r.deps.Logger.With("task", task.ID)
+
+	project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
+	if err != nil {
+		r.fail(task, ReasonInternalError, log, "load project", err)
+		return
+	}
+	wf, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		// The snapshot validated at creation, so this is corruption or a
+		// vincent downgrade — either way the task cannot run.
+		r.fail(task, ReasonInvalidSnapshot, log, "parse workflow snapshot", err)
+		return
+	}
+	if err := r.ensureWorktree(ctx, task, project, log); err != nil {
+		return // ensureWorktree already blocked or re-queued the task
+	}
+
+	for index := task.CurrentStep; index < len(wf.Steps); index++ {
+		if ctx.Err() != nil {
+			r.interrupt(task, log)
+			return
+		}
+		if r.pauseRequested(task.ID) {
+			r.park(task, log)
+			return
+		}
+		env := &stepEnv{
+			task: task, project: project, wf: wf,
+			step: wf.Steps[index], index: index,
+			log: log.With("step", wf.Steps[index].ID, "step_index", index),
+		}
+		if env.step.Type == workflow.StepManual {
+			r.enterGate(ctx, env)
+			return
+		}
+		outcome := r.runStepWithRetries(ctx, env)
+		switch outcome.state {
+		case store.StepSucceeded:
+			task.CurrentStep = index + 1
+			next := task.CurrentStep
+			if err := r.deps.Store.SetTaskProgress(ctx, task.ID, &next, nil); err != nil {
+				env.log.Error("persist step advance", "error", err)
+			}
+		case store.StepInterrupted:
+			r.interrupt(task, log)
+			return
+		case store.StepFailed, store.StepRunning, store.StepApproved, store.StepRejected, store.StepSkipped:
+			r.fail(task, outcome.reason, env.log, "step failed", nil)
+			return
+		}
+	}
+	r.complete(task, log)
+}
+
+// ensureWorktree creates the task's worktree on first admission (§10); a
+// queued task that never ran leaves none behind.
+func (r *Runner) ensureWorktree(ctx context.Context, task *store.Task, project *store.Project, log *slog.Logger) error {
+	if task.WorktreePath != "" {
+		return nil
+	}
+	if task.BranchName == "" { // crash between insert and branch assignment
+		task.BranchName = worktree.BranchName(task.ID, task.Title)
+	}
+	path, err := r.deps.Worktrees.Create(ctx, project.Path, task.ID, task.BranchName, task.BaseBranch)
+	if err != nil {
+		if ctx.Err() != nil {
+			// A shutdown mid-create is an interruption, not a git failure.
+			r.interrupt(task, log)
+			return err
+		}
+		reason := worktree.ReasonOf(err)
+		if reason == "" {
+			reason = worktree.ReasonGitError
+		}
+		r.fail(task, reason, log, "create worktree", err)
+		return err
+	}
+	task.WorktreePath = path
+	if err := r.deps.Store.SetTaskProgress(ctx, task.ID, nil, &path); err != nil {
+		log.Error("persist worktree path", "error", err)
+	}
+	return nil
+}
+
+// runStepWithRetries runs one step until it succeeds, is interrupted, or
+// exhausts its retry budget (§7.2). Interrupted attempts consume no retry.
+func (r *Runner) runStepWithRetries(ctx context.Context, env *stepEnv) stepOutcome {
+	maxRetries := resolveMaxRetries(env.step, env.wf.Defaults)
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, time.Time{})
+	if err != nil {
+		env.log.Error("count step attempts", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	var last stepOutcome
+	for {
+		attempts.Last++
+		last = r.runAttempt(ctx, env, attempts.Last, last)
+		if last.state != store.StepFailed {
+			return last
+		}
+		attempts.Failed++
+		if attempts.Failed > maxRetries {
+			env.log.Warn("step failed; retries exhausted",
+				"reason", last.reason, "attempts", attempts.Last, "max_retries", maxRetries)
+			return last
+		}
+		env.log.Info("retrying step", "reason", last.reason, "next_attempt", attempts.Last+1)
+		r.emit(env.task, eventStepRetrying, map[string]any{
+			"step_id": env.step.ID, "step_index": env.index,
+			"attempt": attempts.Last, "reason": last.reason,
+		})
+	}
+}
+
+// runAttempt runs a single attempt end to end: render, execute, check,
+// persist. previous carries the last failed attempt, which feeds
+// `.LastFailure` and the §8.4 failure block.
+func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, previous stepOutcome) stepOutcome {
+	rc, err := r.renderContext(ctx, env, attempt, previous)
+	if err != nil {
+		env.log.Error("assemble template context", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+
+	run := &store.StepRun{
+		TaskID:    env.task.ID,
+		StepIndex: env.index,
+		StepID:    env.step.ID,
+		StepType:  env.step.Type,
+		Attempt:   attempt,
+		State:     store.StepRunning,
+	}
+	var sel selection
+	if env.step.Type == workflow.StepAgent {
+		sel = resolveSelection(env.step, env.wf.Defaults, env.task)
+		run.Agent, run.Model, run.Effort = sel.Agent, sel.Model, sel.Effort
+	}
+
+	tr, err := openTranscript(r.deps.DataDir, env.task.ID, env.index, attempt)
+	if err != nil {
+		env.log.Error("open transcript", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	defer tr.Close()
+	run.TranscriptPath = tr.Path()
+
+	if err := r.deps.Store.CreateStepRun(r.persistCtx(), run); err != nil {
+		env.log.Error("create step run", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	tr.Note("step_started", map[string]any{
+		"task_id": env.task.ID, "step_id": env.step.ID, "attempt": attempt,
+		"type": env.step.Type, "agent": run.Agent, "model": run.Model, "effort": run.Effort,
+	})
+	r.emit(env.task, eventStepStarted, map[string]any{
+		"step_id": env.step.ID, "step_index": env.index, "attempt": attempt,
+		"step_type": env.step.Type, "run_id": run.ID,
+	})
+
+	var outcome stepOutcome
+	switch env.step.Type {
+	case workflow.StepAgent:
+		outcome = r.runAgentStep(ctx, env, sel, rc, run, tr)
+	case workflow.StepCommand:
+		outcome = r.runCommandStep(ctx, env, rc, tr)
+	default:
+		outcome = stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	if outcome.state == store.StepSucceeded && env.step.Check != "" {
+		outcome = r.runCheck(ctx, env, rc, tr, outcome)
+	}
+
+	r.finishStepRun(run, outcome, env.log)
+	tr.Note("step_finished", map[string]any{
+		"state": string(outcome.state), "failure_reason": outcome.reason,
+		"exit_code": outcome.exitCode, "check_exit_code": outcome.checkExitCode,
+	})
+	r.emit(env.task, eventStepFinished, map[string]any{
+		"step_id": env.step.ID, "step_index": env.index, "attempt": attempt,
+		"run_id": run.ID, "state": string(outcome.state), "failure_reason": outcome.reason,
+	})
+	return outcome
+}
+
+// renderContext assembles the §8.4 template context, including the results
+// of steps completed so far.
+func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, previous stepOutcome) (workflow.RenderContext, error) {
+	runs, err := r.deps.Store.ListStepRuns(ctx, env.task.ID)
+	if err != nil {
+		return workflow.RenderContext{}, fmt.Errorf("list step runs: %w", err)
+	}
+	steps := map[string]workflow.StepResult{}
+	for i := range runs {
+		run := runs[i]
+		switch run.State {
+		case store.StepSucceeded, store.StepApproved, store.StepSkipped:
+		default:
+			continue
+		}
+		res := workflow.StepResult{Status: string(run.State), Result: run.ResultSummary}
+		if run.ExitCode != nil {
+			res.ExitCode = *run.ExitCode
+		}
+		steps[run.StepID] = res
+	}
+	return workflow.RenderContext{
+		Task: workflow.TaskContext{
+			ID: env.task.ID, Title: env.task.Title, Description: env.task.Description,
+			Fields: env.task.Fields, BaseBranch: env.task.BaseBranch, BranchName: env.task.BranchName,
+		},
+		Project: workflow.ProjectContext{
+			Name: env.project.Name, Path: env.project.Path, DefaultBranch: env.project.DefaultBranch,
+		},
+		Workflow: workflow.Info{Name: env.wf.Name, Description: env.wf.Description},
+		Step: workflow.StepContext{
+			ID: env.step.ID, Name: env.step.DisplayName(), Index: env.index, Attempt: attempt,
+		},
+		Steps:       steps,
+		Worktree:    workflow.WorktreeContext{Path: env.task.WorktreePath},
+		LastFailure: workflow.Failure{Reason: previous.reason, Output: previous.output},
+	}, nil
+}
+
+// enterGate parks the task at a manual step: the attempt row is written on
+// entry so the gate's wait is visible in the timeline, and the task gives up
+// its concurrency slot until a human approves or rejects (§6, §11).
+func (r *Runner) enterGate(ctx context.Context, env *stepEnv) {
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, time.Time{})
+	if err != nil {
+		env.log.Error("count gate attempts", "error", err)
+		r.fail(env.task, ReasonInternalError, env.log, "count gate attempts", err)
+		return
+	}
+	instructions := env.step.Instructions
+	if rc, err := r.renderContext(ctx, env, attempts.Last+1, stepOutcome{}); err == nil {
+		if rendered, rerr := workflow.Render("instructions", env.step.Instructions, rc); rerr == nil {
+			instructions = rendered
+		} else {
+			env.log.Warn("gate instructions did not render; showing them raw", "error", rerr)
+		}
+	}
+	run := &store.StepRun{
+		TaskID: env.task.ID, StepIndex: env.index, StepID: env.step.ID,
+		StepType: workflow.StepManual, Attempt: attempts.Last + 1,
+		State: store.StepRunning, ResultSummary: truncate(instructions, resultSummaryLimit),
+	}
+	if err := r.deps.Store.CreateStepRun(r.persistCtx(), run); err != nil {
+		env.log.Error("create gate step run", "error", err)
+	}
+	r.emit(env.task, eventGateWaiting, map[string]any{
+		"step_id": env.step.ID, "step_index": env.index, "run_id": run.ID,
+	})
+	r.transition(env.task, taskstate.Gate, store.TaskChange{}, env.log)
+	env.log.Info("task waiting at a manual gate")
+}
+
+// transition applies an engine action through the §6 state machine and
+// persists it with its durable event.
+func (r *Runner) transition(task *store.Task, action taskstate.Action, ch store.TaskChange, log *slog.Logger) bool {
+	from := taskstate.State(task.State)
+	tr, ok := taskstate.Next(from, action)
+	if !ok {
+		log.Error("engine attempted an invalid transition", "from", from, "action", action)
+		return false
+	}
+	updated, _, err := r.deps.Store.TransitionTask(r.persistCtx(), task.ID,
+		task.State, store.TaskState(tr.To), ch)
+	if err != nil {
+		if conflict, isConflict := store.AsStateConflict(err); isConflict {
+			// A human acted first (cancel, for instance); their transition wins.
+			log.Info("transition superseded", "action", action, "state", conflict.Got)
+			return false
+		}
+		log.Error("persist transition", "action", action, "error", err)
+		return false
+	}
+	*task = *updated
+	return true
+}
+
+func (r *Runner) complete(task *store.Task, log *slog.Logger) {
+	if r.transition(task, taskstate.Complete, store.TaskChange{}, log) {
+		log.Info("task done")
+	}
+}
+
+// fail blocks the task with a reason (§7.2: retries exhausted → blocked).
+func (r *Runner) fail(task *store.Task, reason string, log *slog.Logger, what string, err error) {
+	if err != nil {
+		log.Error(what, "error", err, "reason", reason)
+	}
+	r.transition(task, taskstate.Fail, store.TaskChange{BlockReason: &reason}, log)
+	log.Warn("task blocked", "reason", reason)
+}
+
+// interrupt re-queues a task whose step was cut short by shutdown or crash:
+// the attempt consumes no retry and re-runs on the next admission (§12.4).
+func (r *Runner) interrupt(task *store.Task, log *slog.Logger) {
+	if r.transition(task, taskstate.Interrupt, store.TaskChange{}, log) {
+		log.Info("task interrupted; re-queued")
+	}
+}
+
+// park completes a pause requested while the task was running: §6 lets the
+// current step finish first.
+func (r *Runner) park(task *store.Task, log *slog.Logger) {
+	if r.transition(task, taskstate.Park, store.TaskChange{}, log) {
+		log.Info("task paused at a step boundary")
+	}
+}
+
+func (r *Runner) finishStepRun(run *store.StepRun, outcome stepOutcome, log *slog.Logger) {
+	now := time.Now()
+	run.State = outcome.state
+	run.FailureReason = outcome.reason
+	run.ResultSummary = truncate(outcome.result, resultSummaryLimit)
+	run.ExitCode = outcome.exitCode
+	run.CheckExitCode = outcome.checkExitCode
+	run.PID = nil
+	run.FinishedAt = &now
+	if err := r.deps.Store.UpdateStepRun(r.persistCtx(), run); err != nil {
+		log.Error("persist step run", "run", run.ID, "error", err)
+	}
+}
+
+// emit appends a durable event (spec §13.3). Failures are logged, never
+// fatal: losing an event must not lose the work.
+func (r *Runner) emit(task *store.Task, evType string, payload map[string]any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		r.deps.Logger.Error("marshal event", "type", evType, "error", err)
+		return
+	}
+	ev := &store.Event{
+		Type: evType, TaskID: &task.ID, ProjectID: &task.ProjectID, Payload: body,
+	}
+	if err := r.deps.Store.AppendEvent(r.persistCtx(), ev); err != nil {
+		r.deps.Logger.Error("append event", "type", evType, "error", err)
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -1,6 +1,7 @@
 package taskrun
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/lezli01/vincent/internal/gitx"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
 	"github.com/lezli01/vincent/internal/worktree"
 )
 
@@ -152,22 +154,73 @@ func script(posix, windows string) string {
 	return posix
 }
 
-func TestEngineRunsMultiStepWorkflow(t *testing.T) {
-	h := newEngineHarness(t)
-	snapshot := `name: multi
+// commandStep renders a command step as YAML. The command goes in a literal
+// block scalar: a PowerShell line often starts with a quote, which as a
+// plain `run:` value would be parsed as a quoted scalar and make the rest of
+// the line a YAML error.
+func commandStep(id, cmd string, extra ...string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "  - id: %s\n    type: command\n", id)
+	for _, line := range extra {
+		fmt.Fprintf(&sb, "    %s\n", line)
+	}
+	sb.WriteString("    run: |\n")
+	for _, line := range strings.Split(cmd, "\n") {
+		fmt.Fprintf(&sb, "      %s\n", line)
+	}
+	return sb.String()
+}
+
+// multiStepSnapshot is an agent step followed by a command step writing a
+// marker file from the §8.5 environment.
+func multiStepSnapshot(cmd string) string {
+	return `name: multi
 steps:
   - id: implement
     type: agent
     prompt: |
       Implement {{.Task.Title}} on {{.Task.BranchName}}
-  - id: publish
-    type: command
-    run: ` + script(
-		`echo "task $VINCENT_TASK_ID step $VINCENT_STEP_ID" > marker.txt`,
-		`"task $env:VINCENT_TASK_ID step $env:VINCENT_STEP_ID" | Out-File -Encoding ascii marker.txt`,
-	) + `
-`
-	task := h.createTask(t, snapshot)
+` + commandStep("publish", cmd)
+}
+
+// chainedSnapshot is two command steps, the second reading the first's
+// result through `.Steps` (§8.4).
+func chainedSnapshot(first, second string) string {
+	return "name: chained\nsteps:\n" + commandStep("first", first) + commandStep("second", second)
+}
+
+// TestSnapshotsParseOnEveryPlatform parses both platform variants of every
+// snapshot these tests build, so a YAML mistake in the Windows branch fails
+// on POSIX too instead of only in CI.
+func TestSnapshotsParseOnEveryPlatform(t *testing.T) {
+	snapshots := map[string]string{
+		"multi/posix":   multiStepSnapshot(markerCmdPosix),
+		"multi/windows": multiStepSnapshot(markerCmdWindows),
+		"chained/posix": chainedSnapshot(echoCmdPosix, relayCmdPosix),
+		"chained/win":   chainedSnapshot(echoCmdWindows, relayCmdWindows),
+	}
+	for name, src := range snapshots {
+		if _, err := workflow.Parse([]byte(src), workflow.Options{}); err != nil {
+			t.Errorf("%s does not parse: %v\n%s", name, err, src)
+		}
+	}
+}
+
+// Command bodies used by the engine tests, per platform.
+const (
+	markerCmdPosix   = `echo "task $VINCENT_TASK_ID step $VINCENT_STEP_ID" > marker.txt`
+	markerCmdWindows = `"task $env:VINCENT_TASK_ID step $env:VINCENT_STEP_ID" | Out-File -Encoding ascii marker.txt`
+
+	echoCmdPosix   = `echo first-step-output`
+	echoCmdWindows = `Write-Output first-step-output`
+
+	relayCmdPosix   = `echo "{{ (index .Steps "first").Result }}" > relay.txt`
+	relayCmdWindows = `"{{ (index .Steps "first").Result }}" | Out-File -Encoding ascii relay.txt`
+)
+
+func TestEngineRunsMultiStepWorkflow(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, multiStepSnapshot(script(markerCmdPosix, markerCmdWindows)))
 	h.start(t)
 
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
@@ -234,10 +287,7 @@ steps:
   - id: gate
     type: manual
     instructions: Inspect task {{.Task.ID}} before publishing.
-  - id: after
-    type: command
-    run: echo never
-`
+` + commandStep("after", "echo never")
 	task := h.createTask(t, snapshot)
 	h.start(t)
 
@@ -274,13 +324,7 @@ steps:
 
 func TestEngineRetriesThenBlocks(t *testing.T) {
 	h := newEngineHarness(t)
-	snapshot := `name: flaky
-steps:
-  - id: flaky
-    type: command
-    max_retries: 1
-    run: ` + script("exit 3", "exit 3") + `
-`
+	snapshot := "name: flaky\nsteps:\n" + commandStep("flaky", "exit 3", "max_retries: 1")
 	task := h.createTask(t, snapshot)
 	h.start(t)
 
@@ -315,14 +359,8 @@ steps:
 
 func TestEngineCheckFailureFailsStep(t *testing.T) {
 	h := newEngineHarness(t)
-	snapshot := `name: checked
-steps:
-  - id: build
-    type: command
-    max_retries: 0
-    run: ` + script("echo built", "Write-Output built") + `
-    check: ` + script("exit 7", "exit 7") + `
-`
+	snapshot := "name: checked\nsteps:\n" + commandStep("build",
+		script("echo built", "Write-Output built"), "max_retries: 0", "check: exit 7")
 	task := h.createTask(t, snapshot)
 	h.start(t)
 
@@ -369,14 +407,8 @@ steps:
 
 func TestEngineCommandTimeoutKills(t *testing.T) {
 	h := newEngineHarness(t)
-	snapshot := `name: slow
-steps:
-  - id: slow
-    type: command
-    max_retries: 0
-    timeout: 1s
-    run: ` + script("sleep 30", "Start-Sleep -Seconds 30") + `
-`
+	snapshot := "name: slow\nsteps:\n" + commandStep("slow",
+		script("sleep 30", "Start-Sleep -Seconds 30"), "max_retries: 0", "timeout: 1s")
 	task := h.createTask(t, snapshot)
 	h.start(t)
 
@@ -390,19 +422,10 @@ steps:
 // step reads an earlier step's result.
 func TestEngineStepResultsFlowIntoTemplates(t *testing.T) {
 	h := newEngineHarness(t)
-	snapshot := `name: chained
-steps:
-  - id: first
-    type: command
-    run: ` + script("echo first-step-output", "Write-Output first-step-output") + `
-  - id: second
-    type: command
-    run: ` + script(
-		`echo "{{ (index .Steps "first").Result }}" > relay.txt`,
-		`"{{ (index .Steps "first").Result }}" | Out-File -Encoding ascii relay.txt`,
-	) + `
-`
-	task := h.createTask(t, snapshot)
+	task := h.createTask(t, chainedSnapshot(
+		script(echoCmdPosix, echoCmdWindows),
+		script(relayCmdPosix, relayCmdWindows),
+	))
 	h.start(t)
 
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
@@ -420,14 +443,7 @@ steps:
 
 func TestEnginePinnedShellUnavailable(t *testing.T) {
 	h := newEngineHarness(t)
-	snapshot := `name: pinned
-steps:
-  - id: run
-    type: command
-    max_retries: 0
-    shell: cmd
-    run: echo hi
-`
+	snapshot := "name: pinned\nsteps:\n" + commandStep("run", "echo hi", "max_retries: 0", "shell: cmd")
 	if _, err := lookupShell("cmd"); err == nil {
 		t.Skip("cmd is available on this platform; the unavailable-shell path needs a missing shell")
 	}

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -1,0 +1,475 @@
+package taskrun
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// engineHarness runs the real engine against a real store, a real git repo,
+// and the fake agent binary.
+type engineHarness struct {
+	store     *store.Store
+	runner    *Runner
+	repo      string
+	dataDir   string
+	projectID int64
+}
+
+func newEngineHarness(t *testing.T) *engineHarness {
+	t.Helper()
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	git := gitx.New()
+	repo := testrepo.Init(t, "main")
+	project := &store.Project{Name: "proj", Path: repo, DefaultBranch: "main"}
+	if err := st.CreateProject(t.Context(), project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runner := New(Deps{
+		Store:     st,
+		Config:    config.Default,
+		Worktrees: worktree.NewManager(git, dataDir),
+		Agents:    agent.NewRegistry(claude.New(func() string { return fake })),
+		DataDir:   dataDir,
+		Logger:    log,
+	})
+	return &engineHarness{store: st, runner: runner, repo: repo, dataDir: dataDir, projectID: project.ID}
+}
+
+// start runs the admission loop for the test's lifetime.
+func (h *engineHarness) start(t *testing.T) {
+	t.Helper()
+	h.runner.Start(t.Context())
+	t.Cleanup(h.runner.Stop)
+}
+
+// createTask inserts a queued task carrying the given workflow snapshot.
+func (h *engineHarness) createTask(t *testing.T, snapshot string) *store.Task {
+	t.Helper()
+	task := &store.Task{
+		ProjectID:        h.projectID,
+		Title:            "engine test",
+		Description:      "a task",
+		WorkflowName:     "test",
+		WorkflowSnapshot: snapshot,
+		BaseBranch:       "main",
+		State:            store.TaskQueued,
+	}
+	if err := h.store.CreateTask(t.Context(), task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	task.BranchName = worktree.BranchName(task.ID, task.Title)
+	if err := h.store.UpdateTask(t.Context(), task); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	return task
+}
+
+// waitForState polls until the task reaches one of want, or the test fails.
+func (h *engineHarness) waitForState(t *testing.T, id int64, want ...store.TaskState) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	var last *store.Task
+	for time.Now().Before(deadline) {
+		task, err := h.store.GetTask(t.Context(), id)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		last = task
+		for _, w := range want {
+			if task.State == w {
+				return task
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d stuck in %s (block_reason %q), want one of %v", id, last.State, last.BlockReason, want)
+	return nil
+}
+
+func (h *engineHarness) stepRuns(t *testing.T, id int64) []store.StepRun {
+	t.Helper()
+	runs, err := h.store.ListStepRuns(t.Context(), id)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	return runs
+}
+
+func (h *engineHarness) eventTypes(t *testing.T, id int64) []string {
+	t.Helper()
+	events, err := h.store.ListEvents(t.Context(), store.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	var out []string
+	for _, e := range events {
+		if e.TaskID != nil && *e.TaskID == id {
+			out = append(out, e.Type)
+		}
+	}
+	return out
+}
+
+func hasEvent(types []string, want string) bool {
+	for _, tp := range types {
+		if tp == want {
+			return true
+		}
+	}
+	return false
+}
+
+// script picks the shell syntax for the platform the test runs on; command
+// steps are the workflow author's responsibility to port (§8.3), and these
+// tests are their own authors.
+func script(posix, windows string) string {
+	if runtime.GOOS == "windows" {
+		return windows
+	}
+	return posix
+}
+
+func TestEngineRunsMultiStepWorkflow(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: multi
+steps:
+  - id: implement
+    type: agent
+    prompt: |
+      Implement {{.Task.Title}} on {{.Task.BranchName}}
+  - id: publish
+    type: command
+    run: ` + script(
+		`echo "task $VINCENT_TASK_ID step $VINCENT_STEP_ID" > marker.txt`,
+		`"task $env:VINCENT_TASK_ID step $env:VINCENT_STEP_ID" | Out-File -Encoding ascii marker.txt`,
+	) + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
+	}
+	if done.CurrentStep != 2 {
+		t.Errorf("current_step = %d, want 2", done.CurrentStep)
+	}
+	if done.FinishedAt == nil {
+		t.Error("finished_at not stamped")
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("step runs = %d, want 2: %+v", len(runs), runs)
+	}
+	for _, run := range runs {
+		if run.State != store.StepSucceeded {
+			t.Errorf("step %s = %s, want succeeded (%s)", run.StepID, run.State, run.FailureReason)
+		}
+		if run.Attempt != 1 {
+			t.Errorf("step %s attempt = %d, want 1", run.StepID, run.Attempt)
+		}
+		if run.TranscriptPath == "" {
+			t.Errorf("step %s has no transcript", run.StepID)
+		} else if _, err := os.Stat(run.TranscriptPath); err != nil {
+			t.Errorf("step %s transcript missing: %v", run.StepID, err)
+		}
+	}
+	// The agent step records its resolved selection and usage.
+	if runs[0].Agent != DefaultAgent && runs[0].Agent != "claude" {
+		t.Errorf("agent = %q, want claude", runs[0].Agent)
+	}
+	if runs[0].InputTokens == nil || runs[0].CostUSD == nil {
+		t.Errorf("usage not recorded: tokens=%v cost=%v", runs[0].InputTokens, runs[0].CostUSD)
+	}
+	// The rendered prompt reached the agent (fakeagent echoes it back).
+	if !strings.Contains(runs[0].ResultSummary, "Implement engine test on vincent/") {
+		t.Errorf("result summary %q does not contain the rendered prompt", runs[0].ResultSummary)
+	}
+
+	// The command step ran in the worktree with the §8.5 environment.
+	marker, err := os.ReadFile(filepath.Join(done.WorktreePath, "marker.txt"))
+	if err != nil {
+		t.Fatalf("command step did not write its file: %v", err)
+	}
+	if !strings.Contains(string(marker), "step publish") {
+		t.Errorf("marker = %q, want the step id from the environment", marker)
+	}
+
+	types := h.eventTypes(t, task.ID)
+	for _, want := range []string{store.EventTaskStateChanged, eventStepStarted, eventStepFinished} {
+		if !hasEvent(types, want) {
+			t.Errorf("events %v missing %s", types, want)
+		}
+	}
+}
+
+func TestEngineStopsAtManualGate(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: gated
+steps:
+  - id: gate
+    type: manual
+    instructions: Inspect task {{.Task.ID}} before publishing.
+  - id: after
+    type: command
+    run: echo never
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	gated := h.waitForState(t, task.ID, store.TaskAwaitingGate, store.TaskBlocked, store.TaskDone)
+	if gated.State != store.TaskAwaitingGate {
+		t.Fatalf("task = %s (%s), want awaiting_gate", gated.State, gated.BlockReason)
+	}
+	if gated.CurrentStep != 0 {
+		t.Errorf("current_step = %d, want 0 (the gate has not been approved)", gated.CurrentStep)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("step runs = %d, want the gate row only", len(runs))
+	}
+	if runs[0].StepType != "manual" || runs[0].State != store.StepRunning {
+		t.Errorf("gate row = %+v, want a running manual row", runs[0])
+	}
+	if !strings.Contains(runs[0].ResultSummary, "Inspect task") {
+		t.Errorf("gate instructions = %q, want the rendered text", runs[0].ResultSummary)
+	}
+	if !hasEvent(h.eventTypes(t, task.ID), eventGateWaiting) {
+		t.Error("no gate.waiting event")
+	}
+	// The actor exited: a parked task holds no slot (§11).
+	deadline := time.Now().Add(5 * time.Second)
+	for h.runner.Running(task.ID) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if h.runner.Running(task.ID) {
+		t.Error("actor still live while the task waits at a gate")
+	}
+}
+
+func TestEngineRetriesThenBlocks(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: flaky
+steps:
+  - id: flaky
+    type: command
+    max_retries: 1
+    run: ` + script("exit 3", "exit 3") + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("attempts = %d, want 2 (one retry)", len(runs))
+	}
+	for i, run := range runs {
+		if run.Attempt != i+1 {
+			t.Errorf("attempt %d numbered %d, want %d", i, run.Attempt, i+1)
+		}
+		if run.State != store.StepFailed {
+			t.Errorf("attempt %d = %s, want failed", run.Attempt, run.State)
+		}
+		if run.ExitCode == nil || *run.ExitCode != 3 {
+			t.Errorf("attempt %d exit code = %v, want 3", run.Attempt, run.ExitCode)
+		}
+	}
+	if !hasEvent(h.eventTypes(t, task.ID), eventStepRetrying) {
+		t.Error("no step.retrying event")
+	}
+	// Both attempts kept their own transcript (append-only history).
+	if runs[0].TranscriptPath == runs[1].TranscriptPath {
+		t.Error("both attempts share one transcript file")
+	}
+}
+
+func TestEngineCheckFailureFailsStep(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: checked
+steps:
+  - id: build
+    type: command
+    max_retries: 0
+    run: ` + script("echo built", "Write-Output built") + `
+    check: ` + script("exit 7", "exit 7") + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonCheckFailed {
+		t.Fatalf("task = %s/%q, want blocked/check_failed", blocked.State, blocked.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1 (max_retries 0)", len(runs))
+	}
+	if runs[0].CheckExitCode == nil || *runs[0].CheckExitCode != 7 {
+		t.Errorf("check_exit_code = %v, want 7", runs[0].CheckExitCode)
+	}
+	if runs[0].ExitCode == nil || *runs[0].ExitCode != 0 {
+		t.Errorf("step exit code = %v, want 0 — the body succeeded", runs[0].ExitCode)
+	}
+}
+
+func TestEngineTemplateErrorFailsBeforeSpawn(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: typo
+steps:
+  - id: implement
+    type: agent
+    max_retries: 0
+    prompt: "Work on {{.Task.Titel}}"
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonTemplateError {
+		t.Fatalf("task = %s/%q, want blocked/template_error", blocked.State, blocked.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(runs))
+	}
+	if runs[0].PID != nil {
+		t.Error("a process was spawned despite the render failure")
+	}
+}
+
+func TestEngineCommandTimeoutKills(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: slow
+steps:
+  - id: slow
+    type: command
+    max_retries: 0
+    timeout: 1s
+    run: ` + script("sleep 30", "Start-Sleep -Seconds 30") + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonTimeout {
+		t.Fatalf("task = %s/%q, want blocked/timeout", blocked.State, blocked.BlockReason)
+	}
+}
+
+// TestEngineStepResultsFlowIntoTemplates covers §8.4's `.Steps`: a later
+// step reads an earlier step's result.
+func TestEngineStepResultsFlowIntoTemplates(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: chained
+steps:
+  - id: first
+    type: command
+    run: ` + script("echo first-step-output", "Write-Output first-step-output") + `
+  - id: second
+    type: command
+    run: ` + script(
+		`echo "{{ (index .Steps "first").Result }}" > relay.txt`,
+		`"{{ (index .Steps "first").Result }}" | Out-File -Encoding ascii relay.txt`,
+	) + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
+	}
+	relay, err := os.ReadFile(filepath.Join(done.WorktreePath, "relay.txt"))
+	if err != nil {
+		t.Fatalf("second step did not write its file: %v", err)
+	}
+	if !strings.Contains(string(relay), "first-step-output") {
+		t.Errorf("relay = %q, want the first step's result", relay)
+	}
+}
+
+func TestEnginePinnedShellUnavailable(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: pinned
+steps:
+  - id: run
+    type: command
+    max_retries: 0
+    shell: cmd
+    run: echo hi
+`
+	if _, err := lookupShell("cmd"); err == nil {
+		t.Skip("cmd is available on this platform; the unavailable-shell path needs a missing shell")
+	}
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonShellUnavailable {
+		t.Fatalf("task = %s/%q, want blocked/shell_unavailable", blocked.State, blocked.BlockReason)
+	}
+}
+
+// TestEngineRetryPromptCarriesFailureBlock proves §8.4's failure block
+// reaches the agent on a retry: the fake agent echoes its prompt back.
+func TestEngineRetryPromptCarriesFailureBlock(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "nonzero-exit")
+	h := newEngineHarness(t)
+	snapshot := `name: retrying
+steps:
+  - id: implement
+    type: agent
+    max_retries: 1
+    prompt: "Do the work"
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(runs))
+	}
+	if strings.Contains(runs[0].ResultSummary, "previous-attempt-failure") {
+		t.Error("the first attempt's prompt carried a failure block")
+	}
+	if !strings.Contains(runs[1].ResultSummary, "previous-attempt-failure") {
+		t.Errorf("retry prompt %q carries no failure block", runs[1].ResultSummary)
+	}
+	if !strings.Contains(runs[1].ResultSummary, ReasonNonzeroExit) {
+		t.Errorf("retry prompt %q does not name the previous failure reason", runs[1].ResultSummary)
+	}
+}

--- a/internal/taskrun/resolve.go
+++ b/internal/taskrun/resolve.go
@@ -1,0 +1,123 @@
+package taskrun
+
+import (
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// defaultMaxRetries is the §7.2 default: one retry, i.e. up to two attempts.
+const defaultMaxRetries = 1
+
+// selection is the resolved (agent, model, effort) triple for one agent step
+// (spec §8.6). It is recorded on the StepRun and passed to the adapter.
+type selection struct {
+	Agent  string
+	Model  string
+	Effort string
+}
+
+// resolveSelection applies the §8.6 precedence — explicit step field, then
+// the task-level override, then workflow defaults, then the adapter default
+// (empty, meaning the CLI decides).
+//
+// Model and effort are agent-scoped: they only inherit from a level whose
+// agent matches the step's resolved agent, so a claude alias never reaches
+// codex. T2.11 moves this into internal/agent and adds catalog validation.
+func resolveSelection(step workflow.Step, defaults workflow.Defaults, task *store.Task) selection {
+	// Level 4 of §8.6 is the adapter default; when no level names an agent at
+	// all, the daemon's default adapter runs the step.
+	resolved := firstNonEmpty(step.Agent, task.AgentOverride, defaults.Agent, DefaultAgent)
+
+	// Each level carries the agent it was written for; a level whose agent
+	// differs from the resolved one contributes nothing but its own agent
+	// field. The task override inherits the workflow's agent when it does
+	// not name one, since it replaces the workflow defaults.
+	taskAgent := firstNonEmpty(task.AgentOverride, defaults.Agent)
+	inScope := func(levelAgent string) bool { return levelAgent == "" || levelAgent == resolved }
+
+	sel := selection{Agent: resolved, Model: step.Model, Effort: step.Effort}
+	if sel.Model == "" && inScope(taskAgent) {
+		sel.Model = task.ModelOverride
+	}
+	if sel.Model == "" && inScope(defaults.Agent) {
+		sel.Model = defaults.Model
+	}
+	if sel.Effort == "" && inScope(taskAgent) {
+		sel.Effort = task.EffortOverride
+	}
+	if sel.Effort == "" && inScope(defaults.Agent) {
+		sel.Effort = defaults.Effort
+	}
+	return sel
+}
+
+// resolvePermission resolves the step's permission mode (§9.4): step field,
+// then workflow defaults, then full-auto.
+func resolvePermission(step workflow.Step, defaults workflow.Defaults) agent.PermissionMode {
+	switch firstNonEmpty(step.PermissionMode, defaults.PermissionMode) {
+	case workflow.PermissionRestricted:
+		return agent.Restricted
+	default:
+		return agent.FullAuto
+	}
+}
+
+// resolveInputPolicy resolves the step's reaction to an input request
+// (§7.4): step field, then workflow defaults, then wait.
+func resolveInputPolicy(step workflow.Step, defaults workflow.Defaults) agent.InputPolicy {
+	switch firstNonEmpty(step.OnInput, defaults.OnInput) {
+	case workflow.InputDeny:
+		return agent.InputDeny
+	default:
+		return agent.InputWait
+	}
+}
+
+// resolveMaxRetries resolves the step's retry budget (§7.2): step field,
+// then workflow defaults, then 1.
+func resolveMaxRetries(step workflow.Step, defaults workflow.Defaults) int {
+	if step.MaxRetries != nil {
+		return *step.MaxRetries
+	}
+	if defaults.MaxRetries != nil {
+		return *defaults.MaxRetries
+	}
+	return defaultMaxRetries
+}
+
+// resolveTimeout resolves a step's timeout (§7.2): step field, then workflow
+// defaults, then the daemon default for the step type.
+func resolveTimeout(step workflow.Step, defaults workflow.Defaults, cfg config.Config) time.Duration {
+	if step.Timeout != nil {
+		return step.Timeout.Std()
+	}
+	if defaults.Timeout != nil {
+		return defaults.Timeout.Std()
+	}
+	if step.Type == workflow.StepAgent {
+		return cfg.Defaults.AgentTimeout.Std()
+	}
+	return cfg.Defaults.CommandTimeout.Std()
+}
+
+// resolveCheckTimeout resolves the timeout of a step's check command, which
+// defaults to the daemon's command timeout rather than the step's own.
+func resolveCheckTimeout(step workflow.Step, cfg config.Config) time.Duration {
+	if step.CheckTimeout != nil {
+		return step.CheckTimeout.Std()
+	}
+	return cfg.Defaults.CommandTimeout.Std()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/taskrun/resolve_test.go
+++ b/internal/taskrun/resolve_test.go
@@ -1,0 +1,166 @@
+package taskrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// TestResolveSelection walks the §8.6 precedence ladder and the
+// agent-scoped inheritance rule that keeps a claude alias away from codex.
+func TestResolveSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		step     workflow.Step
+		defaults workflow.Defaults
+		task     store.Task
+		want     selection
+	}{
+		{
+			name: "nothing declared falls back to the daemon default agent",
+			want: selection{Agent: DefaultAgent},
+		},
+		{
+			name:     "workflow defaults apply",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "low"},
+			want:     selection{Agent: "claude", Model: "sonnet", Effort: "low"},
+		},
+		{
+			name:     "task override replaces workflow defaults",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "low"},
+			task:     store.Task{AgentOverride: "claude", ModelOverride: "opus", EffortOverride: "max"},
+			want:     selection{Agent: "claude", Model: "opus", Effort: "max"},
+		},
+		{
+			name:     "explicit step fields beat the task override",
+			step:     workflow.Step{Agent: "claude", Model: "haiku", Effort: "low"},
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet"},
+			task:     store.Task{AgentOverride: "claude", ModelOverride: "opus", EffortOverride: "max"},
+			want:     selection{Agent: "claude", Model: "haiku", Effort: "low"},
+		},
+		{
+			name:     "a step pinning another agent does not inherit its model",
+			step:     workflow.Step{Agent: "codex"},
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "max"},
+			want:     selection{Agent: "codex"},
+		},
+		{
+			name:     "a step pinning another agent keeps its own model and effort",
+			step:     workflow.Step{Agent: "codex", Effort: "high"},
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "max"},
+			want:     selection{Agent: "codex", Effort: "high"},
+		},
+		{
+			name:     "a task override switching agent drops the workflow model",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "max"},
+			task:     store.Task{AgentOverride: "codex"},
+			want:     selection{Agent: "codex"},
+		},
+		{
+			name:     "a task override switching agent carries its own model",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet"},
+			task:     store.Task{AgentOverride: "codex", ModelOverride: "gpt-5.2"},
+			want:     selection{Agent: "codex", Model: "gpt-5.2"},
+		},
+		{
+			name:     "a model-only task override rides the workflow agent",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet"},
+			task:     store.Task{ModelOverride: "opus"},
+			want:     selection{Agent: "claude", Model: "opus"},
+		},
+		{
+			name:     "a model-only task override does not reach a step that switched agent",
+			step:     workflow.Step{Agent: "codex"},
+			defaults: workflow.Defaults{Agent: "claude"},
+			task:     store.Task{ModelOverride: "opus"},
+			want:     selection{Agent: "codex"},
+		},
+		{
+			name:     "workflow defaults fill what the task override leaves unset",
+			defaults: workflow.Defaults{Agent: "claude", Model: "sonnet", Effort: "low"},
+			task:     store.Task{EffortOverride: "max"},
+			want:     selection{Agent: "claude", Model: "sonnet", Effort: "max"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSelection(tt.step, tt.defaults, &tt.task)
+			if got != tt.want {
+				t.Errorf("resolveSelection = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveStepSettings(t *testing.T) {
+	two, zero := 2, 0
+	fiveMin := config.Duration(5 * time.Minute)
+	oneHour := config.Duration(time.Hour)
+	cfg := config.Default()
+
+	// max_retries: step, then defaults, then §7.2's default of 1.
+	if got := resolveMaxRetries(workflow.Step{MaxRetries: &two}, workflow.Defaults{MaxRetries: &zero}); got != 2 {
+		t.Errorf("step max_retries = %d, want 2", got)
+	}
+	if got := resolveMaxRetries(workflow.Step{}, workflow.Defaults{MaxRetries: &zero}); got != 0 {
+		t.Errorf("defaults max_retries = %d, want 0", got)
+	}
+	if got := resolveMaxRetries(workflow.Step{}, workflow.Defaults{}); got != defaultMaxRetries {
+		t.Errorf("fallback max_retries = %d, want %d", got, defaultMaxRetries)
+	}
+
+	// timeout: step, then defaults, then the per-type daemon default.
+	agentStep := workflow.Step{Type: workflow.StepAgent}
+	commandStep := workflow.Step{Type: workflow.StepCommand}
+	if got := resolveTimeout(workflow.Step{Timeout: &fiveMin}, workflow.Defaults{Timeout: &oneHour}, cfg); got != 5*time.Minute {
+		t.Errorf("step timeout = %s, want 5m", got)
+	}
+	if got := resolveTimeout(agentStep, workflow.Defaults{Timeout: &oneHour}, cfg); got != time.Hour {
+		t.Errorf("defaults timeout = %s, want 1h", got)
+	}
+	if got := resolveTimeout(agentStep, workflow.Defaults{}, cfg); got != cfg.Defaults.AgentTimeout.Std() {
+		t.Errorf("agent fallback timeout = %s, want %s", got, cfg.Defaults.AgentTimeout)
+	}
+	if got := resolveTimeout(commandStep, workflow.Defaults{}, cfg); got != cfg.Defaults.CommandTimeout.Std() {
+		t.Errorf("command fallback timeout = %s, want %s", got, cfg.Defaults.CommandTimeout)
+	}
+	// A check inherits the command timeout, never the (much longer) agent one.
+	if got := resolveCheckTimeout(agentStep, cfg); got != cfg.Defaults.CommandTimeout.Std() {
+		t.Errorf("check timeout = %s, want the command default %s", got, cfg.Defaults.CommandTimeout)
+	}
+	if got := resolveCheckTimeout(workflow.Step{CheckTimeout: &fiveMin}, cfg); got != 5*time.Minute {
+		t.Errorf("explicit check timeout = %s, want 5m", got)
+	}
+}
+
+func TestResolvePermissionAndInputPolicy(t *testing.T) {
+	cases := []struct {
+		step     workflow.Step
+		defaults workflow.Defaults
+		wantPerm agent.PermissionMode
+		wantIn   agent.InputPolicy
+	}{
+		{wantPerm: agent.FullAuto, wantIn: agent.InputWait},
+		{
+			defaults: workflow.Defaults{PermissionMode: workflow.PermissionRestricted, OnInput: workflow.InputDeny},
+			wantPerm: agent.Restricted, wantIn: agent.InputDeny,
+		},
+		{
+			step:     workflow.Step{PermissionMode: workflow.PermissionFullAuto, OnInput: workflow.InputWait},
+			defaults: workflow.Defaults{PermissionMode: workflow.PermissionRestricted, OnInput: workflow.InputDeny},
+			wantPerm: agent.FullAuto, wantIn: agent.InputWait,
+		},
+	}
+	for _, tc := range cases {
+		if got := resolvePermission(tc.step, tc.defaults); got != tc.wantPerm {
+			t.Errorf("resolvePermission(%+v, %+v) = %s, want %s", tc.step, tc.defaults, got, tc.wantPerm)
+		}
+		if got := resolveInputPolicy(tc.step, tc.defaults); got != tc.wantIn {
+			t.Errorf("resolveInputPolicy(%+v, %+v) = %s, want %s", tc.step, tc.defaults, got, tc.wantIn)
+		}
+	}
+}

--- a/internal/taskrun/runner.go
+++ b/internal/taskrun/runner.go
@@ -1,20 +1,18 @@
-// Package taskrun executes tasks. In M1 it is the interim runner (phase 1
-// decision): admission bounded by the global max_parallel_tasks cap using
-// the T1.2 scheduler query, and a hardcoded single-agent-step execution path
-// — worktree create → adapter run → StepRun + transcript → done/blocked.
-// T2.3–T2.5 replace the hardcoded path with the real state machine, step
-// executors, and scheduler.
+// Package taskrun is the workflow execution engine: one goroutine per
+// admitted task walks its workflow snapshot step by step and is the sole
+// writer of that task's state (phase 2 decision). An actor lives for exactly
+// one admission — reaching a gate, blocking, or pausing releases the task's
+// concurrency slot and ends the goroutine; the scheduler admits it again
+// when a human unblocks it.
+//
+// Admission here is still the M1 interim loop bounded by the global
+// max_parallel_tasks; T2.5 replaces it with the real scheduler (per-project
+// caps, priority ordering, re-evaluation on every state change).
 package taskrun
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -24,58 +22,69 @@ import (
 	"github.com/lezli01/vincent/internal/worktree"
 )
 
-// DefaultAgent is the agent of the synthesized adhoc workflow (M1 decision).
+// DefaultAgent is used when neither the step, the task override, nor the
+// workflow defaults name an agent.
 const DefaultAgent = "claude"
 
-// Failure/block reasons introduced by the run path; worktree reasons
-// (worktree.Reason*) share the same vocabulary end to end.
-const (
-	ReasonTimeout          = "timeout"
-	ReasonInterrupted      = "interrupted"
-	ReasonNonzeroExit      = "nonzero_exit"
-	ReasonAgentError       = "agent_error"
-	ReasonAgentUnavailable = "agent_unavailable"
-	ReasonInternalError    = "internal_error"
-)
-
-// tickInterval is the admission safety net: normally Wake drives the loop,
+// tickInterval is the admission safety net: Wake normally drives the loop,
 // but a tick also picks up config hot-reloads of max_parallel_tasks.
 const tickInterval = 5 * time.Second
 
-// stopGrace bounds how long Stop waits for executors after the kill.
+// stopGrace bounds how long Stop waits for actors after cancellation.
 const stopGrace = 20 * time.Second
 
-// resultSummaryLimit caps result_summary rows; full text lives in the
-// transcript.
-const resultSummaryLimit = 4096
-
-// Deps are the daemon facilities the runner works with.
+// Deps are the daemon facilities the engine works with.
 type Deps struct {
 	Store     *store.Store
 	Config    func() config.Config
 	Worktrees *worktree.Manager
 	Agents    *agent.Registry
+	Shells    *Shells
 	DataDir   string
 	Logger    *slog.Logger
 }
 
-// Runner admits queued tasks up to the global cap and executes them.
+// Runner admits queued tasks and runs them.
 type Runner struct {
 	deps   Deps
 	wake   chan struct{}
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	// persist is a context detached from shutdown: a task's final state must
+	// still reach the database after the run context is canceled.
+	persist context.Context //nolint:containedctx // deliberately outlives the run
+
+	// live tracks running tasks so human actions and shutdown can reach the
+	// process (phase 2 decision); T2.6 delivers cancel/pause/answer through it.
+	mu   sync.Mutex
+	live map[int64]*liveRun
+}
+
+// liveRun is one task's in-flight execution. T2.6 adds the agent handle to
+// it, so cancel and answer can reach the live process.
+type liveRun struct {
+	// pauseRequested is set by a pause action and read at the next step
+	// boundary (§6: a running task finishes its current step first).
+	pauseRequested bool
 }
 
 // New returns a stopped runner.
 func New(deps Deps) *Runner {
-	return &Runner{deps: deps, wake: make(chan struct{}, 1)}
+	if deps.Shells == nil {
+		deps.Shells = NewShells(deps.Logger)
+	}
+	return &Runner{
+		deps: deps,
+		wake: make(chan struct{}, 1),
+		live: map[int64]*liveRun{},
+	}
 }
 
-// Start sweeps stop/crash leftovers (running rows → interrupted/blocked, M1
-// interim for §12.4) and begins admitting queued tasks until ctx is
-// canceled or Stop is called.
+// Start sweeps leftovers from a previous run and begins admitting queued
+// tasks until ctx is canceled or Stop is called.
 func (r *Runner) Start(ctx context.Context) {
+	r.persist = context.WithoutCancel(ctx)
 	ctx, r.cancel = context.WithCancel(ctx)
 	if n, err := r.deps.Store.SweepInterrupted(ctx); err != nil {
 		r.deps.Logger.Error("startup sweep failed", "error", err)
@@ -86,8 +95,8 @@ func (r *Runner) Start(ctx context.Context) {
 	go r.loop(ctx)
 }
 
-// Stop kills in-flight runs (via context cancellation → process-tree kill)
-// and waits for executors to persist their interrupted state.
+// Stop cancels in-flight runs (tree-killing their processes) and waits for
+// the actors to persist their interrupted state.
 func (r *Runner) Stop() {
 	if r.cancel == nil {
 		return
@@ -110,6 +119,14 @@ func (r *Runner) Wake() {
 	}
 }
 
+// persistCtx returns the context for writes that must survive shutdown.
+func (r *Runner) persistCtx() context.Context {
+	if r.persist == nil {
+		return context.Background()
+	}
+	return r.persist
+}
+
 func (r *Runner) loop(ctx context.Context) {
 	defer r.wg.Done()
 	ticker := time.NewTicker(tickInterval)
@@ -126,8 +143,8 @@ func (r *Runner) loop(ctx context.Context) {
 }
 
 // admit starts queued tasks while the global cap has room, in scheduler
-// order (priority DESC, created_at ASC — the T1.2 query; per-project caps
-// and re-evaluation semantics arrive with T2.5).
+// order (priority DESC, created_at ASC). Per-project caps and re-evaluation
+// semantics arrive with T2.5.
 func (r *Runner) admit(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
@@ -150,280 +167,72 @@ func (r *Runner) admit(ctx context.Context) {
 		if running >= limit || ctx.Err() != nil {
 			return
 		}
-		t := queued[i]
-		now := time.Now()
-		t.State = store.TaskRunning
-		t.StartedAt = &now
-		if err := r.deps.Store.UpdateTask(ctx, &t); err != nil {
-			r.deps.Logger.Error("admission: mark running", "task", t.ID, "error", err)
+		task := queued[i]
+		log := r.deps.Logger.With("task", task.ID)
+		admitted, _, err := r.deps.Store.TransitionTask(ctx, task.ID,
+			store.TaskQueued, store.TaskRunning, store.TaskChange{})
+		if err != nil {
+			if _, conflict := store.AsStateConflict(err); conflict {
+				continue // someone acted on it between the query and now
+			}
+			log.Error("admission: mark running", "error", err)
 			return
 		}
 		running++
+		r.trackRun(admitted.ID)
 		r.wg.Add(1)
 		go func() {
 			defer r.wg.Done()
+			defer r.forgetRun(admitted.ID)
 			defer r.Wake() // slot freed → re-admit
-			r.execute(ctx, &t)
+			r.execute(ctx, admitted)
 		}()
 	}
 }
 
-// persistCtx returns a context for final DB writes: shutdown cancels ctx,
-// but the interrupted/blocked outcome must still be persisted.
-func persistCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 10*time.Second)
+// trackRun registers a task as live so actions can reach it.
+func (r *Runner) trackRun(taskID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.live[taskID] = &liveRun{}
 }
 
-// execute is the hardcoded M1 single-agent-step run (T1.8): worktree →
-// adapter run → StepRun + transcript → done/blocked. No retry — the adhoc
-// snapshot pins max_retries 0 (T1.7–T1.9 decision).
-func (r *Runner) execute(ctx context.Context, task *store.Task) {
-	log := r.deps.Logger.With("task", task.ID)
+func (r *Runner) forgetRun(taskID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.live, taskID)
+}
 
-	project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
-	if err != nil {
-		r.blockTask(task, ReasonInternalError, log)
-		log.Error("execute: load project", "error", err)
-		return
-	}
+func (r *Runner) lookupRun(taskID int64) (*liveRun, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lr, ok := r.live[taskID]
+	return lr, ok
+}
 
-	if task.BranchName == "" { // fallback for a crash between insert and branch update
-		task.BranchName = worktree.BranchName(task.ID, task.Title)
-	}
-	if task.WorktreePath == "" {
-		path, err := r.deps.Worktrees.Create(ctx, project.Path, task.ID, task.BranchName, task.BaseBranch)
-		if err != nil {
-			// A shutdown mid-create must not masquerade as a git failure.
-			if ctx.Err() != nil {
-				r.blockTask(task, ReasonInterrupted, log)
-				return
-			}
-			reason := worktree.ReasonOf(err)
-			if reason == "" {
-				reason = worktree.ReasonGitError
-			}
-			r.blockTask(task, reason, log)
-			log.Error("execute: worktree create", "reason", reason, "error", err)
-			return
-		}
-		task.WorktreePath = path
-		if err := r.updateTask(task); err != nil {
-			log.Error("execute: persist worktree path", "error", err)
-		}
-	}
-
-	// §8.6 resolution, M1 subset: the adhoc workflow's only step declares
-	// nothing, its defaults name claude — so task override > default agent,
-	// and override model/effort ride along (the full engine is T2.11).
-	agentName := task.AgentOverride
-	if agentName == "" {
-		agentName = DefaultAgent
-	}
-	adapter, ok := r.deps.Agents.Get(agentName)
+// RequestPause marks a running task to stop at its next step boundary (§6).
+// It reports whether the task is live; a task that is not running needs no
+// deferral and transitions immediately.
+func (r *Runner) RequestPause(taskID int64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lr, ok := r.live[taskID]
 	if !ok {
-		r.blockTask(task, ReasonAgentUnavailable, log)
-		log.Error("execute: agent not registered", "agent", agentName)
-		return
+		return false
 	}
-
-	run := &store.StepRun{
-		TaskID:    task.ID,
-		StepIndex: 0,
-		StepID:    "run",
-		StepType:  "agent",
-		Attempt:   1,
-		State:     store.StepRunning,
-		Agent:     agentName,
-		Model:     task.ModelOverride,
-		Effort:    task.EffortOverride,
-	}
-	transcriptPath, transcript, err := r.openTranscript(task.ID, run)
-	if err != nil {
-		r.blockTask(task, ReasonInternalError, log)
-		log.Error("execute: open transcript", "error", err)
-		return
-	}
-	defer func() { _ = transcript.Close() }()
-	run.TranscriptPath = transcriptPath
-	{
-		pctx, cancel := persistCtx()
-		err := r.deps.Store.CreateStepRun(pctx, run)
-		cancel()
-		if err != nil {
-			r.blockTask(task, ReasonInternalError, log)
-			log.Error("execute: create step run", "error", err)
-			return
-		}
-	}
-
-	writeVincentLine(transcript, map[string]any{
-		"type": "vincent.step_started", "task_id": task.ID, "step_id": run.StepID,
-		"attempt": run.Attempt, "agent": agentName, "model": run.Model, "effort": run.Effort,
-	})
-
-	timeout := r.deps.Config().Defaults.AgentTimeout.Std()
-	runCtx, cancelRun := context.WithTimeout(ctx, timeout)
-	defer cancelRun()
-	handle, err := adapter.Start(runCtx, agent.RunSpec{
-		Prompt:         adhocPrompt(task),
-		WorkDir:        task.WorktreePath,
-		Model:          task.ModelOverride,
-		Effort:         task.EffortOverride,
-		PermissionMode: agent.FullAuto,
-		OnInput:        agent.InputWait,
-	})
-	if err != nil {
-		writeVincentLine(transcript, map[string]any{"type": "vincent.error", "error": err.Error()})
-		r.finishStep(run, store.StepFailed, ReasonAgentUnavailable, log)
-		r.blockTask(task, ReasonAgentUnavailable, log)
-		log.Error("execute: adapter start", "agent", agentName, "error", err)
-		return
-	}
-	pid := handle.PID()
-	now := time.Now()
-	run.PID = &pid
-	run.ProcStartedAt = &now
-	if err := r.updateStepRun(run); err != nil {
-		log.Error("execute: persist pid", "error", err)
-	}
-	log.Info("agent step running", "agent", agentName, "pid", pid,
-		"model", run.Model, "effort", run.Effort)
-
-	for ev := range handle.Events() {
-		if _, err := transcript.Write(append(ev.Raw, '\n')); err != nil {
-			log.Error("execute: transcript write", "error", err)
-		}
-	}
-	res, waitErr := handle.Wait()
-
-	state, reason := classify(ctx, runCtx, &res, waitErr)
-	writeVincentLine(transcript, map[string]any{
-		"type": "vincent.step_finished", "state": string(state),
-		"exit_code": res.ExitCode, "failure_reason": reason,
-	})
-
-	run.ExitCode = &res.ExitCode
-	run.FailureReason = reason
-	run.ResultSummary = truncate(res.ResultText, resultSummaryLimit)
-	if state == store.StepFailed && run.ResultSummary == "" {
-		run.ResultSummary = truncate(res.ErrorMessage, resultSummaryLimit)
-	}
-	if res.InputTokens > 0 || res.OutputTokens > 0 {
-		run.InputTokens = &res.InputTokens
-		run.OutputTokens = &res.OutputTokens
-	}
-	run.CostUSD = res.CostUSD
-	run.PID = nil
-	r.finishStep(run, state, reason, log)
-
-	switch state {
-	case store.StepSucceeded:
-		finished := time.Now()
-		task.State = store.TaskDone
-		task.FinishedAt = &finished
-		task.BlockReason = ""
-		if err := r.updateTask(task); err != nil {
-			log.Error("execute: persist done", "error", err)
-			return
-		}
-		log.Info("task done", "cost_usd", res.CostUSD,
-			"input_tokens", res.InputTokens, "output_tokens", res.OutputTokens)
-	default:
-		r.blockTask(task, reason, log)
-		log.Warn("task blocked", "reason", reason, "exit_code", res.ExitCode,
-			"error", res.ErrorMessage)
-	}
+	lr.pauseRequested = true
+	return true
 }
 
-// classify maps a finished run to its StepRun state and failure reason
-// (§7.1 success rule; T1.7–T1.9 decisions for timeout/interrupt).
-func classify(daemonCtx, runCtx context.Context, res *agent.RunResult, waitErr error) (store.StepRunState, string) {
-	switch {
-	case daemonCtx.Err() != nil:
-		return store.StepInterrupted, ReasonInterrupted
-	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
-		return store.StepFailed, ReasonTimeout
-	case waitErr != nil:
-		return store.StepFailed, ReasonInternalError
-	case res.ExitCode != 0:
-		return store.StepFailed, ReasonNonzeroExit
-	case res.IsError:
-		return store.StepFailed, ReasonAgentError
-	default:
-		return store.StepSucceeded, ""
-	}
+func (r *Runner) pauseRequested(taskID int64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lr, ok := r.live[taskID]
+	return ok && lr.pauseRequested
 }
 
-func (r *Runner) finishStep(run *store.StepRun, state store.StepRunState, reason string, log *slog.Logger) {
-	now := time.Now()
-	run.State = state
-	run.FailureReason = reason
-	run.FinishedAt = &now
-	if err := r.updateStepRun(run); err != nil {
-		log.Error("persist step run", "run", run.ID, "error", err)
-	}
-}
-
-func (r *Runner) blockTask(task *store.Task, reason string, log *slog.Logger) {
-	task.State = store.TaskBlocked
-	task.BlockReason = reason
-	if err := r.updateTask(task); err != nil {
-		log.Error("persist blocked task", "error", err)
-	}
-}
-
-func (r *Runner) updateTask(task *store.Task) error {
-	ctx, cancel := persistCtx()
-	defer cancel()
-	return r.deps.Store.UpdateTask(ctx, task)
-}
-
-func (r *Runner) updateStepRun(run *store.StepRun) error {
-	ctx, cancel := persistCtx()
-	defer cancel()
-	return r.deps.Store.UpdateStepRun(ctx, run)
-}
-
-// openTranscript creates {data_dir}/transcripts/{task_id}/{step}-{attempt}.jsonl
-// (spec §12.2).
-func (r *Runner) openTranscript(taskID int64, run *store.StepRun) (string, *os.File, error) {
-	dir := filepath.Join(r.deps.DataDir, "transcripts", strconv.FormatInt(taskID, 10))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", nil, fmt.Errorf("create transcript dir: %w", err)
-	}
-	path := filepath.Join(dir, fmt.Sprintf("%d-%d.jsonl", run.StepIndex, run.Attempt))
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return "", nil, fmt.Errorf("create transcript: %w", err)
-	}
-	return path, f, nil
-}
-
-// writeVincentLine appends a namespaced vincent.* annotation to the
-// transcript (phase 1 decision: agent lines verbatim, vincent's own lines
-// namespaced).
-func writeVincentLine(f *os.File, fields map[string]any) {
-	fields["ts"] = time.Now().UTC().Format(time.RFC3339)
-	b, err := json.Marshal(fields)
-	if err != nil {
-		return
-	}
-	_, _ = f.Write(append(b, '\n'))
-}
-
-// adhocPrompt is the fixed M1 prompt embedding title and description — what
-// T2.2's template engine will produce from the AdhocSnapshot definition.
-func adhocPrompt(task *store.Task) string {
-	prompt := adhocIntro + "\n\nTask: " + task.Title
-	if task.Description != "" {
-		prompt += "\n\n" + task.Description
-	}
-	return prompt
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n]
+// Running reports whether the engine currently holds a live run for a task.
+func (r *Runner) Running(taskID int64) bool {
+	_, ok := r.lookupRun(taskID)
+	return ok
 }

--- a/internal/taskrun/shell.go
+++ b/internal/taskrun/shell.go
@@ -1,0 +1,104 @@
+package taskrun
+
+import (
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"runtime"
+	"sync"
+
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// ReasonShellUnavailable is the failure reason when a step pins a shell that
+// is not installed. A pinned shell is never silently replaced (phase 2
+// decision) — a workflow that says pwsh must not quietly run under sh.
+const ReasonShellUnavailable = "shell_unavailable"
+
+// Shells resolves the shell used to run command and check steps (spec §8.3).
+// The platform default is probed once and reused; a step's `shell:` pin is
+// resolved per use and fails the step when the binary is missing.
+type Shells struct {
+	log  *slog.Logger
+	once sync.Once
+	def  Shell
+	err  error
+}
+
+// Shell is a resolved shell: the binary plus the flags that make it run one
+// command string.
+type Shell struct {
+	Name string
+	Path string
+	Args []string // flags preceding the command string
+}
+
+// NewShells returns a resolver logging its probe result once.
+func NewShells(log *slog.Logger) *Shells { return &Shells{log: log} }
+
+// Default returns the platform default shell: /bin/sh on POSIX, pwsh on
+// Windows falling back to powershell (spec §8.3). The probe runs once.
+func (s *Shells) Default() (Shell, error) {
+	s.once.Do(func() {
+		s.def, s.err = probeDefault()
+		if s.err != nil {
+			s.log.Warn("no default shell found; command steps will fail", "error", s.err)
+			return
+		}
+		s.log.Info("shell detected", "shell", s.def.Name, "path", s.def.Path)
+	})
+	return s.def, s.err
+}
+
+// For returns the shell a step should use: its `shell:` pin when set, else
+// the platform default.
+func (s *Shells) For(pin string) (Shell, error) {
+	if pin == "" {
+		return s.Default()
+	}
+	return lookupShell(pin)
+}
+
+func probeDefault() (Shell, error) {
+	if runtime.GOOS == "windows" {
+		if sh, err := lookupShell(workflow.ShellPwsh); err == nil {
+			return sh, nil
+		}
+		// Windows PowerShell 5.1 ships with the OS; pwsh may not be installed.
+		if path, err := exec.LookPath("powershell"); err == nil {
+			return Shell{Name: "powershell", Path: path, Args: []string{"-NoProfile", "-Command"}}, nil
+		}
+		return Shell{}, fmt.Errorf("neither pwsh nor powershell found on PATH")
+	}
+	return lookupShell(workflow.ShellSh)
+}
+
+// lookupShell resolves one of the §8.3 shell names to its binary.
+func lookupShell(name string) (Shell, error) {
+	var candidate, flag string
+	var extra []string
+	switch name {
+	case workflow.ShellSh:
+		candidate, flag = "/bin/sh", "-c"
+		if runtime.GOOS == "windows" {
+			candidate = "sh" // Git Bash's sh, if the author put it on PATH
+		}
+	case workflow.ShellPwsh:
+		candidate = "pwsh"
+		extra, flag = []string{"-NoProfile"}, "-Command"
+	case workflow.ShellCmd:
+		candidate, flag = "cmd", "/C"
+	default:
+		return Shell{}, fmt.Errorf("unknown shell %q", name)
+	}
+	path, err := exec.LookPath(candidate)
+	if err != nil {
+		return Shell{}, fmt.Errorf("shell %q not found: %w", name, err)
+	}
+	return Shell{Name: name, Path: path, Args: append(extra, flag)}, nil
+}
+
+// command builds the argv running one rendered command string.
+func (sh Shell) command(script string) []string {
+	return append(append([]string{sh.Path}, sh.Args...), script)
+}

--- a/internal/taskrun/snapshot.go
+++ b/internal/taskrun/snapshot.go
@@ -2,11 +2,6 @@ package taskrun
 
 import "github.com/lezli01/vincent/internal/workflow"
 
-// adhocIntro opens the adhoc prompt. It is the same text the built-in
-// workflow embeds, so the stored snapshot and the M1 runner's hardcoded
-// prompt cannot drift.
-const adhocIntro = workflow.AdhocIntro
-
 // AdhocSnapshot is the workflow stored as workflow_snapshot for tasks
 // created without naming one. It is now the built-in registry entry (phase 2
 // decision); T2.3 replaces this indirection with a registry lookup that also

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -1,0 +1,283 @@
+package taskrun
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/procx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// runAgentStep runs one agent attempt: render the prompt, spawn the adapter,
+// stream its events into the transcript, and classify the result (§7.1).
+func (r *Runner) runAgentStep(
+	ctx context.Context, env *stepEnv, sel selection,
+	rc workflow.RenderContext, run *store.StepRun, tr *transcript,
+) stepOutcome {
+	prompt, err := workflow.Render("prompt", env.step.Prompt, rc)
+	if err != nil {
+		// §8.4: a render failure fails the step before anything is spawned.
+		tr.Note("error", map[string]any{"error": err.Error()})
+		return stepOutcome{state: store.StepFailed, reason: ReasonTemplateError, result: err.Error()}
+	}
+	prompt = workflow.AppendFailureBlock(prompt, rc.Step.Attempt, rc.LastFailure)
+
+	adapter, ok := r.deps.Agents.Get(sel.Agent)
+	if !ok {
+		tr.Note("error", map[string]any{"error": "agent " + sel.Agent + " is not registered"})
+		return stepOutcome{state: store.StepFailed, reason: ReasonAgentUnavailable}
+	}
+
+	timeout := resolveTimeout(env.step, env.wf.Defaults, r.deps.Config())
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	handle, err := adapter.Start(runCtx, agent.RunSpec{
+		Prompt:         prompt,
+		WorkDir:        env.task.WorktreePath,
+		Model:          sel.Model,
+		Effort:         sel.Effort,
+		PermissionMode: resolvePermission(env.step, env.wf.Defaults),
+		OnInput:        resolveInputPolicy(env.step, env.wf.Defaults),
+	})
+	if err != nil {
+		tr.Note("error", map[string]any{"error": err.Error()})
+		env.log.Error("start agent", "agent", sel.Agent, "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonAgentUnavailable}
+	}
+	pid := handle.PID()
+	started := time.Now()
+	run.PID = &pid
+	run.ProcStartedAt = &started
+	if err := r.deps.Store.UpdateStepRun(r.persistCtx(), run); err != nil {
+		env.log.Error("journal agent pid", "error", err)
+	}
+	env.log.Info("agent step running",
+		"agent", sel.Agent, "pid", pid, "model", sel.Model, "effort", sel.Effort)
+
+	tail := newOutputTail(outputTailLines)
+	for ev := range handle.Events() {
+		tr.Raw(ev.Raw)
+		if ev.Type == agent.EventOutput && ev.Text != "" {
+			tail.add(ev.Text)
+		}
+	}
+	res, waitErr := handle.Wait()
+
+	outcome := classifyAgent(ctx, runCtx, &res, waitErr)
+	outcome.exitCode = &res.ExitCode
+	outcome.result = res.ResultText
+	if outcome.result == "" {
+		outcome.result = res.ErrorMessage
+	}
+	outcome.output = tail.String()
+	if res.InputTokens > 0 || res.OutputTokens > 0 {
+		run.InputTokens, run.OutputTokens = &res.InputTokens, &res.OutputTokens
+	}
+	run.CostUSD = res.CostUSD
+	return outcome
+}
+
+// classifyAgent maps a finished agent run to its attempt state and reason:
+// §7.1 requires exit 0 and a non-error terminal result.
+func classifyAgent(daemonCtx, runCtx context.Context, res *agent.RunResult, waitErr error) stepOutcome {
+	switch {
+	case daemonCtx.Err() != nil:
+		return stepOutcome{state: store.StepInterrupted, reason: ReasonInterrupted}
+	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+		return stepOutcome{state: store.StepFailed, reason: ReasonTimeout}
+	case waitErr != nil:
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	case res.ExitCode != 0:
+		return stepOutcome{state: store.StepFailed, reason: ReasonNonzeroExit}
+	case res.IsError:
+		return stepOutcome{state: store.StepFailed, reason: ReasonAgentError}
+	default:
+		return stepOutcome{state: store.StepSucceeded}
+	}
+}
+
+// runCommandStep runs one command attempt in the worktree (§8.3, §8.5).
+func (r *Runner) runCommandStep(
+	ctx context.Context, env *stepEnv, rc workflow.RenderContext, tr *transcript,
+) stepOutcome {
+	script, err := workflow.Render("run", env.step.Run, rc)
+	if err != nil {
+		tr.Note("error", map[string]any{"error": err.Error()})
+		return stepOutcome{state: store.StepFailed, reason: ReasonTemplateError, result: err.Error()}
+	}
+	timeout := resolveTimeout(env.step, env.wf.Defaults, r.deps.Config())
+	return r.runShellCommand(ctx, env, tr, shellCommand{
+		phase:    "run",
+		script:   script,
+		shellPin: env.step.Shell,
+		env:      commandEnv(rc, env.step.Env),
+		workDir:  env.task.WorktreePath,
+		timeout:  timeout,
+	})
+}
+
+// runCheck runs a step's `check` command after its body succeeded; a
+// non-zero check fails the attempt (§7.1).
+func (r *Runner) runCheck(
+	ctx context.Context, env *stepEnv, rc workflow.RenderContext, tr *transcript, outcome stepOutcome,
+) stepOutcome {
+	script, err := workflow.Render("check", env.step.Check, rc)
+	if err != nil {
+		tr.Note("error", map[string]any{"error": err.Error()})
+		return stepOutcome{state: store.StepFailed, reason: ReasonTemplateError, result: err.Error()}
+	}
+	checkOutcome := r.runShellCommand(ctx, env, tr, shellCommand{
+		phase:    "check",
+		script:   script,
+		shellPin: env.step.Shell,
+		env:      commandEnv(rc, env.step.Env),
+		workDir:  env.task.WorktreePath,
+		timeout:  resolveCheckTimeout(env.step, r.deps.Config()),
+	})
+	outcome.checkExitCode = checkOutcome.exitCode
+	if checkOutcome.state == store.StepSucceeded {
+		return outcome
+	}
+	// The check's failure replaces the step's outcome, but the step's own
+	// result summary is what later steps and the retry block care about.
+	outcome.state = checkOutcome.state
+	outcome.reason = checkFailureReason(checkOutcome.reason)
+	outcome.output = checkOutcome.output
+	return outcome
+}
+
+// checkFailureReason keeps interruption and timeout distinguishable while
+// mapping an ordinary non-zero check to its own reason.
+func checkFailureReason(reason string) string {
+	if reason == ReasonNonzeroExit {
+		return ReasonCheckFailed
+	}
+	return reason
+}
+
+// shellCommand is one rendered command to run under a shell.
+type shellCommand struct {
+	phase    string // "run" | "check" — tags transcript lines
+	script   string
+	shellPin string // step's `shell:` pin; empty = platform default
+	env      []string
+	workDir  string
+	timeout  time.Duration
+}
+
+// runShellCommand executes one command, streaming its output into the
+// transcript and tree-killing it on timeout or shutdown.
+func (r *Runner) runShellCommand(ctx context.Context, env *stepEnv, tr *transcript, sc shellCommand) stepOutcome {
+	sh, err := r.deps.Shells.For(sc.shellPin)
+	if err != nil {
+		tr.Note("error", map[string]any{"error": err.Error()})
+		env.log.Error("resolve shell", "shell", sc.shellPin, "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonShellUnavailable, result: err.Error()}
+	}
+	argv := sh.command(sc.script)
+	tr.Note("command_started", map[string]any{
+		"phase": sc.phase, "shell": sh.Name, "command": sc.script, "cwd": sc.workDir,
+	})
+
+	runCtx, cancel := context.WithTimeout(ctx, sc.timeout)
+	defer cancel()
+
+	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the workflow author's own command, by design (§9.4)
+	cmd.Dir = sc.workDir
+	cmd.Env = sc.env
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError, result: err.Error()}
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError, result: err.Error()}
+	}
+	proc, err := procx.Start(cmd)
+	if err != nil {
+		tr.Note("error", map[string]any{"error": err.Error()})
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError, result: err.Error()}
+	}
+	defer proc.Release()
+
+	// Tree-kill on timeout or daemon shutdown: killing only the shell would
+	// leave its children running in the worktree.
+	killed := make(chan struct{})
+	var killOnce sync.Once
+	go func() {
+		select {
+		case <-runCtx.Done():
+			killOnce.Do(func() { _ = proc.Kill() })
+		case <-killed:
+		}
+	}()
+	defer close(killed)
+
+	tail := newOutputTail(outputTailLines)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	stream := func(rd io.Reader, name string) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(rd)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			tr.Output(sc.phase, name, line)
+			mu.Lock()
+			tail.add(line)
+			mu.Unlock()
+		}
+	}
+	wg.Add(2)
+	go stream(stdout, "stdout")
+	go stream(stderr, "stderr")
+	wg.Wait()
+	waitErr := cmd.Wait()
+
+	exitCode := exitCodeOf(waitErr)
+	outcome := stepOutcome{exitCode: &exitCode, output: tail.String(), result: tail.String()}
+	switch {
+	case ctx.Err() != nil:
+		outcome.state, outcome.reason = store.StepInterrupted, ReasonInterrupted
+	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+		outcome.state, outcome.reason = store.StepFailed, ReasonTimeout
+	case exitCode != 0:
+		outcome.state, outcome.reason = store.StepFailed, ReasonNonzeroExit
+	default:
+		outcome.state = store.StepSucceeded
+	}
+	return outcome
+}
+
+// exitCodeOf extracts the process exit code from Wait's error.
+func exitCodeOf(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+// commandEnv builds the environment of a command or check step: the
+// daemon's own environment, the §8.5 vincent variables, then the step's
+// declared `env` (which wins, so a workflow can override anything).
+func commandEnv(rc workflow.RenderContext, stepEnvVars map[string]string) []string {
+	out := os.Environ()
+	out = append(out, workflow.Env(rc)...)
+	for k, v := range stepEnvVars {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -1,0 +1,92 @@
+package taskrun
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// transcript is one attempt's transcript file (spec §12.2:
+// {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl). Agent
+// stream lines are written verbatim so the file stays replayable; vincent's
+// own annotations are namespaced `vincent.*` (phase 1 decision).
+type transcript struct {
+	path string
+	mu   sync.Mutex
+	f    *os.File
+}
+
+// openTranscript creates the transcript file for one attempt.
+func openTranscript(dataDir string, taskID int64, stepIndex, attempt int) (*transcript, error) {
+	dir := filepath.Join(dataDir, "transcripts", strconv.FormatInt(taskID, 10))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create transcript dir: %w", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%d-%d.jsonl", stepIndex, attempt))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create transcript: %w", err)
+	}
+	return &transcript{path: path, f: f}, nil
+}
+
+// Path is the transcript's location, recorded on the StepRun.
+func (t *transcript) Path() string { return t.path }
+
+// Raw appends a verbatim stream line.
+func (t *transcript) Raw(line []byte) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, _ = t.f.Write(append(line, '\n'))
+}
+
+// Note appends a namespaced vincent annotation.
+func (t *transcript) Note(kind string, fields map[string]any) {
+	entry := make(map[string]any, len(fields)+2)
+	for k, v := range fields {
+		entry[k] = v
+	}
+	entry["type"] = "vincent." + kind
+	entry["ts"] = time.Now().UTC().Format(time.RFC3339)
+	b, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	t.Raw(b)
+}
+
+// Output appends one line of process output, tagged with its stream and the
+// phase that produced it (the step's own command, or its check).
+func (t *transcript) Output(phase, stream, text string) {
+	t.Note("output", map[string]any{"phase": phase, "stream": stream, "text": text})
+}
+
+// Close closes the file.
+func (t *transcript) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_ = t.f.Close()
+}
+
+// outputTail keeps the last n lines of a process's output for the step's
+// result summary (§8.4 `.Steps`) and for the retry failure block (§8.4).
+type outputTail struct {
+	limit int
+	lines []string
+}
+
+func newOutputTail(limit int) *outputTail { return &outputTail{limit: limit} }
+
+func (o *outputTail) add(line string) {
+	o.lines = append(o.lines, line)
+	if len(o.lines) > o.limit {
+		o.lines = o.lines[len(o.lines)-o.limit:]
+	}
+}
+
+func (o *outputTail) String() string { return strings.Join(o.lines, "\n") }

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -1,0 +1,174 @@
+// Package taskstate is the task lifecycle state machine of spec §6. It is
+// pure: no persistence, no I/O. Both the API (which rejects an invalid
+// action with 409) and the engine (which drives a task through its steps)
+// consult it, so there is exactly one definition of what may happen next.
+package taskstate
+
+import "sort"
+
+// State is a task lifecycle state (spec §6).
+type State string
+
+// Task lifecycle states (spec §6).
+const (
+	Queued        State = "queued"
+	Running       State = "running"
+	AwaitingGate  State = "awaiting_gate"
+	AwaitingInput State = "awaiting_input"
+	Blocked       State = "blocked"
+	Paused        State = "paused"
+	Done          State = "done"
+	Aborted       State = "aborted"
+	Archived      State = "archived"
+)
+
+// All lists every state, in the order §6 documents them.
+var All = []State{
+	Queued, Running, AwaitingGate, AwaitingInput,
+	Blocked, Paused, Done, Aborted, Archived,
+}
+
+// Valid reports whether s is a known state.
+func Valid(s State) bool {
+	for _, v := range All {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// HoldsSlot reports whether a task in this state occupies a concurrency slot
+// (spec §6, §11). `awaiting_input` does: its agent process is alive, idle on
+// its stdin (§7.4).
+func HoldsSlot(s State) bool { return s == Running || s == AwaitingInput }
+
+// Terminal reports whether no further transition is possible.
+func Terminal(s State) bool { return s == Archived }
+
+// Action is something that moves a task between states: either a human
+// action (§6) or an engine event.
+type Action string
+
+// Human actions (spec §6). These are the actions the API exposes and the
+// TUI offers; every one is rejected with 409 outside its valid states.
+const (
+	Cancel  Action = "cancel"
+	Pause   Action = "pause"
+	Resume  Action = "resume"
+	Retry   Action = "retry"
+	Skip    Action = "skip"
+	Answer  Action = "answer"
+	Approve Action = "approve"
+	Reject  Action = "reject"
+	Archive Action = "archive"
+)
+
+// Engine events. They are transitions the daemon performs while running a
+// task, and go through the same table so no state change bypasses §6.
+const (
+	// Admit is the scheduler starting a queued task (§11).
+	Admit Action = "admit"
+	// Gate is the engine reaching a manual step (§7.1).
+	Gate Action = "gate"
+	// RequestInput is an agent asking for input mid-step (§7.4).
+	RequestInput Action = "request_input"
+	// Complete is the last step succeeding (§6).
+	Complete Action = "complete"
+	// Fail is a step failing with retries exhausted (§7.2).
+	Fail Action = "fail"
+	// Interrupt is a crash or graceful stop mid-step: the attempt does not
+	// consume a retry and the task is re-queued (§12.4).
+	Interrupt Action = "interrupt"
+	// Park is a requested pause taking effect at the step boundary (§6).
+	Park Action = "park"
+)
+
+// humanActions is the set of actions a client may invoke, in the order §6
+// lists them.
+var humanActions = []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
+
+// Human reports whether a is a human action rather than an engine event.
+func Human(a Action) bool {
+	for _, h := range humanActions {
+		if h == a {
+			return true
+		}
+	}
+	return false
+}
+
+// Transition is the outcome of applying an action.
+type Transition struct {
+	// To is the resulting state.
+	To State
+	// Deferred marks an action accepted now that takes effect later:
+	// pausing a running task lets the current step finish, and the engine
+	// applies Park at the step boundary (§6).
+	Deferred bool
+}
+
+// table is the §6 transition table: action → valid from-state → outcome.
+// Every allowed transition in vincent appears here exactly once.
+var table = map[Action]map[State]Transition{
+	Cancel: {
+		Queued:        {To: Aborted},
+		Running:       {To: Aborted},
+		AwaitingInput: {To: Aborted},
+		AwaitingGate:  {To: Aborted},
+		Blocked:       {To: Aborted},
+		Paused:        {To: Aborted},
+	},
+	Pause: {
+		Queued: {To: Paused},
+		// A running task finishes its current step first; Park completes it.
+		Running: {To: Running, Deferred: true},
+	},
+	Resume:  {Paused: {To: Queued}},
+	Retry:   {Blocked: {To: Queued}},
+	Skip:    {Blocked: {To: Queued}, AwaitingGate: {To: Queued}},
+	Answer:  {AwaitingInput: {To: Running}},
+	Approve: {AwaitingGate: {To: Queued}},
+	Reject:  {AwaitingGate: {To: Blocked}},
+	Archive: {Done: {To: Archived}, Aborted: {To: Archived}},
+
+	Admit:        {Queued: {To: Running}},
+	Gate:         {Running: {To: AwaitingGate}},
+	RequestInput: {Running: {To: AwaitingInput}},
+	Complete:     {Running: {To: Done}},
+	Fail:         {Running: {To: Blocked}, AwaitingInput: {To: Blocked}},
+	Interrupt:    {Running: {To: Queued}, AwaitingInput: {To: Queued}},
+	Park:         {Running: {To: Paused}},
+}
+
+// Next returns the transition for applying a to a task in state from. ok is
+// false when the action is not valid from that state — the caller answers
+// 409 with the current state (§13.1).
+func Next(from State, a Action) (Transition, bool) {
+	t, ok := table[a][from]
+	return t, ok
+}
+
+// Can reports whether action a is valid from state from.
+func Can(from State, a Action) bool {
+	_, ok := Next(from, a)
+	return ok
+}
+
+// CanSetPriority reports whether priority may be changed in this state
+// (§6: queued and paused only). Priority is not a transition — it reorders
+// scheduler admission without changing state.
+func CanSetPriority(s State) bool { return s == Queued || s == Paused }
+
+// HumanActionsFrom lists the human actions valid from a state, sorted so
+// clients render a stable action bar (§15).
+func HumanActionsFrom(s State) []Action {
+	var out []Action
+	for _, a := range humanActions {
+		if Can(s, a) {
+			out = append(out, a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -1,0 +1,205 @@
+package taskstate
+
+import (
+	"slices"
+	"testing"
+)
+
+// allActions is every action the table may contain, human and engine.
+var allActions = []Action{
+	Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive,
+	Admit, Gate, RequestInput, Complete, Fail, Interrupt, Park,
+}
+
+// wantTransitions is the §6 transition table restated independently of the
+// implementation: every (state, action) pair that must be allowed, and the
+// state it must produce. Every pair not listed here must be rejected.
+var wantTransitions = map[State]map[Action]State{
+	Queued: {
+		Cancel: Aborted,
+		Pause:  Paused,
+		Admit:  Running,
+	},
+	Running: {
+		Cancel:       Aborted,
+		Pause:        Running, // deferred to the step boundary
+		Gate:         AwaitingGate,
+		RequestInput: AwaitingInput,
+		Complete:     Done,
+		Fail:         Blocked,
+		Interrupt:    Queued,
+		Park:         Paused,
+	},
+	AwaitingGate: {
+		Cancel:  Aborted,
+		Skip:    Queued,
+		Approve: Queued,
+		Reject:  Blocked,
+	},
+	AwaitingInput: {
+		Cancel:    Aborted,
+		Answer:    Running,
+		Fail:      Blocked,
+		Interrupt: Queued,
+	},
+	Blocked: {
+		Cancel: Aborted,
+		Retry:  Queued,
+		Skip:   Queued,
+	},
+	Paused: {
+		Cancel: Aborted,
+		Resume: Queued,
+	},
+	Done: {
+		Archive: Archived,
+	},
+	Aborted: {
+		Archive: Archived,
+	},
+	Archived: {},
+}
+
+// TestTransitionTable walks every state × every action, so neither an added
+// transition nor a removed one can slip through unnoticed.
+func TestTransitionTable(t *testing.T) {
+	for _, from := range All {
+		for _, a := range allActions {
+			tr, ok := Next(from, a)
+			want, wantOK := wantTransitions[from][a]
+			switch {
+			case wantOK && !ok:
+				t.Errorf("Next(%s, %s) rejected; want %s", from, a, want)
+			case !wantOK && ok:
+				t.Errorf("Next(%s, %s) = %s; want rejected", from, a, tr.To)
+			case wantOK && tr.To != want:
+				t.Errorf("Next(%s, %s) = %s; want %s", from, a, tr.To, want)
+			}
+			if ok != Can(from, a) {
+				t.Errorf("Can(%s, %s) disagrees with Next", from, a)
+			}
+		}
+	}
+}
+
+// TestEveryStateCoveredByTable guards against a state added to All but
+// forgotten in the expectations above.
+func TestEveryStateCoveredByTable(t *testing.T) {
+	for _, s := range All {
+		if _, ok := wantTransitions[s]; !ok {
+			t.Errorf("state %s has no expectations", s)
+		}
+	}
+	if len(wantTransitions) != len(All) {
+		t.Errorf("expectations cover %d states, All has %d", len(wantTransitions), len(All))
+	}
+}
+
+func TestPauseOfRunningIsDeferred(t *testing.T) {
+	tr, ok := Next(Running, Pause)
+	if !ok || !tr.Deferred || tr.To != Running {
+		t.Fatalf("Next(running, pause) = %+v, %v; want a deferred no-op transition", tr, ok)
+	}
+	// Every other transition takes effect immediately.
+	for _, from := range All {
+		for _, a := range allActions {
+			if from == Running && a == Pause {
+				continue
+			}
+			if tr, ok := Next(from, a); ok && tr.Deferred {
+				t.Errorf("Next(%s, %s) is deferred; only pausing a running task is", from, a)
+			}
+		}
+	}
+}
+
+func TestTerminalAndSlots(t *testing.T) {
+	for _, s := range All {
+		if Terminal(s) != (s == Archived) {
+			t.Errorf("Terminal(%s) = %v", s, Terminal(s))
+		}
+		wantSlot := s == Running || s == AwaitingInput
+		if HoldsSlot(s) != wantSlot {
+			t.Errorf("HoldsSlot(%s) = %v, want %v", s, HoldsSlot(s), wantSlot)
+		}
+	}
+	// A terminal state accepts nothing.
+	for _, a := range allActions {
+		if Can(Archived, a) {
+			t.Errorf("Can(archived, %s) = true; archived is terminal", a)
+		}
+	}
+	// Every state that holds a slot must have a way to give it back.
+	for _, s := range All {
+		if !HoldsSlot(s) {
+			continue
+		}
+		if !Can(s, Interrupt) || !Can(s, Cancel) {
+			t.Errorf("state %s holds a slot but cannot be interrupted or canceled", s)
+		}
+	}
+}
+
+func TestHumanActionsFrom(t *testing.T) {
+	tests := map[State][]Action{
+		Queued:        {Cancel, Pause},
+		Running:       {Cancel, Pause},
+		AwaitingGate:  {Approve, Cancel, Reject, Skip},
+		AwaitingInput: {Answer, Cancel},
+		Blocked:       {Cancel, Retry, Skip},
+		Paused:        {Cancel, Resume},
+		Done:          {Archive},
+		Aborted:       {Archive},
+		Archived:      nil,
+	}
+	for state, want := range tests {
+		got := HumanActionsFrom(state)
+		if !slices.Equal(got, want) {
+			t.Errorf("HumanActionsFrom(%s) = %v, want %v", state, got, want)
+		}
+		if !slices.IsSorted(got) {
+			t.Errorf("HumanActionsFrom(%s) = %v, want sorted output", state, got)
+		}
+	}
+}
+
+// TestHumanClassification pins which actions clients may invoke: an engine
+// event must never be reachable through the API.
+func TestHumanClassification(t *testing.T) {
+	human := []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
+	engine := []Action{Admit, Gate, RequestInput, Complete, Fail, Interrupt, Park}
+	for _, a := range human {
+		if !Human(a) {
+			t.Errorf("Human(%s) = false", a)
+		}
+	}
+	for _, a := range engine {
+		if Human(a) {
+			t.Errorf("Human(%s) = true; engine events are not client actions", a)
+		}
+	}
+	if len(human)+len(engine) != len(allActions) {
+		t.Errorf("action classification covers %d actions, allActions has %d",
+			len(human)+len(engine), len(allActions))
+	}
+}
+
+func TestCanSetPriority(t *testing.T) {
+	for _, s := range All {
+		want := s == Queued || s == Paused
+		if CanSetPriority(s) != want {
+			t.Errorf("CanSetPriority(%s) = %v, want %v", s, CanSetPriority(s), want)
+		}
+	}
+}
+
+func TestValid(t *testing.T) {
+	for _, s := range All {
+		if !Valid(s) {
+			t.Errorf("Valid(%s) = false", s)
+		}
+	}
+	if Valid("nonsense") {
+		t.Error(`Valid("nonsense") = true`)
+	}
+}


### PR DESCRIPTION
PR B of the phase 2 plan (PR A merged in #14).

## What lands

**T2.3 — Task state machine**
- `internal/taskstate`: pure §6 transition table (`Can`/`Next`), covering human actions *and* engine events (admit, gate, request_input, complete, fail, interrupt, park), so no state change anywhere bypasses §6.
- `store.TransitionTask`: compare-and-swap on the from-state, writing the state change **and** its `task.state_changed` event in one transaction. A conflicted transition rolls back both — an event never exists without the change that produced it, which is what SSE `Last-Event-ID` resume will depend on.
- `StateConflictError` carries the state actually found, ready for T2.6's 409s.
- §6 timestamp bookkeeping (`started_at` on first run, `finished_at` on done/aborted, `archived_at` on archive) lives in the transition, and leaving `blocked` always clears `block_reason`.
- Task creation snapshots the registry entry the workflow resolved to, replacing T1.8's hardcoded placeholder.

**T2.4 — Step executors**
- Actor per admission walks the snapshot; it exits whenever the task stops holding its slot (gate, block, pause), per the phase 2 decision.
- **Agent steps**: rendered prompt (+ §8.4 failure block on retries), §8.6-resolved agent/model/effort recorded on the StepRun, usage/cost, PID journaled before the run, tree-kill on timeout or shutdown.
- **Command steps**: platform shell (`/bin/sh` / `pwsh`→`powershell`), `shell:` pin honored — a pinned shell that is missing fails the step with `shell_unavailable` rather than silently falling back; §8.5 environment; output streamed to the transcript and tailed for `.Steps[…].Result`.
- **Manual gates**: row written on entry, `gate.waiting` emitted, task parks in `awaiting_gate` and the actor exits.
- Checks, per-step timeouts, and the retry loop honoring `max_retries` (interruptions consume no retry, §7.2). Every attempt keeps its own transcript file.

## Behavior change

An interrupted step now **re-queues** the task (§12.4) instead of blocking it; the M1 test that asserted `blocked/interrupted` was updated. The *startup* sweep is still T1.8's blocking one — T2.8 replaces it.

## Carried forward (noted in tasks.md)

The retry budget counts every failed attempt of a step; `CountStepAttempts` already takes a `since` cursor so T2.6's human `retry` can reset it. The live-run registry currently carries only the pause flag — the agent handle joins it in T2.6, when cancel/answer need to reach the live process.

## Verification

`go run mage.go lint test` clean; full suite green under `-race` (273 tests). New: exhaustive FSM table test (9 states × 16 actions), transition/event atomicity tests, §8.6 precedence + agent-scoped inheritance table, and engine integration tests driving the real runner against real git repos and the fake agent — multi-step run, gate parking, retry-then-blocked, check failure, timeout kill, template error before spawn, `.Steps` chaining, and the failure block reaching a retry prompt. Command-step scripts are written per platform, so the same tests exercise sh and pwsh across the CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)