### PR TITLE
docs: record v0.1.0-rc1 and close T4.5

### DIFF
--- a/OUTSTANDING.md
+++ b/OUTSTANDING.md
@@ -1,0 +1,217 @@
+# Outstanding — actions that need you
+
+Everything in this file needs hardware, privileges, or judgement I do not have
+from a session on your Windows box. Nothing else is blocking.
+
+**How to use it:** fill in the blanks inline — dates, pass/fail, pasted output,
+free-text notes. When you are done (or done with any one section), tell me and
+I will fold the results into `docs/versions/v0/tasks.md`,
+`docs/versions/v0/m5-gate.md` and the spec, then delete this file.
+
+The four sections left are independent — take them in any order.
+
+> **Done: the release tag.** `v0.1.0-rc1`, 2026-08-11,
+> [run 31484132218](https://github.com/lezli01/vincent/actions/runs/31484132218).
+> Verified and recorded against **T4.5, now closed**. §1 below is the direct
+> beneficiary: the artifacts its clock starts from exist at
+> [the release page](https://github.com/lezli01/vincent/releases/tag/v0.1.0-rc1).
+
+---
+
+## 1. T4.6 — M4 acceptance: fresh machine to first completed task
+
+**Why you:** needs a clean VM per OS with **no Go toolchain** — that is what
+proves the released artifact self-sufficient.
+
+**The clock** starts at downloading the release artifact and stops at the first
+completed task. It **includes** Gatekeeper/SmartScreen friction (vincent's own
+cost) and **excludes** installing and authenticating the agent CLI (a
+documented prerequisite). Target: **under 10 minutes**.
+
+Walkthrough: download → unpack → `vincent project add` → copy an example
+workflow → `vincent task add` → watch it finish. The README quickstart is the
+script; deviating from it is itself a finding.
+
+| OS | Clean VM | Time taken | Under 10 min? | Notes |
+|---|---|---|---|---|
+| Windows 11 |  |  | ☐ yes ☐ no |  |
+| macOS |  |  | ☐ yes ☐ no |  |
+| Linux |  |  | ☐ yes ☐ no |  |
+
+Where the time actually went (this is the useful part — I can only act on
+specifics):
+
+```
+
+```
+
+---
+
+## 2. T4.1 — service install matrix
+
+**Why you:** requires a reboot per OS, and an elevated prompt on Windows.
+
+```sh
+vincent service install        # Windows: from an Administrator prompt
+vincent service status
+# reboot
+vincent service status         # must still report running
+vincent task ls                # must reach the daemon with no manual start
+vincent service uninstall
+vincent service status         # must report nothing installed
+```
+
+| OS | Installed | Survived reboot | Uninstalled cleanly | Notes |
+|---|---|---|---|---|
+| Windows 11 | ☐ | ☐ | ☐ |  |
+| macOS | ☐ | ☐ | ☐ |  |
+| Linux | ☐ | ☐ | ☐ |  |
+
+Linux only — did `loginctl enable-linger` succeed automatically, or did the
+installer print the manual command?
+
+```
+
+```
+
+If anything failed, the exact error:
+
+```
+
+```
+
+---
+
+## 3. T5.7 — M5 gate, the real-`cursor-agent` legs
+
+### 3a. Fix the Cursor hooks on this machine (blocks scenario 1)
+
+Two `pretooluse` hooks are registered in **PowerShell** syntax while
+`cursor-agent` runs hooks through **bash**, so every hook errors — and a hook
+that errors *blocks* the tool call. `cursor-agent` can currently think and read
+on this box but cannot edit or run anything.
+
+```
+Hook blocked: --: eval: line 1: syntax error near unexpected token `&'
+`$OutputEncoding = … | & { $input | npx -y context-mode hook cursor pretooluse }'
+`$OutputEncoding = … | & { $input | rtk hook claude }'
+```
+
+They come from the `context-mode` plugin and `rtk`, and are generated at
+runtime rather than stored in a config file I could point at.
+
+Confirm they are fixed:
+
+```sh
+cd "$(mktemp -d)" && git init -q && echo hi > readme.txt
+printf 'Create a file named hi.txt containing hello. Nothing else.' \
+  | cursor-agent -p --output-format stream-json --trust --force --model auto \
+  | grep -o '"rejected":{[^}]*}' | head
+```
+
+Any output means hooks are still blocking.
+
+- Hooks fixed: ☐ yes ☐ no — how: `____________________________________`
+- Probe above returns nothing: ☐ yes ☐ no
+
+Then re-run scenario 1 against the real CLI:
+
+```sh
+VINCENT_GATE_AGENT=cursor VINCENT_GATE_SCENARIO=1 ./scripts/m5-gate.sh
+```
+
+- Result: ☐ pass ☐ fail → output:
+
+  ```
+  
+  ```
+
+### 3b. macOS legs
+
+Scenarios 1, 2 and 4 on a Mac. Scenario 4 matters most: it is the **only**
+place `restricted` genuinely runs rather than being refused, and the refusal
+half has only ever been proven on Windows.
+
+```sh
+./scripts/m5-gate.sh                              # all four, fakeagent
+VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh    # real CLI (1 and 2)
+```
+
+| Leg | Result | Notes |
+|---|---|---|
+| All four, fakeagent | ☐ pass ☐ fail |  |
+| Scenario 1, real CLI | ☐ pass ☐ fail |  |
+| Scenario 2, real CLI | ☐ pass ☐ fail |  |
+| Scenario 4 — restricted actually runs | ☐ pass ☐ fail |  |
+
+cursor-agent version used: `________________`
+
+---
+
+## 4. T4.4 — read the quickstart cold
+
+**Why you:** I wrote it, so I cannot judge it. Ideally someone who has never
+seen vincent; you are the next best thing.
+
+Read [README.md](README.md) from **Install** through **Quickstart** and follow
+it exactly, without filling gaps from what you already know.
+
+- Could you get to a completed task without leaving the README? ☐ yes ☐ no
+- Where did you have to guess, backtrack, or look elsewhere?
+
+  ```
+  
+  ```
+
+- Did the full-auto warning land *before* you ran an agent? ☐ yes ☐ no
+- Anything that read as filler or as obviously written by someone who already
+  knew the answer:
+
+  ```
+  
+  ```
+
+---
+
+## 5. Two decisions I would like confirmed
+
+Neither blocks anything. Both are cheap to reverse **now** and awkward later.
+
+### 5a. `--model auto` overwrites your saved Cursor model
+
+Cursor persists `--model` to `~/.cursor/cli-config.json`, so vincent always
+passes one (defaulting to `auto`) to keep runs reproducible. The cost: every
+cursor step resets the model you picked in your own interactive
+`cursor-agent` sessions.
+
+- ☐ Keep it (reproducible runs, your interactive default gets reset)
+- ☐ Change it (pass `--model` only when §8.6 resolves one; a task's recorded
+  model then may not be what actually ran)
+- Notes:
+
+  ```
+  
+  ```
+
+### 5b. Re-capture the contaminated test fixture
+
+`internal/agent/cursor/testdata/tools_2026.08.04.jsonl` has **reconstructed**
+`tool_call/completed` payloads: the hooks in §3a rejected every tool call
+during capture. The `started` lines — the only ones the adapter normalises —
+are verbatim, and the file says so in its test header.
+
+Worth re-capturing once §3a is fixed?
+
+- ☐ Yes, re-capture from a clean run
+- ☐ No, the reconstruction is documented and sufficient
+
+---
+
+## Anything else you want picked up
+
+```
+
+
+
+
+```

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ follows the task breakdown:
   limits, docs and example workflows, signed release binaries): **in
   progress** — CLI subcommands, retention and limits, service install, the
   §8.6 resolution endpoint, release packaging, and the docs and example
-  workflows have landed. What remains is the M4 fresh-machine acceptance run
-  and the hand-run service-install matrix.
+  workflows have landed. **`v0.1.0-rc1` is the first pre-release**: signed,
+  checksummed, attested, and smoke-tested on all three OSes. What remains is
+  the M4 fresh-machine acceptance run and the hand-run service-install matrix.
 - **Phase 5 — the Cursor adapter** (post-v1): the adapter, its fakeagent
   dialect, config and registry wiring, windowed/filterable option pickers,
   `logged_in` reporting, the `scripts/m5-gate.sh` acceptance gate and an

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,9 +20,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
-| 4 — Polish (M4) | 7 tasks | 3/7 | 🚧 in progress |
+| 4 — Polish (M4) | 7 tasks | 4/7 | 🚧 in progress (T4.1/T4.4 code-complete pending manual sign-off; T4.6 now unblocked by `v0.1.0-rc1`) |
 | 5 — Cursor adapter (M5, post-v1) | 9 tasks | 8/9 | 🚧 in progress (only T5.7 open — needs macOS + a local hook fix) |
-| **Total** | | **49/54** | |
+| **Total** | | **50/54** | |
 
 ---
 
@@ -602,13 +602,14 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
   *README:* a Quickstart section walking register → workflow → task → approve, with the **full-auto warning as a callout at the point of first run** rather than only in the Security section near the bottom — a reader following Install → Quickstart meets the agent before they would ever reach it. Install landed with T4.5.
   *Walking my own quickstart found two real defects*, which is what the exercise is for: `vincent workflow ls` does not show project-scoped workflows without `--project` (the quickstart said otherwise), and **`vincent task show` printed a blank project** — `project_name` was on the list response only, so every client's `TaskDetail.ProjectName` was silently empty. Moved to the shared `taskResponse`, with a handler test asserting both endpoints agree and a CLI e2e assertion on the rendered row.
   **Remaining:** "a reviewer can follow the quickstart cold" needs a reviewer who is not its author. Every command in it is verified to run against a real daemon; whether the prose lands is a human call.
-- [~] **T4.5 — Release packaging.** goreleaser (or equivalent): versioned, signed binaries for all 3 OSes; checksums; install instructions per OS.
+- [x] **T4.5 — Release packaging.** ✓ 2026-08-11 goreleaser (or equivalent): versioned, signed binaries for all 3 OSes; checksums; install instructions per OS.
   *Done when:* tagged pre-release produces working artifacts installed and smoke-tested on each OS.
   *2026-08-11:* landed per the PR X decisions. `.goreleaser.yaml` builds six archives (linux/darwin/windows × amd64/arm64) from **one ubuntu runner** — the binaries are pure Go with `CGO_ENABLED=0`, so a build matrix would produce identical artifacts three times — plus `checksums.txt`, cosign **keyless** signatures over it, and `actions/attest-build-provenance` over every archive. `cmd/fakeagent` is deliberately excluded: it is test scaffolding and must never ship. The ldflags match the mage Build target's three symbols, so a released binary and a locally built one answer `vincent version` the same way. Distribution is GitHub Releases only — no tap, bucket or winget manifest.
   *`.github/workflows/release.yml`* runs on `v*` tags, with a `workflow_dispatch` dry run that builds a snapshot without publishing or signing. The per-OS `smoke` job is the done-when's other half: it unpacks the **real archive** and runs the **real binary** — `version` must report the tag rather than `dev`, `workflow validate` must accept the shipped example, and `task ls` must exit **2** with no daemon. Unpacking is what catches a broken archive layout, a missing execute bit, or a binary that will not start on the OS it was cross-compiled for.
   *Verified locally on Windows:* `goreleaser check` passes; a full `--snapshot` build produced all six archives; the Windows archive contains exactly `LICENSE`, `README.md`, `examples/cursor-review.yaml` and `vincent.exe`; the produced binary reports its injected version, validates the shipped example, and exits 2 with no daemon — the same three assertions the CI smoke job makes. (`checksums:` was the wrong key, caught by `goreleaser check` rather than at release time.)
   *README* gained the install section this task owes: per-OS unpack instructions, the `cosign verify-blob` incantation, and the Gatekeeper/SmartScreen prompts a user **will** meet, including `xattr -d com.apple.quarantine` — §19's ‡ note descoped OS code signing, so documenting the consequence is part of the deal.
-  **Remaining:** the done-when says *tagged* pre-release. Cutting a tag is the repo owner's call, and the signing and attestation steps only execute on a real tag push — the dry run deliberately skips them.
+  *2026-08-11 — done-when met.* **`v0.1.0-rc1`** cut by the owner ([run 31484132218](https://github.com/lezli01/vincent/actions/runs/31484132218)), the first execution of `release.yml` and therefore of the signing and attestation steps, which no PR build can reach. Verified independently of the report: the release carries **9 assets** (6 archives, `checksums.txt`, `.sig`, `.pem`), `isPrerelease: true` — so `prerelease: auto` read the `-rc1` suffix correctly — the run reports `release: success` plus **all three smoke jobs green** (ubuntu, windows, macos), and the Windows archive's digest resolves to an `application/vnd.in-toto+json` build attestation. Nothing unexpected reported.
+  *This unblocks T4.6:* the artifacts its ten-minute clock starts from now exist and are downloadable.
 - [ ] **T4.6 — Phase gate (M4 acceptance).** Fresh-machine (VM) timed test per §19 M4 on each OS; results recorded here.
   *Done when:* all three runs under 10 minutes; notes committed. **v1 complete.**
 **PR T decisions (T4.7; grill session, 2026-08-10):**


### PR DESCRIPTION
The owner cut `v0.1.0-rc1` — the first execution of `release.yml`, and
therefore the first time the signing and attestation steps have run at all. No
PR build can reach them, so until now they were config I had validated but
never seen execute.

## Verified independently, not recorded from the report

- Release published 2026-08-11T10:58:46Z with **9 assets**: six archives,
  `checksums.txt`, `checksums.txt.sig`, `checksums.txt.pem`.
- `isPrerelease: true` — `prerelease: auto` read the `-rc1` suffix correctly.
- [Run 31484132218](https://github.com/lezli01/vincent/actions/runs/31484132218):
  `release: success` plus all three smoke jobs green (ubuntu, windows, macos).
- The Windows archive's digest resolves to an `application/vnd.in-toto+json`
  build attestation.

**T4.5 closes.** Phase 4 is 4/7; total 50/54.

**T4.6 is unblocked** — the artifacts its ten-minute clock starts from now
exist and are downloadable, which was the only thing standing in its way.

## OUTSTANDING.md

Joins the repo tracked rather than sitting untracked in a working tree, now
that it carries a real recorded result. Its release section is replaced by a
pointer to what landed, and the remaining four sections are renumbered. It
gets deleted once they are all closed.
