### PR TITLE
feat(api): POST /v1/resolve reports the §8.6 resolution (T4.7)

### DIFF
--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -875,6 +875,16 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         (shadowing applied); each entry:
                                         { name, scope, project_id, file, description, steps[], errors[]?, warnings[]?, error? }
 POST   /v1/workflows/validate           { yaml } → { valid, errors[], warnings[] }
+POST   /v1/resolve                      { workflow, project_id?, agent?, model?, effort? } →
+                                        { workflow, steps[] } — §8.6 applied to every step
+                                        under a candidate task-level override. Each agent
+                                        step carries { value, source } per field, source being
+                                        the winning level (step|task|workflow|adapter); non-agent
+                                        steps keep their index with null fields. An empty value
+                                        with source "adapter" means the adapter names no default
+                                        of its own — the CLI decides at run time.
+                                        Resolution is server-side only: clients report it,
+                                        never re-derive it (§8.6).
 
 GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=
                                         list rows additionally carry the §15 board fields:

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,8 +20,8 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
-| 4 — Polish (M4) | 7 tasks | 0/7 | ⬜ not started |
-| **Total** | | **38/45** | |
+| 4 — Polish (M4) | 7 tasks | 1/7 | 🚧 in progress |
+| **Total** | | **39/45** | |
 
 ---
 
@@ -587,5 +587,18 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
   *Done when:* tagged pre-release produces working artifacts installed and smoke-tested on each OS.
 - [ ] **T4.6 — Phase gate (M4 acceptance).** Fresh-machine (VM) timed test per §19 M4 on each OS; results recorded here.
   *Done when:* all three runs under 10 minutes; notes committed. **v1 complete.**
-- [ ] **T4.7 — Report the §8.6 model and effort resolution.** T3.8 finding (2026-08-10), narrowed: the **agent** side landed with the walkthrough fixes — the registry already reports each step's agent, so the new-task form names it. Model and effort have no such field on the wire, so "(workflow default)" is all the form can honestly say about them, and the workflow-step list still cannot name which adapter "adapter default" resolves to. Both need new read-only API surface, which relitigates the PR L decision that kept resolution server-side — do that explicitly, not by having the TUI re-implement §8.6.
+**PR T decisions (T4.7; grill session, 2026-08-10):**
+
+- *The endpoint is `POST /v1/resolve`, not a wider workflow DTO.* The two callers ask different questions: the registry listing asks what a step resolves to *as written*, the new-task form asks what it resolves to *under the overrides being typed* — and those overrides have no server-side existence until the task is created. A DTO field answers only the first. One endpoint with an empty override body answers both. **Spec addition** to §13.2.
+- *Provenance rides the resolver, not the handler.* `agent.Resolve` becomes a wrapper over a new `ResolveWithSources`, so the engine and the endpoint share one implementation of the precedence *and* one of the attribution. A handler that re-derived "which level won" would be the second §8.6 implementation this task exists to prevent.
+- *Level 4 is read from the adapter catalog,* through the same binary-identity cache `GET /v1/agents` uses, with `refresh=false` — resolving must never spawn a probe, because the form resolves on every override change. No adapter reports a `DefaultModel` today, so model and effort legitimately come back empty with source `adapter`; the form renders that as "CLI default" rather than inventing a model name. The seam is wired now so the day an adapter reports one, the form names it with no further change.
+- *Non-agent steps keep their index with null fields.* A resolution lines up positionally with the registry's own step list, which is what lets both renderers zip the two together without matching on ids.
+- *The TUI drops its registry-scanning `workflowAgents` entirely* rather than keeping it as a fallback. Two code paths producing the agent summary — one resolved, one derived — is exactly the drift this task closes. Before the reply lands the suffix is simply absent: "(workflow default)" alone is incomplete, never wrong.
+- *A resolution carries the draft it describes.* `resolveKey` (project, workflow, and the override triple) travels with the request and is compared on arrival: a reply for a draft the user has already moved past is dropped, and a failed one clears rather than leaves stale text naming the wrong model. The workflows view caches per scope+name and drops the cache on registry reload — the file that just changed is precisely the one whose resolution may have moved.
+- *The picker preview keeps the registry's wording.* Resolution belongs to the committed workflow; fetching one per highlighted option would be a request per cursor move. `renderWorkflowDetail` uses the resolution only when the name matches the committed draft.
+- *Unavailability checking grows to level-4 steps.* With a resolved agent in hand, a step naming no agent can finally be checked against adapter availability — "the default adapter is missing" is a warning that was impossible to give before, and the old comment saying such steps are "never accused" no longer applies.
+- *Proof is a live test, not a stub.* `TestWorkflowsViewNamesTheAdapterDefault` drives the real handlers through the real client; a stubbed resolution would only assert the TUI renders what it was handed, which was never in doubt. The new-task live test additionally asserts the form names the resolved agent and spells out the unnamed model.
+
+- [x] **T4.7 — Report the §8.6 model and effort resolution.** ✓ 2026-08-10 T3.8 finding (2026-08-10), narrowed: the **agent** side landed with the walkthrough fixes — the registry already reports each step's agent, so the new-task form names it. Model and effort have no such field on the wire, so "(workflow default)" is all the form can honestly say about them, and the workflow-step list still cannot name which adapter "adapter default" resolves to. Both need new read-only API surface, which relitigates the PR L decision that kept resolution server-side — do that explicitly, not by having the TUI re-implement §8.6.
   *Done when:* the model and effort rows name what an unset override resolves to, and a step with no agent names the adapter that will run it.
+  *2026-08-10:* landed per the PR T decisions above. `POST /v1/resolve` serves the per-step triple with its §8.6 source; `agent.ResolveWithSources` is the single implementation both the engine and the endpoint use. Verified: 12 handler tests (precedence, agent-scoped reset, level-4 naming, scope shadowing, null non-agent steps, error envelope), the resolver table extended to pin every field's source, TUI unit tests for the stale-reply and failed-reply guards, and two live tests against the real handlers.

--- a/internal/agent/resolve.go
+++ b/internal/agent/resolve.go
@@ -20,6 +20,29 @@ type Level struct {
 	Effort string
 }
 
+// Source names the §8.6 precedence level a resolved field came from. It is
+// what lets a client report *why* a step runs what it runs without
+// re-implementing the precedence (T4.7 decision).
+type Source string
+
+// The four §8.6 precedence levels, in order.
+const (
+	SourceStep     Source = "step"     // §8.6 level 1
+	SourceTask     Source = "task"     // §8.6 level 2
+	SourceWorkflow Source = "workflow" // §8.6 level 3
+	SourceAdapter  Source = "adapter"  // §8.6 level 4
+)
+
+// Sources reports the level each field of a Selection came from. A field no
+// level set is SourceAdapter — for Agent that means DefaultAgent, for model
+// and effort it means the adapter's own default (empty here; the catalog is
+// what can name it).
+type Sources struct {
+	Agent  Source
+	Model  Source
+	Effort Source
+}
+
 // Resolve applies the §8.6 precedence — explicit step field, then the
 // task-level override, then workflow defaults, then the adapter default
 // (empty, meaning the CLI decides).
@@ -28,9 +51,28 @@ type Level struct {
 // agent matches the step's resolved agent, so a claude alias never reaches
 // codex.
 func Resolve(step, override, defaults Level) Selection {
+	sel, _ := ResolveWithSources(step, override, defaults)
+	return sel
+}
+
+// ResolveWithSources is Resolve plus the provenance of each field. The engine
+// only needs the triple; the API's resolution endpoint (§13.2) needs to say
+// which level won, and both must come from one implementation or the two
+// answers drift.
+func ResolveWithSources(step, override, defaults Level) (Selection, Sources) {
 	// Level 4 of §8.6 is the adapter default; when no level names an agent at
 	// all, the daemon's default adapter runs the step.
 	resolved := firstNonEmpty(step.Agent, override.Agent, defaults.Agent, DefaultAgent)
+
+	src := Sources{Agent: SourceAdapter, Model: SourceAdapter, Effort: SourceAdapter}
+	switch {
+	case step.Agent != "":
+		src.Agent = SourceStep
+	case override.Agent != "":
+		src.Agent = SourceTask
+	case defaults.Agent != "":
+		src.Agent = SourceWorkflow
+	}
 
 	// Each level carries the agent it was written for; a level whose agent
 	// differs from the resolved one contributes nothing but its own agent
@@ -40,19 +82,25 @@ func Resolve(step, override, defaults Level) Selection {
 	inScope := func(levelAgent string) bool { return levelAgent == "" || levelAgent == resolved }
 
 	sel := Selection{Agent: resolved, Model: step.Model, Effort: step.Effort}
-	if sel.Model == "" && inScope(overrideAgent) {
-		sel.Model = override.Model
+	if sel.Model != "" {
+		src.Model = SourceStep
 	}
-	if sel.Model == "" && inScope(defaults.Agent) {
-		sel.Model = defaults.Model
+	if sel.Effort != "" {
+		src.Effort = SourceStep
 	}
-	if sel.Effort == "" && inScope(overrideAgent) {
-		sel.Effort = override.Effort
+	if sel.Model == "" && inScope(overrideAgent) && override.Model != "" {
+		sel.Model, src.Model = override.Model, SourceTask
 	}
-	if sel.Effort == "" && inScope(defaults.Agent) {
-		sel.Effort = defaults.Effort
+	if sel.Model == "" && inScope(defaults.Agent) && defaults.Model != "" {
+		sel.Model, src.Model = defaults.Model, SourceWorkflow
 	}
-	return sel
+	if sel.Effort == "" && inScope(overrideAgent) && override.Effort != "" {
+		sel.Effort, src.Effort = override.Effort, SourceTask
+	}
+	if sel.Effort == "" && inScope(defaults.Agent) && defaults.Effort != "" {
+		sel.Effort, src.Effort = defaults.Effort, SourceWorkflow
+	}
+	return sel, src
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/agent/resolve_test.go
+++ b/internal/agent/resolve_test.go
@@ -6,6 +6,10 @@ import "testing"
 // inheritance rule that keeps a claude alias away from codex. Moved from
 // taskrun with the resolver (T2.11); taskrun keeps a mapping test for its
 // wrapper.
+//
+// Every case also pins the *source* of each field (T4.7): the resolution
+// endpoint reports which level won, and a refactor that quietly re-attributes
+// a value would otherwise ship a form that misexplains a spend decision.
 func TestResolve(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -13,21 +17,25 @@ func TestResolve(t *testing.T) {
 		override Level
 		defaults Level
 		want     Selection
+		wantSrc  Sources
 	}{
 		{
-			name: "nothing declared falls back to the daemon default agent",
-			want: Selection{Agent: DefaultAgent},
+			name:    "nothing declared falls back to the daemon default agent",
+			want:    Selection{Agent: DefaultAgent},
+			wantSrc: Sources{SourceAdapter, SourceAdapter, SourceAdapter},
 		},
 		{
 			name:     "workflow defaults apply",
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "low"},
 			want:     Selection{Agent: "claude", Model: "sonnet", Effort: "low"},
+			wantSrc:  Sources{SourceWorkflow, SourceWorkflow, SourceWorkflow},
 		},
 		{
 			name:     "task override replaces workflow defaults",
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "low"},
 			override: Level{Agent: "claude", Model: "opus", Effort: "max"},
 			want:     Selection{Agent: "claude", Model: "opus", Effort: "max"},
+			wantSrc:  Sources{SourceTask, SourceTask, SourceTask},
 		},
 		{
 			name:     "explicit step fields beat the task override",
@@ -35,36 +43,42 @@ func TestResolve(t *testing.T) {
 			defaults: Level{Agent: "claude", Model: "sonnet"},
 			override: Level{Agent: "claude", Model: "opus", Effort: "max"},
 			want:     Selection{Agent: "claude", Model: "haiku", Effort: "low"},
+			wantSrc:  Sources{SourceStep, SourceStep, SourceStep},
 		},
 		{
 			name:     "a step pinning another agent does not inherit its model",
 			step:     Level{Agent: "codex"},
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "max"},
 			want:     Selection{Agent: "codex"},
+			wantSrc:  Sources{SourceStep, SourceAdapter, SourceAdapter},
 		},
 		{
 			name:     "a step pinning another agent keeps its own model and effort",
 			step:     Level{Agent: "codex", Effort: "high"},
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "max"},
 			want:     Selection{Agent: "codex", Effort: "high"},
+			wantSrc:  Sources{SourceStep, SourceAdapter, SourceStep},
 		},
 		{
 			name:     "a task override switching agent drops the workflow model",
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "max"},
 			override: Level{Agent: "codex"},
 			want:     Selection{Agent: "codex"},
+			wantSrc:  Sources{SourceTask, SourceAdapter, SourceAdapter},
 		},
 		{
 			name:     "a task override switching agent carries its own model",
 			defaults: Level{Agent: "claude", Model: "sonnet"},
 			override: Level{Agent: "codex", Model: "gpt-5.2"},
 			want:     Selection{Agent: "codex", Model: "gpt-5.2"},
+			wantSrc:  Sources{SourceTask, SourceTask, SourceAdapter},
 		},
 		{
 			name:     "a model-only task override rides the workflow agent",
 			defaults: Level{Agent: "claude", Model: "sonnet"},
 			override: Level{Model: "opus"},
 			want:     Selection{Agent: "claude", Model: "opus"},
+			wantSrc:  Sources{SourceWorkflow, SourceTask, SourceAdapter},
 		},
 		{
 			name:     "a model-only task override does not reach a step that switched agent",
@@ -72,12 +86,14 @@ func TestResolve(t *testing.T) {
 			defaults: Level{Agent: "claude"},
 			override: Level{Model: "opus"},
 			want:     Selection{Agent: "codex"},
+			wantSrc:  Sources{SourceStep, SourceAdapter, SourceAdapter},
 		},
 		{
 			name:     "workflow defaults fill what the task override leaves unset",
 			defaults: Level{Agent: "claude", Model: "sonnet", Effort: "low"},
 			override: Level{Effort: "max"},
 			want:     Selection{Agent: "claude", Model: "sonnet", Effort: "max"},
+			wantSrc:  Sources{SourceWorkflow, SourceWorkflow, SourceTask},
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +101,14 @@ func TestResolve(t *testing.T) {
 			got := Resolve(tt.step, tt.override, tt.defaults)
 			if got != tt.want {
 				t.Errorf("Resolve = %+v, want %+v", got, tt.want)
+			}
+			// Resolve is the thin wrapper, so the two must never disagree.
+			detailed, src := ResolveWithSources(tt.step, tt.override, tt.defaults)
+			if detailed != got {
+				t.Errorf("ResolveWithSources selection = %+v, Resolve = %+v", detailed, got)
+			}
+			if src != tt.wantSrc {
+				t.Errorf("sources = %+v, want %+v", src, tt.wantSrc)
 			}
 		})
 	}

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// resolveRequest is the POST /v1/resolve body (spec §13.2): a workflow, the
+// project whose scope resolves its name, and the task-level override triple
+// as it stands right now — which is the part no GET can serve, because those
+// overrides exist only in the form the user is still filling in.
+type resolveRequest struct {
+	Workflow  string `json:"workflow"`
+	ProjectID *int64 `json:"project_id,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Effort    string `json:"effort,omitempty"`
+}
+
+// resolvedField is one resolved §8.6 value plus the level that supplied it.
+// An empty value with source "adapter" is meaningful and honest: the adapter
+// reported no default of its own, so the CLI decides at run time.
+type resolvedField struct {
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+// resolvedStepResponse carries one step's resolution. Non-agent steps keep
+// their place in the list — indexes match the workflow listing — with null
+// fields, since agent/model/effort mean nothing for a command or a gate.
+type resolvedStepResponse struct {
+	ID     string         `json:"id"`
+	Name   string         `json:"name"`
+	Type   string         `json:"type"`
+	Agent  *resolvedField `json:"agent"`
+	Model  *resolvedField `json:"model"`
+	Effort *resolvedField `json:"effort"`
+}
+
+type resolveResponse struct {
+	Workflow string                 `json:"workflow"`
+	Steps    []resolvedStepResponse `json:"steps"`
+}
+
+// handleResolve serves POST /v1/resolve: §8.6 applied to every step of a
+// workflow under a candidate task-level override.
+//
+// It exists so no client re-implements the precedence. The registry listing
+// answers "what does this step say", which is a different question — a step
+// naming no agent resolves to level 4, and only the daemon holds both the
+// adapter catalog and the resolver needed to name it (T4.7 decision; the PR L
+// decision that resolution stays server-side is honored, not relitigated).
+func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
+	var req resolveRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	name := strings.TrimSpace(req.Workflow)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "workflow is required")
+		return
+	}
+	var projectID int64
+	if req.ProjectID != nil {
+		if *req.ProjectID < 1 {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				"project_id must be a positive integer")
+			return
+		}
+		if _, err := s.deps.Store.GetProject(r.Context(), *req.ProjectID); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				writeError(w, http.StatusNotFound, CodeNotFound,
+					fmt.Sprintf("project %d not found", *req.ProjectID))
+				return
+			}
+			s.internalError(w, "resolve: get project", err)
+			return
+		}
+		projectID = *req.ProjectID
+	}
+	entry, ok := s.deps.Workflows.Lookup(projectID, name)
+	if !ok {
+		writeError(w, http.StatusNotFound, CodeNotFound,
+			fmt.Sprintf("workflow %q not found for project %d", name, projectID))
+		return
+	}
+	if entry.Workflow == nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("workflow %q is invalid: %s", name, entry.Errors.Error()))
+		return
+	}
+
+	override := agent.Level{
+		Agent:  strings.TrimSpace(req.Agent),
+		Model:  strings.TrimSpace(req.Model),
+		Effort: strings.TrimSpace(req.Effort),
+	}
+	defaults := agent.Level{
+		Agent:  entry.Workflow.Defaults.Agent,
+		Model:  entry.Workflow.Defaults.Model,
+		Effort: entry.Workflow.Defaults.Effort,
+	}
+	out := resolveResponse{Workflow: entry.Name, Steps: []resolvedStepResponse{}}
+	for _, st := range entry.Workflow.Steps {
+		row := resolvedStepResponse{ID: st.ID, Name: st.DisplayName(), Type: st.Type}
+		if st.Type == workflow.StepAgent {
+			sel, src := agent.ResolveWithSources(
+				agent.Level{Agent: st.Agent, Model: st.Model, Effort: st.Effort},
+				override, defaults,
+			)
+			model, effort := s.adapterDefaults(r, sel)
+			row.Agent = &resolvedField{Value: sel.Agent, Source: string(src.Agent)}
+			row.Model = &resolvedField{Value: firstNonBlank(sel.Model, model), Source: string(src.Model)}
+			row.Effort = &resolvedField{Value: firstNonBlank(sel.Effort, effort), Source: string(src.Effort)}
+		}
+		out.Steps = append(out.Steps, row)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// adapterDefaults names §8.6 level 4 for the resolved agent: the model and
+// effort the adapter itself reports. It reads the binary-identity cache
+// without refreshing, so resolving a workflow never spawns a probe — this is
+// called on every keystroke-driven refresh of the new-task form.
+//
+// Both returns are "" when the adapter is unknown or reports no default of
+// its own, which stays a truthful level-4 answer: the CLI decides.
+func (s *Server) adapterDefaults(r *http.Request, sel agent.Selection) (model, effort string) {
+	if s.deps.Catalog == nil {
+		return "", ""
+	}
+	e, ok := s.deps.Catalog.Entry(r.Context(), sel.Agent, false)
+	if !ok {
+		return "", ""
+	}
+	return e.Options.DefaultModel, e.Options.DefaultEffort
+}

--- a/internal/api/resolve_test.go
+++ b/internal/api/resolve_test.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// newResolveHarness serves a registry that knows both adapters, so a workflow
+// may legally switch agents mid-list — the §8.6 agent-scoped inheritance case
+// the endpoint exists to get right.
+func newResolveHarness(t *testing.T) *workflowHarness {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	git := gitx.New()
+	wt := worktree.NewManager(git, t.TempDir())
+	globalDir := filepath.Join(t.TempDir(), "workflows")
+	reg := workflow.NewRegistry(globalDir,
+		workflow.Options{KnownAgents: []string{"claude", "codex"}}, nil)
+	s := New(Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+		Git:         git,
+		Worktrees:   wt,
+		Workflows:   reg,
+		OnProjectsChanged: func() {
+			projects, err := st.ListProjects(t.Context())
+			if err != nil {
+				return
+			}
+			roots := make(map[int64]string, len(projects))
+			for i := range projects {
+				roots[projects[i].ID] = projects[i].Path
+			}
+			reg.SetProjects(roots)
+		},
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return &workflowHarness{
+		projectHarness: &projectHarness{ts: ts, store: st, wt: wt},
+		reg:            reg,
+		globalDir:      globalDir,
+	}
+}
+
+func postResolve(t *testing.T, h *workflowHarness, body map[string]any) (*http.Response, resolveResponse) {
+	t.Helper()
+	resp, raw := h.doJSON(t, http.MethodPost, "/v1/resolve", body)
+	var out resolveResponse
+	if resp.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("resolve body not JSON: %v (%s)", err, raw)
+		}
+	}
+	return resp, out
+}
+
+// stepByID finds a resolved step, failing the test when the endpoint dropped
+// it — indexes lining up with the registry listing is part of the contract.
+func stepByID(t *testing.T, res resolveResponse, id string) resolvedStepResponse {
+	t.Helper()
+	for _, s := range res.Steps {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("step %q missing from resolution: %+v", id, res.Steps)
+	return resolvedStepResponse{}
+}
+
+func assertField(t *testing.T, got *resolvedField, wantValue, wantSource, what string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s: field is null, want %q from %q", what, wantValue, wantSource)
+	}
+	if got.Value != wantValue || got.Source != wantSource {
+		t.Errorf("%s = %q (from %q), want %q (from %q)",
+			what, got.Value, got.Source, wantValue, wantSource)
+	}
+}
+
+// resolveYAML has one step riding the defaults, one command step, and one
+// step pinning its own agent and model — the three shapes a form must render
+// differently.
+const resolveYAML = `name: mixed
+defaults:
+  agent: claude
+  model: sonnet
+  effort: high
+steps:
+  - {id: plan, type: agent, prompt: hi}
+  - {id: build, type: command, run: "echo hi"}
+  - {id: ship, type: agent, prompt: hi, agent: codex, model: gpt-5-codex}
+`
+
+func TestResolveWorkflowDefaultsAndStepPins(t *testing.T) {
+	h := newResolveHarness(t)
+	writeWorkflowFile(t, h.globalDir, "mixed", resolveYAML)
+	h.reg.ReloadGlobal()
+
+	resp, res := postResolve(t, h, map[string]any{"workflow": "mixed"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if res.Workflow != "mixed" || len(res.Steps) != 3 {
+		t.Fatalf("resolution = %+v, want three steps of mixed", res)
+	}
+
+	plan := stepByID(t, res, "plan")
+	assertField(t, plan.Agent, "claude", "workflow", "plan agent")
+	assertField(t, plan.Model, "sonnet", "workflow", "plan model")
+	assertField(t, plan.Effort, "high", "workflow", "plan effort")
+
+	// A step pinning its own agent takes level 1 for the fields it names and
+	// resets the rest: the workflow's claude-scoped effort must not reach codex.
+	ship := stepByID(t, res, "ship")
+	assertField(t, ship.Agent, "codex", "step", "ship agent")
+	assertField(t, ship.Model, "gpt-5-codex", "step", "ship model")
+	assertField(t, ship.Effort, "", "adapter", "ship effort")
+
+	// A command step keeps its place with nothing resolved.
+	build := stepByID(t, res, "build")
+	if build.Agent != nil || build.Model != nil || build.Effort != nil {
+		t.Errorf("command step carries a resolution: %+v", build)
+	}
+	if res.Steps[1].ID != "build" {
+		t.Errorf("step order = %v, want the registry's own order", res.Steps)
+	}
+}
+
+func TestResolveTaskOverrideReplacesWorkflowDefaults(t *testing.T) {
+	h := newResolveHarness(t)
+	writeWorkflowFile(t, h.globalDir, "mixed", resolveYAML)
+	h.reg.ReloadGlobal()
+
+	_, res := postResolve(t, h, map[string]any{"workflow": "mixed", "model": "opus"})
+	plan := stepByID(t, res, "plan")
+	assertField(t, plan.Agent, "claude", "workflow", "plan agent")
+	assertField(t, plan.Model, "opus", "task", "plan model")
+	// The step's own pin still wins over the task override (§8.6 level 1).
+	assertField(t, stepByID(t, res, "ship").Model, "gpt-5-codex", "step", "ship model")
+}
+
+// TestResolveOverrideSwitchingAgentResets is §8.6's agent-scoped inheritance:
+// an override that moves a step to codex must not carry claude's model along.
+func TestResolveOverrideSwitchingAgentResets(t *testing.T) {
+	h := newResolveHarness(t)
+	writeWorkflowFile(t, h.globalDir, "mixed", resolveYAML)
+	h.reg.ReloadGlobal()
+
+	_, res := postResolve(t, h, map[string]any{"workflow": "mixed", "agent": "codex"})
+	plan := stepByID(t, res, "plan")
+	assertField(t, plan.Agent, "codex", "task", "plan agent")
+	assertField(t, plan.Model, "", "adapter", "plan model")
+	assertField(t, plan.Effort, "", "adapter", "plan effort")
+}
+
+// TestResolveNamesTheAdapterDefault is the T4.7 finding itself: a workflow
+// naming no agent anywhere still runs *something*, and the registry listing
+// cannot say what. Resolution names it.
+func TestResolveNamesTheAdapterDefault(t *testing.T) {
+	h := newResolveHarness(t)
+	writeWorkflowFile(t, h.globalDir, "bare",
+		"name: bare\nsteps:\n  - {id: work, type: agent, prompt: hi}\n")
+	h.reg.ReloadGlobal()
+
+	_, res := postResolve(t, h, map[string]any{"workflow": "bare"})
+	work := stepByID(t, res, "work")
+	assertField(t, work.Agent, "claude", "adapter", "bare agent")
+	// No adapter reports a default model today, so level 4 is honestly empty:
+	// the CLI decides at run time, and the form says exactly that.
+	assertField(t, work.Model, "", "adapter", "bare model")
+}
+
+func TestResolveProjectScopeShadowing(t *testing.T) {
+	h := newResolveHarness(t)
+	repo := testrepo.Init(t, "main")
+	writeWorkflowFile(t, h.globalDir, "feature",
+		"name: feature\ndefaults:\n  agent: claude\nsteps:\n  - {id: a, type: agent, prompt: hi}\n")
+	writeWorkflowFile(t, filepath.Join(repo, workflow.ProjectDirName), "feature",
+		"name: feature\ndefaults:\n  agent: codex\nsteps:\n  - {id: a, type: agent, prompt: hi}\n")
+	h.reg.ReloadGlobal()
+	p := h.mustCreate(t, map[string]any{"path": repo})
+	id := int64(p["id"].(float64))
+
+	_, global := postResolve(t, h, map[string]any{"workflow": "feature"})
+	assertField(t, stepByID(t, global, "a").Agent, "claude", "workflow", "global scope agent")
+
+	_, scoped := postResolve(t, h, map[string]any{"workflow": "feature", "project_id": id})
+	assertField(t, stepByID(t, scoped, "a").Agent, "codex", "workflow", "project scope agent")
+}
+
+func TestResolveErrors(t *testing.T) {
+	h := newResolveHarness(t)
+	writeWorkflowFile(t, h.globalDir, "mixed", resolveYAML)
+	h.reg.ReloadGlobal()
+
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"no workflow", map[string]any{}, http.StatusBadRequest},
+		{"blank workflow", map[string]any{"workflow": "   "}, http.StatusBadRequest},
+		{"unknown workflow", map[string]any{"workflow": "nope"}, http.StatusNotFound},
+		{"bad project id", map[string]any{"workflow": "mixed", "project_id": 0}, http.StatusBadRequest},
+		{"missing project", map[string]any{"workflow": "mixed", "project_id": 4242}, http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, _ := postResolve(t, h, tc.body)
+			if resp.StatusCode != tc.want {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveRejectsGet keeps the §13.1 envelope on the wrong method: the
+// endpoint takes a body, so GET has to fail like every other POST route.
+func TestResolveRejectsGet(t *testing.T) {
+	h := newResolveHarness(t)
+	resp, _ := h.doJSON(t, http.MethodGet, "/v1/resolve", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,6 +138,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodDelete, "/v1/projects/{id}", s.handleProjectDelete)
 	rt.handle(http.MethodGet, "/v1/workflows", s.handleWorkflowList)
 	rt.handle(http.MethodPost, "/v1/workflows/validate", s.handleWorkflowValidate)
+	rt.handle(http.MethodPost, "/v1/resolve", s.handleResolve)
 	rt.handle(http.MethodGet, "/v1/tasks", s.handleTaskList)
 	rt.handle(http.MethodPost, "/v1/tasks", s.handleTaskCreate)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}", s.handleTaskGet)

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -65,8 +65,10 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 	return out
 }
 
-// agentOf reports the agent a step would use before task-level overrides
-// (§8.6 levels 1 and 3); the full resolution engine lands in T2.11.
+// agentOf reports the agent a step *names* — §8.6 levels 1 and 3 only, with
+// no override applied and level 4 left empty. That is deliberately the
+// registry's question ("what does this file say"); the resolved answer,
+// including the adapter default, is what POST /v1/resolve serves (T4.7).
 func agentOf(wf *workflow.Workflow, st workflow.Step) string {
 	if st.Type != workflow.StepAgent {
 		return ""

--- a/internal/apiclient/resolve.go
+++ b/internal/apiclient/resolve.go
@@ -1,0 +1,115 @@
+package apiclient
+
+import "context"
+
+// §8.6 precedence levels, as POST /v1/resolve reports them.
+const (
+	SourceStep     = "step"
+	SourceTask     = "task"
+	SourceWorkflow = "workflow"
+	SourceAdapter  = "adapter"
+)
+
+// ResolveRequest asks what a workflow's agent steps would run under a
+// candidate task-level override. Every field but Workflow is optional; an
+// empty override triple answers "as written".
+type ResolveRequest struct {
+	Workflow  string `json:"workflow"`
+	ProjectID *int64 `json:"project_id,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Effort    string `json:"effort,omitempty"`
+}
+
+// ResolvedField is one §8.6 value and the level that supplied it. Value is
+// empty only for a level-4 answer the adapter itself does not name, which
+// means the CLI picks at run time — display that, never a guessed model.
+type ResolvedField struct {
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+// FromAdapter reports whether this field fell all the way through to §8.6
+// level 4, which is the case a form has to phrase carefully.
+func (f ResolvedField) FromAdapter() bool { return f.Source == SourceAdapter }
+
+// ResolvedStep is one step's resolution. Agent, Model and Effort are nil for
+// non-agent steps, which keep their index so a resolution lines up with the
+// registry's own step list.
+type ResolvedStep struct {
+	ID     string         `json:"id"`
+	Name   string         `json:"name"`
+	Type   string         `json:"type"`
+	Agent  *ResolvedField `json:"agent"`
+	Model  *ResolvedField `json:"model"`
+	Effort *ResolvedField `json:"effort"`
+}
+
+// Resolution is POST /v1/resolve's answer for one workflow.
+type Resolution struct {
+	Workflow string         `json:"workflow"`
+	Steps    []ResolvedStep `json:"steps"`
+}
+
+// Agents lists the distinct resolved agents across the agent steps, in step
+// order. It is what a summary line names instead of "(workflow default)".
+func (r Resolution) Agents() []string {
+	var out []string
+	for _, s := range r.Steps {
+		if s.Agent == nil || s.Agent.Value == "" {
+			continue
+		}
+		if !containsString(out, s.Agent.Value) {
+			out = append(out, s.Agent.Value)
+		}
+	}
+	return out
+}
+
+// Values lists the distinct resolved values of one field across the agent
+// steps, in step order. unnamed reports whether some step resolved to a
+// level-4 answer the adapter does not name — the caller phrases that, since
+// "the CLI decides" reads differently per field.
+func (r Resolution) Values(field func(ResolvedStep) *ResolvedField) (values []string, unnamed bool) {
+	for _, s := range r.Steps {
+		f := field(s)
+		if f == nil {
+			continue
+		}
+		if f.Value == "" {
+			unnamed = true
+			continue
+		}
+		if !containsString(values, f.Value) {
+			values = append(values, f.Value)
+		}
+	}
+	return values, unnamed
+}
+
+// ModelOf is the Values selector for the model field; it exists so callers
+// name a field without writing a closure at every call site.
+func ModelOf(s ResolvedStep) *ResolvedField { return s.Model }
+
+// EffortOf is the Values selector for the effort field.
+func EffortOf(s ResolvedStep) *ResolvedField { return s.Effort }
+
+// Resolve applies §8.6 to every step of a workflow under the given override.
+// The daemon owns the precedence; this is the only way a client learns what
+// an unset override actually resolves to (T4.7).
+func (c *Client) Resolve(ctx context.Context, req ResolveRequest) (Resolution, error) {
+	var out Resolution
+	if err := c.post(ctx, "/v1/resolve", req, &out); err != nil {
+		return Resolution{}, err
+	}
+	return out, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -74,6 +74,14 @@ type (
 		entries   []apiclient.WorkflowEntry
 		err       error
 	}
+	// ntResolvedMsg carries POST /v1/resolve for one draft state. The key
+	// travels with it because the user keeps typing while it is in flight;
+	// a reply for a draft that has moved on is dropped, not rendered.
+	ntResolvedMsg struct {
+		key        resolveKey
+		resolution apiclient.Resolution
+		err        error
+	}
 	// ntDescriptionMsg carries the result of editing the description in
 	// $EDITOR.
 	ntDescriptionMsg struct {
@@ -125,6 +133,13 @@ type newTask struct {
 	mode     ntMode
 	pick     *picker
 	fieldsEd *fieldsEditor
+
+	// resolution is what the daemon says the committed draft would actually
+	// run, per §8.6 — fetched, never derived: the TUI must not own a second
+	// implementation of the precedence (PR L decision, T4.7). resolvedFor
+	// records the draft it describes, so a stale reply cannot be shown.
+	resolution  apiclient.Resolution
+	resolvedFor resolveKey
 
 	// rowErr is the daemon's complaint parked on the row it named.
 	rowErr map[ntRow]string
@@ -252,6 +267,75 @@ func (n *newTask) loadCmd(refresh bool) tea.Cmd {
 	}
 }
 
+// resolveKey identifies the draft state a resolution describes: everything
+// POST /v1/resolve takes as input. Equality is the whole point — a reply
+// whose key no longer matches the draft is discarded.
+type resolveKey struct {
+	projectID               int64
+	workflow                string
+	agent, model, effortSel string
+}
+
+func (n *newTask) resolveKey() resolveKey {
+	return resolveKey{
+		projectID: n.projectID,
+		workflow:  n.workflow,
+		agent:     n.agent,
+		model:     n.model,
+		effortSel: n.effort,
+	}
+}
+
+// resolveCmd asks the daemon what the current draft would run. It fires on
+// every change to the workflow or the override triple — five fields, one
+// cheap loopback call each, and the alternative is a form that says
+// "(workflow default)" about a spend decision (the T3.8 finding).
+func (n *newTask) resolveCmd() tea.Cmd {
+	client := n.client
+	key := n.resolveKey()
+	if client == nil || key.workflow == "" {
+		return nil
+	}
+	req := apiclient.ResolveRequest{
+		Workflow: key.workflow,
+		Agent:    key.agent,
+		Model:    key.model,
+		Effort:   key.effortSel,
+	}
+	if key.projectID != 0 {
+		req.ProjectID = ptr(key.projectID)
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		res, err := client.Resolve(ctx, req)
+		return ntResolvedMsg{key: key, resolution: res, err: err}
+	}
+}
+
+// applyResolution takes a reply only when it still describes the draft. A
+// failure clears the resolution rather than keeping a stale one: the summary
+// lines fall back to naming no resolved value, which is honest, where stale
+// text would name the wrong model.
+func (n *newTask) applyResolution(msg ntResolvedMsg) {
+	if msg.key != n.resolveKey() {
+		return
+	}
+	if msg.err != nil {
+		n.resolution, n.resolvedFor = apiclient.Resolution{}, resolveKey{}
+		return
+	}
+	n.resolution, n.resolvedFor = msg.resolution, msg.key
+}
+
+// resolved reports the resolution when it describes the draft on screen.
+func (n *newTask) resolved() (apiclient.Resolution, bool) {
+	if n.resolvedFor == (resolveKey{}) || n.resolvedFor != n.resolveKey() {
+		return apiclient.Resolution{}, false
+	}
+	return n.resolution, true
+}
+
 func (n *newTask) workflowsCmd(projectID int64) tea.Cmd {
 	client := n.client
 	if client == nil {
@@ -279,7 +363,11 @@ func (n *newTask) update(msg tea.Msg) (panel, tea.Cmd) {
 		if msg.projectID == n.projectID && msg.err == nil {
 			n.workflows = msg.entries
 			n.selectDefaultWorkflow()
+			return n, n.resolveCmd()
 		}
+		return n, nil
+	case ntResolvedMsg:
+		n.applyResolution(msg)
 		return n, nil
 	case ntDescriptionMsg:
 		n.applyDescription(msg)
@@ -334,7 +422,7 @@ func (n *newTask) applyLoaded(msg ntLoadedMsg) tea.Cmd {
 	if p, ok := n.project(); ok {
 		return n.workflowsCmd(p.ID)
 	}
-	return nil
+	return n.resolveCmd()
 }
 
 // selectDefaultProject prefers the project the caller was looking at, then
@@ -699,14 +787,23 @@ func (n *newTask) applyFailure(err error) {
 }
 
 // unavailableSteps lists the agent steps of a workflow whose resolved agent
-// is a known adapter that is not usable. A step with no agent resolves to
-// the adapter default (§8.6 level 4), which the registry cannot report, so
-// it is never accused.
+// is a known adapter that is not usable.
+//
+// With a resolution to hand, a step naming no agent is checked too: §8.6
+// level 4 still runs an adapter, and "the default one is missing" is exactly
+// the warning that used to be impossible to give. Without one, such a step
+// is reported, never accused — the registry cannot say what it resolves to.
 func (n *newTask) unavailableSteps(e apiclient.WorkflowEntry) []string {
+	res, resolved := n.resolved()
+	resolved = resolved && e.Name == n.workflow
 	var out []string
-	for _, s := range e.Steps {
-		if n.agents.Unavailable(s.Agent) {
-			out = append(out, fmt.Sprintf("%s → %s", firstNonEmpty(s.Name, s.ID), s.Agent))
+	for i, s := range e.Steps {
+		name := s.Agent
+		if resolved && i < len(res.Steps) && res.Steps[i].Agent != nil {
+			name = res.Steps[i].Agent.Value
+		}
+		if n.agents.Unavailable(name) {
+			out = append(out, fmt.Sprintf("%s → %s", firstNonEmpty(s.Name, s.ID), name))
 		}
 	}
 	return out

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -152,22 +152,69 @@ func TestNewTaskFallsBackToAdhocWithoutAProjectDefault(t *testing.T) {
 	}
 }
 
-// TestNewTaskNamesTheWorkflowDefaultAgent is a T3.8 finding: "(workflow
-// default)" told nobody which agent would run, and that is a spend
-// decision. The names come from the registry's own per-step report, so a
-// step naming none still reads as the adapter default rather than a guess.
+// resolveField is a resolved §8.6 value with its source, spelled short.
+func resolveField(value, source string) *apiclient.ResolvedField {
+	return &apiclient.ResolvedField{Value: value, Source: source}
+}
+
+// feedResolution delivers a daemon resolution for the form's current draft,
+// exactly as the command's reply arrives.
+func feedResolution(n *newTask, steps ...apiclient.ResolvedStep) {
+	n.update(ntResolvedMsg{
+		key:        n.resolveKey(),
+		resolution: apiclient.Resolution{Workflow: n.workflow, Steps: steps},
+	})
+}
+
+// twoStepResolution is what POST /v1/resolve says about the two-step
+// fixture: the third step names no agent and resolves to claude, and no
+// adapter reports a default model, so that field comes back empty.
+func twoStepResolution() []apiclient.ResolvedStep {
+	return []apiclient.ResolvedStep{
+		{
+			ID: "implement", Type: "agent",
+			Agent: resolveField("claude", apiclient.SourceStep),
+			Model: resolveField("sonnet", apiclient.SourceWorkflow),
+		},
+		{
+			ID: "review", Type: "agent",
+			Agent: resolveField("codex", apiclient.SourceStep),
+			Model: resolveField("", apiclient.SourceAdapter),
+		},
+		{
+			ID: "unset", Type: "agent",
+			Agent: resolveField("claude", apiclient.SourceAdapter),
+			Model: resolveField("sonnet", apiclient.SourceWorkflow),
+		},
+		{ID: "publish", Type: "command"},
+	}
+}
+
+// TestNewTaskNamesTheWorkflowDefaultAgent is a T3.8 finding closed by T4.7:
+// "(workflow default)" told nobody which agent would run, and that is a
+// spend decision. The names come from the daemon's resolution, so even a
+// step naming no agent is reported by name rather than as "adapter default".
 func TestNewTaskNamesTheWorkflowDefaultAgent(t *testing.T) {
 	n := loadedForm(t)
 	n.workflow = "two-step"
+
+	// Before the resolution lands the form says only what it knows.
+	if got := n.agentSummary(); strings.Contains(got, "→") {
+		t.Errorf("agent summary = %q, want no resolved names before the reply", got)
+	}
+	feedResolution(n, twoStepResolution()...)
 
 	summary := n.agentSummary()
 	if !strings.Contains(summary, "workflow default") {
 		t.Fatalf("agent summary = %q, want it to still say the workflow decides", summary)
 	}
-	for _, want := range []string{"codex", "adapter default"} {
+	for _, want := range []string{"claude", "codex"} {
 		if !strings.Contains(summary, want) {
 			t.Errorf("agent summary = %q, want it to name %q", summary, want)
 		}
+	}
+	if strings.Contains(summary, "adapter default") {
+		t.Errorf("agent summary = %q, want the resolved adapter named, not described", summary)
 	}
 	// The picker's own default row carries the same names.
 	opts := n.agentOptions()
@@ -178,20 +225,54 @@ func TestNewTaskNamesTheWorkflowDefaultAgent(t *testing.T) {
 		t.Errorf("default option note = %q, want the workflow's agents", opts[0].note)
 	}
 
+	// Model names what it resolves to, including the step whose adapter
+	// reports no default of its own — that one is the CLI's call at run time.
+	model := n.overrideSummary(n.model, apiclient.ModelOf)
+	for _, want := range []string{"workflow default", "sonnet", "CLI default"} {
+		if !strings.Contains(model, want) {
+			t.Errorf("model summary = %q, want it to name %q", model, want)
+		}
+	}
+
 	// An explicit override replaces it outright — no "(default)" noise.
 	n.agent = "claude"
 	if got := n.agentSummary(); got != "claude" {
 		t.Errorf("agent summary with an override = %q, want just the agent", got)
 	}
+}
 
-	// Model and effort stay unnamed: the registry does not report them per
-	// step, and inventing a value would be worse than saying nothing (T4.7).
-	n.model = ""
-	if got := n.overrideSummary(n.model); !strings.Contains(got, "workflow default") {
-		t.Errorf("model summary = %q", got)
+// TestNewTaskDropsAStaleResolution proves the key guard: a reply for a draft
+// the user has already moved past must not be rendered, or the form names
+// the model of a workflow nobody selected.
+func TestNewTaskDropsAStaleResolution(t *testing.T) {
+	n := loadedForm(t)
+	n.workflow = "two-step"
+	stale := ntResolvedMsg{
+		key: n.resolveKey(),
+		resolution: apiclient.Resolution{Workflow: "two-step", Steps: []apiclient.ResolvedStep{
+			{ID: "implement", Type: "agent", Agent: resolveField("codex", apiclient.SourceWorkflow)},
+		}},
 	}
-	if strings.Contains(n.overrideSummary(n.model), "→") {
-		t.Error("the model summary names a value the API never reported")
+	n.workflow = "adhoc" // the user moves on while the request is in flight
+	n.update(stale)
+	if got := n.agentSummary(); strings.Contains(got, "codex") {
+		t.Errorf("agent summary = %q, want the stale resolution ignored", got)
+	}
+}
+
+// TestNewTaskForgetsAFailedResolution: a resolution that errors clears what
+// was shown. Keeping the old triple would name a model for a workflow the
+// user has since changed.
+func TestNewTaskForgetsAFailedResolution(t *testing.T) {
+	n := loadedForm(t)
+	n.workflow = "two-step"
+	feedResolution(n, twoStepResolution()...)
+	if !strings.Contains(n.agentSummary(), "codex") {
+		t.Fatal("fixture did not take")
+	}
+	n.update(ntResolvedMsg{key: n.resolveKey(), err: errors.New("daemon said no")})
+	if got := n.agentSummary(); strings.Contains(got, "→") {
+		t.Errorf("agent summary = %q, want no names after a failed resolution", got)
 	}
 }
 
@@ -206,13 +287,47 @@ func TestNewTaskFlagsStepsNeedingAnUnavailableAgent(t *testing.T) {
 	if !strings.Contains(out, "⚠ unavailable") {
 		t.Errorf("workflow detail does not flag the codex step:\n%s", out)
 	}
-	// The step that names no agent resolves to §8.6 level 4, which the
-	// registry cannot report. Reporting it is fine; accusing it is not.
+	// Without a resolution the step that names no agent is reported, never
+	// accused: the registry cannot say what §8.6 level 4 resolves to.
 	if !strings.Contains(out, "adapter default") {
 		t.Errorf("unset agent not reported as the adapter default:\n%s", out)
 	}
 	if strings.Count(out, "⚠ unavailable") != 1 {
 		t.Errorf("more than one step flagged:\n%s", out)
+	}
+
+	// With one, the same step is named — and stays unflagged, because the
+	// adapter it resolves to is installed.
+	n.workflow = "two-step"
+	feedResolution(n, twoStepResolution()...)
+	out = strings.Join(n.renderWorkflowDetail("two-step"), "\n")
+	if strings.Contains(out, "adapter default") {
+		t.Errorf("resolved step still described instead of named:\n%s", out)
+	}
+	if strings.Count(out, "⚠ unavailable") != 1 {
+		t.Errorf("resolution changed which steps are flagged:\n%s", out)
+	}
+}
+
+// TestNewTaskFlagsAnUnavailableAdapterDefault is what the resolution buys:
+// a workflow naming no agent anywhere is now checkable, because the daemon
+// says which adapter would run it.
+func TestNewTaskFlagsAnUnavailableAdapterDefault(t *testing.T) {
+	n := loadedForm(t)
+	n.workflow = "two-step"
+	feedResolution(n,
+		apiclient.ResolvedStep{ID: "implement", Type: "agent", Agent: resolveField("claude", apiclient.SourceStep)},
+		apiclient.ResolvedStep{ID: "review", Type: "agent", Agent: resolveField("claude", apiclient.SourceStep)},
+		// The step naming no agent falls to an adapter that is not installed.
+		apiclient.ResolvedStep{ID: "unset", Type: "agent", Agent: resolveField("codex", apiclient.SourceAdapter)},
+		apiclient.ResolvedStep{ID: "publish", Type: "command"},
+	)
+	bad := n.unavailableSteps(*n.workflowEntry("two-step"))
+	if len(bad) != 1 || !strings.Contains(bad[0], "codex") {
+		t.Fatalf("unavailableSteps = %v, want the step whose adapter default is missing", bad)
+	}
+	if !strings.Contains(bad[0], "Whatever the adapter says") {
+		t.Errorf("flagged step = %q, want the one that names no agent", bad[0])
 	}
 }
 

--- a/internal/tui/newtasklive_test.go
+++ b/internal/tui/newtasklive_test.go
@@ -271,6 +271,22 @@ func TestNewTaskFlowCreatesRunnableTask(t *testing.T) {
 		t.Fatalf("workflow = %q, want the one just picked", n.workflow)
 	}
 
+	// T4.7: picking a workflow asks the daemon what the unset overrides
+	// resolve to, and the rows say so. The agent comes back named because the
+	// workflow's defaults name it; the model comes back unnamed because no
+	// adapter reports a default of its own — which is the CLI's call at run
+	// time, and the form says exactly that instead of guessing a model.
+	h.p.until(10*time.Second, "the resolution to arrive", func() bool {
+		_, ok := n.resolved()
+		return ok
+	})
+	if got := n.agentSummary(); !strings.Contains(got, "claude") {
+		t.Errorf("agent summary = %q, want the resolved agent named", got)
+	}
+	if got := n.overrideSummary(n.model, apiclient.ModelOf); !strings.Contains(got, "CLI default") {
+		t.Errorf("model summary = %q, want the unnamed adapter default spelled out", got)
+	}
+
 	moveTo(n, ntTitle)
 	h.sendKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 	h.typeText("wire the form")

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -262,8 +262,11 @@ func (n *newTask) applyPick(row ntRow, value string) tea.Cmd {
 	case ntEffort:
 		n.effort = value
 	case ntTitle, ntDescription, ntFields, ntBranch, ntPriority, ntCreate, ntRowCount:
+		return nil
 	}
-	return nil
+	// Every row that falls through here is a §8.6 input, so what the draft
+	// resolves to has just changed.
+	return n.resolveCmd()
 }
 
 func (n *newTask) projectOptions() []pickerOption {
@@ -300,7 +303,7 @@ func (n *newTask) agentOptions() []pickerOption {
 	out := []pickerOption{{
 		value: "",
 		label: "(workflow default)",
-		note:  strings.TrimPrefix(n.workflowAgents(), " → "),
+		note:  strings.TrimPrefix(n.resolvedAgents(), " → "),
 	}}
 	for _, a := range n.agents {
 		opt := pickerOption{value: a.Name, label: a.Name}

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/lezli01/vincent/internal/apiclient"
 )
 
 // ntLabels are the row captions, in row order.
@@ -113,9 +115,9 @@ func (n *newTask) rowValue(row ntRow) string {
 	case ntAgent:
 		return n.agentSummary()
 	case ntModel:
-		return n.overrideSummary(n.model)
+		return n.overrideSummary(n.model, apiclient.ModelOf)
 	case ntEffort:
-		return n.overrideSummary(n.effort)
+		return n.overrideSummary(n.effort, apiclient.EffortOf)
 	case ntCreate, ntRowCount:
 	}
 	return ""
@@ -155,61 +157,62 @@ func (n *newTask) descriptionSummary() string {
 }
 
 // overrideSummary states plainly that an unset override means the workflow
-// decides — the one thing §8.6 confusion turns into a wrong agent.
+// decides — the one thing §8.6 confusion turns into a wrong agent — and then
+// names what it decides. The names come from POST /v1/resolve, so the form
+// reports the daemon's own resolution instead of re-deriving §8.6 (T4.7).
 //
-// Model and effort stop at that: the registry reports each step's agent
-// (§8.6 levels 1 and 3) but not its model or effort, so naming those would
-// mean guessing. T4.7 is the task that exposes the resolution properly.
-func (n *newTask) overrideSummary(v string) string {
-	if v == "" {
-		return styleDim.Render("(workflow default)")
+// Until the resolution arrives (or when it failed) the suffix is simply
+// absent: "(workflow default)" alone is incomplete, never wrong.
+func (n *newTask) overrideSummary(v string, field func(apiclient.ResolvedStep) *apiclient.ResolvedField) string {
+	if v != "" {
+		return v
 	}
-	return v
+	return styleDim.Render("(workflow default" + n.resolvedSuffix(field) + ")")
 }
 
-// agentSummary names what "(workflow default)" actually means for the
-// selected workflow, which is the T3.8 finding: an unnamed default is a
-// spend decision nobody can review. The agents come from the registry's own
-// per-step report, not from the TUI re-implementing §8.6 — steps that name
-// none resolve to the adapter default, which the API cannot report and this
-// says so rather than inventing a name.
+// agentSummary is overrideSummary for the agent row. It exists separately
+// because an unresolved agent still names a value — §8.6 level 4 is the
+// daemon's default adapter, not "nothing".
 func (n *newTask) agentSummary() string {
 	if n.agent != "" {
 		return n.agent
 	}
-	return styleDim.Render("(workflow default" + n.workflowAgents() + ")")
+	return styleDim.Render("(workflow default" + n.resolvedAgents() + ")")
 }
 
-// workflowAgents renders the distinct agents the selected workflow's agent
-// steps name, in step order: " → claude", " → claude, codex" when they
-// differ, " → adapter default" when none does, and nothing at all when no
-// workflow is picked yet.
-func (n *newTask) workflowAgents() string {
-	e := n.workflowEntry(n.workflow)
-	if e == nil {
+// resolvedAgents renders the distinct agents the draft's agent steps resolve
+// to, in step order: " → claude", " → claude, codex" when they differ, and
+// nothing at all before the resolution lands or when the workflow has no
+// agent steps to run.
+func (n *newTask) resolvedAgents() string {
+	res, ok := n.resolved()
+	if !ok {
 		return ""
 	}
-	var names []string
-	adapterDefault := false
-	for _, s := range e.Steps {
-		if s.Type != "agent" {
-			continue
-		}
-		if s.Agent == "" {
-			adapterDefault = true
-			continue
-		}
-		if !contains(names, s.Agent) {
-			names = append(names, s.Agent)
-		}
-	}
-	if adapterDefault {
-		names = append(names, "adapter default")
-	}
+	names := res.Agents()
 	if len(names) == 0 {
 		return "" // a workflow with no agent steps: the override is moot
 	}
 	return " → " + strings.Join(names, ", ")
+}
+
+// resolvedSuffix is resolvedAgents for model and effort, where §8.6 level 4
+// may genuinely name nothing: an adapter that reports no default of its own
+// leaves the choice to the CLI at run time, and that is what gets rendered
+// rather than a guessed model name.
+func (n *newTask) resolvedSuffix(field func(apiclient.ResolvedStep) *apiclient.ResolvedField) string {
+	res, ok := n.resolved()
+	if !ok {
+		return ""
+	}
+	values, unnamed := res.Values(field)
+	if unnamed {
+		values = append(values, "CLI default")
+	}
+	if len(values) == 0 {
+		return ""
+	}
+	return " → " + strings.Join(values, ", ")
 }
 
 // renderExpansion draws whatever the focused row opened underneath it.
@@ -261,15 +264,22 @@ func (n *newTask) renderWorkflowDetail(name string) []string {
 	if e.Description != "" {
 		out = append(out, styleDim.Render("    "+e.Description))
 	}
+	// The resolution describes the *committed* workflow; the picker previews
+	// other entries, and those keep the registry's own text rather than a
+	// resolution fetched for a different draft.
+	res, resolved := n.resolved()
+	resolved = resolved && name == n.workflow
 	for i, s := range e.Steps {
 		agent := s.Agent
 		suffix := ""
+		if resolved && i < len(res.Steps) && res.Steps[i].Agent != nil {
+			agent = res.Steps[i].Agent.Value
+		}
 		switch {
 		case s.Type != "agent":
 			agent = ""
 		case agent == "":
-			// §8.6 level 4: the adapter's own default. The registry does not
-			// resolve it, so it is reported, never accused.
+			// §8.6 level 4 with no resolution to hand: reported, never accused.
 			agent = "adapter default"
 		case n.agents.Unavailable(agent):
 			suffix = "  " + styleWarn.Render("⚠ unavailable")

--- a/internal/tui/resolvelive_test.go
+++ b/internal/tui/resolvelive_test.go
@@ -1,0 +1,112 @@
+package tui
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// bareLiveYAML names no agent anywhere: the §8.6 level-4 case the registry
+// listing cannot answer.
+const bareLiveYAML = `name: bare
+description: One step, no agent named.
+steps:
+  - id: work
+    type: agent
+    prompt: do the thing
+`
+
+// TestWorkflowsViewNamesTheAdapterDefault is T4.7's done-when for the
+// registry view, proved against the real handlers: a step with no agent
+// names the adapter that will run it.
+//
+// It is a live test rather than a unit test because the whole point of the
+// task is that this answer belongs to the daemon — §8.6 resolution stays
+// server-side (PR L decision). A stubbed resolution would assert the TUI
+// renders what it was handed, which was never in doubt; what needed proving
+// is that the daemon and the client agree on the wire.
+func TestWorkflowsViewNamesTheAdapterDefault(t *testing.T) {
+	const token = "resolve-live-token"
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	broker := events.New()
+	t.Cleanup(broker.Close)
+	st.SetEventHook(broker.Publish)
+
+	repo := testrepo.Init(t, "main")
+	project := &store.Project{Name: "app", Path: repo, DefaultBranch: "main"}
+	if err := st.CreateProject(context.Background(), project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	globalDir := filepath.Join(t.TempDir(), "workflows")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	writeFile(t, filepath.Join(globalDir, "bare.yaml"), bareLiveYAML)
+
+	agents := agent.NewRegistry()
+	registry := workflow.NewRegistry(globalDir, workflow.Options{KnownAgents: agents.Names()}, nil)
+	registry.Reload()
+
+	s := api.New(api.Deps{
+		Token:       token,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+		Broker:      broker,
+		Git:         gitx.New(),
+		Agents:      agents,
+		Workflows:   registry,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+
+	m := newRoot(testCtx(t), liveConnector(t, ts.URL, token), ackedDir(t))
+	msg := runCmd(t, m.Init(), 10*time.Second)
+	if _, ok := msg.(connectedMsg); !ok {
+		t.Fatalf("probe = %T, want connectedMsg", msg)
+	}
+	_, cmd := m.Update(msg)
+	p := newPump(t, m, cmd)
+
+	_, cmd = m.Update(selectViewMsg{id: viewWorkflows})
+	p.push(cmd)
+	p.until(10*time.Second, "the bare workflow to reach the view", func() bool {
+		return strings.Contains(content(m), "bare")
+	})
+
+	// enter expands the entry under the cursor into its step list.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	p.push(cmd)
+	p.until(10*time.Second, "the resolved adapter to be named", func() bool {
+		return strings.Contains(content(m), "→ "+agent.DefaultAgent)
+	})
+	if strings.Contains(content(m), "adapter default") {
+		t.Errorf("the step is still described instead of named:\n%s", content(m))
+	}
+}

--- a/internal/tui/workflowrender.go
+++ b/internal/tui/workflowrender.go
@@ -122,12 +122,21 @@ func (w *workflowsView) renderSteps(line wfLine) []string {
 	for _, f := range e.Warnings {
 		out = append(out, styleWarn.Render("      ⚠ "+findingText(f)))
 	}
+	// The daemon's resolution names §8.6 level 4; the registry listing cannot
+	// (T4.7). Until it arrives the old wording stands — "adapter default" is
+	// incomplete, not wrong.
+	res := w.resolutionFor(line)
 	for i, s := range e.Steps {
 		label := firstNonEmpty(s.Name, s.ID)
 		row := fmt.Sprintf("      %d. %s  %s", i+1, label, styleDim.Render(s.Type))
-		if s.Agent != "" {
-			row += "  " + styleDim.Render("→ "+s.Agent)
-		} else if s.Type == "agent" {
+		name := s.Agent
+		if i < len(res.Steps) && res.Steps[i].Agent != nil {
+			name = res.Steps[i].Agent.Value
+		}
+		switch {
+		case name != "":
+			row += "  " + styleDim.Render("→ "+name)
+		case s.Type == "agent":
 			row += "  " + styleDim.Render("→ adapter default")
 		}
 		out = append(out, row)
@@ -136,6 +145,19 @@ func (w *workflowsView) renderSteps(line wfLine) []string {
 		out = append(out, styleDim.Render("      no steps"))
 	}
 	return out
+}
+
+// resolutionFor returns the cached resolution for a line, or the zero value
+// when none has arrived — callers index into Steps, which is empty then.
+func (w *workflowsView) resolutionFor(line wfLine) apiclient.Resolution {
+	if line.entry == nil {
+		return apiclient.Resolution{}
+	}
+	key := wfResolveKey{name: line.entry.Name}
+	if line.block != nil {
+		key.projectID = line.block.projectID
+	}
+	return w.resolutions[key]
 }
 
 // findingText prefixes a validation finding with its source line when the

--- a/internal/tui/workflows.go
+++ b/internal/tui/workflows.go
@@ -29,7 +29,21 @@ type (
 	// what the file now says reaches the view through the registry reload,
 	// which is the same path an external editor takes.
 	workflowEditedMsg struct{ err error }
+	// workflowResolvedMsg carries POST /v1/resolve for one expanded entry —
+	// which adapter each agent step would actually run (§8.6, T4.7).
+	workflowResolvedMsg struct {
+		key        wfResolveKey
+		resolution apiclient.Resolution
+		err        error
+	}
 )
+
+// wfResolveKey identifies an entry across scopes: the same name means
+// different files in the global block and in a project's own.
+type wfResolveKey struct {
+	projectID int64
+	name      string
+}
 
 // wfBlock is one scope's entries. The global block comes first and each
 // project follows in project-list order, because shadowing is a relationship
@@ -68,6 +82,11 @@ type workflowsView struct {
 	cursor   int
 	expanded bool
 	err      string
+
+	// resolutions caches what the daemon says each expanded entry resolves
+	// to, keyed by scope + name. A registry reload drops the cache: the file
+	// that just changed is exactly the one whose resolution may have moved.
+	resolutions map[wfResolveKey]apiclient.Resolution
 
 	refreshPending bool
 	width, height  int
@@ -178,6 +197,14 @@ func (w *workflowsView) update(msg tea.Msg) (panel, tea.Cmd) {
 		return w, w.loadCmd()
 	case workflowsLoadedMsg:
 		w.applyLoaded(msg)
+		return w, w.resolveCmd()
+	case workflowResolvedMsg:
+		if msg.err == nil {
+			if w.resolutions == nil {
+				w.resolutions = map[wfResolveKey]apiclient.Resolution{}
+			}
+			w.resolutions[msg.key] = msg.resolution
+		}
 		return w, nil
 	case workflowEditedMsg:
 		if msg.err != nil {
@@ -207,7 +234,39 @@ func (w *workflowsView) applyLoaded(msg workflowsLoadedMsg) {
 	w.loaded = true
 	w.lastLoad = w.now()
 	w.blocks = msg.blocks
+	// A reload is the one event that can change what a step resolves to, so
+	// nothing cached against the old registry survives it.
+	w.resolutions = nil
 	w.snapCursor()
+}
+
+// resolveCmd fetches the resolution for the entry under the cursor, once.
+// It is called when the cursor moves and when the registry reloads — the
+// step list only shows an expanded entry, but resolving on cursor movement
+// means the names are already there when it opens.
+func (w *workflowsView) resolveCmd() tea.Cmd {
+	client := w.client
+	line, ok := w.currentLine()
+	if client == nil || !ok {
+		return nil
+	}
+	key := wfResolveKey{name: line.entry.Name}
+	if line.block != nil {
+		key.projectID = line.block.projectID
+	}
+	if _, cached := w.resolutions[key]; cached {
+		return nil
+	}
+	req := apiclient.ResolveRequest{Workflow: key.name}
+	if key.projectID != 0 {
+		req.ProjectID = ptr(key.projectID)
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		res, err := client.Resolve(ctx, req)
+		return workflowResolvedMsg{key: key, resolution: res, err: err}
+	}
 }
 
 // snapCursor puts the cursor on a selectable line. Line 0 is always a scope
@@ -246,10 +305,13 @@ func (w *workflowsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	switch msg.String() {
 	case "up", "k":
 		w.moveCursor(-1)
+		return w, w.resolveCmd()
 	case "down", "j":
 		w.moveCursor(1)
+		return w, w.resolveCmd()
 	case "enter":
 		w.expanded = !w.expanded
+		return w, w.resolveCmd()
 	case "e":
 		return w, w.editCmd()
 	case "R":


### PR DESCRIPTION
PR **T** of Phase 4. Closes T4.7 — the T3.8 finding that the new-task form could not say what an unset override actually resolves to.

## The problem

The form said `(workflow default)` about model and effort, and a step naming no agent rendered as `adapter default` in two different views. Both are spend decisions nobody could review. The registry listing cannot answer either: §8.6 level 4 lives in the adapter catalog, and the task-level override the user is currently typing has no server-side existence at all.

## The shape

- **`agent.ResolveWithSources`** — `agent.Resolve` becomes a thin wrapper over it. The engine and the endpoint now share one implementation of the precedence *and* one of the attribution; a handler that re-derived "which level won" would be the second §8.6 implementation this task exists to prevent.
- **`POST /v1/resolve`** (`{workflow, project_id?, agent?, model?, effort?}`) → per-step `{value, source}` triples, `source` being `step|task|workflow|adapter`. Non-agent steps keep their index with null fields so a resolution zips positionally against the registry's step list. Level 4 is read through the same binary-identity cache `GET /v1/agents` uses, with `refresh=false` — resolving must never spawn a probe, because the form resolves on every override change.
- **`apiclient.Resolve`** plus `Resolution.Agents()` / `Values()` for the distinct-values-in-step-order rendering both views need.
- **TUI** — `workflowAgents` (the registry-scanning derivation) is deleted rather than kept as a fallback: two paths producing the same summary is the drift this closes. A `resolveKey` travels with each request so a reply for a draft the user has moved past is dropped, and a failed one clears rather than leaving text that names the wrong model. The workflows view caches per scope+name and drops the cache on registry reload.

## Worth knowing

No adapter reports a `DefaultModel` today, so model and effort legitimately resolve to empty with source `adapter`. The form renders that as **"CLI default"** rather than inventing a model name. The seam is wired now, so the day an adapter reports one it is named with no further change.

One capability falls out for free: with a resolved agent in hand, a step naming *no* agent can finally be checked against adapter availability. "The default adapter is missing" is a warning that was previously impossible to give.

## Verification

`go run mage.go lint test` clean.

- 12 handler tests: precedence, agent-scoped reset (a claude alias must not reach codex), level-4 naming, project-scope shadowing, null non-agent steps, the §13.1 error envelope on all five failure modes.
- The resolver's table now pins every field's *source* alongside its value, and asserts `Resolve` and `ResolveWithSources` can never disagree.
- TUI unit tests for the stale-reply and failed-reply guards.
- Two live tests against the real handlers through the real client: `TestWorkflowsViewNamesTheAdapterDefault` (the done-when for the registry view) and the new-task live flow asserting the form names the resolved agent and spells out the unnamed model. A stubbed resolution would only prove the TUI renders what it was handed, which was never in doubt.

Spec: §13.2 gains the endpoint, including the rule that resolution is server-side only.

Task IDs: T4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)