### PR TITLE
refactor(tui): panel shell — board and detail fused (T3.10)

### DIFF
--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 13 tasks | 7/13 | 🟡 in progress |
+| 3 — TUI (M3) | 13 tasks | 8/13 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **32/44** | |
+| **Total** | | **33/44** | |
 
 ---
 
@@ -490,7 +490,17 @@ superseded in layout and routing by T3.10–T3.13.
 
 - [x] **T3.9 — Refactor spec & friction record (docs only).** ✓ 2026-08-09 Rewrite §15's layout and key prose for the three-pane panel shell (`:` palette, footer, `esc` stack, panel-local `/`, disconnected banner, terminal floors), keeping its numbered 1–6 list as the capability contract and leaving §19 untouched. Add `docs/versions/v0/tui-friction.md`, derived from the current binding surface (`internal/tui/help.go`, the `1..6` routing in `views.go`, `actionbar.go`'s task-scoped hints) — the outgoing UI is not walked.
   *Done when:* §15 describes the target UI with no stale key table; `tui-friction.md` lists concrete friction items, each phrased so T3.8 can re-check it.
-- [ ] **T3.10 — Panel shell; board and detail fused.** `panel` interface (renamed from `view`), `shell.go` owning layout/focus/accordion, `layout.go` as a pure `layout(w, h, focus) → []box`. Three panes (task table · timeline · output|diff tabs), focused-panel borders, single-panel mode below 80×20, explicit too-small below 60×15. Debounced running-task-only SSE subscription. `NO_COLOR` and 16-colour downgrade. *Depends:* T3.9.
+**PR P decisions (T3.10; grill session, 2026-08-10):**
+
+- *The answer form becomes the §15 popup in this PR, not later.* The fused layout has no inline slot — the form used to take half the output pane, and boxing that into a quarter-height panel is exactly the shape the refactor decisions called wrong for an interrupt. Building it inline now means building it twice. It opens on a human key press only — `enter` on an `awaiting_input` row — and `esc` closes it; it never auto-opens and never steals focus. The announce surfaces stay where they were planned (jump key T3.11, footer hint T3.12); until then the row badge and the bell are the announcement, which is what they already are today.
+- *The disconnected code lands here.* §15's amended "Disconnected" prose (T3.9) is implemented by the same PR that rewrites root's body rendering: `reconnecting`/`failed` with a loaded board renders the panels marked stale behind a banner with `r` to retry. The initial probe/start keeps the current connect screens — before the first connection there is no "last known task table", so a stale empty shell would be a lie, not information. Takeover screens keep the connection gate; the daemon view exception is unchanged.
+- *The task fetch rides the same settle as the subscribe.* The refactor decision pinned only the SSE subscription to a ~250ms settle; the `GetTask` + transcript fetch join it rather than firing per cursor move. One mechanism, one test, and a 20-row hold-down costs one fetch instead of twenty. Cursor move = immediate unsubscribe + placeholder; settle = fetch + subscribe iff the task is running.
+- *The accordion is vertical, between bands.* "Collapse to title + one line" applies to the unfocused band, not to the timeline/output pair individually: collapsing the output while navigating the timeline would defeat the reason they sit side by side — selecting an attempt *is* how scrollback is navigated (§15). Focus on tasks → the bottom band is two title+line strips; focus below → the tasks panel sits on its 5-row floor and the band keeps its 40/60 split.
+- *`detail` stays one sub-model rendering two boxes* (timeline, output|diff). Splitting it into two models would divorce the timeline cursor from the transcript state it drives, for no testing gain; the shell's focus maps onto its internal focus.
+- *Two action lines is the accepted interim.* Action keys route to the focused panel's bar — board's inside the tasks panel, detail's below the band — both gated on the same `available_actions` for the same selected task. T3.12's footer is the PR that unifies them; dragging that work forward would make this PR two PRs.
+- *`1`/`2` collapse onto the fused screen* (`2` focusing the timeline) and `3..6` keep their meanings until T3.11 retires the digits — capability parity during the interim, no new keys born early.
+
+- [~] **T3.10 — Panel shell; board and detail fused.** `panel` interface (renamed from `view`), `shell.go` owning layout/focus/accordion, `layout.go` as a pure `layout(w, h, focus) → []box`. Three panes (task table · timeline · output|diff tabs), focused-panel borders, single-panel mode below 80×20, explicit too-small below 60×15. Debounced running-task-only SSE subscription. `NO_COLOR` and 16-colour downgrade. *Depends:* T3.9.
   *Done when:* `layout` is table-tested across sizes and focus targets; holding `down` across the table asserts one subscription, not one per row; existing board/detail render assertions pass against the boxed sub-models.
 - [ ] **T3.11 — Command palette; `1..6` retired.** `bindings.go` registry (key, label, scope, priority) as the single source for palette, footer and `?`. `:` opens a searchable list of valid task actions + navigation to the four takeover screens + panel-local commands, each showing its direct key; invalid task actions omitted. `esc` stack, panel-local `/`, `tab`-commits-filter. Jump-to-next-attention key. *Depends:* T3.10.
   *Done when:* `1..6` is gone and every takeover screen is reachable from `:`; a test asserts every registry entry is reachable from the palette; the `?` overlay renders from the registry, not a literal list.

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 13 tasks | 8/13 | 🟡 in progress |
+| 3 — TUI (M3) | 13 tasks | 9/13 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **33/44** | |
+| **Total** | | **34/44** | |
 
 ---
 
@@ -500,8 +500,9 @@ superseded in layout and routing by T3.10–T3.13.
 - *Two action lines is the accepted interim.* Action keys route to the focused panel's bar — board's inside the tasks panel, detail's below the band — both gated on the same `available_actions` for the same selected task. T3.12's footer is the PR that unifies them; dragging that work forward would make this PR two PRs.
 - *`1`/`2` collapse onto the fused screen* (`2` focusing the timeline) and `3..6` keep their meanings until T3.11 retires the digits — capability parity during the interim, no new keys born early.
 
-- [~] **T3.10 — Panel shell; board and detail fused.** `panel` interface (renamed from `view`), `shell.go` owning layout/focus/accordion, `layout.go` as a pure `layout(w, h, focus) → []box`. Three panes (task table · timeline · output|diff tabs), focused-panel borders, single-panel mode below 80×20, explicit too-small below 60×15. Debounced running-task-only SSE subscription. `NO_COLOR` and 16-colour downgrade. *Depends:* T3.9.
+- [x] **T3.10 — Panel shell; board and detail fused.** ✓ 2026-08-10 `panel` interface (renamed from `view`), `shell.go` owning layout/focus/accordion, `layout.go` as a pure `layout(w, h, focus) → []box`. Three panes (task table · timeline · output|diff tabs), focused-panel borders, single-panel mode below 80×20, explicit too-small below 60×15. Debounced running-task-only SSE subscription. `NO_COLOR` and 16-colour downgrade. *Depends:* T3.9.
   *Done when:* `layout` is table-tested across sizes and focus targets; holding `down` across the table asserts one subscription, not one per row; existing board/detail render assertions pass against the boxed sub-models.
+  *2026-08-10:* landed per the PR P decisions above. Also fixed in passing: resizing across a board column breakpoint crashed bubbles' table (stale wider rows re-rendered against the narrower column set) — found by the new single-panel-mode test, fixed in `board.render`.
 - [ ] **T3.11 — Command palette; `1..6` retired.** `bindings.go` registry (key, label, scope, priority) as the single source for palette, footer and `?`. `:` opens a searchable list of valid task actions + navigation to the four takeover screens + panel-local commands, each showing its direct key; invalid task actions omitted. `esc` stack, panel-local `/`, `tab`-commits-filter. Jump-to-next-attention key. *Depends:* T3.10.
   *Done when:* `1..6` is gone and every takeover screen is reachable from `:`; a test asserts every registry entry is reachable from the palette; the `?` overlay renders from the registry, not a literal list.
 - [ ] **T3.12 — Contextual footer.** Generalize `actionbar` into a one-line, never-wrapping footer: focused-panel keys (max 5, priority-ordered) · `available_actions` · right-pinned `: commands  ? help  q quit`. Left-truncates with `…`; the pinned segment never truncates. Attention-jump hint appears only when the count is non-zero. *Depends:* T3.11.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
+	github.com/charmbracelet/colorprofile v0.4.3
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/gofrs/flock v0.13.0
@@ -59,9 +61,7 @@ require (
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/ClickHouse/clickhouse-go-linter v1.2.0 h1:zbm174up3hTKjp0wKZVnTzRiG7t
 github.com/ClickHouse/clickhouse-go-linter v1.2.0/go.mod h1:pLorS7ffPTfuUV9M0SJgfHA/h/WQPQUk2FWG9x74cQ4=
 github.com/Djarvur/go-err113 v0.1.1 h1:eHfopDqXRwAi+YmCUas75ZE0+hoBHJ2GQNLYRSxao4g=
 github.com/Djarvur/go-err113 v0.1.1/go.mod h1:IaWJdYFLg76t2ihfflPZnM1LIQszWOsFDh2hhhAVF6k=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/MirrexOne/unqueryvet v1.5.4 h1:38QOxShO7JmMWT+eCdDMbcUgGCOeJphVkzzRgyLJgsQ=

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -47,9 +47,9 @@ type (
 	}
 	// boardTickMsg drives the elapsed column.
 	boardTickMsg time.Time
-	// selectTaskMsg asks the shell to open a task. The board does not route
-	// itself: the root owns view routing, and PR J's detail view receives
-	// this same message unchanged.
+	// selectTaskMsg asks the home shell to select a task in the table and
+	// open it in the detail panels immediately — the explicit path, used by
+	// task creation. Cursor movement goes through the settle window instead.
 	selectTaskMsg struct{ id int64 }
 )
 
@@ -187,7 +187,7 @@ func (b *board) scheduleRefresh() tea.Cmd {
 	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg { return boardRefreshMsg{} })
 }
 
-func (b *board) update(msg tea.Msg) (view, tea.Cmd) {
+func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		b.width, b.height = msg.Width, msg.Height
@@ -310,7 +310,7 @@ func (b *board) ringsFor(ev apiclient.Event) bool {
 	return true
 }
 
-func (b *board) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	if b.filtering {
 		switch msg.String() {
 		case "esc":
@@ -342,11 +342,6 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
 	case "esc":
 		if b.filter.Value() != "" {
 			b.filter.SetValue("")
-		}
-		return b, nil
-	case "enter":
-		if id, ok := b.selected(); ok {
-			return b, func() tea.Msg { return selectTaskMsg{id: id} }
 		}
 		return b, nil
 	}
@@ -446,12 +441,25 @@ func (b *board) render(width, height int) string {
 	}
 
 	cols, set := boardColumns(b.width)
+	// SetColumns re-renders the rows it already holds: when a resize crosses
+	// a column breakpoint, yesterday's wider rows meet today's narrower
+	// column set and the table indexes out of range. Clear the rows first —
+	// the real ones are set right back.
+	if len(cols) != len(b.tbl.Columns()) {
+		b.tbl.SetRows(nil)
+	}
 	b.tbl.SetColumns(cols)
 	b.tbl.SetRows(b.rowsFor(rows, set))
 	b.tbl.SetWidth(b.width)
 	// Two lines of chrome above, plus the filter line when it is showing.
 	b.tbl.SetHeight(max(3, b.height-b.chromeLines()))
 	b.restoreSelection(rows)
+	// Passing through an empty row set (the breakpoint clear above, or a
+	// board that emptied and refilled) parks the cursor at -1; with rows on
+	// screen the cursor belongs on one.
+	if b.tbl.Cursor() < 0 && len(rows) > 0 {
+		b.tbl.SetCursor(0)
+	}
 	sb.WriteString(b.tbl.View())
 	sb.WriteString("\n")
 	sb.WriteString(b.actionLine())
@@ -468,7 +476,7 @@ func (b *board) actionLine() string {
 	}
 	var extra []string
 	if t.has(apiclient.ActionAnswer) {
-		extra = append(extra, styleAsk.Render("enter → answer in the detail view"))
+		extra = append(extra, styleAsk.Render("enter → answer"))
 	}
 	return b.actions.render(t, extra...)
 }

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -425,34 +425,8 @@ func TestSelectionTracksTaskIDAcrossResort(t *testing.T) {
 	}
 }
 
-// TestEnterEmitsSelectTaskMsg wires the board to the shell's routing.
-func TestEnterEmitsSelectTaskMsg(t *testing.T) {
-	b := testBoard()
-	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{task(7, stateRunning)}})
-	b.render(120, 20)
-
-	_, cmd := b.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if cmd == nil {
-		t.Fatal("enter produced no command")
-	}
-	msg, ok := cmd().(selectTaskMsg)
-	if !ok {
-		t.Fatalf("enter produced %T, want selectTaskMsg", cmd())
-	}
-	if msg.id != 7 {
-		t.Errorf("selected id = %d, want 7", msg.id)
-	}
-}
-
-// TestEnterOnEmptyBoardIsSafe: no rows, no selection, no panic.
-func TestEnterOnEmptyBoardIsSafe(t *testing.T) {
-	b := testBoard()
-	b.updateLoaded(boardLoadedMsg{tasks: nil})
-	b.render(120, 20)
-	if _, cmd := b.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
-		t.Error("enter on an empty board produced a command")
-	}
-}
+// Enter moved to the shell in T3.10: opening the row under the cursor is
+// the fused screen's job (shell_test.go), not a message the board emits.
 
 func TestFilterCapturesKeys(t *testing.T) {
 	b := testBoard()

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -231,14 +231,15 @@ func TestBoardEnterOpensDetail(t *testing.T) {
 		t.Fatal("enter on the board produced no command")
 	}
 	h.p.push(cmd)
-	h.p.until(5*time.Second, "the detail view to open", func() bool {
-		return h.m.active == viewDetail
-	})
-	if h.m.selectedTask != task.ID {
-		t.Errorf("selected task = %d, want %d", h.m.selectedTask, task.ID)
+	s := h.m.views[viewHome].(*shell)
+	if s.focus != panelTimeline {
+		t.Fatalf("focus = %v, want the timeline panel after enter", s.focus)
 	}
-	// The detail view fetches on activation, so the header naming the task is
-	// also proof the hand-off reached a view with a working client.
+	if s.detail.taskID != task.ID {
+		t.Fatalf("detail task = %d, want %d", s.detail.taskID, task.ID)
+	}
+	// The open fetches immediately, so the header naming the task is also
+	// proof the hand-off reached a sub-model with a working client.
 	want := "#" + strconv.FormatInt(task.ID, 10) + " openable task"
 	h.p.until(10*time.Second, "the detail header to render", func() bool {
 		return strings.Contains(content(h.m), want)

--- a/internal/tui/daemon.go
+++ b/internal/tui/daemon.go
@@ -164,7 +164,7 @@ func (d *daemonView) refreshCmd() tea.Cmd {
 	return tea.Batch(d.infoCmd(), d.configCmd(), d.logCmd())
 }
 
-func (d *daemonView) update(msg tea.Msg) (view, tea.Cmd) {
+func (d *daemonView) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		d.width, d.height = msg.Width, msg.Height
@@ -240,7 +240,7 @@ func (d *daemonView) applyLog(msg daemonLogMsg) {
 	d.logDirty = true
 }
 
-func (d *daemonView) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (d *daemonView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch msg.String() {
 	case "R":
 		return d, d.refreshCmd()

--- a/internal/tui/daemon_test.go
+++ b/internal/tui/daemon_test.go
@@ -267,11 +267,11 @@ func TestDaemonViewTickerStopsWhenTheViewGoesOffScreen(t *testing.T) {
 // Another view's activation is not this view's.
 func TestDaemonViewIgnoresAnotherViewsActivation(t *testing.T) {
 	d := newTestDaemonView(nil, nil)
-	if _, cmd := d.update(viewActivatedMsg{id: viewBoard}); cmd != nil {
-		t.Error("the board's activation started the daemon view")
+	if _, cmd := d.update(viewActivatedMsg{id: viewHome}); cmd != nil {
+		t.Error("the home screen's activation started the daemon view")
 	}
 	if d.visible {
-		t.Error("the board's activation marked the daemon view visible")
+		t.Error("the home screen's activation marked the daemon view visible")
 	}
 }
 

--- a/internal/tui/daemonshell_test.go
+++ b/internal/tui/daemonshell_test.go
@@ -61,7 +61,7 @@ func TestFailureScreenPointsAtTheDaemonView(t *testing.T) {
 // running, and only when the board knows.
 func TestQuitReminderCountsRunningTasks(t *testing.T) {
 	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
-	b := m.views[viewBoard].(*board)
+	b := m.views[viewHome].(*shell).board
 
 	t.Run("board never loaded", func(t *testing.T) {
 		b.loaded = false

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -26,15 +26,14 @@ const (
 	detailRefreshDebounce = 150 * time.Millisecond
 )
 
-// detailFocus is which pane the keyboard drives.
+// detailFocus is which pane the keyboard drives. The shell maps its panel
+// focus onto it; the answer form is a popup the shell owns (T3.10), not a
+// focus target.
 type detailFocus int
 
 const (
 	focusTimeline detailFocus = iota
 	focusOutput
-	// focusForm exists only while a task is awaiting_input; tab cycles into
-	// it and back out again.
-	focusForm
 )
 
 // detailTab is which pane the lower half shows.
@@ -70,8 +69,8 @@ type (
 	// taskStreamDoneMsg reports the per-task note channel closed.
 	taskStreamDoneMsg struct{}
 	// viewActivatedMsg and viewDeactivatedMsg tell a view it came on or off
-	// screen. The detail view holds a live subscription and must not keep it
-	// open for a task nobody is watching.
+	// screen. The shell translates them for the detail sub-model, whose live
+	// subscription must not stay open for a task nobody is watching.
 	viewActivatedMsg   struct{ id viewID }
 	viewDeactivatedMsg struct{ id viewID }
 )
@@ -88,6 +87,10 @@ type detail struct {
 	task    apiclient.TaskDetail
 	loaded  bool
 	loadErr error
+	// stateHint is the board row's state at open time: it decides whether
+	// the subscription opens before the authoritative fetch lands (§13.3 —
+	// only a running task has live output worth a stream).
+	stateHint string
 
 	// selectedRun tracks the attempt under the cursor by id, so a refresh
 	// that adds or reorders rows cannot silently select a different one.
@@ -130,6 +133,10 @@ type detail struct {
 	notes      <-chan apiclient.Note
 	stopStream context.CancelFunc
 	streamID   int64
+	// openStream opens the per-task stream; injected so tests can count
+	// subscriptions without a server (T3.10 done-when: holding `down`
+	// across the table opens one, not one per row).
+	openStream func(ctx context.Context, id int64, opts apiclient.StreamOptions) <-chan apiclient.Note
 
 	refreshPending bool
 	width, height  int
@@ -146,74 +153,59 @@ func newDetail(ctx context.Context) *detail {
 	}
 }
 
-func (d *detail) title() string { return "Task detail" }
-
 // setClient wires the view to a connected daemon. Called again on reconnect,
 // which is when a fresh load and a fresh subscription are exactly right.
 func (d *detail) setClient(c *apiclient.Client) tea.Cmd {
 	d.client = c
+	d.openStream = c.StreamTask
 	if d.taskID == 0 {
 		return nil
 	}
 	return tea.Batch(d.loadCmd(), d.syncStream())
 }
 
-func (d *detail) update(msg tea.Msg) (view, tea.Cmd) {
+func (d *detail) update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		d.width, d.height = msg.Width, msg.Height
-		return d, nil
-	case selectTaskMsg:
-		return d, d.open(msg.id)
-	case viewActivatedMsg:
-		if msg.id == viewDetail {
-			d.active = true
-			return d, tea.Batch(d.loadCmd(), d.syncStream())
-		}
-		return d, nil
-	case viewDeactivatedMsg:
-		if msg.id == viewDetail {
-			d.active = false
-			return d, d.syncStream()
-		}
-		return d, nil
+		return nil
 	case detailLoadedMsg:
-		return d, d.applyLoaded(msg)
+		return d.applyLoaded(msg)
 	case taskCreatedMsg:
 		// The 201's advisory findings — a catalog-unknown model, say. The
 		// task exists and will run, so this is a status line, not an error.
 		if len(msg.task.Warnings) > 0 {
 			d.actions.setStatus("created with warnings: "+strings.Join(msg.task.Warnings, "; "), false)
 		}
-		return d, nil
+		return nil
 	case detailTranscriptMsg:
 		d.applyTranscript(msg)
-		return d, nil
+		return nil
 	case detailRefreshMsg:
 		if msg.id != d.taskID {
-			return d, nil
+			return nil
 		}
 		d.refreshPending = false
-		return d, d.loadCmd()
+		return d.loadCmd()
 	case noteMsg:
 		// The global stream drives refreshes; the per-task stream is for live
 		// output. One refresh trigger, not two.
-		return d, d.updateGlobalNote(msg.note)
+		return d.updateGlobalNote(msg.note)
 	case taskNoteMsg:
-		return d, d.updateTaskNote(msg)
+		return d.updateTaskNote(msg)
 	case taskStreamDoneMsg:
-		return d, nil
+		return nil
 	case diffLoadedMsg:
 		d.diff.apply(msg)
-		return d, nil
+		return nil
 	case actionResultMsg:
-		return d, d.applyAction(msg)
+		return d.applyAction(msg)
 	case editRetryMsg:
-		return d, d.applyEdit(msg)
+		return d.applyEdit(msg)
 	case tea.KeyPressMsg:
 		return d.updateKey(msg)
 	}
-	return d, nil
+	return nil
 }
 
 // applyAction records what an action did and refetches: the response already
@@ -234,12 +226,15 @@ func (d *detail) applyAction(msg actionResultMsg) tea.Cmd {
 	return d.loadCmd()
 }
 
-// open switches the view to a task, discarding everything about the last one.
-func (d *detail) open(id int64) tea.Cmd {
+// open switches the view to a task, discarding everything about the last
+// one. stateHint is the board row's state, deciding whether the stream
+// opens before the fetch confirms the task is running.
+func (d *detail) open(id int64, stateHint string) tea.Cmd {
 	if id == d.taskID {
 		return nil
 	}
 	d.taskID = id
+	d.stateHint = stateHint
 	d.task = apiclient.TaskDetail{}
 	d.loaded, d.loadErr = false, nil
 	d.selectedRun, d.displayRun = 0, 0
@@ -251,6 +246,23 @@ func (d *detail) open(id int64) tea.Cmd {
 	d.form = nil
 	d.diff.open(id)
 	return tea.Batch(d.loadCmd(), d.syncStream())
+}
+
+// deselect drops the task without opening another: the table cursor moved
+// and the settle window is still open. The subscription is torn down here,
+// immediately — an explicit unsubscribe on move (PR P decision) — while any
+// new subscription waits for the settle.
+func (d *detail) deselect() {
+	d.taskID = 0
+	d.stateHint = ""
+	d.task = apiclient.TaskDetail{}
+	d.loaded, d.loadErr = false, nil
+	d.selectedRun, d.displayRun = 0, 0
+	d.resetOutput()
+	d.buffer = nil
+	d.actions.clear()
+	d.form = nil
+	d.syncStream()
 }
 
 // resetOutput clears the pane for a different attempt. It deliberately keeps
@@ -320,12 +332,24 @@ func (d *detail) applyLoaded(msg detailLoadedMsg) tea.Cmd {
 	runs := d.attempts()
 	if len(runs) == 0 {
 		d.selectedRun = 0
-		return nil
+		// The authoritative state may disagree with the hint the open used —
+		// a task that stopped running drops its stream, one that started
+		// gains it.
+		return d.syncStream()
 	}
 	if wasLive || d.runIndex(d.selectedRun) < 0 {
 		d.selectedRun = runs[len(runs)-1].ID
 	}
-	return d.syncOutput()
+	return tea.Batch(d.syncOutput(), d.syncStream())
+}
+
+// running reports whether the task has live output worth a stream: the
+// loaded state when there is one, the board row's hint before that.
+func (d *detail) running() bool {
+	if d.loaded {
+		return d.task.State == stateRunning
+	}
+	return d.stateHint == stateRunning
 }
 
 // syncForm keeps the answer form in step with the task: it exists exactly
@@ -334,20 +358,16 @@ func (d *detail) applyLoaded(msg detailLoadedMsg) tea.Cmd {
 func (d *detail) syncForm() {
 	req, ok, err := d.task.PendingRequest()
 	if err != nil || !ok {
-		if d.form != nil {
-			d.form = nil
-			if d.focus == focusForm {
-				d.focus = focusTimeline
-			}
-		}
+		d.form = nil
 		return
 	}
 	if d.form != nil && d.form.sameRequest(req) {
 		return
 	}
+	// The form exists as state; it renders as a popup the human opens. It
+	// never steals focus — auto-opening under a keystroke is how an answer
+	// gets lost (§15).
 	d.form = newAnswerForm(req)
-	// A task that stopped for you is the reason you are looking at it.
-	d.focus = focusForm
 }
 
 // syncOutput makes the output pane match the selected attempt, fetching its
@@ -510,10 +530,13 @@ func (d *detail) hold(n apiclient.OutputNote) {
 }
 
 // syncStream opens or closes the per-task subscription so it exists exactly
-// while this view is on screen with a task.
+// while this sub-model is on screen with a *running* task — a finished or
+// parked task has no live output, and its transcript is the durable copy
+// (§13.3). The running-only rule plus the shell's settle window is what
+// keeps a cursor sweep from opening a stream per row.
 func (d *detail) syncStream() tea.Cmd {
 	want := int64(0)
-	if d.active && d.client != nil {
+	if d.active && d.openStream != nil && d.running() {
 		want = d.taskID
 	}
 	if want == d.streamID {
@@ -529,7 +552,7 @@ func (d *detail) syncStream() tea.Cmd {
 	ctx, cancel := context.WithCancel(d.ctx)
 	d.stopStream = cancel
 	d.streamID = want
-	d.notes = d.client.StreamTask(ctx, want, apiclient.StreamOptions{})
+	d.notes = d.openStream(ctx, want, apiclient.StreamOptions{})
 	return waitTaskNote(d.notes, want)
 }
 
@@ -547,59 +570,45 @@ func waitTaskNote(ch <-chan apiclient.Note, taskID int64) tea.Cmd {
 	}
 }
 
-func (d *detail) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
-	// A pending confirmation is a question; the form is a text surface. Both
-	// own the keyboard until they are done with it.
+func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
+	// A pending confirmation is a question: it owns the keyboard until it is
+	// answered. (The answer form is a popup the shell routes to before the
+	// key ever reaches here.)
 	if d.actions.capturing() {
 		cmd, _ := d.actions.handleKey(msg.String(), d.client, d.target())
-		return d, cmd
-	}
-	if d.focus == focusForm && d.form != nil {
-		cmd, exit := d.form.update(msg, d.client, d.taskID)
-		if exit {
-			d.focus = focusTimeline
-		}
-		return d, cmd
+		return cmd
 	}
 
 	switch msg.String() {
-	case "tab":
-		d.cycleFocus(1)
-		return d, nil
-	case "shift+tab":
-		d.cycleFocus(-1)
-		return d, nil
 	case "d":
-		return d, d.toggleTab()
+		return d.toggleTab()
 	case "E":
 		if d.target().has(apiclient.ActionRetry) {
-			return d, d.editRetry()
+			return d.editRetry()
 		}
-		return d, nil
+		return nil
 	case "f":
 		d.setFollowing(true)
-		return d, nil
-	case "esc":
-		return d, func() tea.Msg { return selectViewMsg{id: viewBoard} }
+		return nil
 	}
 
 	// Action keys work from any focus: they act on the task, not on a pane.
 	if cmd, handled := d.actions.handleKey(msg.String(), d.client, d.target()); handled {
-		return d, cmd
+		return cmd
 	}
 
 	if d.tab == tabDiff && d.focus == focusOutput {
-		return d, d.diff.update(msg)
+		return d.diff.update(msg)
 	}
 
 	if d.focus == focusTimeline {
 		switch msg.String() {
 		case "up", "k":
-			return d, d.moveSelection(-1)
+			return d.moveSelection(-1)
 		case "down", "j":
-			return d, d.moveSelection(1)
+			return d.moveSelection(1)
 		}
-		return d, nil
+		return nil
 	}
 
 	// Output pane: scrolling away from the bottom drops follow, and coming
@@ -607,7 +616,7 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
 	switch msg.String() {
 	case "G", "end":
 		d.setFollowing(true)
-		return d, nil
+		return nil
 	case "j", "down":
 		d.vp.ScrollDown(1)
 	case "k", "up":
@@ -616,10 +625,10 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
 		var cmd tea.Cmd
 		d.vp, cmd = d.vp.Update(msg)
 		d.syncFollowToViewport()
-		return d, cmd
+		return cmd
 	}
 	d.syncFollowToViewport()
-	return d, nil
+	return nil
 }
 
 func (d *detail) setFollowing(on bool) {
@@ -690,36 +699,16 @@ func (d *detail) runByID(id int64) apiclient.StepRun {
 	return apiclient.StepRun{}
 }
 
-// capturesInput reports whether the view is consuming raw keystrokes: the
-// answer form's text entry, and a y/n confirmation. Neither may lose a key to
-// the shell's global bindings — typing "q" into an answer must not quit.
+// capturesInput reports whether the sub-model is consuming raw keystrokes:
+// a y/n confirmation. (The answer form's text entry is captured by the
+// shell's popup routing before keys reach here.)
 func (d *detail) capturesInput() bool {
-	if d.actions.capturing() {
-		return true
-	}
-	return d.form != nil && d.form.capturing()
+	return d.actions.capturing()
 }
 
 // target is the slice of the task the action bar works from.
 func (d *detail) target() taskActions {
 	return taskActions{id: d.taskID, state: d.task.State, actions: d.task.AvailableActions}
-}
-
-// cycleFocus walks timeline → pane → form and back, skipping the form when
-// no request is pending.
-func (d *detail) cycleFocus(delta int) {
-	order := []detailFocus{focusTimeline, focusOutput}
-	if d.form != nil {
-		order = append(order, focusForm)
-	}
-	at := 0
-	for i, f := range order {
-		if f == d.focus {
-			at = i
-		}
-	}
-	next := (at + delta + len(order)) % len(order)
-	d.focus = order[next]
 }
 
 // toggleTab switches the lower pane between output and diff. Opening the diff
@@ -732,9 +721,6 @@ func (d *detail) toggleTab() tea.Cmd {
 		return nil
 	}
 	d.tab = tabDiff
-	if d.focus == focusForm {
-		d.focus = focusOutput
-	}
 	d.diff.open(d.taskID)
 	return d.diff.fetch(d.client, true)
 }

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -64,7 +64,7 @@ func TestDetailTimelineRendersAttempts(t *testing.T) {
 	live.OutputTokens = ptr(int64(120))
 	loadDetail(d, []apiclient.StepRun{failed, live})
 
-	got := d.render(120, 30)
+	got := d.timelinePanel(30)
 	for _, want := range []string{
 		"#42 detail task", // header names the task
 		"1 implement",     // step group header, 1-based
@@ -168,7 +168,7 @@ func TestDetailChunkForUnknownAttemptIsHeld(t *testing.T) {
 	d.streamID = 3          // a live subscription for this task
 	d.refreshPending = true // a debounce is already pending and must be bypassed
 
-	_, cmd := d.update(taskNoteMsgFor(3, 77, 10, "first line of a new step"))
+	cmd := d.update(taskNoteMsgFor(3, 77, 10, "first line of a new step"))
 	if cmd == nil {
 		t.Fatal("an unknown attempt did not trigger a refetch")
 	}
@@ -209,8 +209,8 @@ func TestDetailFollowDropsAndRearms(t *testing.T) {
 	if d.newLines != 1 {
 		t.Errorf("new-line counter = %d, want 1", d.newLines)
 	}
-	if !strings.Contains(d.paneHeader(), "1 new") {
-		t.Errorf("paused header does not report unread output: %q", d.paneHeader())
+	if !strings.Contains(d.outputTitle(), "1 new") {
+		t.Errorf("paused title does not report unread output: %q", d.outputTitle())
 	}
 
 	d.focus = focusOutput
@@ -218,8 +218,8 @@ func TestDetailFollowDropsAndRearms(t *testing.T) {
 	if !d.following || d.newLines != 0 {
 		t.Errorf("f did not re-arm follow: following=%v new=%d", d.following, d.newLines)
 	}
-	if !strings.Contains(d.paneHeader(), "following") {
-		t.Errorf("following header missing: %q", d.paneHeader())
+	if !strings.Contains(d.outputTitle(), "following") {
+		t.Errorf("following title missing: %q", d.outputTitle())
 	}
 }
 
@@ -257,8 +257,9 @@ func TestDetailEmptyStates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := newTestDetail(t)
 			tc.setup(d)
-			if got := d.render(120, 30); !strings.Contains(got, tc.want) {
-				t.Errorf("render missing %q:\n%s", tc.want, got)
+			got := d.timelinePanel(15) + "\n" + d.outputPanel(120, 15)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("panels missing %q:\n%s", tc.want, got)
 			}
 		})
 	}
@@ -318,37 +319,45 @@ func TestDetailRecordCapDropsOldest(t *testing.T) {
 }
 
 // TestDetailStreamLifecycle proves the subscription exists exactly while the
-// view is on screen with a task: a tail nobody is watching costs a connection
-// and unbounded memory for output the transcript already holds.
+// sub-model is on screen with a *running* task: a tail nobody is watching
+// costs a connection and unbounded memory for output the transcript already
+// holds, and a task that is not running has no live output at all (T3.10).
 func TestDetailStreamLifecycle(t *testing.T) {
 	d := newTestDetail(t)
-	d.client = apiclient.New("http://127.0.0.1:1", "token")
+	d.setClient(apiclient.New("http://127.0.0.1:1", "token"))
 
-	d.update(selectTaskMsg{id: 12})
+	d.open(12, stateRunning)
 	if d.streamID != 0 {
-		t.Fatal("subscribed before the view was on screen")
+		t.Fatal("subscribed before the panels were on screen")
 	}
-	d.update(viewActivatedMsg{id: viewDetail})
+	d.active = true
+	d.syncStream()
 	if d.streamID != 12 {
-		t.Fatalf("stream task = %d, want 12 after activation", d.streamID)
+		t.Fatalf("stream task = %d, want 12 once on screen", d.streamID)
 	}
-	d.update(viewDeactivatedMsg{id: viewDetail})
+	d.active = false
+	d.syncStream()
 	if d.streamID != 0 {
-		t.Errorf("stream still open (task %d) after leaving the view", d.streamID)
+		t.Errorf("stream still open (task %d) after leaving the screen", d.streamID)
 	}
-}
 
-// TestDetailEscReturnsToBoard covers the one navigation key the view owns.
-func TestDetailEscReturnsToBoard(t *testing.T) {
-	d := newTestDetail(t)
-	d.taskID = 1
-	_, cmd := d.updateKey(tea.KeyPressMsg{Code: tea.KeyEscape})
-	if cmd == nil {
-		t.Fatal("esc produced no command")
+	// A parked task has no live output: opening it must not subscribe.
+	d.active = true
+	d.open(13, stateAwaitingInput)
+	if d.streamID != 0 {
+		t.Errorf("stream open (task %d) for a task that is not running", d.streamID)
 	}
-	msg, ok := cmd().(selectViewMsg)
-	if !ok || msg.id != viewBoard {
-		t.Errorf("esc = %#v, want selectViewMsg{viewBoard}", msg)
+
+	// The authoritative fetch overrides the hint in both directions.
+	loadDetail(d, nil) // loadDetail installs stateRunning
+	if d.streamID != 13 {
+		t.Errorf("stream task = %d, want 13 once the fetch says it is running", d.streamID)
+	}
+	d.applyLoaded(detailLoadedMsg{id: 13, task: apiclient.TaskDetail{
+		Task: apiclient.Task{ID: 13, State: stateBlocked},
+	}})
+	if d.streamID != 0 {
+		t.Errorf("stream still open (task %d) after the task stopped running", d.streamID)
 	}
 }
 

--- a/internal/tui/detailactions_live_test.go
+++ b/internal/tui/detailactions_live_test.go
@@ -216,7 +216,13 @@ func TestDetailAnswersLiveAgentQuestion(t *testing.T) {
 		t.Errorf("available actions = %v, want answer without approve", actions.actions)
 	}
 
-	// Pick the first option and submit, exactly as a human would.
+	// Open the popup, pick the first option and submit, exactly as a human
+	// would: the form never opens itself (§15 — it announces itself and the
+	// human presses the key).
+	h.press(t, "enter")
+	if s := h.m.views[viewHome].(*shell); !s.popup {
+		t.Fatal("enter did not open the answer popup")
+	}
 	h.press(t, " ")
 	h.press(t, "enter")
 
@@ -285,8 +291,7 @@ func keyPress(key string) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: rune(key[0]), Text: key}
 }
 
-// detailOf reaches the detail view for assertions about its state.
+// detailOf reaches the detail sub-model for assertions about its state.
 func detailOf(m *root) *detail {
-	d, _ := m.views[viewDetail].(*detail)
-	return d
+	return m.views[viewHome].(*shell).detail
 }

--- a/internal/tui/detaillive_test.go
+++ b/internal/tui/detaillive_test.go
@@ -29,6 +29,13 @@ func TestDetailTailJoinsTranscriptWithoutGapOrDuplicate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "0-1.jsonl")
 	covered := writeTranscript(t, path, "line-one", "line-two")
 
+	// The task must actually be running: T3.10's subscription rule only
+	// opens the live tail for a running task, which is the only state that
+	// produces live output.
+	if _, _, err := h.st.TransitionTask(ctx, task.ID,
+		store.TaskQueued, store.TaskRunning, store.TaskChange{}); err != nil {
+		t.Fatalf("transition to running: %v", err)
+	}
 	run := &store.StepRun{
 		TaskID: task.ID, StepIndex: 0, StepID: "one", StepType: "command",
 		Attempt: 1, State: store.StepRunning, TranscriptPath: path,

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -11,10 +11,6 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// timelineShare is how much of the body the step timeline takes. The output
-// pane gets the rest: the timeline is an index, the output is the content.
-const timelineShare = 0.4
-
 var (
 	styleStepHeader = lipgloss.NewStyle().Bold(true)
 	styleSelected   = lipgloss.NewStyle().Background(lipgloss.Color("237")).Bold(true)
@@ -28,55 +24,79 @@ var (
 // before retrying it (§6). A glyph, so it survives a monochrome terminal.
 const editedBadge = "✎"
 
-func (d *detail) render(width, height int) string {
+// timelinePanel renders the timeline pane's content for the shell: the task
+// header, a stale-refresh note when there is one, and the attempt timeline.
+// At one line — the collapsed band — it shows the selected attempt, which is
+// the line the cursor would land on (§15: title bar plus the selected line).
+func (d *detail) timelinePanel(height int) string {
+	if d.taskID == 0 {
+		return styleDim.Render("  no task selected")
+	}
+	if height <= 1 {
+		if run := d.runByID(d.selectedRun); run.ID != 0 {
+			return d.attemptLine(run)
+		}
+		return d.headerLine()
+	}
+	var sb strings.Builder
+	sb.WriteString(d.headerLine())
+	used := 1
+	if line := d.errorLine(); line != "" && height > 2 {
+		sb.WriteString("\n")
+		sb.WriteString(line)
+		used++
+	}
+	sb.WriteString("\n")
+	sb.WriteString(d.renderTimeline(height - used))
+	return sb.String()
+}
+
+// outputPanel renders the output|diff pane's content for the shell. The tab
+// strip lives in the panel title (outputTitle), so the content is the pane
+// alone. At one line it shows the tail's last line — the freshest thing a
+// collapsed output pane can say.
+func (d *detail) outputPanel(width, height int) string {
+	if d.taskID == 0 {
+		return styleDim.Render("  no task selected")
+	}
 	if width > 0 {
 		d.width = width
 	}
-	if height > 0 {
-		d.height = height
+	if height <= 1 {
+		return d.collapsedOutputLine()
 	}
-	if d.taskID == 0 {
-		return styleDim.Render("\n  no task selected — press 1, pick a row, enter\n")
-	}
-
-	var sb strings.Builder
-	sb.WriteString(d.headerLine())
-	sb.WriteString("\n")
-	if line := d.errorLine(); line != "" {
-		sb.WriteString(line)
-		sb.WriteString("\n")
-	}
-
-	// Header, the optional error line, the pane header and the action bar are
-	// the chrome the body divides what is left of.
-	body := max(d.height-3, 4)
-	timelineHeight := max(int(float64(body)*timelineShare), 3)
-	paneHeight := max(body-timelineHeight-1, 3)
-
-	formHeight := 0
-	if d.form != nil {
-		// The form takes at most half the pane: the tail underneath is what
-		// says why the agent is asking.
-		formHeight = min(d.form.height(), max(paneHeight/2, 3))
-		paneHeight = max(paneHeight-formHeight, 2)
-	}
-
-	sb.WriteString(d.renderTimeline(timelineHeight))
-	sb.WriteString("\n")
-	if formHeight > 0 {
-		sb.WriteString(d.form.render(formHeight))
-		sb.WriteString("\n")
-	}
-	sb.WriteString(d.paneHeader())
-	sb.WriteString("\n")
 	if d.tab == tabDiff {
-		sb.WriteString(d.diff.render(d.width, paneHeight))
-	} else {
-		sb.WriteString(d.renderOutputPane(paneHeight))
+		return d.diff.render(d.width, height)
 	}
-	sb.WriteString("\n")
-	sb.WriteString(d.actions.render(d.target(), d.detailHints()...))
-	return sb.String()
+	return d.renderOutputPane(height)
+}
+
+// collapsedOutputLine is the one line a collapsed output pane shows: the
+// last rendered line of the tail, or why there is none.
+func (d *detail) collapsedOutputLine() string {
+	if body, ok := d.outputEmptyState(); ok {
+		return styleDim.Render("  " + body)
+	}
+	lines := d.outputLines()
+	if len(lines) == 0 {
+		return ""
+	}
+	return lines[len(lines)-1]
+}
+
+// outputTitle is the output panel's border title: the §15 tab strip plus
+// the follow state, so which tab is live and whether the tail follows stay
+// visible even collapsed.
+func (d *detail) outputTitle() string {
+	strip := tabLabel("output", d.tab == tabOutput) +
+		styleDim.Render(" │ ") + tabLabel("diff", d.tab == tabDiff)
+	if d.tab == tabDiff {
+		if d.diff.truncated {
+			return strip + styleDim.Render(" · truncated")
+		}
+		return strip
+	}
+	return strip + d.followIndicator()
 }
 
 // detailHints are the view's own keys, shown beside the task's actions so the
@@ -87,7 +107,7 @@ func (d *detail) detailHints() []string {
 		hints = []string{styleKey.Render("d") + " output"}
 	}
 	if d.form != nil {
-		hints = append(hints, styleAsk.Render("answer in the form above"))
+		hints = append(hints, styleAsk.Render("enter answer"))
 	}
 	if d.target().has("retry") {
 		if step, ok := d.task.Step(d.task.CurrentStep); ok {
@@ -249,24 +269,6 @@ func window(lines []string, focus, height int) []string {
 	start := focus - height/2
 	start = min(max(start, 0), len(lines)-height)
 	return lines[start : start+height]
-}
-
-// paneHeader is the tab strip plus, on the output tab, the follow indicator.
-func (d *detail) paneHeader() string {
-	tabs := []string{tabLabel("output", d.tab == tabOutput), tabLabel("diff", d.tab == tabDiff)}
-	strip := " " + strings.Join(tabs, styleDim.Render(" | "))
-	if d.focus == focusOutput {
-		strip = styleFocus.Render(" ▸") + strip
-	} else {
-		strip = "  " + strip
-	}
-	if d.tab == tabDiff {
-		if d.diff.truncated {
-			return strip + styleDim.Render(" · truncated")
-		}
-		return strip
-	}
-	return strip + d.followIndicator()
 }
 
 func tabLabel(name string, active bool) string {

--- a/internal/tui/doc.go
+++ b/internal/tui/doc.go
@@ -3,8 +3,11 @@
 // it never affects work. Bare `vincent` launches it, auto-starting the
 // daemon in the background when unreachable (§12.1).
 //
-// Phase 3 lands it PR by PR: this foundation ships the shell — connection
-// management, /v1/events subscription, view routing, global keys, and the
-// help overlay — with stub views that later PRs replace (board, task
-// detail, new-task flow, projects/workflows/daemon).
+// The root owns connection management, the /v1/events subscription, screen
+// routing and the global keys. The home screen (shell.go) fuses §15's board
+// and task detail into one persistent three-panel layout — task table on
+// top, step timeline and output|diff side by side below — with layout.go's
+// pure layout function deciding the accordion, the single-panel fallback
+// and the too-small floor (T3.10). The remaining §15 surfaces (new task,
+// projects, workflows, daemon) stay full-screen takeovers.
 package tui

--- a/internal/tui/editor_test.go
+++ b/internal/tui/editor_test.go
@@ -73,7 +73,7 @@ func editorDetail(t *testing.T, client *apiclient.Client, typed string, runErr e
 // path ends up making.
 func runEdit(t *testing.T, d *detail) {
 	t.Helper()
-	_, cmd := d.updateKey(keyPress("E"))
+	cmd := d.updateKey(keyPress("E"))
 	if cmd == nil {
 		return
 	}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -6,7 +6,9 @@ import "strings"
 func helpText() string {
 	rows := [][2]string{
 		{"?", "toggle this help"},
-		{"1..6", "switch view: board · task detail · new task · projects · workflows · daemon"},
+		{"tab", "move focus between the panels (shift+tab goes back)"},
+		{"1..6", "switch screen: home (board+detail) · new task · projects · workflows · daemon"},
+		{"esc", "back to the task table; on it, clear the filter"},
 		{"n", "start a new task for the project you are looking at"},
 		{"q", "quit the TUI (the daemon keeps running)"},
 		{"ctrl+c", "quit the TUI"},
@@ -23,23 +25,20 @@ func helpText() string {
 		{"A", "archive a finished task (asks first — the worktree is removed)"},
 	}
 	boardRows := [][2]string{
-		{"↑/↓", "move the selection"},
-		{"enter", "open the selected task"},
+		{"↑/↓", "move the selection (the panels below follow the cursor)"},
+		{"enter", "open the selected task in the panels — or its answer form when it is asking"},
 		{"/", "filter by id, title, project or state"},
-		{"esc", "clear the filter"},
 	}
 	detailRows := [][2]string{
-		{"tab", "move focus: timeline → output → answer form"},
 		{"d", "switch the pane between output and diff (reloads the diff)"},
 		{"↑/↓", "select an attempt, or scroll the pane"},
 		{"f / G", "follow the live output again"},
-		{"esc", "back to the board"},
 	}
 	formRows := [][2]string{
 		{"space", "pick an option (toggles, for a multi-select question)"},
 		{"e", "type your own answer — options are suggestions, never a list"},
 		{"enter", "submit the answer; the run resumes where it stopped"},
-		{"esc", "leave the form without answering"},
+		{"esc", "close the popup without answering (what you picked is kept)"},
 	}
 	newTaskRows := [][2]string{
 		{"↑/↓", "move between fields"},

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,0 +1,83 @@
+package tui
+
+// panelID indexes the three panes of the fused home screen (§15 layout):
+// the task table on top, the step timeline and the output|diff pane side by
+// side underneath.
+type panelID int
+
+const (
+	panelTasks panelID = iota
+	panelTimeline
+	panelOutput
+)
+
+// box places one panel on the shell's canvas. x,y are zero-based cell
+// coordinates of the top-left corner, w,h the outer size with the border
+// included. The coordinates exist for T3.13's hitTest as much as for
+// rendering, which is why layout returns geometry rather than strings.
+type box struct {
+	id         panelID
+	x, y, w, h int
+}
+
+// §15 states its floors in terminal cells: below 80×20 the shell drops to
+// single-panel mode, below 60×15 it renders only the size line. layout is
+// given the *panel area* — the terminal minus the shell's fixed chrome
+// (header, event line, footer, action-bar line: shellChromeH lines) — so the
+// height floors here are the §15 terminal floors shifted by that chrome.
+// Width has no chrome, so the width floors are §15's verbatim.
+const (
+	minTermW = 60
+	minTermH = 15
+
+	minShellW = 80
+	minShellH = 20
+
+	// shellChromeH is what the shell and root draw around the panel area.
+	shellChromeH = 4
+
+	minAreaH3 = minShellH - shellChromeH // three-pane floor
+	minAreaH1 = minTermH - shellChromeH  // single-panel floor
+
+	// collapsedBandH is an unfocused bottom band: the title border, one
+	// content line, the bottom border (§15: collapse to title + one line).
+	collapsedBandH = 3
+
+	// tasksFloorH keeps five task rows visible while a bottom panel has
+	// focus — the table is the navigation spine (§15). Outer height: five
+	// rows + the table header + the board's own header and action lines +
+	// one spare + two border lines.
+	tasksFloorH = 11
+
+	// timelineShareW is the timeline's share of the bottom band: the
+	// timeline is an index, the output is the content (§15).
+	timelineShareW = 0.4
+)
+
+// layout is the §15 arrangement as a pure function of the panel-area size
+// and the focused panel. It returns nil below the hard floor (the shell
+// renders the explicit too-small line instead), a single full-area box in
+// single-panel mode, and otherwise the three boxes top to bottom: tasks,
+// timeline, output. The accordion is vertical, between the two bands: the
+// focused band expands and the other collapses (PR P decision) — collapsing
+// the output while navigating the timeline would defeat why they sit side
+// by side.
+func layout(w, h int, focus panelID) []box {
+	if w < minTermW || h < minAreaH1 {
+		return nil
+	}
+	if w < minShellW || h < minAreaH3 {
+		return []box{{id: focus, x: 0, y: 0, w: w, h: h}}
+	}
+	tasksH := tasksFloorH
+	if focus == panelTasks {
+		tasksH = h - collapsedBandH
+	}
+	bandH := h - tasksH
+	tlW := int(float64(w) * timelineShareW)
+	return []box{
+		{id: panelTasks, x: 0, y: 0, w: w, h: tasksH},
+		{id: panelTimeline, x: 0, y: tasksH, w: tlW, h: bandH},
+		{id: panelOutput, x: tlW, y: tasksH, w: w - tlW, h: bandH},
+	}
+}

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -1,0 +1,119 @@
+package tui
+
+import "testing"
+
+// TestLayoutThreePane covers the accordion across focus targets: the focused
+// band expands, the other collapses, and the task table never drops below
+// its five-row floor.
+func TestLayoutThreePane(t *testing.T) {
+	cases := []struct {
+		name  string
+		w, h  int
+		focus panelID
+		tasks int // wanted outer height of the tasks box
+	}{
+		{"tasks focused", 120, 32, panelTasks, 32 - collapsedBandH},
+		{"timeline focused", 120, 32, panelTimeline, tasksFloorH},
+		{"output focused", 120, 32, panelOutput, tasksFloorH},
+		{"tasks focused at the floor", 80, minAreaH3, panelTasks, minAreaH3 - collapsedBandH},
+		{"output focused at the floor", 80, minAreaH3, panelOutput, tasksFloorH},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			boxes := layout(tc.w, tc.h, tc.focus)
+			if len(boxes) != 3 {
+				t.Fatalf("layout(%d, %d) returned %d boxes, want 3", tc.w, tc.h, len(boxes))
+			}
+			tasks, tl, out := boxes[0], boxes[1], boxes[2]
+			if tasks.id != panelTasks || tl.id != panelTimeline || out.id != panelOutput {
+				t.Fatalf("box order = %v %v %v, want tasks timeline output", tasks.id, tl.id, out.id)
+			}
+			if tasks.h != tc.tasks {
+				t.Errorf("tasks box height = %d, want %d", tasks.h, tc.tasks)
+			}
+			// The task table is the navigation spine: full width, on top.
+			if tasks.x != 0 || tasks.y != 0 || tasks.w != tc.w {
+				t.Errorf("tasks box = %+v, want full-width at the origin", tasks)
+			}
+			// The bottom band tiles the rest exactly: side by side, no gap,
+			// no overlap, flush with both edges.
+			if tl.y != tasks.h || out.y != tasks.h {
+				t.Errorf("band y = %d/%d, want %d", tl.y, out.y, tasks.h)
+			}
+			if tl.h != tc.h-tasks.h || out.h != tc.h-tasks.h {
+				t.Errorf("band heights = %d/%d, want %d", tl.h, out.h, tc.h-tasks.h)
+			}
+			if tl.x != 0 || out.x != tl.w || tl.w+out.w != tc.w {
+				t.Errorf("band widths: timeline %+v output %+v do not tile width %d", tl, out, tc.w)
+			}
+			// The timeline is the index, the output the content.
+			if tl.w >= out.w {
+				t.Errorf("timeline width %d >= output width %d", tl.w, out.w)
+			}
+		})
+	}
+}
+
+// TestLayoutFloors pins §15's stated floors, shifted by the shell chrome:
+// below 80 wide or the three-pane area floor the shell falls to a single
+// panel; below 60 wide or the hard area floor it renders nothing but the
+// size line.
+func TestLayoutFloors(t *testing.T) {
+	cases := []struct {
+		name  string
+		w, h  int
+		boxes int
+	}{
+		{"three-pane at the floor", minShellW, minAreaH3, 3},
+		{"one column too narrow", minShellW - 1, minAreaH3, 1},
+		{"one row too short", minShellW, minAreaH3 - 1, 1},
+		{"single-panel at the floor", minTermW, minAreaH1, 1},
+		{"below the hard width floor", minTermW - 1, minAreaH1, 0},
+		{"below the hard height floor", minTermW, minAreaH1 - 1, 0},
+		{"tiny", 10, 3, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			boxes := layout(tc.w, tc.h, panelTasks)
+			if len(boxes) != tc.boxes {
+				t.Fatalf("layout(%d, %d) returned %d boxes, want %d", tc.w, tc.h, len(boxes), tc.boxes)
+			}
+		})
+	}
+}
+
+// TestLayoutSinglePanel asserts single-panel mode shows exactly the focused
+// panel, full area — tab swapping which is the shell's job, so layout must
+// honor every focus target.
+func TestLayoutSinglePanel(t *testing.T) {
+	for _, focus := range []panelID{panelTasks, panelTimeline, panelOutput} {
+		boxes := layout(70, 12, focus)
+		if len(boxes) != 1 {
+			t.Fatalf("layout(70, 12, %v) returned %d boxes, want 1", focus, len(boxes))
+		}
+		b := boxes[0]
+		if b.id != focus {
+			t.Errorf("single panel = %v, want the focused %v", b.id, focus)
+		}
+		if b.x != 0 || b.y != 0 || b.w != 70 || b.h != 12 {
+			t.Errorf("single panel box = %+v, want the full 70×12 area", b)
+		}
+	}
+}
+
+// TestLayoutTasksRowFloor asserts the five-row promise concretely: the
+// collapsed tasks box leaves enough content height for the board's chrome,
+// the table header, and five task rows.
+func TestLayoutTasksRowFloor(t *testing.T) {
+	boxes := layout(100, 40, panelOutput)
+	if len(boxes) != 3 {
+		t.Fatalf("layout returned %d boxes, want 3", len(boxes))
+	}
+	content := boxes[0].h - 2 // borders
+	// The board spends chromeLines() on its header and action lines; the
+	// bubbles table spends one more on the column header row.
+	rows := content - 3 - 1
+	if rows < 5 {
+		t.Fatalf("collapsed tasks box shows %d rows, want at least 5", rows)
+	}
+}

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -223,7 +223,7 @@ func (n *newTask) workflowsCmd(projectID int64) tea.Cmd {
 	}
 }
 
-func (n *newTask) update(msg tea.Msg) (view, tea.Cmd) {
+func (n *newTask) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		n.width, n.height = msg.Width, msg.Height
@@ -360,7 +360,7 @@ func (n *newTask) workflowEntry(name string) *apiclient.WorkflowEntry {
 	return nil
 }
 
-func (n *newTask) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (n *newTask) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch n.mode {
 	case ntEditing:
 		return n, n.updateEditing(msg)
@@ -375,7 +375,7 @@ func (n *newTask) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
 	return n.updateNavigating(msg)
 }
 
-func (n *newTask) updateNavigating(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (n *newTask) updateNavigating(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch msg.String() {
 	case "up", "k":
 		n.moveCursor(-1)
@@ -495,19 +495,19 @@ func (n *newTask) nudgePriority(delta int) {
 
 // abandon leaves the form. A touched draft asks first; an untouched one is
 // nothing to lose.
-func (n *newTask) abandon() (view, tea.Cmd) {
+func (n *newTask) abandon() (panel, tea.Cmd) {
 	if !n.touched {
-		return n, func() tea.Msg { return selectViewMsg{id: viewBoard} }
+		return n, func() tea.Msg { return selectViewMsg{id: viewHome} }
 	}
 	n.mode = ntConfirming
 	return n, nil
 }
 
-func (n *newTask) updateConfirm(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (n *newTask) updateConfirm(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
 		n.reset()
-		return n, func() tea.Msg { return selectViewMsg{id: viewBoard} }
+		return n, func() tea.Msg { return selectViewMsg{id: viewHome} }
 	default:
 		n.mode = ntNavigating
 		return n, nil

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -395,7 +395,7 @@ func TestNewTaskEscOnAnUntouchedDraftJustLeaves(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("esc on a clean form did nothing")
 	}
-	if msg, ok := cmd().(selectViewMsg); !ok || msg.id != viewBoard {
+	if msg, ok := cmd().(selectViewMsg); !ok || msg.id != viewHome {
 		t.Errorf("esc = %#v, want a switch back to the board", cmd())
 	}
 	if n.mode == ntConfirming {

--- a/internal/tui/newtasklive_test.go
+++ b/internal/tui/newtasklive_test.go
@@ -293,8 +293,8 @@ func TestNewTaskFlowCreatesRunnableTask(t *testing.T) {
 	h.p.until(20*time.Second, "the form to create the task", func() bool {
 		return h.m.selectedTask != 0
 	})
-	if h.m.active != viewDetail {
-		t.Errorf("active view = %v, want the detail view of the new task", h.m.active)
+	if h.m.active != viewHome {
+		t.Errorf("active view = %v, want the home screen on the new task", h.m.active)
 	}
 	id := h.m.selectedTask
 

--- a/internal/tui/projects.go
+++ b/internal/tui/projects.go
@@ -167,7 +167,7 @@ func (p *projectsView) scheduleRefresh() tea.Cmd {
 	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg { return projectsRefreshMsg{} })
 }
 
-func (p *projectsView) update(msg tea.Msg) (view, tea.Cmd) {
+func (p *projectsView) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		p.width, p.height = msg.Width, msg.Height
@@ -239,7 +239,7 @@ func (p *projectsView) updateNote(n apiclient.Note) tea.Cmd {
 	return nil
 }
 
-func (p *projectsView) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (p *projectsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	if p.form != nil {
 		return p, p.form.updateKey(msg)
 	}
@@ -312,7 +312,7 @@ func (p *projectsView) askDelete() {
 	}
 }
 
-func (p *projectsView) updateConfirm(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (p *projectsView) updateConfirm(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	c := p.confirm
 	switch msg.String() {
 	case "y", "Y":

--- a/internal/tui/projects_test.go
+++ b/internal/tui/projects_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // pressView sends one named key to a view and returns whatever it asked for.
-func pressView(v view, name string) tea.Cmd {
+func pressView(v panel, name string) tea.Cmd {
 	_, cmd := v.update(namedKey(name))
 	return cmd
 }
@@ -334,7 +334,7 @@ func TestProjectsRefetchOnActivationAndOnEvents(t *testing.T) {
 	if _, cmd := p.update(viewActivatedMsg{id: viewProjects}); cmd == nil {
 		t.Error("activation did not refetch")
 	}
-	if _, cmd := p.update(viewActivatedMsg{id: viewBoard}); cmd != nil {
+	if _, cmd := p.update(viewActivatedMsg{id: viewHome}); cmd != nil {
 		t.Error("another view's activation triggered a fetch")
 	}
 	for _, evType := range []string{"project.created", "task.state_changed", eventWorkflowRegistryChanged} {

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -65,7 +65,7 @@ type root struct {
 	streamLive bool
 
 	active viewID
-	views  [viewCount]view
+	views  [viewCount]panel
 	help   bool
 	// notice is §16's full-auto warning. It owns the whole screen until it
 	// is dismissed, ahead of and independent of the connect flow: the
@@ -129,13 +129,12 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.updateKey(msg)
 	case selectTaskMsg:
-		// A view asked to open a task. Routing is the shell's job, so the
-		// board never reaches into the view table itself.
+		// A caller asked to open a task explicitly — task creation, and the
+		// live tests. The home shell selects the row and opens the detail
+		// panels without waiting out a settle window.
 		m.selectedTask = msg.id
-		// The detail view must have the task before it is told it is on
-		// screen: activation is what opens its per-task subscription.
-		cmd := m.deliver(viewDetail, msg)
-		return m, tea.Batch(cmd, m.switchTo(viewDetail))
+		cmd := m.deliver(viewHome, msg)
+		return m, tea.Batch(cmd, m.switchTo(viewHome))
 	case selectViewMsg:
 		return m, m.switchTo(msg.id)
 	case taskCreatedMsg:
@@ -186,8 +185,17 @@ func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.help = false
 			return m, nil
 		}
-	case "1", "2", "3", "4", "5", "6":
-		return m, m.switchTo(viewID(key[0] - '1'))
+	case "1", "2":
+		// Board and detail are one screen now; the digits keep their §15
+		// meanings until T3.11 retires them, so 2 lands focused on the
+		// timeline.
+		cmds := []tea.Cmd{m.switchTo(viewHome)}
+		if key == "2" {
+			cmds = append(cmds, m.deliver(viewHome, focusPanelMsg{id: panelTimeline}))
+		}
+		return m, tea.Batch(cmds...)
+	case "3", "4", "5", "6":
+		return m, m.switchTo(viewID(key[0]-'3') + viewNewTask)
 	case "n":
 		// Not while the form is already up: there, n is "no" to the discard
 		// prompt, and re-opening would throw away the draft it is asking
@@ -237,9 +245,9 @@ func (m *root) openNewTask() tea.Cmd {
 func (m *root) updateTaskCreated(msg taskCreatedMsg) (tea.Model, tea.Cmd) {
 	m.selectedTask = msg.task.ID
 	cmds := []tea.Cmd{
-		m.deliver(viewDetail, selectTaskMsg{id: msg.task.ID}),
-		m.deliver(viewDetail, msg),
-		m.switchTo(viewDetail),
+		m.deliver(viewHome, selectTaskMsg{id: msg.task.ID}),
+		m.deliver(viewHome, msg),
+		m.switchTo(viewHome),
 	}
 	return m, tea.Batch(cmds...)
 }
@@ -440,10 +448,18 @@ func (m *root) body() string {
 	}
 	// The daemon view is the exception to the connection gate (§15): its log
 	// tail comes off the filesystem, and a daemon that is down is exactly
-	// when that log is worth reading. Views 1-5 have nothing to show without
-	// the daemon and stay behind the screens below.
+	// when that log is worth reading.
 	if m.active == viewDaemon && m.phase != phaseConnected {
 		return m.views[viewDaemon].render(m.width, m.bodyHeight())
+	}
+	// The home panels stay on screen while the daemon is unreachable, marked
+	// stale behind the shell's banner (§15 Disconnected) — provided there was
+	// ever anything to show; before the first connection a stale empty board
+	// would be a lie, not information (PR P decision). The takeovers are
+	// forms against a live daemon and stay behind the screens below.
+	if m.active == viewHome && m.homeLoaded() &&
+		(m.phase == phaseReconnecting || m.phase == phaseFailed) {
+		return m.views[viewHome].render(m.width, m.bodyHeight())
 	}
 	switch m.phase {
 	case phaseProbing:
@@ -472,11 +488,11 @@ func (m *root) body() string {
 // tasks running" from a TUI that never reached the daemon is a false
 // statement, not a reassuring one.
 func (m *root) quitReminder() (string, bool) {
-	b, ok := m.views[viewBoard].(*board)
-	if !ok || !b.loaded {
+	s, ok := m.views[viewHome].(*shell)
+	if !ok || !s.board.loaded {
 		return "", false
 	}
-	n := countRunning(b.tasks)
+	n := countRunning(s.board.tasks)
 	if n == 0 {
 		return "", false
 	}
@@ -488,8 +504,16 @@ func (m *root) quitReminder() (string, bool) {
 		n, noun), true
 }
 
+// homeLoaded reports whether the home shell ever loaded a task list — the
+// difference between "stale panels are information" and "there is nothing
+// to mark stale".
+func (m *root) homeLoaded() bool {
+	s, ok := m.views[viewHome].(*shell)
+	return ok && s.board.loaded
+}
+
 func (m *root) footerLine() string {
-	hints := " 1-6 views · n new task · ? help · q quit"
+	hints := " tab panels · 1-6 views · n new task · ? help · q quit"
 	if m.phase == phaseFailed || m.phase == phaseReconnecting {
 		hints += " · r retry"
 	}

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -210,13 +210,19 @@ func TestConnectFailureAndRetry(t *testing.T) {
 func TestViewRoutingAndHelp(t *testing.T) {
 	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
 	m.phase = phaseConnected
+	// The shell sizes its panels; below the floor it renders the size line
+	// instead, so routing tests need a real terminal size first.
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	m.Update(key("2"))
-	if m.active != viewDetail {
-		t.Fatalf("active = %v, want viewDetail", m.active)
+	if m.active != viewHome {
+		t.Fatalf("active = %v, want viewHome", m.active)
 	}
-	if !strings.Contains(content(m), "Task detail") {
-		t.Errorf("view 2 lacks 'Task detail': %q", content(m))
+	if s := m.views[viewHome].(*shell); s.focus != panelTimeline {
+		t.Fatalf("focus = %v, want the timeline panel after 2", s.focus)
+	}
+	if !strings.Contains(content(m), "Timeline") {
+		t.Errorf("view 2 lacks the timeline panel: %q", content(m))
 	}
 
 	m.Update(key("?"))

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -128,7 +128,14 @@ func (s *shell) update(msg tea.Msg) (panel, tea.Cmd) {
 	case viewActivatedMsg:
 		if msg.id == viewHome {
 			s.detail.active = true
-			return s, tea.Batch(s.detail.loadCmd(), s.detail.syncStream())
+			cmds := []tea.Cmd{s.detail.loadCmd(), s.detail.syncStream()}
+			// A settle window that fired while a takeover screen was active
+			// was delivered to that screen and lost; coming back with the
+			// panels still empty re-opens the tracked row.
+			if s.lastSel != 0 && s.detail.taskID != s.lastSel {
+				cmds = append(cmds, s.detail.open(s.lastSel, s.stateOf(s.lastSel)))
+			}
+			return s, tea.Batch(cmds...)
 		}
 		return s, nil
 	case viewDeactivatedMsg:

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -1,0 +1,495 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// selectionSettle is how long the task-table cursor must rest on a row
+// before the detail panels fetch it and — for a running task — subscribe to
+// its live output. Holding `down` across twenty rows must open one
+// subscription, not twenty (PR P decision: the fetch rides the same settle).
+const selectionSettle = 250 * time.Millisecond
+
+type (
+	// selectionSettledMsg fires when the settle window closes. It carries
+	// the task it was armed for, so a window opened for a row the cursor
+	// has since left is ignored.
+	selectionSettledMsg struct{ id int64 }
+	// focusPanelMsg asks the shell to focus one panel — the root sends it
+	// for the interim `2` key.
+	focusPanelMsg struct{ id panelID }
+)
+
+// shell is the fused home screen (§15 layout): the task table, the step
+// timeline and the output|diff pane as three panels of one persistent
+// screen. It owns layout, focus and the accordion; the board and detail
+// sub-models own everything they always did, just rendered into boxes.
+type shell struct {
+	board  *board
+	detail *detail
+
+	focus panelID
+	// popup shows the §7.4 answer form over the panels. It never opens
+	// itself — `enter` on the awaiting task does (§15: the form announces
+	// itself and the human opens it).
+	popup bool
+	// connected mirrors the root's connection state: false renders the
+	// panels marked stale behind a banner instead of hiding them (§15
+	// Disconnected).
+	connected bool
+
+	// cursor is the task id under the table cursor at the last look;
+	// lastSel is the task the detail panels are tracking (or waiting out a
+	// settle window for). They differ so an explicit open — a created task
+	// not yet in the table — is not immediately torn down by a cursor that
+	// has not caught up.
+	cursor  int64
+	lastSel int64
+
+	// termW/termH are the terminal size (for the §15 too-small line);
+	// bodyW/bodyH the area the root hands render.
+	termW, termH int
+	bodyW, bodyH int
+}
+
+func newShell(ctx context.Context) *shell {
+	s := &shell{
+		board:     newBoard(),
+		detail:    newDetail(ctx),
+		connected: true,
+	}
+	// The home screen starts on screen: the detail sub-model is live from
+	// the first frame, unlike the old detail view that waited to be opened.
+	s.detail.active = true
+	return s
+}
+
+func (s *shell) title() string { return "Board" }
+
+// setClient wires both sub-models to a connected daemon; called again on
+// reconnect.
+func (s *shell) setClient(c *apiclient.Client) tea.Cmd {
+	return tea.Batch(s.board.setClient(c), s.detail.setClient(c))
+}
+
+// setConnected implements connectionAware: the panels stay rendered, the
+// banner and stale marks come from this flag.
+func (s *shell) setConnected(ok bool) { s.connected = ok }
+
+// hintedProject forwards the board's cursor project to the new-task form.
+func (s *shell) hintedProject() int64 { return s.board.hintedProject() }
+
+// capturesInput reports whether a text surface owns the keyboard: the answer
+// popup, or the focused panel's own capture (§15: the shell consults the
+// focused panel only).
+func (s *shell) capturesInput() bool {
+	if s.popup {
+		return true
+	}
+	return s.focusedCaptures()
+}
+
+func (s *shell) focusedCaptures() bool {
+	if s.focus == panelTasks {
+		return s.board.capturesInput()
+	}
+	return s.detail.capturesInput()
+}
+
+func (s *shell) update(msg tea.Msg) (panel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.termW, s.termH = msg.Width, msg.Height
+		return s, s.forward(msg)
+	case tea.KeyPressMsg:
+		return s.updateKey(msg)
+	case focusPanelMsg:
+		s.focus = msg.id
+		return s, nil
+	case selectTaskMsg:
+		// An explicit open — task creation, or a caller that knows the id.
+		// It skips the settle window: a deliberate action is not a cursor
+		// passing through.
+		return s, s.openNow(msg.id)
+	case selectionSettledMsg:
+		if msg.id != s.lastSel || msg.id == s.detail.taskID {
+			return s, nil // the cursor moved on, or the task is already open
+		}
+		return s, s.detail.open(msg.id, s.stateOf(msg.id))
+	case viewActivatedMsg:
+		if msg.id == viewHome {
+			s.detail.active = true
+			return s, tea.Batch(s.detail.loadCmd(), s.detail.syncStream())
+		}
+		return s, nil
+	case viewDeactivatedMsg:
+		if msg.id == viewHome {
+			s.detail.active = false
+			return s, s.detail.syncStream()
+		}
+		return s, nil
+	}
+	// Everything else — loads, notes, ticks, action results — goes to both
+	// sub-models; each ignores the other's message types. The board may
+	// have moved its cursor (a refresh that dropped the selected row), so
+	// the selection is reconciled after.
+	return s, tea.Batch(s.forward(msg), s.checkSelection())
+}
+
+// forward hands one message to both sub-models and keeps the popup honest:
+// a request that was answered or withdrawn takes its form — and therefore
+// the popup — with it.
+func (s *shell) forward(msg tea.Msg) tea.Cmd {
+	_, bc := s.board.update(msg)
+	dc := s.detail.update(msg)
+	if s.popup && s.detail.form == nil {
+		s.popup = false
+	}
+	return tea.Batch(bc, dc)
+}
+
+func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if s.popup && s.detail.form != nil {
+		cmd, exit := s.detail.form.update(msg, s.detail.client, s.detail.taskID)
+		if exit {
+			s.popup = false
+		}
+		return s, cmd
+	}
+	if s.focusedCaptures() {
+		// A filter or a confirmation owns every key; the cursor may still
+		// move underneath (a filter narrowing the rows), so reconcile.
+		return s, tea.Batch(s.routeKey(msg), s.checkSelection())
+	}
+	switch msg.String() {
+	case "tab":
+		s.cycleFocus(1)
+		return s, nil
+	case "shift+tab":
+		s.cycleFocus(-1)
+		return s, nil
+	case "esc":
+		// The full §15 esc stack lands in T3.11; until then esc walks back
+		// to the navigation spine, and on it, clears the board's filter.
+		if s.focus != panelTasks {
+			s.focus = panelTasks
+			return s, nil
+		}
+	case "enter":
+		if s.openAnswer() {
+			return s, nil
+		}
+		if s.focus == panelTasks {
+			return s, s.openSelected()
+		}
+	case "E":
+		// Edit+retry needs the failing step's text, which detail holds —
+		// the key acts on the task, so it works from any panel.
+		s.syncDetailFocus()
+		return s, s.detail.update(msg)
+	}
+	return s, tea.Batch(s.routeKey(msg), s.checkSelection())
+}
+
+// routeKey hands a key to the focused panel's sub-model.
+func (s *shell) routeKey(msg tea.KeyPressMsg) tea.Cmd {
+	if s.focus == panelTasks {
+		_, cmd := s.board.update(msg)
+		return cmd
+	}
+	s.syncDetailFocus()
+	return s.detail.update(msg)
+}
+
+// syncDetailFocus maps the shell's panel focus onto detail's internal one,
+// which decides whether ↑/↓ select an attempt or scroll the pane.
+func (s *shell) syncDetailFocus() {
+	if s.focus == panelOutput {
+		s.detail.focus = focusOutput
+	} else {
+		s.detail.focus = focusTimeline
+	}
+}
+
+func (s *shell) cycleFocus(delta int) {
+	s.focus = panelID((int(s.focus) + delta + 3) % 3)
+}
+
+// openAnswer opens the answer popup when the tracked task has a pending
+// request, reporting whether it did. It handles `enter` from any panel: the
+// form is an interrupt, and the row badge plus the action-bar hint told the
+// human to press it.
+func (s *shell) openAnswer() bool {
+	d := s.detail
+	if d.form == nil || d.taskID == 0 || d.taskID != s.lastSel {
+		return false
+	}
+	s.popup = true
+	return true
+}
+
+// openSelected is `enter` on the task table: open the row under the cursor
+// now — skipping any settle window still pending — and move focus to the
+// timeline.
+func (s *shell) openSelected() tea.Cmd {
+	id, ok := s.board.selected()
+	if !ok {
+		return nil
+	}
+	s.focus = panelTimeline
+	if s.detail.taskID == id {
+		return nil
+	}
+	s.lastSel = id
+	s.cursor = id
+	return s.detail.open(id, s.stateOf(id))
+}
+
+// openNow selects a task in the table and opens it immediately — the
+// explicit path (task creation, live tests). The board may not list the
+// task yet; selectedID makes the next refresh put the cursor on it.
+func (s *shell) openNow(id int64) tea.Cmd {
+	s.board.selectedID = id
+	s.board.restoreSelection(s.board.visible())
+	s.lastSel = id
+	s.focus = panelTimeline
+	return s.detail.open(id, s.stateOf(id))
+}
+
+// checkSelection reconciles the detail panels with the table cursor. On a
+// move the subscription is torn down immediately and the fetch waits out
+// the settle window (PR P decision); a cursor that has not moved does
+// nothing, so an explicit open of a task the table has not caught up with
+// is left alone.
+func (s *shell) checkSelection() tea.Cmd {
+	id, ok := s.board.selected()
+	if !ok {
+		id = 0
+	}
+	if id == s.cursor {
+		return nil
+	}
+	s.cursor = id
+	if id == s.lastSel {
+		return nil
+	}
+	s.lastSel = id
+	s.detail.deselect()
+	if id == 0 {
+		return nil
+	}
+	return tea.Tick(selectionSettle, func(time.Time) tea.Msg {
+		return selectionSettledMsg{id: id}
+	})
+}
+
+// stateOf reads a task's state off the board's rows — the hint that decides
+// whether an open subscribes before the authoritative fetch lands.
+func (s *shell) stateOf(id int64) string {
+	for _, t := range s.board.tasks {
+		if t.ID == id {
+			return t.State
+		}
+	}
+	return ""
+}
+
+func (s *shell) render(width, height int) string {
+	if width > 0 {
+		s.bodyW = width
+	}
+	if height > 0 {
+		s.bodyH = height
+	}
+
+	areaH := s.bodyH - 1 // the action-bar line under the panels
+	var banner string
+	if !s.connected {
+		banner = styleWarn.Render(" ⚠ daemon unreachable — panels show the last known state · ") +
+			styleKey.Render("r") + styleWarn.Render(" retry")
+		areaH--
+	}
+
+	boxes := layout(s.bodyW, areaH, s.focus)
+	if boxes == nil {
+		return fmt.Sprintf("\n  terminal too small (%d×%d, need %d×%d)",
+			s.termW, s.termH, minTermW, minTermH)
+	}
+
+	parts := make([]string, 0, 4)
+	if banner != "" {
+		parts = append(parts, banner)
+	}
+	if len(boxes) == 1 {
+		parts = append(parts, s.renderBox(boxes[0]))
+	} else {
+		parts = append(parts,
+			s.renderBox(boxes[0]),
+			lipgloss.JoinHorizontal(lipgloss.Top,
+				s.renderBox(boxes[1]), s.renderBox(boxes[2])))
+	}
+	parts = append(parts, s.actionBarLine())
+	out := strings.Join(parts, "\n")
+	if s.popup && s.detail.form != nil {
+		out = s.overlayPopup(out)
+	}
+	return out
+}
+
+func (s *shell) renderBox(b box) string {
+	title := s.panelTitle(b.id)
+	if !s.connected {
+		title += styleDim.Render(" · stale")
+	}
+	return frame(title, s.panelContent(b.id, b.w-2, b.h-2), b.w, b.h, s.focus == b.id)
+}
+
+func (s *shell) panelTitle(id panelID) string {
+	switch id {
+	case panelTasks:
+		return "Tasks"
+	case panelTimeline:
+		if s.detail.taskID != 0 {
+			return fmt.Sprintf("Timeline — #%d", s.detail.taskID)
+		}
+		return "Timeline"
+	default:
+		return s.detail.outputTitle()
+	}
+}
+
+func (s *shell) panelContent(id panelID, w, h int) string {
+	if id == panelTasks {
+		return s.board.render(w, h)
+	}
+	if body, ok := s.detailPlaceholder(); ok {
+		return body
+	}
+	if id == panelTimeline {
+		return s.detail.timelinePanel(h)
+	}
+	return s.detail.outputPanel(w, h)
+}
+
+// detailPlaceholder is what the bottom panels show while no task is tracked
+// or a settle window is still open — the previous task's content would be a
+// lie about the row under the cursor.
+func (s *shell) detailPlaceholder() (string, bool) {
+	switch {
+	case s.lastSel == 0:
+		return styleDim.Render("  no task selected"), true
+	case s.detail.taskID != s.lastSel:
+		return styleDim.Render(fmt.Sprintf("  #%d — loading…", s.lastSel)), true
+	default:
+		return "", false
+	}
+}
+
+// actionBarLine is the detail action bar under the panels: the §6 actions
+// for the tracked task plus detail's own hints. Blank until the tracked
+// task's detail is loaded — the board's own action line covers the settle
+// window. (Two action lines is the accepted PR P interim; T3.12's footer
+// unifies them.)
+func (s *shell) actionBarLine() string {
+	if s.lastSel == 0 || s.detail.taskID != s.lastSel {
+		return ""
+	}
+	return s.detail.actions.render(s.detail.target(), s.detail.detailHints()...)
+}
+
+// overlayPopup draws the answer form over the panels. A popup gets the full
+// width a quarter-pane could not give multi-select options and free text
+// (§15), and the panels stay visible around it — the tail underneath is
+// what says why the agent is asking.
+func (s *shell) overlayPopup(bg string) string {
+	form := s.detail.form
+	pw := min(s.bodyW-6, 76)
+	if pw < 20 {
+		pw = s.bodyW
+	}
+	ph := min(form.height()+2, max(s.bodyH-4, 6))
+	title := fmt.Sprintf("Answer — #%d", s.detail.taskID)
+	popup := frame(title, form.render(ph-2), pw, ph, true)
+	x := max((s.bodyW-pw)/2, 0)
+	y := max((s.bodyH-ph)/3, 1)
+	return overlay(bg, popup, x, y)
+}
+
+// frame draws content inside a bordered box of exactly w×h cells, the title
+// embedded in the top border. Focus is a colour *and* a glyph, so it
+// survives NO_COLOR (§15 Colour). Content lines are ANSI-truncated to the
+// inner width — a panel must never leak into its neighbour — and padded to
+// the inner height.
+func frame(title, content string, w, h int, focused bool) string {
+	if w < 2 || h < 2 {
+		return ""
+	}
+	border := styleDim
+	label := " " + title + " "
+	if focused {
+		border = styleFocus
+		label = " " + focusGlyph + " " + title + " "
+	}
+	inner := w - 2
+
+	label = ansi.Truncate(label, max(inner-1, 0), "…")
+	fill := inner - 1 - ansi.StringWidth(label)
+	var sb strings.Builder
+	sb.WriteString(border.Render("┌─"))
+	sb.WriteString(label)
+	sb.WriteString(border.Render(strings.Repeat("─", max(fill, 0)) + "┐"))
+
+	lines := strings.Split(content, "\n")
+	side := border.Render("│")
+	for i := range h - 2 {
+		var line string
+		if i < len(lines) {
+			line = ansi.Truncate(lines[i], inner, "…")
+		}
+		pad := inner - ansi.StringWidth(line)
+		sb.WriteString("\n")
+		sb.WriteString(side)
+		sb.WriteString(line)
+		if pad > 0 {
+			sb.WriteString(strings.Repeat(" ", pad))
+		}
+		sb.WriteString(side)
+	}
+	sb.WriteString("\n")
+	sb.WriteString(border.Render("└" + strings.Repeat("─", inner) + "┘"))
+	return sb.String()
+}
+
+// focusGlyph marks the focused panel's title. A glyph, not just a colour:
+// it has to survive a monochrome terminal.
+const focusGlyph = "▸"
+
+// overlay splices fg over bg with fg's top-left at column x, row y. The
+// background lines are cut ANSI-aware around the box; a background shorter
+// than the box clips the box rather than growing the screen.
+func overlay(bg, fg string, x, y int) string {
+	bgLines := strings.Split(bg, "\n")
+	for i, fl := range strings.Split(fg, "\n") {
+		r := y + i
+		if r < 0 || r >= len(bgLines) {
+			break
+		}
+		line := bgLines[r]
+		left := ansi.Truncate(line, x, "")
+		if pad := x - ansi.StringWidth(left); pad > 0 {
+			left += strings.Repeat(" ", pad)
+		}
+		right := ansi.TruncateLeft(line, x+ansi.StringWidth(fl), "")
+		bgLines[r] = left + fl + right
+	}
+	return strings.Join(bgLines, "\n")
+}

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -1,0 +1,347 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// newShellFixture builds a shell with a counting stream opener and a loaded,
+// rendered board. The client stays nil: commands returned by updates are
+// never executed here, so nothing fetches, and the subscription count is
+// exactly the openStream calls syncStream made.
+func newShellFixture(t *testing.T, tasks ...apiclient.Task) (*shell, *int) {
+	t.Helper()
+	s := newShell(testCtx(t))
+	s.board.now = func() time.Time { return testNow }
+	s.board.bell = func() {}
+	subs := new(int)
+	s.detail.openStream = func(context.Context, int64, apiclient.StreamOptions) <-chan apiclient.Note {
+		*subs++
+		return make(chan apiclient.Note)
+	}
+	s.update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	if len(tasks) > 0 {
+		s.update(boardLoadedMsg{tasks: tasks})
+	}
+	s.render(120, 37)
+	return s, subs
+}
+
+// settle drains the pending settle window the way the runtime would: the
+// cursor rested, the tick fired.
+func (s *shell) settle() {
+	s.update(selectionSettledMsg{id: s.lastSel})
+}
+
+// TestShellHoldingDownOpensOneSubscription is the T3.10 done-when: holding
+// `down` across the table must open one subscription — for the row the
+// cursor settles on — not one per row it passed through.
+func TestShellHoldingDownOpensOneSubscription(t *testing.T) {
+	tasks := make([]apiclient.Task, 0, 6)
+	for id := int64(1); id <= 6; id++ {
+		tasks = append(tasks, task(id, stateRunning))
+	}
+	s, subs := newShellFixture(t, tasks...)
+
+	// The initial selection settles on the first row and subscribes once.
+	s.settle()
+	if *subs != 1 {
+		t.Fatalf("subscriptions after the first settle = %d, want 1", *subs)
+	}
+	first := s.detail.taskID
+
+	// Hold `down` across the rest of the table. Every move tears the stream
+	// down at once and nothing new opens while the cursor is moving.
+	for range 5 {
+		s.update(tea.KeyPressMsg{Code: tea.KeyDown})
+		s.render(120, 37)
+	}
+	if *subs != 1 {
+		t.Fatalf("subscriptions while moving = %d, want still 1", *subs)
+	}
+	if s.detail.taskID != 0 {
+		t.Fatalf("detail still tracks #%d mid-move, want a torn-down panel", s.detail.taskID)
+	}
+	if s.detail.streamID != 0 {
+		t.Fatalf("stream still open for #%d mid-move; the unsubscribe is not immediate", s.detail.streamID)
+	}
+
+	// Stale settle windows — armed for rows the cursor already left — are
+	// ignored; only the row it rests on opens.
+	s.update(selectionSettledMsg{id: first})
+	if *subs != 1 || s.detail.taskID != 0 {
+		t.Fatal("a stale settle window opened a task")
+	}
+	s.settle()
+	if *subs != 2 {
+		t.Fatalf("subscriptions after the cursor rested = %d, want 2", *subs)
+	}
+	if got, ok := s.board.selected(); !ok || s.detail.taskID != got {
+		t.Fatalf("detail tracks #%d, cursor is on #%d", s.detail.taskID, got)
+	}
+}
+
+// TestShellSubscribesOnlyForRunningTasks: a parked task has no live output,
+// so settling on it fetches but never streams.
+func TestShellSubscribesOnlyForRunningTasks(t *testing.T) {
+	s, subs := newShellFixture(t, task(1, stateBlocked), task(2, stateDone))
+	s.settle()
+	if s.detail.taskID == 0 {
+		t.Fatal("settling did not open the task")
+	}
+	if *subs != 0 {
+		t.Fatalf("subscriptions = %d for a task that is not running, want 0", *subs)
+	}
+}
+
+// TestShellFocusCycling covers tab/shift+tab and esc-back-to-the-spine.
+func TestShellFocusCycling(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	if s.focus != panelTasks {
+		t.Fatalf("initial focus = %v, want the task table", s.focus)
+	}
+	press := func(k tea.KeyPressMsg) { s.update(k) }
+	press(tea.KeyPressMsg{Code: tea.KeyTab})
+	if s.focus != panelTimeline {
+		t.Fatalf("after tab focus = %v, want timeline", s.focus)
+	}
+	press(tea.KeyPressMsg{Code: tea.KeyTab})
+	if s.focus != panelOutput {
+		t.Fatalf("after tab tab focus = %v, want output", s.focus)
+	}
+	press(tea.KeyPressMsg{Code: tea.KeyTab})
+	if s.focus != panelTasks {
+		t.Fatalf("tab does not wrap: focus = %v", s.focus)
+	}
+	press(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	if s.focus != panelOutput {
+		t.Fatalf("shift+tab focus = %v, want output", s.focus)
+	}
+	press(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if s.focus != panelTasks {
+		t.Fatalf("esc focus = %v, want back on the task table", s.focus)
+	}
+}
+
+// TestShellEnterOpensImmediately: enter is a deliberate action, so it skips
+// the settle window and lands focused on the timeline.
+func TestShellEnterOpensImmediately(t *testing.T) {
+	s, subs := newShellFixture(t, task(9, stateRunning))
+	s.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if s.focus != panelTimeline {
+		t.Fatalf("focus = %v, want timeline after enter", s.focus)
+	}
+	if s.detail.taskID != 9 {
+		t.Fatalf("detail task = %d, want 9 without waiting for a settle", s.detail.taskID)
+	}
+	if *subs != 1 {
+		t.Fatalf("subscriptions = %d, want 1", *subs)
+	}
+}
+
+// TestShellAnswerPopup: the form never opens itself; enter opens it, its
+// keys stay inside it, esc closes one layer, and an answered request takes
+// the popup with it.
+func TestShellAnswerPopup(t *testing.T) {
+	s, _ := newShellFixture(t, task(3, stateAwaitingInput))
+	s.settle()
+	if s.detail.taskID != 3 {
+		t.Fatalf("detail task = %d, want 3", s.detail.taskID)
+	}
+	s.detail.form = newAnswerForm(apiclient.InputRequest{
+		Kind: apiclient.InputKindQuestion,
+		Questions: []apiclient.InputQuestion{
+			{Text: "Which colour?", Options: []string{"teal", "mauve"}},
+		},
+	})
+	if s.popup {
+		t.Fatal("the popup opened itself")
+	}
+
+	s.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !s.popup {
+		t.Fatal("enter did not open the answer popup")
+	}
+	if !strings.Contains(s.render(120, 37), "Which colour?") {
+		t.Fatal("open popup does not render the question")
+	}
+
+	// Keys go to the form, not the panels: space picks an option.
+	s.update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	if got := s.detail.form.answers["Which colour?"]; len(got) != 1 || got[0] != "teal" {
+		t.Fatalf("space picked %v, want the first option", got)
+	}
+	if s.focus != panelTasks {
+		t.Fatalf("focus moved to %v while the popup was open", s.focus)
+	}
+
+	// esc closes the popup — one layer — and the typed answer survives for
+	// the next open.
+	s.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if s.popup {
+		t.Fatal("esc did not close the popup")
+	}
+	if got := s.detail.form.answers["Which colour?"]; len(got) != 1 {
+		t.Fatalf("closing the popup lost the picked answer: %v", got)
+	}
+
+	// A cleared request (the refetch after an answer) closes an open popup.
+	s.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	s.detail.form = nil
+	s.update(boardLoadedMsg{tasks: []apiclient.Task{task(3, stateRunning)}})
+	if s.popup {
+		t.Fatal("the popup outlived its request")
+	}
+}
+
+// TestShellRendersThreePanes pins the composed frame: three titled panels,
+// exactly one carrying the focus glyph, the action-bar line underneath.
+func TestShellRendersThreePanes(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.settle()
+	got := s.render(120, 37)
+
+	for _, want := range []string{"Tasks", "Timeline — #1", "output", "diff"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("frame missing %q:\n%s", want, got)
+		}
+	}
+	if n := strings.Count(got, focusGlyph); n != 1 {
+		t.Errorf("focus glyph appears %d times, want exactly 1", n)
+	}
+	// The frame must fill the box heights exactly: body 37 lines.
+	if lines := strings.Count(got, "\n") + 1; lines != 37 {
+		t.Errorf("frame is %d lines, want 37", lines)
+	}
+	// No line may exceed the body width — a panel leaking into its
+	// neighbour breaks the tiling silently.
+	for i, line := range strings.Split(got, "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Errorf("line %d is %d cells wide, want ≤ 120", i, w)
+		}
+	}
+}
+
+// TestShellSinglePanelMode: below 80×20 the focused panel gets the whole
+// area and tab swaps which one that is (§15).
+func TestShellSinglePanelMode(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.update(tea.WindowSizeMsg{Width: 70, Height: 18})
+	got := s.render(70, 15)
+	if !strings.Contains(got, "Tasks") || strings.Contains(got, "Timeline") {
+		t.Fatalf("single-panel mode shows more than the focused panel:\n%s", got)
+	}
+	s.update(tea.KeyPressMsg{Code: tea.KeyTab})
+	got = s.render(70, 15)
+	if !strings.Contains(got, "Timeline") || strings.Contains(got, "Tasks") {
+		t.Fatalf("tab did not swap the single panel:\n%s", got)
+	}
+}
+
+// TestShellTooSmall: below 60×15 the shell renders the size it has and the
+// size it needs, nothing else (§15).
+func TestShellTooSmall(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.update(tea.WindowSizeMsg{Width: 58, Height: 14})
+	got := s.render(58, 11)
+	if !strings.Contains(got, "terminal too small (58×14, need 60×15)") {
+		t.Fatalf("too-small floor not stated:\n%s", got)
+	}
+	if strings.Contains(got, "Tasks") {
+		t.Fatalf("too-small mode still renders panels:\n%s", got)
+	}
+}
+
+// TestShellDisconnectedBanner: the panels stay on screen marked stale behind
+// a banner — nothing force-navigates (§15 Disconnected).
+func TestShellDisconnectedBanner(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.setConnected(false)
+	got := s.render(120, 37)
+	for _, want := range []string{"daemon unreachable", "retry", "stale", "Tasks"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("disconnected frame missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestShellActionKeysWorkFromEveryPanel: task actions act on the task, not
+// on a pane, so the focused panel must not gate them away.
+func TestShellActionKeysWorkFromEveryPanel(t *testing.T) {
+	s, _ := newShellFixture(t, task(4, stateRunning, func(t *apiclient.Task) {
+		t.AvailableActions = []string{apiclient.ActionPause}
+	}))
+	// A real client, never called: the returned commands are not executed,
+	// but a nil client makes the action bar refuse with "not connected".
+	c := apiclient.New("http://127.0.0.1:1", "token")
+	s.board.client = c
+	s.detail.client = c
+	s.settle()
+	// The detail fetch is a command this test never executes; install its
+	// result so detail's bar knows the same available_actions the row does.
+	s.detail.applyLoaded(detailLoadedMsg{id: 4, task: apiclient.TaskDetail{
+		Task: apiclient.Task{ID: 4, State: stateRunning, AvailableActions: []string{apiclient.ActionPause}},
+	}})
+	for _, focus := range []panelID{panelTasks, panelTimeline, panelOutput} {
+		s.focus = focus
+		_, cmd := s.update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+		if cmd == nil {
+			t.Errorf("p from %v produced no action command", focus)
+		}
+	}
+}
+
+// TestShellColourDowngrade is the §15 colour contract: the palette degrades
+// under NO_COLOR (ASCII profile) and on 16-colour terminals without losing
+// content, and focus stays discernible because it is a glyph, not only a
+// colour.
+func TestShellColourDowngrade(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning), task(2, stateAwaitingInput))
+	s.update(tea.KeyPressMsg{Code: tea.KeyTab}) // focus timeline: glyph off the default
+	frame := s.render(120, 37)
+
+	downgrade := func(p colorprofile.Profile) string {
+		var buf bytes.Buffer
+		w := &colorprofile.Writer{Forward: &buf, Profile: p}
+		if _, err := w.Write([]byte(frame)); err != nil {
+			t.Fatalf("downgrade write: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("NO_COLOR", func(t *testing.T) {
+		plain := downgrade(colorprofile.ASCII)
+		if ansi.Strip(plain) != ansi.Strip(frame) {
+			t.Error("stripping colour changed the content")
+		}
+		if !strings.Contains(plain, focusGlyph+" Timeline") {
+			t.Error("focus is not discernible without colour")
+		}
+		for _, seq := range []string{"[38;5;", "[38;2;", "[48;5;", "[31m", "[32m"} {
+			if strings.Contains(plain, seq) {
+				t.Errorf("colour sequence %q survived the NO_COLOR downgrade", seq)
+			}
+		}
+	})
+
+	t.Run("16-colour", func(t *testing.T) {
+		basic := downgrade(colorprofile.ANSI)
+		if ansi.Strip(basic) != ansi.Strip(frame) {
+			t.Error("the 16-colour downgrade changed the content")
+		}
+		for _, seq := range []string{"[38;5;", "[38;2;", "[48;5;", "[48;2;"} {
+			if strings.Contains(basic, seq) {
+				t.Errorf("extended colour %q survived the 16-colour downgrade", seq)
+			}
+		}
+	})
+}

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -203,6 +203,25 @@ func TestShellAnswerPopup(t *testing.T) {
 	}
 }
 
+// TestShellReopensAfterALostSettle: a settle window that fires while a
+// takeover screen is active is delivered there and lost; returning to the
+// home screen must not leave the panels on "loading…" forever.
+func TestShellReopensAfterALostSettle(t *testing.T) {
+	s, subs := newShellFixture(t, task(1, stateRunning))
+	// The cursor rested on row 1, but its settle tick fired into a takeover.
+	if s.lastSel != 1 || s.detail.taskID != 0 {
+		t.Fatalf("fixture: lastSel=%d taskID=%d, want a pending selection", s.lastSel, s.detail.taskID)
+	}
+	s.update(viewDeactivatedMsg{id: viewHome})
+	s.update(viewActivatedMsg{id: viewHome})
+	if s.detail.taskID != 1 {
+		t.Fatalf("detail task = %d, want the tracked row reopened", s.detail.taskID)
+	}
+	if *subs != 1 {
+		t.Fatalf("subscriptions = %d, want 1 for the reopened running task", *subs)
+	}
+}
+
 // TestShellRendersThreePanes pins the composed frame: three titled panels,
 // exactly one carrying the focus glyph, the action-bar line underneath.
 func TestShellRendersThreePanes(t *testing.T) {

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -8,12 +8,14 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// viewID indexes the six §15 views; the 1..6 global keys map onto it.
+// viewID indexes the root's routed screens: the fused home screen (§15
+// views 1–2 as one persistent three-panel shell) and the four full-screen
+// takeovers (§15 views 3–6). The digits 1..6 keep their §15 meanings until
+// T3.11 retires them — 1 and 2 both land on the home screen.
 type viewID int
 
 const (
-	viewBoard viewID = iota
-	viewDetail
+	viewHome viewID = iota
 	viewNewTask
 	viewProjects
 	viewWorkflows
@@ -21,11 +23,13 @@ const (
 	viewCount
 )
 
-// view is one routed screen. Views are sub-models: the root delegates
-// non-global messages to the active view only.
-type view interface {
+// panel is one routed screen (T3.10: renamed from view). Screens are
+// sub-models: the root delegates non-global messages to the active one only.
+// The home shell implements it too, and composes the board and detail
+// sub-models into the three §15 panes behind it.
+type panel interface {
 	title() string
-	update(msg tea.Msg) (view, tea.Cmd)
+	update(msg tea.Msg) (panel, tea.Cmd)
 	render(width, height int) string
 }
 
@@ -56,25 +60,25 @@ type dataDirAware interface {
 
 // connectionAware is implemented by views that render while the daemon is
 // unreachable and therefore have to say which of their contents are still
-// true. Only the daemon view is reachable in that state.
+// true: the daemon view, and the home shell whose panels stay on screen
+// marked stale (§15 Disconnected).
 type connectionAware interface {
 	setConnected(bool)
 }
 
 // clientAware is implemented by views that talk to the daemon themselves.
 // The root hands each one the client as the connection comes up (and again
-// after a reconnect) rather than widening the view interface, which every
+// after a reconnect) rather than widening the panel interface, which every
 // stub would then have to implement meaninglessly.
 type clientAware interface {
 	setClient(*apiclient.Client) tea.Cmd
 }
 
 // newViews returns the initial view set. ctx bounds background work a view
-// owns — the detail view's per-task subscription.
-func newViews(ctx context.Context) [viewCount]view {
-	return [viewCount]view{
-		viewBoard:     newBoard(),
-		viewDetail:    newDetail(ctx),
+// owns — the detail sub-model's per-task subscription.
+func newViews(ctx context.Context) [viewCount]panel {
+	return [viewCount]panel{
+		viewHome:      newShell(ctx),
 		viewNewTask:   newNewTask(),
 		viewProjects:  newProjectsView(),
 		viewWorkflows: newWorkflowsView(),

--- a/internal/tui/workflows.go
+++ b/internal/tui/workflows.go
@@ -163,7 +163,7 @@ func (w *workflowsView) scheduleRefresh() tea.Cmd {
 	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg { return workflowsRefreshMsg{} })
 }
 
-func (w *workflowsView) update(msg tea.Msg) (view, tea.Cmd) {
+func (w *workflowsView) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		w.width, w.height = msg.Width, msg.Height
@@ -242,7 +242,7 @@ func (w *workflowsView) updateNote(n apiclient.Note) tea.Cmd {
 	return nil
 }
 
-func (w *workflowsView) updateKey(msg tea.KeyPressMsg) (view, tea.Cmd) {
+func (w *workflowsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch msg.String() {
 	case "up", "k":
 		w.moveCursor(-1)

--- a/internal/tui/workflows_test.go
+++ b/internal/tui/workflows_test.go
@@ -225,7 +225,7 @@ func TestWorkflowsRefetchOnActivationAndOnRegistryEvents(t *testing.T) {
 	if _, cmd := w.update(viewActivatedMsg{id: viewWorkflows}); cmd == nil {
 		t.Error("activation did not refetch")
 	}
-	if _, cmd := w.update(viewActivatedMsg{id: viewBoard}); cmd != nil {
+	if _, cmd := w.update(viewActivatedMsg{id: viewHome}); cmd != nil {
 		t.Error("another view's activation triggered a fetch")
 	}
 	for _, evType := range []string{eventWorkflowRegistryChanged, "project.created"} {


### PR DESCRIPTION
Delivers **T3.10** (PR P of the Phase 3 TUI refactor): the daily loop fuses into one persistent three-panel screen, per the rewritten §15 and the PR P grill block recorded in tasks.md.

## What changed

- **`panel` interface** (renamed from `view`); `viewBoard`/`viewDetail` collapse into `viewHome`. The four takeover screens are untouched; `1`/`2` land on the fused screen (`2` focuses the timeline) and `3..6` keep their meanings until T3.11 retires the digits.
- **`shell.go`** owns focus, the accordion and composition over the existing `board`/`detail` sub-models. `detail` stays one sub-model rendering two boxes (timeline · output|diff), per the refactor decision.
- **`layout.go`** is the pure `layout(w, h, focus) → []box`, table-tested across sizes and focus targets: three-pane accordion (vertical, between bands; tasks table never below 5 rows), single-panel mode below 80×20, explicit `terminal too small (58×14, need 60×15)` below 60×15.
- **Selection → detail is a 250ms settle window**: cursor move tears the SSE subscription down immediately; the fetch *and* the (running-task-only) subscription open when the cursor rests. Holding `down` across the table opens one subscription, not one per row — asserted by `TestShellHoldingDownOpensOneSubscription` with an injected stream opener.
- **The §7.4 answer form is a popup**: it never opens itself and never steals focus; `enter` on the awaiting task opens it, `esc` closes one layer, an answered request takes it with it. The live fake-agent answer test drives the popup path end to end.
- **Disconnected stops hiding the screen** (§15 amendment, T3.9): with a loaded board, `reconnecting`/`failed` render the panels marked stale behind a banner with `r` to retry; before the first connection the connect screens remain (PR P decision — there is no last-known table to show).
- **Colour degrades**: `NO_COLOR` (ASCII) and 16-colour downgrades are asserted via `colorprofile`; focus survives both because it is a glyph (`▸`) as well as a border colour.

## Also fixed in passing

Resizing across a board column breakpoint crashed the bubbles table: `SetColumns` re-renders the rows it already holds, so yesterday's wider rows met the narrower column set and indexed out of range. Found by the new single-panel-mode test; fixed in `board.render` (clear rows across a breakpoint, re-seat a parked cursor).

## Interim states, recorded in the grill block

- Two action lines (board's in-panel, detail's under the band) until T3.12's footer unifies them.
- The full `esc` stack, palette, and binding registry are T3.11; the attention-jump key and footer hint arrive with their PRs.

## Testing

- `go test ./...` — 783 pass; `go run mage.go lint` — clean.
- `testrace` needs cgo + a C compiler, which this Windows machine lacks — relying on CI's three-platform race matrix.

Refs T3.10 in docs/versions/v0/tasks.md (marked [x] with the PR P decision block).