### PR TITLE
fix(tui): walkthrough polish — clicks, project columns, contextual help, palette sections (T3.8)

### DIFF
--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -457,6 +457,14 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
   *Done when:* walkthrough passes on both; notes committed.
   *2026-08-09:* deferred behind T3.9–T3.13 (see the TUI refactor decisions below). The walkthrough runs **once**, against the panel UI, and never against the one being replaced; its sweep section grows the items listed in T3.13. `scripts/m3-gate.sh` and section A of `m3-gate.md` carry over unchanged — the seed is UI-agnostic and the §19 loop is spec-derived.
   *2026-08-10:* first Windows pass surfaced four findings before any run was recorded; graded per the rule above (none block the loop). Fixed pre-run: console windows flashing for every daemon child (procx/gitx `CREATE_NO_WINDOW`), the takeovers' duplicate key rows and missing frames (both runs will judge the fixed build). Deferred: naming what "(workflow default)" resolves to in the new-task form → T4.7.
+  *2026-08-10 (first full Windows walkthrough):* Section A **passed** — the §19 loop completed without leaving the TUI — with nine findings, all fixed pre-record so the recorded runs judge one build:
+  1. **The task table stopped updating** (`0/3 running` with four tasks queued; only a restart showed them). Not cosmetic: `root` routed every non-input message to the *active* view, so the board's refresh debounce fired into the new-task form, `refreshPending` stayed true and every later task event was ignored. The elapsed ticker died the same way. Input is now routed, background work is broadcast. This predates the refactor; the fused screen is what made it visible.
+  2. Clicking blank space below the last row selected the last task (the move clamps) — clicks now land only on rendered rows.
+  3. The Projects table ignored the bubbles cell padding and overflowed by a column's worth, cutting `running / cap`; the path column also grew unbounded. Widths now degrade like the board's (squeeze the name, shed workflow then branch) with the path capped, and the row builder shares one column set with the header.
+  4. `?` listed all eight surfaces' sections; it is now the focused surface's keys plus the globals, framed and titled with the surface name.
+  5. `?` showed the underlying surface's footer while open; it now carries its own key row.
+  6. The palette's group headings looked like its entries; sections are now styled and ruled, with navigation in its own **views** section.
+  7. "(workflow default)" named no agent. The registry already reports each step's agent (§8.6 levels 1 and 3), so the form now reads "(workflow default → claude, adapter default)" from the server's own report. Model and effort stay unnamed — the API does not report them per step, which is exactly T4.7's remaining scope.
 
 **Phase 3 TUI refactor decisions (grill session, 2026-08-09):**
 
@@ -561,5 +569,5 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
   *Done when:* tagged pre-release produces working artifacts installed and smoke-tested on each OS.
 - [ ] **T4.6 — Phase gate (M4 acceptance).** Fresh-machine (VM) timed test per §19 M4 on each OS; results recorded here.
   *Done when:* all three runs under 10 minutes; notes committed. **v1 complete.**
-- [ ] **T4.7 — Name what "default" resolves to in the new-task form.** T3.8 finding (2026-08-10): the agent/model/effort pickers offer "(workflow default)" without saying what that is; a spend decision deserves a name. Needs new read-only API surface exposing the §8.6 resolution (the PR L decision deliberately kept resolution server-side and left the "adapter default" hole open — this task relitigates that explicitly).
-  *Done when:* the pickers show the resolved value beside "(workflow default)" wherever the server can know it, and the workflow-step list's "adapter default" names the adapter.
+- [ ] **T4.7 — Report the §8.6 model and effort resolution.** T3.8 finding (2026-08-10), narrowed: the **agent** side landed with the walkthrough fixes — the registry already reports each step's agent, so the new-task form names it. Model and effort have no such field on the wire, so "(workflow default)" is all the form can honestly say about them, and the workflow-step list still cannot name which adapter "adapter default" resolves to. Both need new read-only API surface, which relitigates the PR L decision that kept resolution server-side — do that explicitly, not by having the TUI re-implement §8.6.
+  *Done when:* the model and effort rows name what an unset override resolves to, and a step with no agent names the adapter that will run it.

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -390,8 +391,16 @@ func (b *board) clickRow(line int) {
 	if len(rows) < 2 {
 		return
 	}
+	body := rows[1:] // the column header is line 0
+	// A table shorter than its pane is padded with blank lines. Clicking one
+	// used to select the last row, because the move clamps — so clicking
+	// empty space below the list silently changed the selection (T3.8
+	// finding). Nothing is a row unless something is rendered on it.
+	if line >= len(body) || strings.TrimSpace(ansi.Strip(body[line])) == "" {
+		return
+	}
 	cursorLine := -1
-	for i, row := range rows[1:] { // the column header is line 0
+	for i, row := range body {
 		if strings.Contains(row, marker) {
 			cursorLine = i
 			break

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -116,6 +116,17 @@ func buildFooter(width int, panelRows []binding, bar *actionBar, target taskActi
 	return line + strings.Repeat(" ", pad) + pinned.String(), hits
 }
 
+// padBetween pins right to the right edge of width, left where it is, and at
+// least two spaces between them. It never truncates: callers that can
+// overflow (the contextual footer) trim their left side first.
+func padBetween(left, right string, width int) string {
+	pad := 2
+	if width > 0 {
+		pad = max(width-ansi.StringWidth(left)-ansi.StringWidth(right), 2)
+	}
+	return left + strings.Repeat(" ", pad) + right
+}
+
 func pinnedHits(x int, segs []footerSeg) []footerHit {
 	out := make([]footerHit, 0, len(segs))
 	for _, s := range segs {

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -2,16 +2,39 @@ package tui
 
 import "strings"
 
-// helpText is the §15 keys overlay, rendered from the binding registry —
-// the same source the palette (and T3.12's footer) draw from, so the help
-// cannot promise a key the code does not bind.
-func helpText() string {
+// helpTitle names the surface the overlay is describing, so it is obvious
+// the sheet is about where you are.
+func helpTitle(ctx bindingContext) string {
+	if ctx == "" {
+		return "Help"
+	}
+	return "Help — " + string(ctx)
+}
+
+// helpFooter is the overlay's own key row. While help is open the footer
+// stops advertising the surface underneath: those keys do nothing until the
+// sheet is closed, and offering them is what made two contradictory rows
+// (T3.8 finding).
+func helpFooter(width int) string {
+	pinned := styleKey.Render("?") + styleDim.Render(" close  ") +
+		styleKey.Render("esc") + styleDim.Render(" close")
+	line := " " + styleDim.Render("the keys of the surface you were on, plus the global ones")
+	return padBetween(line, pinned, width)
+}
+
+// helpText is the §15 cheat sheet for one surface, rendered from the binding
+// registry — the same source the palette and the footer draw from, so the
+// help cannot promise a key the code does not bind. It shows the keys that
+// work *here*: the focused surface's own, the global ones, the task actions,
+// and the palette's navigation. Printing all eight surfaces' sections at
+// once meant reading past seven irrelevant ones (T3.8 finding).
+func helpText(ctx bindingContext) string {
 	var b strings.Builder
 	writeSection := func(title string, rows []binding) {
 		if len(rows) == 0 {
 			return
 		}
-		b.WriteString("\n  " + title + "\n\n")
+		b.WriteString("\n " + styleTitle.Render(strings.ToUpper(title)) + "\n\n")
 		for _, r := range rows {
 			key := r.key
 			if key == "" {
@@ -36,24 +59,20 @@ func helpText() string {
 			actions = append(actions, r)
 		}
 	}
-	writeSection("Global keys", global)
-	writeSection("Go to (from the : palette)", nav)
-	writeSection("Task actions (on the selected task, offered only when valid)", actions)
-	for _, sec := range []struct {
-		ctx   bindingContext
-		title string
-	}{
-		{ctxTasks, "Task table"},
-		{ctxTimeline, "Timeline"},
-		{ctxOutput, "Output pane"},
-		{ctxForm, "Answer form (while a task is waiting on you)"},
-		{ctxNewTask, "New task"},
-		{ctxProjects, "Projects"},
-		{ctxWorkflows, "Workflows"},
-		{ctxDaemon, "Daemon (the only view that still works when the daemon is down)"},
-	} {
-		writeSection(sec.title, bindingsFor(sec.ctx))
+	// This surface first: it is the answer to "what can I do here".
+	if ctx != "" {
+		writeSection(string(ctx), bindingsFor(ctx))
 	}
+	// The answer form's keys ride along with the panels it pops up over —
+	// it has no focus of its own to be the context.
+	if ctx == ctxTasks || ctx == ctxTimeline || ctx == ctxOutput {
+		writeSection("answer form (while a task is waiting on you)", bindingsFor(ctxForm))
+	}
+	if ctx == ctxTasks || ctx == ctxTimeline || ctx == ctxOutput {
+		writeSection("task actions (on the selected task, offered only when valid)", actions)
+	}
+	writeSection("global keys", global)
+	writeSection("go to (from the : palette)", nav)
 	return b.String()
 }
 

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -103,6 +103,35 @@ func TestShellClickSelectsRow(t *testing.T) {
 	}
 }
 
+// TestShellClickBelowTheRowsIsIgnored is a T3.8 finding: the table is
+// padded with blank lines when it has fewer rows than pane, and clicking
+// one used to select the last task because the move clamps.
+func TestShellClickBelowTheRowsIsIgnored(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning), task(2, stateRunning))
+	s.settle()
+	before, ok := s.board.selected()
+	if !ok {
+		t.Fatal("fixture selected nothing")
+	}
+	box := s.lastBoxes[0]
+	firstRow := box.y + 2 + s.board.chromeLines()
+
+	// Well past two rows, still inside the panel.
+	for _, offset := range []int{2, 3, 5} {
+		s.update(tea.MouseClickMsg{X: 10, Y: firstRow + offset, Button: tea.MouseLeft})
+		s.render(120, 37)
+		if got, _ := s.board.selected(); got != before {
+			t.Fatalf("a click %d lines below the last row moved the selection to #%d", offset, got)
+		}
+	}
+	// The row above it still selects, so the bound is not simply "ignore".
+	s.update(tea.MouseClickMsg{X: 10, Y: firstRow + 1, Button: tea.MouseLeft})
+	s.render(120, 37)
+	if got, _ := s.board.selected(); got == before {
+		t.Fatal("clicking the second row selected nothing")
+	}
+}
+
 // TestShellWheelScrollsFocusedPanel: §15 — the wheel scrolls the focused
 // panel, not the hovered one.
 func TestShellWheelScrollsFocusedPanel(t *testing.T) {
@@ -220,7 +249,7 @@ func TestRootMouseToggle(t *testing.T) {
 		t.Fatalf("mouse mode = %v after M M, want cell motion again", v.MouseMode)
 	}
 	// The toggle is discoverable: a registry row, so palette and ? carry it.
-	if !strings.Contains(helpText(), "toggle the mouse") {
+	if !strings.Contains(helpText(ctxTasks), "toggle the mouse") {
 		t.Error("the mouse toggle is not in the help overlay")
 	}
 }

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -152,6 +152,49 @@ func TestNewTaskFallsBackToAdhocWithoutAProjectDefault(t *testing.T) {
 	}
 }
 
+// TestNewTaskNamesTheWorkflowDefaultAgent is a T3.8 finding: "(workflow
+// default)" told nobody which agent would run, and that is a spend
+// decision. The names come from the registry's own per-step report, so a
+// step naming none still reads as the adapter default rather than a guess.
+func TestNewTaskNamesTheWorkflowDefaultAgent(t *testing.T) {
+	n := loadedForm(t)
+	n.workflow = "two-step"
+
+	summary := n.agentSummary()
+	if !strings.Contains(summary, "workflow default") {
+		t.Fatalf("agent summary = %q, want it to still say the workflow decides", summary)
+	}
+	for _, want := range []string{"codex", "adapter default"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("agent summary = %q, want it to name %q", summary, want)
+		}
+	}
+	// The picker's own default row carries the same names.
+	opts := n.agentOptions()
+	if len(opts) == 0 || opts[0].value != "" {
+		t.Fatal("the first agent option is not the workflow default")
+	}
+	if !strings.Contains(opts[0].note, "codex") {
+		t.Errorf("default option note = %q, want the workflow's agents", opts[0].note)
+	}
+
+	// An explicit override replaces it outright — no "(default)" noise.
+	n.agent = "claude"
+	if got := n.agentSummary(); got != "claude" {
+		t.Errorf("agent summary with an override = %q, want just the agent", got)
+	}
+
+	// Model and effort stay unnamed: the registry does not report them per
+	// step, and inventing a value would be worse than saying nothing (T4.7).
+	n.model = ""
+	if got := n.overrideSummary(n.model); !strings.Contains(got, "workflow default") {
+		t.Errorf("model summary = %q", got)
+	}
+	if strings.Contains(n.overrideSummary(n.model), "→") {
+		t.Error("the model summary names a value the API never reported")
+	}
+}
+
 func TestNewTaskFlagsStepsNeedingAnUnavailableAgent(t *testing.T) {
 	n := loadedForm(t)
 	e := n.workflowEntry("two-step")

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -287,7 +287,11 @@ func (n *newTask) workflowOptions() []pickerOption {
 // workflow". An unavailable adapter stays selectable — it may be installed
 // before the task is admitted — but says so.
 func (n *newTask) agentOptions() []pickerOption {
-	out := []pickerOption{{value: "", label: "(workflow default)"}}
+	out := []pickerOption{{
+		value: "",
+		label: "(workflow default)",
+		note:  strings.TrimPrefix(n.workflowAgents(), " → "),
+	}}
 	for _, a := range n.agents {
 		opt := pickerOption{value: a.Name, label: a.Name}
 		switch {

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -111,7 +111,7 @@ func (n *newTask) rowValue(row ntRow) string {
 		return firstNonEmpty(strings.TrimSpace(n.priority.Value()), "0") + "  " +
 			styleDim.Render("higher runs first · +/-")
 	case ntAgent:
-		return n.overrideSummary(n.agent)
+		return n.agentSummary()
 	case ntModel:
 		return n.overrideSummary(n.model)
 	case ntEffort:
@@ -156,11 +156,60 @@ func (n *newTask) descriptionSummary() string {
 
 // overrideSummary states plainly that an unset override means the workflow
 // decides — the one thing §8.6 confusion turns into a wrong agent.
+//
+// Model and effort stop at that: the registry reports each step's agent
+// (§8.6 levels 1 and 3) but not its model or effort, so naming those would
+// mean guessing. T4.7 is the task that exposes the resolution properly.
 func (n *newTask) overrideSummary(v string) string {
 	if v == "" {
 		return styleDim.Render("(workflow default)")
 	}
 	return v
+}
+
+// agentSummary names what "(workflow default)" actually means for the
+// selected workflow, which is the T3.8 finding: an unnamed default is a
+// spend decision nobody can review. The agents come from the registry's own
+// per-step report, not from the TUI re-implementing §8.6 — steps that name
+// none resolve to the adapter default, which the API cannot report and this
+// says so rather than inventing a name.
+func (n *newTask) agentSummary() string {
+	if n.agent != "" {
+		return n.agent
+	}
+	return styleDim.Render("(workflow default" + n.workflowAgents() + ")")
+}
+
+// workflowAgents renders the distinct agents the selected workflow's agent
+// steps name, in step order: " → claude", " → claude, codex" when they
+// differ, " → adapter default" when none does, and nothing at all when no
+// workflow is picked yet.
+func (n *newTask) workflowAgents() string {
+	e := n.workflowEntry(n.workflow)
+	if e == nil {
+		return ""
+	}
+	var names []string
+	adapterDefault := false
+	for _, s := range e.Steps {
+		if s.Type != "agent" {
+			continue
+		}
+		if s.Agent == "" {
+			adapterDefault = true
+			continue
+		}
+		if !contains(names, s.Agent) {
+			names = append(names, s.Agent)
+		}
+	}
+	if adapterDefault {
+		names = append(names, "adapter default")
+	}
+	if len(names) == 0 {
+		return "" // a workflow with no agent steps: the override is moot
+	}
+	return " → " + strings.Join(names, ", ")
 }
 
 // renderExpansion draws whatever the focused row opened underneath it.

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -57,10 +57,13 @@ func paletteEntries(ctx bindingContext, target taskActions, editable, connected 
 			out = append(out, paletteEntry{group: group, label: b.label, key: b.key})
 		}
 	}
+	// Views get their own section: navigating to them is the reason the
+	// digits could be retired, so it must not read as one more command
+	// (T3.8 finding).
 	for _, b := range bindings {
 		if b.nav {
 			out = append(out, paletteEntry{
-				group: "go to", label: b.label, key: b.key,
+				group: "views", label: b.label, key: b.key,
 				nav: true, navTarget: b.navTarget,
 			})
 		}
@@ -145,7 +148,16 @@ func (p *palette) render(w, h int) string {
 	for i, e := range m {
 		if e.group != group {
 			group = e.group
-			rows = append(rows, styleDim.Render("  "+group))
+			// A section header, not another dim line: a list where the
+			// headings look like the entries reads as one flat wall
+			// (T3.8 finding). Blank line above, rule to the right edge.
+			if len(rows) > 0 {
+				rows = append(rows, "")
+			}
+			label := " " + strings.ToUpper(group) + " "
+			fill := max(inner-ansi.StringWidth(label)-1, 0)
+			rows = append(rows, styleTitle.Render(label)+
+				styleDim.Render(strings.Repeat("─", fill)))
 		}
 		mark, style := "  ", styleDim
 		if i == cursor {

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -99,6 +100,33 @@ func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
 	}
 }
 
+// TestPaletteSectionsAreVisiblySeparate is a T3.8 finding: the group
+// headings looked exactly like the entries, so the list read as one flat
+// wall — and navigation needs its own section, since reaching the takeover
+// screens is why the digits could be retired.
+func TestPaletteSectionsAreVisiblySeparate(t *testing.T) {
+	p := newPalette(paletteEntries(ctxTasks, everyAction, true, true))
+	out := p.render(60, 18)
+	plain := ansi.Strip(out)
+
+	if !strings.Contains(plain, "VIEWS") {
+		t.Errorf("no views section:\n%s", plain)
+	}
+	// Headings are styled and ruled; entries are not.
+	if !strings.Contains(out, styleTitle.Render(" VIEWS ")) {
+		t.Error("the views heading is not rendered as a heading")
+	}
+	if !strings.Contains(plain, "─") {
+		t.Errorf("no section rule:\n%s", plain)
+	}
+	// Section names, one per group present.
+	for _, want := range []string{"ACTIONS ON #9", "VIEWS"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("missing section %q:\n%s", want, plain)
+		}
+	}
+}
+
 // TestPaletteRunsKeyedEntryThroughItsKey: executing an entry replays its
 // direct keypress — one path, so the palette cannot diverge from the
 // shortcut it teaches.
@@ -160,16 +188,54 @@ func TestPaletteSearchNarrowsAndEscCloses(t *testing.T) {
 // TestHelpRendersFromRegistry: the ? overlay is generated, not hand-written
 // — a registry row's label must appear verbatim.
 func TestHelpRendersFromRegistry(t *testing.T) {
-	got := helpText()
+	got := helpText(ctxTasks)
 	for _, want := range []string{
 		"jump to the next task needing a human",
 		"open the command palette",
 		"open the selected task",
 		"filter by id",
-		"Go to (from the : palette)",
+		"GO TO (FROM THE : PALETTE)",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("help overlay missing %q", want)
+		}
+	}
+}
+
+// TestHelpIsContextual is a T3.8 finding: the sheet answers "what can I do
+// here", so it carries the focused surface's keys — not all eight
+// surfaces' sections at once.
+func TestHelpIsContextual(t *testing.T) {
+	tasks := helpText(ctxTasks)
+	if !strings.Contains(tasks, "filter by id") {
+		t.Error("the task table's help lacks its own filter key")
+	}
+	for _, elsewhere := range []string{"register a repository", "re-read the registry", "re-probe the adapters"} {
+		if strings.Contains(tasks, elsewhere) {
+			t.Errorf("the task table's help carries another surface's key: %q", elsewhere)
+		}
+	}
+
+	projects := helpText(ctxProjects)
+	if !strings.Contains(projects, "register a repository") {
+		t.Error("the projects help lacks its own add key")
+	}
+	for _, elsewhere := range []string{"filter by id", "follow the live output"} {
+		if strings.Contains(projects, elsewhere) {
+			t.Errorf("the projects help carries a panel key: %q", elsewhere)
+		}
+	}
+	// Task actions belong to the panels, where a task is selected.
+	if strings.Contains(projects, "approve the gate") {
+		t.Error("the projects help offers task actions")
+	}
+	if !strings.Contains(helpText(ctxTasks), "approve the gate") {
+		t.Error("the task table's help omits the task actions")
+	}
+	// The globals are everywhere, because they work everywhere.
+	for _, ctx := range []bindingContext{ctxTasks, ctxProjects, ctxDaemon, ctxNewTask} {
+		if !strings.Contains(helpText(ctx), "quit the TUI") {
+			t.Errorf("%s help omits the global keys", ctx)
 		}
 	}
 }

--- a/internal/tui/projectrender.go
+++ b/internal/tui/projectrender.go
@@ -33,44 +33,138 @@ func (p *projectsView) render(width, height int) string {
 		return sb.String()
 	}
 
-	p.tbl.SetColumns(projectColumns(p.width))
-	p.tbl.SetRows(p.rowsFor(rows))
+	cols, set := projectColumns(p.width)
+	if len(cols) != len(p.tbl.Columns()) {
+		// Crossing a breakpoint: clear the rows first, or the table
+		// re-renders the previous shape against the new column set.
+		p.tbl.SetRows(nil)
+	}
+	p.tbl.SetColumns(cols)
+	p.tbl.SetRows(p.rowsFor(rows, set))
 	p.tbl.SetWidth(p.width)
 	p.tbl.SetHeight(max(3, p.height-len(p.statusLines())-3))
 	p.restoreSelection(rows)
+	// Passing through an empty row set parks the cursor at -1; with rows on
+	// screen it belongs on one, or nothing is selected and every key that
+	// acts on a row goes nowhere.
+	if p.tbl.Cursor() < 0 && len(rows) > 0 {
+		p.tbl.SetCursor(0)
+	}
 	sb.WriteString(p.tbl.View())
 	return sb.String()
 }
 
-// projectColumns drops the path first on a narrow terminal: it is the
-// longest column and the one a name already stands in for.
-func projectColumns(width int) []table.Column {
-	cols := []table.Column{
-		{Title: "id", Width: 4},
-		{Title: "name", Width: 18},
-	}
-	if width >= 90 {
-		cols = append(cols, table.Column{Title: "path", Width: width - 76})
-	}
-	return append(cols,
-		table.Column{Title: "branch", Width: 14},
-		table.Column{Title: "workflow", Width: 16},
-		table.Column{Title: "running / cap", Width: 20},
-	)
+// Projects column widths. As on the board, the table pads every cell by one
+// space either side, so a column occupies its width plus two — the original
+// widths ignored that and overflowed by a whole column's padding, which the
+// table swallowed by cutting the last column: "running / cap" arrived
+// unreadable (T3.8 finding).
+const (
+	pcolID       = 4
+	pcolName     = 20
+	pcolBranch   = 14
+	pcolWorkflow = 16
+	pcolCap      = 20
+	// pcolMinName is where squeezing the name stops and a whole column goes
+	// instead; pcolMaxName is where a wide terminal stops widening it.
+	pcolMinName = 14
+	pcolMaxName = 40
+	// pcolMinPath is not worth rendering below; pcolMaxPath is where a wide
+	// terminal stops handing space to the one column that needs it least.
+	pcolMinPath = 24
+	pcolMaxPath = 60
+)
+
+// projectColSet records which optional columns survived the current width,
+// so the row builder cannot disagree with the header about how many cells a
+// row has — a mismatch is an index panic on the next resize.
+type projectColSet struct {
+	path     bool
+	branch   bool
+	workflow bool
 }
 
-func (p *projectsView) rowsFor(projects []apiclient.Project) []table.Row {
+// projectColumns fits §15's project columns into the width it has. The path
+// is the first thing a narrow terminal loses — it is the longest column and
+// the one a name already stands in for — and on a wide one it stops growing
+// at pcolMaxPath rather than pushing the figures off the edge.
+func projectColumns(width int) ([]table.Column, projectColSet) {
+	// id, name and running/cap always exist: the identity, the thing you
+	// scan for, and the figure the view is for.
+	base := pcolID + pcolCap + 3*colPadding
+	name := pcolName
+	branch, workflow := true, true
+	cost := func() int {
+		c := base + name
+		if branch {
+			c += pcolBranch + colPadding
+		}
+		if workflow {
+			c += pcolWorkflow + colPadding
+		}
+		return c
+	}
+	// Squeeze the name to its floor first — repo names are short — then shed
+	// the configuration columns, which a narrow terminal can live without.
+squeeze:
+	for cost() > width {
+		switch {
+		case name > pcolMinName:
+			name = max(pcolMinName, name-(cost()-width))
+		case workflow:
+			workflow = false
+		case branch:
+			branch = false
+		default:
+			break squeeze // nothing left to shed; the table will truncate
+		}
+	}
+
+	path := 0
+	if slack := width - cost(); slack >= pcolMinPath+colPadding {
+		path = min(slack-colPadding, pcolMaxPath)
+	} else if slack > 0 {
+		// No room for a path column, so the space goes to the name rather
+		// than sitting empty at the right edge.
+		name = min(name+slack, pcolMaxName)
+	}
+
+	cols := []table.Column{
+		{Title: "id", Width: pcolID},
+		{Title: "name", Width: name},
+	}
+	if path > 0 {
+		cols = append(cols, table.Column{Title: "path", Width: path})
+	}
+	if branch {
+		cols = append(cols, table.Column{Title: "branch", Width: pcolBranch})
+	}
+	if workflow {
+		cols = append(cols, table.Column{Title: "workflow", Width: pcolWorkflow})
+	}
+	return append(cols,
+		table.Column{Title: "running / cap", Width: pcolCap},
+	), projectColSet{path: path > 0, branch: branch, workflow: workflow}
+}
+
+func (p *projectsView) rowsFor(projects []apiclient.Project, set projectColSet) []table.Row {
 	out := make([]table.Row, 0, len(projects))
 	for _, pr := range projects {
 		row := table.Row{strconv.FormatInt(pr.ID, 10), pr.Name}
-		if p.width >= 90 {
+		if set.path {
 			row = append(row, pr.Path)
 		}
-		workflow := styleDim.Render("adhoc")
-		if pr.DefaultWorkflow != nil && *pr.DefaultWorkflow != "" {
-			workflow = *pr.DefaultWorkflow
+		if set.branch {
+			row = append(row, pr.DefaultBranch)
 		}
-		out = append(out, append(row, pr.DefaultBranch, workflow, p.capCell(pr)))
+		if set.workflow {
+			workflow := styleDim.Render("adhoc")
+			if pr.DefaultWorkflow != nil && *pr.DefaultWorkflow != "" {
+				workflow = *pr.DefaultWorkflow
+			}
+			row = append(row, workflow)
+		}
+		out = append(out, append(row, p.capCell(pr)))
 	}
 	return out
 }

--- a/internal/tui/projects_test.go
+++ b/internal/tui/projects_test.go
@@ -348,6 +348,70 @@ func TestProjectsRefetchOnActivationAndOnEvents(t *testing.T) {
 	}
 }
 
+// TestProjectColumnsFitTheirWidth is a T3.8 finding: the widths ignored the
+// table's per-cell padding and overflowed by a whole column's worth, so the
+// last column ("running / cap") arrived cut. The path column is also the
+// one that must not eat a wide terminal.
+func TestProjectColumnsFitTheirWidth(t *testing.T) {
+	for _, width := range []int{80, 100, 120, 160, 240} {
+		cols, set := projectColumns(width)
+		total := 0
+		for _, c := range cols {
+			total += c.Width + colPadding
+		}
+		if total > width {
+			t.Errorf("width %d: columns need %d cells — the last one gets cut", width, total)
+		}
+		// Whatever survives has to be readable, the last column included.
+		last := cols[len(cols)-1]
+		if last.Title != "running / cap" || last.Width != pcolCap {
+			t.Errorf("width %d: last column = %q/%d, want the full cap column", width, last.Title, last.Width)
+		}
+		for _, c := range cols {
+			if c.Width < 4 {
+				t.Errorf("width %d: column %q shrank to %d", width, c.Title, c.Width)
+			}
+			if c.Title == "path" && c.Width > pcolMaxPath {
+				t.Errorf("width %d: path took %d cells, capped at %d", width, c.Width, pcolMaxPath)
+			}
+		}
+		if width >= 160 && !set.path {
+			t.Errorf("width %d dropped the path column", width)
+		}
+	}
+}
+
+// The header and the rows must agree about how many cells a row has, or the
+// table indexes out of range on the next resize.
+func TestProjectRowsMatchTheirColumns(t *testing.T) {
+	p := newProjectsView()
+	loadedProjects(p, []apiclient.Project{testProject(1, "vincent")}, nil)
+	for _, width := range []int{70, 100, 200} {
+		cols, set := projectColumns(width)
+		rows := p.rowsFor(p.visible(), set)
+		if len(rows) == 0 {
+			t.Fatal("no rows built")
+		}
+		if len(rows[0]) != len(cols) {
+			t.Errorf("width %d: row has %d cells, header has %d", width, len(rows[0]), len(cols))
+		}
+	}
+}
+
+// A resize across the path breakpoint must not panic or lose the selection.
+func TestProjectsSurviveAColumnBreakpoint(t *testing.T) {
+	p := newProjectsView()
+	loadedProjects(p, []apiclient.Project{testProject(1, "a"), testProject(2, "b")}, nil)
+	p.render(200, 24)
+	p.tbl.SetCursor(1)
+	p.rememberSelection()
+	p.render(80, 24) // path column disappears
+	p.render(200, 24)
+	if got, ok := p.current(); !ok || got.ID != 2 {
+		t.Errorf("selection after two resizes = %+v, want project 2", got)
+	}
+}
+
 func TestProjectsHintTheProjectUnderTheCursor(t *testing.T) {
 	p := newProjectsView()
 	loadedProjects(p, []apiclient.Project{testProject(7, "vincent")}, nil)

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -552,7 +552,14 @@ func (m *root) connBadge() string {
 
 func (m *root) body() string {
 	if m.help {
-		return helpText()
+		// The sheet describes the surface it was opened over, framed like
+		// every other surface (T3.8 findings).
+		ctx, _ := m.activeContext()
+		h := m.bodyHeight()
+		if m.width < 4 || h < 3 {
+			return helpText(ctx)
+		}
+		return frame(helpTitle(ctx), helpText(ctx), m.width, h, true)
 	}
 	// The daemon view is the exception to the connection gate (§15): its log
 	// tail comes off the filesystem, and a daemon that is down is exactly
@@ -638,6 +645,11 @@ func (m *root) homeLoaded() bool {
 // footerLine is the §15 contextual footer, rendered from the registry and
 // the shell's action bar.
 func (m *root) footerLine() string {
+	if m.help {
+		// The overlay owns the keyboard, so it owns the key row: the keys
+		// underneath do nothing until it closes.
+		return helpFooter(m.width)
+	}
 	ctx, s := m.activeContext()
 	var (
 		bar       *actionBar

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -252,14 +252,18 @@ func TestViewRoutingAndHelp(t *testing.T) {
 
 	m.Update(key("?"))
 	help := content(m)
-	if !strings.Contains(help, "Global keys") {
+	if !strings.Contains(help, "GLOBAL KEYS") {
 		t.Errorf("help overlay missing after ?: %q", help)
 	}
-	// The board's keys are documented as they land (T3.2).
-	for _, k := range []string{"open the selected task", "filter by id"} {
+	// The sheet is contextual (T3.8): on the home screen it carries the
+	// focused panel's keys, and its own key row replaces the footer's.
+	for _, k := range []string{"open the selected task", "filter by id", "esc"} {
 		if !strings.Contains(help, k) {
 			t.Errorf("help overlay lacks %q: %q", k, help)
 		}
+	}
+	if strings.Contains(help, "register a repository") {
+		t.Errorf("help overlay carries another surface's keys: %q", help)
 	}
 	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if strings.Contains(content(m), "toggle this help") {


### PR DESCRIPTION
Six of the nine findings from the first full Windows walkthrough. None blocked the §19 loop (Section A **passed**), but all of them were fixed before any run is recorded so both OS runs judge one build. The seventh — the task table going stale — is #38, which this stacks on top of.

## Fixes

**Clicks land only on rows.** The table pads with blank lines when it has fewer rows than pane; clicking one selected the *last* task, because the underlying move clamps. Nothing is a row unless something is rendered on it.

**Projects columns fit their width.** They ignored the bubbles per-cell padding and overflowed by a whole column's worth — the table absorbed it by cutting the last column, so `running / cap` arrived unreadable — while the path column grew unbounded on a wide terminal. Widths now degrade the way the board's do (squeeze the name to a floor, then shed workflow, then branch), the path is capped, and `projectColumns` returns a column *set* the row builder shares, so header and rows cannot disagree about a row's cell count (that disagreement is an index panic on the next resize).

**`?` is contextual.** It listed all eight surfaces' sections; it now shows the focused surface's keys plus the globals (and task actions where a task is selected), framed and titled with the surface it describes — still generated from the registry.

**`?` owns its own key row.** While the sheet is open the footer no longer advertises the surface underneath — those keys do nothing until it closes, and showing them was two contradictory rows at once.

**Palette sections are visibly sections.** Group headings looked exactly like entries, so the list read as one flat wall. They are styled, ruled to the edge, and separated by a blank line — and navigation gets its own `VIEWS` section, since reaching the takeovers is why the digits could be retired.

**"(workflow default)" names the agent.** The registry already reports each step's agent (§8.6 levels 1 and 3), so the form reads `(workflow default → claude, adapter default)` from the server's own report — no client-side resolution, and a step naming none still reads as the adapter default rather than a guess. Model and effort have no per-step field on the wire, so they stay unnamed; that is exactly what remains of **T4.7**, now narrowed in tasks.md.

## Testing

- `go test ./...` — 826 pass; lint clean.
- New: click-below-the-rows is ignored (and the row above still selects), project columns fit every width with the last column intact and the path capped, rows match their columns, a resize across the path breakpoint keeps the selection, help is contextual in both directions, palette sections are styled and named, the agent default names the workflow's agents while model/effort stay silent.

Refs T3.8; findings and dispositions recorded under its entry in tasks.md.