### PR TITLE
feat(tui): PR H — TUI foundation (T3.1)

### DIFF
--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,7 +19,7 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 8 tasks | 0/8 | ⬜ not started |
+| 3 — TUI (M3) | 8 tasks | 0/8 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
 | **Total** | | **25/39** | |
 
@@ -285,7 +285,20 @@ Milestone acceptance (§19 M2): a multi-step workflow (gate + command publish) r
 
 Milestone acceptance (§19 M3): the full loop — register project, author workflow, run 3 parallel tasks, approve a gate, archive — without leaving the TUI.
 
-- [ ] **T3.1 — TUI foundation.** Bubble Tea shell; API client (token + `daemon.json` discovery); daemon auto-start when unreachable (§12.1); `/v1/events` subscription driving re-render; view routing, global keys, help overlay (§15).
+**Phase 3 decisions (grill session, 2026-08-08):**
+
+- *Delivery:* 7 PRs — H: T3.1 foundation · I: T3.2 board · J: T3.3 detail timeline/tail · K: T3.4 detail diff/actions · L: T3.5 new-task flow · M: T3.6+T3.7 projects/workflows/daemon views · N: T3.8 gate. Each independently green in CI; tasks.md updated per PR; each PR opens with its own grill block (Phase 2 pattern).
+- *Framework:* Bubble Tea **v2** (`charm.land/bubbletea/v2` + `charm.land/bubbles/v2` + `charm.land/lipgloss/v2`) — greenfield TUI, v2 is the stable, maintained line; choosing it now avoids a v1→v2 migration later. No v1-only third-party widgets (task table = bubbles v2).
+- *API client:* new shared `internal/apiclient` — typed methods over §13.2, token + `daemon.json` discovery, SSE subscriber with `Last-Event-ID` reconnect and §13.3 snapshot-then-stream catch-up. The client owns its wire structs (server DTOs stay unexported); drift can't ship unnoticed because client and server live in one binary and the client is integration-tested against the real handlers. T4.2's CLI subcommands reuse this package.
+- *Testing:* TUI covered by pure Update/View unit tests (feed msgs, assert on state + rendered strings — no terminal emulation, deterministic on the 3-OS matrix); apiclient integration-tested against an `httptest` server running the real API; daemon auto-start covered by binary e2e like the Phase 1 daemon tests. No teatest/golden frames. Manual polish checks stay in the T3.8 gate.
+
+**PR H decisions (T3.1; grill session, 2026-08-08):**
+
+- *Auto-start UX:* bare `vincent` always enters the TUI immediately; a connect state runs `daemon.StartDetached()` + the phase-1 health poll as a `tea.Cmd` behind a "starting daemon…" screen; failure = in-TUI error screen (daemon log path, `r` retry, `q` quit). The same state doubles as the reconnect screen if the daemon dies mid-session.
+- *Shell shape:* one root model owning view routing (`1..6`), global keys, and the `?` help overlay; views are sub-models. PR H ships stub views for board/detail/new-task/projects/workflows/daemon; view-specific action keys land with their views in later PRs.
+- *SSE wiring:* apiclient subscription goroutine → `Program.Send` msgs; the home stub renders connection state + the last-received event line, which is how the done-when ("reflects an externally-made state change live") is demonstrated and unit-tested.
+
+- [~] **T3.1 — TUI foundation.** Bubble Tea shell; API client (token + `daemon.json` discovery); daemon auto-start when unreachable (§12.1); `/v1/events` subscription driving re-render; view routing, global keys, help overlay (§15).
   *Done when:* TUI connects, auto-starts a stopped daemon, and reflects an externally-made state change live.
 - [ ] **T3.2 — Board view.** Task table (id, project, title, state color-coded, step k/n, elapsed, cost), filters, scheduler-order sort; header with daemon status, agent availability, running/cap counts, needs-attention count; needs-attention tasks (`awaiting_input`/`awaiting_gate`/`blocked`) pinned on top with a distinct badge; terminal bell on `task.awaiting_input` (§7.4, §15).
   *Done when:* board renders live updates from SSE without polling; filters work; an awaiting-input fake-agent task visibly alerts (pin + badge + bell).

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 8 tasks | 0/8 | 🟡 in progress |
+| 3 — TUI (M3) | 8 tasks | 1/8 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **25/39** | |
+| **Total** | | **26/39** | |
 
 ---
 
@@ -298,8 +298,8 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
 - *Shell shape:* one root model owning view routing (`1..6`), global keys, and the `?` help overlay; views are sub-models. PR H ships stub views for board/detail/new-task/projects/workflows/daemon; view-specific action keys land with their views in later PRs.
 - *SSE wiring:* apiclient subscription goroutine → `Program.Send` msgs; the home stub renders connection state + the last-received event line, which is how the done-when ("reflects an externally-made state change live") is demonstrated and unit-tested.
 
-- [~] **T3.1 — TUI foundation.** Bubble Tea shell; API client (token + `daemon.json` discovery); daemon auto-start when unreachable (§12.1); `/v1/events` subscription driving re-render; view routing, global keys, help overlay (§15).
-  *Done when:* TUI connects, auto-starts a stopped daemon, and reflects an externally-made state change live.
+- [x] **T3.1 — TUI foundation.** Bubble Tea shell; API client (token + `daemon.json` discovery); daemon auto-start when unreachable (§12.1); `/v1/events` subscription driving re-render; view routing, global keys, help overlay (§15). ✓ 2026-08-08
+  *Done when:* TUI connects, auto-starts a stopped daemon, and reflects an externally-made state change live. *(Verified: PR #22 matrix green on ubuntu/macos/windows — apiclient integration tests against the real handlers (live delivery, disconnect + Last-Event-ID resume with cursor assert, server-side type filter, auth envelope, SSE spec framing, discovery); TUI Update/View unit tests (auto-start state machine, failure + retry, routing, help, quit, event line, reconnect); `TestAutoStartRealDaemon` e2e drives the built binary probe-miss → auto-start → live re-render on an external `project.created` → graceful stop.)*
 - [ ] **T3.2 — Board view.** Task table (id, project, title, state color-coded, step k/n, elapsed, cost), filters, scheduler-order sort; header with daemon status, agent availability, running/cap counts, needs-attention count; needs-attention tasks (`awaiting_input`/`awaiting_gate`/`blocked`) pinned on top with a distinct badge; terminal bell on `task.awaiting_input` (§7.4, §15).
   *Done when:* board renders live updates from SSE without polling; filters work; an awaiting-input fake-agent task visibly alerts (pin + badge + bell).
 - [ ] **T3.3 — Task detail: timeline & tail.** Step timeline with attempts/durations/tokens/cost; live output tail with follow mode; scrollback into past transcripts via ranged transcript endpoint.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@ require (
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
-	charm.land/lipgloss/v2 v2.0.3 // indirect
+	charm.land/bubbles/v2 v2.1.1 // indirect
+	charm.land/bubbletea/v2 v2.0.8 // indirect
+	charm.land/lipgloss/v2 v2.0.5 // indirect
 	codeberg.org/chavacava/garif v0.2.0 // indirect
 	codeberg.org/polyfloyd/go-errorlint v1.9.0 // indirect
 	dev.gaijin.team/go/exhaustruct/v4 v4.0.0 // indirect
@@ -57,7 +59,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
@@ -142,7 +144,7 @@ require (
 	github.com/matoous/godox v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
+	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mgechev/revive v1.15.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,14 @@
 4d63.com/gocheckcompilerdirectives v1.3.0/go.mod h1:ofsJ4zx2QAuIP/NO/NAh1ig6R1Fb18/GI7RVMwz7kAY=
 4d63.com/gochecknoglobals v0.2.2 h1:H1vdnwnMaZdQW/N+NrkT1SZMTBmcwHe9Vq8lJcYYTtU=
 4d63.com/gochecknoglobals v0.2.2/go.mod h1:lLxwTQjL5eIesRbvnzIP3jZtG140FnTdz+AlMa+ogt0=
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
+charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
+charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
+charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -135,6 +141,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 h1:OqDqxQZliC7C8adA7KjelW3OjtAxREfeHkNcd66wpeI=
 github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318/go.mod h1:Y6kE2GzHfkyQQVCSL9r2hwokSrIlHGzZG+71+wDYSZI=
+github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 h1:3FmWoGNWK4STvqg0O0Aeav2T7rodWJAPeF0QpH+8gFw=
+github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
@@ -437,6 +445,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
+github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgechev/revive v1.15.0 h1:vJ0HzSBzfNyPbHKolgiFjHxLek9KUijhqh42yGoqZ8Q=

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -1,0 +1,276 @@
+package apiclient_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+const testToken = "test-token"
+
+// noteTimeout bounds one expected stream delivery; loopback is fast, CI is
+// not always.
+const noteTimeout = 10 * time.Second
+
+// harness is a real store wired to a real broker behind the real handlers —
+// the client is exercised against the same server the daemon runs (Phase 3
+// decision: client-owned wire types, drift caught here).
+type harness struct {
+	ts        *httptest.Server
+	st        *store.Store
+	projectID int64
+	taskID    int64
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	broker := events.New()
+	t.Cleanup(broker.Close)
+	st.SetEventHook(broker.Publish)
+
+	ctx := context.Background()
+	p := &store.Project{Name: "client", Path: "/nowhere", DefaultBranch: "main"}
+	if err := st.CreateProject(ctx, p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	task := &store.Task{
+		ProjectID: p.ID, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
+		BaseBranch: "main", BranchName: "b", State: store.TaskQueued,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	s := api.New(api.Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+		Broker:      broker,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return &harness{ts: ts, st: st, projectID: p.ID, taskID: task.ID}
+}
+
+// append writes one durable event; the store hook publishes it to the broker.
+func (h *harness) append(t *testing.T, evType string) *store.Event {
+	t.Helper()
+	e := &store.Event{Type: evType, TaskID: &h.taskID, ProjectID: &h.projectID}
+	if err := h.st.AppendEvent(context.Background(), e); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	return e
+}
+
+func (h *harness) client() *apiclient.Client {
+	return apiclient.New(h.ts.URL, testToken)
+}
+
+// testStreamOptions keeps reconnect pacing fast enough for tests.
+func testStreamOptions() apiclient.StreamOptions {
+	return apiclient.StreamOptions{
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+	}
+}
+
+func nextNote(t *testing.T, ch <-chan apiclient.Note) apiclient.Note {
+	t.Helper()
+	select {
+	case n, ok := <-ch:
+		if !ok {
+			t.Fatal("note channel closed unexpectedly")
+		}
+		return n
+	case <-time.After(noteTimeout):
+		t.Fatal("timed out waiting for a stream note")
+		return nil
+	}
+}
+
+func TestHealth(t *testing.T) {
+	h := newHarness(t)
+	got, err := h.client().Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if got.Status != "ok" {
+		t.Errorf("Health.Status = %q, want %q", got.Status, "ok")
+	}
+}
+
+func TestStreamEventsBadTokenSurfacesEnvelope(t *testing.T) {
+	h := newHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := apiclient.New(h.ts.URL, "wrong").StreamEvents(ctx, testStreamOptions())
+	n := nextNote(t, ch)
+	d, ok := n.(apiclient.DisconnectedNote)
+	if !ok {
+		t.Fatalf("first note = %T, want DisconnectedNote", n)
+	}
+	var apiErr *apiclient.Error
+	if !errors.As(d.Err, &apiErr) {
+		t.Fatalf("DisconnectedNote.Err = %v, want *apiclient.Error", d.Err)
+	}
+	if apiErr.Code != "unauthorized" || apiErr.Status != http.StatusUnauthorized {
+		t.Errorf("error = code %q status %d, want unauthorized/401", apiErr.Code, apiErr.Status)
+	}
+}
+
+// TestStreamEventsLiveResumeAcrossReconnect is the §13.3 client contract:
+// live delivery, a dropped connection surfaces as a note, and the automatic
+// reconnect resumes from the last seen event id so nothing durable is lost.
+func TestStreamEventsLiveResumeAcrossReconnect(t *testing.T) {
+	h := newHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := h.client().StreamEvents(ctx, testStreamOptions())
+	if _, ok := nextNote(t, ch).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note is not ConnectedNote")
+	}
+
+	ev1 := h.append(t, "task.state_changed")
+	n := nextNote(t, ch)
+	en, ok := n.(apiclient.EventNote)
+	if !ok {
+		t.Fatalf("note = %T, want EventNote", n)
+	}
+	if en.Event.ID != ev1.ID || en.Event.Type != "task.state_changed" {
+		t.Errorf("event = #%d %q, want #%d task.state_changed", en.Event.ID, en.Event.Type, ev1.ID)
+	}
+	if en.Event.TaskID == nil || *en.Event.TaskID != h.taskID {
+		t.Errorf("event task id = %v, want %d", en.Event.TaskID, h.taskID)
+	}
+
+	// Drop every established connection; the subscription must notice and
+	// reconnect on its own, resuming after ev1.
+	h.ts.CloseClientConnections()
+	ev2 := h.append(t, "step.started")
+
+	sawDisconnect := false
+	for {
+		switch n := nextNote(t, ch).(type) {
+		case apiclient.DisconnectedNote:
+			sawDisconnect = true
+		case apiclient.ConnectedNote:
+			if n.Cursor != ev1.ID {
+				t.Errorf("reconnect cursor = %d, want %d", n.Cursor, ev1.ID)
+			}
+		case apiclient.EventNote:
+			if n.Event.ID != ev2.ID || n.Event.Type != "step.started" {
+				t.Fatalf("resumed event = #%d %q, want #%d step.started", n.Event.ID, n.Event.Type, ev2.ID)
+			}
+			if !sawDisconnect {
+				t.Error("stream delivered ev2 without reporting the disconnect")
+			}
+			return
+		}
+	}
+}
+
+func TestStreamEventsTypeFilter(t *testing.T) {
+	h := newHarness(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := testStreamOptions()
+	opts.Types = []string{"gate.waiting"}
+	ch := h.client().StreamEvents(ctx, opts)
+	if _, ok := nextNote(t, ch).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note is not ConnectedNote")
+	}
+
+	h.append(t, "task.state_changed") // filtered out server-side
+	want := h.append(t, "gate.waiting")
+	n := nextNote(t, ch)
+	en, ok := n.(apiclient.EventNote)
+	if !ok {
+		t.Fatalf("note = %T, want EventNote", n)
+	}
+	// Events deliver in id order: receiving the later, matching event first
+	// proves the earlier one was filtered.
+	if en.Event.ID != want.ID || en.Event.Type != "gate.waiting" {
+		t.Errorf("event = #%d %q, want #%d gate.waiting", en.Event.ID, en.Event.Type, want.ID)
+	}
+}
+
+// TestStreamEventsSpecFraming exercises SSE details the real server doesn't
+// produce today but the spec allows: comment heartbeats and data split
+// across multiple data: lines.
+func TestStreamEventsSpecFraming(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl := w.(http.Flusher)
+		_, _ = io.WriteString(w, ":heartbeat\n\n")
+		_, _ = io.WriteString(w, "id: 5\nevent: spec.frame\n")
+		_, _ = io.WriteString(w, "data: {\"id\":5,\"ts\":\"2026-08-08T00:00:00Z\",\n")
+		_, _ = io.WriteString(w, "data: \"type\":\"spec.frame\",\"payload\":null}\n\n")
+		fl.Flush()
+		<-r.Context().Done()
+	}))
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := apiclient.New(ts.URL, testToken).StreamEvents(ctx, testStreamOptions())
+
+	if _, ok := nextNote(t, ch).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note is not ConnectedNote")
+	}
+	n := nextNote(t, ch)
+	en, ok := n.(apiclient.EventNote)
+	if !ok {
+		t.Fatalf("note = %T, want EventNote", n)
+	}
+	if en.Event.ID != 5 || en.Event.Type != "spec.frame" {
+		t.Errorf("event = #%d %q, want #5 spec.frame", en.Event.ID, en.Event.Type)
+	}
+}
+
+func TestDiscover(t *testing.T) {
+	dataDir := t.TempDir()
+	if _, err := apiclient.Discover(dataDir); err == nil {
+		t.Error("Discover on an empty data dir succeeded; want error")
+	}
+
+	ri := daemon.RuntimeInfo{Port: 4242, PID: 1, StartedAt: time.Now()}
+	if err := daemon.WriteRuntimeInfo(dataDir, ri); err != nil {
+		t.Fatalf("WriteRuntimeInfo: %v", err)
+	}
+	if _, err := daemon.EnsureToken(dataDir); err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+	c, err := apiclient.Discover(dataDir)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if want := "http://127.0.0.1:4242"; c.BaseURL() != want {
+		t.Errorf("BaseURL = %q, want %q", c.BaseURL(), want)
+	}
+}

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -1,0 +1,135 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+// requestTimeout bounds plain REST calls. Everything here talks to loopback,
+// so a slow response means a wedged daemon, not a slow network.
+const requestTimeout = 10 * time.Second
+
+// Client talks to one vincent daemon. It is safe for concurrent use.
+type Client struct {
+	baseURL string
+	token   string
+	// rest carries request/response calls and enforces requestTimeout;
+	// stream has no timeout because SSE responses never end on their own.
+	rest   *http.Client
+	stream *http.Client
+}
+
+// New returns a client for the daemon at baseURL (e.g. "http://127.0.0.1:7777")
+// authenticating with token.
+func New(baseURL, token string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		rest:    &http.Client{Timeout: requestTimeout},
+		stream:  &http.Client{},
+	}
+}
+
+// Discover builds a client from the daemon's on-disk discovery records:
+// daemon.json for the port and the token file for auth (§12.2). It does not
+// verify the daemon is actually reachable — callers health-check separately.
+func Discover(dataDir string) (*Client, error) {
+	ri, err := daemon.ReadRuntimeInfo(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("discover daemon: %w", err)
+	}
+	token, err := daemon.ReadToken(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("read api token: %w", err)
+	}
+	return New(fmt.Sprintf("http://127.0.0.1:%d", ri.Port), token), nil
+}
+
+// BaseURL reports the daemon address this client targets.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+// Error is the §13.1 error envelope as a Go error. Status is the HTTP
+// status; Code is the stable snake_case code clients may branch on.
+type Error struct {
+	Status  int
+	Code    string
+	Message string
+	Details map[string]string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s (%s, http %d)", e.Message, e.Code, e.Status)
+}
+
+// Health is the GET /v1/health response body.
+type Health struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+// Health calls the daemon's unauthenticated health endpoint.
+func (c *Client) Health(ctx context.Context) (Health, error) {
+	var h Health
+	if err := c.get(ctx, "/v1/health", &h); err != nil {
+		return Health{}, err
+	}
+	return h, nil
+}
+
+// get performs an authenticated GET and decodes the JSON response into out.
+// Non-2xx responses come back as *Error.
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("build request %s: %w", path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.rest.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return decodeError(resp)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode %s response: %w", path, err)
+	}
+	return nil
+}
+
+// decodeError maps a non-2xx response onto *Error, falling back to a bare
+// status when the body is not the §13.1 envelope.
+func decodeError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var envelope struct {
+		Error struct {
+			Code    string            `json:"code"`
+			Message string            `json:"message"`
+			Details map[string]string `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error.Code != "" {
+		return &Error{
+			Status:  resp.StatusCode,
+			Code:    envelope.Error.Code,
+			Message: envelope.Error.Message,
+			Details: envelope.Error.Details,
+		}
+	}
+	return &Error{
+		Status:  resp.StatusCode,
+		Code:    "unexpected_response",
+		Message: fmt.Sprintf("unexpected status %s", resp.Status),
+	}
+}

--- a/internal/apiclient/doc.go
+++ b/internal/apiclient/doc.go
@@ -1,0 +1,7 @@
+// Package apiclient is the typed HTTP + SSE client for the vincent daemon
+// API (spec §13). It is the one client shared by the TUI (Phase 3) and the
+// CLI subcommands (T4.2). The package owns its wire types — the server's
+// DTOs stay unexported — and drift cannot ship unnoticed because client and
+// server live in the same binary and this package is integration-tested
+// against the real handlers (Phase 3 decision).
+package apiclient

--- a/internal/apiclient/events.go
+++ b/internal/apiclient/events.go
@@ -1,0 +1,220 @@
+package apiclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultInitialBackoff is the first reconnect delay; loopback comes back
+	// fast, so start eager.
+	defaultInitialBackoff = 250 * time.Millisecond
+	// defaultMaxBackoff caps the reconnect delay while the daemon is down.
+	defaultMaxBackoff = 5 * time.Second
+	// maxFrameSize bounds one SSE line; payloads are ids + small JSON, but a
+	// diff-bearing future payload should not kill the stream.
+	maxFrameSize = 1 << 20
+)
+
+// Event is one durable state event as framed on the wire (§13.3): the full
+// envelope, so no side channel is needed to interpret it.
+type Event struct {
+	ID        int64           `json:"id"`
+	TS        time.Time       `json:"ts"`
+	Type      string          `json:"type"`
+	TaskID    *int64          `json:"task_id,omitempty"`
+	ProjectID *int64          `json:"project_id,omitempty"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// Note is one item on an event stream: an event, or a connection-state
+// transition the UI renders.
+type Note interface{ isNote() }
+
+// EventNote delivers one durable event.
+type EventNote struct{ Event Event }
+
+// ConnectedNote reports a (re)established stream. Cursor is the resume
+// position the connection asked for (0 = live-only).
+type ConnectedNote struct{ Cursor int64 }
+
+// DisconnectedNote reports a dropped stream; the subscription retries by
+// itself after RetryIn.
+type DisconnectedNote struct {
+	Err     error
+	RetryIn time.Duration
+}
+
+func (EventNote) isNote()        {}
+func (ConnectedNote) isNote()    {}
+func (DisconnectedNote) isNote() {}
+
+// StreamOptions filter and position a durable-event subscription (§13.3).
+type StreamOptions struct {
+	// Types filters to these event types (server-side, ?types=).
+	Types []string
+	// ProjectID filters to one project (server-side, ?project_id=).
+	ProjectID int64
+	// LastEventID resumes after this event id; 0 starts live at the next
+	// committed event (the stream never replays history unasked).
+	LastEventID int64
+	// InitialBackoff/MaxBackoff tune reconnect pacing; zero means defaults.
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+// StreamEvents subscribes to GET /v1/events and delivers durable events on
+// the returned channel. The subscription reconnects forever with capped
+// backoff, resuming via Last-Event-ID so no durable event is lost; it stops
+// and closes the channel only when ctx is canceled.
+func (c *Client) StreamEvents(ctx context.Context, opts StreamOptions) <-chan Note {
+	ch := make(chan Note)
+	go c.streamLoop(ctx, opts, ch)
+	return ch
+}
+
+func (c *Client) streamLoop(ctx context.Context, opts StreamOptions, ch chan<- Note) {
+	defer close(ch)
+	initial := opts.InitialBackoff
+	if initial <= 0 {
+		initial = defaultInitialBackoff
+	}
+	maxB := opts.MaxBackoff
+	if maxB <= 0 {
+		maxB = defaultMaxBackoff
+	}
+	cursor := opts.LastEventID
+	backoff := initial
+	for {
+		connected, err := c.streamOnce(ctx, opts, &cursor, ch)
+		if ctx.Err() != nil {
+			return
+		}
+		if connected {
+			backoff = initial // the connection worked; the drop is fresh news
+		}
+		if !send(ctx, ch, DisconnectedNote{Err: err, RetryIn: backoff}) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxB)
+	}
+}
+
+// streamOnce runs one connection: dial, announce, then decode frames until
+// the stream breaks. connected reports whether the dial reached streaming.
+func (c *Client) streamOnce(
+	ctx context.Context, opts StreamOptions, cursor *int64, ch chan<- Note,
+) (connected bool, err error) {
+	req, err := c.buildStreamRequest(ctx, opts, *cursor)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.stream.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("connect event stream: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, decodeError(resp)
+	}
+	if !send(ctx, ch, ConnectedNote{Cursor: *cursor}) {
+		return true, ctx.Err()
+	}
+	return true, c.readFrames(ctx, resp.Body, cursor, ch)
+}
+
+func (c *Client) buildStreamRequest(
+	ctx context.Context, opts StreamOptions, cursor int64,
+) (*http.Request, error) {
+	q := url.Values{}
+	if len(opts.Types) > 0 {
+		q.Set("types", strings.Join(opts.Types, ","))
+	}
+	if opts.ProjectID != 0 {
+		q.Set("project_id", strconv.FormatInt(opts.ProjectID, 10))
+	}
+	u := c.baseURL + "/v1/events"
+	if len(q) > 0 {
+		u += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build event stream request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "text/event-stream")
+	if cursor > 0 {
+		req.Header.Set("Last-Event-ID", strconv.FormatInt(cursor, 10))
+	}
+	return req, nil
+}
+
+// readFrames decodes SSE frames until the body ends. Comment lines
+// (heartbeats) are skipped; a frame dispatches on its blank line, with
+// multiple data: lines joined by newlines per the SSE spec.
+func (c *Client) readFrames(
+	ctx context.Context, body io.Reader, cursor *int64, ch chan<- Note,
+) error {
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), maxFrameSize)
+	var data []string
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			if len(data) > 0 {
+				if !c.dispatch(ctx, strings.Join(data, "\n"), cursor, ch) {
+					return ctx.Err()
+				}
+				data = data[:0]
+			}
+		case strings.HasPrefix(line, ":"): // comment/heartbeat
+		case strings.HasPrefix(line, "data:"):
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		default: // id:/event: fields — the data envelope repeats both
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("read event stream: %w", err)
+	}
+	return errors.New("event stream ended")
+}
+
+// dispatch decodes one frame body and delivers it. Frames without an id
+// (live-output chunks on per-task streams) never advance the resume cursor.
+func (c *Client) dispatch(ctx context.Context, data string, cursor *int64, ch chan<- Note) bool {
+	var ev Event
+	if err := json.Unmarshal([]byte(data), &ev); err != nil {
+		// A malformed frame is a server bug; skipping it beats killing the
+		// stream and replaying everything.
+		return true
+	}
+	if ev.ID > 0 {
+		*cursor = ev.ID
+	}
+	return send(ctx, ch, EventNote{Event: ev})
+}
+
+// send delivers n unless ctx ends first; it reports whether delivery happened.
+func send(ctx context.Context, ch chan<- Note, n Note) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- n:
+		return true
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/lezli01/vincent/internal/tui"
 	"github.com/lezli01/vincent/internal/version"
 )
 
@@ -32,8 +33,9 @@ func newRootCmd() *cobra.Command {
 		Short:        "vincent — local AI workload orchestrator",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), "The vincent TUI is not implemented yet (Phase 3). Try `vincent version`.")
-			return err
+			// Bare `vincent` is the TUI (§12.1); it auto-starts the daemon
+			// in the background when unreachable.
+			return tui.Run(cmd.Context())
 		},
 	}
 	root.AddCommand(newDaemonCmd(), newVersionCmd())

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -54,6 +54,12 @@ type Options struct {
 // listener → daemon.json; teardown reverses it, removing daemon.json only on
 // this graceful path (spec §12.2, §12.4).
 func Run(ctx context.Context, opts Options) error {
+	return runWithAgents(ctx, opts, nil)
+}
+
+// runWithAgents is Run with an injectable registry for lifecycle tests. A nil
+// registry builds the production adapters from the live configuration.
+func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) error {
 	dirs, err := config.ResolveDirs()
 	if err != nil {
 		return err
@@ -141,12 +147,15 @@ func Run(ctx context.Context, opts Options) error {
 	// §9.6 binary-identity cache — primed asynchronously here, stat-checked
 	// per request, so a CLI installed after daemon start is visible without
 	// a restart (T2.11).
-	agents := agent.NewRegistry(
-		claude.New(func() string { return currentConfig().Agents.Claude.Path }),
-		codex.New(func() string { return currentConfig().Agents.Codex.Path }),
-	)
+	if agents == nil {
+		agents = agent.NewRegistry(
+			claude.New(func() string { return currentConfig().Agents.Claude.Path }),
+			codex.New(func() string { return currentConfig().Agents.Codex.Path }),
+		)
+	}
 	catalog := agent.NewCatalogCache(agents)
-	go primeAgentCatalog(ctx, logger, catalog)
+	stopCatalogPrime := startAgentCatalogPrime(ctx, logger, catalog)
+	defer stopCatalogPrime()
 
 	// Workflow registry: global scope from {config_dir}/workflows, project
 	// scopes from every registered repo's .vincent/workflows (§5.2). Both
@@ -318,6 +327,24 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	logger.Info("daemon stopped")
 	return nil
+}
+
+// startAgentCatalogPrime starts the asynchronous startup probe and returns a
+// stop function that cancels and joins it. Run defers the stop before closing
+// the logger so a canceled probe cannot write through lumberjack afterward and
+// reopen daemon.log during shutdown (notably breaking TempDir cleanup on
+// Windows).
+func startAgentCatalogPrime(ctx context.Context, logger *slog.Logger, catalog *agent.CatalogCache) func() {
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		primeAgentCatalog(ctx, logger, catalog)
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 // syncWorkflowProjects points the registry at the current set of registered

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lezli01/vincent/internal/agent"
 	"github.com/lezli01/vincent/internal/config"
 )
 
@@ -118,12 +119,16 @@ func TestLogTail(t *testing.T) {
 // startTestDaemon runs Run in-process against temp dirs and returns the
 // discovered runtime info plus the Run result channel.
 func startTestDaemon(ctx context.Context, t *testing.T) (dataDir string, ri RuntimeInfo, done <-chan error) {
+	return startTestDaemonWithAgents(ctx, t, nil)
+}
+
+func startTestDaemonWithAgents(ctx context.Context, t *testing.T, agents *agent.Registry) (dataDir string, ri RuntimeInfo, done <-chan error) {
 	t.Helper()
 	dataDir = t.TempDir()
 	t.Setenv(config.EnvDataDir, dataDir)
 	t.Setenv(config.EnvConfigDir, t.TempDir())
 	ch := make(chan error, 1)
-	go func() { ch <- Run(ctx, Options{}) }()
+	go func() { ch <- runWithAgents(ctx, Options{}, agents) }()
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		var err error
@@ -141,6 +146,77 @@ func startTestDaemon(ctx context.Context, t *testing.T) (dataDir string, ri Runt
 	}
 	t.Fatal("daemon did not become healthy within 15s")
 	return "", RuntimeInfo{}, nil
+}
+
+type blockingCatalogAdapter struct {
+	started  chan struct{}
+	finished chan struct{}
+}
+
+func (a *blockingCatalogAdapter) Name() string { return "blocking" }
+
+func (a *blockingCatalogAdapter) Detect(ctx context.Context) (agent.Availability, error) {
+	close(a.started)
+	<-ctx.Done()
+	return agent.Availability{Error: ctx.Err().Error()}, nil
+}
+
+func (a *blockingCatalogAdapter) Options(ctx context.Context) (agent.Options, error) {
+	<-ctx.Done()
+	// Model a canceled subprocess that takes a moment to be reaped. Run must
+	// still join the prime before the logger and its file are closed.
+	time.Sleep(250 * time.Millisecond)
+	close(a.finished)
+	return agent.Options{}, nil
+}
+
+func (a *blockingCatalogAdapter) Path() (string, error) {
+	return "", errors.New("blocking adapter has no binary")
+}
+
+func (a *blockingCatalogAdapter) Curated() agent.Options { return agent.Options{} }
+
+func (a *blockingCatalogAdapter) Start(context.Context, agent.RunSpec) (agent.RunHandle, error) {
+	return nil, errors.New("blocking adapter cannot run")
+}
+
+func TestRunJoinsAgentCatalogPrimeBeforeReturn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	adapter := &blockingCatalogAdapter{
+		started:  make(chan struct{}),
+		finished: make(chan struct{}),
+	}
+	dataDir, ri, done := startTestDaemonWithAgents(ctx, t, agent.NewRegistry(adapter))
+
+	select {
+	case <-adapter.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent catalog prime did not start")
+	}
+	token, err := ReadToken(dataDir)
+	if err != nil {
+		t.Fatalf("ReadToken: %v", err)
+	}
+	if err := RequestStop(ctx, ri.Port, token); err != nil {
+		t.Fatalf("RequestStop: %v", err)
+	}
+	if err := waitDone(t, done); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	select {
+	case <-adapter.finished:
+		// The prime stopped before Run returned, as required.
+	default:
+		cancel()
+		select {
+		case <-adapter.finished:
+		case <-time.After(5 * time.Second):
+			t.Fatal("agent catalog prime ignored context cancellation")
+		}
+		t.Fatal("Run returned before the agent catalog prime stopped")
+	}
 }
 
 func waitDone(t *testing.T, done <-chan error) error {

--- a/internal/procx/procx_windows.go
+++ b/internal/procx/procx_windows.go
@@ -90,6 +90,12 @@ func KillPID(pid int) error {
 	}
 	defer func() { _ = windows.CloseHandle(h) }()
 	if err := windows.TerminateProcess(h, 1); err != nil {
+		// Windows documents ERROR_ACCESS_DENIED when the process terminated
+		// after its handle was opened. OpenProcess already granted
+		// PROCESS_TERMINATE, so this is the successful already-gone case.
+		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			return nil
+		}
 		return fmt.Errorf("terminate process %d: %w", pid, err)
 	}
 	return nil

--- a/internal/tui/connect.go
+++ b/internal/tui/connect.go
@@ -1,0 +1,140 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+const (
+	// startTimeout bounds the auto-start health poll — same bound as
+	// `vincent daemon start` (phase 1 decision).
+	startTimeout = 10 * time.Second
+	// pollInterval paces the auto-start poll loop.
+	pollInterval = 100 * time.Millisecond
+	// probeTimeout bounds one reachability check against a daemon that may
+	// be wedged; CheckHealth's own client timeout is the real ceiling.
+	probeTimeout = 3 * time.Second
+)
+
+// connector is the daemon discovery/auto-start seam (§12.1). Fields default
+// to the real implementations; tests inject fakes or a built binary.
+type connector struct {
+	resolveDataDir func() (string, error)
+	readRuntime    func(dataDir string) (daemon.RuntimeInfo, error)
+	checkHealth    func(ctx context.Context, port int) (daemon.HealthInfo, error)
+	newClient      func(dataDir string) (*apiclient.Client, error)
+	startDetached  func() (int, error)
+	startTimeout   time.Duration
+	pollInterval   time.Duration
+}
+
+func defaultConnector() connector {
+	return connector{
+		resolveDataDir: func() (string, error) {
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return "", fmt.Errorf("resolve data dir: %w", err)
+			}
+			return dirs.Data, nil
+		},
+		readRuntime:   daemon.ReadRuntimeInfo,
+		checkHealth:   daemon.CheckHealth,
+		newClient:     apiclient.Discover,
+		startDetached: daemon.StartDetached,
+		startTimeout:  startTimeout,
+		pollInterval:  pollInterval,
+	}
+}
+
+// connectedMsg reports a healthy daemon and a ready client.
+type connectedMsg struct {
+	client      *apiclient.Client
+	health      daemon.HealthInfo
+	dataDir     string
+	autoStarted bool
+}
+
+// probeFailedMsg reports an unreachable daemon; the root switches to the
+// "starting daemon…" phase and issues startCmd.
+type probeFailedMsg struct{ dataDir string }
+
+// connectFailedMsg reports a connect flow that ended without a healthy
+// daemon; the root shows the error screen (log path, retry).
+type connectFailedMsg struct {
+	err     error
+	logPath string
+}
+
+// probeCmd checks for a reachable daemon via daemon.json + /v1/health. It
+// resolves fast: either the daemon is there, or auto-start takes over.
+func (cn connector) probeCmd() tea.Cmd {
+	return func() tea.Msg {
+		dataDir, err := cn.resolveDataDir()
+		if err != nil {
+			return connectFailedMsg{err: err}
+		}
+		ri, err := cn.readRuntime(dataDir)
+		if err != nil {
+			return probeFailedMsg{dataDir: dataDir}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+		defer cancel()
+		h, err := cn.checkHealth(ctx, ri.Port)
+		if err != nil {
+			return probeFailedMsg{dataDir: dataDir}
+		}
+		return cn.finish(dataDir, h, false)
+	}
+}
+
+// startCmd auto-starts the daemon (§12.1) and polls it healthy, matching
+// the spawned pid so a stale daemon.json can't be mistaken for the child.
+func (cn connector) startCmd(dataDir string) tea.Cmd {
+	return func() tea.Msg {
+		pid, err := cn.startDetached()
+		if err != nil {
+			return connectFailedMsg{
+				err:     fmt.Errorf("start daemon: %w", err),
+				logPath: daemonLogPath(dataDir),
+			}
+		}
+		deadline := time.Now().Add(cn.startTimeout)
+		for time.Now().Before(deadline) {
+			ri, err := cn.readRuntime(dataDir)
+			if err == nil && ri.PID == pid {
+				ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+				h, err := cn.checkHealth(ctx, ri.Port)
+				cancel()
+				if err == nil {
+					return cn.finish(dataDir, h, true)
+				}
+			}
+			time.Sleep(cn.pollInterval)
+		}
+		return connectFailedMsg{
+			err:     fmt.Errorf("daemon did not become healthy within %s", cn.startTimeout),
+			logPath: daemonLogPath(dataDir),
+		}
+	}
+}
+
+// finish builds the API client once the daemon is provably healthy.
+func (cn connector) finish(dataDir string, h daemon.HealthInfo, autoStarted bool) tea.Msg {
+	client, err := cn.newClient(dataDir)
+	if err != nil {
+		return connectFailedMsg{err: err, logPath: daemonLogPath(dataDir)}
+	}
+	return connectedMsg{client: client, health: h, dataDir: dataDir, autoStarted: autoStarted}
+}
+
+func daemonLogPath(dataDir string) string {
+	return filepath.Join(dataDir, "logs", "daemon.log")
+}

--- a/internal/tui/doc.go
+++ b/internal/tui/doc.go
@@ -1,3 +1,10 @@
-// Package tui will implement the Bubble Tea terminal UI: board, task detail,
-// new-task flow, projects/workflows/daemon views (spec §15; Phase 3).
+// Package tui implements the Bubble Tea terminal UI (spec §15). The TUI is
+// a pure API client: it holds no state the daemon doesn't have, and killing
+// it never affects work. Bare `vincent` launches it, auto-starting the
+// daemon in the background when unreachable (§12.1).
+//
+// Phase 3 lands it PR by PR: this foundation ships the shell — connection
+// management, /v1/events subscription, view routing, global keys, and the
+// help overlay — with stub views that later PRs replace (board, task
+// detail, new-task flow, projects/workflows/daemon).
 package tui

--- a/internal/tui/e2e_test.go
+++ b/internal/tui/e2e_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// vincentBin is the real binary under test, built once in TestMain: the
+// auto-start path must be proven against an actual daemon process.
+var vincentBin string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "vincent-tui-e2e-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "e2e setup:", err)
+		os.Exit(1)
+	}
+	vincentBin = filepath.Join(tmp, "vincent")
+	if runtime.GOOS == "windows" {
+		vincentBin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", vincentBin, "github.com/lezli01/vincent/cmd/vincent")
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e setup: build vincent: %v\n%s", err, out)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
+// TestAutoStartRealDaemon is the T3.1 acceptance against a real daemon: no
+// daemon → the shell starts one, connects, and re-renders on a state change
+// made by an external API client.
+func TestAutoStartRealDaemon(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	env := append(os.Environ(),
+		config.EnvDataDir+"="+dataDir,
+		config.EnvConfigDir+"="+cfgDir,
+	)
+	t.Cleanup(func() {
+		// Never leak a daemon, even when an assertion fails.
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = env
+		_, _ = cmd.CombinedOutput()
+	})
+
+	cn := connector{
+		resolveDataDir: func() (string, error) { return dataDir, nil },
+		readRuntime:    daemon.ReadRuntimeInfo,
+		checkHealth:    daemon.CheckHealth,
+		newClient:      defaultConnector().newClient,
+		// The TUI's real startDetached self-execs os.Executable(), which in
+		// tests is the test binary; substitute the built vincent. Detaching
+		// is `vincent daemon start`'s concern, proven in the cli e2e.
+		startDetached: func() (int, error) {
+			cmd := exec.Command(vincentBin, "daemon")
+			cmd.Env = env
+			if err := cmd.Start(); err != nil {
+				return 0, err
+			}
+			go func() { _ = cmd.Wait() }()
+			return cmd.Process.Pid, nil
+		},
+		startTimeout: 30 * time.Second,
+		pollInterval: 100 * time.Millisecond,
+	}
+
+	m := newRoot(testCtx(t), cn)
+	msg := runCmd(t, m.Init(), 10*time.Second)
+	if _, ok := msg.(probeFailedMsg); !ok {
+		t.Fatalf("probe with no daemon = %T, want probeFailedMsg", msg)
+	}
+	_, cmd := m.Update(msg)
+	if !strings.Contains(content(m), "starting daemon") {
+		t.Errorf("starting view lacks 'starting daemon': %q", content(m))
+	}
+
+	msg = runCmd(t, cmd, 60*time.Second)
+	conn, ok := msg.(connectedMsg)
+	if !ok {
+		t.Fatalf("auto-start = %#v, want connectedMsg", msg)
+	}
+	if !conn.autoStarted {
+		t.Error("connectedMsg.autoStarted = false, want true")
+	}
+	_, cmd = m.Update(msg)
+
+	// Externally-made change: a plain HTTP client registers a project while
+	// the shell watches the event stream.
+	ri, err := daemon.ReadRuntimeInfo(dataDir)
+	if err != nil {
+		t.Fatalf("ReadRuntimeInfo: %v", err)
+	}
+	token, err := daemon.ReadToken(dataDir)
+	if err != nil {
+		t.Fatalf("ReadToken: %v", err)
+	}
+	repo := testrepo.Init(t, "main")
+	body, _ := json.Marshal(map[string]string{"path": repo})
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("http://127.0.0.1:%d/v1/projects", ri.Port), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build register request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("register project: %v", err)
+	}
+	respBody := new(bytes.Buffer)
+	_, _ = respBody.ReadFrom(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("register project: status %s: %s", resp.Status, respBody)
+	}
+
+	// Pump stream notes until the change shows on screen.
+	deadline := time.Now().Add(30 * time.Second)
+	for !strings.Contains(content(m), "project.created") {
+		if time.Now().After(deadline) {
+			t.Fatalf("project.created never rendered; view: %q", content(m))
+		}
+		msg = runCmd(t, cmd, 10*time.Second)
+		_, cmd = m.Update(msg)
+	}
+
+	// Graceful stop through the real CLI; the daemon must not linger.
+	stop := exec.Command(vincentBin, "daemon", "stop")
+	stop.Env = env
+	if out, err := stop.CombinedOutput(); err != nil || !strings.Contains(string(out), "daemon stopped") {
+		t.Fatalf("daemon stop: %v\n%s", err, out)
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,33 @@
+package tui
+
+import "strings"
+
+// helpText is the §15 global-keys overlay. View-specific keys (p, c, a, r,
+// s, A, /, enter, n) arrive with their views in later Phase 3 PRs and get
+// documented here as they land.
+func helpText() string {
+	rows := [][2]string{
+		{"?", "toggle this help"},
+		{"1..6", "switch view: board · task detail · new task · projects · workflows · daemon"},
+		{"r", "retry connecting (when the daemon is unreachable)"},
+		{"q", "quit the TUI (the daemon keeps running)"},
+		{"ctrl+c", "quit the TUI"},
+	}
+	var b strings.Builder
+	b.WriteString("\n  Keys\n\n")
+	for _, r := range rows {
+		b.WriteString("  ")
+		b.WriteString(padRight(r[0], 8))
+		b.WriteString(r[1])
+		b.WriteString("\n")
+	}
+	b.WriteString("\n  View-specific actions land with their views (PRs I–M).\n")
+	return b.String()
+}
+
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s + " "
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/internal/tui/live_test.go
+++ b/internal/tui/live_test.go
@@ -1,0 +1,117 @@
+package tui
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// TestLiveChangeFromRealServer is the T3.1 done-when in automated form: the
+// shell, connected to the real handlers, re-renders when the daemon commits
+// a state change the TUI didn't make.
+func TestLiveChangeFromRealServer(t *testing.T) {
+	const token = "live-token"
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	broker := events.New()
+	t.Cleanup(broker.Close)
+	st.SetEventHook(broker.Publish)
+
+	ctx := context.Background()
+	p := &store.Project{Name: "live", Path: "/nowhere", DefaultBranch: "main"}
+	if err := st.CreateProject(ctx, p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	task := &store.Task{
+		ProjectID: p.ID, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
+		BaseBranch: "main", BranchName: "b", State: store.TaskQueued,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	s := api.New(api.Deps{
+		Token:       token,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+		Broker:      broker,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server url: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("test server port: %v", err)
+	}
+
+	// Real health check and real client against the real server; only the
+	// on-disk discovery is faked.
+	cn := connector{
+		resolveDataDir: func() (string, error) { return t.TempDir(), nil },
+		readRuntime: func(string) (daemon.RuntimeInfo, error) {
+			return daemon.RuntimeInfo{PID: 1, Port: port, StartedAt: time.Now()}, nil
+		},
+		checkHealth: daemon.CheckHealth,
+		newClient: func(string) (*apiclient.Client, error) {
+			return apiclient.New(ts.URL, token), nil
+		},
+		startDetached: func() (int, error) { t.Fatal("auto-start must not trigger"); return 0, nil },
+		startTimeout:  time.Second,
+		pollInterval:  time.Millisecond,
+	}
+
+	m := newRoot(testCtx(t), cn)
+	msg := runCmd(t, m.Init(), 10*time.Second)
+	if _, ok := msg.(connectedMsg); !ok {
+		t.Fatalf("probe = %T, want connectedMsg", msg)
+	}
+	_, cmd := m.Update(msg)
+
+	// First note announces the live stream.
+	msg = runCmd(t, cmd, 10*time.Second)
+	_, cmd = m.Update(msg)
+	if m.phase != phaseConnected {
+		t.Fatalf("phase = %v, want phaseConnected", m.phase)
+	}
+
+	// The externally-made change: another client appends a durable event
+	// through the store hook, exactly like the runner would.
+	ev := &store.Event{Type: store.EventTaskStateChanged, TaskID: &task.ID, ProjectID: &p.ID}
+	if err := st.AppendEvent(ctx, ev); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	deadline := time.Now().Add(15 * time.Second)
+	for !strings.Contains(content(m), store.EventTaskStateChanged) {
+		if time.Now().After(deadline) {
+			t.Fatalf("event never rendered; view: %q", content(m))
+		}
+		msg = runCmd(t, cmd, 10*time.Second)
+		_, cmd = m.Update(msg)
+	}
+}

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -1,0 +1,293 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// connPhase is the daemon-connection state machine the shell renders. The
+// failed and reconnecting screens share the retry affordance (PR H decision:
+// the auto-start screen doubles as the reconnect screen).
+type connPhase int
+
+const (
+	phaseProbing connPhase = iota
+	phaseStarting
+	phaseConnected
+	phaseReconnecting
+	phaseFailed
+)
+
+var (
+	styleTitle = lipgloss.NewStyle().Bold(true)
+	styleOK    = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	styleWarn  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	styleBad   = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	styleDim   = lipgloss.NewStyle().Faint(true)
+)
+
+// noteMsg wraps one stream Note for Update.
+type noteMsg struct{ note apiclient.Note }
+
+// streamDoneMsg reports the note channel closed (stream context ended).
+type streamDoneMsg struct{}
+
+// root is the shell model: connection lifecycle, view routing, global keys,
+// help overlay (§15). Views own everything else.
+type root struct {
+	cn  connector
+	ctx context.Context
+
+	phase       connPhase
+	client      *apiclient.Client
+	version     string
+	dataDir     string
+	autoStarted bool
+	connErr     error
+	logPath     string
+	retryIn     time.Duration
+
+	notes      <-chan apiclient.Note
+	stopStream context.CancelFunc
+	lastEvent  *apiclient.Event
+
+	active viewID
+	views  [viewCount]view
+	help   bool
+
+	width  int
+	height int
+}
+
+// newRoot builds the shell. ctx bounds background work (the SSE stream);
+// Run passes the program's lifetime.
+func newRoot(ctx context.Context, cn connector) *root {
+	return &root{
+		cn:    cn,
+		ctx:   ctx,
+		phase: phaseProbing,
+		views: newViews(),
+	}
+}
+
+// Init starts the connect flow immediately: probe first, auto-start on miss.
+func (m *root) Init() tea.Cmd { return m.cn.probeCmd() }
+
+// Update implements tea.Model.
+func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyPressMsg:
+		return m.updateKey(msg)
+	case connectedMsg:
+		return m.updateConnected(msg)
+	case probeFailedMsg:
+		m.phase = phaseStarting
+		m.dataDir = msg.dataDir
+		return m, m.cn.startCmd(msg.dataDir)
+	case connectFailedMsg:
+		m.phase = phaseFailed
+		m.connErr = msg.err
+		m.logPath = msg.logPath
+		return m, nil
+	case noteMsg:
+		return m.updateNote(msg.note)
+	case streamDoneMsg:
+		return m, nil
+	}
+	return m.delegate(msg)
+}
+
+func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch key := msg.String(); key {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "?":
+		m.help = !m.help
+		return m, nil
+	case "esc":
+		m.help = false
+		return m, nil
+	case "1", "2", "3", "4", "5", "6":
+		m.active = viewID(key[0] - '1')
+		m.help = false
+		return m, nil
+	case "r":
+		if m.phase == phaseFailed || m.phase == phaseReconnecting {
+			return m, m.restartConnect()
+		}
+	}
+	return m.delegate(msg)
+}
+
+// restartConnect tears down any live stream and reruns the full connect
+// flow, auto-start included — the retry key on the failure screen.
+func (m *root) restartConnect() tea.Cmd {
+	if m.stopStream != nil {
+		m.stopStream()
+		m.stopStream = nil
+		m.notes = nil
+	}
+	m.phase = phaseProbing
+	m.connErr = nil
+	return m.cn.probeCmd()
+}
+
+func (m *root) updateConnected(msg connectedMsg) (tea.Model, tea.Cmd) {
+	m.phase = phaseConnected
+	m.client = msg.client
+	m.version = msg.health.Version
+	m.dataDir = msg.dataDir
+	m.autoStarted = msg.autoStarted
+	m.connErr = nil
+	streamCtx, cancel := context.WithCancel(m.ctx)
+	m.stopStream = cancel
+	m.notes = m.client.StreamEvents(streamCtx, apiclient.StreamOptions{})
+	return m, waitNote(m.notes)
+}
+
+func (m *root) updateNote(n apiclient.Note) (tea.Model, tea.Cmd) {
+	if m.notes == nil {
+		// A stale note from a stream torn down by retry; never re-arm on a
+		// nil channel — that receive would block forever.
+		return m, nil
+	}
+	switch n := n.(type) {
+	case apiclient.EventNote:
+		ev := n.Event
+		m.lastEvent = &ev
+	case apiclient.ConnectedNote:
+		m.phase = phaseConnected
+		m.connErr = nil
+	case apiclient.DisconnectedNote:
+		m.phase = phaseReconnecting
+		m.connErr = n.Err
+		m.retryIn = n.RetryIn
+	}
+	return m, waitNote(m.notes)
+}
+
+// delegate routes a message to the active view.
+func (m *root) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	v, cmd := m.views[m.active].update(msg)
+	m.views[m.active] = v
+	return m, cmd
+}
+
+// waitNote receives the next stream note as a message; Update re-arms it.
+func waitNote(ch <-chan apiclient.Note) tea.Cmd {
+	return func() tea.Msg {
+		n, ok := <-ch
+		if !ok {
+			return streamDoneMsg{}
+		}
+		return noteMsg{note: n}
+	}
+}
+
+// View implements tea.Model.
+func (m *root) View() tea.View {
+	var b strings.Builder
+	b.WriteString(m.headerLine())
+	b.WriteString("\n")
+	b.WriteString(m.eventLine())
+	b.WriteString("\n")
+	b.WriteString(m.body())
+	b.WriteString("\n")
+	b.WriteString(m.footerLine())
+	return tea.NewView(b.String())
+}
+
+func (m *root) headerLine() string {
+	name := "vincent"
+	if m.version != "" {
+		name += " " + m.version
+	}
+	return fmt.Sprintf(" %s  %s  %s",
+		styleTitle.Render(name), m.connBadge(),
+		styleDim.Render("["+m.views[m.active].title()+"]"))
+}
+
+func (m *root) connBadge() string {
+	switch m.phase {
+	case phaseProbing:
+		return styleWarn.Render("◌ connecting…")
+	case phaseStarting:
+		return styleWarn.Render("⧗ starting daemon…")
+	case phaseConnected:
+		return styleOK.Render("● connected")
+	case phaseReconnecting:
+		return styleWarn.Render("⟳ reconnecting…")
+	default:
+		return styleBad.Render("✗ disconnected")
+	}
+}
+
+// eventLine renders the last durable event received — the foundation's
+// visible proof that external state changes reach the TUI live (T3.1).
+func (m *root) eventLine() string {
+	if m.lastEvent == nil {
+		return styleDim.Render(" no events yet")
+	}
+	ev := m.lastEvent
+	line := fmt.Sprintf(" last event: %s #%d", ev.Type, ev.ID)
+	if ev.TaskID != nil {
+		line += fmt.Sprintf(" · task %d", *ev.TaskID)
+	}
+	line += " · " + ev.TS.Local().Format("15:04:05")
+	return styleDim.Render(line)
+}
+
+func (m *root) body() string {
+	if m.help {
+		return helpText()
+	}
+	switch m.phase {
+	case phaseProbing:
+		return "\n  connecting to daemon…\n"
+	case phaseStarting:
+		return "\n  starting daemon…\n"
+	case phaseFailed:
+		return fmt.Sprintf("\n  %s\n\n  log: %s\n\n  press r to retry, q to quit\n",
+			styleBad.Render("daemon unreachable: "+errString(m.connErr)), m.logPath)
+	case phaseReconnecting:
+		return fmt.Sprintf("\n  %s\n\n  retrying in %s — press r to restart the daemon if it stays down\n",
+			styleWarn.Render("connection lost: "+errString(m.connErr)), m.retryIn)
+	default:
+		return m.views[m.active].render(m.width, m.bodyHeight())
+	}
+}
+
+func (m *root) footerLine() string {
+	hints := " 1-6 views · ? help · q quit"
+	if m.phase == phaseFailed || m.phase == phaseReconnecting {
+		hints += " · r retry"
+	}
+	return styleDim.Render(hints)
+}
+
+// bodyHeight is the space left for the active view: total minus header,
+// event line, and footer.
+func (m *root) bodyHeight() int {
+	const chrome = 3
+	if m.height <= chrome {
+		return 0
+	}
+	return m.height - chrome
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	return err.Error()
+}

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -1,0 +1,222 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+// key builds a printable-key press ("q", "?", "1", "r").
+func key(s string) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: []rune(s)[0], Text: s}
+}
+
+// content renders the model to its plain frame string.
+func content(m *root) string { return m.View().Content }
+
+// runCmd executes one tea.Cmd with a deadline, returning its message.
+func runCmd(t *testing.T, cmd tea.Cmd, timeout time.Duration) tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("nil command")
+	}
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		return msg
+	case <-time.After(timeout):
+		t.Fatal("command did not return in time")
+		return nil
+	}
+}
+
+// testCtx is a context canceled at test end so stream goroutines die with
+// the test.
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// fakeConnector simulates the §12.1 flow: no daemon until startDetached,
+// healthy daemon after.
+func fakeConnector() connector {
+	started := false
+	return connector{
+		resolveDataDir: func() (string, error) { return "/data", nil },
+		readRuntime: func(string) (daemon.RuntimeInfo, error) {
+			if !started {
+				return daemon.RuntimeInfo{}, errors.New("no daemon.json")
+			}
+			return daemon.RuntimeInfo{PID: 42, Port: 9}, nil
+		},
+		checkHealth: func(context.Context, int) (daemon.HealthInfo, error) {
+			return daemon.HealthInfo{Status: "ok", Version: "test-v"}, nil
+		},
+		newClient: func(string) (*apiclient.Client, error) {
+			return apiclient.New("http://127.0.0.1:9", "t"), nil
+		},
+		startDetached: func() (int, error) { started = true; return 42, nil },
+		startTimeout:  time.Second,
+		pollInterval:  time.Millisecond,
+	}
+}
+
+// TestAutoStartFlow drives probe-miss → auto-start → connected through the
+// root state machine (T3.1: auto-starts a stopped daemon).
+func TestAutoStartFlow(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector())
+
+	msg := runCmd(t, m.Init(), 5*time.Second)
+	if _, ok := msg.(probeFailedMsg); !ok {
+		t.Fatalf("probe with no daemon = %T, want probeFailedMsg", msg)
+	}
+	_, cmd := m.Update(msg)
+	if m.phase != phaseStarting {
+		t.Fatalf("phase = %v, want phaseStarting", m.phase)
+	}
+	if !strings.Contains(content(m), "starting daemon") {
+		t.Errorf("starting view lacks 'starting daemon': %q", content(m))
+	}
+
+	msg = runCmd(t, cmd, 5*time.Second)
+	conn, ok := msg.(connectedMsg)
+	if !ok {
+		t.Fatalf("start result = %T, want connectedMsg", msg)
+	}
+	if !conn.autoStarted {
+		t.Error("connectedMsg.autoStarted = false, want true")
+	}
+	if _, cmd = m.Update(msg); cmd == nil {
+		t.Error("connected update returned no stream command")
+	}
+	if m.phase != phaseConnected {
+		t.Fatalf("phase = %v, want phaseConnected", m.phase)
+	}
+	got := content(m)
+	if !strings.Contains(got, "connected") || !strings.Contains(got, "test-v") {
+		t.Errorf("connected view lacks badge/version: %q", got)
+	}
+}
+
+func TestConnectFailureAndRetry(t *testing.T) {
+	cn := fakeConnector()
+	cn.startDetached = func() (int, error) { return 0, errors.New("spawn refused") }
+	m := newRoot(testCtx(t), cn)
+
+	msg := runCmd(t, m.Init(), 5*time.Second)
+	_, cmd := m.Update(msg) // probeFailedMsg → starting
+	msg = runCmd(t, cmd, 5*time.Second)
+	if _, ok := msg.(connectFailedMsg); !ok {
+		t.Fatalf("start result = %T, want connectFailedMsg", msg)
+	}
+	m.Update(msg)
+	if m.phase != phaseFailed {
+		t.Fatalf("phase = %v, want phaseFailed", m.phase)
+	}
+	got := content(m)
+	for _, want := range []string{"spawn refused", "daemon.log", "r to retry"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("failure view lacks %q: %q", want, got)
+		}
+	}
+
+	// r reruns the whole connect flow.
+	_, cmd = m.Update(key("r"))
+	if m.phase != phaseProbing || cmd == nil {
+		t.Fatalf("retry: phase = %v, cmd nil = %v; want probing with a command", m.phase, cmd == nil)
+	}
+}
+
+func TestViewRoutingAndHelp(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector())
+	m.phase = phaseConnected
+
+	m.Update(key("2"))
+	if m.active != viewDetail {
+		t.Fatalf("active = %v, want viewDetail", m.active)
+	}
+	if !strings.Contains(content(m), "Task detail") {
+		t.Errorf("view 2 lacks 'Task detail': %q", content(m))
+	}
+
+	m.Update(key("?"))
+	if !strings.Contains(content(m), "Keys") {
+		t.Errorf("help overlay missing after ?: %q", content(m))
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if strings.Contains(content(m), "toggle this help") {
+		t.Errorf("help overlay still visible after esc: %q", content(m))
+	}
+
+	m.Update(key("6"))
+	if m.active != viewDaemon {
+		t.Fatalf("active = %v, want viewDaemon", m.active)
+	}
+}
+
+func TestQuitKeys(t *testing.T) {
+	for _, k := range []tea.KeyPressMsg{
+		key("q"),
+		{Code: 'c', Mod: tea.ModCtrl},
+	} {
+		m := newRoot(testCtx(t), fakeConnector())
+		_, cmd := m.Update(k)
+		if cmd == nil {
+			t.Fatalf("%q returned no command", k.String())
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Errorf("%q command is not tea.Quit", k.String())
+		}
+	}
+}
+
+// TestLiveEventLine renders a delivered event on the shell's event line —
+// the foundation's visible re-render on external change.
+func TestLiveEventLine(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector())
+	m.phase = phaseConnected
+	m.notes = make(chan apiclient.Note)
+
+	if !strings.Contains(content(m), "no events yet") {
+		t.Errorf("initial view lacks 'no events yet': %q", content(m))
+	}
+
+	taskID := int64(3)
+	m.updateNote(apiclient.EventNote{Event: apiclient.Event{
+		ID: 7, Type: "task.state_changed", TaskID: &taskID, TS: time.Now(),
+	}})
+	got := content(m)
+	if !strings.Contains(got, "task.state_changed #7") || !strings.Contains(got, "task 3") {
+		t.Errorf("event line missing details: %q", got)
+	}
+}
+
+func TestReconnectingState(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector())
+	m.phase = phaseConnected
+	m.notes = make(chan apiclient.Note)
+
+	m.updateNote(apiclient.DisconnectedNote{Err: errors.New("conn reset"), RetryIn: time.Second})
+	if m.phase != phaseReconnecting {
+		t.Fatalf("phase = %v, want phaseReconnecting", m.phase)
+	}
+	got := content(m)
+	if !strings.Contains(got, "connection lost") || !strings.Contains(got, "conn reset") {
+		t.Errorf("reconnect view lacks error: %q", got)
+	}
+
+	m.updateNote(apiclient.ConnectedNote{})
+	if m.phase != phaseConnected {
+		t.Fatalf("phase after reconnect = %v, want phaseConnected", m.phase)
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,0 +1,22 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Run launches the TUI and blocks until the user quits (§12.1: bare
+// `vincent`). The daemon keeps running after quit; if none is reachable at
+// launch, the shell auto-starts one in the background.
+func Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // stops the SSE stream goroutine with the program
+
+	p := tea.NewProgram(newRoot(ctx, defaultConnector()), tea.WithContext(ctx))
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("run tui: %w", err)
+	}
+	return nil
+}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// viewID indexes the six §15 views; the 1..6 global keys map onto it.
+type viewID int
+
+const (
+	viewBoard viewID = iota
+	viewDetail
+	viewNewTask
+	viewProjects
+	viewWorkflows
+	viewDaemon
+	viewCount
+)
+
+// view is one routed screen. Views are sub-models: the root delegates
+// non-global messages to the active view only.
+type view interface {
+	title() string
+	update(msg tea.Msg) (view, tea.Cmd)
+	render(width, height int) string
+}
+
+// stubView is a placeholder screen for a view a later Phase 3 PR replaces.
+type stubView struct {
+	name string
+	note string
+}
+
+func (s stubView) title() string                  { return s.name }
+func (s stubView) update(tea.Msg) (view, tea.Cmd) { return s, nil }
+func (s stubView) render(int, int) string         { return "\n  " + s.note + "\n" }
+
+// newViews returns the initial view set: all stubs in PR H; each later PR
+// swaps its own slot for the real screen.
+func newViews() [viewCount]view {
+	return [viewCount]view{
+		viewBoard:     stubView{name: "Board", note: "Board lands in PR I (T3.2)."},
+		viewDetail:    stubView{name: "Task detail", note: "Task detail lands in PRs J/K (T3.3, T3.4)."},
+		viewNewTask:   stubView{name: "New task", note: "The new-task flow lands in PR L (T3.5)."},
+		viewProjects:  stubView{name: "Projects", note: "Projects lands in PR M (T3.6)."},
+		viewWorkflows: stubView{name: "Workflows", note: "Workflows lands in PR M (T3.6)."},
+		viewDaemon:    stubView{name: "Daemon", note: "The daemon view lands in PR M (T3.7)."},
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 opens with the TUI foundation (spec §15, §12.1):

- **Bubble Tea v2 shell** (`charm.land/bubbletea/v2`): root model with view routing (`1..6`), global keys, `?` help overlay, and stub views that PRs I–M replace.
- **`internal/apiclient`** — the shared typed HTTP+SSE client (client-owned wire types; also feeds T4.2's CLI subcommands): `daemon.json` + token discovery, §13.1 error-envelope mapping, and an SSE subscriber that reconnects forever with capped backoff, resuming via `Last-Event-ID` so no durable event is lost.
- **Daemon auto-start** (§12.1): bare `vincent` enters the TUI immediately; a connect state runs `daemon.StartDetached()` + the phase-1 health poll behind a "starting daemon…" screen; failure shows the daemon log path with `r` retry. The same state doubles as the reconnect screen.
- Decisions recorded in tasks.md (Phase 3 + PR H grill blocks): 7-PR delivery (H–N), Bubble Tea v2, shared apiclient, Update/View-level testing.

Verification (all automated):
- apiclient integration tests run against the **real handlers** (real store + broker under httptest): live delivery, disconnect + resume-with-cursor, server-side type filter, auth envelope, SSE spec framing, discovery.
- TUI Update/View unit tests: auto-start state machine, failure + retry, view routing, help overlay, quit keys, event line, reconnect state.
- `TestAutoStartRealDaemon` e2e: builds the real binary, proves probe-miss → auto-start → connect → **live re-render on an externally-made `project.created`** → graceful stop.

## Related

T3.1 (docs/versions/v0/tasks.md, Phase 3 / PR H)

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] `docs/versions/v0/tasks.md` updated if this completes/changes a task