### PR TITLE
fix: Windows testing findings — concurrent control requests and three docs defects (T4.8-T4.10)

### DIFF
--- a/OUTSTANDING.md
+++ b/OUTSTANDING.md
@@ -1,0 +1,217 @@
+# Outstanding — actions that need you
+
+Everything in this file needs hardware, privileges, or judgement I do not have
+from a session on your Windows box. Nothing else is blocking.
+
+**How to use it:** fill in the blanks inline — dates, pass/fail, pasted output,
+free-text notes. When you are done (or done with any one section), tell me and
+I will fold the results into `docs/versions/v0/tasks.md`,
+`docs/versions/v0/m5-gate.md` and the spec, then delete this file.
+
+The four sections left are independent — take them in any order.
+
+> **Done: the release tag.** `v0.1.0-rc1`, 2026-08-11,
+> [run 31484132218](https://github.com/lezli01/vincent/actions/runs/31484132218).
+> Verified and recorded against **T4.5, now closed**. §1 below is the direct
+> beneficiary: the artifacts its clock starts from exist at
+> [the release page](https://github.com/lezli01/vincent/releases/tag/v0.1.0-rc1).
+
+---
+
+## 1. T4.6 — M4 acceptance: fresh machine to first completed task
+
+**Why you:** needs a clean VM per OS with **no Go toolchain** — that is what
+proves the released artifact self-sufficient.
+
+**The clock** starts at downloading the release artifact and stops at the first
+completed task. It **includes** Gatekeeper/SmartScreen friction (vincent's own
+cost) and **excludes** installing and authenticating the agent CLI (a
+documented prerequisite). Target: **under 10 minutes**.
+
+Walkthrough: download → unpack → `vincent project add` → copy an example
+workflow → `vincent task add` → watch it finish. The README quickstart is the
+script; deviating from it is itself a finding.
+
+| OS | Clean VM | Time taken | Under 10 min? | Notes |
+|---|---|---|---|---|
+| Windows 11 |  |  | ☐ yes ☐ no |  |
+| macOS |  |  | ☐ yes ☐ no |  |
+| Linux |  |  | ☐ yes ☐ no |  |
+
+Where the time actually went (this is the useful part — I can only act on
+specifics):
+
+```
+
+```
+
+---
+
+## 2. T4.1 — service install matrix
+
+**Why you:** requires a reboot per OS, and an elevated prompt on Windows.
+
+```sh
+vincent service install        # Windows: from an Administrator prompt
+vincent service status
+# reboot
+vincent service status         # must still report running
+vincent task ls                # must reach the daemon with no manual start
+vincent service uninstall
+vincent service status         # must report nothing installed
+```
+
+| OS | Installed | Survived reboot | Uninstalled cleanly | Notes |
+|---|---|---|---|---|
+| Windows 11 | ☐ | ☐ | ☐ |  |
+| macOS | ☐ | ☐ | ☐ |  |
+| Linux | ☐ | ☐ | ☐ |  |
+
+Linux only — did `loginctl enable-linger` succeed automatically, or did the
+installer print the manual command?
+
+```
+
+```
+
+If anything failed, the exact error:
+
+```
+
+```
+
+---
+
+## 3. T5.7 — M5 gate, the real-`cursor-agent` legs
+
+### 3a. Fix the Cursor hooks on this machine (blocks scenario 1)
+
+Two `pretooluse` hooks are registered in **PowerShell** syntax while
+`cursor-agent` runs hooks through **bash**, so every hook errors — and a hook
+that errors *blocks* the tool call. `cursor-agent` can currently think and read
+on this box but cannot edit or run anything.
+
+```
+Hook blocked: --: eval: line 1: syntax error near unexpected token `&'
+`$OutputEncoding = … | & { $input | npx -y context-mode hook cursor pretooluse }'
+`$OutputEncoding = … | & { $input | rtk hook claude }'
+```
+
+They come from the `context-mode` plugin and `rtk`, and are generated at
+runtime rather than stored in a config file I could point at.
+
+Confirm they are fixed:
+
+```sh
+cd "$(mktemp -d)" && git init -q && echo hi > readme.txt
+printf 'Create a file named hi.txt containing hello. Nothing else.' \
+  | cursor-agent -p --output-format stream-json --trust --force --model auto \
+  | grep -o '"rejected":{[^}]*}' | head
+```
+
+Any output means hooks are still blocking.
+
+- Hooks fixed: ☐ yes ☐ no — how: `____________________________________`
+- Probe above returns nothing: ☐ yes ☐ no
+
+Then re-run scenario 1 against the real CLI:
+
+```sh
+VINCENT_GATE_AGENT=cursor VINCENT_GATE_SCENARIO=1 ./scripts/m5-gate.sh
+```
+
+- Result: ☐ pass ☐ fail → output:
+
+  ```
+  
+  ```
+
+### 3b. macOS legs
+
+Scenarios 1, 2 and 4 on a Mac. Scenario 4 matters most: it is the **only**
+place `restricted` genuinely runs rather than being refused, and the refusal
+half has only ever been proven on Windows.
+
+```sh
+./scripts/m5-gate.sh                              # all four, fakeagent
+VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh    # real CLI (1 and 2)
+```
+
+| Leg | Result | Notes |
+|---|---|---|
+| All four, fakeagent | ☐ pass ☐ fail |  |
+| Scenario 1, real CLI | ☐ pass ☐ fail |  |
+| Scenario 2, real CLI | ☐ pass ☐ fail |  |
+| Scenario 4 — restricted actually runs | ☐ pass ☐ fail |  |
+
+cursor-agent version used: `________________`
+
+---
+
+## 4. T4.4 — read the quickstart cold
+
+**Why you:** I wrote it, so I cannot judge it. Ideally someone who has never
+seen vincent; you are the next best thing.
+
+Read [README.md](README.md) from **Install** through **Quickstart** and follow
+it exactly, without filling gaps from what you already know.
+
+- Could you get to a completed task without leaving the README? ☐ yes ☐ no
+- Where did you have to guess, backtrack, or look elsewhere?
+
+  ```
+  
+  ```
+
+- Did the full-auto warning land *before* you ran an agent? ☐ yes ☐ no
+- Anything that read as filler or as obviously written by someone who already
+  knew the answer:
+
+  ```
+  
+  ```
+
+---
+
+## 5. Two decisions I would like confirmed
+
+Neither blocks anything. Both are cheap to reverse **now** and awkward later.
+
+### 5a. `--model auto` overwrites your saved Cursor model
+
+Cursor persists `--model` to `~/.cursor/cli-config.json`, so vincent always
+passes one (defaulting to `auto`) to keep runs reproducible. The cost: every
+cursor step resets the model you picked in your own interactive
+`cursor-agent` sessions.
+
+- ☐ Keep it (reproducible runs, your interactive default gets reset)
+- ☐ Change it (pass `--model` only when §8.6 resolves one; a task's recorded
+  model then may not be what actually ran)
+- Notes:
+
+  ```
+  
+  ```
+
+### 5b. Re-capture the contaminated test fixture
+
+`internal/agent/cursor/testdata/tools_2026.08.04.jsonl` has **reconstructed**
+`tool_call/completed` payloads: the hooks in §3a rejected every tool call
+during capture. The `started` lines — the only ones the adapter normalises —
+are verbatim, and the file says so in its test header.
+
+Worth re-capturing once §3a is fixed?
+
+- ☐ Yes, re-capture from a clean run
+- ☐ No, the reconstruction is documented and sufficient
+
+---
+
+## Anything else you want picked up
+
+```
+
+
+
+
+```

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ follows the task breakdown:
   limits, docs and example workflows, signed release binaries): **in
   progress** — CLI subcommands, retention and limits, service install, the
   §8.6 resolution endpoint, release packaging, and the docs and example
-  workflows have landed. What remains is the M4 fresh-machine acceptance run
-  and the hand-run service-install matrix.
+  workflows have landed. **`v0.1.0-rc1` is the first pre-release**: signed,
+  checksummed, attested, and smoke-tested on all three OSes. What remains is
+  the M4 fresh-machine acceptance run and the hand-run service-install matrix.
 - **Phase 5 — the Cursor adapter** (post-v1): the adapter, its fakeagent
   dialect, config and registry wiring, windowed/filterable option pickers,
   `logged_in` reporting, the `scripts/m5-gate.sh` acceptance gate and an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/logo.png" alt="vincent" width="520">
+  <img src="https://raw.githubusercontent.com/lezli01/vincent/master/docs/assets/logo.png" alt="vincent" width="520">
 </p>
 
 <p align="center">
@@ -233,14 +233,33 @@ vincent project add /path/to/your/repo
 vincent project ls
 ```
 
-**2. Add a workflow.** Copy one of the shipped examples into the repo, so it
-travels with it:
+**2. Add a workflow.** Two places to put one:
+
+- **Global** — available to every project. Drop it in the `workflows/` folder
+  of your config directory:
+  `%APPDATA%\vincent\workflows\` (Windows),
+  `~/Library/Application Support/vincent/workflows/` (macOS),
+  `~/.config/vincent/workflows/` (Linux).
+- **Project** — travels with the repo, and shadows a global file of the same
+  name: `.vincent/workflows/` inside the repo.
+
+Either way the daemon picks it up on save; there is no restart or apply step.
+Global is the easier start:
 
 ```sh
-mkdir -p /path/to/your/repo/.vincent/workflows
-cp examples/feature-pr.yaml /path/to/your/repo/.vincent/workflows/
-vincent workflow validate /path/to/your/repo/.vincent/workflows/feature-pr.yaml
-vincent workflow ls --project 1        # project-scoped files need --project
+# Windows (PowerShell)
+mkdir -Force $env:APPDATA\vincent\workflows
+copy examples\feature-pr.yaml $env:APPDATA\vincent\workflows\
+
+# macOS / Linux
+mkdir -p ~/.config/vincent/workflows          # macOS: ~/Library/Application\ Support/vincent/workflows
+cp examples/feature-pr.yaml ~/.config/vincent/workflows/
+```
+
+```sh
+vincent workflow validate examples/feature-pr.yaml
+vincent workflow ls              # global + built-in
+vincent workflow ls --project 1  # add this project's own .vincent/workflows
 ```
 
 `feature-pr` runs an agent, checks that the result still builds and passes

--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -339,8 +339,18 @@ Behavior with `on_input: wait` (the default):
 3. The engineer answers via `POST /v1/tasks/{id}/answer` or the TUI answer form
    (§15). The adapter translates the answer back to its native protocol and
    writes it to the live process; the task returns to `running` and the step
-   clock resumes. Requests are serial — an agent blocks on its pending request,
-   so at most one `pending_input` exists per task.
+   clock resumes. **At most one `pending_input` exists per task**, because a
+   task has one `awaiting_input` state.
+
+   That is enforced by the *adapter*, not assumed of the CLI. The original
+   wording said requests were serial because an agent blocks on its pending
+   request; real claude disproves it — it batches parallel tool calls, so a
+   restricted run can raise several `can_use_tool` requests at once. Treating
+   the second as a protocol violation failed live runs (Windows testing,
+   2026-08-11). An adapter that receives a concurrent request now **queues**
+   it, transcripts it verbatim, and surfaces it when the current one is
+   answered — the CLI is blocked on both, so nothing else would ever carry
+   it. Clients and the engine are unchanged: they still see one at a time.
 
 `on_input: deny` (workflow `defaults` or per step) keeps runs strictly unattended:
 vincent immediately auto-responds through the adapter's `Respond()` — questions
@@ -548,7 +558,7 @@ type RunHandle interface {
     Kill() error
 }
 
-type InputRequest struct {          // §7.4; at most one pending per run
+type InputRequest struct {          // §7.4; one surfaced at a time, adapter-queued
     Kind       string           // "question" | "permission"
     Questions  []Question       // kind=question: one or more structured questions
     Permission *PermissionReq   // kind=permission: tool name + action summary

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,9 +20,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
-| 4 — Polish (M4) | 7 tasks | 4/7 | 🚧 in progress (T4.1/T4.4 code-complete pending manual sign-off; T4.6 now unblocked by `v0.1.0-rc1`) |
+| 4 — Polish (M4) | 11 tasks | 7/11 | 🚧 in progress (T4.8–T4.10 from Windows testing; T4.11 open; T4.1/T4.4 pending manual sign-off) |
 | 5 — Cursor adapter (M5, post-v1) | 9 tasks | 8/9 | 🚧 in progress (only T5.7 open — needs macOS + a local hook fix) |
-| **Total** | | **50/54** | |
+| **Total** | | **53/58** | |
 
 ---
 
@@ -623,6 +623,18 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
 - *The picker preview keeps the registry's wording.* Resolution belongs to the committed workflow; fetching one per highlighted option would be a request per cursor move. `renderWorkflowDetail` uses the resolution only when the name matches the committed draft.
 - *Unavailability checking grows to level-4 steps.* With a resolved agent in hand, a step naming no agent can finally be checked against adapter availability — "the default adapter is missing" is a warning that was impossible to give before, and the old comment saying such steps are "never accused" no longer applies.
 - *Proof is a live test, not a stub.* `TestWorkflowsViewNamesTheAdapterDefault` drives the real handlers through the real client; a stubbed resolution would only assert the TUI renders what it was handed, which was never in doubt. The new-task live test additionally asserts the form names the resolved agent and spells out the unnamed model.
+
+**Windows testing findings (owner, 2026-08-11).** Five reports from a real run on Windows 11 against the `v0.1.0-rc1` artifact. Three were my own doing, two were genuine defects:
+
+- [x] **T4.8 — Concurrent control requests killed live claude runs.** ✓ 2026-08-11 §7.4 asserted requests were serial "because an agent blocks on its pending request". Real claude disproves it: it batches parallel tool calls, so a restricted run raises several `can_use_tool` requests at once, and the adapter failed the attempt on the second with `input_protocol_error`. **No fixture could have caught this** — `cmd/fakeagent` only ever emits one, which is exactly the assumption under test. The adapter now **queues** concurrent requests and promotes the next when the current one is answered; the engine and clients still see one at a time, because a task has one `awaiting_input` state. Delivery needed a mux goroutine: `readLoop` owns and closes the events channel, and the CLI is blocked on *both* requests so no later stream line would ever carry the second. Spec §7.4 rewritten — the serialization is the adapter's job, not a promise the CLI keeps.
+  *Verified:* the old "second request is a violation" test replaced by one asserting the queue, plus a promotion test that fails if the queued request is never surfaced (the shape that would hang a real run).
+
+- [x] **T4.9 — The shipped `docs-update` example set `permission_mode: restricted`.** ✓ 2026-08-11 Two of the five reports were this one example: cursor **refused every step on Windows** (no sandbox, §9.4) and claude **prompted for permission on every non-allowlisted tool** — both correct behavior for restricted, and both read as bugs to someone who never asked for it. A shipped example is copied on day one; demonstrating an edge case that breaks one adapter on one OS is a bad trade. Now full-auto like the others, with the restricted opt-in documented in a comment and in `docs/workflows.md`. The engine's default was never wrong: `resolvePermission` returns `FullAuto` for anything unset.
+
+- [x] **T4.10 — README: archive logo and global workflows.** ✓ 2026-08-11 The README inside a release archive rendered no logo — it referenced `docs/assets/logo.png`, which the archive does not carry — so the image is now an absolute raw URL that works in the repo, in the archive, and anywhere else the file travels. The quickstart also only documented **project-scoped** workflows; it now names the config-dir location per OS, states that project scope shadows global, and shows both.
+
+- [ ] **T4.11 — The TUI cannot show a full transcript.** The detail view fetches a bounded *tail* (`DefaultTailBytes`, capped at `maxRecords`) with no way to page back, so a failed step cannot be diagnosed from the TUI — which is where a user is when it fails. The transcript on disk is the complete record and the ranged endpoint already serves it; only the UI is missing. Partial mitigation shipped: `vincent task show` now prints each attempt's transcript path.
+  *Done when:* a step's whole transcript is reachable from the detail view — scrollback, or `$EDITOR`/pager the way `e` already opens a workflow file.
 
 - [x] **T4.7 — Report the §8.6 model and effort resolution.** ✓ 2026-08-10 T3.8 finding (2026-08-10), narrowed: the **agent** side landed with the walkthrough fixes — the registry already reports each step's agent, so the new-task form names it. Model and effort have no such field on the wire, so "(workflow default)" is all the form can honestly say about them, and the workflow-step list still cannot name which adapter "adapter default" resolves to. Both need new read-only API surface, which relitigates the PR L decision that kept resolution server-side — do that explicitly, not by having the TUI re-implement §8.6.
   *Done when:* the model and effort rows name what an unset override resolves to, and a step with no agent names the adapter that will run it.

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,9 +20,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
-| 4 — Polish (M4) | 7 tasks | 3/7 | 🚧 in progress |
+| 4 — Polish (M4) | 7 tasks | 4/7 | 🚧 in progress (T4.1/T4.4 code-complete pending manual sign-off; T4.6 now unblocked by `v0.1.0-rc1`) |
 | 5 — Cursor adapter (M5, post-v1) | 9 tasks | 8/9 | 🚧 in progress (only T5.7 open — needs macOS + a local hook fix) |
-| **Total** | | **49/54** | |
+| **Total** | | **50/54** | |
 
 ---
 
@@ -602,13 +602,14 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
   *README:* a Quickstart section walking register → workflow → task → approve, with the **full-auto warning as a callout at the point of first run** rather than only in the Security section near the bottom — a reader following Install → Quickstart meets the agent before they would ever reach it. Install landed with T4.5.
   *Walking my own quickstart found two real defects*, which is what the exercise is for: `vincent workflow ls` does not show project-scoped workflows without `--project` (the quickstart said otherwise), and **`vincent task show` printed a blank project** — `project_name` was on the list response only, so every client's `TaskDetail.ProjectName` was silently empty. Moved to the shared `taskResponse`, with a handler test asserting both endpoints agree and a CLI e2e assertion on the rendered row.
   **Remaining:** "a reviewer can follow the quickstart cold" needs a reviewer who is not its author. Every command in it is verified to run against a real daemon; whether the prose lands is a human call.
-- [~] **T4.5 — Release packaging.** goreleaser (or equivalent): versioned, signed binaries for all 3 OSes; checksums; install instructions per OS.
+- [x] **T4.5 — Release packaging.** ✓ 2026-08-11 goreleaser (or equivalent): versioned, signed binaries for all 3 OSes; checksums; install instructions per OS.
   *Done when:* tagged pre-release produces working artifacts installed and smoke-tested on each OS.
   *2026-08-11:* landed per the PR X decisions. `.goreleaser.yaml` builds six archives (linux/darwin/windows × amd64/arm64) from **one ubuntu runner** — the binaries are pure Go with `CGO_ENABLED=0`, so a build matrix would produce identical artifacts three times — plus `checksums.txt`, cosign **keyless** signatures over it, and `actions/attest-build-provenance` over every archive. `cmd/fakeagent` is deliberately excluded: it is test scaffolding and must never ship. The ldflags match the mage Build target's three symbols, so a released binary and a locally built one answer `vincent version` the same way. Distribution is GitHub Releases only — no tap, bucket or winget manifest.
   *`.github/workflows/release.yml`* runs on `v*` tags, with a `workflow_dispatch` dry run that builds a snapshot without publishing or signing. The per-OS `smoke` job is the done-when's other half: it unpacks the **real archive** and runs the **real binary** — `version` must report the tag rather than `dev`, `workflow validate` must accept the shipped example, and `task ls` must exit **2** with no daemon. Unpacking is what catches a broken archive layout, a missing execute bit, or a binary that will not start on the OS it was cross-compiled for.
   *Verified locally on Windows:* `goreleaser check` passes; a full `--snapshot` build produced all six archives; the Windows archive contains exactly `LICENSE`, `README.md`, `examples/cursor-review.yaml` and `vincent.exe`; the produced binary reports its injected version, validates the shipped example, and exits 2 with no daemon — the same three assertions the CI smoke job makes. (`checksums:` was the wrong key, caught by `goreleaser check` rather than at release time.)
   *README* gained the install section this task owes: per-OS unpack instructions, the `cosign verify-blob` incantation, and the Gatekeeper/SmartScreen prompts a user **will** meet, including `xattr -d com.apple.quarantine` — §19's ‡ note descoped OS code signing, so documenting the consequence is part of the deal.
-  **Remaining:** the done-when says *tagged* pre-release. Cutting a tag is the repo owner's call, and the signing and attestation steps only execute on a real tag push — the dry run deliberately skips them.
+  *2026-08-11 — done-when met.* **`v0.1.0-rc1`** cut by the owner ([run 31484132218](https://github.com/lezli01/vincent/actions/runs/31484132218)), the first execution of `release.yml` and therefore of the signing and attestation steps, which no PR build can reach. Verified independently of the report: the release carries **9 assets** (6 archives, `checksums.txt`, `.sig`, `.pem`), `isPrerelease: true` — so `prerelease: auto` read the `-rc1` suffix correctly — the run reports `release: success` plus **all three smoke jobs green** (ubuntu, windows, macos), and the Windows archive's digest resolves to an `application/vnd.in-toto+json` build attestation. Nothing unexpected reported.
+  *This unblocks T4.6:* the artifacts its ten-minute clock starts from now exist and are downloadable.
 - [ ] **T4.6 — Phase gate (M4 acceptance).** Fresh-machine (VM) timed test per §19 M4 on each OS; results recorded here.
   *Done when:* all three runs under 10 minutes; notes committed. **v1 complete.**
 **PR T decisions (T4.7; grill session, 2026-08-10):**

--- a/examples/docs-update.yaml
+++ b/examples/docs-update.yaml
@@ -5,16 +5,20 @@
 # it. That is the honest shape for a docs task rather than pretending a
 # command can judge writing.
 #
-# It also shows `restricted` permission mode. A docs pass has no business
-# running arbitrary commands, and restricting it costs nothing here.
-# Note: cursor cannot honor restricted on Windows and will refuse the step
-# (§9.4) — this workflow names claude explicitly for that reason.
+# Runs full-auto like every other example. `restricted` would suit a docs pass
+# — it has no business running arbitrary commands — but a *shipped example* is
+# something you copy and run on day one, and restricted changes behavior in two
+# ways that read as bugs when you did not ask for them: claude turns every
+# non-allowlisted tool into a permission prompt, and cursor refuses the step
+# outright on Windows, where its sandbox does not exist (§9.4).
+#
+# If you want it, add `permission_mode: restricted` under defaults below and
+# read the "Permission modes" section of docs/workflows.md first.
 name: docs-update
 description: Update documentation to match the current code, then have a human read it.
 
 defaults:
   agent: claude
-  permission_mode: restricted
   max_retries: 1
   timeout: 30m
 

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -194,6 +194,8 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 		stdin:      stdin,
 		inputMode:  inputMode,
 		events:     make(chan agent.Event, 64),
+		raw:        make(chan agent.Event, 64),
+		promote:    make(chan agent.Event, 8),
 		readerDone: make(chan struct{}),
 		procDone:   make(chan struct{}),
 	}
@@ -203,6 +205,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 			return nil, fmt.Errorf("write prompt to claude: %w", err)
 		}
 	}
+	go r.mux()
 	go r.readLoop(bufio.NewScanner(stdout))
 	go func() {
 		select {
@@ -232,22 +235,64 @@ type run struct {
 	readerDone chan struct{}
 	procDone   chan struct{}
 
+	// raw carries readLoop's events to the mux; promote carries requests
+	// surfaced by Respond. One goroutine owns events and closes it, so
+	// Respond can deliver a queued request without racing readLoop's close.
+	raw     chan agent.Event
+	promote chan agent.Event
+
 	mu       sync.Mutex
 	terminal *agent.RunResult // parsed result event, if any
-	pending  *pendingRequest  // at most one (spec §7.4); guarded by mu
+	pending  *pendingRequest  // the one the engine is answering; guarded by mu
+	// queue holds requests that arrived while another was pending. The real
+	// CLI does issue concurrent control requests — it batches parallel tool
+	// calls, so a restricted run can ask about several at once — and failing
+	// the attempt on the second one killed real runs (found in Windows
+	// testing, 2026-08-11). The engine still sees exactly one at a time,
+	// because a task has one awaiting_input state (§6); the adapter
+	// serializes rather than the CLI promising to.
+	queue []queuedRequest
 
 	waitOnce sync.Once
 	waitRes  agent.RunResult
 	waitErr  error
 }
 
+// queuedRequest is a control request waiting for its turn: the event to
+// surface and the state needed to answer it.
+type queuedRequest struct {
+	ev   agent.Event
+	pend *pendingRequest
+}
+
 // maxLineBytes bounds one stream-json line; agent messages embed file
 // contents, so lines can be large.
 const maxLineBytes = 16 * 1024 * 1024
 
+// mux owns the events channel. readLoop and Respond both produce events, and
+// only one goroutine may close a channel — routing both through here is what
+// lets Respond surface a queued request at all. It forwards rather than
+// blocks, so a consumer calling Respond from its own event loop cannot
+// deadlock against it.
+func (r *run) mux() {
+	defer close(r.events)
+	for {
+		select {
+		case ev, ok := <-r.raw:
+			if !ok {
+				// The stream ended; nothing queued can still be answered.
+				return
+			}
+			r.events <- ev
+		case ev := <-r.promote:
+			r.events <- ev
+		}
+	}
+}
+
 func (r *run) readLoop(sc *bufio.Scanner) {
 	defer close(r.readerDone)
-	defer close(r.events)
+	defer close(r.raw)
 	defer r.closeStdin()
 	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
 	for sc.Scan() {
@@ -266,7 +311,7 @@ func (r *run) readLoop(sc *bufio.Scanner) {
 			// for another user message after the result — end the session.
 			r.closeStdin()
 		}
-		r.events <- ev
+		r.raw <- ev
 	}
 	// A scanner error (over-long line, pipe error) ends normalization; the
 	// process itself is still waited on and its exit code judged.
@@ -291,13 +336,11 @@ func (r *run) parseStreamLine(line []byte) agent.Event {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		if r.pending != nil {
-			// Requests are serial (spec §7.4); a second concurrent request
-			// breaks the contract — fail fast rather than mis-route answers.
-			return agent.Event{
-				Type:    agent.EventInputRequest,
-				Message: "control_request while another is pending",
-				Raw:     line,
-			}
+			// Queue it rather than failing the attempt. The engine answers
+			// one at a time; Respond promotes the next when this one is done.
+			// The line is still returned so the transcript keeps it verbatim.
+			r.queue = append(r.queue, queuedRequest{ev: ev, pend: pend})
+			return agent.Event{Type: agent.EventUnknown, Raw: line}
 		}
 		r.pending = pend
 		return ev
@@ -351,7 +394,25 @@ func (r *run) Respond(resp agent.InputResponse) error {
 	}
 	r.mu.Lock()
 	r.pending = nil
+	var next *queuedRequest
+	if len(r.queue) > 0 {
+		q := r.queue[0]
+		r.queue = r.queue[1:]
+		r.pending = q.pend
+		next = &q
+	}
 	r.mu.Unlock()
+
+	if next != nil {
+		// The CLI is blocked waiting on this one too, so it will emit no
+		// further lines to carry it: surfacing it here is the only way the
+		// engine ever sees it. readerDone guards against a run that died
+		// between the answer and the promotion.
+		select {
+		case r.promote <- next.ev:
+		case <-r.readerDone:
+		}
+	}
 	return nil
 }
 

--- a/internal/agent/claude/input_test.go
+++ b/internal/agent/claude/input_test.go
@@ -7,11 +7,13 @@ package claude
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
 )
@@ -284,18 +286,89 @@ func TestControlProtocolViolations(t *testing.T) {
 	}
 }
 
-func TestSecondRequestWhilePendingIsViolation(t *testing.T) {
+// TestConcurrentRequestsAreQueued replaces an assertion that the adapter
+// treated a second concurrent control_request as a protocol violation.
+//
+// The real CLI issues them: it batches parallel tool calls, so a restricted
+// run can ask about several at once. Failing the attempt on the second one
+// killed real runs (Windows testing, 2026-08-11). The engine still sees one
+// at a time — a task has one awaiting_input state — but the *adapter*
+// serializes them now instead of the CLI being expected to.
+func TestConcurrentRequestsAreQueued(t *testing.T) {
 	r := &run{inputMode: true}
 	first := `{"type":"control_request","request_id":"a","request":{"subtype":"can_use_tool","tool_name":"Write","input":{}}}`
 	second := `{"type":"control_request","request_id":"b","request":{"subtype":"can_use_tool","tool_name":"Edit","input":{}}}`
-	if ev := r.parseStreamLine([]byte(first)); ev.Request == nil {
+
+	ev := r.parseStreamLine([]byte(first))
+	if ev.Request == nil {
 		t.Fatalf("first request rejected: %s", ev.Message)
 	}
-	ev := r.parseStreamLine([]byte(second))
-	if ev.Type != agent.EventInputRequest || ev.Request != nil {
-		t.Errorf("second concurrent request = %+v, want a protocol violation", ev)
+
+	ev = r.parseStreamLine([]byte(second))
+	if ev.Type != agent.EventUnknown {
+		t.Errorf("second concurrent request = %v, want it queued (unknown, transcripted)", ev.Type)
+	}
+	if len(ev.Raw) == 0 {
+		t.Error("queued request lost its raw line; the transcript must stay verbatim")
+	}
+	if len(r.queue) != 1 || r.queue[0].pend.id != "b" {
+		t.Fatalf("queue = %+v, want the second request held", r.queue)
+	}
+	if r.pending == nil || r.pending.id != "a" {
+		t.Errorf("pending = %+v, want the first still awaiting an answer", r.pending)
 	}
 }
+
+// TestQueuedRequestIsPromotedOnAnswer: the CLI is blocked on both requests,
+// so it emits no further lines to carry the second. Respond surfacing it is
+// the only way the engine ever sees it.
+func TestQueuedRequestIsPromotedOnAnswer(t *testing.T) {
+	r := newTestRun(t)
+	first := `{"type":"control_request","request_id":"a","request":{"subtype":"can_use_tool","tool_name":"Write","input":{}}}`
+	second := `{"type":"control_request","request_id":"b","request":{"subtype":"can_use_tool","tool_name":"Edit","input":{}}}`
+	r.parseStreamLine([]byte(first))
+	r.parseStreamLine([]byte(second))
+
+	allow := true
+	if err := r.Respond(agent.InputResponse{Allow: &allow}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	select {
+	case ev := <-r.events:
+		if ev.Type != agent.EventInputRequest || ev.Request == nil {
+			t.Fatalf("promoted event = %+v, want the queued input request", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the queued request was never surfaced; the run would hang here")
+	}
+	if r.pending == nil || r.pending.id != "b" {
+		t.Errorf("pending = %+v, want the promoted request", r.pending)
+	}
+	if len(r.queue) != 0 {
+		t.Errorf("queue = %+v, want it drained", r.queue)
+	}
+}
+
+// newTestRun builds a run with the channels and mux wired but no process, so
+// the queue and promotion can be driven directly.
+func newTestRun(t *testing.T) *run {
+	t.Helper()
+	r := &run{
+		inputMode:  true,
+		stdin:      nopWriteCloser{io.Discard},
+		events:     make(chan agent.Event, 64),
+		raw:        make(chan agent.Event, 64),
+		promote:    make(chan agent.Event, 8),
+		readerDone: make(chan struct{}),
+	}
+	go r.mux()
+	t.Cleanup(func() { close(r.raw) })
+	return r
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
 
 func TestControlCancelRequest(t *testing.T) {
 	r := &run{inputMode: true}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -223,7 +223,23 @@ func newTaskShowCmd() *cobra.Command {
 						dash(deref(s.Agent)), dash(deref(s.FailureReason)),
 					})
 				}
-				return table(out, []string{"RUN", "STEP", "STATE", "AGENT", "REASON"}, rows)
+				if err := table(out, []string{"RUN", "STEP", "STATE", "AGENT", "REASON"}, rows); err != nil {
+					return err
+				}
+				// The transcript is the complete record of what the agent did
+				// (§17); the TUI shows only its tail. Naming the file is what
+				// lets someone diagnose a failed step at all right now.
+				var paths []string
+				for _, s := range t.Steps {
+					if p := deref(s.TranscriptPath); p != "" {
+						paths = append(paths, fmt.Sprintf("  %d  %s", s.ID, p))
+					}
+				}
+				if len(paths) == 0 {
+					return nil
+				}
+				_, err = fmt.Fprintf(out, "\ntranscripts:\n%s\n", strings.Join(paths, "\n"))
+				return err
 			})
 		},
 	}


### PR DESCRIPTION
Five reports from real Windows testing against `v0.1.0-rc1`. **Three were my
own doing**; one is a genuine bug that killed live runs; one is filed rather
than fixed.

## T4.8 — concurrent control requests (the real bug)

> *"failed with control_request while another is pending"*

§7.4 asserted requests were serial "because an agent blocks on its pending
request". Real claude disproves it: it **batches parallel tool calls**, so a
restricted run raises several `can_use_tool` requests at once. The adapter
treated the second as a protocol violation and failed the attempt.

**No fixture could have caught this** — `cmd/fakeagent` only ever emits one
request, which is precisely the assumption under test. It took a real CLI on a
real machine.

Concurrent requests are now **queued** and promoted when the current one is
answered. The engine and every client are unchanged: a task has one
`awaiting_input` state, so they still see one at a time. Delivery needed a mux
goroutine — `readLoop` owns and closes the events channel, and the CLI is
blocked on *both* requests, so no later stream line would ever carry the
second. Spec §7.4 rewritten: serialization is the **adapter's** job, not a
promise the CLI keeps.

## T4.9 — two reports, one example of mine

> *"cursor can not be used… restricted mode needs the CLI sandbox, but I do
> not want restrictions"*
> *"it always asked me for permissions… my expectation is that the tasks have
> full permissions"*

Both are `examples/docs-update.yaml` shipping `permission_mode: restricted`.
With cursor that is refused on Windows (no sandbox, §9.4); with claude it turns
every non-allowlisted tool into a permission prompt. Both are *correct* for
restricted — and both read as bugs to someone who never asked for it.

A shipped example is copied on day one. Demonstrating an edge case that breaks
one adapter on one OS is a bad trade, so it is full-auto like the others now,
with the opt-in documented instead.

The engine default was never wrong: `resolvePermission` returns `FullAuto` for
anything unset, and I verified that before changing anything.

## T4.10 — two documentation defects

> *"The zip provided readme does not have the logo"* — the archive carries no
> `docs/assets/`, so the relative path resolved to nothing. Absolute raw URL
> now, which renders in the repo, in the archive, and anywhere else it travels.

> *"does not tell me how to add global workflows, only repo based"* — the
> quickstart now names the config-dir location per OS, states that project
> scope shadows global, and shows both.

## T4.11 — filed, not fixed

> *"I can not open full discussion log on the tui to see what actually went
> wrong"*

Correct, and it is the worst of the five in one way: you are in the TUI
precisely when a step fails. The detail view fetches a bounded *tail* with no
paging; the transcript on disk is complete and the ranged endpoint already
serves it, so only the UI is missing. That is a real piece of work, filed as
T4.11 rather than rushed into a fix PR.

**Shipped as mitigation:** `vincent task show` now prints each attempt's
transcript path, so a failed step is diagnosable today.

## Verification

934 tests green; lint clean for windows, darwin and linux. The old "second
request is a violation" test is replaced by one asserting the queue, plus a
promotion test that fails if a queued request is never surfaced — the shape
that would hang a real run.
