### PR TITLE
docs(spec): rewrite §15 for the panel shell; add the friction record (T3.9)

### DIFF
--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -1097,9 +1097,10 @@ stream for the live tail.
    (§7.4). OS desktop notifications remain out of v1 (§20).
 2. **Task detail.** Step timeline (every attempt, with durations, tokens, cost);
    live output tail of the running step (follow mode); scrollback into full
-   transcripts of past steps. Layout is stacked — timeline above, output below in a
-   tabbed pane the diff joins — because selecting an attempt *is* how scrollback is
-   navigated, so neither half can hide behind the other. Attempt duration here is
+   transcripts of past steps. Timeline and output are **side by side, both always
+   visible** — selecting an attempt *is* how scrollback is navigated, so neither
+   half can hide behind the other. The output side is a tabbed pane the diff
+   joins. Attempt duration here is
    §17's active time (`finished_at - started_at - input_wait_ms`) with the excluded
    wait shown beside it rather than silently subtracted; this is deliberately not
    the board's wall-clock `elapsed`, because the per-step figure is diagnostic while
@@ -1110,9 +1111,13 @@ stream for the live tail.
    bar for exactly the actions valid in the current state (§6), including gate
    approve/reject with the rendered gate instructions, and edit+retry which opens
    `$EDITOR` on the failing step's prompt/command. When the task is
-   `awaiting_input`, the pending question or permission request is rendered in
-   place (options, multi-select, free-text entry) above the live tail, and
-   submitting the answer resumes the run in the same session (§7.4).
+   `awaiting_input`, the pending question or permission request (options,
+   multi-select, free-text entry) opens as a **popup**, and submitting the answer
+   resumes the run in the same session (§7.4). It is a popup rather than a pane
+   region because it is an interrupt, not a view of the task — the same reason
+   the board pins those tasks and rings the bell. It **never steals focus**:
+   auto-opening under a keystroke is how an answer gets lost, so it announces
+   itself with a badge on the row and a footer hint, and the human opens it.
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
    `$EDITOR`) → custom fields (key/value) → base branch (default prefilled) →
@@ -1131,45 +1136,142 @@ stream for the live tail.
    at launch has no business killing it. The log tail is read straight from
    `{data_dir}/logs/daemon.log`, the one place the TUI is not a pure API client:
    an endpoint cannot serve the log when the daemon is the thing that died, which
-   is when the log is worth reading. For the same reason this is the only view
-   reachable while disconnected — views 1–5 stay behind the connection, view 6
-   renders the log and the resolved paths with the daemon-supplied blocks marked
-   unavailable.
+   is when the log is worth reading — so it is the one view with something true to
+   show while disconnected. See *Disconnected* below for what the rest of the UI
+   does in that state.
 
-### Global keys
+### Layout
 
-`?` help · `n` new task · `1..6` switch views · `/` filter · `enter` open ·
-`p` pause/resume · `c` cancel · `a` approve · `r` retry · `s` skip · `A` archive ·
-`q` quit TUI (daemon keeps running; a status line reminds of running task count on exit).
+The list above is a contract about **capabilities**, not about screens. Views 1
+and 2 — the daily loop — are one persistent screen of three panels; views 3–6 are
+full-screen takeovers reached from the command palette.
 
-The action keys act on the selected task — the row under the cursor on the board,
-the open task in the detail view — and are offered only when the daemon reports
-them in `available_actions`, so an invalid action is never on screen. `E` opens
-`$EDITOR` for edit+retry, `x` rejects a gate (`r` is taken by retry), and `d`
-toggles the detail pane between output and diff. `r` doubles as *retry connecting*
-on the disconnected screen, where no task is reachable anyway. Destructive actions
-confirm inline before firing: `c` cancel (kills a live process) and `A` archive
-(removes the worktree; a dirty one re-prompts for `force`). `set priority` (§6) has
-no key in v1 — priority is chosen in the new-task flow.
+```
+┌─ Tasks ──────────────────────────────────────────────┐
+│  #12  api    add rate limiting   running   3/5  …    │   ← always full width
+│  #13  web    fix flaky test      ● gate    2/4  …    │
+└──────────────────────────────────────────────────────┘
+┌─ Timeline ───────────┐┌─ Output │ Diff ──────────────┐
+│  1 ✓ plan      1m2s  ││  … live tail …               │
+│  2 ▸ implement 4m9s  ││                              │
+└──────────────────────┘└──────────────────────────────┘
+ tab focus · enter open · / filter        : commands  ? help  q quit
+```
 
-Detail view keys: `tab`/`shift+tab` cycle focus (timeline → pane → answer form,
-when one is pending) · `d` output/diff · `f`/`G` re-arm follow · `esc` back to the
-board. In the answer form, `space` picks or toggles a choice, `e` opens free-text
-entry, `enter` submits, `esc` abandons it without touching the task.
+The task table keeps the full §15 column set at full width. A narrow left rail
+would have to drop most of it, and cost-so-far and step `k/n` are the two columns
+a human scans to decide where to intervene.
 
-Projects view keys: `a` add · `enter`/`e` edit · `d` delete · `/` filter. Workflows
-view keys: `e` edit the file · `enter` expand the step list · `R` re-read the
-registry. The action keys above are task-scoped and unreachable here, so these two
-views bind freely; `n` still opens the new-task form, seeded with the project under
-the cursor. Deleting a project confirms inline, and a project holding non-archived
-tasks re-prompts to archive them (the `?force` of `DELETE /v1/projects/{id}`) — but
-a *running* task is refused outright, since no confirmation makes that delete legal.
+**The focused panel expands; the others collapse** to their title bar plus the
+selected line. The task table never collapses below 5 rows — it is the navigation
+spine, and a spine you cannot see is a modal round-trip wearing a border.
 
-Daemon view keys: `R` re-read everything · `f`/`G` follow the log again · `↑/↓`,
-`pgup`/`pgdn` scroll it. Identity, config and adapters refresh when the view opens
-and on `R`; the log alone re-reads on a short timer, because it is the only part
-that changes while you watch. Uptime ticks locally from the daemon's `started_at`
-rather than from a fetched figure, so it cannot drift between refreshes.
+Terminal size is a stated floor, not a hope. Below **80×20** the shell drops to
+single-panel mode: the focused panel alone, full screen, `tab` swapping which.
+Below **60×15** it renders the size it has and the size it needs, and nothing
+else. A layout that silently becomes illegible is worse than one that says so, and
+a floor is testable where "looks cramped" is not.
+
+Views 3–6 stay full-screen because they are forms and lists, not observations: the
+new-task flow is eight fields with pickers, and squeezing it beside a live tail
+serves neither. Takeovers are for surfaces you visit deliberately; popups are for
+small things — the palette, confirmations, and the answer form.
+
+### Discovery
+
+Three surfaces, one source. **`bindings.go` is the single registry** — every
+binding declares its key, label, scope (global · panel · task-action) and priority,
+and the palette, the footer and `?` all render from it. Hand-maintained parallel
+lists drift within two PRs and the drift is invisible until a human presses a key
+the help promised.
+
+**`:` opens the command palette.** It lists, searchable by intent: the task
+actions valid *right now*, navigation to views 3–6, and the focused panel's own
+commands — each with its direct key beside it, so the palette teaches shortcuts
+rather than replacing them. Invalid task actions are omitted rather than greyed,
+holding the same invariant the action bar always had: an action that cannot happen
+is not on screen. Navigation living here is what lets view-switching keys be
+retired without substituting a different set to memorise.
+
+**The footer is one line and never wraps.** Left to right: the focused panel's
+keys (at most five, in registry priority order), then the task's
+`available_actions`, then — pinned right and never truncated — `: commands`,
+`? help`, `q quit`. Overflow truncates from the left with `…`. The pinned segment
+is exempt because `:` is the escape hatch that makes every other key optional; a
+narrow terminal dropping it would fail exactly when the human is most lost.
+
+`?` remains, as a compact cheat sheet grouped by panel, rendered from the registry.
+
+### Keys
+
+Global: `:` palette · `?` help · `n` new task · `q` quit (the daemon keeps running;
+a status line reminds of the running task count on exit) · `tab`/`shift+tab` move
+focus between panels · `M` toggle mouse.
+
+Task actions act on the selected task and are offered only when the daemon reports
+them in `available_actions`: `p` pause/resume · `a` approve · `x` reject · `r`
+retry · `s` skip · `E` edit+retry in `$EDITOR` · `c` cancel · `A` archive. `x`
+rejects because `r` is taken; `r` doubles as *retry connecting* while disconnected,
+where no task is reachable anyway. Destructive actions confirm inline: `c` kills a
+live process, `A` removes the worktree and a dirty one re-prompts for `force`.
+`set priority` (§6) has no key — priority is chosen in the new-task flow.
+
+Panel-local: `/` filters **whichever list has focus** — tasks, projects, workflows
+— so one key means one thing everywhere. `enter` opens or expands. `[`/`]` switch
+the output pane's tabs (`d` kept as an alias). `f`/`G` re-arm follow on a live
+tail or the daemon log. `e` opens `$EDITOR` where a view has a file to edit. `R`
+re-reads a registry or the daemon blocks. One key jumps to the next task needing a
+human, surfaced in the footer only when that count is non-zero — the board has
+always pinned and belled those tasks without offering any way to *go* to one.
+
+**`esc` cancels one layer per press**, by a fixed stack: popup (palette,
+confirmation, answer form) → takeover screen → active filter → nothing. It is a
+no-op at the bottom and it **never quits** — `esc`-to-exit surprises anyone who
+pressed it meaning "back". "Back to the board" is not among its meanings any more,
+because the board is always on screen.
+
+A filter is view state, not a mode: `tab` **commits** it and moves focus, leaving
+it applied and named in the panel title; only `esc` clears it. Losing a filter
+because you glanced at the output pane is the kind of thing that trains people to
+distrust a UI. The shell consults the **focused** panel for whether it is capturing
+input, so global single-key bindings stay live everywhere else without leaking
+keystrokes into a text field.
+
+Deleting a project confirms inline, and a project holding non-archived tasks
+re-prompts to archive them (the `?force` of `DELETE /v1/projects/{id}`) — but a
+*running* task is refused outright, since no confirmation makes that delete legal.
+
+In the daemon view, identity, config and adapters refresh on open and on `R`; the
+log alone re-reads on a short timer, because it is the only part that changes while
+you watch. Uptime ticks locally from the daemon's `started_at` rather than from a
+fetched figure, so it cannot drift between refreshes.
+
+### Mouse
+
+On by default, `M` toggles it, and the toggle is in the palette. Click to focus a
+panel, click a row to select it, wheel to scroll the focused panel, click a footer
+hint to fire it, click a tab to switch it. No drag, no right-click.
+
+Capturing the mouse costs native click-drag text selection. Every terminal has a
+modifier override for it (shift-drag; option-drag on Terminal.app and iTerm) and
+the toggle covers what is left — whereas shipping it off by default would make the
+feature that exists for discoverability itself undiscoverable.
+
+### Colour
+
+A fixed palette: panel borders, a focus colour, and the existing state colours. It
+degrades under `NO_COLOR` and on 16-colour terminals. No theme setting in v1 — that
+is configuration surface, a docs section and a support burden for no acceptance
+value.
+
+### Disconnected
+
+The panels stay on screen with their contents **marked stale**, behind a banner
+saying the daemon is unreachable, with `r` to retry. Nothing force-navigates: the
+last known task table is information as long as it is labelled as such, and
+connect and reconnect are the same state, so a takeover on every blip would be
+hostile. `:` still reaches the daemon view, which is the one surface with something
+currently true to show (§15 view 6).
 
 ## 16. Security considerations
 

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 13 tasks | 6/13 | 🟡 in progress |
+| 3 — TUI (M3) | 13 tasks | 7/13 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **31/44** | |
+| **Total** | | **32/44** | |
 
 ---
 
@@ -459,14 +459,15 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
 
 **Phase 3 TUI refactor decisions (grill session, 2026-08-09):**
 
-The M3 TUI reached T3.8 as six full-screen views routed by `1..6`, with 45 keys
-spread across eight groups in the `?` overlay. It works and it is tested; it is
+The M3 TUI reached T3.8 as six full-screen views routed by `1..6`, with 42 distinct
+keystrokes bound and 45 help rows across nine groups behind `?` (measured in
+`tui-friction.md`). It works and it is tested; it is
 also unlearnable without the overlay open. The refactor keeps every capability and
 changes how it is reached. T3.1–T3.7 stay `[x]` — they are not undone, they are
 superseded in layout and routing by T3.10–T3.13.
 
 - *Refactor first, then gate — the outgoing UI is never walked at all.* T3.8 is acceptance evidence, and evidence for a UI about to be deleted is worth nothing: a two-OS walkthrough with real `claude` costs hours of human time and pins a commit SHA that the next PR invalidates. Nothing is discarded by skipping it, because nothing was recorded — `m3-gate.md` holds a template with no run in it, so T3.8 simply stays `[~]` until T3.13 lands. The gate's *artifacts* do carry over: `scripts/m3-gate.sh` never touches the TUI (it seeds two repos, the workflows and a bare remote, then prints a paste-ready launch line) and section A is quoted from §19, so only section B's key-specific sweep items are rewritten, in T3.13.
-- *The friction record is derived, not walked.* `tui-friction.md` still exists and is still what the refactor is graded against, but its provenance changes: it is read off the current binding surface — `internal/tui/help.go`'s 45 keys in eight groups, the six views behind `1..6`, `actionbar.go`'s hints being task-scoped only — rather than harvested from a session at a terminal. The friction is already legible in the source; spending a human hour to rediscover it buys nothing that reading `help.go` does not. What matters is that the list is written down **before** the refactor, so "is this better?" is settled against a fixed record instead of taste at review time.
+- *The friction record is derived, not walked.* `tui-friction.md` still exists and is still what the refactor is graded against, but its provenance changes: it is read off the current binding surface — 42 bound keystrokes against 45 help rows in nine groups, the six views behind `1..6`, `actionbar.go`'s hints being task-scoped only — rather than harvested from a session at a terminal. The derivation is reproducible and the measurement method is stated in the file, which is what stops the "before" figure being renegotiated once the "after" is known. The friction is already legible in the source; spending a human hour to rediscover it buys nothing that reading `help.go` does not. What matters is that the list is written down **before** the refactor, so "is this better?" is settled against a fixed record instead of taste at review time.
 - *Bubble Tea v2 stays.* lazygit's feel comes from layout and contextual menus, not from gocui; tview and gocui would both discard ~7k lines, every `*live_test.go`, and the Phase 3 framework decision to buy nothing the current stack cannot do. bubbletea v2 has mouse and focus, lipgloss v2 has borders and joins. No goal below needs a different engine.
 - *Hybrid, not full lazygit.* The daily loop (board → detail → back) fuses into one persistent screen; projects, workflows, daemon and new-task stay full-screen takeovers, reached from the command palette instead of `1..6`. A full lazygit port would force §15's eight-field new-task wizard into a popup, which is worse than what exists. Config surfaces visited twice a week do not earn permanent screen width.
 - *Three panes, accordion.* Top: the full-width task table, keeping all eight §15 columns — a 30%-wide left rail would delete five of them, and cost and step `k/n` are spec'd and load-bearing. Bottom: timeline (left) beside output/diff (right), which satisfies §15's "neither half can hide behind the other" as well as the stacked layout did. The focused panel expands and the others collapse to title + one line; the task table never drops below 5 rows because it is the navigation spine. Below **80×20** the shell falls to single-panel mode (focused panel full screen, `tab` swaps); below **60×15** it renders an explicit `terminal too small (58×14, need 60×15)`. A silently illegible layout is worse than a stated floor, and the floor is testable.
@@ -487,7 +488,7 @@ superseded in layout and routing by T3.10–T3.13.
 - *Five PRs, docs first, each independently green* — O: T3.9 · P: T3.10 · Q: T3.11 · R: T3.12 · S: T3.13. Each opens with its own grill block, per the Phase 2/3 pattern.
 - *Success is measured against the "before".* Every item in `tui-friction.md` becomes a checkbox re-checked during the T3.8 walk, each carrying its disposition — fixed, deferred to a Phase 4 task ID, or won't-fix with a reason. Without that, "is it easier now?" is settled by whoever argues hardest in the PR thread, which is how 45 keys happened.
 
-- [ ] **T3.9 — Refactor spec & friction record (docs only).** Rewrite §15's layout and key prose for the three-pane panel shell (`:` palette, footer, `esc` stack, panel-local `/`, disconnected banner, terminal floors), keeping its numbered 1–6 list as the capability contract and leaving §19 untouched. Add `docs/versions/v0/tui-friction.md`, derived from the current binding surface (`internal/tui/help.go`, the `1..6` routing in `views.go`, `actionbar.go`'s task-scoped hints) — the outgoing UI is not walked.
+- [x] **T3.9 — Refactor spec & friction record (docs only).** ✓ 2026-08-09 Rewrite §15's layout and key prose for the three-pane panel shell (`:` palette, footer, `esc` stack, panel-local `/`, disconnected banner, terminal floors), keeping its numbered 1–6 list as the capability contract and leaving §19 untouched. Add `docs/versions/v0/tui-friction.md`, derived from the current binding surface (`internal/tui/help.go`, the `1..6` routing in `views.go`, `actionbar.go`'s task-scoped hints) — the outgoing UI is not walked.
   *Done when:* §15 describes the target UI with no stale key table; `tui-friction.md` lists concrete friction items, each phrased so T3.8 can re-check it.
 - [ ] **T3.10 — Panel shell; board and detail fused.** `panel` interface (renamed from `view`), `shell.go` owning layout/focus/accordion, `layout.go` as a pure `layout(w, h, focus) → []box`. Three panes (task table · timeline · output|diff tabs), focused-panel borders, single-panel mode below 80×20, explicit too-small below 60×15. Debounced running-task-only SSE subscription. `NO_COLOR` and 16-colour downgrade. *Depends:* T3.9.
   *Done when:* `layout` is table-tested across sizes and focus targets; holding `down` across the table asserts one subscription, not one per row; existing board/detail render assertions pass against the boxed sub-models.

--- a/docs/versions/v0/tui-friction.md
+++ b/docs/versions/v0/tui-friction.md
@@ -1,0 +1,72 @@
+# TUI friction record (T3.9)
+
+The "before" the panel refactor (T3.10–T3.13) is graded against. Every item here
+comes back as a checkbox in the T3.8 walkthrough, each carrying its disposition:
+**fixed**, **deferred** to a Phase 4 task ID, or **won't-fix** with a reason.
+
+Written *before* the refactor on purpose. Without a fixed record, "is the TUI
+easier now?" is settled by whoever argues hardest in the PR thread — which is how
+42 keystrokes accumulated without anyone deciding to add them.
+
+## How this was produced
+
+Derived from the source, not from a walkthrough. The outgoing UI is never walked
+(see the Phase 3 TUI refactor decisions in `tasks.md`): a two-OS session with real
+`claude` costs hours and pins a commit SHA the next PR invalidates, and the
+friction is already legible in `internal/tui`. Measurements below are reproducible
+against the tree at the commit that adds this file:
+
+- **Bound keystrokes** — every distinct string in a `case "…":` in a non-test
+  `internal/tui/*.go`, minus event-type constants, unioned with the keys of the
+  `actionKeys` map in `actionbar.go`.
+- **Documented keystrokes** — the left column of the row tables in `help.go`.
+
+Counts are of *distinct keystrokes*, not of help rows: `help.go` has 45 rows, but
+several rows carry two keys (`a / x`, `f / G`, `+ / -`, `enter/e`) and one carries
+six (`1..6`).
+
+## Findings
+
+| ID | Finding | Evidence |
+|---|---|---|
+| **F1** | **42 distinct keystrokes are bound; the screen shows a fraction of them at any moment.** The only complete list is behind `?`. | 42 measured by the method above |
+| **F2** | **`?` is a full-screen modal you must leave the work to read, and cannot act from.** It is 45 rows in 9 groups — longer than most terminals, so it also scrolls. | `help.go:6-92`; 9 groups counted at `help.go:73-90` |
+| **F3** | **Bindings live in three hand-maintained places and have already drifted.** Task actions are a map, everything else is per-view `case` arms, and the overlay is a third literal list. At least 8 bound keystrokes appear nowhere in `?`: `j` `k` `y` `Y` `_` `=` `end` `shift+tab`. | `actionbar.go:32`, per-view switches, `help.go:7-71` |
+| **F4** | **Navigation is six numbered keys with no on-screen legend.** Nothing maps `3` to "new task" except the overlay; there is no tab strip, no breadcrumb, no title bar naming the other five. | `views.go:14-22`, `root.go:189` |
+| **F5** | **Board and detail are a modal round-trip.** `enter` in, `esc` out. A task's live output and the rest of the queue are never on screen together, so watching three parallel tasks means cycling. | `board.go:347`, `detail.go:582` |
+| **F6** | **The same key means different things per view, with nothing on screen saying which.** `d` is output/diff in detail and *delete* in projects. `a` is approve on a task and *add* in projects. `r` and `R` are different commands. | `detail.go:572`, `projects.go`, `workflows.go` |
+| **F7** | **Only task actions get a contextual hint; every other view's keys are invisible until `?`.** The action bar renders exactly the valid `available_actions` — the right idea, applied to one of nine key groups. | `actionbar.go:231-256` |
+| **F8** | **Attention tasks are pinned and ring the bell, but there is no way to *go* to one.** You find the task blocking on you by eye, then move the cursor by hand. | §15 pinning; no jump binding exists |
+| **F9** | **No mouse.** Clicking a row, a pane, or a hint does nothing. | no mouse handling in `internal/tui` |
+| **F10** | **There is no command surface.** If you do not know the key, the only recourse is `?` and reading. Nothing is searchable by intent — you cannot type "archive" and find `A`. | absent |
+| **F11** | **`esc` is overloaded and its meaning is positional.** Clear filter · back to board · leave the answer form · in new-task, leave the *field*, then the *form*, with a confirm if the draft was touched. | `board.go:342`, `detail.go:582`, `newtask.go` |
+| **F12** | **The answer form — the one screen where a task is blocked on the human — is a stop in a `tab` cycle.** Reaching it requires knowing that `tab` cycles timeline → pane → form, and that the form is only in the cycle when a question is pending. | `detail.go:566`, `help.go:32` |
+
+## Where each is addressed
+
+| Finding | Task | Mechanism |
+|---|---|---|
+| F1, F10 | T3.11 | `:` command palette — searchable by intent, shows each entry's direct key |
+| F2, F3 | T3.11 | One `bindings.go` registry renders palette, footer and `?`; drift becomes a test failure |
+| F4 | T3.11 | `1..6` retired; the four takeover screens are palette entries |
+| F5 | T3.10 | Board and detail fuse into one three-pane screen |
+| F6 | T3.12 | Footer names the focused panel's keys, so the meaning in force is on screen |
+| F7 | T3.12 | The action bar generalises into the footer for every panel |
+| F8 | T3.11 | Jump-to-next-attention key, surfaced in the footer only when the count is non-zero |
+| F9 | T3.13 | Click-to-focus, click-row-select, wheel scroll, clickable hints and tabs |
+| F11 | T3.10/T3.11 | Explicit `esc` stack: popup → takeover → filter → no-op; never quits |
+| F12 | T3.10 | Answer form becomes a popup with a row badge and a footer hint; it never steals focus |
+
+## Non-goals
+
+Two things this record deliberately does **not** ask for, so that T3.8 does not
+grade against them:
+
+- **A smaller command surface.** The refactor unhides keys; it does not delete
+  capability. The count goes from 42 to roughly 41 — `1..6` dies, one
+  attention-jump key is born. The win is that memorisation stops being required,
+  not that there is less to memorise. Cutting further means removing things the
+  TUI can do, which was considered and rejected.
+- **A tutorial or guided tour.** One line on the existing first-run screen names
+  `:` and `?`; the permanently pinned footer hint is the real teacher. A tour is
+  what you build when the UI cannot explain itself.


### PR DESCRIPTION
**PR O — T3.9.** Docs only. Stacked on #30; retarget to `master` once that merges.

Closes T3.9. Dashboard `6/13` → `7/13`, total `32/44`.

## §15 rewrite

The numbered 1–6 list stays as the **capability** contract — all six surfaces still exist, only routing and layout change — so §19's "six views" acceptance phrase stays literally true and collects no footnote. What changed:

- **New sections**: Layout, Discovery, Keys, Mouse, Colour, Disconnected. The old "Global keys" prose is gone.
- **Views 1+2 fuse** into one persistent three-pane screen (task table full width on top; timeline beside output/diff below), with an ASCII sketch in the spec. Focused panel expands, others collapse; the task table never drops below 5 rows.
- **Stated terminal floors**: single-panel mode below 80×20, an explicit "too small" render below 60×15. Testable, where "looks cramped" is not.
- **Views 3–6 become takeovers** reached from `:`, because they're forms and lists, not observations.
- **One `bindings.go` registry** feeds palette, footer and `?`. The footer never wraps, and its right-pinned `: commands ? help q quit` is exempt from truncation — `:` is the escape hatch that makes every other key optional.
- **`esc` gets a fixed stack** — popup → takeover → filter → no-op — and never quits. "Back to the board" stops being one of its meanings because the board is always on screen.
- **The answer form becomes a popup that never steals focus.** It's an interrupt, not a view of the task; auto-opening under a keystroke is how an answer gets lost, so it announces itself with a row badge and a footer hint.
- **Disconnection** marks panels stale behind a banner with `r` to retry, instead of hiding views 1–5. Amends the old "views 1–5 stay behind the connection".

## `tui-friction.md`

The "before" the refactor is graded against, written *before* it exists. Twelve findings, each mapped to the task that addresses it and each phrased to come back as a T3.8 checkbox.

Derived from source, not from a walkthrough — the method is stated in the file and is reproducible, which is what stops the "before" figure being renegotiated once the "after" is known:

- **42 distinct keystrokes bound**, against 45 help rows in **nine** groups.
- **8 bound keystrokes documented nowhere** in `?`: `j` `k` `y` `Y` `_` `=` `end` `shift+tab` — the drift three hand-maintained binding lists produce.
- Bindings live in three places: the `actionKeys` map, per-view `case` arms, and `help.go`'s literals.

Two **non-goals** are named explicitly so the gate cannot grade against them: a smaller command surface (42 → ~41; the win is that memorisation stops being required, not that there's less of it), and a guided tour.

Also corrects the count in the T3.9–T3.13 decision block, which said 45 keys in eight groups.

No code, no CI surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)