### PR TITLE
fix(tui): frame the takeover screens; one key row, the footer's (T3.8 findings)

### DIFF
--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,8 +20,8 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 12/13 | 🟡 in progress |
-| 4 — Polish (M4) | 6 tasks | 0/6 | ⬜ not started |
-| **Total** | | **37/44** | |
+| 4 — Polish (M4) | 7 tasks | 0/7 | ⬜ not started |
+| **Total** | | **37/45** | |
 
 ---
 
@@ -456,6 +456,7 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
 - [~] **T3.8 — Phase gate (M3 acceptance).** Manual scripted walkthrough of the §19 M3 loop on Windows + one POSIX OS, using fake agents for parallelism and real `claude` for one task; results recorded here.
   *Done when:* walkthrough passes on both; notes committed.
   *2026-08-09:* deferred behind T3.9–T3.13 (see the TUI refactor decisions below). The walkthrough runs **once**, against the panel UI, and never against the one being replaced; its sweep section grows the items listed in T3.13. `scripts/m3-gate.sh` and section A of `m3-gate.md` carry over unchanged — the seed is UI-agnostic and the §19 loop is spec-derived.
+  *2026-08-10:* first Windows pass surfaced four findings before any run was recorded; graded per the rule above (none block the loop). Fixed pre-run: console windows flashing for every daemon child (procx/gitx `CREATE_NO_WINDOW`), the takeovers' duplicate key rows and missing frames (both runs will judge the fixed build). Deferred: naming what "(workflow default)" resolves to in the new-task form → T4.7.
 
 **Phase 3 TUI refactor decisions (grill session, 2026-08-09):**
 
@@ -560,3 +561,5 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
   *Done when:* tagged pre-release produces working artifacts installed and smoke-tested on each OS.
 - [ ] **T4.6 — Phase gate (M4 acceptance).** Fresh-machine (VM) timed test per §19 M4 on each OS; results recorded here.
   *Done when:* all three runs under 10 minutes; notes committed. **v1 complete.**
+- [ ] **T4.7 — Name what "default" resolves to in the new-task form.** T3.8 finding (2026-08-10): the agent/model/effort pickers offer "(workflow default)" without saying what that is; a spend decision deserves a name. Needs new read-only API surface exposing the §8.6 resolution (the PR L decision deliberately kept resolution server-side and left the "adapter default" hole open — this task relitigates that explicitly).
+  *Done when:* the pickers show the resolved value beside "(workflow default)" wherever the server can know it, and the workflow-step list's "adapter default" names the adapter.

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -156,14 +156,14 @@ func TestBoardRendersLiveFromSSE(t *testing.T) {
 	if err := h.st.SetTaskProgress(ctx, task.ID, &step, nil); err != nil {
 		t.Fatalf("SetTaskProgress: %v", err)
 	}
-	h.p.until(20*time.Second, "the step counter to advance", func() bool {
-		return strings.Contains(content(h.m), "2/3")
+	// The step name travels with the counter, so the board says what is
+	// running. Waiting for the name, not the count: since the panels fused,
+	// "2/3" can render on the detail header from its own fetch before the
+	// board's debounced refresh lands, so a bare count is not proof the
+	// *board* updated (macOS CI caught the gap).
+	h.p.until(20*time.Second, "the advanced step to render on the board", func() bool {
+		return strings.Contains(content(h.m), "2/3 two")
 	})
-
-	// The step name travels with it, so the board says what is running.
-	if got := content(h.m); !strings.Contains(got, "two") {
-		t.Errorf("board does not name the current step: %q", got)
-	}
 }
 
 // TestBoardPinsAndBadgesAwaitingInput is the rest of the done-when: a task

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -31,8 +31,8 @@ func (d *daemonView) render(width, height int) string {
 	out = append(out, "")
 
 	head := strings.Join(out, "\n")
-	paneHeight := max(d.height-len(out)-2, logPaneMinHeight)
-	return head + "\n" + d.renderLog(paneHeight) + "\n" + d.footer()
+	paneHeight := max(d.height-len(out)-1, logPaneMinHeight)
+	return head + "\n" + d.renderLog(paneHeight)
 }
 
 // identityLines is what the daemon is: version, process, and the three paths
@@ -208,15 +208,6 @@ func (d *daemonView) logPathOrUnknown() string {
 		return styleDim.Render("(unresolved)")
 	}
 	return daemon.LogPath(d.dataDir)
-}
-
-func (d *daemonView) footer() string {
-	keys := []string{
-		styleKey.Render("R") + " refresh",
-		styleKey.Render("f/G") + " follow the log",
-		styleKey.Render("↑/↓") + " scroll",
-	}
-	return styleDim.Render(" ") + strings.Join(keys, styleDim.Render(" · "))
 }
 
 func field(label, value string) string {

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -274,11 +274,9 @@ func (n *newTask) statusLines() []string {
 	case n.submitting:
 		return []string{styleDim.Render("  creating…")}
 	}
-	hint := "  ↑↓ move · enter open · ctrl+s create · R re-probe adapters · esc back"
-	if n.cursor == ntDescription {
-		hint = "  ↑↓ move · enter type · e $EDITOR · ctrl+s create · esc back"
-	}
-	return []string{styleDim.Render(hint)}
+	// The key hints live in the registry footer (T3.12); only form *state*
+	// earns a line here.
+	return nil
 }
 
 // priorityValue is the integer the form would send, for tests and for the

--- a/internal/tui/projectrender.go
+++ b/internal/tui/projectrender.go
@@ -39,8 +39,6 @@ func (p *projectsView) render(width, height int) string {
 	p.tbl.SetHeight(max(3, p.height-len(p.statusLines())-3))
 	p.restoreSelection(rows)
 	sb.WriteString(p.tbl.View())
-	sb.WriteString("\n")
-	sb.WriteString(p.footer())
 	return sb.String()
 }
 
@@ -115,16 +113,6 @@ func (p *projectsView) emptyBody(rows []apiclient.Project) (string, bool) {
 	default:
 		return styleDim.Render("\n  no projects registered — press a to add a repository\n"), true
 	}
-}
-
-func (p *projectsView) footer() string {
-	return styleDim.Render(" ") + strings.Join([]string{
-		styleKey.Render("a") + " add",
-		styleKey.Render("e") + " edit",
-		styleKey.Render("d") + " delete",
-		styleKey.Render("/") + " filter",
-		styleKey.Render("n") + " new task here",
-	}, styleDim.Render(" · "))
 }
 
 func (f *projectForm) render() string {

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -558,7 +558,7 @@ func (m *root) body() string {
 	// tail comes off the filesystem, and a daemon that is down is exactly
 	// when that log is worth reading.
 	if m.active == viewDaemon && m.phase != phaseConnected {
-		return m.views[viewDaemon].render(m.width, m.bodyHeight())
+		return m.framedView(viewDaemon)
 	}
 	// The home panels stay on screen while the daemon is unreachable, marked
 	// stale behind the shell's banner (§15 Disconnected) — provided there was
@@ -582,8 +582,23 @@ func (m *root) body() string {
 		return fmt.Sprintf("\n  %s\n\n  retrying in %s — press r to restart the daemon if it stays down\n",
 			styleWarn.Render("connection lost: "+errString(m.connErr)), m.retryIn)
 	default:
-		return m.views[m.active].render(m.width, m.bodyHeight())
+		if m.active == viewHome {
+			return m.views[viewHome].render(m.width, m.bodyHeight())
+		}
+		return m.framedView(m.active)
 	}
+}
+
+// framedView wraps a takeover screen in the same bordered chrome the home
+// panels wear (T3.8 finding: the six surfaces should read as one program).
+// A takeover is the only surface on screen, so its frame is always focused.
+func (m *root) framedView(id viewID) string {
+	h := m.bodyHeight()
+	if m.width < 4 || h < 3 {
+		return m.views[id].render(m.width, h)
+	}
+	content := m.views[id].render(m.width-2, h-2)
+	return frame(m.views[id].title(), content, m.width, h, true)
 }
 
 // quitReminder is §15's exit line: the daemon keeps working after the TUI

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -267,6 +267,43 @@ func TestViewRoutingAndHelp(t *testing.T) {
 	}
 }
 
+// TestTakeoversShareThePanelChrome pins a T3.8 walkthrough finding: the
+// four takeover screens wear the same bordered frame as the home panels,
+// and the key guidance appears once — in the registry footer — not again
+// as a second, differently-styled row inside the view.
+func TestTakeoversShareThePanelChrome(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	views := map[viewID]string{
+		viewNewTask:   "New task",
+		viewProjects:  "Projects",
+		viewWorkflows: "Workflows",
+		viewDaemon:    "Daemon",
+	}
+	for id, title := range views {
+		m.Update(selectViewMsg{id: id})
+		body := content(m)
+		if !strings.Contains(body, focusGlyph+" "+title) {
+			t.Errorf("%s: no framed title in the body", title)
+		}
+		if !strings.Contains(body, "┌─") || !strings.Contains(body, "└") {
+			t.Errorf("%s: no frame borders", title)
+		}
+		// The retired duplicate rows must be gone; the registry footer is
+		// the one key surface.
+		for _, stale := range []string{"new task here", "follow the log", "re-read", "re-probe adapters · esc back"} {
+			if strings.Contains(body, stale) {
+				t.Errorf("%s: the old in-view key row is back: %q", title, stale)
+			}
+		}
+		if got := strings.Count(body, "commands"); got != 1 {
+			t.Errorf("%s: %d key rows mention the palette, want exactly the footer's 1", title, got)
+		}
+	}
+}
+
 func TestQuitKeys(t *testing.T) {
 	for _, k := range []tea.KeyPressMsg{
 		key("q"),

--- a/internal/tui/workflowrender.go
+++ b/internal/tui/workflowrender.go
@@ -27,7 +27,6 @@ func (w *workflowsView) render(width, height int) string {
 			out = append(out, w.renderSteps(line)...)
 		}
 	}
-	out = append(out, "", w.footer())
 	return strings.Join(out, "\n")
 }
 
@@ -146,12 +145,4 @@ func findingText(f apiclient.WorkflowFinding) string {
 		return fmt.Sprintf("line %d: %s", f.Line, f.Message)
 	}
 	return f.Message
-}
-
-func (w *workflowsView) footer() string {
-	return styleDim.Render(" ") + strings.Join([]string{
-		styleKey.Render("e") + " edit the file",
-		styleKey.Render("enter") + " steps",
-		styleKey.Render("R") + " re-read",
-	}, styleDim.Render(" · "))
 }


### PR DESCRIPTION
Second batch of T3.8 walkthrough findings (Windows 11), graded per the gate's pre-agreed rule — non-blocking, fixed pre-run so both OS runs judge the same build.

## What changed

- **All six §15 surfaces now share the panel chrome**: the four takeover screens (new task, projects, workflows, daemon) render inside the same `frame()` borders as the home panels, title in the border, via `root.framedView`. The daemon view's disconnected path is framed too.
- **One key row.** The takeovers' hand-made hint/footer rows (`projectrender`, `workflowrender`, `daemonrender`, `newtaskrender`) duplicated the registry footer in a different style — exactly the drift T3.12's single-source registry exists to prevent. They're gone; form *state* lines (confirm/error/submitting) stay.
- **Finding #4 deferred as T4.7** (tasks.md): naming what "(workflow default)" resolves to needs new read-only API surface for the §8.6 resolution and explicitly relitigates the PR L "resolution stays server-side" decision.
- tasks.md records the findings and dispositions under T3.8's entry.

## Testing

- `go test ./...` — 817 pass; lint clean.
- New regression test walks all four takeovers through the root: framed title present, old hint rows absent, exactly one key row mentioning the palette.

Refs T3.8; companion to #36 (console-window flicker).