### PR TITLE
feat(worktree): branch template context and name validation (001.1, 001.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,34 @@ type — that is the exhaustive index; this is the human summary.
 
 ### Added
 
-- Groundwork for configurable branch names
-  ([task 001](docs/tasks/001-configurable-branch-names.md), 001.1 and 001.2): a
-  branch-name template context and renderer, git-delegated branch-name
-  validation, and a collision probe that catches directory/file ref conflicts an
-  exact-match check reports as free. No user-visible behaviour yet — task
-  branches are still `vincent/{id}-{slug}`.
+- **Configurable branch names**
+  ([task 001](docs/tasks/001-configurable-branch-names.md)). A task's branch no
+  longer has to be `vincent/{id}-{slug}`. Names resolve through a chain, most
+  specific first: a per-task literal (`vincent task add --branch feat/OPS-123`, or
+  `branch_name` on `POST /v1/tasks`), a project template
+  (`branch_template` on `PATCH /v1/projects/{id}`), the global
+  [`branch_template`](docs/reference/configuration.md#branch_template) in
+  `config.yaml`, and finally the built-in name. **The default is unchanged**, so
+  nothing moves unless you configure it.
+
+  Templates get `{{.ID}}`, `{{.Title}}`, `{{.Slug}}`, `{{.BaseBranch}}`,
+  `{{.Fields.NAME}}`, `{{.Project.*}}` and a `slug` function. The new-task form
+  previews the resolved name and the level it came from as you type, via
+  `POST /v1/resolve`.
+
+  Two things to know. Because vincent never deletes branches, a template with no
+  discriminator in it collides on the *second* task for the same input — put
+  `{{.ID}}` in it or expect to name repeats by hand. And `{{.Fields.x}}` fails
+  loudly on a missing field while `{{ index .Fields "x" }}` renders nothing, which
+  yields a legal-but-wrong name like `feat/-fix-login`; prefer the first.
+
+- `branch_override` on `POST /v1/tasks/{id}/retry`, which makes a `branch_exists`
+  block recoverable: the branch is renamed and the task re-admitted, keeping its
+  id and history. Previously nothing in the API could change a branch name.
+
+- `branch_name_invalid` block reason. Branch names are validated by
+  `git check-ref-format` rather than a hand-rolled matcher, and a rejected name is
+  reported rather than silently rewritten.
 
 - `go run mage.go vuln` and a weekly `Vulnerabilities` workflow: govulncheck
   over the module's reachable code, swept across `linux`, `darwin` and `windows`
@@ -31,6 +53,15 @@ type — that is the exhaustive index; this is the human summary.
 
 ### Changed
 
+- A task's branch name is now resolved and written inside the same transaction as
+  the task row, so no committed task can carry an empty one. This removes a window
+  in which a crash between two writes left the name unset — harmless while names
+  were derived from `(id, title)`, but it would have silently discarded a
+  configured name and run the task on a default branch.
+- `docs/` is no longer versioned: `docs/versions/v0/spec.md` is now
+  [`docs/spec.md`](docs/spec.md), the single platform spec, amended in place.
+  Planned work lives in [`docs/tasks/`](docs/tasks/README.md), the closed v0 ledger
+  in `docs/history/`, and the gate walkthroughs in `docs/gates/`.
 - A `go install`ed binary now reports the module version from `vincent version`
   instead of `dev`.
 - CI runs the three acceptance gates as steps of one per-OS job rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ type — that is the exhaustive index; this is the human summary.
 
 ### Added
 
+- Groundwork for configurable branch names
+  ([task 001](docs/tasks/001-configurable-branch-names.md), 001.1 and 001.2): a
+  branch-name template context and renderer, git-delegated branch-name
+  validation, and a collision probe that catches directory/file ref conflicts an
+  exact-match check reports as free. No user-visible behaviour yet — task
+  branches are still `vincent/{id}-{slug}`.
+
 - `go run mage.go vuln` and a weekly `Vulnerabilities` workflow: govulncheck
   over the module's reachable code, swept across `linux`, `darwin` and `windows`
   because 15 packages (`x/sys/windows/svc`, `modernc.org/libc/*`) reach the

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ vincent            # the TUI: board, live output, diff, and the gate
 ```
 
 The task appears on the board, runs in its own worktree on branch
-`vincent/{id}-{slug}`, and stops at the `review` gate. Read the diff in the
+`vincent/{id}-{slug}` by default, and stops at the `review` gate. Read the diff in the
 TUI, press `a` to approve, and the publish step pushes the branch. `q` quits
 the TUI — the daemon and any running task keep going without it.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,13 +38,19 @@ pointing it at anything sensitive.
 
 ### Does it touch my working copy?
 
-No. Each task gets its own `git worktree` on its own branch
-(`vincent/{id}-{slug}`). Your checkout, current branch and stash are untouched.
+No. Each task gets its own `git worktree` on its own branch — `vincent/{id}-{slug}`
+unless you configure a different convention. Your checkout, current branch and
+stash are untouched.
 
 ### Does it delete my branches?
 
 Never. Archiving a task removes its **worktree** and keeps the branch and the
-record. Clean up with `git branch --list 'vincent/*'` when you are ready.
+record. To find what to clean up, ask vincent rather than git — with configurable
+names a glob no longer finds them all:
+
+```sh
+vincent task ls --archived      # the branch column lists every branch vincent made
+```
 
 ### What happens if I close the TUI?
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -97,7 +97,9 @@ worth knowing up front:
 ## A worktree
 
 Every task gets its own `git worktree` on its own branch, named
-`vincent/{id}-{slug}`, based on the task's base branch. That is where the agent
+`vincent/{id}-{slug}` by default, based on the task's base branch. You can set a
+different convention per project or globally, or name one task's branch outright —
+see [Configuration](../reference/configuration.md). That is where the agent
 runs and where commands execute.
 
 What this **does** buy you: two tasks in the same repository never collide, your

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -217,9 +217,10 @@ Then delete the binary and, if you want the state gone too, the config and data
 directories listed in [Files and directories](../reference/files.md). Deleting
 the data directory removes the database, transcripts and worktrees.
 
-**Branches are never deleted by vincent.** Task branches named
-`vincent/{id}-{slug}` stay in your repositories until you remove them:
+**Branches are never deleted by vincent.** Task branches stay in your repositories
+until you remove them. Ask vincent which ones it made — branch names are
+configurable, so a `vincent/*` glob is not guaranteed to find them all:
 
 ```sh
-git branch --list 'vincent/*'
+vincent task ls --archived      # read the branch column
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -130,12 +130,13 @@ vincent task ls
 ```
 
 The task is `queued` immediately. When a scheduler slot frees up it becomes
-`running` in its own git worktree, on a branch named `vincent/{id}-{slug}`.
-Nothing touches your checkout.
+`running` in its own git worktree, on a branch named `vincent/{id}-{slug}` unless
+you configured a different convention. Nothing touches your checkout.
 
 Useful additions at creation time:
 
 ```sh
+--branch feat/OPS-123  # name this task's branch outright
 --priority 10          # higher runs first
 --agent codex          # override the workflow's agent for this task only
 --model sonnet         # …and its model

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -145,14 +145,31 @@ discard, then archive again.
 
 ### `branch_exists` / `worktree_path_occupied`
 
-A branch named `vincent/{id}-{slug}` or the worktree directory already exists
-from an earlier run. vincent **never deletes a branch**, so leftovers accumulate
-if you re-create tasks with the same title. Clean up by hand:
+The branch this task would use, or its worktree directory, already exists from an
+earlier run. vincent **never deletes a branch**, so leftovers accumulate if you
+re-create tasks with the same title — or if a branch template has no discriminator
+in it, in which case the *second* task for the same input collides every time.
+
+Most collisions are caught at creation with a `400`, but the check at creation is
+racy by nature, so this block is the authority.
+
+Two ways out. Give the task a different name and let it re-admit, which keeps its
+history and transcripts:
 
 ```sh
-git branch --list 'vincent/*'
+curl -X POST .../v1/tasks/7/retry -d '{"branch_override":"feat/second-attempt"}'
+```
+
+Or delete the leftover branch yourself, then retry:
+
+```sh
+vincent task ls --archived      # find the branches vincent made
 git worktree list
 ```
+
+A related failure is a **ref hierarchy conflict**: `feat/foo` cannot be created
+while `feat/foo/bar` exists, because git stores refs as a path hierarchy. The
+message names the branch that is in the way.
 
 ### `base_branch_missing` / `project_path_missing`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -96,7 +96,7 @@ first (force-removing worktrees), and is refused while any task is running.
 |---|---|---|
 | `GET` | `/v1/workflows?project_id=` | The merged registry: built-in + global + that project's, with shadowing applied |
 | `POST` | `/v1/workflows/validate` | `{ yaml }` → `{ valid, errors[], warnings[] }` |
-| `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort? }` → resolution per step |
+| `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort?, title?, fields?, base_branch?, branch_name? }` → resolution per step, plus the previewed branch name |
 
 Registry entries carry
 `{ name, scope, project_id, file, description, steps[], errors[]?, warnings[]?, error? }`.
@@ -106,6 +106,20 @@ to every step under a candidate task-level override, returning `{ value, source 
 per field — `source` being the winning level (`step`, `task`, `workflow`,
 `adapter`). Non-agent steps keep their index with null fields, so a client can zip
 the two lists positionally.
+
+When the request names a `project_id` it also returns `branch`, the name this draft
+task would get:
+
+```json
+{ "value": "feat/OPS-123-retry-logic", "source": "project", "placeholder": false }
+```
+
+`source` is the winning level of the branch chain (`default`, `config`, `project`,
+`task`). `placeholder: true` means `value` carries a literal `<id>` where the task id
+will go, because the id does not exist until the task is created — the daemon does not
+guess the next one. This is why a client should not render branch templates itself:
+resolution stays server-side so there is only ever one implementation of the
+precedence.
 
 An empty value with source `adapter` means the adapter names no default of its
 own and the CLI decides at run time — which the TUI renders as "CLI default"
@@ -118,7 +132,7 @@ rather than inventing a model name.
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/v1/tasks?project_id=&state=&archived=&limit=&offset=` | List |
-| `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, priority?, agent?, model?, effort? }` |
+| `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort? }` — `branch_name` is used verbatim and wins over any template |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
 | `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt |
@@ -130,7 +144,7 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 | `/cancel` | most states | |
 | `/pause` | queued, running | |
 | `/resume` | paused | |
-| `/retry` | blocked | `{ prompt_override?, run_override? }` |
+| `/retry` | blocked | `{ prompt_override?, run_override?, branch_override? }` — `branch_override` renames the branch before re-admission, which is how a `branch_exists` block is recovered |
 | `/skip` | blocked, awaiting_gate | |
 | `/approve` | awaiting_gate | |
 | `/reject` | awaiting_gate | |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -154,7 +154,8 @@ Lists registered projects with their ids, paths and defaults.
 ```sh
 vincent task add --project ID --title TITLE
                  [--workflow NAME] [--description TEXT] [--base-branch BRANCH]
-                 [--priority N] [--agent NAME] [--model M] [--effort E] [--json]
+                 [--branch NAME] [--priority N] [--agent NAME] [--model M]
+                 [--effort E] [--json]
 ```
 
 Creates a task. It is `queued` immediately — there is no draft state.
@@ -164,7 +165,8 @@ Creates a task. It is `queued` immediately — there is no draft state.
 | `--project` | **Required** |
 | `--title` | **Required**; also the source of the branch slug |
 | `--workflow` | Defaults to the project's default workflow |
-| `--base-branch` | Defaults to the project's default branch |
+| `--base-branch` | What the task branches **from**. Defaults to the project's default branch |
+| `--branch` | What the task's branch is **called**. Used verbatim and wins over any template; defaults to the project's or the global [`branch_template`](configuration.md#branch_template) |
 | `--priority` | Higher runs first; default 0 |
 | `--agent` / `--model` / `--effort` | The task-level override. It replaces workflow `defaults`, never an explicit step field |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,6 +101,55 @@ belongs to.
 
 Real agents cost money; this is the knob that bounds it.
 
+### `branch_template`
+
+```yaml
+branch_template: "vincent/{{.ID}}{{with .Slug}}-{{.}}{{end}}"
+```
+
+The naming convention for task branches. Empty (the default) means the built-in
+`vincent/{id}-{slug}`, with `vincent/{id}` when a title sanitizes to nothing.
+
+Names resolve through a chain, most specific first:
+
+| Level | Set where |
+|---|---|
+| the task's own name | `--branch` / `branch_name`, used **verbatim**, never rendered |
+| project template | `PATCH /v1/projects/{id}` → `branch_template` |
+| global template | this key |
+| built-in | nothing configured |
+
+Available in a template:
+
+| Reference | Meaning |
+|---|---|
+| `{{.ID}}` | The task id. Resolved after the row exists, so it is always unique |
+| `{{.Title}}` | The title verbatim |
+| `{{.Slug}}` | The title slugged the way the built-in name does it |
+| `{{.BaseBranch}}` | What the task branches from |
+| `{{.Fields.NAME}}` | A task field — **errors** when the task does not set it |
+| `{{.Project.Name}}`, `.Path`, `.DefaultBranch` | The project |
+| `{{ slug X }}` | Slug any value: `{{ slug (index .Fields "ticket") }}` |
+
+Two things to get right, because git will not catch them for you:
+
+**Put a discriminator in it.** vincent never deletes branches, so a template like
+`feat/{{.Fields.ticket}}` collides on the *second* task for the same ticket. Include
+`{{.ID}}`, or expect to name repeats by hand.
+
+**Prefer `{{.Fields.x}}` over `{{ index .Fields "x" }}`.** The first fails loudly when
+the field is missing; the second renders *nothing*, giving you `feat/-fix-login` — a
+perfectly legal branch name that is not what you meant. Use `index` only for a segment
+you deliberately want optional, and wrap it:
+
+```yaml
+branch_template: 'feat/{{ with index .Fields "ticket" }}{{.}}-{{ end }}{{.Slug}}'
+```
+
+An invalid template fails at startup rather than silently reverting to the built-in
+name. On hot-reload the previous value is kept and a warning logged, so one bad edit
+does not also revert an unrelated change in the same save.
+
 ### `defaults`
 
 ```yaml
@@ -284,6 +333,7 @@ them in the TUI's projects view, or `PATCH /v1/projects/{id}`:
 | `default_branch` | What new tasks branch from |
 | `default_workflow` | Used when a task names none |
 | `max_parallel_tasks` | Per-project cap, applied on top of the global one |
+| `branch_template` | This repository's branch convention; overrides the global [`branch_template`](#branch_template). Set it to `null` or `""` to inherit the global one again |
 
 ```sh
 vincent project add /path/to/repo --name api --default-branch develop \

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -75,15 +75,20 @@ vincent/{id}-{slug}
 where `slug` comes from the task title. A title that sanitizes to nothing gives
 `vincent/{id}` with no trailing dash.
 
+That is the **default**. The name is configurable — a template per project or in
+`config.yaml`, or a literal for one task — see
+[Configuration](configuration.md#branch_template).
+
 Two rules worth internalizing:
 
 - **The worktree is disposable.** Archiving a task removes it. If it has
   uncommitted changes, archiving refuses unless forced — that work would be lost.
 - **The branch is not.** vincent never deletes a branch. Task branches accumulate
-  in your repository until you remove them:
+  in your repository until you remove them. The daemon is the reliable list, since
+  a configured name need not start with `vincent/`:
 
   ```sh
-  git branch --list 'vincent/*'
+  vincent task ls --archived      # the branch column
   git worktree list
   ```
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -143,8 +143,10 @@ same thing wherever it originated.
 | `internal_error` | A bug. Please [report it](https://github.com/lezli01/vincent/issues/new/choose) |
 
 Worktree-layer reasons: `project_path_missing`, `base_branch_missing`,
-`branch_exists`, `worktree_dirty`, `worktree_missing`,
-`worktree_path_occupied`, `git_error`. See
+`branch_exists`, `branch_name_invalid`, `worktree_dirty`, `worktree_missing`,
+`worktree_path_occupied`, `git_error`. A `branch_exists` block is recoverable
+without losing the task: `POST /v1/tasks/{id}/retry` accepts a `branch_override`
+that renames the branch and re-admits it. See
 [Troubleshooting](../guides/troubleshooting.md#projects-and-worktrees).
 
 ## Interruption is not failure

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -79,7 +79,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 14 | Concurrency | Configurable global cap **and** per-project cap on parallel running tasks |
 | 15 | Task shape | Title, markdown description, project, workflow, base branch, free-form key/value fields |
 | 16 | Monitoring | Board + live tail (SSE) + per-step duration/tokens/cost + durable transcripts |
-| 17 | Worktrees | Under daemon data dir; branch `vincent/{task}-{slug}`; removed only on archive; branches never auto-deleted |
+| 17 | Worktrees | Under daemon data dir; branch `vincent/{task}-{slug}` by default, configurable per project or globally (§10, task 001); removed only on archive; branches never auto-deleted |
 | 18 | Daemon lifecycle | TUI auto-starts daemon; `vincent daemon start/stop/status`; optional OS service install; interrupted steps re-run on restart |
 | 19 | Name | `vincent` |
 | 20 | v1 scope | Everything above, both agent adapters |
@@ -143,6 +143,7 @@ A registered local git repository.
 | `default_branch` | base branch for new tasks (auto-detected from `origin/HEAD`, falls back to `main`/`master`; editable) |
 | `default_workflow` | optional workflow name preselected in task creation |
 | `max_parallel_tasks` | per-project cap; `null` = no per-project limit (global cap still applies) |
+| `branch_template` | *added 2026-08-13 (task 001).* Optional branch-naming template for this project; `null` inherits `config.yaml`'s `branch_template`, and an unset config means the built-in name. Parsed when written, so a broken template fails at `PATCH /v1/projects/{id}` rather than at every task creation |
 
 Registering a project performs validation only (path exists, is a git repo, worktrees
 supported). The repo itself is never modified by registration.
@@ -177,7 +178,7 @@ A unit of work delivered by running a workflow against a project.
 | `workflow_name` | name as resolved at creation time |
 | `workflow_snapshot` | full YAML content captured at creation; **execution always uses the snapshot**, so later edits to workflow files never mutate in-flight or historical tasks |
 | `base_branch` | defaults to project `default_branch` |
-| `branch_name` | `vincent/{id}-{slug}` (slug: lowercase title, `[a-z0-9-]`, max 40 chars) |
+| `branch_name` | `vincent/{id}-{slug}` by default (slug: lowercase title, `[a-z0-9-]`, max 40 chars). *Amended 2026-08-13 (task 001):* configurable through the chain `built-in < config.yaml < project < per-task literal`. Resolved and persisted inside the task's insert transaction, so no committed task carries an empty one |
 | `worktree_path` | assigned when the worktree is created |
 | `priority` | integer, default 0; higher runs first |
 | `agent_override` / `model_override` / `effort_override` | optional, chosen at creation (§13.2); replace the workflow's `defaults` but never an explicit step field (§8.6) |
@@ -966,9 +967,30 @@ would invalidate every one of them.
 - **Creation** (when the scheduler first admits the task):
   `git -C {project.path} worktree add {worktree_path} -b {branch_name} {base_branch}`.
   If `base_branch` doesn't resolve locally, task creation fails fast with a clear error.
-- **Branch naming:** `vincent/{task_id}-{slug}`; collisions are impossible (ids are
-  unique) but a pre-existing branch of the same name fails the task with a clear error
-  rather than reusing it.
+- **Branch naming:** `vincent/{task_id}-{slug}` by default. A pre-existing branch of
+  the same name fails the task with a clear error rather than reusing it.
+
+  *Amended 2026-08-13 (task 001).* This section used to add "collisions are impossible
+  (ids are unique)". That is no longer true, and the change is the reason most of the
+  rest of this bullet exists. Names are configurable —
+  `built-in < config.yaml < project < per-task literal` — and because vincent **never
+  deletes branches**, a template without a discriminator collides on the *second* task
+  for the same input. So collision is a routine outcome, not a defensive check:
+  - **Legality** is delegated to `git check-ref-format --branch`, never a
+    reimplementation of git's grammar, and a rejected name is `branch_name_invalid`
+    (§18) rather than silently sanitized.
+  - **Collision** is checked twice. At creation, against existing refs and against
+    other unarchived tasks' claimed names → `400`, mirroring how `base_branch` already
+    fails fast. At admission, `branch_exists` remains the **authority**, because the
+    creation check is inherently racy.
+  - The collision probe is wider than an exact ref match: git stores refs as a path
+    hierarchy, so `feat/foo` cannot be created while `feat/foo/bar` exists, and
+    `git rev-parse --verify refs/heads/feat/foo` reports *not found* in that case.
+  - A name that needs the task id is rendered inside the insert transaction; the
+    git-side checks never run with that transaction open, since a slow git would stall
+    every write in the daemon.
+  - `branch_exists` is recoverable through `POST /v1/tasks/{id}/retry`'s
+    `branch_override` (§12.2). Without it a blocked task would be permanently dead.
 - **Isolation caveat (documented, not solved):** git worktrees isolate the working
   tree and index, but share the object store and refs — and **do not** isolate
   process-level resources (global caches, package stores, ports, docker). True
@@ -1301,8 +1323,15 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         (shadowing applied); each entry:
                                         { name, scope, project_id, file, description, steps[], errors[]?, warnings[]?, error? }
 POST   /v1/workflows/validate           { yaml } → { valid, errors[], warnings[] }
-POST   /v1/resolve                      { workflow, project_id?, agent?, model?, effort? } →
-                                        { workflow, steps[] } — §8.6 applied to every step
+POST   /v1/resolve                      { workflow, project_id?, agent?, model?, effort?,
+                                          title?, fields?, base_branch?, branch_name? } →
+                                        { workflow, steps[], branch } — §8.6 applied to every step
+                                        plus, when project_id is given, the branch name this
+                                        draft would get as { value, source, placeholder }.
+                                        source is the winning level (default|config|project|task);
+                                        placeholder means value carries a literal `<id>` because
+                                        the task id does not exist yet — deliberately not a
+                                        guess (task 001)
                                         under a candidate task-level override. Each agent
                                         step carries { value, source } per field, source being
                                         the winning level (step|task|workflow|adapter); non-agent
@@ -1324,7 +1353,10 @@ GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=
                                         archived, ?archived=all → both). state=archived
                                         still selects them explicitly
 POST   /v1/tasks                        { project_id, workflow, title, description?, fields?,
-                                          base_branch?, priority?, agent?, model?, effort? }
+                                          base_branch?, branch_name?, priority?, agent?,
+                                          model?, effort? }
+                                        branch_name is used verbatim and wins over every
+                                        template (§10, task 001)
                                         → task (state=queued); agent/model/effort form the
                                         task-level override (§8.6), validated per §8.2 —
                                         known-invalid = 400, catalog-unknown values are
@@ -1343,7 +1375,12 @@ PATCH  /v1/tasks/{id}                   { priority }               (queued/pause
 POST   /v1/tasks/{id}/cancel
 POST   /v1/tasks/{id}/pause
 POST   /v1/tasks/{id}/resume
-POST   /v1/tasks/{id}/retry            { prompt_override?, run_override? }   (blocked only)
+POST   /v1/tasks/{id}/retry            { prompt_override?, run_override?, branch_override? }
+                                        (blocked only). branch_override renames the task's
+                                        branch before re-admission — the recovery path for a
+                                        branch_exists block (§10, task 001); it is validated
+                                        and collision-checked exactly as creation is, and
+                                        unlike the other two it does not touch the snapshot
 POST   /v1/tasks/{id}/skip             (blocked/awaiting_gate only)
 POST   /v1/tasks/{id}/approve          (awaiting_gate only)
 POST   /v1/tasks/{id}/reject           (awaiting_gate only)
@@ -1820,7 +1857,9 @@ currently true to show (§15 view 6).
 | Runaway step output (agent or command) | Past `transcript_max_bytes` (§12.3) the process tree is killed and the attempt fails `transcript_limit`, under the retry policy. The line that trips the cap is written **whole** — a truncated line would turn a size failure into a parse failure for every later reader of the JSONL — and the partial transcript is kept with a closing `vincent.transcript_limit` annotation, because the lines that got there are what explain the runaway |
 | Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). DB rows are never deleted; retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |
 | Base branch doesn't exist | Task creation fails fast |
-| Branch `vincent/{id}-{slug}` already exists | Task blocked with clear reason (never reuse) |
+| Branch already exists (or a ref hierarchy conflict blocks the name) | Rejected at creation with `400` where the name is known then; otherwise the task blocks with `branch_exists` at admission, which stays the authority. Never reused, never auto-renamed. Recover with `retry { branch_override }` (§10, task 001) |
+| Configured branch name is not a legal git ref | `400` with `branch_name_invalid`, quoting git's own rules. Never sanitized into something legal — a branch the user did not ask for is worse than a rejection (task 001) |
+| Branch template references a field the task does not set | `400` at creation. Note that `{{.Fields.x}}` errors while `{{ index .Fields "x" }}` renders empty by design (§8.4's `missingkey=error` covers map *field* access only), and `feat/-slug` is a legal ref — so the loud form is the documented default for branch templates |
 | Worktree dir manually deleted | Next step fails → blocked with `worktree_missing`; retry recreates the worktree from the branch if it survives |
 | Project path missing | New/step-starting tasks in that project → blocked with `project_path_missing` |
 | Daemon port taken | Ephemeral port by default makes this nearly impossible; pinned-port conflict fails startup with a clear message |

--- a/docs/tasks/001-configurable-branch-names.md
+++ b/docs/tasks/001-configurable-branch-names.md
@@ -1,6 +1,6 @@
 # 001 — Configurable branch names
 
-**Status:** not started (0/11) · **Opened:** 2026-08-13
+**Status:** in progress (2/11) · **Opened:** 2026-08-13
 
 Today every task's branch is `vincent/{id}-{slug}`, computed by
 `worktree.BranchName` and unchangeable. The goal is that a user can decide what
@@ -108,6 +108,30 @@ it beat, because that is the part that is expensive to reconstruct later.
   phase 2 decision exists to prevent, so the branch context omits them and
   referencing one is an error. It also makes self-reference unrepresentable.
 
+  *2026-08-13 — amended twice while implementing 001.1.*
+
+  **It lives in `internal/worktree`, not `internal/workflow`.** `Slug` and
+  `BranchName` are already there and branch naming is that package's documented
+  role; `worktree` depends only on `gitx`, `workflow` depends on `agent` and
+  `config`, and neither imports the other. Putting the context in `workflow`
+  would have added a package edge to reach `Slug` and bought nothing. The cost is
+  that the `missingkey=error` option is now expressed in two packages, so the
+  comment on `RenderBranch` cites the phase 2 decision to keep them from drifting.
+
+  **`missingkey=error` does not cover the `index` builtin,** which invalidates
+  the example used elsewhere in this document. `{{.Fields.ticket}}` errors when
+  the field is absent; `{{ index .Fields "ticket" }}` renders nothing — and
+  deliberately so, since `workflow.TaskContext` documents `index` as *the* way to
+  read an optional field. So a template written as
+  `feat/{{ index .Fields "ticket" }}-{{.Slug}}` silently yields
+  `feat/-fix-login`, which `git check-ref-format` **accepts**. git only catches
+  the degenerate ends (`feat/`, and the empty string); a hole in the middle is a
+  legal ref. Field syntax is therefore the documented default for branch
+  templates, `{{ with index … }}` is the way to make a segment genuinely
+  optional, and `RenderBranch` rejects an empty result itself rather than leaving
+  it to a git message that names no template. Pinned by
+  `TestIndexIsTheQuietFormAndFieldAccessIsTheLoudOne`.
+
 - **Resolution stays server-side.** The branch chain is precedence resolution,
   and `POST /v1/resolve` exists "so no client re-implements the precedence"
   (T4.7; the PR L decision that resolution is server-side is honored, not
@@ -136,24 +160,49 @@ it beat, because that is the part that is expensive to reconstruct later.
 
 ## Tasks
 
-- [ ] **001.1 — `BranchContext` and the branch template renderer.** New type in
-  `internal/workflow` holding `ID()` (method, errors while nil), `Title`, `Slug`,
-  `BaseBranch`, `Fields`, `Project`; a `slug` template func for arbitrary values;
+- [x] **001.1 — `BranchContext` and the branch template renderer.** ✓ 2026-08-13
+  `internal/worktree/branch.go` — see the amended decision above for why it is
+  there rather than in `internal/workflow`. Holds `ID()` (method, errors while
+  nil), `Title`, `Slug`, `BaseBranch`, `Fields`, `Project`; a `slug` template func
+  for arbitrary values; `ValidateBranchTemplate` for parse-time checking;
   rendering through the same `missingkey=error` option `Render` uses. Sentinel
   `ErrBranchNeedsID`.
   *Done when:* table tests cover `{{.Slug}}`, `{{ slug (index .Fields "ticket") }}`,
   a missing field erroring, `.Worktree`/`.BranchName` failing, and `{{.ID}}`
   returning `ErrBranchNeedsID` with a nil id and the real id otherwise.
+  *(Verified: 14 tests in `branch_test.go`.
+  `TestIDBeforeInsertIsRoutingSignal` pins the assumption the whole routing
+  design rests on — that `errors.Is` reaches `ErrBranchNeedsID` through
+  `text/template`'s `ExecError` wrapping of a method error — because if that ever
+  stops holding, `RenderBranch` silently reports a generic failure and the caller
+  takes the wrong path. `TestWithIDDoesNotMutateReceiver` pins that the pre-insert
+  context stays id-less after `WithID`, since pass 1 renders it first.
+  `TestDefaultShapeIsExpressibleAsATemplate` asserts the faithful template equals
+  `BranchName` across five titles including the empty-slug case, **and** that the
+  naive form does not — so the trap recorded in the decision cannot quietly stop
+  being true.)*
 
-- [ ] **001.2 — Ref legality and the widened collision check.** `gitx` gains
-  `CheckRefFormat` (delegating to `git check-ref-format --branch`).
-  `internal/worktree` gains a conflict probe covering the exact ref, refs under
-  the name, and refs that are prefixes of it, plus
-  `ReasonBranchNameInvalid = "branch_name_invalid"`.
+- [x] **001.2 — Ref legality and the widened collision check.** ✓ 2026-08-13
+  `gitx.CheckRefFormat` delegates to `git check-ref-format --branch`, run with no
+  working directory so `--branch`'s shorthand expansion has nothing to resolve
+  against. `worktree.ValidateBranchName` wraps it in the reason taxonomy as
+  `ReasonBranchNameInvalid = "branch_name_invalid"`, and
+  `worktree.BranchConflict` probes the exact ref, refs under the name (a
+  trailing-slash `for-each-ref` pattern, which cannot match the name itself), and
+  every `/`-prefix of the name.
   *Done when:* tests in a `testrepo` prove the D/F case both directions
   (`feat/foo` blocked by `feat/foo/bar`, and `feat/foo/bar` blocked by
   `feat/foo`), and a table of illegal names is rejected — including `a..b`,
   `a~b`, `a.lock`, `-a`, `a.`, `a//b`, `a@{b}`, and one with a control character.
+  *(Verified: `branchcheck_test.go`. Both D/F directions asserted, and the
+  under-the-name case first asserts that `localBranchExists` reports the name as
+  **free** — so the test fails loudly if the trap this task exists for ever
+  disappears. `TestBranchConflictAgreesWithGit` cross-checks the probe against
+  `git branch` in both directions, catching false alarms as well as a false
+  all-clear. Delegation earned itself twice over: git **accepts** `refs/heads/x`
+  as a branch name and **accepts** the single character `@`, contradicting its own
+  documentation — both were assertions I had written the other way, and both are
+  now pinned so a future git change surfaces here rather than in a user's repo.)*
 
 - [ ] **001.3 — Resolve the chain server-side.** `config.branch_template`
   (global, hot-reloaded like the rest of `config.yaml`), a `branch_template`

--- a/docs/tasks/001-configurable-branch-names.md
+++ b/docs/tasks/001-configurable-branch-names.md
@@ -1,6 +1,6 @@
 # 001 — Configurable branch names
 
-**Status:** in progress (2/11) · **Opened:** 2026-08-13
+**Status:** done (11/11) · **Opened:** 2026-08-13 · **Completed:** 2026-08-13
 
 Today every task's branch is `vincent/{id}-{slug}`, computed by
 `worktree.BranchName` and unchangeable. The goal is that a user can decide what
@@ -204,7 +204,7 @@ it beat, because that is the part that is expensive to reconstruct later.
   documentation — both were assertions I had written the other way, and both are
   now pinned so a future git change surfaces here rather than in a user's repo.)*
 
-- [ ] **001.3 — Resolve the chain server-side.** `config.branch_template`
+- [x] **001.3 — Resolve the chain server-side.** `config.branch_template`
   (global, hot-reloaded like the rest of `config.yaml`), a `branch_template`
   column on projects (append-only migration), and the resolver producing
   `(name, source)` where source is `default|config|project|task`. Templates are
@@ -213,8 +213,18 @@ it beat, because that is the part that is expensive to reconstruct later.
   *Done when:* unit tests cover each level winning, a project template shadowing
   config, a literal beating both, and an unparseable template rejected at
   `PATCH /v1/projects` with a 400 rather than accepted.
+  ✓ 2026-08-13 `config.branch_template`, a `branch_template` column on projects
+  (migration `0005`), and `worktree.ResolveBranchName` returning `(name, source)`.
+  *(Verified: the resolver's chain is unit-tested in `branch_test.go`;
+  `TestProjectBranchTemplateIsValidatedOnWrite` proves an unparseable template is a
+  400 at `PATCH /v1/projects` and that clearing it restores inheritance. One
+  correction to the plan: `internal/config` is a leaf package and cannot import
+  `worktree`, so the **config-level** template is validated in `internal/daemon`
+  instead — a hard failure at startup, and on hot-reload the previous value is kept
+  with a warning rather than dropping the whole reload, so one bad edit does not
+  also revert an unrelated change in the same save.)*
 
-- [ ] **001.4 — Atomic persist; delete the second write and the recompute.**
+- [x] **001.4 — Atomic persist; delete the second write and the recompute.**
   Resolve inside `CreateTask`'s existing transaction: pass 1 without an id (final
   name → collision-checked before the transaction opens → single `INSERT`), or on
   `ErrBranchNeedsID` render after `LastInsertId` and `UPDATE` in the same
@@ -226,38 +236,67 @@ it beat, because that is the part that is expensive to reconstruct later.
   `task.created` event; and a test proves a literal survives what used to be the
   crash window — the recompute is gone, so a custom name cannot degrade to a
   default.
+  ✓ 2026-08-13 `CreateTask` takes a `resolveBranch` callback, so a name needing the
+  id is rendered and written inside the insert's own transaction; the claim query
+  runs there too, on both paths. `SetTaskBranchName` survives repurposed for the
+  retry rename only, and `engine.go`'s recompute is gone.
+  *(Verified: `TestCreateTaskBranchIsAtomic` proves no committed row carries an
+  empty `branch_name` and that a rejected creation leaves none behind. The new
+  invariant immediately caught ~25 test fixtures that had been creating tasks with
+  no branch name or a shared literal — `taskrun`'s own helper was doing
+  insert-then-`UpdateTask`, i.e. the very two-write pattern this task removed, so it
+  now goes through the resolver like production does.)*
 
-- [ ] **001.5 — `POST /v1/tasks` accepts `branch_name`.** Request field, 400s for
+- [x] **001.5 — `POST /v1/tasks` accepts `branch_name`.** Request field, 400s for
   `branch_name_invalid` and for both collision kinds, and the resolved name in
   the response. *Depends: 001.4.*
   *Done when:* handler tests cover an invalid ref, a name taken by an existing
   git branch, a name claimed by another queued task, and a happy path asserting
   the stored name.
+  ✓ 2026-08-13 *(Verified: `TestCreateTaskWithBranchName` covers an illegal ref, a
+  name an existing branch holds, a **directory/file conflict** an exact-match check
+  would have called free, and a name another live task claims — the last of which
+  git cannot see, since neither branch exists yet.
+  `TestCreateTaskDefaultBranchUnchanged` is the regression guard for every existing
+  user.)*
 
-- [ ] **001.6 — `POST /v1/tasks/{id}/retry` accepts `branch_override`.**
+- [x] **001.6 — `POST /v1/tasks/{id}/retry` accepts `branch_override`.**
   Blocked-only, validated and collision-checked exactly as creation, persisted
   before the block is cleared. *Depends: 001.5.*
   *Done when:* a test drives a task to `blocked`/`branch_exists`, retries with a
   free name, and asserts the worktree is created on the new branch with the
   task's history intact; a second asserts a still-colliding override returns 400
   and leaves the task blocked.
+  ✓ 2026-08-13 *(Verified: `TestRetryWithBranchOverride` covers adoption plus
+  re-admission, an illegal name leaving the branch untouched, a still-colliding name
+  leaving the task blocked, and a 409 on a non-blocked task — the rename is refused
+  before it happens rather than left behind by a retry that then fails.)*
 
-- [ ] **001.7 — `POST /v1/resolve` previews the branch.** Request gains `title`,
+- [x] **001.7 — `POST /v1/resolve` previews the branch.** Request gains `title`,
   `fields`, `base_branch`; response gains `branch: {value, source}`. An id-bearing
   template renders with an `<id>` placeholder rather than a fabricated number.
   *Depends: 001.3.*
   *Done when:* a live test through the real handlers asserts each source level is
   reported, and that an id-bearing template previews with the placeholder and
   never `0`.
+  ✓ 2026-08-13 *(Verified: `TestResolvePreviewsTheBranch` asserts each source level
+  and that an id-bearing template previews as `vincent/<id>-fix-login` — a literal
+  marker, never a guessed number, because guessing is wrong the moment two drafts
+  are open.)*
 
-- [ ] **001.8 — CLI surface.** `--branch` on `task add` and on `task retry`,
+- [x] **001.8 — CLI surface.** `--branch` on `task add` and on `task retry`,
   following the existing pointer-flag pattern in `internal/cli/task.go`.
   *Depends: 001.5, 001.6.*
   *Done when:* the flags round-trip through `apiclient` and appear in
   `vincent task add --help`; a `task ls` run shows a custom branch in the branch
   column.
+  ✓ 2026-08-13 `--branch` on `task add`.
+  *(Scope correction: the plan also said `task retry`, but **the CLI has no retry
+  subcommand** — only `add`, `ls`, `show`, `cancel`. Adding one is its own surface
+  with its own questions, so `branch_override` is reachable from the API and the TUI
+  and not from the CLI. Recorded rather than quietly dropped.)*
 
-- [ ] **001.9 — TUI new-task row and live preview.** A branch-name row distinct
+- [x] **001.9 — TUI new-task row and live preview.** A branch-name row distinct
   from the existing base-branch input — which is labelled "base branch" and must
   not read as renamed — reusing the debounced `/v1/resolve` round-trip and the
   `resolveKey` stale-reply drop the form already has. Shows the resolved name and
@@ -265,8 +304,12 @@ it beat, because that is the part that is expensive to reconstruct later.
   *Done when:* a live test types a title and asserts the previewed branch updates
   from the real handlers; a second asserts a stale reply for a superseded draft is
   dropped; `bindings.go` and the TUI key docs updated if a key is added.
+  ✓ 2026-08-13 A `branch` row distinct from `base branch`, previewing the resolved
+  name and the level it came from through the existing debounced `/v1/resolve`
+  round-trip. `resolveKey` grew the branch inputs so a stale preview is dropped like
+  any other; `fields` is digested to a string because the key is compared with `==`.
 
-- [ ] **001.10 — Spec amendments and user docs.** Dated in-place amendments to
+- [x] **001.10 — Spec amendments and user docs.** Dated in-place amendments to
   [../spec.md](../spec.md): §5.3 (`branch_name`), §10 (branch naming, and the
   retirement of "collisions are impossible"), §17 row 17, §18 (the
   `branch_exists` row, plus `branch_name_invalid`), §12.2 (the `retry` payload)
@@ -277,8 +320,12 @@ it beat, because that is the part that is expensive to reconstruct later.
   to `vincent task ls --archived`. *Depends: 001.1–001.9.*
   *Done when:* no page still states `vincent/{id}-{slug}` as the only possible
   shape, and §10 no longer claims collisions are impossible.
+  ✓ 2026-08-13 Eight dated amendments to `../spec.md` (§5.2, §5.3, §10, §12.2, §13.2
+  ×2, §17, §18) and eight user-facing pages, including a full `branch_template`
+  reference section. The cleanup guidance moved off `git branch --list 'vincent/*'`,
+  which configurable names break.
 
-- [ ] **001.11 — Acceptance gate.** Extend
+- [x] **001.11 — Acceptance gate.** Extend
   [`scripts/m2-gate.sh`](../../scripts/m2-gate.sh) with a scenario that drives a
   real daemon over curl: create a task with a project template and assert the
   branch, create a second task that collides and assert the 400, force a
@@ -286,6 +333,15 @@ it beat, because that is the part that is expensive to reconstruct later.
   worktree lands on the new branch. *Depends: 001.10.*
   *Done when:* the new scenario is green on ubuntu, macOS and Windows in CI, and
   [`CHANGELOG.md`](../../CHANGELOG.md) carries the feature under `## [Unreleased]`.
+  ✓ 2026-08-13 `scripts/m2-gate.sh` scenario 4.
+  *(It drives the **real** admission race rather than simulating it: the global cap
+  is 1, a slow task holds the only slot, and the conflicting branch is created while
+  the second task sits queued — so admission is what discovers it, which is the
+  scenario the "creation check is a courtesy, not a guarantee" decision exists for.
+  The gate earned its keep on the first run by failing an assertion I had written
+  from a wrong mental model: a task blocked at worktree creation has run no steps,
+  so there was no step history to preserve. The assertion now states what is
+  actually true and says why.)*
 
 ## Notes
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -15,7 +15,7 @@ description of how the system actually behaves.
 
 | ID | Work | Status |
 |---|---|---|
-| [001](001-configurable-branch-names.md) | Configurable branch names | 🟡 in progress (2/11) |
+| [001](001-configurable-branch-names.md) | Configurable branch names | ✅ done (11/11) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -15,7 +15,7 @@ description of how the system actually behaves.
 
 | ID | Work | Status |
 |---|---|---|
-| [001](001-configurable-branch-names.md) | Configurable branch names | ⬜ not started (0/11) |
+| [001](001-configurable-branch-names.md) | Configurable branch names | 🟡 in progress (2/11) |
 
 ## How to add and update a task document
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskrun"
@@ -60,12 +61,22 @@ func (s *Server) handleTaskReject(w http.ResponseWriter, r *http.Request) {
 type retryRequest struct {
 	PromptOverride string `json:"prompt_override"`
 	RunOverride    string `json:"run_override"`
+	// BranchOverride renames the task's branch before the retry re-admits it.
+	// It is what makes a `branch_exists` block recoverable at all (task 001):
+	// nothing else in the API can change a branch name, so without it a blocked
+	// task would be permanently dead and its transcripts orphaned.
+	BranchOverride string `json:"branch_override"`
 }
 
 func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 	var req retryRequest
 	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
 		return
+	}
+	if branch := strings.TrimSpace(req.BranchOverride); branch != "" {
+		if !s.renameBranchForRetry(w, r, branch) {
+			return
+		}
 	}
 	s.runAction(w, r, func(id int64) (*store.Task, error) {
 		t, err := s.deps.Runner.Retry(r.Context(), id,
@@ -188,12 +199,12 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 
 	case isInvalidAction(err):
 		e, _ := taskrun.AsInvalidAction(err)
-		writeConflict(w, CodeInvalidState, e.Error(),
+		writeConflict(w, e.Error(),
 			map[string]string{"state": string(e.State)})
 
 	case isStateConflict(err):
 		e, _ := store.AsStateConflict(err)
-		writeConflict(w, CodeInvalidState, e.Error(),
+		writeConflict(w, e.Error(),
 			map[string]string{"state": string(e.Got)})
 
 	case isOverrideMismatch(err):
@@ -210,7 +221,7 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 	// means the task is untouched — `worktree_dirty` is the one a client
 	// resolves by re-sending with force (§13.2).
 	case worktree.ReasonOf(err) != "":
-		writeConflict(w, CodeInvalidState, err.Error(),
+		writeConflict(w, err.Error(),
 			map[string]string{"reason": worktree.ReasonOf(err)})
 
 	default:

--- a/internal/api/branch.go
+++ b/internal/api/branch.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// placeholderTaskID stands in for the real task id when a branch name has to be
+// checked for *legality* before the row that would supply the id exists.
+//
+// This is sound because ref legality does not depend on which digits the id
+// renders to: every positive integer is a legal ref component everywhere in a
+// name, so a template that produces an illegal name with this id produces one
+// with every id, and vice versa. It lets an id-bearing template's syntax be
+// rejected with a 400 at creation instead of surfacing as a blocked task later.
+//
+// Collision is the part that genuinely cannot be pre-checked on this path, and it
+// is not pre-checked: the name a real id produces is a different string. That is
+// the original §10 argument still holding — an id-bearing name is unique by
+// construction — with the admission-time `branch_exists` check as the guard.
+const placeholderTaskID = 1
+
+// branchPreview is a resolved name and the level of the chain that produced it.
+type branchPreview struct {
+	Name string
+	// Source is one of worktree.BranchSource*.
+	Source string
+	// NeedsID reports that the real name can only be produced after the insert,
+	// so Name was rendered with placeholderTaskID and is a preview, not the name.
+	NeedsID bool
+}
+
+// branchSpec assembles the naming chain for a task: the literal the caller
+// supplied, this project's template, and the global one from config.yaml.
+func (s *Server) branchSpec(literal string, p *store.Project) worktree.BranchSpec {
+	return worktree.BranchSpec{
+		Literal:         literal,
+		ProjectTemplate: p.BranchTemplate,
+		ConfigTemplate:  s.deps.Config().BranchTemplate,
+	}
+}
+
+// branchContext builds the template context for a task that does not exist yet.
+func branchContext(title, baseBranch string, fields map[string]string, p *store.Project) worktree.BranchContext {
+	return worktree.NewBranchContext(title, baseBranch, fields, worktree.BranchProject{
+		Name:          p.Name,
+		Path:          p.Path,
+		DefaultBranch: p.DefaultBranch,
+	})
+}
+
+// resolveBranchPreview applies the chain without a task id. A template that needs
+// one is re-rendered with placeholderTaskID so the result is still inspectable —
+// legal-or-not for creation, human-readable for /v1/resolve — with NeedsID set.
+//
+// The returned error is a template failure the caller should report as a 400: a
+// missing field, a syntax error, or a name that rendered empty.
+func resolveBranchPreview(spec worktree.BranchSpec, bctx worktree.BranchContext) (branchPreview, error) {
+	name, source, err := worktree.ResolveBranchName(spec, bctx)
+	if err == nil {
+		return branchPreview{Name: name, Source: source}, nil
+	}
+	if !errors.Is(err, worktree.ErrBranchNeedsID) {
+		return branchPreview{}, err
+	}
+	name, source, err = worktree.ResolveBranchName(spec, bctx.WithID(placeholderTaskID))
+	if err != nil {
+		return branchPreview{}, err
+	}
+	return branchPreview{Name: name, Source: source, NeedsID: true}, nil
+}
+
+// checkBranchLegality rejects a name git itself would refuse, returning the
+// message for a 400 (empty means legal). It applies on both resolution paths,
+// because legality does not depend on the id — see placeholderTaskID.
+func (s *Server) checkBranchLegality(ctx context.Context, branch string) string {
+	if err := s.deps.Worktrees.ValidateBranchName(ctx, branch); err != nil {
+		return fmt.Sprintf("branch name %q is not valid: %s", branch, gitRefRules)
+	}
+	return ""
+}
+
+// checkBranchCollision rejects a name an existing branch already blocks,
+// returning the message for a 400 (empty means free). It only applies where the
+// resolved name is final, since a placeholder-rendered preview would be checking
+// the wrong string.
+//
+// It shells out to git, so like checkBranchLegality it must run *outside* any
+// database transaction: SQLite has a single writer and gitx allows 30 seconds, so
+// holding the write lock across it would stall every admission and step_run write
+// in the daemon.
+//
+// It is a courtesy, not a guarantee — a branch can appear between this check and
+// the worktree creation that follows, which is why admission still refuses a
+// pre-existing branch and remains the authority.
+func (s *Server) checkBranchCollision(ctx context.Context, repo, branch string) string {
+	conflict, err := s.deps.Worktrees.BranchConflict(ctx, repo, branch)
+	if err != nil {
+		// A git failure here is not the caller's fault. Let the task be created
+		// and let admission, the authority, report it.
+		s.deps.Logger.Warn("branch conflict pre-check failed", "branch", branch, "error", err)
+		return ""
+	}
+	switch conflict {
+	case "":
+		return ""
+	case branch:
+		return fmt.Sprintf("branch %q already exists in %s; vincent never reuses a branch", branch, repo)
+	default:
+		return fmt.Sprintf("branch %q cannot be created because %q exists: git stores refs as a "+
+			"path hierarchy, so a branch and a branch under it cannot coexist", branch, conflict)
+	}
+}
+
+// renameBranchForRetry applies a retry's branch_override, writing the response
+// itself and reporting whether the retry should proceed.
+//
+// It runs *before* the retry, because the point is to re-admit onto the new name,
+// and it insists the task is `blocked` first: renaming a task that then turns out
+// not to be retryable would leave a rename nobody asked for. Runner.Retry remains
+// the authority on the transition — this only declines to rename early.
+func (s *Server) renameBranchForRetry(w http.ResponseWriter, r *http.Request, branch string) bool {
+	ctx := r.Context()
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return false
+	}
+	task, err := s.deps.Store.GetTask(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, fmt.Sprintf("task %d not found", id))
+		return false
+	}
+	if err != nil {
+		s.internalError(w, "get task", err)
+		return false
+	}
+	if task.State != store.TaskBlocked {
+		writeConflict(w,
+			fmt.Sprintf("branch_override needs a blocked task; task %d is %s", id, task.State),
+			map[string]string{"state": string(task.State)})
+		return false
+	}
+	project, err := s.deps.Store.GetProject(ctx, task.ProjectID)
+	if err != nil {
+		s.internalError(w, "get project", err)
+		return false
+	}
+	if msg := s.checkBranchLegality(ctx, branch); msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return false
+	}
+	if msg := s.checkBranchCollision(ctx, project.Path, branch); msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return false
+	}
+	if err := s.deps.Store.SetTaskBranchName(ctx, id, task.ProjectID, branch); err != nil {
+		var claimed *store.BranchClaimedError
+		if errors.As(err, &claimed) {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("branch %q is already claimed by task %d", claimed.Branch, claimed.TaskID))
+			return false
+		}
+		s.internalError(w, "rename task branch", err)
+		return false
+	}
+	return true
+}
+
+// previewBranch answers the branch half of POST /v1/resolve: the name this draft
+// would get and the level that decided it (task 001, §13.2).
+//
+// A name that depends on the task id is rendered with a literal `<id>` marker
+// rather than a guessed number. Predicting the next id would be wrong as soon as
+// two drafts are open, and a preview that is confidently wrong is worse than one
+// that admits which part it cannot know.
+func (s *Server) previewBranch(ctx context.Context, projectID int64, req resolveRequest) (*resolvedBranch, error) {
+	project, err := s.deps.Store.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("project %d: %w", projectID, err)
+	}
+	baseBranch := req.BaseBranch
+	if strings.TrimSpace(baseBranch) == "" {
+		baseBranch = project.DefaultBranch
+	}
+	spec := s.branchSpec(strings.TrimSpace(req.BranchName), project)
+	bctx := branchContext(req.Title, baseBranch, req.Fields, project)
+
+	name, source, err := worktree.ResolveBranchName(spec, bctx)
+	if err == nil {
+		return &resolvedBranch{Value: name, Source: source}, nil
+	}
+	if !errors.Is(err, worktree.ErrBranchNeedsID) {
+		return nil, fmt.Errorf("branch name could not be resolved: %w", err)
+	}
+	// Render with the placeholder id, then put the marker back where the digits
+	// landed. Substitution beats a second template context: the id can appear
+	// anywhere in the name, more than once, and only the template knows where.
+	name, source, err = worktree.ResolveBranchName(spec, bctx.WithID(placeholderTaskID))
+	if err != nil {
+		return nil, fmt.Errorf("branch name could not be resolved: %w", err)
+	}
+	marked := strings.ReplaceAll(name, strconv.Itoa(placeholderTaskID), "<id>")
+	return &resolvedBranch{Value: marked, Source: source, Placeholder: true}, nil
+}
+
+// gitRefRules summarises what git rejects, so a 400 tells the user what to change
+// instead of only that something was wrong.
+const gitRefRules = `a branch name cannot contain "..", "~", "^", ":", "?", "*", "[", "\\", ` +
+	`whitespace or control characters, cannot contain "@{" or "//", cannot begin with "-" ` +
+	`or end with "." or ".lock", and cannot be "HEAD"`

--- a/internal/api/branch_test.go
+++ b/internal/api/branch_test.go
@@ -1,0 +1,355 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// setProjectBranchTemplate points the harness project at a convention.
+func (h *taskHarness) setProjectBranchTemplate(t *testing.T, tmpl string) {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodPatch, "/v1/projects/"+itoa(h.projectID),
+		map[string]any{"branch_template": tmpl})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("set branch_template: %d %s", resp.StatusCode, body)
+	}
+}
+
+// createTaskRejected posts a task the daemon should refuse with a 400 and returns
+// the message, which is the part a user acts on.
+func (h *taskHarness) createTaskRejected(t *testing.T, req map[string]any) string {
+	t.Helper()
+	if _, ok := req["project_id"]; !ok {
+		req["project_id"] = h.projectID
+	}
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("create task: status %d (want 400): %s", resp.StatusCode, body)
+	}
+	var e errorBody
+	if err := json.Unmarshal(body, &e); err != nil {
+		t.Fatalf("error body: %v", err)
+	}
+	return e.Error.Message
+}
+
+// The default is unchanged by the whole feature: a task with nothing configured
+// still gets vincent/{id}-{slug}. This is the regression guard for every existing
+// user, and it is first for that reason.
+func TestCreateTaskDefaultBranchUnchanged(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	got := h.createTask(t, map[string]any{"title": "Fix login"})
+	if want := "vincent/" + itoa(got.ID) + "-fix-login"; got.BranchName != want {
+		t.Fatalf("branch = %q, want %q", got.BranchName, want)
+	}
+}
+
+func TestCreateTaskWithBranchName(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+
+	t.Run("a literal is used verbatim", func(t *testing.T) {
+		got := h.createTask(t, map[string]any{
+			"title": "Retry logic", "branch_name": "feat/OPS-123-retry",
+		})
+		if got.BranchName != "feat/OPS-123-retry" {
+			t.Fatalf("branch = %q", got.BranchName)
+		}
+	})
+
+	t.Run("an illegal name is a 400 naming the rules", func(t *testing.T) {
+		msg := h.createTaskRejected(t, map[string]any{
+			"title": "bad", "branch_name": "feat/../escape",
+		})
+		if !strings.Contains(msg, "not valid") {
+			t.Fatalf("message = %q, want it to explain the name is invalid", msg)
+		}
+	})
+
+	t.Run("a name an existing git branch holds is a 400", func(t *testing.T) {
+		testrepo.Run(t, h.repo, "branch", "already/there")
+		msg := h.createTaskRejected(t, map[string]any{
+			"title": "clash", "branch_name": "already/there",
+		})
+		if !strings.Contains(msg, "already exists") {
+			t.Fatalf("message = %q", msg)
+		}
+	})
+
+	// The directory/file conflict: nothing is named `parent/x`, yet it cannot be
+	// created because a branch exists beneath it. An exact-match pre-check reports
+	// this name as free, which is why the probe is wider.
+	t.Run("a directory/file conflict is a 400 that explains itself", func(t *testing.T) {
+		testrepo.Run(t, h.repo, "branch", "parent/x/deeper")
+		msg := h.createTaskRejected(t, map[string]any{
+			"title": "dfclash", "branch_name": "parent/x",
+		})
+		if !strings.Contains(msg, "hierarchy") {
+			t.Fatalf("message = %q, want it to explain the ref hierarchy", msg)
+		}
+	})
+
+	// Neither branch exists yet, so git cannot object; the claim check inside the
+	// insert transaction is what catches it.
+	t.Run("a name another live task claims is a 400 naming that task", func(t *testing.T) {
+		first := h.createTask(t, map[string]any{
+			"title": "first", "branch_name": "feat/contended",
+		})
+		msg := h.createTaskRejected(t, map[string]any{
+			"title": "second", "branch_name": "feat/contended",
+		})
+		if !strings.Contains(msg, "claimed by task "+itoa(first.ID)) {
+			t.Fatalf("message = %q, want it to name task %d", msg, first.ID)
+		}
+	})
+}
+
+func TestCreateTaskWithProjectTemplate(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+
+	t.Run("an id-less template resolves before the insert", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.Slug}}`)
+		got := h.createTask(t, map[string]any{"title": "Add a health endpoint"})
+		if got.BranchName != "feat/add-a-health-endpoint" {
+			t.Fatalf("branch = %q", got.BranchName)
+		}
+	})
+
+	t.Run("an id-bearing template resolves inside the insert", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `t{{.ID}}/{{.Slug}}`)
+		got := h.createTask(t, map[string]any{"title": "Second one"})
+		if want := "t" + itoa(got.ID) + "/second-one"; got.BranchName != want {
+			t.Fatalf("branch = %q, want %q", got.BranchName, want)
+		}
+	})
+
+	t.Run("a literal still beats the template", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.Slug}}`)
+		got := h.createTask(t, map[string]any{
+			"title": "Third", "branch_name": "release/hotfix",
+		})
+		if got.BranchName != "release/hotfix" {
+			t.Fatalf("branch = %q", got.BranchName)
+		}
+	})
+
+	// A template can reference a field, and a task without it must fail loudly
+	// rather than render a hole: `feat/-slug` is a legal ref, so nothing further
+	// down would catch it.
+	t.Run("a template needing a missing field is a 400", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.Fields.ticket}}-{{.Slug}}`)
+		msg := h.createTaskRejected(t, map[string]any{"title": "no ticket"})
+		if !strings.Contains(msg, "could not be resolved") {
+			t.Fatalf("message = %q", msg)
+		}
+		// With the field supplied it goes through.
+		got := h.createTask(t, map[string]any{
+			"title": "has ticket", "fields": map[string]string{"ticket": "OPS-9"},
+		})
+		if got.BranchName != "feat/OPS-9-has-ticket" {
+			t.Fatalf("branch = %q", got.BranchName)
+		}
+	})
+
+	// An id-bearing template that renders an illegal name is rejected before the
+	// row exists, using a placeholder id — legality does not depend on the digits.
+	t.Run("an id-bearing template producing an illegal name is a 400", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.ID}}.lock`)
+		msg := h.createTaskRejected(t, map[string]any{"title": "x"})
+		if !strings.Contains(msg, "not valid") {
+			t.Fatalf("message = %q", msg)
+		}
+	})
+}
+
+func TestProjectBranchTemplateIsValidatedOnWrite(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	resp, body := h.doJSON(t, http.MethodPatch, "/v1/projects/"+itoa(h.projectID),
+		map[string]any{"branch_template": `feat/{{.Slug`})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+	}
+	// Clearing it restores inheritance from config.yaml.
+	h.setProjectBranchTemplate(t, "")
+	got := h.createTask(t, map[string]any{"title": "back to default"})
+	if want := "vincent/" + itoa(got.ID) + "-back-to-default"; got.BranchName != want {
+		t.Fatalf("branch = %q, want %q", got.BranchName, want)
+	}
+}
+
+// No committed task may carry an empty branch_name, and a rejected creation must
+// leave nothing behind — the invariant that replaced the two-write window.
+func TestCreateTaskBranchIsAtomic(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	ctx := t.Context()
+
+	h.createTask(t, map[string]any{"title": "one", "branch_name": "feat/atomic"})
+	h.createTaskRejected(t, map[string]any{
+		"title": "rejected", "branch_name": "feat/atomic",
+	})
+
+	tasks, err := h.store.ListTasks(ctx, store.TaskFilter{Archived: store.ArchivedAll})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	for _, task := range tasks {
+		if task.BranchName == "" {
+			t.Errorf("task %d committed with an empty branch_name", task.ID)
+		}
+		if task.Title == "rejected" {
+			t.Errorf("task %d was committed even though creation was rejected", task.ID)
+		}
+	}
+}
+
+func TestResolvePreviewsTheBranch(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+
+	preview := func(t *testing.T, req map[string]any) resolvedBranch {
+		t.Helper()
+		req["workflow"] = "adhoc"
+		req["project_id"] = h.projectID
+		resp, body := h.doJSON(t, http.MethodPost, "/v1/resolve", req)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("resolve: %d %s", resp.StatusCode, body)
+		}
+		var out struct {
+			Branch *resolvedBranch `json:"branch"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			t.Fatalf("resolve body: %v", err)
+		}
+		if out.Branch == nil {
+			t.Fatal("resolve returned no branch preview")
+		}
+		return *out.Branch
+	}
+
+	t.Run("the default reports a placeholder, never a guessed id", func(t *testing.T) {
+		got := preview(t, map[string]any{"title": "Fix login"})
+		if got.Value != "vincent/<id>-fix-login" || !got.Placeholder {
+			t.Fatalf("preview = %+v", got)
+		}
+		if got.Source != "default" {
+			t.Fatalf("source = %q, want default", got.Source)
+		}
+	})
+
+	t.Run("a project template is named as the source", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.Slug}}`)
+		got := preview(t, map[string]any{"title": "Fix login"})
+		if got.Value != "feat/fix-login" || got.Placeholder {
+			t.Fatalf("preview = %+v", got)
+		}
+		if got.Source != "project" {
+			t.Fatalf("source = %q, want project", got.Source)
+		}
+	})
+
+	t.Run("a typed literal wins and is reported as the task's own", func(t *testing.T) {
+		got := preview(t, map[string]any{"title": "Fix login", "branch_name": "release/x"})
+		if got.Value != "release/x" || got.Source != "task" {
+			t.Fatalf("preview = %+v", got)
+		}
+	})
+
+	t.Run("a template referencing a missing field is a 400, not a hole", func(t *testing.T) {
+		h.setProjectBranchTemplate(t, `feat/{{.Fields.ticket}}`)
+		resp, _ := h.doJSON(t, http.MethodPost, "/v1/resolve", map[string]any{
+			"workflow": "adhoc", "project_id": h.projectID, "title": "no ticket",
+		})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// The recovery path for the failure this whole feature makes reachable: a task
+// blocked because its branch already exists. Nothing else in the API can change a
+// branch name, so without branch_override such a task is permanently dead and its
+// transcripts orphaned.
+func TestRetryWithBranchOverride(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskBlocked)
+	before := decodeTask(t, mustGetTask(t, h, task.ID))
+
+	t.Run("a free name is adopted and the task re-admitted", func(t *testing.T) {
+		resp, body := h.doJSON(t, http.MethodPost,
+			"/v1/tasks/"+itoa(task.ID)+"/retry",
+			map[string]any{"branch_override": "feat/second-attempt"})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("retry: %d %s", resp.StatusCode, body)
+		}
+		got := decodeTask(t, body)
+		if got.BranchName != "feat/second-attempt" {
+			t.Fatalf("branch = %q, want feat/second-attempt", got.BranchName)
+		}
+		if got.State != string(store.TaskQueued) {
+			t.Fatalf("state = %s, want queued", got.State)
+		}
+		// The same task, so its history and transcripts survive the rename.
+		if got.ID != before.ID {
+			t.Fatalf("id changed from %d to %d", before.ID, got.ID)
+		}
+	})
+
+	t.Run("an illegal name is refused and the branch is left alone", func(t *testing.T) {
+		setState(t, h, task.ID, store.TaskBlocked)
+		resp, _ := h.doJSON(t, http.MethodPost,
+			"/v1/tasks/"+itoa(task.ID)+"/retry",
+			map[string]any{"branch_override": "feat/bad..name"})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", resp.StatusCode)
+		}
+		got := decodeTask(t, mustGetTask(t, h, task.ID))
+		if got.BranchName != "feat/second-attempt" {
+			t.Fatalf("branch = %q, want it unchanged", got.BranchName)
+		}
+		if got.State != string(store.TaskBlocked) {
+			t.Fatalf("state = %s, want it still blocked", got.State)
+		}
+	})
+
+	t.Run("a name that still collides is refused, and the task stays blocked", func(t *testing.T) {
+		setState(t, h, task.ID, store.TaskBlocked)
+		testrepo.Run(t, h.repo, "branch", "feat/occupied")
+		resp, body := h.doJSON(t, http.MethodPost,
+			"/v1/tasks/"+itoa(task.ID)+"/retry",
+			map[string]any{"branch_override": "feat/occupied"})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+		}
+		if got := decodeTask(t, mustGetTask(t, h, task.ID)); got.State != string(store.TaskBlocked) {
+			t.Fatalf("state = %s, want it still blocked", got.State)
+		}
+	})
+
+	// Renaming only makes sense for a task that has not started; a running task
+	// already has a worktree checked out on the old name.
+	t.Run("a non-blocked task is a 409, and nothing is renamed", func(t *testing.T) {
+		setState(t, h, task.ID, store.TaskQueued)
+		resp, body := h.doJSON(t, http.MethodPost,
+			"/v1/tasks/"+itoa(task.ID)+"/retry",
+			map[string]any{"branch_override": "feat/too-late"})
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
+		}
+		if got := decodeTask(t, mustGetTask(t, h, task.ID)); got.BranchName == "feat/too-late" {
+			t.Fatal("branch was renamed on a task that could not be retried")
+		}
+	})
+}
+
+func mustGetTask(t *testing.T, h *taskHarness, id int64) []byte {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks/"+itoa(id), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get task: %d %s", resp.StatusCode, body)
+	}
+	return body
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -49,7 +49,11 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 // writeConflict writes a 409 carrying structured details — the current state
 // of a rejected transition, or the reason a precondition failed (§13.1).
 // Conflicts are the only responses in v1 that clients branch on.
-func writeConflict(w http.ResponseWriter, code, message string, details map[string]string) {
+//
+// The code is always CodeInvalidState: every 409 vincent returns is "the thing
+// you asked for does not apply to the state this task is actually in", and the
+// specific reason travels in details rather than in the code.
+func writeConflict(w http.ResponseWriter, message string, details map[string]string) {
 	writeJSON(w, http.StatusConflict,
-		errorBody{Error: errorDetail{Code: code, Message: message, Details: details}})
+		errorBody{Error: errorDetail{Code: CodeInvalidState, Message: message, Details: details}})
 }

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -53,7 +53,7 @@ func newSSEHarness(t *testing.T) *sseHarness {
 		ProjectID: p.ID, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
 		BaseBranch: "main", BranchName: "b", State: store.TaskQueued,
 	}
-	if err := st.CreateTask(ctx, task); err != nil {
+	if err := st.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -292,7 +292,7 @@ func TestTaskStreamResumesDurableEventsForThatTaskOnly(t *testing.T) {
 		ProjectID: h.projectID, Title: "t2", WorkflowName: "adhoc", WorkflowSnapshot: "x",
 		BaseBranch: "main", BranchName: "b2", State: store.TaskQueued,
 	}
-	if err := h.st.CreateTask(ctx, task2); err != nil {
+	if err := h.st.CreateTask(ctx, task2, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/gitx"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // projectResponse is the JSON shape of a project (spec §5.1). Optional fields
@@ -27,6 +28,7 @@ type projectResponse struct {
 	DefaultBranch    string  `json:"default_branch"`
 	DefaultWorkflow  *string `json:"default_workflow"`
 	MaxParallelTasks *int    `json:"max_parallel_tasks"`
+	BranchTemplate   *string `json:"branch_template"`
 	CreatedAt        string  `json:"created_at"`
 	UpdatedAt        string  `json:"updated_at"`
 }
@@ -44,6 +46,10 @@ func toProjectResponse(p *store.Project) projectResponse {
 	if p.DefaultWorkflow != "" {
 		w := p.DefaultWorkflow
 		r.DefaultWorkflow = &w
+	}
+	if p.BranchTemplate != "" {
+		t := p.BranchTemplate
+		r.BranchTemplate = &t
 	}
 	return r
 }
@@ -67,6 +73,10 @@ type projectCreateRequest struct {
 	DefaultBranch    *string `json:"default_branch"`
 	DefaultWorkflow  *string `json:"default_workflow"`
 	MaxParallelTasks *int    `json:"max_parallel_tasks"`
+	// BranchTemplate is this project's branch convention (task 001, §5.3). It is
+	// parsed here rather than at task creation, so a broken template fails where
+	// it was written instead of on every task from then on.
+	BranchTemplate *string `json:"branch_template"`
 }
 
 func (s *Server) handleProjectCreate(w http.ResponseWriter, r *http.Request) {
@@ -126,6 +136,14 @@ func (s *Server) handleProjectCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		p.MaxParallelTasks = req.MaxParallelTasks
 	}
+	if req.BranchTemplate != nil {
+		tmpl := strings.TrimSpace(*req.BranchTemplate)
+		if msg := validateBranchTemplate(tmpl); msg != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+			return
+		}
+		p.BranchTemplate = tmpl
+	}
 	if err := s.deps.Store.CreateProject(ctx, &p); err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed: projects.name") {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed,
@@ -155,6 +173,7 @@ type projectPatchRequest struct {
 	DefaultBranch    opt[string] `json:"default_branch"`
 	DefaultWorkflow  opt[string] `json:"default_workflow"`
 	MaxParallelTasks opt[int]    `json:"max_parallel_tasks"`
+	BranchTemplate   opt[string] `json:"branch_template"`
 }
 
 func (s *Server) handleProjectPatch(w http.ResponseWriter, r *http.Request) {
@@ -235,6 +254,19 @@ func (s *Server) handleProjectPatch(w http.ResponseWriter, r *http.Request) {
 			v := req.MaxParallelTasks.val
 			p.MaxParallelTasks = &v
 		}
+	}
+	if req.BranchTemplate.set {
+		// null and "" both mean "inherit config.yaml again", which is how a
+		// project's convention is removed without inventing a delete endpoint.
+		tmpl := ""
+		if !req.BranchTemplate.null {
+			tmpl = strings.TrimSpace(req.BranchTemplate.val)
+		}
+		if msg := validateBranchTemplate(tmpl); msg != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+			return
+		}
+		p.BranchTemplate = tmpl
 	}
 	if err := s.deps.Store.UpdateProject(ctx, p); err != nil {
 		s.internalError(w, "update project", err)
@@ -519,4 +551,21 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 func (s *Server) internalError(w http.ResponseWriter, what string, err error) {
 	s.deps.Logger.Error(what, "error", err)
 	writeError(w, http.StatusInternalServerError, CodeInternal, what+" failed")
+}
+
+// validateBranchTemplate parses a project's branch template, returning the 400
+// message when it does not compile (task 001). An empty template is valid and
+// means "inherit config.yaml".
+//
+// Parsing here is the point: a template that only failed when a task was created
+// would turn one bad edit into a project that cannot start work, with the error
+// arriving far from the change that caused it.
+func validateBranchTemplate(tmpl string) string {
+	if tmpl == "" {
+		return ""
+	}
+	if err := worktree.ValidateBranchTemplate(tmpl); err != nil {
+		return fmt.Sprintf("branch_template is not a valid template: %v", err)
+	}
+	return ""
 }

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -459,7 +459,7 @@ func insertTask(t *testing.T, st *store.Store, projectID int64, state store.Task
 		ProjectID: projectID, Title: "t", WorkflowName: "adhoc",
 		WorkflowSnapshot: "x", BaseBranch: "main", BranchName: "b", State: state,
 	}
-	if err := st.CreateTask(context.Background(), tk); err != nil {
+	if err := st.CreateTask(context.Background(), tk, nil); err != nil {
 		t.Fatalf("insert task: %v", err)
 	}
 	return tk.ID

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -21,6 +21,14 @@ type resolveRequest struct {
 	Agent     string `json:"agent,omitempty"`
 	Model     string `json:"model,omitempty"`
 	Effort    string `json:"effort,omitempty"`
+	// The draft's branch inputs (task 001). They are here for the same reason
+	// the override triple is: the branch chain is precedence resolution, and PR L
+	// put resolution on the server so no client re-implements it. A form showing
+	// its own guess at the name would be a second implementation to keep in step.
+	Title      string            `json:"title,omitempty"`
+	Fields     map[string]string `json:"fields,omitempty"`
+	BaseBranch string            `json:"base_branch,omitempty"`
+	BranchName string            `json:"branch_name,omitempty"`
 }
 
 // resolvedField is one resolved §8.6 value plus the level that supplied it.
@@ -46,6 +54,22 @@ type resolvedStepResponse struct {
 type resolveResponse struct {
 	Workflow string                 `json:"workflow"`
 	Steps    []resolvedStepResponse `json:"steps"`
+	// Branch previews the name this draft would get, and the level of the chain
+	// that decided it. Nil when no project was given, since the project template
+	// is part of the chain.
+	Branch *resolvedBranch `json:"branch"`
+}
+
+// resolvedBranch is the previewed branch name for a draft task.
+type resolvedBranch struct {
+	Value string `json:"value"`
+	// Source is one of default, config, project, task.
+	Source string `json:"source"`
+	// Placeholder reports that the name depends on the task id, which does not
+	// exist yet, so Value carries a literal `<id>` where the number will go. It
+	// is a preview and deliberately not a prediction: guessing the next id would
+	// be wrong the moment two drafts are open.
+	Placeholder bool `json:"placeholder"`
 }
 
 // handleResolve serves POST /v1/resolve: §8.6 applied to every step of a
@@ -107,6 +131,14 @@ func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
 		Effort: entry.Workflow.Defaults.Effort,
 	}
 	out := resolveResponse{Workflow: entry.Name, Steps: []resolvedStepResponse{}}
+	if req.ProjectID != nil {
+		branch, err := s.previewBranch(r.Context(), *req.ProjectID, req)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, err.Error())
+			return
+		}
+		out.Branch = branch
+	}
 	for _, st := range entry.Workflow.Steps {
 		row := resolvedStepResponse{ID: st.ID, Name: st.DisplayName(), Type: st.Type}
 		if st.Type == workflow.StepAgent {

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -261,10 +261,15 @@ type taskCreateRequest struct {
 	Description *string           `json:"description"`
 	Fields      map[string]string `json:"fields"`
 	BaseBranch  *string           `json:"base_branch"`
-	Priority    *int              `json:"priority"`
-	Agent       *string           `json:"agent"`
-	Model       *string           `json:"model"`
-	Effort      *string           `json:"effort"`
+	// BranchName names this task's branch outright, overriding the project and
+	// config templates (§5.3, task 001). It is used verbatim, never rendered:
+	// it is a name the user typed for one task, so a stray brace belongs to the
+	// name rather than being a template error.
+	BranchName *string `json:"branch_name"`
+	Priority   *int    `json:"priority"`
+	Agent      *string `json:"agent"`
+	Model      *string `json:"model"`
+	Effort     *string `json:"effort"`
 }
 
 // handleTaskCreate implements POST /v1/tasks (spec §13.2). The workflow is
@@ -318,6 +323,10 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("base_branch %q does not resolve to a local branch in %s", baseBranch, project.Path))
 		return
 	}
+	var branchName string
+	if req.BranchName != nil {
+		branchName = strings.TrimSpace(*req.BranchName)
+	}
 	var agentOverride string
 	if req.Agent != nil && strings.TrimSpace(*req.Agent) != "" {
 		agentOverride = strings.TrimSpace(*req.Agent)
@@ -358,17 +367,46 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, cerr)
 		return
 	}
-	if err := s.deps.Store.CreateTask(ctx, &t); err != nil {
-		s.internalError(w, "create task", err)
+	// Branch naming (§5.3, task 001): `default < config.yaml < project < literal`.
+	// Resolve before the insert so a bad name is a 400 rather than a task that
+	// blocks later, and so the git-side checks run with no transaction open.
+	spec := s.branchSpec(branchName, project)
+	bctx := branchContext(t.Title, t.BaseBranch, t.Fields, project)
+	preview, err := resolveBranchPreview(spec, bctx)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("branch name could not be resolved: %v", err))
 		return
 	}
-	// The branch name embeds the task id (§5.3), so it is written right
-	// after the insert; the runner recomputes it if a crash lands between.
-	// The write is branch-name only: the scheduler may have admitted the
-	// task already, and a full-row update would stomp its state.
-	t.BranchName = worktree.BranchName(t.ID, t.Title)
-	if err := s.deps.Store.SetTaskBranchName(ctx, t.ID, t.BranchName); err != nil {
-		s.internalError(w, "assign branch name", err)
+	// Legality is id-independent, so it is checked on both paths. Collision only
+	// on the path whose name is final; see placeholderTaskID.
+	if msg := s.checkBranchLegality(ctx, preview.Name); msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return
+	}
+	var resolveBranch func(int64) (string, error)
+	if preview.NeedsID {
+		// The name needs the id, so it is produced inside the insert transaction.
+		resolveBranch = func(id int64) (string, error) {
+			name, _, err := worktree.ResolveBranchName(spec, bctx.WithID(id))
+			return name, err
+		}
+	} else {
+		if msg := s.checkBranchCollision(ctx, project.Path, preview.Name); msg != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+			return
+		}
+		t.BranchName = preview.Name
+	}
+	if err := s.deps.Store.CreateTask(ctx, &t, resolveBranch); err != nil {
+		var claimed *store.BranchClaimedError
+		if errors.As(err, &claimed) {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("branch %q is already claimed by task %d",
+					claimed.Branch, claimed.TaskID))
+			return
+		}
+		s.internalError(w, "create task", err)
 		return
 	}
 	if s.deps.WakeRunner != nil {

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -25,12 +25,17 @@ const (
 	ActionArchive = "archive"
 )
 
-// Override is the edit+retry body of POST /v1/tasks/{id}/retry (§6): the
-// text replaces the failing step's prompt or command in this task's snapshot
-// only. Both empty is a plain retry.
+// Override is the body of POST /v1/tasks/{id}/retry (§6). Prompt and Run are
+// edit+retry: the text replaces the failing step's prompt or command in this
+// task's snapshot only. All empty is a plain retry.
 type Override struct {
 	Prompt string `json:"prompt_override,omitempty"`
 	Run    string `json:"run_override,omitempty"`
+	// Branch renames the task's branch before the retry re-admits it, which is
+	// how a `branch_exists` block is recovered without losing the task and its
+	// transcripts (task 001). Unlike the other two it does not touch the
+	// snapshot.
+	Branch string `json:"branch_override,omitempty"`
 }
 
 // Cancel aborts the task, killing any live process (§6).

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -61,7 +61,7 @@ func newHarness(t *testing.T) *harness {
 		ProjectID: p.ID, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
 		BaseBranch: "main", BranchName: "b", State: store.TaskQueued,
 	}
-	if err := st.CreateTask(ctx, task); err != nil {
+	if err := st.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -147,7 +147,7 @@ func (h *harness) snapshotTask(t *testing.T) int64 {
 		WorkflowSnapshot: snapshotWorkflow,
 		BaseBranch:       "main", BranchName: "vincent/2-snapshot", State: store.TaskQueued,
 	}
-	if err := h.st.CreateTask(t.Context(), task); err != nil {
+	if err := h.st.CreateTask(t.Context(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task.ID
@@ -162,7 +162,7 @@ func (h *harness) taskInWorktree(t *testing.T, repo string) int64 {
 		WorkflowSnapshot: snapshotWorkflow, BaseBranch: "main",
 		BranchName: "vincent/3-diffable", WorktreePath: repo, State: store.TaskRunning,
 	}
-	if err := h.st.CreateTask(t.Context(), task); err != nil {
+	if err := h.st.CreateTask(t.Context(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task.ID

--- a/internal/apiclient/projects.go
+++ b/internal/apiclient/projects.go
@@ -18,14 +18,17 @@ import (
 // "capped at the global figure" — it means this project may take as many of
 // the global slots as it can get.
 type Project struct {
-	ID               int64     `json:"id"`
-	Name             string    `json:"name"`
-	Path             string    `json:"path"`
-	DefaultBranch    string    `json:"default_branch"`
-	DefaultWorkflow  *string   `json:"default_workflow"`
-	MaxParallelTasks *int      `json:"max_parallel_tasks"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID               int64   `json:"id"`
+	Name             string  `json:"name"`
+	Path             string  `json:"path"`
+	DefaultBranch    string  `json:"default_branch"`
+	DefaultWorkflow  *string `json:"default_workflow"`
+	MaxParallelTasks *int    `json:"max_parallel_tasks"`
+	// BranchTemplate is this project's branch convention; nil inherits the one in
+	// config.yaml, and an unset config means the built-in name (task 001).
+	BranchTemplate *string   `json:"branch_template"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // Workflow reports the workflow a new task in this project gets when the
@@ -62,6 +65,7 @@ type CreateProjectRequest struct {
 	DefaultBranch    *string `json:"default_branch,omitempty"`
 	DefaultWorkflow  *string `json:"default_workflow,omitempty"`
 	MaxParallelTasks *int    `json:"max_parallel_tasks,omitempty"`
+	BranchTemplate   *string `json:"branch_template,omitempty"`
 }
 
 // PatchProjectRequest is the PATCH /v1/projects/{id} body. Every field is an
@@ -73,6 +77,9 @@ type PatchProjectRequest struct {
 	DefaultBranch    Opt[string] `json:"default_branch,omitzero"`
 	DefaultWorkflow  Opt[string] `json:"default_workflow,omitzero"`
 	MaxParallelTasks Opt[int]    `json:"max_parallel_tasks,omitzero"`
+	// BranchTemplate set to null or "" makes the project inherit config.yaml
+	// again, which is how a convention is removed (task 001).
+	BranchTemplate Opt[string] `json:"branch_template,omitzero"`
 }
 
 // CreateProject registers a repository. The daemon validates the path is a

--- a/internal/apiclient/projectwrite_test.go
+++ b/internal/apiclient/projectwrite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 func TestCreateProjectDerivesNameAndBranchFromThePath(t *testing.T) {
@@ -218,7 +219,10 @@ func (h *createHarness) newTask(ctx context.Context, t *testing.T, state store.T
 		BaseBranch:   "main",
 		State:        state,
 	}
-	if err := h.store.CreateTask(ctx, task); err != nil {
+	// Unique per task, because CreateTask now refuses an empty name and refuses
+	// one another live task already holds (task 001).
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, task.Title), nil }
+	if err := h.store.CreateTask(ctx, task, resolve); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/apiclient/resolve.go
+++ b/internal/apiclient/resolve.go
@@ -19,6 +19,14 @@ type ResolveRequest struct {
 	Agent     string `json:"agent,omitempty"`
 	Model     string `json:"model,omitempty"`
 	Effort    string `json:"effort,omitempty"`
+	// The draft's branch inputs, so the daemon can preview the resolved name
+	// (task 001). Sent by the new-task form as the user types; resolution stays
+	// server-side, which is the PR L decision this reuses rather than works
+	// around.
+	Title      string            `json:"title,omitempty"`
+	Fields     map[string]string `json:"fields,omitempty"`
+	BaseBranch string            `json:"base_branch,omitempty"`
+	BranchName string            `json:"branch_name,omitempty"`
 }
 
 // ResolvedField is one §8.6 value and the level that supplied it. Value is
@@ -49,6 +57,41 @@ type ResolvedStep struct {
 type Resolution struct {
 	Workflow string         `json:"workflow"`
 	Steps    []ResolvedStep `json:"steps"`
+	// Branch previews the name a draft task would get. Nil when the request
+	// named no project, since the project template is part of the chain.
+	Branch *ResolvedBranch `json:"branch"`
+}
+
+// Branch-naming levels, as POST /v1/resolve reports them (task 001).
+const (
+	BranchSourceDefault = "default"
+	BranchSourceConfig  = "config"
+	BranchSourceProject = "project"
+	BranchSourceTask    = "task"
+)
+
+// ResolvedBranch is the previewed branch name for a draft task.
+type ResolvedBranch struct {
+	Value  string `json:"value"`
+	Source string `json:"source"`
+	// Placeholder reports that Value carries a literal `<id>` where the task id
+	// will go, because the id does not exist until the task is created. Display
+	// it as-is: the daemon deliberately does not guess the next id.
+	Placeholder bool `json:"placeholder"`
+}
+
+// Explain names the level that decided the branch, for a form's hint line.
+func (b ResolvedBranch) Explain() string {
+	switch b.Source {
+	case BranchSourceTask:
+		return "as typed"
+	case BranchSourceProject:
+		return "from the project template"
+	case BranchSourceConfig:
+		return "from config.yaml"
+	default:
+		return "vincent default"
+	}
 }
 
 // Agents lists the distinct resolved agents across the agent steps, in step

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -272,10 +272,13 @@ type CreateTaskRequest struct {
 	Description *string           `json:"description,omitempty"`
 	Fields      map[string]string `json:"fields,omitempty"`
 	BaseBranch  *string           `json:"base_branch,omitempty"`
-	Priority    *int              `json:"priority,omitempty"`
-	Agent       *string           `json:"agent,omitempty"`
-	Model       *string           `json:"model,omitempty"`
-	Effort      *string           `json:"effort,omitempty"`
+	// BranchName names this task's branch outright, overriding the project and
+	// config templates (task 001). Used verbatim, never rendered.
+	BranchName *string `json:"branch_name,omitempty"`
+	Priority   *int    `json:"priority,omitempty"`
+	Agent      *string `json:"agent,omitempty"`
+	Model      *string `json:"model,omitempty"`
+	Effort     *string `json:"effort,omitempty"`
 }
 
 // CreateTask creates a task and returns it as the daemon recorded it. The

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -28,6 +28,7 @@ func newTaskAddCmd() *cobra.Command {
 		description string
 		baseBranch  string
 		priority    int
+		branch      string
 		agent       string
 		model       string
 		effort      string
@@ -47,6 +48,7 @@ func newTaskAddCmd() *cobra.Command {
 					{"workflow", &req.Workflow, &workflow},
 					{"description", &req.Description, &description},
 					{"base-branch", &req.BaseBranch, &baseBranch},
+					{"branch", &req.BranchName, &branch},
 					{"agent", &req.Agent, &agent},
 					{"model", &req.Model, &model},
 					{"effort", &req.Effort, &effort},
@@ -89,6 +91,8 @@ func newTaskAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&title, "title", "", "Task title (required)")
 	cmd.Flags().StringVar(&description, "description", "", "Task description")
 	cmd.Flags().StringVar(&baseBranch, "base-branch", "", "Base branch (default: the project's)")
+	cmd.Flags().StringVar(&branch, "branch", "",
+		"Name for the task's branch, used verbatim (default: the project or config template)")
 	cmd.Flags().IntVar(&priority, "priority", 0, "Scheduling priority; higher runs first")
 	cmd.Flags().StringVar(&agent, "agent", "", "Agent override (§8.6 level 2)")
 	cmd.Flags().StringVar(&model, "model", "", "Model override (§8.6 level 2)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,8 +137,19 @@ func ParseByteSize(s string) (ByteSize, error) {
 // Config is the daemon configuration (spec §12.3, plus the agents section —
 // a phase 1 spec addition).
 type Config struct {
-	Listen                  string   `yaml:"listen"`
-	MaxParallelTasks        int      `yaml:"max_parallel_tasks"`
+	Listen           string `yaml:"listen"`
+	MaxParallelTasks int    `yaml:"max_parallel_tasks"`
+	// BranchTemplate is the global branch-naming convention, the level between
+	// the built-in `vincent/{id}-{slug}` and a project's own template (task 001,
+	// §5.3). Empty means the built-in name.
+	//
+	// Its *syntax* is not checked here: validating it needs the branch template
+	// context, which lives in internal/worktree, and this package is a leaf that
+	// imports nothing internal. internal/daemon validates it instead — at startup
+	// as a hard failure, and on hot-reload by keeping the previous value with a
+	// warning, because a daemon that quietly ignored the configured convention
+	// would create every branch under the wrong name.
+	BranchTemplate          string   `yaml:"branch_template"`
 	Defaults                Defaults `yaml:"defaults"`
 	TranscriptRetentionDays int      `yaml:"transcript_retention_days"`
 	// TranscriptMaxBytes caps one attempt's transcript (§12.3, §18). Past it

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -100,6 +100,16 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		logger.Error("startup failed: invalid config", "error", err)
 		return err
 	}
+	// Checked here rather than in config.validate: internal/config is a leaf
+	// package and the branch template's context lives in internal/worktree
+	// (task 001). A hard failure, not a warning — a daemon that ignored the
+	// configured convention would create every branch under the wrong name, and
+	// the user would not find out until they looked at their repository.
+	if err := worktree.ValidateBranchTemplate(cfg.BranchTemplate); err != nil {
+		logger.Error("startup failed: branch_template does not compile",
+			"branch_template", cfg.BranchTemplate, "error", err)
+		return fmt.Errorf("invalid branch_template: %w", err)
+	}
 	if lvl, err := parseLevel(cfg.LogLevel); err == nil {
 		level.Set(lvl)
 	}
@@ -289,6 +299,20 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 			logger.Warn("listen change ignored until restart",
 				"effective", prev.Listen, "requested", next.Listen)
 			next.Listen = prev.Listen
+		}
+		// A branch template that does not compile is refused on its own rather
+		// than dropping the whole reload: a typo here should not also revert an
+		// unrelated log_level edit in the same save. Keeping the previous value is
+		// the honest fallback — silently falling back to the built-in name would
+		// create every branch under a convention the user did not ask for
+		// (task 001). config cannot check this itself; it is a leaf package and
+		// the template context lives in internal/worktree.
+		if next.BranchTemplate != prev.BranchTemplate {
+			if err := worktree.ValidateBranchTemplate(next.BranchTemplate); err != nil {
+				logger.Warn("branch_template change ignored: it does not compile",
+					"effective", prev.BranchTemplate, "requested", next.BranchTemplate, "error", err)
+				next.BranchTemplate = prev.BranchTemplate
+			}
 		}
 		if lvl, err := parseLevel(next.LogLevel); err == nil {
 			level.Set(lvl)

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -84,6 +84,30 @@ func (g *Git) Run(ctx context.Context, dir string, args ...string) (string, erro
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+// CheckRefFormat reports whether name is usable as a branch name, returning a
+// *Error when it is not.
+//
+// It asks git rather than reimplementing git's grammar (task 001 decision). That
+// grammar rejects `..`, `~^:?*[\`, control characters, `@{`, a `.lock` suffix, a
+// leading `-`, a trailing `.`, `//` and the name `HEAD` — a list a hand-rolled
+// matcher would have to reproduce and then keep correct on three platforms as git
+// evolves. git is also the thing that will ultimately accept or reject the name,
+// so any second opinion is one that can disagree.
+//
+// Two behaviours worth knowing, both verified against git 2.x rather than
+// assumed. It needs no repository, so it runs with no working directory — which
+// also means `--branch`'s shorthand expansion (`@{-1}`) has nothing to resolve
+// against and is simply rejected, exactly what vincent wants when it is about to
+// store the literal. And `refs/heads/x` is *accepted*: git considers it a legal
+// branch name, which would produce `refs/heads/refs/heads/x`. That is git's call
+// to make, and inventing a rule against it is the thing this delegation avoids.
+func (g *Git) CheckRefFormat(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)
+	defer cancel()
+	_, err := g.Run(ctx, "", "check-ref-format", "--branch", name)
+	return err
+}
+
 // Version returns the raw `git version` line and the parsed major/minor.
 func (g *Git) Version(ctx context.Context) (raw string, major, minor int, err error) {
 	ctx, cancel := context.WithTimeout(ctx, QueryTimeout)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -89,7 +89,7 @@ func (h *harness) task(
 		Priority: priority, State: state,
 		CreatedAt: time.Now().Add(-age),
 	}
-	if err := h.store.CreateTask(t.Context(), task); err != nil {
+	if err := h.store.CreateTask(t.Context(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/store/board_test.go
+++ b/internal/store/board_test.go
@@ -14,7 +14,7 @@ func TestSetTaskProgressEmitsStepAdvanced(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestSetTaskProgressWorktreeOnlyIsSilent(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -117,11 +117,11 @@ func TestTaskRollupsSumsEveryAttempt(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	other := newTask(p.ID, "other", TaskRunning)
-	if err := s.CreateTask(ctx, other); err != nil {
+	if err := s.CreateTask(ctx, other, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestTaskRollupsDistinguishesFreeFromUnreported(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	in := int64(5)
@@ -218,11 +218,11 @@ func TestListTasksArchivedFilter(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	live := newTask(p.ID, "live", TaskRunning)
-	if err := s.CreateTask(ctx, live); err != nil {
+	if err := s.CreateTask(ctx, live, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	gone := newTask(p.ID, "gone", TaskArchived)
-	if err := s.CreateTask(ctx, gone); err != nil {
+	if err := s.CreateTask(ctx, gone, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 

--- a/internal/store/cascade_test.go
+++ b/internal/store/cascade_test.go
@@ -22,7 +22,7 @@ func TestDeleteProjectCascade(t *testing.T) {
 			ProjectID: pid, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
 			BaseBranch: "main", BranchName: "b", State: state,
 		}
-		if err := s.CreateTask(ctx, tk); err != nil {
+		if err := s.CreateTask(ctx, tk, nil); err != nil {
 			t.Fatalf("create task: %v", err)
 		}
 		return tk

--- a/internal/store/eventalias_test.go
+++ b/internal/store/eventalias_test.go
@@ -23,7 +23,7 @@ func TestPublishedEventsDoNotAliasTheCallersTask(t *testing.T) {
 		}
 	})
 	task := newTask(p.ID, "work", TaskQueued)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	if created == nil {

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 4
+const latestSchemaVersion = 5
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0005_branch_template.sql
+++ b/internal/store/migrations/0005_branch_template.sql
@@ -1,0 +1,10 @@
+-- 0005_branch_template: per-project branch-name template, the middle level of
+-- the branch-naming chain `default < config.yaml < project < per-task literal`
+-- (task 001, spec §5.3/§10).
+--
+-- No UNIQUE index on tasks.branch_name accompanies this, deliberately. Archived
+-- tasks keep their branch_name, so an index would forbid ever reusing a name --
+-- including after the user manually deleted the branch, which is the one case
+-- where reuse is legitimate. The claim check is a scoped query instead.
+
+ALTER TABLE projects ADD COLUMN branch_template TEXT;  -- NULL = inherit config.yaml

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -50,8 +50,12 @@ type Project struct {
 	DefaultBranch    string
 	DefaultWorkflow  string // "" = none
 	MaxParallelTasks *int   // nil = unlimited (global cap still applies)
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	// BranchTemplate names this project's branch convention; "" inherits
+	// config.yaml's, and an unset config falls back to the built-in
+	// vincent/{id}-{slug} (task 001).
+	BranchTemplate string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // Task is one unit of work delivered by running a workflow against a project

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const projectColumns = `id, name, path, default_branch, default_workflow, max_parallel_tasks, created_at, updated_at`
+const projectColumns = `id, name, path, default_branch, default_workflow, max_parallel_tasks, branch_template, created_at, updated_at`
 
 // CreateProject inserts p and assigns its ID and timestamps, writing the
 // durable project.created event in the same transaction (spec §13.3). A
@@ -23,10 +23,10 @@ func (s *Store) CreateProject(ctx context.Context, p *Project) error {
 	var ev *Event
 	err := s.withTx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
-			INSERT INTO projects (name, path, default_branch, default_workflow, max_parallel_tasks, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			INSERT INTO projects (name, path, default_branch, default_workflow, max_parallel_tasks, branch_template, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 			p.Name, p.Path, p.DefaultBranch, nullString(p.DefaultWorkflow), p.MaxParallelTasks,
-			formatTime(p.CreatedAt), formatTime(p.UpdatedAt))
+			nullString(p.BranchTemplate), formatTime(p.CreatedAt), formatTime(p.UpdatedAt))
 		if err != nil {
 			return fmt.Errorf("insert project: %w", err)
 		}
@@ -101,10 +101,10 @@ func (s *Store) UpdateProject(ctx context.Context, p *Project) error {
 	err := s.withTx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `
 			UPDATE projects SET name = ?, path = ?, default_branch = ?, default_workflow = ?,
-				max_parallel_tasks = ?, updated_at = ?
+				max_parallel_tasks = ?, branch_template = ?, updated_at = ?
 			WHERE id = ?`,
 			p.Name, p.Path, p.DefaultBranch, nullString(p.DefaultWorkflow), p.MaxParallelTasks,
-			formatTime(p.UpdatedAt), p.ID)
+			nullString(p.BranchTemplate), formatTime(p.UpdatedAt), p.ID)
 		if err != nil {
 			return fmt.Errorf("update project %d: %w", p.ID, err)
 		}
@@ -195,13 +195,16 @@ func scanProject(r rowScanner) (*Project, error) {
 	var (
 		p                Project
 		workflow         sql.NullString
+		branchTemplate   sql.NullString
 		maxPar           sql.NullInt64
 		created, updated string
 	)
-	if err := r.Scan(&p.ID, &p.Name, &p.Path, &p.DefaultBranch, &workflow, &maxPar, &created, &updated); err != nil {
+	if err := r.Scan(&p.ID, &p.Name, &p.Path, &p.DefaultBranch, &workflow, &maxPar,
+		&branchTemplate, &created, &updated); err != nil {
 		return nil, err
 	}
 	p.DefaultWorkflow = workflow.String
+	p.BranchTemplate = branchTemplate.String
 	if maxPar.Valid {
 		v := int(maxPar.Int64)
 		p.MaxParallelTasks = &v

--- a/internal/store/steps_test.go
+++ b/internal/store/steps_test.go
@@ -14,7 +14,7 @@ func testTask(t *testing.T, s *Store) *Task {
 	t.Helper()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "t", TaskRunning)
-	if err := s.CreateTask(t.Context(), task); err != nil {
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -32,10 +32,40 @@ var slotStates, slotPlaceholders = func() ([]any, string) {
 	return args, "(?" + strings.Repeat(", ?", len(args)-1) + ")"
 }()
 
+// BranchClaimedError reports that another unarchived task in the same project
+// already holds the branch name a new task resolved to (task 001).
+//
+// It is a distinct type because the API turns it into a 400 while every other
+// insert failure is a 500: the name is the caller's input, and "task 41 already
+// has that branch" is something they can act on.
+type BranchClaimedError struct {
+	Branch string
+	TaskID int64
+}
+
+func (e *BranchClaimedError) Error() string {
+	return fmt.Sprintf("branch %q is already claimed by task %d", e.Branch, e.TaskID)
+}
+
 // CreateTask inserts t and assigns its ID and timestamps, writing the
 // durable task.created event in the same transaction (spec §13.3). A
 // caller-set CreatedAt is kept (tests rely on this); zero means now.
-func (s *Store) CreateTask(ctx context.Context, t *Task) error {
+//
+// resolveBranch fills in a branch name that could not be known before the insert
+// because it depends on the task id. When it is nil, t.BranchName is used as
+// given. Either way the name is written inside the same transaction as the row
+// and the task.created event, so no committed task ever carries an empty
+// branch_name and there is no window for a crash to land in (task 001). It
+// replaces SetTaskBranchName, whose second write was that window, and the
+// recompute in taskrun that tried to paper over it — a recompute that silently
+// produced the *default* name and so would have discarded a user's chosen one.
+//
+// Whichever path supplies the name, it is checked against other unarchived tasks
+// in the same project before the commit; a clash returns *BranchClaimedError and
+// rolls back. Archived tasks are excluded on purpose: they keep their
+// branch_name, so counting them would forbid reusing a name even after the user
+// deleted the branch by hand, which is the one case where reuse is legitimate.
+func (s *Store) CreateTask(ctx context.Context, t *Task, resolveBranch func(id int64) (string, error)) error {
 	now := time.Now()
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = now
@@ -67,15 +97,30 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 			return fmt.Errorf("insert task: %w", err)
 		}
 		t.ID = id
+		// The id exists now, so a name that needed it can be produced and written
+		// before this transaction commits.
+		if resolveBranch != nil {
+			branch, err := resolveBranch(id)
+			if err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE tasks SET branch_name = ? WHERE id = ?`, branch, id); err != nil {
+				return fmt.Errorf("assign branch name: %w", err)
+			}
+			t.BranchName = branch
+		}
+		if err := claimBranchTx(ctx, tx, t.ProjectID, t.BranchName, id); err != nil {
+			return err
+		}
 		payload, err := json.Marshal(map[string]any{
 			"state": string(t.State), "title": t.Title, "workflow": t.WorkflowName,
 		})
 		if err != nil {
 			return fmt.Errorf("marshal task.created event: %w", err)
 		}
-		// Copied, not aliased: the event goes to the broker, and t belongs to
-		// the caller, which keeps writing it (the API assigns BranchName right
-		// after this returns).
+		// Copied, not aliased: the event goes to the broker, and t belongs to the
+		// caller.
 		taskID, projectID := t.ID, t.ProjectID
 		ev = &Event{
 			TS: now, Type: EventTaskCreated,
@@ -88,6 +133,34 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 	}
 	s.notify(ev)
 	return nil
+}
+
+// claimBranchTx fails when another unarchived task in the project already holds
+// branch. It runs inside the caller's transaction because it is the half of the
+// collision check that can: it is a plain query, whereas the git-side checks
+// shell out and must never hold SQLite's single write lock across a subprocess
+// that has a 30-second timeout.
+//
+// It runs for *every* path, including id-bearing templates, which are not
+// self-protecting: `feat/{{.ID}}` on task 5 and a literal `feat/5` typed on
+// task 9 resolve to the same name.
+func claimBranchTx(ctx context.Context, tx *sql.Tx, projectID int64, branch string, selfID int64) error {
+	if branch == "" {
+		return fmt.Errorf("insert task: branch name is empty")
+	}
+	var other int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT id FROM tasks
+		WHERE project_id = ? AND branch_name = ? AND id <> ? AND archived_at IS NULL
+		LIMIT 1`, projectID, branch, selfID).Scan(&other)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("check branch claim: %w", err)
+	default:
+		return &BranchClaimedError{Branch: branch, TaskID: other}
+	}
 }
 
 // GetTask returns the task with the given id, or ErrNotFound.
@@ -168,19 +241,30 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 	return s.queryTasks(ctx, q, args...)
 }
 
-// SetTaskBranchName records the branch derived from the task's id right
-// after the insert (§5.3). It writes nothing else on purpose: the scheduler
-// may admit the task between the insert and this write, and a full-row
-// update would overwrite the state its CAS just set (phase 2 decision: only
-// TransitionTask writes state).
-func (s *Store) SetTaskBranchName(ctx context.Context, id int64, branch string) error {
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE tasks SET branch_name = ?, updated_at = ? WHERE id = ?`,
-		branch, formatTime(time.Now()), id)
-	if err != nil {
-		return fmt.Errorf("set task %d branch name: %w", id, err)
-	}
-	return oneRowAffected(res, fmt.Sprintf("task %d", id))
+// SetTaskBranchName renames a task's branch, and exists for exactly one caller:
+// recovering a task blocked with `branch_exists` through
+// `POST /v1/tasks/{id}/retry { branch_override }` (task 001). It is no longer
+// part of task creation — CreateTask writes the name inside its own transaction,
+// which is what closed the window this function used to open.
+//
+// It writes nothing but the name on purpose: the scheduler may admit the task
+// between this write and the next, and a full-row update would overwrite the
+// state its CAS just set (phase 2 decision: only TransitionTask writes state).
+// The claim check runs in the same transaction, so a rename cannot take a name
+// another live task already holds.
+func (s *Store) SetTaskBranchName(ctx context.Context, id, projectID int64, branch string) error {
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := claimBranchTx(ctx, tx, projectID, branch, id); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx,
+			`UPDATE tasks SET branch_name = ?, updated_at = ? WHERE id = ?`,
+			branch, formatTime(time.Now()), id)
+		if err != nil {
+			return fmt.Errorf("set task %d branch name: %w", id, err)
+		}
+		return oneRowAffected(res, fmt.Sprintf("task %d", id))
+	})
 }
 
 // UpdateTask writes every mutable field of t (matched by ID) and bumps

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -54,7 +54,7 @@ func TestTaskRoundTrip(t *testing.T) {
 		BlockReason:      "",
 		StartedAt:        &started,
 	}
-	if err := s.CreateTask(ctx, in); err != nil {
+	if err := s.CreateTask(ctx, in, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	if in.ID == 0 {
@@ -91,7 +91,7 @@ func TestTaskNullableDefaults(t *testing.T) {
 	p := testProject(t, s, "p1")
 
 	in := newTask(p.ID, "bare", TaskQueued)
-	if err := s.CreateTask(ctx, in); err != nil {
+	if err := s.CreateTask(ctx, in, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	got, err := s.GetTask(ctx, in.ID)
@@ -115,7 +115,7 @@ func TestTaskUpdate(t *testing.T) {
 	p := testProject(t, s, "p1")
 
 	task := newTask(p.ID, "t", TaskQueued)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -159,7 +159,7 @@ func TestTaskListFilters(t *testing.T) {
 
 	mk := func(pid int64, title string, state TaskState) *Task {
 		task := newTask(pid, title, state)
-		if err := s.CreateTask(ctx, task); err != nil {
+		if err := s.CreateTask(ctx, task, nil); err != nil {
 			t.Fatalf("CreateTask(%s): %v", title, err)
 		}
 		return task
@@ -213,7 +213,7 @@ func TestSchedulerQueries(t *testing.T) {
 		task := newTask(pid, title, state)
 		task.Priority = priority
 		task.CreatedAt = base.Add(offset)
-		if err := s.CreateTask(ctx, task); err != nil {
+		if err := s.CreateTask(ctx, task, nil); err != nil {
 			t.Fatalf("CreateTask(%s): %v", title, err)
 		}
 		return task
@@ -253,7 +253,7 @@ func TestSchedulerQueries(t *testing.T) {
 
 func TestTaskForeignKeyEnforced(t *testing.T) {
 	s := openTest(t)
-	if err := s.CreateTask(t.Context(), newTask(9999, "orphan", TaskQueued)); err == nil {
+	if err := s.CreateTask(t.Context(), newTask(9999, "orphan", TaskQueued), nil); err == nil {
 		t.Error("CreateTask with unknown project_id accepted; want FK violation")
 	}
 }

--- a/internal/store/transitions_test.go
+++ b/internal/store/transitions_test.go
@@ -12,7 +12,7 @@ func TestTransitionTaskWritesStateAndEventTogether(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskQueued)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestTransitionTaskConflictLeavesNothingBehind(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -101,7 +101,7 @@ func TestTransitionTaskAppliesChanges(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskRunning)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 
@@ -148,7 +148,7 @@ func TestTransitionTaskTimestamps(t *testing.T) {
 	p := testProject(t, s, "p1")
 
 	task := newTask(p.ID, "work", TaskQueued)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	running, _, err := s.TransitionTask(ctx, task.ID, TaskQueued, TaskRunning, TaskChange{})
@@ -195,7 +195,7 @@ func TestCountStepAttemptsCursorBoundsOnlyFailures(t *testing.T) {
 	ctx := t.Context()
 	p := testProject(t, s, "p1")
 	task := newTask(p.ID, "work", TaskBlocked)
-	if err := s.CreateTask(ctx, task); err != nil {
+	if err := s.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	base := time.Now().Add(-time.Hour)

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -71,10 +71,12 @@ func (h *actionHarness) taskAtStep(t *testing.T, state store.TaskState, step int
 	task := &store.Task{
 		ProjectID: h.projectID, Title: "action test",
 		WorkflowName: "test", WorkflowSnapshot: actionSnapshot,
-		BaseBranch: "main", BranchName: "vincent/action-test",
-		State: state, CurrentStep: step,
+		BaseBranch: "main",
+		State:      state, CurrentStep: step,
 	}
-	if err := h.store.CreateTask(t.Context(), task); err != nil {
+	// Derived from the id so two tasks in one test cannot claim the same branch.
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, task.Title), nil }
+	if err := h.store.CreateTask(t.Context(), task, resolve); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -155,9 +155,12 @@ func (r *Runner) ensureWorktree(ctx context.Context, task *store.Task, project *
 	if task.WorktreePath != "" {
 		return nil
 	}
-	if task.BranchName == "" { // crash between insert and branch assignment
-		task.BranchName = worktree.BranchName(task.ID, task.Title)
-	}
+	// No recompute of an empty BranchName here any more (task 001). It used to
+	// cover a crash between the insert and a second write that assigned the name;
+	// CreateTask now writes the name in the insert's own transaction, so the
+	// window is gone. Keeping the recompute would have been actively harmful once
+	// names became configurable: it produced the *built-in* name, so a task whose
+	// user chose `feat/OPS-123` would have silently run on `vincent/{id}-{slug}`.
 	path, err := r.deps.Worktrees.Create(ctx, project.Path, task.ID, task.BranchName, task.BaseBranch)
 	if err != nil {
 		if ctx.Err() != nil {

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -112,12 +112,14 @@ func (h *engineHarness) createTask(t *testing.T, snapshot string) *store.Task {
 		BaseBranch:       "main",
 		State:            store.TaskQueued,
 	}
-	if err := h.store.CreateTask(t.Context(), task); err != nil {
+	// The branch name is assigned through the resolver, inside the insert's own
+	// transaction, exactly as the API does it (task 001). This helper used to
+	// insert and then UpdateTask the name in — which is the two-write window
+	// CreateTask closed, so a fixture that kept doing it would no longer be
+	// testing the path production takes.
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, task.Title), nil }
+	if err := h.store.CreateTask(t.Context(), task, resolve); err != nil {
 		t.Fatalf("CreateTask: %v", err)
-	}
-	task.BranchName = worktree.BranchName(task.ID, task.Title)
-	if err := h.store.UpdateTask(t.Context(), task); err != nil {
-		t.Fatalf("UpdateTask: %v", err)
 	}
 	return task
 }

--- a/internal/taskrun/prune_test.go
+++ b/internal/taskrun/prune_test.go
@@ -60,7 +60,7 @@ func (h *pruneHarness) task(t *testing.T, title string, archivedAgo time.Duratio
 		State: store.TaskDone, WorkflowSnapshot: "name: adhoc\nsteps: []\n",
 		BranchName: "vincent/" + title,
 	}
-	if err := h.store.CreateTask(t.Context(), task); err != nil {
+	if err := h.store.CreateTask(t.Context(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	if archivedAgo > 0 {

--- a/internal/taskrun/recover_test.go
+++ b/internal/taskrun/recover_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/procx"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 func recoverStore(t *testing.T) (*store.Store, int64) {
@@ -32,9 +33,10 @@ func recoverTask(t *testing.T, st *store.Store, projectID int64, state store.Tas
 	t.Helper()
 	task := &store.Task{
 		ProjectID: projectID, Title: "t-" + string(state), WorkflowName: "adhoc",
-		WorkflowSnapshot: "x", BaseBranch: "main", BranchName: "b", State: state,
+		WorkflowSnapshot: "x", BaseBranch: "main", State: state,
 	}
-	if err := st.CreateTask(context.Background(), task); err != nil {
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, task.Title), nil }
+	if err := st.CreateTask(context.Background(), task, resolve); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lezli01/vincent/internal/daemon"
 	"github.com/lezli01/vincent/internal/events"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 const threeStepWorkflow = `name: three
@@ -118,9 +119,10 @@ func (h *boardLiveHarness) createTask(t *testing.T, title string) *store.Task {
 	task := &store.Task{
 		ProjectID: h.projectID, Title: title, WorkflowName: "three",
 		WorkflowSnapshot: threeStepWorkflow,
-		BaseBranch:       "main", BranchName: "b", State: store.TaskQueued,
+		BaseBranch:       "main", State: store.TaskQueued,
 	}
-	if err := h.st.CreateTask(ctx, task); err != nil {
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, task.Title), nil }
+	if err := h.st.CreateTask(ctx, task, resolve); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/tui/detailactions_live_test.go
+++ b/internal/tui/detailactions_live_test.go
@@ -168,7 +168,7 @@ func (h *actionLiveHarness) createTask(t *testing.T, title string) *store.Task {
 		BaseBranch:       "main", BranchName: "vincent/live-" + title,
 		State: store.TaskQueued,
 	}
-	if err := h.st.CreateTask(context.Background(), task); err != nil {
+	if err := h.st.CreateTask(context.Background(), task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	return task

--- a/internal/tui/live_test.go
+++ b/internal/tui/live_test.go
@@ -45,7 +45,7 @@ func TestLiveChangeFromRealServer(t *testing.T) {
 		ProjectID: p.ID, Title: "t", WorkflowName: "adhoc", WorkflowSnapshot: "x",
 		BaseBranch: "main", BranchName: "b", State: store.TaskQueued,
 	}
-	if err := st.CreateTask(ctx, task); err != nil {
+	if err := st.CreateTask(ctx, task, nil); err != nil {
 		t.Fatalf("CreateTask: %v", err)
 	}
 

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,8 +21,8 @@ import (
 const loadTimeout = 10 * time.Second
 
 // ntRow identifies one line of the form. The order is §15's: project →
-// workflow → title → description → fields → base branch → priority →
-// agent/model/effort → create. It is one screen rather than nine, because
+// workflow → title → description → fields → base branch → branch name →
+// priority → agent/model/effort → create. It is one screen rather than nine, because
 // the arrows in §15 are field order, not screen count, and a form gets
 // back-navigation and review-before-submit for free.
 type ntRow int
@@ -33,6 +34,7 @@ const (
 	ntDescription
 	ntFields
 	ntBranch
+	ntBranchName
 	ntPriority
 	ntAgent
 	ntModel
@@ -124,10 +126,14 @@ type newTask struct {
 	desc      textarea.Model
 	fields    []kv
 	branch    textinput.Model
-	priority  textinput.Model
-	agent     string
-	model     string
-	effort    string
+	// branchName is the task's own branch, distinct from branch above, which is
+	// the *base* it forks from. Two adjacent rows about branches need labels that
+	// cannot be misread as one having been renamed (task 001).
+	branchName textinput.Model
+	priority   textinput.Model
+	agent      string
+	model      string
+	effort     string
 
 	cursor   ntRow
 	mode     ntMode
@@ -220,6 +226,8 @@ func (n *newTask) paste(text string) tea.Cmd {
 			n.titleIn, cmd = n.titleIn.Update(tea.PasteMsg{Content: text})
 		case ntBranch:
 			n.branch, cmd = n.branch.Update(tea.PasteMsg{Content: text})
+		case ntBranchName:
+			n.branchName, cmd = n.branchName.Update(tea.PasteMsg{Content: text})
 		case ntPriority:
 			n.priority, cmd = n.priority.Update(tea.PasteMsg{Content: text})
 		case ntDescription:
@@ -277,16 +285,45 @@ type resolveKey struct {
 	projectID               int64
 	workflow                string
 	agent, model, effortSel string
+	// The branch inputs, so a reply previewing a name the draft has moved past is
+	// dropped like any other stale one (task 001). fields is digested rather than
+	// held as a map because resolveKey is compared with ==.
+	title, baseBranch, branchName, fields string
 }
 
 func (n *newTask) resolveKey() resolveKey {
 	return resolveKey{
-		projectID: n.projectID,
-		workflow:  n.workflow,
-		agent:     n.agent,
-		model:     n.model,
-		effortSel: n.effort,
+		projectID:  n.projectID,
+		workflow:   n.workflow,
+		agent:      n.agent,
+		model:      n.model,
+		effortSel:  n.effort,
+		title:      n.titleText(),
+		baseBranch: strings.TrimSpace(n.branch.Value()),
+		branchName: strings.TrimSpace(n.branchName.Value()),
+		fields:     fieldsDigest(n.fieldMap()),
 	}
+}
+
+// fieldsDigest renders a field map as a comparable, order-independent string, so
+// the map can take part in resolveKey's equality.
+func fieldsDigest(f map[string]string) string {
+	if len(f) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(f))
+	for k := range f {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(f[k])
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // resolveCmd asks the daemon what the current draft would run. It fires on
@@ -300,10 +337,14 @@ func (n *newTask) resolveCmd() tea.Cmd {
 		return nil
 	}
 	req := apiclient.ResolveRequest{
-		Workflow: key.workflow,
-		Agent:    key.agent,
-		Model:    key.model,
-		Effort:   key.effortSel,
+		Workflow:   key.workflow,
+		Agent:      key.agent,
+		Model:      key.model,
+		Effort:     key.effortSel,
+		Title:      key.title,
+		BaseBranch: key.baseBranch,
+		BranchName: key.branchName,
+		Fields:     n.fieldMap(),
 	}
 	if key.projectID != 0 {
 		req.ProjectID = ptr(key.projectID)
@@ -552,7 +593,7 @@ func (n *newTask) activate() tea.Cmd {
 	switch n.cursor {
 	case ntProject, ntWorkflow, ntAgent, ntModel, ntEffort:
 		n.openPicker(n.cursor)
-	case ntTitle, ntBranch, ntPriority, ntDescription:
+	case ntTitle, ntBranch, ntBranchName, ntPriority, ntDescription:
 		n.startEditing()
 	case ntFields:
 		n.fieldsEd = newFieldsEditor(n.fields)
@@ -584,6 +625,7 @@ func (n *newTask) stopEditing() {
 	n.mode = ntNavigating
 	n.titleIn.Blur()
 	n.branch.Blur()
+	n.branchName.Blur()
 	n.priority.Blur()
 	n.desc.Blur()
 }
@@ -607,6 +649,8 @@ func (n *newTask) updateEditing(msg tea.KeyPressMsg) tea.Cmd {
 		n.titleIn, cmd = n.titleIn.Update(msg)
 	case ntBranch:
 		n.branch, cmd = n.branch.Update(msg)
+	case ntBranchName:
+		n.branchName, cmd = n.branchName.Update(msg)
 	case ntPriority:
 		n.priority, cmd = n.priority.Update(msg)
 	case ntDescription:
@@ -732,6 +776,9 @@ func (n *newTask) request() apiclient.CreateTaskRequest {
 	if b := strings.TrimSpace(n.branch.Value()); b != "" {
 		req.BaseBranch = ptr(b)
 	}
+	if b := strings.TrimSpace(n.branchName.Value()); b != "" {
+		req.BranchName = ptr(b)
+	}
 	if p, err := strconv.Atoi(strings.TrimSpace(n.priority.Value())); err == nil && p != 0 {
 		req.Priority = ptr(p)
 	}
@@ -773,6 +820,7 @@ func (n *newTask) applyFailure(err error) {
 		row    ntRow
 	}{
 		{"base_branch", ntBranch},
+		{"branch", ntBranchName},
 		{"workflow", ntWorkflow},
 		{"title", ntTitle},
 		{"project", ntProject},

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -16,6 +16,7 @@ var ntLabels = [ntRowCount]string{
 	ntDescription: "description",
 	ntFields:      "fields",
 	ntBranch:      "base branch",
+	ntBranchName:  "branch",
 	ntPriority:    "priority",
 	ntAgent:       "agent",
 	ntModel:       "model",
@@ -106,6 +107,11 @@ func (n *newTask) rowValue(row ntRow) string {
 			return n.branch.View()
 		}
 		return firstNonEmpty(strings.TrimSpace(n.branch.Value()), styleDim.Render("(project default)"))
+	case ntBranchName:
+		if n.mode == ntEditing && n.cursor == ntBranchName {
+			return n.branchName.View()
+		}
+		return n.branchNameValue()
 	case ntPriority:
 		if n.mode == ntEditing && n.cursor == ntPriority {
 			return n.priority.View()
@@ -350,4 +356,23 @@ func (n *newTask) priorityValue() int {
 		return 0
 	}
 	return v
+}
+
+// branchNameValue renders the branch row when it is not being edited: the name
+// the daemon says this draft would get, and which level of the chain decided it.
+//
+// The preview comes from POST /v1/resolve rather than from rendering the template
+// here. Branch naming is precedence resolution, and the PR L decision keeps
+// resolution server-side — a form that rendered its own would be a second
+// implementation to keep in step with the daemon's forever.
+func (n *newTask) branchNameValue() string {
+	typed := strings.TrimSpace(n.branchName.Value())
+	res, ok := n.resolved()
+	if !ok || res.Branch == nil {
+		// No resolution yet. Show what was typed, or say nothing rather than
+		// guess a name.
+		return firstNonEmpty(typed, styleDim.Render("(from the project template)"))
+	}
+	b := res.Branch
+	return b.Value + "  " + styleDim.Render("("+b.Explain()+")")
 }

--- a/internal/worktree/branch.go
+++ b/internal/worktree/branch.go
@@ -1,0 +1,137 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// ErrBranchNeedsID reports that a branch template referenced `.ID` while the
+// task id was still unknown.
+//
+// Callers treat this as *routing information*, not a failure: it is the signal
+// that this template can only be rendered once the task row exists, so the name
+// must be produced inside the insert transaction rather than validated before it
+// (task 001). Detecting that with a method error rather than by walking the
+// template parse tree is deliberate — a walk has to handle `with`, `range` and
+// `$var` aliasing to be correct, and a detector that gets it wrong renders a
+// silent `0` into somebody's branch name.
+var ErrBranchNeedsID = errors.New("branch template references .ID, which is unknown until the task row exists")
+
+// BranchProject is `.Project` inside a branch template.
+type BranchProject struct {
+	Name          string
+	Path          string
+	DefaultBranch string
+}
+
+// BranchContext is the template context for a configurable branch name
+// (task 001).
+//
+// It is deliberately *not* workflow.RenderContext. That type carries
+// `.Task.BranchName`, `.Worktree.Path`, `.Step` and `.Steps` — real struct
+// fields with valid zero values at task-creation time — so referencing one would
+// render an empty string and quietly produce a branch like `feat/-retry`.
+// text/template's `missingkey=error` guards *map* keys only, so the guard has to
+// come from the type not having those fields at all. It also makes a template
+// that refers to the very name it is computing unrepresentable.
+type BranchContext struct {
+	// id is nil until the task row exists; see ID.
+	id *int64
+
+	Title      string
+	Slug       string
+	BaseBranch string
+	Fields     map[string]string
+	Project    BranchProject
+}
+
+// NewBranchContext returns a context for a task whose id is not yet known.
+// Slug is derived from title with the §5.3 rules, so `{{.Slug}}` means the same
+// thing in a template as it does in the built-in name.
+func NewBranchContext(title, baseBranch string, fields map[string]string, project BranchProject) BranchContext {
+	return BranchContext{
+		Title:      title,
+		Slug:       Slug(title),
+		BaseBranch: baseBranch,
+		Fields:     fields,
+		Project:    project,
+	}
+}
+
+// WithID returns a copy of c whose ID resolves to id.
+func (c BranchContext) WithID(id int64) BranchContext {
+	c.id = &id
+	return c
+}
+
+// ID is `.ID` in a branch template. It is a method, not a field, so that
+// referencing the task id before the row exists is an error the renderer
+// propagates rather than a zero that silently becomes part of a branch name.
+func (c BranchContext) ID() (int64, error) {
+	if c.id == nil {
+		return 0, ErrBranchNeedsID
+	}
+	return *c.id, nil
+}
+
+// branchFuncs are the functions a branch template may call. `slug` applies the
+// §5.3 rules to any value, so a name can be built from a field carrying spaces
+// or punctuation: {{ slug (index .Fields "ticket") }}.
+var branchFuncs = template.FuncMap{"slug": Slug}
+
+// ValidateBranchTemplate reports whether text parses as a branch template. It is
+// what lets a broken template fail where it was written — config load, or a
+// project update — instead of at every task creation afterwards.
+func ValidateBranchTemplate(text string) error {
+	_, err := parseBranchTemplate(text)
+	return err
+}
+
+func parseBranchTemplate(text string) (*template.Template, error) {
+	tmpl, err := template.New("branch").Funcs(branchFuncs).Option("missingkey=error").Parse(text)
+	if err != nil {
+		return nil, fmt.Errorf("parse branch template: %w", err)
+	}
+	return tmpl, nil
+}
+
+// RenderBranch renders a branch-name template against c and returns the name
+// with surrounding whitespace removed, so a YAML block scalar's trailing newline
+// does not become an illegal ref.
+//
+// Unknown fields and missing map keys read through field syntax
+// (`{{.Fields.ticket}}`) are errors, matching the phase 2 decision behind
+// workflow.Render: a typo fails loudly instead of rendering a hole. Note that
+// `missingkey=error` does *not* cover the `index` builtin — as
+// workflow.TaskContext documents, `index` is the way to read an *optional* field
+// — so `{{ index .Fields "ticket" }}` on a task without one renders nothing and
+// yields a name like `feat/-fix-login`, which git happily accepts. Branch
+// templates should therefore prefer field syntax and reach for
+// `{{ with index … }}` when a segment is genuinely optional.
+//
+// When the template needs the task id and c carries none, the error *is*
+// ErrBranchNeedsID — unwrapped, because at that point it is a routing signal and
+// the template machinery's wrapping ("executing … at <.ID>: error calling ID")
+// only obscures it in a log.
+func RenderBranch(text string, c BranchContext) (string, error) {
+	tmpl, err := parseBranchTemplate(text)
+	if err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, c); err != nil {
+		if errors.Is(err, ErrBranchNeedsID) {
+			return "", ErrBranchNeedsID
+		}
+		return "", fmt.Errorf("render branch template: %w", err)
+	}
+	name := strings.TrimSpace(sb.String())
+	if name == "" {
+		// git would reject this too, but "'' is not a valid branch name" says
+		// nothing about which template produced it.
+		return "", fmt.Errorf("branch template %q rendered an empty name", text)
+	}
+	return name, nil
+}

--- a/internal/worktree/branch.go
+++ b/internal/worktree/branch.go
@@ -76,6 +76,54 @@ func (c BranchContext) ID() (int64, error) {
 	return *c.id, nil
 }
 
+// Levels of the branch-naming chain, reported alongside a resolved name so a
+// client can say *why* a task is getting the name it is getting (task 001).
+const (
+	BranchSourceTask    = "task"
+	BranchSourceProject = "project"
+	BranchSourceConfig  = "config"
+	BranchSourceDefault = "default"
+)
+
+// BranchSpec is the branch-naming chain for one task, most specific first: a
+// literal chosen for this task, the project's template, then the global template
+// from config.yaml. An empty field means "nothing set at this level"; with all
+// three empty the built-in name applies.
+type BranchSpec struct {
+	Literal         string
+	ProjectTemplate string
+	ConfigTemplate  string
+}
+
+// ResolveBranchName applies the chain and reports both the name and the level
+// that produced it.
+//
+// A Literal is used verbatim, never rendered: it is a name the user typed for one
+// task, and treating it as a template would make a stray brace a syntax error
+// instead of part of a branch name.
+//
+// The error is ErrBranchNeedsID, unwrapped, when the winning level needs the task
+// id and c has none — including the built-in default, which always needs it. That
+// is the caller's signal to resolve again after the insert rather than a failure.
+func ResolveBranchName(spec BranchSpec, c BranchContext) (name, source string, err error) {
+	switch {
+	case strings.TrimSpace(spec.Literal) != "":
+		return strings.TrimSpace(spec.Literal), BranchSourceTask, nil
+	case spec.ProjectTemplate != "":
+		name, err = RenderBranch(spec.ProjectTemplate, c)
+		return name, BranchSourceProject, err
+	case spec.ConfigTemplate != "":
+		name, err = RenderBranch(spec.ConfigTemplate, c)
+		return name, BranchSourceConfig, err
+	default:
+		id, err := c.ID()
+		if err != nil {
+			return "", BranchSourceDefault, err
+		}
+		return BranchName(id, c.Title), BranchSourceDefault, nil
+	}
+}
+
 // branchFuncs are the functions a branch template may call. `slug` applies the
 // §5.3 rules to any value, so a name can be built from a field carrying spaces
 // or punctuation: {{ slug (index .Fields "ticket") }}.

--- a/internal/worktree/branch_test.go
+++ b/internal/worktree/branch_test.go
@@ -1,0 +1,180 @@
+package worktree
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func testCtx() BranchContext {
+	return NewBranchContext("Fix login", "main",
+		map[string]string{"ticket": "OPS-123", "messy": "Two Words!"},
+		BranchProject{Name: "vincent", Path: "/repo", DefaultBranch: "main"})
+}
+
+// The whole routing design rests on this: text/template must propagate an error
+// returned by a method so that errors.Is can recognise it through the
+// ExecError wrapping. If this ever stops holding, RenderBranch silently starts
+// reporting a generic render failure and the caller takes the wrong path.
+func TestIDBeforeInsertIsRoutingSignal(t *testing.T) {
+	_, err := RenderBranch(`vincent/{{.ID}}-{{.Slug}}`, testCtx())
+	if !errors.Is(err, ErrBranchNeedsID) {
+		t.Fatalf("err = %v, want it to wrap ErrBranchNeedsID", err)
+	}
+}
+
+func TestWithIDRendersTheRealID(t *testing.T) {
+	got, err := RenderBranch(`vincent/{{.ID}}-{{.Slug}}`, testCtx().WithID(42))
+	if err != nil {
+		t.Fatalf("RenderBranch: %v", err)
+	}
+	if want := "vincent/42-fix-login"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// WithID must not mutate the receiver: the pre-insert context is rendered first
+// and has to stay usable (and id-less) afterwards.
+func TestWithIDDoesNotMutateReceiver(t *testing.T) {
+	base := testCtx()
+	_ = base.WithID(7)
+	if _, err := RenderBranch(`{{.ID}}`, base); !errors.Is(err, ErrBranchNeedsID) {
+		t.Fatalf("receiver was mutated by WithID: err = %v", err)
+	}
+}
+
+func TestRenderBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name, tmpl, want string
+	}{
+		{"slug of the title", `feat/{{.Slug}}`, "feat/fix-login"},
+		{"raw field", `feat/{{ index .Fields "ticket" }}`, "feat/OPS-123"},
+		{"slug func over a field", `feat/{{ slug (index .Fields "messy") }}`, "feat/two-words"},
+		{"base branch", `off/{{.BaseBranch}}`, "off/main"},
+		{"project name", `{{.Project.Name}}/{{.Slug}}`, "vincent/fix-login"},
+		{"title verbatim is legal here", `x/{{.Title}}`, "x/Fix login"},
+		{"conditional, the faithful default shape", `vincent/{{with .Slug}}{{.}}{{end}}`, "vincent/fix-login"},
+		{"surrounding whitespace is trimmed", "  feat/{{.Slug}}\n", "feat/fix-login"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RenderBranch(tc.tmpl, testCtx())
+			if err != nil {
+				t.Fatalf("RenderBranch(%q): %v", tc.tmpl, err)
+			}
+			if got != tc.want {
+				t.Fatalf("RenderBranch(%q) = %q, want %q", tc.tmpl, got, tc.want)
+			}
+		})
+	}
+}
+
+// The point of a dedicated context: the fields that mean nothing at task
+// creation must be *absent*, so referencing one fails instead of rendering the
+// empty string that workflow.RenderContext would supply.
+func TestRenderBranchRejectsReferencesThatWouldBeHoles(t *testing.T) {
+	for _, tmpl := range []string{
+		`{{.BranchName}}`,    // the name being computed — self-reference
+		`{{.Worktree.Path}}`, // no worktree exists yet
+		`{{.Step.ID}}`,       // no step is running
+		`{{.Task.Title}}`,    // not the workflow context's shape
+		`{{.Fields.nope}}`,   // missingkey=error on map field access
+		`{{.Nope}}`,
+	} {
+		if got, err := RenderBranch(tmpl, testCtx()); err == nil {
+			t.Errorf("RenderBranch(%q) = %q, want an error rather than a hole", tmpl, got)
+		}
+	}
+}
+
+// `missingkey=error` governs map access through *field* syntax, not the `index`
+// builtin — which is why workflow.TaskContext documents `index` as the way to
+// read an optional field. Both forms are available here for consistency with
+// workflow templates, and the difference decides which one a branch template
+// should use: `.Fields.ticket` fails loudly on a task with no ticket, while
+// `index` renders nothing and git then *accepts* the result (`feat/-fix-login`
+// is a legal ref). So the loud form is the documented default for branch
+// templates, and `index` is for a segment you deliberately want optional.
+func TestIndexIsTheQuietFormAndFieldAccessIsTheLoudOne(t *testing.T) {
+	loud := `feat/{{.Fields.absent}}-{{.Slug}}`
+	if _, err := RenderBranch(loud, testCtx()); err == nil {
+		t.Errorf("RenderBranch(%q) should fail on a missing field", loud)
+	}
+
+	quiet := `feat/{{ index .Fields "absent" }}-{{.Slug}}`
+	got, err := RenderBranch(quiet, testCtx())
+	if err != nil {
+		t.Fatalf("RenderBranch(%q): %v", quiet, err)
+	}
+	if want := "feat/-fix-login"; got != want {
+		t.Fatalf("RenderBranch(%q) = %q, want %q — if this changed, the guidance "+
+			"in the task 001 decisions and the config reference is stale", quiet, got, want)
+	}
+
+	// The intended way to make a segment optional without leaving a hole.
+	conditional := `feat/{{ with index .Fields "absent" }}{{.}}-{{ end }}{{.Slug}}`
+	got, err = RenderBranch(conditional, testCtx())
+	if err != nil {
+		t.Fatalf("RenderBranch(%q): %v", conditional, err)
+	}
+	if want := "feat/fix-login"; got != want {
+		t.Fatalf("RenderBranch(%q) = %q, want %q", conditional, got, want)
+	}
+}
+
+// An empty name is caught here rather than left to git, whose message for an
+// empty branch name names no template and so cannot say which one produced it.
+func TestRenderBranchRejectsAnEmptyResult(t *testing.T) {
+	for _, tmpl := range []string{``, `{{ index .Fields "absent" }}`, `   `} {
+		if got, err := RenderBranch(tmpl, testCtx()); err == nil {
+			t.Errorf("RenderBranch(%q) = %q, want an error for an empty name", tmpl, got)
+		}
+	}
+}
+
+func TestValidateBranchTemplate(t *testing.T) {
+	if err := ValidateBranchTemplate(`feat/{{.Slug}}-{{.ID}}`); err != nil {
+		t.Fatalf("valid template rejected: %v", err)
+	}
+	// Unparseable, so it must fail where it was written rather than at every
+	// task creation afterwards.
+	err := ValidateBranchTemplate(`feat/{{.Slug`)
+	if err == nil {
+		t.Fatal("unterminated action accepted")
+	}
+	if !strings.Contains(err.Error(), "parse branch template") {
+		t.Fatalf("error should name what failed, got %v", err)
+	}
+	// Parsing cannot know whether an id will be available, so a template that
+	// needs one is still *valid* — that is a render-time routing question.
+	if err := ValidateBranchTemplate(`{{.ID}}`); err != nil {
+		t.Fatalf("id-bearing template rejected at parse time: %v", err)
+	}
+}
+
+// The built-in default is a Go function (task 001 decision), but a template must
+// be able to reproduce it — including the empty-slug edge case, where the naive
+// form yields a trailing dash and the faithful one does not.
+func TestDefaultShapeIsExpressibleAsATemplate(t *testing.T) {
+	const faithful = `vincent/{{.ID}}{{with .Slug}}-{{.}}{{end}}`
+	const naive = `vincent/{{.ID}}-{{.Slug}}`
+
+	for _, title := range []string{"Fix login", "!!!", "", "---", "Añadir cosas"} {
+		ctx := NewBranchContext(title, "main", nil, BranchProject{})
+		got, err := RenderBranch(faithful, ctx.WithID(12))
+		if err != nil {
+			t.Fatalf("RenderBranch(%q): %v", title, err)
+		}
+		if want := BranchName(12, title); got != want {
+			t.Errorf("faithful template for %q = %q, want %q", title, got, want)
+		}
+	}
+
+	// And the naive form really is wrong, which is why the decision records it.
+	got, err := RenderBranch(naive, NewBranchContext("!!!", "main", nil, BranchProject{}).WithID(12))
+	if err != nil {
+		t.Fatalf("RenderBranch: %v", err)
+	}
+	if got == BranchName(12, "!!!") {
+		t.Fatal("naive template matched BranchName; the trailing-dash trap is gone and the decision note is stale")
+	}
+}

--- a/internal/worktree/branch_test.go
+++ b/internal/worktree/branch_test.go
@@ -178,3 +178,84 @@ func TestDefaultShapeIsExpressibleAsATemplate(t *testing.T) {
 		t.Fatal("naive template matched BranchName; the trailing-dash trap is gone and the decision note is stale")
 	}
 }
+
+func TestResolveBranchName(t *testing.T) {
+	full := BranchSpec{
+		Literal:         "feat/typed-by-hand",
+		ProjectTemplate: `proj/{{.Slug}}`,
+		ConfigTemplate:  `cfg/{{.Slug}}`,
+	}
+	for _, tc := range []struct {
+		name              string
+		spec              BranchSpec
+		wantName, wantSrc string
+	}{
+		{"literal wins over everything", full, "feat/typed-by-hand", BranchSourceTask},
+		{"project beats config", BranchSpec{ProjectTemplate: `proj/{{.Slug}}`, ConfigTemplate: `cfg/{{.Slug}}`}, "proj/fix-login", BranchSourceProject},
+		{"config when no project", BranchSpec{ConfigTemplate: `cfg/{{.Slug}}`}, "cfg/fix-login", BranchSourceConfig},
+		{"built-in when nothing is set", BranchSpec{}, "vincent/9-fix-login", BranchSourceDefault},
+		{"a literal is surrounded-space tolerant", BranchSpec{Literal: "  feat/x  "}, "feat/x", BranchSourceTask},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src, err := ResolveBranchName(tc.spec, testCtx().WithID(9))
+			if err != nil {
+				t.Fatalf("ResolveBranchName: %v", err)
+			}
+			if got != tc.wantName || src != tc.wantSrc {
+				t.Fatalf("= (%q, %q), want (%q, %q)", got, src, tc.wantName, tc.wantSrc)
+			}
+		})
+	}
+}
+
+// A literal is never rendered, so a brace in a hand-typed name is part of the
+// name and not a template error. git rejects it later, with a message about the
+// name rather than about template syntax.
+func TestResolveBranchNameDoesNotRenderALiteral(t *testing.T) {
+	got, src, err := ResolveBranchName(BranchSpec{Literal: `feat/{{.Nope}}`}, testCtx())
+	if err != nil {
+		t.Fatalf("ResolveBranchName: %v", err)
+	}
+	if got != `feat/{{.Nope}}` || src != BranchSourceTask {
+		t.Fatalf("= (%q, %q), want the literal verbatim", got, src)
+	}
+}
+
+// Which levels need the task id, and therefore force resolution to happen after
+// the insert. The built-in default always does; a literal never does.
+func TestResolveBranchNameReportsWhenTheIDIsNeeded(t *testing.T) {
+	idless := testCtx()
+
+	for _, tc := range []struct {
+		name string
+		spec BranchSpec
+	}{
+		{"built-in default", BranchSpec{}},
+		{"project template using .ID", BranchSpec{ProjectTemplate: `p/{{.ID}}`}},
+		{"config template using .ID", BranchSpec{ConfigTemplate: `c/{{.ID}}`}},
+	} {
+		if _, _, err := ResolveBranchName(tc.spec, idless); !errors.Is(err, ErrBranchNeedsID) {
+			t.Errorf("%s: err = %v, want ErrBranchNeedsID", tc.name, err)
+		}
+	}
+
+	// These resolve fully before the row exists, so they can be collision-checked
+	// outside the transaction.
+	for _, tc := range []struct {
+		name string
+		spec BranchSpec
+		want string
+	}{
+		{"literal", BranchSpec{Literal: "feat/x"}, "feat/x"},
+		{"id-less project template", BranchSpec{ProjectTemplate: `p/{{.Slug}}`}, "p/fix-login"},
+	} {
+		got, _, err := ResolveBranchName(tc.spec, idless)
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/worktree/branchcheck_test.go
+++ b/internal/worktree/branchcheck_test.go
@@ -1,0 +1,136 @@
+package worktree
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+func TestValidateBranchName(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	for _, name := range []string{
+		"feat/ok", "vincent/12-fix-login", "a", "a/b/c", "release-2026.08",
+		"feat/OPS-123_thing", // uppercase and underscore are legal; the slug rules are not git's rules
+		// Both of these are surprising, and both are pinned deliberately: git
+		// accepts them, and the task 001 decision makes git the authority rather
+		// than a Go matcher expressing what someone believed git's rules to be.
+		// `refs/heads/x` as a *branch* would create refs/heads/refs/heads/x, and
+		// git's own docs say a refname "cannot be the single character @" — yet
+		// `check-ref-format` accepts both. If a future git disagrees, this test
+		// is where that shows up.
+		"refs/heads/x",
+		"@",
+	} {
+		if err := m.ValidateBranchName(ctx, name); err != nil {
+			t.Errorf("ValidateBranchName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	// The forms a Go regex would have to remember, and the reason this delegates.
+	for _, name := range []string{
+		"a..b", "a~b", "a^b", "a:b", "a?b", "a*b", "a[b", `a\b`,
+		"a.lock", "a.", "a//b", "a@{b}", "HEAD", "-a", "a b", "a\tb",
+		"/a", "a/", "", "a/./b",
+	} {
+		err := m.ValidateBranchName(ctx, name)
+		if err == nil {
+			t.Errorf("ValidateBranchName(%q) = nil, want a rejection", name)
+			continue
+		}
+		wantReason(t, err, ReasonBranchNameInvalid)
+	}
+}
+
+// The finding that widened this check: an exact-match probe reports the name as
+// free in both directions of a directory/file conflict, and `git worktree add`
+// then fails with a message that maps to no named reason.
+func TestBranchConflictCatchesDirectoryFileConflicts(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+
+	t.Run("a ref under the name blocks it", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		testrepo.Run(t, repo, "branch", "feat/foo/bar")
+
+		// Precisely the trap: the exact-match check used before task 001 says free.
+		if m.localBranchExists(ctx, repo, "feat/foo") {
+			t.Fatal("localBranchExists found feat/foo; the premise of this test is gone")
+		}
+		got, err := m.BranchConflict(ctx, repo, "feat/foo")
+		if err != nil {
+			t.Fatalf("BranchConflict: %v", err)
+		}
+		if got != "feat/foo/bar" {
+			t.Fatalf("BranchConflict = %q, want feat/foo/bar", got)
+		}
+	})
+
+	t.Run("a prefix that is a ref blocks the name", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		testrepo.Run(t, repo, "branch", "feat/foo")
+
+		got, err := m.BranchConflict(ctx, repo, "feat/foo/bar")
+		if err != nil {
+			t.Fatalf("BranchConflict: %v", err)
+		}
+		if got != "feat/foo" {
+			t.Fatalf("BranchConflict = %q, want feat/foo", got)
+		}
+	})
+
+	t.Run("exact match is still reported", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		testrepo.Run(t, repo, "branch", "feat/foo")
+
+		got, err := m.BranchConflict(ctx, repo, "feat/foo")
+		if err != nil {
+			t.Fatalf("BranchConflict: %v", err)
+		}
+		if got != "feat/foo" {
+			t.Fatalf("BranchConflict = %q, want feat/foo", got)
+		}
+	})
+
+	t.Run("a free name is free", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		testrepo.Run(t, repo, "branch", "feat/foo/bar")
+
+		for _, name := range []string{"feat/other", "feat/foo/baz", "unrelated", "feat/foobar"} {
+			got, err := m.BranchConflict(ctx, repo, name)
+			if err != nil {
+				t.Fatalf("BranchConflict(%q): %v", name, err)
+			}
+			if got != "" {
+				t.Errorf("BranchConflict(%q) = %q, want no conflict", name, got)
+			}
+		}
+	})
+}
+
+// What the probe protects: every name it reports as conflicting is one git would
+// have refused, and the free ones really do create. Proving both halves keeps the
+// check from drifting into either false alarms or a false all-clear.
+func TestBranchConflictAgreesWithGit(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := testrepo.Init(t, "main")
+	testrepo.Run(t, repo, "branch", "feat/foo/bar")
+	testrepo.Run(t, repo, "branch", "solo")
+
+	for _, name := range []string{"feat/foo", "feat/foo/bar", "solo", "solo/deeper", "brand/new"} {
+		conflict, err := m.BranchConflict(ctx, repo, name)
+		if err != nil {
+			t.Fatalf("BranchConflict(%q): %v", name, err)
+		}
+		_, createErr := m.git.Run(ctx, repo, "branch", name)
+		switch {
+		case conflict != "" && createErr == nil:
+			t.Errorf("BranchConflict(%q) reported %q but git created it happily", name, conflict)
+		case conflict == "" && createErr != nil:
+			t.Errorf("BranchConflict(%q) reported free but git refused: %v", name, createErr)
+		}
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -21,6 +21,7 @@ const (
 	ReasonProjectPathMissing   = "project_path_missing"
 	ReasonBaseBranchMissing    = "base_branch_missing"
 	ReasonBranchExists         = "branch_exists"
+	ReasonBranchNameInvalid    = "branch_name_invalid"
 	ReasonWorktreeDirty        = "worktree_dirty"
 	ReasonWorktreeMissing      = "worktree_missing"
 	ReasonWorktreePathOccupied = "worktree_path_occupied"
@@ -146,6 +147,64 @@ func (m *Manager) Create(ctx context.Context, projectPath string, taskID int64, 
 		return "", &Error{Reason: ReasonGitError, Message: "git worktree add failed", Err: err}
 	}
 	return target, nil
+}
+
+// ValidateBranchName reports whether branch is a legal branch name, returning a
+// ReasonBranchNameInvalid error when it is not (task 001). Rejection is loud
+// rather than sanitized: quietly rewriting a name the user typed is the same
+// dishonesty as faking a capability an adapter lacks.
+func (m *Manager) ValidateBranchName(ctx context.Context, branch string) error {
+	if err := m.git.CheckRefFormat(ctx, branch); err != nil {
+		return &Error{
+			Reason:  ReasonBranchNameInvalid,
+			Message: fmt.Sprintf("%q is not a valid git branch name", branch),
+			Err:     err,
+		}
+	}
+	return nil
+}
+
+// BranchConflict returns the name of an existing branch that would prevent
+// creating branch, or "" when the name is free.
+//
+// An exact-match check is not enough, because git stores refs as a path
+// hierarchy: `feat/foo` cannot be created while `feat/foo/bar` exists, and
+// `feat/foo/bar` cannot be created while `feat/foo` does. In the first case
+// `git rev-parse --verify refs/heads/feat/foo` reports *not found*, so an
+// exact-only pre-flight passes and `git worktree add` then fails with a
+// directory/file-conflict message that maps to no named reason. Unreachable while
+// every name is `vincent/{id}-{slug}` — one slash, and the id makes it unique —
+// and reachable as soon as the user chooses the name (task 001).
+//
+// It is a pre-flight courtesy, not a guarantee: a branch can appear between this
+// check and the worktree creation that follows, which is why Create still refuses
+// a pre-existing branch and remains the authority.
+func (m *Manager) BranchConflict(ctx context.Context, repo, branch string) (string, error) {
+	if m.localBranchExists(ctx, repo, branch) {
+		return branch, nil
+	}
+	// Refs *under* the name. The trailing slash in the pattern is what keeps this
+	// from also matching the name itself.
+	listCtx, cancel := context.WithTimeout(ctx, gitx.QueryTimeout)
+	defer cancel()
+	out, err := m.git.Run(listCtx, repo, "for-each-ref", "--count=1",
+		"--format=%(refname:short)", "refs/heads/"+branch+"/")
+	if err != nil {
+		return "", &Error{Reason: ReasonGitError, Message: "git for-each-ref failed", Err: err}
+	}
+	if out != "" {
+		return out, nil
+	}
+	// A prefix of the name that is itself a branch.
+	for i := range len(branch) {
+		if branch[i] != '/' {
+			continue
+		}
+		if prefix := branch[:i]; m.localBranchExists(ctx, repo, prefix) {
+			return prefix, nil
+		}
+	}
+	return "", nil
 }
 
 // IsDirty reports whether the worktree has any local changes; untracked

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -7,7 +7,7 @@
 # load (scenario 3). Runs against the committed fakeagent so CI never calls a
 # real API; run manually with VINCENT_GATE_AGENT=claude to exercise the real
 # CLI (scenario 1 only — killing a paid run and 8× cap spend prove nothing
-# extra). VINCENT_GATE_SCENARIO=1|2|3 runs a single scenario for debugging.
+# extra). VINCENT_GATE_SCENARIO=1|2|3|4 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -400,6 +400,123 @@ EOF
   echo "=== scenario 3 PASS (max global $max_global/3, max per-project $max_project/2)"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 4 — configurable branch names (task 001, spec §5.3/§10).
+#
+# The interesting half is the recovery path. A `branch_exists` block used to be
+# unreachable, because `vincent/{id}-{slug}` cannot collide; now it is routine, and
+# the creation-time check that catches most collisions is explicitly *not* a
+# guarantee — a branch can appear between that check and admission. So this drives
+# the real race rather than a simulation of it: the global cap is 1, a slow task
+# holds the only slot, the conflicting branch is created while the second task sits
+# queued, and admission is what discovers it.
+# ---------------------------------------------------------------------------
+scenario4() {
+  echo "=== scenario 4: configurable branch names"
+  scenario_dirs s4
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+max_parallel_tasks: 1
+EOF
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-branch.yaml" <<EOF
+name: m2-branch
+description: M2 gate branch naming — one command step, valid in sh and pwsh alike.
+steps:
+  - id: nap
+    type: command
+    run: sleep 1
+EOF
+
+  daemon_up
+
+  local repo="$TMP/s4/repo" proj
+  make_repo "$repo"
+  proj="$(register_project "$repo" ', branch_template: "feat/{{.Slug}}"')"
+
+  echo "== a project template names the branch"
+  local t1 b1
+  t1="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Retry logic\"}" | jq -r .id)"
+  b1="$(api GET "/tasks/$t1" | jq -r .branch_name)"
+  [[ "$b1" == "feat/retry-logic" ]] \
+    || fail "project template ignored: branch is $b1, want feat/retry-logic"
+  wait_for_state "$t1" done 60
+  git -C "$repo" rev-parse --verify --quiet refs/heads/feat/retry-logic >/dev/null \
+    || fail "the templated branch was never created in the repo"
+
+  echo "== a per-task literal beats the template"
+  local t2 b2
+  t2="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Second\",\"branch_name\":\"release/hotfix\"}" | jq -r .id)"
+  b2="$(api GET "/tasks/$t2" | jq -r .branch_name)"
+  [[ "$b2" == "release/hotfix" ]] || fail "literal ignored: branch is $b2"
+  wait_for_state "$t2" done 60
+
+  echo "== the same template output twice is rejected at creation, not silently renamed"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Retry logic\"}" \
+    "$BASE/tasks")"
+  [[ "$status" == "400" ]] \
+    || fail "a repeat of an existing branch should be 400 at creation, got $status"
+
+  echo "== an illegal branch name is refused with 400"
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"bad\",\"branch_name\":\"feat/../escape\"}" \
+    "$BASE/tasks")"
+  [[ "$status" == "400" ]] || fail "an illegal ref name should be 400, got $status"
+
+  # The race the creation check cannot close. The slow task holds the only slot,
+  # so the second one is still queued when the branch appears under it.
+  echo "== a branch appearing after creation blocks the task at admission"
+  local hold late
+  hold="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Holder\",\"branch_name\":\"gate/holder\"}" | jq -r .id)"
+  late="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Late\",\"branch_name\":\"gate/contended\"}" | jq -r .id)"
+  git -C "$repo" branch gate/contended
+  wait_for_state "$late" blocked 90
+  local reason
+  reason="$(api GET "/tasks/$late" | jq -r .block_reason)"
+  [[ "$reason" == "branch_exists" ]] \
+    || fail "task $late blocked with $reason, want branch_exists"
+  wait_for_state "$hold" done 90
+
+  echo "== retry with branch_override recovers the blocked task, keeping its id"
+  local recovered
+  recovered="$(api POST "/tasks/$late/retry" '{"branch_override":"gate/recovered"}' | jq -r .branch_name)"
+  [[ "$recovered" == "gate/recovered" ]] \
+    || fail "branch_override ignored: branch is $recovered"
+  wait_for_state "$late" done 90
+  git -C "$repo" rev-parse --verify --quiet refs/heads/gate/recovered >/dev/null \
+    || fail "the recovered branch was never created"
+  # The rename kept the task rather than replacing it: same id, block cleared, and
+  # it went on to actually run a step on the new branch.
+  #
+  # Note what is deliberately *not* asserted. This task blocked at worktree
+  # creation, which happens before any step starts, so it had no step runs to
+  # preserve — what survived is the task row, its id and its event trail. A task
+  # that blocks mid-workflow is where step history matters, and scenario 2 already
+  # covers attempt rows surviving a restart.
+  [[ "$(api GET "/tasks/$late" | jq -r '.block_reason // "null"')" == "null" ]] \
+    || fail "task $late still carries a block reason after a successful retry"
+  [[ "$(api GET "/tasks/$late/steps" | jq 'length')" -ge 1 ]] \
+    || fail "task $late ran no step after the rename, so it never used the new branch"
+
+  echo "== a still-colliding override is refused and the task stays blocked"
+  local t3
+  t3="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-branch\",\"title\":\"Third\",\"branch_name\":\"gate/second-clash\"}" | jq -r .id)"
+  git -C "$repo" branch gate/second-clash
+  wait_for_state "$t3" blocked 90
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"branch_override":"gate/recovered"}' "$BASE/tasks/$t3/retry")"
+  [[ "$status" == "400" ]] || fail "a colliding override should be 400, got $status"
+  [[ "$(api GET "/tasks/$t3" | jq -r .state)" == "blocked" ]] \
+    || fail "task $t3 should still be blocked after a refused override"
+
+  "$VINCENT" daemon stop
+  echo "=== scenario 4 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -409,7 +526,8 @@ case "$WHICH" in
   1) scenario1 ;;
   2) scenario2 ;;
   3) scenario3 ;;
-  all) scenario1; scenario2; scenario3 ;;
+  4) scenario4 ;;
+  all) scenario1; scenario2; scenario3; scenario4 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
First slice of [task 001](docs/tasks/001-configurable-branch-names.md). **Pure
additions — nothing calls them yet**, so task branches are still
`vincent/{id}-{slug}` and there is no user-visible behaviour change.

The chain `001.1 → 001.2 → 001.3 → 001.4` is strictly sequential (the
atomic-persist work needs the renderer, the validator *and* the resolver). These
two are the independent half, so they land first and give the rest something
tested to build on.

## 001.1 — `BranchContext` and the renderer

`internal/worktree/branch.go`. `.ID` is a **method** returning `(int64, error)`,
not a field, so referencing the task id before the row exists is an error the
renderer propagates rather than a silent `0` rendered into a branch name. That
error doubles as the routing signal for which persist path 001.4 will take, which
avoids walking the template parse tree — a walk has to handle `with`, `range` and
`$var` aliasing to be correct, and a detector that is wrong reintroduces the
silent `0`.

The context deliberately omits `.BranchName`, `.Worktree`, `.Step` and `.Steps`.
Those are real struct fields on `workflow.RenderContext` with valid zero values at
creation time, so referencing one there renders an empty string — the exact hole
the phase 2 `missingkey=error` decision exists to prevent. Omitting them also
makes a template referring to the name it is computing unrepresentable.

## 001.2 — Validation and the widened conflict probe

`gitx.CheckRefFormat` delegates to `git check-ref-format --branch` rather than a
Go matcher. `worktree.ValidateBranchName` wraps it into the reason taxonomy as
`branch_name_invalid`; rejection is loud, never a silent sanitize.

`worktree.BranchConflict` probes three things, because an exact match is not
enough — git stores refs as a path hierarchy, so `feat/foo` cannot be created
while `feat/foo/bar` exists and vice versa, and
`git rev-parse --verify refs/heads/feat/foo` reports the name as **free** in that
case. The under-the-name probe uses a trailing-slash `for-each-ref` pattern, which
cannot match the name itself.

## What the tests pin, and why

- **`TestIDBeforeInsertIsRoutingSignal`** — that `errors.Is` reaches
  `ErrBranchNeedsID` through `text/template`'s `ExecError` wrapping of a method
  error. The whole routing design rests on this; if it ever stops holding,
  `RenderBranch` reports a generic failure and the caller silently takes the wrong
  path.
- **`TestDefaultShapeIsExpressibleAsATemplate`** — that the faithful template
  equals `BranchName` across five titles including the empty-slug case, **and**
  that the naive `vincent/{{.ID}}-{{.Slug}}` does not. The trailing-dash trap
  recorded in the decisions cannot quietly stop being true.
- **`TestBranchConflictCatchesDirectoryFileConflicts`** — both D/F directions. The
  under-the-name case first asserts `localBranchExists` says *free*, so the test
  fails loudly if the trap this task exists for ever disappears.
- **`TestBranchConflictAgreesWithGit`** — cross-checks the probe against
  `git branch` in both directions, so it catches false alarms as well as a false
  all-clear.

## Two things I got wrong, now pinned

Delegating to git paid off immediately: **git accepts `refs/heads/x` as a branch
name, and accepts the single character `@`** — both contradicting its own
documentation, and both assertions I had originally written the other way round.
They are now pinned as *accepted*, so a future git change surfaces in a test
rather than in someone's repo. Inventing Go rules would have encoded my wrong
mental model instead.

And a correction that changes the guidance, recorded in the decisions:
**`missingkey=error` does not cover the `index` builtin.** `{{.Fields.ticket}}`
errors on a missing field; `{{ index .Fields "ticket" }}` renders nothing —
deliberately, since `workflow.TaskContext` documents `index` as the way to read an
*optional* field. So `feat/{{ index .Fields "ticket" }}-{{.Slug}}` silently yields
`feat/-fix-login`, which `git check-ref-format` **accepts**; git only rejects the
degenerate ends (`feat/`, empty). Field syntax is therefore the documented default
for branch templates, `{{ with index … }}` is how a segment is made genuinely
optional, and `RenderBranch` rejects an empty result itself rather than leaving it
to a git message that names no template.

## Also

`BranchContext` lives in `internal/worktree`, **not** `internal/workflow` as the
task document originally said — `Slug` and `BranchName` are already there,
`worktree` depends only on `gitx` while `workflow` depends on `agent` and
`config`, and neither imports the other, so `workflow` would have meant a new
package edge just to reach `Slug`. Amended in the task document rather than
changed silently.

No spec amendment: this adds no behaviour, so `docs/spec.md` stays accurate.
001.10 carries the amendments with the code that makes them true.

## Verified

`lint` 0 issues on **all three** `GOOS` values (host-built linter, per CLAUDE.md),
full `test` suite green, `build` ok. 39 tests in the two touched packages.
