### PR TITLE
feat: debug record per run and a workflow column on the board (T4.12, T4.13)

### DIFF
--- a/docs/versions/v0/spec.md
+++ b/docs/versions/v0/spec.md
@@ -975,6 +975,7 @@ defaults:
 transcript_retention_days: 90   # transcripts of *archived* tasks older than this are pruned
 transcript_max_bytes: 512MB     # per-run transcript cap (§18); past it the step fails `transcript_limit`
 log_level: info
+debug: false                 # record each step's resolved settings and full argv in its transcript
 agents:
   claude: { path: "" }         # "" = resolve from PATH
   codex:  { path: "" }

--- a/docs/versions/v0/tasks.md
+++ b/docs/versions/v0/tasks.md
@@ -20,9 +20,9 @@ implementation progress; the executing agent updates it in place as work proceed
 | 1 — Spine (M1) | 9 tasks | 9/9 | ✅ done |
 | 2 — Workflow engine (M2) | 12 tasks | 12/12 | ✅ done |
 | 3 — TUI (M3) | 13 tasks | 13/13 | ✅ done |
-| 4 — Polish (M4) | 11 tasks | 7/11 | 🚧 in progress (T4.8–T4.10 from Windows testing; T4.11 open; T4.1/T4.4 pending manual sign-off) |
+| 4 — Polish (M4) | 14 tasks | 9/14 | 🚧 in progress (T4.8–T4.10 from Windows testing; T4.11 open; T4.1/T4.4 pending manual sign-off) |
 | 5 — Cursor adapter (M5, post-v1) | 9 tasks | 8/9 | 🚧 in progress (only T5.7 open — needs macOS + a local hook fix) |
-| **Total** | | **53/58** | |
+| **Total** | | **55/61** | |
 
 ---
 
@@ -632,6 +632,16 @@ Milestone acceptance (§19 M4): fresh machine → first completed task in under 
 - [x] **T4.9 — The shipped `docs-update` example set `permission_mode: restricted`.** ✓ 2026-08-11 Two of the five reports were this one example: cursor **refused every step on Windows** (no sandbox, §9.4) and claude **prompted for permission on every non-allowlisted tool** — both correct behavior for restricted, and both read as bugs to someone who never asked for it. A shipped example is copied on day one; demonstrating an edge case that breaks one adapter on one OS is a bad trade. Now full-auto like the others, with the restricted opt-in documented in a comment and in `docs/workflows.md`. The engine's default was never wrong: `resolvePermission` returns `FullAuto` for anything unset.
 
 - [x] **T4.10 — README: archive logo and global workflows.** ✓ 2026-08-11 The README inside a release archive rendered no logo — it referenced `docs/assets/logo.png`, which the archive does not carry — so the image is now an absolute raw URL that works in the repo, in the archive, and anywhere else the file travels. The quickstart also only documented **project-scoped** workflows; it now names the config-dir location per OS, states that project scope shadows global, and shows both.
+
+- [x] **T4.12 — `debug` config knob.** ✓ 2026-08-11 Requested after a run that prompted for permissions gave no way to see it had resolved to `restricted` — diagnosing it meant reading the stored snapshot out of the API by hand. `debug: true` in `config.yaml` writes a `vincent.debug` line into every step's transcript: resolved agent/model/effort, **permission mode**, `on_input`, workdir, timeout, attempt, and the **full argv** of the spawned process. Command steps get the same, including which shell §8.3 resolved. The daemon also logs the transcript path at info, so "where did it write the log" has an answer you can grep for.
+  *Design:* the record goes in the transcript rather than the daemon log, so it travels with the run a user pastes into an issue. Off by default because argv carries the rendered prompt. `agent.RunHandle` gained `Argv()` — the argv was unanswerable from outside the adapter, which is exactly the question a misbehaving run raises.
+  *Verified:* a real claude run with `debug: true` recorded `permission_mode: full-auto` and the complete argv — the two facts whose absence cost an hour of debugging on 2026-08-11.
+
+- [x] **T4.13 — Board shows the workflow.** ✓ 2026-08-11 The board named the current step but not the workflow it belongs to, and "survey" means nothing without "docs-update". New WORKFLOW column, dropped **after** the step name under width pressure: a workflow alone still says what a task is doing, while a step name alone does not.
+
+- [ ] **T4.14 — Richer agent output in the detail view.** The output pane renders a tool use as its bare name (`▸ Bash`) and drops everything it does not normalize, so watching a run shows keywords rather than what is happening. `agent.ToolUse` carries only `Name`; the adapters all have the detail to hand and throw it away — claude's `input`, cursor's `args` (command, path), codex's item fields.
+  *Done when:* a tool use renders with its subject (the command run, the file edited), and unnormalized lines are visible rather than silently dropped.
+  *Shape:* `ToolUse` gains a summary the adapters fill; it rides the existing `agent.tool_use` record to `renderRecord`. Touches the interface, three adapters, the wire DTO and the TUI — filed rather than rushed into a fix PR.
 
 - [ ] **T4.11 — The TUI cannot show a full transcript.** The detail view fetches a bounded *tail* (`DefaultTailBytes`, capped at `maxRecords`) with no way to page back, so a failed step cannot be diagnosed from the TUI — which is where a user is when it fails. The transcript on disk is the complete record and the ranged endpoint already serves it; only the UI is missing. Partial mitigation shipped: `vincent task show` now prints each attempt's transcript path.
   *Done when:* a step's whole transcript is reachable from the detail view — scrollback, or `$EDITOR`/pager the way `e` already opens a workflow file.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -112,6 +112,12 @@ type RunHandle interface {
 	// PID returns the OS process id of the run — recorded on the StepRun
 	// (spec §14 pid column) for crash-recovery journaling (§12.4).
 	PID() int
+	// Argv is the command line the adapter actually spawned, for the §12.3
+	// debug record. It exists because "which flags did this run get" was
+	// unanswerable from outside the adapter, and that is precisely the
+	// question a misbehaving run raises — a step that prompted for
+	// permissions could not be shown to have resolved to `restricted`.
+	Argv() []string
 }
 
 // EventType classifies normalized agent events (spec §9.1).

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -485,3 +485,6 @@ func (w *tailWriter) String() string {
 	defer w.mu.Unlock()
 	return strings.TrimSpace(string(w.buf))
 }
+
+// Argv implements agent.RunHandle: the command line actually spawned.
+func (r *run) Argv() []string { return r.cmd.Args }

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -283,3 +283,6 @@ func (w *tailWriter) String() string {
 	defer w.mu.Unlock()
 	return strings.TrimSpace(string(w.buf))
 }
+
+// Argv implements agent.RunHandle: the command line actually spawned.
+func (r *run) Argv() []string { return r.cmd.Args }

--- a/internal/agent/cursor/cursor.go
+++ b/internal/agent/cursor/cursor.go
@@ -374,3 +374,6 @@ func (w *tailWriter) String() string {
 	defer w.mu.Unlock()
 	return strings.TrimSpace(string(w.buf))
 }
+
+// Argv implements agent.RunHandle: the command line actually spawned.
+func (r *run) Argv() []string { return r.cmd.Args }

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -42,6 +42,12 @@ transcript_max_bytes: 512MB
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
+# Record how every step was actually invoked in its transcript: resolved
+# agent/model/effort, permission mode, working directory, and the full argv.
+# Turn this on when a run does something you cannot explain, then paste the
+# transcript. Off by default because argv includes the rendered prompt.
+debug: false
+
 # Agent CLI locations. An empty path resolves the binary from PATH.
 agents:
   claude:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,7 +147,17 @@ type Config struct {
 	// which is timeouts only (PR V decision).
 	TranscriptMaxBytes ByteSize `yaml:"transcript_max_bytes"`
 	LogLevel           string   `yaml:"log_level"`
-	Agents             Agents   `yaml:"agents"`
+	// Debug records, in every step's transcript, the exact conditions the
+	// step ran under: the resolved agent/model/effort, the permission mode,
+	// the working directory, and the full argv of the process spawned.
+	//
+	// It exists because none of that was visible when a run misbehaved. A
+	// step that asked for permissions gave no way to see it had resolved to
+	// `restricted`, and diagnosing it meant reading the stored snapshot out
+	// of the database. Off by default: argv can carry a prompt, and a
+	// transcript is something people paste into issues.
+	Debug  bool   `yaml:"debug"`
+	Agents Agents `yaml:"agents"`
 }
 
 // Defaults holds fallback step timeouts, applied when a workflow step does

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -276,6 +276,12 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 	// on the retry rather than after a daemon restart.
 	tr.SetMax(r.deps.Config().TranscriptMaxBytes.Bytes())
 	run.TranscriptPath = tr.Path()
+	if r.deps.Config().Debug {
+		// Where the log went, said out loud. A transcript nobody can find is
+		// not a record — this is the line a user greps for when asked to
+		// paste one.
+		env.log.Info("step transcript", "attempt", run.Attempt, "path", tr.Path())
+	}
 
 	// An `edit + retry` left its text on the task, because the handler ran
 	// while the task was blocked and this row did not exist yet (§6). The

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -70,6 +70,23 @@ func (r *Runner) runAgentStep(
 	// Register the live process so a cancel can reach it (§6).
 	defer r.setProc(env.task.ID, handle)()
 
+	// The §12.3 debug record: what this step actually resolved to and how the
+	// process was actually invoked. Written into the transcript rather than
+	// the daemon log so it travels with the run a user pastes into an issue.
+	if r.deps.Config().Debug {
+		tr.Note("debug", map[string]any{
+			"agent":           sel.Agent,
+			"model":           sel.Model,
+			"effort":          sel.Effort,
+			"permission_mode": string(resolvePermission(env.step, env.wf.Defaults)),
+			"on_input":        string(onInput),
+			"workdir":         env.task.WorktreePath,
+			"argv":            handle.Argv(),
+			"timeout":         timeout.String(),
+			"attempt":         run.Attempt,
+		})
+	}
+
 	pid := handle.PID()
 	started := time.Now()
 	run.PID = &pid
@@ -379,6 +396,15 @@ func (r *Runner) runShellCommand(
 	tr.Note("command_started", map[string]any{
 		"phase": sc.phase, "shell": sh.Name, "command": sc.script, "cwd": sc.workDir,
 	})
+	if r.deps.Config().Debug {
+		// The shell a command step gets is platform-resolved (§8.3), so
+		// "which shell ran this" is exactly as invisible as an agent's argv
+		// was, and just as often the answer.
+		tr.Note("debug", map[string]any{
+			"phase": sc.phase, "shell": sh.Name, "shell_path": sh.Path,
+			"argv": argv, "cwd": sc.workDir, "timeout": sc.timeout.String(),
+		})
+	}
 
 	runCtx, cancel := context.WithTimeout(ctx, sc.timeout)
 	defer cancel()

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -593,6 +593,9 @@ func (b *board) rowsFor(tasks []apiclient.Task, set columnSet) []table.Row {
 		if set.project {
 			row = append(row, t.ProjectName)
 		}
+		if set.workflow {
+			row = append(row, t.Workflow)
+		}
 		elapsed := "—"
 		if d, ok := t.Elapsed(now); ok {
 			elapsed = formatElapsed(d)

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -160,22 +160,28 @@ func TestFilterTasks(t *testing.T) {
 }
 
 // TestColumnsDropByPriority pins the degradation order: cost, then the step
-// name, then the project.
+// name, then the workflow, then the project.
+//
+// The workflow outranks the step name deliberately. "survey" tells a reader
+// nothing on its own — it needs the workflow it belongs to — while the
+// workflow alone still says what a task is doing.
 func TestColumnsDropByPriority(t *testing.T) {
 	for _, tc := range []struct {
-		width                   int
-		project, stepName, cost bool
+		width                             int
+		project, workflow, stepName, cost bool
 	}{
-		{200, true, true, true},
-		{140, true, true, true},
-		{100, true, true, false},  // cost goes first
-		{85, true, false, false},  // then the step name
-		{70, false, false, false}, // then the project
+		{220, true, true, true, true},
+		{160, true, true, true, true},
+		{115, true, true, true, false},   // cost goes first
+		{100, true, true, false, false},  // then the step name
+		{85, true, false, false, false},  // then the workflow
+		{70, false, false, false, false}, // then the project
 	} {
 		got := columnsFor(tc.width)
-		if got.project != tc.project || got.stepName != tc.stepName || got.cost != tc.cost {
-			t.Errorf("width %d = %+v, want project=%v stepName=%v cost=%v",
-				tc.width, got, tc.project, tc.stepName, tc.cost)
+		if got.project != tc.project || got.workflow != tc.workflow ||
+			got.stepName != tc.stepName || got.cost != tc.cost {
+			t.Errorf("width %d = %+v, want project=%v workflow=%v stepName=%v cost=%v",
+				tc.width, got, tc.project, tc.workflow, tc.stepName, tc.cost)
 		}
 	}
 }

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -10,6 +10,7 @@ const (
 	colPadding     = 2
 	widthID        = 5
 	widthProject   = 14
+	widthWorkflow  = 14
 	widthState     = 18 // fits "! awaiting_input"
 	widthStepShort = 7  // "12/12"
 	widthStepLong  = 18
@@ -20,7 +21,11 @@ const (
 
 // columnSet records which optional columns survived the current width.
 type columnSet struct {
-	project  bool
+	project bool
+	// workflow answers "what is this task actually running", which the step
+	// name alone cannot: "survey" means nothing without knowing it belongs to
+	// docs-update.
+	workflow bool
 	stepName bool
 	cost     bool
 }
@@ -31,6 +36,10 @@ func (s columnSet) fixedWidth() int {
 	count := 4 // id, title, state, elapsed
 	if s.project {
 		total += widthProject
+		count++
+	}
+	if s.workflow {
+		total += widthWorkflow
 		count++
 	}
 	if s.stepName {
@@ -55,17 +64,23 @@ func (s columnSet) titleWidth(width int) int { return width - s.fixedWidth() }
 // proportionally leaves a row of unreadable stubs — a 6-character title
 // tells you nothing. Whole columns are dropped instead, in increasing order
 // of how much you navigate by them: cost, then the step name, then the
-// project. Dropping continues until the title clears its minimum, so the
-// thresholds follow from the widths rather than being second-guessed as
-// constants that can silently disagree with them.
+// workflow, then the project. Dropping continues until the title clears its
+// minimum, so the thresholds follow from the widths rather than being
+// second-guessed as constants that can silently disagree with them.
+//
+// The workflow outranks the step name: "survey" is meaningless without
+// knowing it belongs to docs-update, while the workflow alone still tells you
+// what a task is doing.
 func columnsFor(width int) columnSet {
-	set := columnSet{project: true, stepName: true, cost: true}
+	set := columnSet{project: true, workflow: true, stepName: true, cost: true}
 	for set.titleWidth(width) < minTitle {
 		switch {
 		case set.cost:
 			set.cost = false
 		case set.stepName:
 			set.stepName = false
+		case set.workflow:
+			set.workflow = false
 		case set.project:
 			set.project = false
 		default:
@@ -87,10 +102,13 @@ func boardColumns(width int) ([]table.Column, columnSet) {
 		stepWidth = widthStepLong
 	}
 
-	cols := make([]table.Column, 0, 7)
+	cols := make([]table.Column, 0, 8)
 	cols = append(cols, table.Column{Title: "ID", Width: widthID})
 	if set.project {
 		cols = append(cols, table.Column{Title: "PROJECT", Width: widthProject})
+	}
+	if set.workflow {
+		cols = append(cols, table.Column{Title: "WORKFLOW", Width: widthWorkflow})
 	}
 	cols = append(cols,
 		table.Column{Title: "TITLE", Width: title},


### PR DESCRIPTION
Two of the three requests from Windows testing. The third (richer output) is
filed as T4.14 with a design rather than rushed in here.

## T4.12 — `debug: true`

Writes a `vincent.debug` line into **every step's transcript**:

```json
{"type":"vincent.debug","agent":"claude","model":"","effort":"",
 "permission_mode":"full-auto","on_input":"wait","attempt":1,
 "workdir":"…\worktrees\1","timeout":"1h0m0s",
 "argv":["…\claude.exe","-p","--output-format","stream-json","--verbose",
         "--dangerously-skip-permissions","--input-format","stream-json",
         "--permission-prompt-tool","stdio"]}
```

Command steps get the same, including which shell §8.3 resolved — that is as
invisible as an agent's argv was, and just as often the answer.

Three deliberate choices:

- **In the transcript, not the daemon log.** It travels with the run someone
  pastes into an issue.
- **Off by default.** argv carries the rendered prompt.
- **`agent.RunHandle` gained `Argv()`.** Which flags a run actually got was
  unanswerable from outside the adapter — and that is precisely the question a
  misbehaving run raises. A step prompting for permissions could not be shown
  to have resolved to `restricted`. That cost an hour of debugging today; this
  record answers it in seconds.

The daemon also logs the transcript path at info under debug, so "where did it
write the log" is greppable. `vincent task show` already prints the paths.

## T4.13 — WORKFLOW column on the board

The board named the current step but never the workflow it belongs to, and
`survey` means nothing without `docs-update`. It drops **after** the step name
under width pressure: a workflow alone still says what a task is doing, a step
name alone does not. The drop-priority test is updated to pin the new order.

## T4.14 — filed, not fixed

The output pane renders a tool use as its bare name (`▸ Bash`) and silently
drops what it cannot normalize, so watching a run shows keywords rather than
what is happening. `agent.ToolUse` carries only `Name`, while every adapter has
the detail to hand and throws it away — claude's `input`, cursor's `args`
(command, path), codex's item fields.

That is an interface change plus three adapters plus the wire DTO plus the TUI.
Filed with the shape written down rather than half-done here.

## Verification

Verified with a **real claude run** under `debug: true`: the record captured
`permission_mode: full-auto` and the complete argv — the two facts whose
absence caused today's misdiagnosis. 934 tests green; lint clean for windows,
darwin and linux.
