### PR TITLE
fix(procx,gitx): stop daemon children flashing console windows on Windows

### DIFF
--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -63,6 +63,7 @@ func New() *Git { return &Git{path: "git"} }
 // returned as *Error with stderr captured.
 func (g *Git) Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, g.path, args...)
+	hideConsole(cmd)
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/gitx/sysproc_other.go
+++ b/internal/gitx/sysproc_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package gitx
+
+import "os/exec"
+
+// hideConsole is Windows-only: nothing else puts a window on screen for a
+// child process.
+func hideConsole(*exec.Cmd) {}

--- a/internal/gitx/sysproc_windows.go
+++ b/internal/gitx/sysproc_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package gitx
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// hideConsole keeps git off the desktop: the daemon runs detached with no
+// console of its own, so without CREATE_NO_WINDOW every git invocation — a
+// diff fetch runs one per call — would flash a console window at the user
+// (T3.8 finding).
+func hideConsole(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
+}

--- a/internal/gitx/sysproc_windows_test.go
+++ b/internal/gitx/sysproc_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package gitx
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestHideConsoleSetsWindowFlags pins the T3.8 finding: a git child spawned
+// by the console-less daemon must not open a console window of its own.
+func TestHideConsoleSetsWindowFlags(t *testing.T) {
+	cmd := exec.Command("git", "version")
+	hideConsole(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("no SysProcAttr set")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow not set")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("CREATE_NO_WINDOW not set")
+	}
+}

--- a/internal/procx/procx_windows.go
+++ b/internal/procx/procx_windows.go
@@ -6,14 +6,23 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
-// setSysProcAttr needs no flags on Windows; tree containment comes from the
-// Job object assigned in attach.
-func setSysProcAttr(*exec.Cmd) {}
+// setSysProcAttr keeps the child off the desktop: the daemon runs detached
+// with no console of its own, so without CREATE_NO_WINDOW every agent and
+// command step would flash a new console window at the user (T3.8 finding).
+// Tree containment still comes from the Job object assigned in attach; the
+// flag does not affect the pipes or the job.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
+}
 
 // signalProcess has no graceful equivalent on Windows for a console-less
 // child, so the fallback path kills outright.

--- a/internal/procx/procx_windows_test.go
+++ b/internal/procx/procx_windows_test.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package procx
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestSetSysProcAttrHidesConsole pins the T3.8 finding: step subprocesses
+// spawned by the console-less daemon must not flash console windows.
+func TestSetSysProcAttrHidesConsole(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit 0")
+	setSysProcAttr(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("no SysProcAttr set")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Error("HideWindow not set")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("CREATE_NO_WINDOW not set")
+	}
+}


### PR DESCRIPTION
First T3.8 walkthrough finding (Windows 11): constant console-window flicker while tasks run.

The daemon runs detached with no console of its own, so every child it spawned — agent steps, command steps, and every `git` invocation (the diff endpoint runs one per fetch) — got a brand-new console window. `procx.Start` (which both step executors go through) and `gitx.Run` now set `HideWindow` + `CREATE_NO_WINDOW` on Windows.

- Pipes and the Job-object tree containment are unaffected — the taskrun suite runs real subprocesses through the new flags on Windows CI.
- Windows-tagged unit tests pin the flags in both packages.
- Disposition per the gate's grading rule: non-blocking finding, fixed pre-run; the m3-gate results will reference this PR.

Refs T3.8.