### PR TITLE
feat(tui): mouse — click to focus and select, wheel, footer hints, tabs (T3.13)

### DIFF
--- a/docs/versions/v0/m3-gate.md
+++ b/docs/versions/v0/m3-gate.md
@@ -44,13 +44,13 @@ session, and *leaving the TUI to get something done is itself a failure*.
 | ID | Step | Passes when |
 |---|---|---|
 | **L1** | Launch `vincent` with no daemon running. | The TUI comes up on its own, shows it is starting the daemon, and reaches the board without you starting anything by hand. On the very first launch the full-auto notice appears; `enter` dismisses it. |
-| **L2** | Register the app repo: view `4`, `a`, paste the seeded app-repo path, `ctrl+s`. | The project appears in the list with its name derived from the directory, and no error. |
-| **L3** | Author a workflow: view `5`, select **m3-parallel** on the app project, `e`. | Your `$EDITOR` opens *the project-scoped file* (`.vincent/workflows/m3-parallel.yaml`, 2 steps — not the 1-step global copy). Change the step id `work-shadow` to something you will recognise, save, quit the editor. The row updates **without a restart**. |
+| **L2** | Register the app repo: `:` → projects, `a`, paste the seeded app-repo path, `ctrl+s`. | The project appears in the list with its name derived from the directory, and no error. |
+| **L3** | Author a workflow: `:` → workflows, select **m3-parallel** on the app project, `e`. | Your `$EDITOR` opens *the project-scoped file* (`.vincent/workflows/m3-parallel.yaml`, 2 steps — not the 1-step global copy). Change the step id `work-shadow` to something you will recognise, save, quit the editor. The row updates **without a restart**. |
 | **L4** | Read the shadowing row on the Workflows view. | **m3-parallel** is one row, not two, and says it shadows the global entry. |
 | **L5** | Create four tasks on the app project with **m3-parallel**: `n`, title, pick the workflow, override `agent` to `codex`, `ctrl+s`. Repeat. | Four tasks exist. |
 | **L6** | Watch the board. | Exactly **three** run at once and the fourth sits `queued`; each running row shows the step name you typed in L3 (proving the shadow ran, not the global copy) and a step count of 2. When the first finishes, the fourth starts on its own — no keypress, no refresh. |
 | **L7** | Open one running task (`enter`), watch the output pane. | Output is still arriving while you watch; `f`/`G` re-follows after you scroll away. Press `d` for the diff — it shows the agent's README.md edit. |
-| **L8** | Create a task on the app project with **m3-loop** (agent `claude`, the real CLI). Wait. | The task reaches `awaiting_input` and the TUI alerts you. Open it, `tab` to the answer form, pick an option, `enter`. The run resumes in place — no new attempt, no restart — and finishes the agent step. |
+| **L8** | Create a task on the app project with **m3-loop** (agent `claude`, the real CLI). Wait. | The task reaches `awaiting_input` and the TUI alerts you. Jump to it (`!`), open the answer popup (`enter`), pick an option, `enter`. The run resumes in place — no new attempt, no restart — and finishes the agent step. |
 | **L9** | The task stops at the gate. Approve it: `a`. | The manual step shows as approved, the publish step runs, and the task reaches `done`. `git -C <bare remote> log --oneline --all` shows the branch with the agent's commit. |
 | **L10** | Archive the finished loop task: `A`, confirm. | It asks first, naming the consequence; on `y` the task shows as archived and its worktree is gone from disk. |
 

--- a/docs/versions/v0/m3-gate.md
+++ b/docs/versions/v0/m3-gate.md
@@ -62,19 +62,24 @@ gate unless they blocked Section A.
 
 | ID | §19 phrase | Look at |
 |---|---|---|
-| **S1** | "All six views" | `1`–`6` all render, none blank or panicking; `?` lists the keys each one actually has. |
+| **S1** | "All six views" | All six §15 surfaces render, none blank or panicking: the home panels plus the four takeovers reached from the `:` palette; `?` lists the keys each surface actually has, straight from the registry. |
 | **S2** | "live tail" | Covered by L7; additionally, a tail left open across a task's completion ends cleanly rather than hanging on "following". |
 | **S3** | "diff view" | `d` on a task with no commits yet, on a finished task, and on an archived one (worktree removed) — three different situations, three intelligible messages. |
 | **S4** | "all actions" | `p` pause/resume a running task · `c` cancel (asks first) · `s` skip a step · `r` retry a blocked task · `E` edit the failing step in `$EDITOR` and retry · `x` reject a gate. Each offered only when valid for that task's state. |
 | **S5** | "input-request alerts + answer form" | Covered by L8; additionally `e` in the form types a free-text answer instead of picking, and `esc` leaves without answering and the task stays parked. |
 | **S6** | "`$EDITOR` integration" | Covered by L3 (workflow file) and S4 (`E` on a step); also `e` on the description field in the new-task form. The TUI redraws correctly after the editor exits in all three. |
 | **S7** | "daemon auto-start" | Covered by L1. |
-| **S8** | Reconnect (PR H made connect and reconnect one state) | From a second terminal, `vincent daemon stop --force`. The TUI notices, shows the connect/reconnect screen with the log path, and `r` brings it back without losing the view you were on. |
+| **S8** | Reconnect (PR H made connect and reconnect one state) | From a second terminal, `vincent daemon stop --force`. The panels stay on screen marked stale behind the banner (§15 Disconnected), `:` still reaches the daemon view, and `r` brings the connection back without losing where you were. |
 | **S9** | Projects view states | The spare repo gives the list a second row; `d` on a project with a running task is refused with a reason; `enter`/`e` edits and saves. |
 | **S10** | Workflows view states | **m3-broken** renders as invalid, carrying the registry's own message (unknown step type, line 5); the built-in `adhoc` renders as built-in with no `e`. |
-| **S11** | Daemon view | `6` shows version, uptime, pid, listen address, the three paths, `max_parallel_tasks: 3`, both adapters with their resolved paths, and a log tail that matches what the daemon is actually writing. `R` refreshes all three. |
+| **S11** | Daemon view | The daemon entry in `:` shows version, uptime, pid, listen address, the three paths, `max_parallel_tasks: 3`, both adapters with their resolved paths, and a log tail that matches what the daemon is actually writing. `R` refreshes all three. |
 | **S12** | Destructive confirmation | `A` on one of the **m3-parallel** tasks — its worktree is dirty (the agent edited README.md and nothing committed). The prompt says changes will be lost. Answer `n` first: the task is still there. Then `y`. |
 | **S13** | Quit reminder | `q` with tasks still running prints the running-task count after the alt screen tears down, and the line survives in scrollback. |
+| **S14** | Mouse (T3.13) | On both Windows hosts (Windows Terminal + pwsh, Git Bash/mintty): click focuses a panel, click selects a task row, the wheel scrolls the focused panel, clicking a footer hint fires it, clicking the output/diff tab switches it. `M` turns it off and native click-drag text selection returns. |
+| **S15** | Resize across both floors (T3.13) | Shrink below 80×20 — single-panel mode, `tab` swaps which; below 60×15 — the explicit size line; grow back — three panels return, nothing panics, selection and any committed filter survive. |
+| **S16** | Palette reachable and complete (T3.13) | `:` opens on every surface; entries match it — the selected task's valid actions, navigation, the surface's own keys — and running an entry behaves exactly like pressing the key it shows. |
+| **S17** | Accordion at 24 rows (T3.13) | On a 24-row terminal focus each panel in turn: the focused band expands, the collapsed band is title + one line, and the task table never shows fewer than five rows. |
+| **S18** | `NO_COLOR` (T3.13) | A `NO_COLOR=1` run: focus still discernible (the ▸ glyph), states legible as text, box-drawing intact, nothing invisible. |
 
 ## Results
 

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 13 tasks | 11/13 | 🟡 in progress |
+| 3 — TUI (M3) | 13 tasks | 12/13 | 🟡 in progress |
 | 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **36/44** | |
+| **Total** | | **37/44** | |
 
 ---
 
@@ -540,8 +540,9 @@ superseded in layout and routing by T3.10–T3.13.
 - *Takeover screens get wheel delegation for free and no click surfaces.* Nothing §15 lists exists there; their lists stay keyboard until someone misses it at the gate.
 - *The T3.8 sweep grows five items and three are reworded:* S1/S8/S11 were written against the retired digits and the old connect screen; they now walk the palette route and the stale-panels banner. New items cover mouse on both Windows hosts, resize across both floors, palette completeness, the accordion at 24 rows, and `NO_COLOR`.
 
-- [~] **T3.13 — Mouse.** Click-to-focus, click-row-select, wheel scroll in the focused panel, click a footer hint to fire it, click a tab. `hitTest(x, y, []box) → panelID` as a pure function. On by default, `M` toggles, toggle listed in the palette. Grow the T3.8 checklist: mouse on Windows Terminal + Git Bash, resize across both floors, palette reachable and complete, accordion at 24 rows, `NO_COLOR`. *Depends:* T3.12.
+- [x] **T3.13 — Mouse.** ✓ 2026-08-10 Click-to-focus, click-row-select, wheel scroll in the focused panel, click a footer hint to fire it, click a tab. `hitTest(x, y, []box) → panelID` as a pure function. On by default, `M` toggles, toggle listed in the palette. Grow the T3.8 checklist: mouse on Windows Terminal + Git Bash, resize across both floors, palette reachable and complete, accordion at 24 rows, `NO_COLOR`. *Depends:* T3.12.
   *Done when:* `hitTest` is table-tested; `MouseClickMsg` tests assert focus and selection changes; `m3-gate.md`'s sweep carries the new items.
+  *2026-08-10:* landed per the PR S decisions above; the sweep gained S14–S18 and S1/S8/S11 were reworded off the retired digits.
 
 ## Phase 4 — Polish (M4)
 

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -529,7 +529,18 @@ superseded in layout and routing by T3.10–T3.13.
 - [x] **T3.12 — Contextual footer.** ✓ 2026-08-10 Generalize `actionbar` into a one-line, never-wrapping footer: focused-panel keys (max 5, priority-ordered) · `available_actions` · right-pinned `: commands  ? help  q quit`. Left-truncates with `…`; the pinned segment never truncates. Attention-jump hint appears only when the count is non-zero. *Depends:* T3.11.
   *Done when:* narrow-terminal tests assert the pinned segment survives and the line never wraps.
   *2026-08-10:* landed per the PR R decisions above; the event line is gone and the T3.1 live proofs now assert the event-driven refresh renders the change itself.
-- [ ] **T3.13 — Mouse.** Click-to-focus, click-row-select, wheel scroll in the focused panel, click a footer hint to fire it, click a tab. `hitTest(x, y, []box) → panelID` as a pure function. On by default, `M` toggles, toggle listed in the palette. Grow the T3.8 checklist: mouse on Windows Terminal + Git Bash, resize across both floors, palette reachable and complete, accordion at 24 rows, `NO_COLOR`. *Depends:* T3.12.
+**PR S decisions (T3.13; grill session, 2026-08-10):**
+
+- *The wheel scrolls the focused panel, not the hovered one* — §15 verbatim. Hover tracking is drag-adjacent machinery for a behavior §15 does not ask for.
+- *A click on a row selects it and rides the settle window,* exactly like cursor movement — §15 says "click a row to select it", and a click that opened would make selecting without opening impossible. Opening stays `enter`'s job.
+- *Row mapping reads the rendered frame, not bubbles' private scroll state.* The table's scroll offset is unexported and its clamp logic is not a contract; the clicked line's distance from the styled cursor row drives `MoveUp`/`MoveDown` — the same path as key movement, so the table's own bookkeeping stays consistent.
+- *Footer hints fire by synthesizing the hint's key* — the palette's one-execution-path rule again; the hit ranges are computed from the same segments the footer renders, truncation included, so a hint that was cut cannot be clicked.
+- *The palette and the answer popup ignore clicks.* §15 scopes the mouse to focus, select, scroll, footer and tabs; popup interaction stays keyboard, and a stray click must not answer a question.
+- *The mouse rides `tea.View.MouseMode`* — bubbletea v2 sets it per frame — so `M` is a flag flip: on by default per §15, the toggle in the registry and therefore the palette and `?`.
+- *Takeover screens get wheel delegation for free and no click surfaces.* Nothing §15 lists exists there; their lists stay keyboard until someone misses it at the gate.
+- *The T3.8 sweep grows five items and three are reworded:* S1/S8/S11 were written against the retired digits and the old connect screen; they now walk the palette route and the stale-panels banner. New items cover mouse on both Windows hosts, resize across both floors, palette completeness, the accordion at 24 rows, and `NO_COLOR`.
+
+- [~] **T3.13 — Mouse.** Click-to-focus, click-row-select, wheel scroll in the focused panel, click a footer hint to fire it, click a tab. `hitTest(x, y, []box) → panelID` as a pure function. On by default, `M` toggles, toggle listed in the palette. Grow the T3.8 checklist: mouse on Windows Terminal + Git Bash, resize across both floors, palette reachable and complete, accordion at 24 rows, `NO_COLOR`. *Depends:* T3.12.
   *Done when:* `hitTest` is table-tested; `MouseClickMsg` tests assert focus and selection changes; `m3-gate.md`'s sweep carries the new items.
 
 ## Phase 4 — Polish (M4)

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -65,6 +65,7 @@ var bindings = []binding{
 	{key: "?", label: "toggle this help", scope: scopeGlobal},
 	{key: "tab", label: "move focus between the panels; commits a filter (shift+tab goes back)", scope: scopeGlobal},
 	{key: "!", label: "jump to the next task needing a human", scope: scopeGlobal},
+	{key: "M", label: "toggle the mouse (native text selection needs it off — or shift-drag)", scope: scopeGlobal},
 	{key: "esc", label: "close one layer: popup → screen → filter — never quits", scope: scopeGlobal, noPalette: true},
 	{key: "q", label: "quit the TUI (the daemon keeps running)", scope: scopeGlobal},
 	{key: "ctrl+c", label: "quit the TUI", scope: scopeGlobal, noPalette: true},

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -376,6 +376,50 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	return b, cmd
 }
 
+// clickRow selects the table row rendered at the given body line (0 = the
+// first row under the column header). The table's scroll offset is private,
+// so the clicked line's distance from the *styled cursor row* drives the
+// same MoveUp/MoveDown path the keys use — bubbles keeps its own scroll
+// bookkeeping consistent that way.
+func (b *board) clickRow(line int) {
+	marker, _, _ := strings.Cut(tableSelectedStyle().Render("~"), "~")
+	if marker == "" {
+		return
+	}
+	rows := strings.Split(b.tbl.View(), "\n")
+	if len(rows) < 2 {
+		return
+	}
+	cursorLine := -1
+	for i, row := range rows[1:] { // the column header is line 0
+		if strings.Contains(row, marker) {
+			cursorLine = i
+			break
+		}
+	}
+	if cursorLine < 0 {
+		return
+	}
+	switch delta := line - cursorLine; {
+	case delta > 0:
+		b.tbl.MoveDown(delta)
+	case delta < 0:
+		b.tbl.MoveUp(-delta)
+	}
+	b.rememberSelection()
+}
+
+// wheelMove is one wheel notch on the task table: the cursor moves, and the
+// panels below follow it through the usual settle window.
+func (b *board) wheelMove(delta int) {
+	if delta > 0 {
+		b.tbl.MoveDown(delta)
+	} else {
+		b.tbl.MoveUp(-delta)
+	}
+	b.rememberSelection()
+}
+
 // visible is the filtered, sorted task list currently on screen.
 func (b *board) visible() []apiclient.Task {
 	tasks := filterTasks(b.tasks, b.filter.Value())

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -147,6 +147,11 @@ type detail struct {
 	loadSeq    uint64
 	appliedSeq uint64
 
+	// timelineTop and visibleRuns are the last-rendered timeline geometry,
+	// kept so a click can name the attempt on the line it landed on.
+	timelineTop int
+	visibleRuns []int64
+
 	width, height int
 }
 

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -48,7 +49,49 @@ func (d *detail) timelinePanel(height int) string {
 	}
 	sb.WriteString("\n")
 	sb.WriteString(d.renderTimeline(height - used))
+	d.timelineTop = used
 	return sb.String()
+}
+
+// clickTimeline selects the attempt rendered at the given content line —
+// the mouse half of "selecting an attempt is how scrollback is navigated".
+// Step headers and chrome lines fall through to a plain focus click.
+func (d *detail) clickTimeline(line int) tea.Cmd {
+	idx := line - d.timelineTop
+	if idx < 0 || idx >= len(d.visibleRuns) {
+		return nil
+	}
+	id := d.visibleRuns[idx]
+	if id == 0 || id == d.selectedRun {
+		return nil
+	}
+	d.selectedRun = id
+	return d.syncOutput()
+}
+
+// clickOutputTitle switches the output|diff tab when the click lands on its
+// span in the panel title (§15: click a tab). x,y are box-relative; the
+// focus glyph shifts the spans by two cells.
+func (d *detail) clickOutputTitle(x, y int, focused bool) tea.Cmd {
+	if y != 0 {
+		return nil
+	}
+	start := 3 // after "┌─ "
+	if focused {
+		start += 2 // the "▸ " glyph
+	}
+	const outputW, sepW, diffW = 6, 3, 4
+	switch {
+	case x >= start && x < start+outputW:
+		if d.tab == tabDiff {
+			return d.toggleTab()
+		}
+	case x >= start+outputW+sepW && x < start+outputW+sepW+diffW:
+		if d.tab == tabOutput {
+			return d.toggleTab()
+		}
+	}
+	return nil
 }
 
 // outputPanel renders the output|diff pane's content for the shell. The tab
@@ -166,6 +209,7 @@ func (d *detail) errorLine() string {
 func (d *detail) renderTimeline(height int) string {
 	runs := d.attempts()
 	if len(runs) == 0 {
+		d.visibleRuns = nil
 		if !d.loaded {
 			return styleDim.Render("  loading…")
 		}
@@ -173,6 +217,7 @@ func (d *detail) renderTimeline(height int) string {
 	}
 
 	lines := make([]string, 0, len(runs)*2)
+	ids := make([]int64, 0, len(runs)*2)
 	cursorLine := 0
 	lastStep := -1
 	for _, r := range runs {
@@ -180,6 +225,7 @@ func (d *detail) renderTimeline(height int) string {
 			lastStep = r.StepIndex
 			lines = append(lines, styleStepHeader.Render(
 				fmt.Sprintf("  %d %s", r.StepIndex+1, stepLabel(r))))
+			ids = append(ids, 0)
 		}
 		line := d.attemptLine(r)
 		if r.ID == d.selectedRun {
@@ -187,8 +233,16 @@ func (d *detail) renderTimeline(height int) string {
 			line = styleSelected.Render(line)
 		}
 		lines = append(lines, line)
+		ids = append(ids, r.ID)
 	}
-	return strings.Join(window(lines, cursorLine, height), "\n")
+	// The windowed ids are kept for hit-testing clicks on the same lines.
+	start := windowStart(len(lines), cursorLine, height)
+	end := len(lines)
+	if height > 0 && len(lines) > height {
+		end = start + height
+	}
+	d.visibleRuns = ids[start:end]
+	return strings.Join(lines[start:end], "\n")
 }
 
 func stepLabel(r apiclient.StepRun) string {
@@ -273,9 +327,17 @@ func window(lines []string, focus, height int) []string {
 	if height <= 0 || len(lines) <= height {
 		return lines
 	}
-	start := focus - height/2
-	start = min(max(start, 0), len(lines)-height)
+	start := windowStart(len(lines), focus, height)
 	return lines[start : start+height]
+}
+
+// windowStart is where a height-line window over n lines begins so the
+// focused line stays visible.
+func windowStart(n, focus, height int) int {
+	if height <= 0 || n <= height {
+		return 0
+	}
+	return min(max(focus-height/2, 0), n-height)
 }
 
 func tabLabel(name string, active bool) string {

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -21,64 +21,149 @@ import (
 // maxFooterHints caps the focused surface's key segment.
 const maxFooterHints = 5
 
-// renderFooter composes the line. bar is the shell's action bar (nil on a
-// takeover); a pending confirmation replaces the left segments outright —
-// it owns the keyboard, so nothing else is actionable anyway. attention is
-// the needs-a-human count behind the `!` hint, shown only when non-zero;
-// retry adds the reconnect hint while the daemon is unreachable.
+// footerHit is one clickable span: clicking it fires the key it shows
+// (§15 Mouse) — the palette's one-execution-path rule again.
+type footerHit struct {
+	x0, x1 int
+	key    string
+}
+
+// footerSeg is one composed segment; key is empty for unclickable text
+// (statuses).
+type footerSeg struct {
+	text string
+	key  string
+}
+
+// renderFooter composes the line; buildFooter additionally reports the
+// clickable spans. bar is the shell's action bar (nil on a takeover); a
+// pending confirmation replaces the left segments outright — it owns the
+// keyboard, so nothing else is actionable anyway. attention is the
+// needs-a-human count behind the `!` hint, shown only when non-zero; retry
+// adds the reconnect hint while the daemon is unreachable.
 func renderFooter(width int, panelRows []binding, bar *actionBar, target taskActions, attention int, retry bool) string {
-	pinned := styleKey.Render(":") + styleDim.Render(" commands  ") +
-		styleKey.Render("?") + styleDim.Render(" help  ") +
-		styleKey.Render("q") + styleDim.Render(" quit")
+	line, _ := buildFooter(width, panelRows, bar, target, attention, retry)
+	return line
+}
 
-	var left string
+func buildFooter(width int, panelRows []binding, bar *actionBar, target taskActions, attention int, retry bool) (string, []footerHit) {
+	pinnedSegs := []footerSeg{
+		{text: styleKey.Render(":") + styleDim.Render(" commands  "), key: ":"},
+		{text: styleKey.Render("?") + styleDim.Render(" help  "), key: "?"},
+		{text: styleKey.Render("q") + styleDim.Render(" quit"), key: "q"},
+	}
+
+	var segs []footerSeg
 	if bar != nil && bar.capturing() {
-		left = strings.TrimPrefix(bar.render(target), " ")
+		// The pending y/n owns the keyboard and the left of the line.
+		segs = []footerSeg{{text: strings.TrimPrefix(bar.render(target), " ")}}
 	} else {
-		sep := styleDim.Render(" · ")
-		segs := make([]string, 0, 4)
-		if hints := footerHints(panelRows); len(hints) > 0 {
-			segs = append(segs, strings.Join(hints, sep))
-		}
-		if bar != nil && target.id != 0 {
-			var extra []string
-			if target.has(apiclient.ActionAnswer) {
-				extra = append(extra, styleAsk.Render("enter answer"))
-			}
-			if actions := strings.TrimPrefix(bar.render(target, extra...), " "); actions != "" {
-				segs = append(segs, actions)
-			}
-		}
-		if attention > 0 {
-			segs = append(segs, styleWarn.Render(fmt.Sprintf("! next attention (%d)", attention)))
-		}
-		if retry {
-			segs = append(segs, styleKey.Render("r")+" retry")
-		}
-		left = strings.Join(segs, sep)
+		segs = footerLeftSegs(panelRows, bar, target, attention, retry)
 	}
 
-	line := " " + left
-	if width <= 0 {
-		return line + "  " + pinned
+	sep := styleDim.Render(" · ")
+	sepW := ansi.StringWidth(sep)
+	var sb strings.Builder
+	sb.WriteString(" ")
+	x := 1
+	hits := make([]footerHit, 0, len(segs)+3)
+	for i, s := range segs {
+		if i > 0 {
+			sb.WriteString(sep)
+			x += sepW
+		}
+		w := ansi.StringWidth(s.text)
+		if s.key != "" {
+			hits = append(hits, footerHit{x0: x, x1: x + w, key: s.key})
+		}
+		sb.WriteString(s.text)
+		x += w
 	}
-	pw := ansi.StringWidth(pinned)
+	line := sb.String()
+
+	var pinned strings.Builder
+	for _, s := range pinnedSegs {
+		pinned.WriteString(s.text)
+	}
+	pw := ansi.StringWidth(pinned.String())
+
+	if width <= 0 {
+		return line + "  " + pinned.String(), nil
+	}
 	avail := width - pw - 2
 	if avail <= 0 {
 		// Below any §15 floor: the pinned segment alone, never truncated.
-		return " " + pinned
+		return " " + pinned.String(), pinnedHits(1, pinnedSegs)
 	}
 	lw := ansi.StringWidth(line)
 	if lw > avail {
-		line = "…" + ansi.TruncateLeft(line, lw-avail+1, "")
+		cut := lw - avail + 1
+		line = "…" + ansi.TruncateLeft(line, cut, "")
 		lw = ansi.StringWidth(line)
+		// Shift the spans left; a hint that was cut cannot be clicked.
+		kept := hits[:0]
+		for _, h := range hits {
+			h.x0 -= cut - 1
+			h.x1 -= cut - 1
+			if h.x0 >= 1 {
+				kept = append(kept, h)
+			}
+		}
+		hits = kept
 	}
-	return line + strings.Repeat(" ", max(width-lw-pw, 2)) + pinned
+	pad := max(width-lw-pw, 2)
+	hits = append(hits, pinnedHits(lw+pad, pinnedSegs)...)
+	return line + strings.Repeat(" ", pad) + pinned.String(), hits
 }
 
-// footerHints renders the surface's footer-worthy keys: rows with a hint,
-// in priority order, at most five.
-func footerHints(rows []binding) []string {
+func pinnedHits(x int, segs []footerSeg) []footerHit {
+	out := make([]footerHit, 0, len(segs))
+	for _, s := range segs {
+		w := ansi.StringWidth(s.text)
+		out = append(out, footerHit{x0: x, x1: x + w, key: s.key})
+		x += w
+	}
+	return out
+}
+
+// footerLeftSegs builds the non-confirming left side: panel hints, the
+// task's valid actions, the answer/attention/retry extras, and the action
+// bar's last status.
+func footerLeftSegs(panelRows []binding, bar *actionBar, target taskActions, attention int, retry bool) []footerSeg {
+	segs := footerHintSegs(panelRows)
+	if bar != nil && target.id != 0 {
+		for _, o := range actionOrder {
+			if target.has(o.action) {
+				segs = append(segs, footerSeg{
+					text: styleKey.Render(o.key) + " " + o.action, key: o.key,
+				})
+			}
+		}
+		if target.has(apiclient.ActionAnswer) {
+			segs = append(segs, footerSeg{text: styleAsk.Render("enter answer"), key: "enter"})
+		}
+	}
+	if attention > 0 {
+		segs = append(segs, footerSeg{
+			text: styleWarn.Render(fmt.Sprintf("! next attention (%d)", attention)), key: "!",
+		})
+	}
+	if retry {
+		segs = append(segs, footerSeg{text: styleKey.Render("r") + " retry", key: "r"})
+	}
+	if bar != nil && bar.status != "" {
+		style := styleDim
+		if bar.statusBad {
+			style = styleBad
+		}
+		segs = append(segs, footerSeg{text: style.Render(bar.status)})
+	}
+	return segs
+}
+
+// footerHintSegs renders the surface's footer-worthy keys: rows with a
+// hint, in priority order, at most five.
+func footerHintSegs(rows []binding) []footerSeg {
 	hinted := make([]binding, 0, len(rows))
 	for _, r := range rows {
 		if r.hint != "" {
@@ -89,14 +174,16 @@ func footerHints(rows []binding) []string {
 	if len(hinted) > maxFooterHints {
 		hinted = hinted[:maxFooterHints]
 	}
-	out := make([]string, 0, len(hinted))
+	out := make([]footerSeg, 0, len(hinted))
 	for _, r := range hinted {
 		key, rest, ok := strings.Cut(r.hint, " ")
 		if !ok {
-			out = append(out, styleKey.Render(r.hint))
+			out = append(out, footerSeg{text: styleKey.Render(r.hint), key: r.key})
 			continue
 		}
-		out = append(out, styleKey.Render(key)+" "+styleDim.Render(rest))
+		out = append(out, footerSeg{
+			text: styleKey.Render(key) + " " + styleDim.Render(rest), key: r.key,
+		})
 	}
 	return out
 }

--- a/internal/tui/footer_test.go
+++ b/internal/tui/footer_test.go
@@ -52,13 +52,13 @@ func TestFooterFiveKeyCap(t *testing.T) {
 			key: "k", hint: "k hint" + strings.Repeat("!", i+1), priority: 7 - i,
 		})
 	}
-	hints := footerHints(rows)
+	hints := footerHintSegs(rows)
 	if len(hints) != maxFooterHints {
 		t.Fatalf("footer shows %d hints, want the cap of %d", len(hints), maxFooterHints)
 	}
 	// Priority order: the lowest numbers made the cut, lowest first.
-	if !strings.Contains(hints[0], strings.Repeat("!", 7)) {
-		t.Errorf("first hint = %q, want the priority-1 row", ansi.Strip(hints[0]))
+	if !strings.Contains(hints[0].text, strings.Repeat("!", 7)) {
+		t.Errorf("first hint = %q, want the priority-1 row", ansi.Strip(hints[0].text))
 	}
 }
 

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -62,6 +62,18 @@ const (
 // focused band expands and the other collapses (PR P decision) — collapsing
 // the output while navigating the timeline would defeat why they sit side
 // by side.
+// hitTest reports which box contains the cell at x,y — the pure half of
+// click-to-focus (§15 Mouse). Coordinates are in the same panel-area space
+// the boxes were laid out in.
+func hitTest(x, y int, boxes []box) (panelID, bool) {
+	for _, b := range boxes {
+		if x >= b.x && x < b.x+b.w && y >= b.y && y < b.y+b.h {
+			return b.id, true
+		}
+	}
+	return 0, false
+}
+
 func layout(w, h int, focus panelID) []box {
 	if w < minTermW || h < minAreaH1 {
 		return nil

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,226 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// TestHitTest is the T3.13 done-when: the pure half of click-to-focus,
+// table-tested against a real layout.
+func TestHitTest(t *testing.T) {
+	boxes := layout(120, 32, panelTasks)
+	if len(boxes) != 3 {
+		t.Fatalf("layout returned %d boxes", len(boxes))
+	}
+	band := boxes[1].y
+	cases := []struct {
+		name string
+		x, y int
+		want panelID
+		ok   bool
+	}{
+		{"top-left corner", 0, 0, panelTasks, true},
+		{"inside the table", 40, 3, panelTasks, true},
+		{"tasks bottom edge", 119, band - 1, panelTasks, true},
+		{"timeline first cell", 0, band, panelTimeline, true},
+		{"timeline body", 10, band + 1, panelTimeline, true},
+		{"output first cell", boxes[2].x, band, panelOutput, true},
+		{"output body", 119, band + 2, panelOutput, true},
+		{"right of everything", 120, 3, 0, false},
+		{"below everything", 4, 32, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := hitTest(tc.x, tc.y, boxes)
+			if ok != tc.ok || (ok && got != tc.want) {
+				t.Fatalf("hitTest(%d,%d) = %v,%v; want %v,%v", tc.x, tc.y, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+	if _, ok := hitTest(1, 1, nil); ok {
+		t.Error("hitTest hit something in an empty layout")
+	}
+}
+
+// TestShellClickFocusesPanels: a click lands focus where it points (§15).
+func TestShellClickFocusesPanels(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	boxes := s.lastBoxes
+	if len(boxes) != 3 {
+		t.Fatalf("fixture rendered %d boxes", len(boxes))
+	}
+	s.update(tea.MouseClickMsg{X: 2, Y: boxes[1].y + 1, Button: tea.MouseLeft})
+	if s.focus != panelTimeline {
+		t.Fatalf("focus = %v after clicking the timeline, want it focused", s.focus)
+	}
+	s.update(tea.MouseClickMsg{X: boxes[2].x + 2, Y: boxes[2].y + 1, Button: tea.MouseLeft})
+	if s.focus != panelOutput {
+		t.Fatalf("focus = %v after clicking the output pane", s.focus)
+	}
+	s.update(tea.MouseClickMsg{X: 2, Y: 2, Button: tea.MouseLeft})
+	if s.focus != panelTasks {
+		t.Fatalf("focus = %v after clicking the table", s.focus)
+	}
+}
+
+// TestShellClickSelectsRow: clicking a row moves the cursor there, and the
+// selection rides the settle window exactly like key movement — no
+// subscription until the cursor rests.
+func TestShellClickSelectsRow(t *testing.T) {
+	tasks := make([]apiclient.Task, 0, 4)
+	for id := int64(1); id <= 4; id++ {
+		tasks = append(tasks, task(id, stateRunning))
+	}
+	s, subs := newShellFixture(t, tasks...)
+	s.settle()
+	if *subs != 1 {
+		t.Fatalf("subscriptions after settle = %d, want 1", *subs)
+	}
+	rows := s.board.visible()
+
+	// The third data row: box top border, board header, table header, then
+	// row 0, 1, 2…
+	y := s.lastBoxes[0].y + 2 + s.board.chromeLines() + 2
+	s.update(tea.MouseClickMsg{X: 10, Y: y, Button: tea.MouseLeft})
+	s.render(120, 37)
+
+	if got, ok := s.board.selected(); !ok || got != rows[2].ID {
+		t.Fatalf("selected = %d, want row 2's #%d", got, rows[2].ID)
+	}
+	if s.detail.taskID != 0 || s.detail.streamID != 0 {
+		t.Fatal("a click opened or subscribed before the settle window closed")
+	}
+	if *subs != 1 {
+		t.Fatalf("subscriptions right after the click = %d, want still 1", *subs)
+	}
+	s.settle()
+	if s.detail.taskID != rows[2].ID || *subs != 2 {
+		t.Fatalf("after settle: detail #%d subs %d, want #%d and 2", s.detail.taskID, *subs, rows[2].ID)
+	}
+}
+
+// TestShellWheelScrollsFocusedPanel: §15 — the wheel scrolls the focused
+// panel, not the hovered one.
+func TestShellWheelScrollsFocusedPanel(t *testing.T) {
+	tasks := make([]apiclient.Task, 0, 4)
+	for id := int64(1); id <= 4; id++ {
+		tasks = append(tasks, task(id, stateRunning))
+	}
+	s, _ := newShellFixture(t, tasks...)
+	rows := s.board.visible()
+
+	s.update(tea.MouseWheelMsg{X: 5, Y: 3, Button: tea.MouseWheelDown})
+	s.render(120, 37)
+	if got, _ := s.board.selected(); got != rows[1].ID {
+		t.Fatalf("wheel on the focused table selected #%d, want #%d", got, rows[1].ID)
+	}
+
+	// Focus the output pane: the wheel now scrolls it, and the table cursor
+	// stays put even though the pointer is over the table.
+	s.focus = panelOutput
+	before, _ := s.board.selected()
+	s.update(tea.MouseWheelMsg{X: 5, Y: 3, Button: tea.MouseWheelDown})
+	s.render(120, 37)
+	if got, _ := s.board.selected(); got != before {
+		t.Fatalf("wheel moved the unfocused table from #%d to #%d", before, got)
+	}
+}
+
+// TestShellClickOutputTab: clicking the diff span in the output panel's
+// title switches the tab; clicking output switches back (§15: click a tab).
+func TestShellClickOutputTab(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.settle()
+	out := s.lastBoxes[2]
+
+	// "┌─ output │ diff …": the diff span sits after "output" and " │ ".
+	diffX := out.x + 3 + 6 + 3 + 1
+	s.update(tea.MouseClickMsg{X: diffX, Y: out.y, Button: tea.MouseLeft})
+	if s.detail.tab != tabDiff {
+		t.Fatalf("tab = %v after clicking diff, want the diff tab", s.detail.tab)
+	}
+	if s.focus != panelOutput {
+		t.Fatalf("focus = %v, want the clicked panel focused", s.focus)
+	}
+	// The glyph shifts the spans while the panel is focused.
+	outputX := out.x + 3 + 2 + 1
+	s.update(tea.MouseClickMsg{X: outputX, Y: out.y, Button: tea.MouseLeft})
+	if s.detail.tab != tabOutput {
+		t.Fatalf("tab = %v after clicking output, want the output tab", s.detail.tab)
+	}
+}
+
+// TestShellPopupIgnoresClicks: popup interaction stays keyboard — a stray
+// click must not answer a question or steal focus from it.
+func TestShellPopupIgnoresClicks(t *testing.T) {
+	s, _ := newShellFixture(t, task(3, stateAwaitingInput))
+	s.settle()
+	s.detail.form = newAnswerForm(apiclient.InputRequest{
+		Kind:      apiclient.InputKindQuestion,
+		Questions: []apiclient.InputQuestion{{Text: "Sure?", Options: []string{"y"}}},
+	})
+	s.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !s.popup {
+		t.Fatal("fixture: popup did not open")
+	}
+	before := s.focus
+	s.update(tea.MouseClickMsg{X: 2, Y: s.lastBoxes[1].y + 1, Button: tea.MouseLeft})
+	if !s.popup || s.focus != before {
+		t.Fatal("a click reached the panels under the popup")
+	}
+}
+
+// TestRootFooterClickFiresHint: clicking a footer hint replays its key —
+// the pinned `q quit` is the always-present span to prove it with.
+func TestRootFooterClickFiresHint(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	content(m) // render once so the footer records its spans
+
+	var quit *footerHit
+	for i, h := range m.footerHits {
+		if h.key == "q" {
+			quit = &m.footerHits[i]
+		}
+	}
+	if quit == nil {
+		t.Fatalf("no q span in the footer hits: %+v", m.footerHits)
+	}
+	_, cmd := m.Update(tea.MouseClickMsg{X: quit.x0, Y: 39, Button: tea.MouseLeft})
+	if cmd == nil {
+		t.Fatal("clicking the quit hint produced no command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("clicking the quit hint produced %T, want tea.Quit", cmd())
+	}
+}
+
+// TestRootMouseToggle: on by default per §15, M turns it off and the view
+// stops requesting mouse events — native text selection returns.
+func TestRootMouseToggle(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.notice.active = false
+
+	if v := m.View(); v.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("mouse mode = %v, want cell motion on by default", v.MouseMode)
+	}
+	m.Update(key("M"))
+	if v := m.View(); v.MouseMode != tea.MouseModeNone {
+		t.Fatalf("mouse mode = %v after M, want none", v.MouseMode)
+	}
+	m.Update(key("M"))
+	if v := m.View(); v.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("mouse mode = %v after M M, want cell motion again", v.MouseMode)
+	}
+	// The toggle is discoverable: a registry row, so palette and ? carry it.
+	if !strings.Contains(helpText(), "toggle the mouse") {
+		t.Error("the mouse toggle is not in the help overlay")
+	}
+}

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -70,6 +70,11 @@ type root struct {
 	// the root because it must overlay every screen, takeovers included —
 	// while disconnected it is how the daemon view stays reachable.
 	palette *palette
+	// mouseOn drives tea.View's mouse mode: on by default, M toggles (§15
+	// Mouse). Off restores native click-drag text selection.
+	mouseOn bool
+	// footerHits are the clickable spans of the last-rendered footer.
+	footerHits []footerHit
 	// notice is §16's full-auto warning. It owns the whole screen until it
 	// is dismissed, ahead of and independent of the connect flow: the
 	// warning is about what the daemon will do, so it must not wait on the
@@ -95,6 +100,7 @@ func newRoot(ctx context.Context, cn connector, dataDir string) *root {
 		phase:   phaseProbing,
 		dataDir: dataDir,
 		views:   newViews(ctx),
+		mouseOn: true,
 		notice:  firstRunNotice{active: !noticeAcknowledged(dataDir)},
 	}
 	m.setDataDir(dataDir)
@@ -154,12 +160,39 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.logPath = msg.logPath
 		m.setConnected(false)
 		return m, nil
+	case tea.MouseClickMsg:
+		return m.updateMouseClick(msg)
+	case tea.MouseWheelMsg:
+		if m.notice.active || m.palette != nil || m.help {
+			return m, nil
+		}
+		msg.Y-- // the body starts under the header line
+		return m, m.deliver(m.active, msg)
 	case noteMsg:
 		return m.updateNote(msg.note)
 	case streamDoneMsg:
 		return m, nil
 	}
 	return m.delegate(msg)
+}
+
+// updateMouseClick is §15's click scope: a footer hint fires its key, and
+// everything else lands in the active screen's body. Popups stay keyboard;
+// right-clicks and the rest are out of scope.
+func (m *root) updateMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	if msg.Button != tea.MouseLeft || m.notice.active || m.palette != nil || m.help {
+		return m, nil
+	}
+	if m.height > 0 && msg.Y == m.height-1 {
+		for _, h := range m.footerHits {
+			if msg.X >= h.x0 && msg.X < h.x1 {
+				return m.updateKey(synthKey(h.key))
+			}
+		}
+		return m, nil
+	}
+	msg.Y-- // the body starts under the header line
+	return m, m.deliver(m.active, msg)
 }
 
 func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -196,6 +229,9 @@ func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.help = false
 			return m, nil
 		}
+	case "M":
+		m.mouseOn = !m.mouseOn
+		return m, nil
 	case "!":
 		// Jump to the next task needing a human — global, so it also pulls
 		// a takeover screen back to the board it acts on.
@@ -482,7 +518,11 @@ func (m *root) View() tea.View {
 		ph := min(18, max(m.height-4, 6))
 		frame = overlay(frame, m.palette.render(pw, ph), max((m.width-pw)/2, 0), 2)
 	}
-	return tea.NewView(frame)
+	v := tea.NewView(frame)
+	if m.mouseOn && !m.notice.active {
+		v.MouseMode = tea.MouseModeCellMotion
+	}
+	return v
 }
 
 func (m *root) headerLine() string {
@@ -597,7 +637,9 @@ func (m *root) footerLine() string {
 		}
 	}
 	retry := m.phase == phaseFailed || m.phase == phaseReconnecting
-	return renderFooter(m.width, bindingsFor(ctx), bar, target, attention, retry)
+	line, hits := buildFooter(m.width, bindingsFor(ctx), bar, target, attention, retry)
+	m.footerHits = hits
+	return line
 }
 
 // bodyHeight is the space left for the active view: total minus header,

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -64,6 +64,12 @@ type shell struct {
 	// bodyW/bodyH the area the root hands render.
 	termW, termH int
 	bodyW, bodyH int
+
+	// lastBoxes and bannerLines are the geometry of the last frame, kept
+	// for hit-testing: a click lands on what was on screen, not on what the
+	// next layout would be.
+	lastBoxes   []box
+	bannerLines int
 }
 
 func newShell(ctx context.Context) *shell {
@@ -122,6 +128,10 @@ func (s *shell) update(msg tea.Msg) (panel, tea.Cmd) {
 		return s, s.forward(msg)
 	case tea.KeyPressMsg:
 		return s.updateKey(msg)
+	case tea.MouseClickMsg:
+		return s, s.updateClick(msg)
+	case tea.MouseWheelMsg:
+		return s, s.updateWheel(msg)
 	case focusPanelMsg:
 		s.focus = msg.id
 		return s, nil
@@ -327,6 +337,74 @@ func (s *shell) checkSelection() tea.Cmd {
 	})
 }
 
+// updateClick is §15's click scope on the home screen: click a panel to
+// focus it, click a row to select it, click the output panel's title tabs
+// to switch them. Coordinates arrive body-relative (the root strips its
+// header); the banner line is the shell's own offset. Popups stay keyboard:
+// a stray click must not answer a question.
+func (s *shell) updateClick(msg tea.MouseClickMsg) tea.Cmd {
+	if s.popup {
+		return nil
+	}
+	y := msg.Y - s.bannerLines
+	id, ok := hitTest(msg.X, y, s.lastBoxes)
+	if !ok {
+		return nil
+	}
+	// The frame that was clicked was rendered with the *old* focus — the
+	// output title's tab spans shift by the focus glyph, so remember what
+	// was actually on screen before moving focus.
+	wasFocusedOutput := s.focus == panelOutput
+	s.focus = id
+	var b box
+	for _, cand := range s.lastBoxes {
+		if cand.id == id {
+			b = cand
+		}
+	}
+	switch id {
+	case panelTasks:
+		// Inside the border sit the board's chrome lines, then the table's
+		// own column header, then the rows. A click above the rows just
+		// focuses.
+		line := y - b.y - 2 - s.board.chromeLines()
+		if line >= 0 {
+			s.board.clickRow(line)
+		}
+		return s.checkSelection()
+	case panelTimeline:
+		s.syncDetailFocus()
+		return s.detail.clickTimeline(y - b.y - 1)
+	default:
+		s.syncDetailFocus()
+		return s.detail.clickOutputTitle(msg.X-b.x, y-b.y, wasFocusedOutput)
+	}
+}
+
+// updateWheel scrolls the focused panel (§15: focused, not hovered).
+func (s *shell) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
+	delta := 1
+	if msg.Button == tea.MouseWheelUp {
+		delta = -1
+	}
+	switch s.focus {
+	case panelTasks:
+		s.board.wheelMove(delta)
+		return s.checkSelection()
+	case panelTimeline:
+		s.syncDetailFocus()
+		return s.detail.moveSelection(delta)
+	default:
+		if delta > 0 {
+			s.detail.vp.ScrollDown(1)
+		} else {
+			s.detail.vp.ScrollUp(1)
+		}
+		s.detail.syncFollowToViewport()
+		return nil
+	}
+}
+
 // jumpAttention moves to the next task needing a human, wrapping through
 // the pinned attention rows in board order, and opens it immediately — a
 // jump is deliberate, like enter, so it skips the settle window.
@@ -391,6 +469,12 @@ func (s *shell) render(width, height int) string {
 	}
 
 	boxes := layout(s.bodyW, areaH, s.focus)
+	// Kept for hit-testing: a click lands on what was on screen.
+	s.lastBoxes = boxes
+	s.bannerLines = 0
+	if banner != "" {
+		s.bannerLines = 1
+	}
 	if boxes == nil {
 		return fmt.Sprintf("\n  terminal too small (%d×%d, need %d×%d)",
 			s.termW, s.termH, minTermW, minTermH)


### PR DESCRIPTION
Delivers **T3.13** (PR S, the last of the five Phase 3 TUI refactor PRs), per §15 Mouse and the PR S grill block recorded in tasks.md.

## What changed

- **`hitTest(x, y, []box) → (panelID, bool)`** is the pure half of click-to-focus, table-tested against real layouts like `layout` itself.
- **Click to focus, click a row to select**: a row click moves the table cursor by its distance from the *styled cursor row* — the same `MoveUp`/`MoveDown` path the keys use, so bubbles' unexported scroll bookkeeping stays consistent (grill decision: its offset state is not a contract) — and the selection rides the settle window exactly like key movement: no fetch, no subscription until the cursor rests.
- **Timeline clicks select the attempt** on the clicked line (the windowed run ids are recorded at render); **output-title clicks switch the output|diff tab**, glyph-shift aware — including a fix for hit-testing against the frame that was actually on screen rather than the post-click focus.
- **The wheel scrolls the focused panel, not the hovered one** (§15 verbatim).
- **Footer hints fire on click**, truncation-aware: the footer now records its clickable spans as it composes, and a click replays the hint's key — the palette's one-execution-path rule again. A hint that was truncated away cannot be clicked.
- **The palette and the answer popup ignore clicks** — popup interaction stays keyboard, and a stray click must not answer a question.
- **On by default, `M` toggles** — mouse reporting rides bubbletea v2's per-frame `tea.View.MouseMode`, and the toggle is a registry row, so the palette and `?` carry it. Off restores native click-drag text selection.
- **The T3.8 sweep grows S14–S18** (mouse on both Windows hosts, resize across both floors, palette completeness, accordion at 24 rows, `NO_COLOR`) and S1/S8/S11 are reworded off the retired digits and the old connect screen.

## Testing

- `go test ./...` — 816 pass; `go run mage.go lint` — clean.
- New: `hitTest` table, click-focus, click-row-selects-with-settle (asserting no premature subscription), wheel-follows-focus-not-hover, tab-span clicks both directions, popup click immunity, footer-hint click firing `q` → `tea.Quit`, `M` toggle flipping `View.MouseMode` + registry discoverability.
- `testrace` needs cgo; this machine has no C compiler — relying on CI's three-platform race matrix.

Refs T3.13 in docs/versions/v0/tasks.md (marked [x] with the PR S decision block).