### PR TITLE
fix(tui): broadcast background messages so a takeover cannot swallow them

### DIFF
--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -173,7 +173,17 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamDoneMsg:
 		return m, nil
 	}
-	return m.delegate(msg)
+	// Input is routed; everything else is broadcast. Keys and mouse events
+	// belong to the surface in front of the human and are handled above;
+	// what reaches here is background work — a debounce firing, a fetch
+	// landing, a ticker re-arming — and it belongs to the view that started
+	// it, which is not necessarily the visible one. Delivering these to the
+	// active view only was a wedge: the board's refresh debounce fired while
+	// the new-task form was up, the form dropped it, and `refreshPending`
+	// stayed true forever, so the board ignored every later task event until
+	// the TUI was restarted (T3.8 finding). A tea.Tick that is not re-armed
+	// is gone for good, so the same routing killed the elapsed ticker.
+	return m, m.broadcast(msg)
 }
 
 // updateMouseClick is §15's click scope: a footer hint fires its key, and

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -304,6 +304,47 @@ func TestTakeoversShareThePanelChrome(t *testing.T) {
 	}
 }
 
+// TestBackgroundMessagesReachTheirOwnView is the T3.8 finding: background
+// work belongs to the view that started it, not to whichever screen the
+// human is looking at. The board's refresh debounce fired while the
+// new-task form was up, the form swallowed it, and the board never
+// refetched again — "0/3 running" with tasks in the daemon until restart.
+func TestBackgroundMessagesReachTheirOwnView(t *testing.T) {
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	b := m.views[viewHome].(*shell).board
+	b.client = apiclient.New("http://127.0.0.1:1", "token")
+
+	// A task event opens the debounce window, then the human opens the form.
+	if cmd := b.scheduleRefresh(); cmd == nil {
+		t.Fatal("scheduleRefresh returned no tick")
+	}
+	m.Update(selectViewMsg{id: viewNewTask})
+	if m.active != viewNewTask {
+		t.Fatalf("active = %v, want the takeover", m.active)
+	}
+
+	// The tick lands while the form is on screen. It must reach the board.
+	_, cmd := m.Update(boardRefreshMsg{})
+	if b.refreshPending {
+		t.Fatal("the board's debounce is still pending; the refresh was swallowed")
+	}
+	if cmd == nil {
+		t.Fatal("the debounce fired without issuing a refetch")
+	}
+	// And the window reopens, so later events are not ignored either.
+	if next := b.scheduleRefresh(); next == nil {
+		t.Fatal("the board cannot schedule another refresh; it is wedged")
+	}
+
+	// The elapsed ticker survives a takeover for the same reason: an
+	// unre-armed tea.Tick never comes back.
+	if _, cmd = m.Update(boardTickMsg(testNow)); cmd == nil {
+		t.Fatal("the elapsed ticker died while a takeover was on screen")
+	}
+}
+
 func TestQuitKeys(t *testing.T) {
 	for _, k := range []tea.KeyPressMsg{
 		key("q"),


### PR DESCRIPTION
The load-bearing T3.8 walkthrough finding: **the task table stopped updating** — it read `0/3 running` with four tasks queued in the daemon, and only a TUI restart brought them on screen.

## Cause

`root.Update` routed every non-input message to the *active* view. Background work belongs to the view that started it, which is not necessarily the visible one:

1. Creating a task emits task events, which open the board's 150ms refresh debounce.
2. The human is still in the new-task form, so `boardRefreshMsg` is delivered to the form, which ignores it.
3. `refreshPending` stays `true` forever, and `scheduleRefresh` returns nil for every later event — the board never refetches again.

The same routing killed the elapsed ticker: an unre-armed `tea.Tick` never comes back, so `boardTickMsg` delivered to a takeover stopped the clock permanently.

This predates the refactor (the board was one view among six), but the fused screen makes it constantly visible — the table is now always on screen, so its staleness is what you look at.

## Fix

Input is routed to the surface in front of the human (keys and mouse are handled in their own cases); **everything else is broadcast**. Each view already ignores message types it doesn't own, and the daemon view's `visible` flag was written on this assumption — it drops its own tick when off-screen rather than relying on misrouting to do it.

## Testing

- `go test ./...` — 820 pass; lint clean.
- New regression test: schedule the board's debounce, open a takeover, fire the tick — the board clears `refreshPending`, issues a refetch, can schedule again, and the elapsed ticker survives.

Refs T3.8.