### PR TITLE
docs: drop the pre-release note from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ daemon, the workflow engine, the TUI, the CLI subcommands, OS service
 registration and all three agent adapters are built, released as signed
 binaries, and exercised on Windows, macOS and Linux in CI on every pull
 request — unit tests, the race detector, the linter, and three end-to-end
-acceptance gates that drive a real daemon over HTTP. Releases are
-pre-release tags so far; the binaries on the
+acceptance gates that drive a real daemon over HTTP. Binaries on the
 [releases page](https://github.com/lezli01/vincent/releases) are signed,
 checksummed and attested.
 


### PR DESCRIPTION
Pre-flight for cutting `v0.1.0`.

`.goreleaser.yaml` packs `README.md` into every archive:

```yaml
archives:
  - files:
      - README.md
```

So the sentence *"Releases are pre-release tags so far"* would ship **inside** the `v0.1.0` archives, stating something false about the very release containing it.

What that clause was guarding against — "complete" reading as a finished release next to an `-rc` tag — stops applying the moment the tag has no suffix. The signing/checksum/attestation sentence stays, since it is true of every release either way.

Docs only. Merging this first means the commit `v0.1.0` points at is the one whose README is correct.
