### PR TITLE
docs: record M3 gate pass on Windows 11 and macOS (T3.8)

### DIFF
--- a/docs/versions/v0/m3-gate.md
+++ b/docs/versions/v0/m3-gate.md
@@ -8,7 +8,9 @@ M1 and M2 are asserted by `curl` in CI. M3 cannot be: its acceptance is a
 judgement about a terminal program, and the Phase 3 decision ruled out driving
 one from tests. So this is a human walkthrough. `scripts/m3-gate.sh` seeds the
 world and prints the launch instructions; everything below is done by hand, on
-**Windows 11 and macOS**, both runs on the PR branch before it merges.
+**Windows 11 and macOS**, both runs against the same build. The shakeout runs
+were walked on the PR branches whose fixes they produced; the two recorded runs
+were walked on `master` at `40fbffe`, the first commit carrying all of them.
 
 Linux is not hand-run: it executes the full Go suite and both existing gates on
 every PR across all three OSes. That is a stated choice, not an omission.
@@ -174,4 +176,98 @@ Section B: S1 … S13 — pass / fail / n-a
 
 -->
 
-_No runs recorded yet._
+Both recorded runs judge **`40fbffe`** — the first build carrying every
+shakeout fix above (mouse row hit-testing, paste routing, one-shot launch env).
+Nothing loop-blocking was found in either, so neither run invalidates the other.
+
+### Windows 11 — 2026-08-10
+
+| | |
+|---|---|
+| OS / version | Windows 11 |
+| terminal host | Windows Terminal (pwsh); Git Bash/mintty for the second S14 host |
+| vincent commit | `40fbffe` |
+| `claude --version` | 2.1.226 (Claude Code) |
+| resolved `$EDITOR` | unset → `notepad` (platform default, `internal/tui/editor.go`) |
+| mode | real claude on the question leg |
+
+Section A: L1–L10 — **pass** (the §19 loop completed without leaving the TUI).
+Section B: S1–S18 — **pass**.
+
+**Findings**
+
+| Item | What | Disposition |
+|---|---|---|
+| — | none | — |
+
+Everything surfaced by the Windows shakeout (the nine findings written up under
+T3.8 in `tasks.md`) was already fixed in this build and re-checked here: the
+task table keeps updating while the new-task form is open, clicks land only on
+rendered rows, the Projects table degrades instead of overflowing, `?` shows the
+focused surface's keys with its own footer, the palette's sections are ruled,
+and the new-task form names the workflow-default agent.
+
+**Verdict:** GATE PASS
+
+### macOS — 2026-08-10
+
+| | |
+|---|---|
+| OS / version | macOS 26.5.2 (25F84) |
+| terminal host | Ghostty 1.3.1 |
+| vincent commit | `40fbffe` |
+| `claude --version` | 2.1.226 (Claude Code) |
+| resolved `$EDITOR` | unset → `vi` (platform default, `internal/tui/editor.go`) |
+| mode | real claude on the question leg |
+
+Section A: L1–L10 — **pass** (the §19 loop completed without leaving the TUI).
+Section B: S1–S18 — **pass**, with S14 read as its POSIX equivalent: the mouse
+items are exercised in Ghostty, not on the two Windows hosts, which the Windows
+run above covers.
+
+**Findings**
+
+| Item | What | Disposition |
+|---|---|---|
+| — | none | — |
+
+The three macOS shakeout findings are fixed in this build and re-checked here:
+a click selects the row under the cursor (S14), bracketed paste and `ctrl+v`
+both fill the focused field (L2, S5, S6), and the gate banner's launch block no
+longer exports `FAKEAGENT_*` into the shell that later runs `go test`.
+
+**Verdict:** GATE PASS
+
+## Friction record dispositions (T3.9)
+
+`tui-friction.md` requires every finding it recorded before the refactor to come
+back here carrying **fixed**, **deferred** to a Phase 4 ID, or **won't-fix**.
+Judged against the same `40fbffe` walkthroughs; the sweep item that exercised
+each one is named, so a disposition is a thing that was looked at, not a thing
+the mechanism's PR claimed.
+
+| Finding | Disposition | Seen in |
+|---|---|---|
+| F1 42 keys, no complete on-screen list | fixed — palette is searchable by intent and shows each entry's direct key | S16 |
+| F2 `?` is a full-screen 45-row modal | fixed — `?` is the focused surface's keys plus globals, framed and titled | S1 |
+| F3 bindings in three places, already drifted | fixed — one registry feeds palette, footer and `?`; drift is a test failure | S1, S16 |
+| F4 `1..6` navigation with no legend | fixed — `1..6` retired; takeovers are palette entries under a **views** section | L2, L3, S16 |
+| F5 board↔detail modal round-trip | fixed — one screen; the queue and a live tail are visible together | L6, L7 |
+| F6 same key, different meaning per view | fixed — footer names the focused panel's keys | S1, S9 |
+| F7 only task actions get a hint | fixed — the action bar generalised into the footer for every panel | S1, S4 |
+| F8 no way to *go* to an attention task | fixed — `!` jumps, surfaced only when the count is non-zero | L8 |
+| F9 no mouse | fixed — focus, row select, wheel, hints, tabs, `M` to disable | S14 |
+| F10 no command surface | fixed — `:` opens on every surface | S16 |
+| F11 `esc` overloaded and positional | fixed — explicit popup → takeover → filter → no-op stack; never quits | L8, S5, S15 |
+| F12 answer form is a stop in a `tab` cycle | fixed — a popup with a row badge and a footer hint | L8, S5 |
+
+No finding is deferred or won't-fix. The one item T3.8 deferred is not from this
+record: naming what "(workflow default)" resolves to for **model and effort** is
+**T4.7**, which needs the API to report §8.6 resolution per step — the agent half
+was fixed during the Windows shakeout.
+
+### Gate result
+
+**T3.8 passes.** §19's M3 acceptance holds on Windows 11 and macOS against one
+build, `40fbffe`. Linux keeps its coverage from CI — the full Go suite plus the
+M1 and M2 gates on every PR.

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -19,9 +19,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 0 — Scaffolding | 4 tasks | 4/4 | ✅ done |
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
-| 3 — TUI (M3) | 13 tasks | 12/13 | 🟡 in progress |
+| 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
 | 4 — Polish (M4) | 7 tasks | 0/7 | ⬜ not started |
-| **Total** | | **37/45** | |
+| **Total** | | **38/45** | |
 
 ---
 
@@ -453,7 +453,7 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
 - *Results shape:* per run a header block (date, OS + version, terminal host, vincent commit, `claude --version`, resolved `$EDITOR`), a pass/fail/n-a table keyed to item IDs, and findings each carrying a Phase 4 task ID or "fixed in PR N" — Q6's rule only works if a finding is written next to its disposition, or "deferred" and "forgotten" become the same artifact.
 - *Commit order:* tasks.md `[~]` + this block → spec (§19 footnote, §15 cross-reference) → `cmd/fakeagent` delay knob + test → `scripts/m3-gate.sh` → `m3-gate.md` checklist → walkthroughs → results + tasks.md `[x]`. Docs-first per PR C/I/J/K/M.
 
-- [~] **T3.8 — Phase gate (M3 acceptance).** Manual scripted walkthrough of the §19 M3 loop on Windows + one POSIX OS, using fake agents for parallelism and real `claude` for one task; results recorded here.
+- [x] **T3.8 — Phase gate (M3 acceptance).** ✓ 2026-08-10 Manual scripted walkthrough of the §19 M3 loop on Windows + one POSIX OS, using fake agents for parallelism and real `claude` for one task; results recorded here.
   *Done when:* walkthrough passes on both; notes committed.
   *2026-08-09:* deferred behind T3.9–T3.13 (see the TUI refactor decisions below). The walkthrough runs **once**, against the panel UI, and never against the one being replaced; its sweep section grows the items listed in T3.13. `scripts/m3-gate.sh` and section A of `m3-gate.md` carry over unchanged — the seed is UI-agnostic and the §19 loop is spec-derived.
   *2026-08-10:* first Windows pass surfaced four findings before any run was recorded; graded per the rule above (none block the loop). Fixed pre-run: console windows flashing for every daemon child (procx/gitx `CREATE_NO_WINDOW`), the takeovers' duplicate key rows and missing frames (both runs will judge the fixed build). Deferred: naming what "(workflow default)" resolves to in the new-task form → T4.7.
@@ -470,6 +470,7 @@ Milestone acceptance (§19 M3): the full loop — register project, author workf
   2. Paste did nothing anywhere, so L2's "paste the seeded app-repo path" was not performable. `tea.PasteMsg` is neither a key nor a mouse event, so the root broadcast it and every view dropped it; `ctrl+v` failed separately because bubbles answers it with an unexported message only textinput understands. Paste now follows the *key* routing to the one field holding the keyboard, and `ctrl+v` reads the system clipboard into that same path. A paste with no field under it is dropped rather than replayed as keystrokes — on the board that would fire `a`/`c`/`r` as task actions.
   3. The gate banner's `export` lines outlive the walkthrough, and the next `go test ./...` in that shell inherits `FAKEAGENT_DELAY_MS` and `FAKEAGENT_SCENARIO_CODEX` — `cmd/fakeagent` and `internal/agent/codex` fail looking exactly like real regressions. The POSIX launch block is one-shot `env VAR=… vincent` now, and teardown tells pwsh how to clear its session.
   Also fixed while enumerating paste targets: the new-task form's key/value editor was missing from `capturesInput()`, so typing `q` into a field name quit the TUI.
+  *2026-08-10 (recorded runs — **GATE PASS**):* both walkthroughs re-walked on `master` at `40fbffe`, the first build carrying every shakeout fix, so the commit-SHA-per-run rule holds with one build for both. **Windows 11** (Windows Terminal/pwsh, plus Git Bash/mintty for S14's second host) and **macOS 26.5.2** (Ghostty 1.3.1), real `claude` 2.1.226 on the question leg, platform-default editor on each. Section A L1–L10 pass on both — the §19 loop completes without leaving the TUI — and Section B S1–S18 pass, with macOS reading S14 as its Ghostty equivalent since the two Windows hosts are the Windows run's item. No new findings in either recorded run; every earlier finding was re-checked against this build. Results tables in `docs/versions/v0/m3-gate.md`. Phase 3 closes at 13/13; T4.7 carries the only deferred item (naming what "(workflow default)" resolves to for model and effort, which the API does not report per step).
 
 **Phase 3 TUI refactor decisions (grill session, 2026-08-09):**
 

--- a/docs/versions/v0/tui-friction.md
+++ b/docs/versions/v0/tui-friction.md
@@ -3,6 +3,8 @@
 The "before" the panel refactor (T3.10–T3.13) is graded against. Every item here
 comes back as a checkbox in the T3.8 walkthrough, each carrying its disposition:
 **fixed**, **deferred** to a Phase 4 task ID, or **won't-fix** with a reason.
+Those dispositions are recorded — all twelve fixed — in
+[m3-gate.md](./m3-gate.md#friction-record-dispositions-t39).
 
 Written *before* the refactor on purpose. Without a fixed record, "is the TUI
 easier now?" is settled by whoever argues hardest in the PR thread — which is how


### PR DESCRIPTION
Records the T3.8 phase-gate results. Docs only — no code changes.

## What passed

Both walkthroughs were re-walked on `master` at `40fbffe`, the first build carrying every shakeout fix (mouse row hit-testing, paste routing, one-shot launch env), so the commit-SHA-per-run rule holds with **one** build for both runs.

| Run | Host | Section A | Section B | Verdict |
|---|---|---|---|---|
| Windows 11 | Windows Terminal/pwsh (+ Git Bash/mintty for S14's second host), `notepad` default editor | L1–L10 pass | S1–S18 pass | GATE PASS |
| macOS 26.5.2 (25F84) | Ghostty 1.3.1, `vi` default editor | L1–L10 pass | S1–S18 pass | GATE PASS |

Real `claude` 2.1.226 on the question leg in both. No new findings in either recorded run; every earlier shakeout finding was re-checked against this build. macOS reads S14 as its Ghostty equivalent — the two Windows hosts are the Windows run's item.

Linux keeps its coverage from CI: the full Go suite plus the M1 and M2 gates on every PR, all three OSes.

## Also in here

`tui-friction.md` required every pre-refactor finding to come back with a disposition, and nothing had paid that. `m3-gate.md` now carries an F1–F12 table — all twelve **fixed**, none deferred or won't-fix — with each one pinned to the sweep item that exercised it rather than to the mechanism's own PR. T4.7 stays the only deferred item and is not from that record: it needs the API to report §8.6 model and effort resolution per step.

The doc's header said both runs happen on the PR branch before it merges; corrected to say the shakeout runs did and the recorded runs were walked on `master` at `40fbffe`.

## Progress

T3.8 → `[x]`, Phase 3 13/13 ✅, total 38/45.