### PR TITLE
feat: classify agent usage limits and auth expiry instead of collapsing them into nonzero_exit/agent_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,43 @@ type — that is the exhaustive index; this is the human summary.
 
 ### Added
 
+- **Agent usage limits are now a wait, not a failure**
+  ([task 003](docs/tasks/003-usage-limit-classification.md)). When a step stops
+  because the agent's usage quota for the window is spent, vincent records the
+  attempt as `usage_limit`, **consumes no retry**, releases the task's
+  concurrency slot, and re-queues it until the window reopens — the step then
+  re-runs with **no human action**. Previously that run was indistinguishable
+  from a genuine failure: it burned the whole retry budget in seconds (there is
+  no delay between attempts) and blocked the task with `agent_error`, which sent
+  you to read a transcript about a task that was fine. With several tasks running
+  on the same agent, the whole board went down at once.
+
+  A held task shows when it resumes — `queued → 14:20` on the board,
+  `queued · usage limit → 14:20` in the detail header — and gives up its slot, so
+  other work carries on. The resume time is the reset the CLI reported; when it
+  reports none, vincent waits
+  [`usage_limit_recheck_interval`](docs/reference/configuration.md#usage_limit_recheck_interval)
+  (new, default 15m) and tries again. Cancelling, pausing or resuming a held task
+  drops the wait immediately.
+
+  Only the **claude** adapter recognizes usage-limit wording today. Capturing a
+  real quota exhaustion means burning a real five-hour window, so codex and
+  cursor deliberately ship no pattern and behave exactly as before — a wrong
+  guess would park a genuinely failed task in a wait it never leaves.
+
+- **`agent_unauthenticated` block reason**
+  ([task 003](docs/tasks/003-usage-limit-classification.md)). A claude step that
+  fails because the CLI is not logged in now says so, instead of surfacing as
+  `nonzero_exit` or `agent_error`. Nothing else changes: the step still runs, the
+  retry budget still applies, and the task still blocks — the reason just names
+  the fix.
+
+- `queued_reason` and `admit_not_before` on every task in the API and on
+  `GET /v1/config`'s `usage_limit_recheck_interval`. Both task fields are `null`
+  for an ordinarily queued task, so the addition is invisible to existing
+  clients, and they are separate from `block_reason`, which still means only
+  "stopped, needs a human".
+
 - **Homebrew install on macOS** ([task 002](docs/tasks/002-homebrew-tap.md)).
   `brew install lezli01/tap/vincent`. The cask clears the quarantine attribute
   during install, so macOS users no longer meet the Gatekeeper "unidentified

--- a/cmd/fakeagent/codex.go
+++ b/cmd/fakeagent/codex.go
@@ -35,24 +35,48 @@ func codexMain(scenario string) {
 	case "big-usage":
 		emitCodexMessage("burning tokens")
 		emitCodexTurnCompleted(prompt, 2_500_000, 1_200_000)
-	default: // success
-		emit(map[string]any{"type": "item.started", "item": map[string]any{
-			"id": "item_0", "type": "command_execution",
-			"command": "echo fake", "status": "in_progress",
-		}})
-		emit(map[string]any{"type": "item.completed", "item": map[string]any{
-			"id": "item_0", "type": "command_execution",
-			"command": "echo fake", "aggregated_output": "fake\n",
-			"exit_code": 0, "status": "completed",
-		}})
-		emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
-		workFor(emitCodexMessage)
-		if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
-			editFile(f)
+	case "usage-limit":
+		// The codex leg of task 003. The codex adapter deliberately classifies
+		// nothing — its wording is not fixture-verified — so this scenario
+		// exists to *prove* that: a quota stop here still reads as it always
+		// did, an ordinary failed turn under the §7.2 budget.
+		if usageLimitSpent() {
+			emitCodexMessage("stopping: the usage limit for this window is spent")
+			emit(map[string]any{"type": "turn.failed", "error": map[string]any{
+				"message": usageLimitMessage(),
+			}})
+			os.Exit(1)
 		}
-		emitCodexMessage("done: " + flatten(string(prompt), 1000))
-		emitCodexTurnCompleted(prompt, 100, 42)
+		codexSuccess(prompt)
+	case "unauthenticated":
+		emit(map[string]any{"type": "turn.failed", "error": map[string]any{
+			"message": unauthenticatedMessage,
+		}})
+		os.Exit(1)
+	default: // success
+		codexSuccess(prompt)
 	}
+}
+
+// codexSuccess is the `success` body, shared with a usage-limit run whose
+// window has reopened.
+func codexSuccess(prompt []byte) {
+	emit(map[string]any{"type": "item.started", "item": map[string]any{
+		"id": "item_0", "type": "command_execution",
+		"command": "echo fake", "status": "in_progress",
+	}})
+	emit(map[string]any{"type": "item.completed", "item": map[string]any{
+		"id": "item_0", "type": "command_execution",
+		"command": "echo fake", "aggregated_output": "fake\n",
+		"exit_code": 0, "status": "completed",
+	}})
+	emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
+	workFor(emitCodexMessage)
+	if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
+		editFile(f)
+	}
+	emitCodexMessage("done: " + flatten(string(prompt), 1000))
+	emitCodexTurnCompleted(prompt, 100, 42)
 }
 
 // emitCodexMessage emits an agent_message item — codex's assistant text.

--- a/cmd/fakeagent/cursor.go
+++ b/cmd/fakeagent/cursor.go
@@ -66,32 +66,57 @@ func cursorMain(scenario string) {
 	case "big-usage":
 		emitCursorText("burning tokens")
 		emitCursorResult(prompt, 2_500_000, 1_200_000)
-	default: // success
-		emit(map[string]any{
-			"type": "thinking", "subtype": "delta",
-			"text": "thinking about it", "session_id": "fake-session-1",
-		})
-		emit(map[string]any{"type": "thinking", "subtype": "completed", "session_id": "fake-session-1"})
-		emitCursorText("Working on: " + firstLine(string(prompt)))
-		emit(map[string]any{
-			"type": "tool_call", "subtype": "started", "call_id": "tool_fake_1",
-			"tool_call": map[string]any{"editToolCall": map[string]any{
-				"args": map[string]any{"path": "fake.txt"},
-			}},
-		})
-		emit(map[string]any{
-			"type": "tool_call", "subtype": "completed", "call_id": "tool_fake_1",
-			"tool_call": map[string]any{"editToolCall": map[string]any{
-				"result": map[string]any{"success": map[string]any{}},
-			}},
-		})
-		emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
-		workFor(emitCursorText)
-		if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
-			editFile(f)
+	case "usage-limit":
+		// The cursor leg of task 003, and the same point codex's makes: this
+		// adapter classifies nothing, so the scenario pins that a quota stop
+		// still reads exactly as it did before — an error result under §7.2.
+		if usageLimitSpent() {
+			emitCursorText("stopping: the usage limit for this window is spent")
+			emit(map[string]any{
+				"type": "result", "subtype": "error", "is_error": true,
+				"result": usageLimitMessage(),
+			})
+			os.Exit(1)
 		}
-		emitCursorResult(prompt, 100, 42)
+		cursorSuccess(prompt)
+	case "unauthenticated":
+		emit(map[string]any{
+			"type": "result", "subtype": "error", "is_error": true,
+			"result": unauthenticatedMessage,
+		})
+		os.Exit(1)
+	default: // success
+		cursorSuccess(prompt)
 	}
+}
+
+// cursorSuccess is the `success` body, shared with a usage-limit run whose
+// window has reopened.
+func cursorSuccess(prompt []byte) {
+	emit(map[string]any{
+		"type": "thinking", "subtype": "delta",
+		"text": "thinking about it", "session_id": "fake-session-1",
+	})
+	emit(map[string]any{"type": "thinking", "subtype": "completed", "session_id": "fake-session-1"})
+	emitCursorText("Working on: " + firstLine(string(prompt)))
+	emit(map[string]any{
+		"type": "tool_call", "subtype": "started", "call_id": "tool_fake_1",
+		"tool_call": map[string]any{"editToolCall": map[string]any{
+			"args": map[string]any{"path": "fake.txt"},
+		}},
+	})
+	emit(map[string]any{
+		"type": "tool_call", "subtype": "completed", "call_id": "tool_fake_1",
+		"tool_call": map[string]any{"editToolCall": map[string]any{
+			"result": map[string]any{"success": map[string]any{}},
+		}},
+	})
+	emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
+	workFor(emitCursorText)
+	if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
+		editFile(f)
+	}
+	emitCursorResult(prompt, 100, 42)
 }
 
 // emitCursorText emits an assistant message — whole, never a delta (§9.7).

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -19,8 +19,21 @@
 //	                      flood (emits until killed — the transcript cap) |
 //	                      report-env (echoes FAKEAGENT_REPORT_ENV's named
 //	                      variables as its result — the §12.3 environment
-//	                      policy) | sleep (internal: silent child)
+//	                      policy) | usage-limit | unauthenticated (task 003) |
+//	                      sleep (internal: silent child)
 //	FAKEAGENT_REPORT_ENV  comma-separated variable names for report-env
+//	FAKEAGENT_USAGE_LIMIT_RESET
+//	                      usage-limit: seconds from now until the window
+//	                      reopens, embedded in the message as the CLI does.
+//	                      Unset or non-positive reports no reset time, which
+//	                      is the leg where the daemon falls back to
+//	                      `usage_limit_recheck_interval` (§12.3)
+//	FAKEAGENT_USAGE_LIMIT_MARKER
+//	                      usage-limit: path to a marker file. The first
+//	                      invocation creates it and reports the limit; every
+//	                      later one finds it and behaves like `success`. The
+//	                      state is the fake CLI's own, so "the task recovers
+//	                      with no human action" is observed rather than staged
 //	FAKEAGENT_SCENARIO_CODEX
 //	                      overrides FAKEAGENT_SCENARIO for codex-shaped argv
 //	                      only — lets one process environment drive two
@@ -222,18 +235,85 @@ func main() {
 		for {
 			emitText(strings.Repeat("flooding the transcript ", 40))
 		}
-	default: // success
-		emitText("Working on: " + firstLine(string(prompt)))
-		emit(map[string]any{"type": "assistant", "message": map[string]any{
-			"content": []any{map[string]any{"type": "tool_use", "name": "Edit", "input": map[string]any{}}},
-		}})
-		emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
-		workFor(emitText)
-		if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
-			editFile(f)
+	case "usage-limit":
+		// A CLI that stops because the account's quota for this window is
+		// spent (task 003). With a marker file it walls once and succeeds
+		// thereafter, which is the unattended-recovery path.
+		if usageLimitSpent() {
+			emitText("stopping: the usage limit for this window is spent")
+			emit(map[string]any{
+				"type": "result", "subtype": "error_during_execution", "is_error": true,
+				"result": usageLimitMessage(),
+				"usage":  map[string]int64{"input_tokens": 12, "output_tokens": 0},
+			})
+			os.Exit(1) // the real CLI exits nonzero here; the reason must still win
 		}
-		emitSuccessResult(prompt, 100, 42)
+		claudeSuccess(prompt)
+	case "unauthenticated":
+		emit(map[string]any{
+			"type": "result", "subtype": "error_during_execution", "is_error": true,
+			"result": unauthenticatedMessage,
+		})
+		os.Exit(1)
+	default: // success
+		claudeSuccess(prompt)
 	}
+}
+
+// claudeSuccess is the `success` scenario's body, shared with the scenarios
+// that end up succeeding — a usage-limit run whose window has reopened.
+func claudeSuccess(prompt []byte) {
+	emitText("Working on: " + firstLine(string(prompt)))
+	emit(map[string]any{"type": "assistant", "message": map[string]any{
+		"content": []any{map[string]any{"type": "tool_use", "name": "Edit", "input": map[string]any{}}},
+	}})
+	emit(map[string]any{"type": "fake_marker", "note": "unknown event type for tolerant-parsing tests"})
+	workFor(emitText)
+	if f := os.Getenv("FAKEAGENT_EDIT_FILE"); f != "" {
+		editFile(f)
+	}
+	emitSuccessResult(prompt, 100, 42)
+}
+
+// unauthenticatedMessage is the wording an adapter's classifier matches for a
+// CLI that is not logged in (task 003). Like the usage-limit wording it is
+// **not fixture-verified** — see internal/agent/claude/failure.go, which is
+// where the matching lives and where that caveat is argued.
+const unauthenticatedMessage = "Invalid API key · Please run /login"
+
+// usageLimitSpent reports whether this invocation should wall.
+//
+// With FAKEAGENT_USAGE_LIMIT_MARKER set it is true exactly once: the first
+// call creates the marker and reports the limit, and every later call finds it
+// and behaves like `success`. The state lives in the fake CLI's own
+// filesystem rather than in the test process, which is what makes "the task
+// recovers with no human action" an observation rather than a staging.
+// Without a marker every invocation walls, which is the steady-state case.
+func usageLimitSpent() bool {
+	marker := os.Getenv("FAKEAGENT_USAGE_LIMIT_MARKER")
+	if marker == "" {
+		return true
+	}
+	f, err := os.OpenFile(marker, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return false // the marker exists: the window has reopened
+	}
+	_ = f.Close()
+	return true
+}
+
+// usageLimitMessage renders the quota wording, with the reset time the real
+// CLI appends as unix seconds when it reports one. FAKEAGENT_USAGE_LIMIT_RESET
+// is seconds from now; unset or non-positive reports no reset time at all,
+// which is the leg that exercises the interval fallback.
+func usageLimitMessage() string {
+	const base = "Claude AI usage limit reached"
+	secs, err := strconv.Atoi(os.Getenv("FAKEAGENT_USAGE_LIMIT_RESET"))
+	if err != nil || secs <= 0 {
+		return base
+	}
+	reset := time.Now().Add(time.Duration(secs) * time.Second).Unix()
+	return base + "|" + strconv.FormatInt(reset, 10)
 }
 
 // tickInterval bounds how long the stream stays silent while delaying.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -32,6 +32,7 @@ silently drops.
 | `effort:` | ✅ | ✅ | **—** (it lives in the model id) |
 | `restricted` mode | ✅ | ✅ | ✅ on macOS/Linux, **fails on Windows** |
 | Reports whether you are logged in | — | — | ✅ |
+| Recognizes a usage limit / auth failure in a run | ✅ | — | — |
 
 `vincent daemon status`, the TUI's daemon view, and `GET /v1/agents` all report
 what vincent actually resolved on your machine — path, version, and the model
@@ -54,6 +55,15 @@ The most capable adapter, and the only one that can be interrupted mid-step.
   a vincent release.
 - **Reports token usage and cost.** The board's cost column sums every attempt,
   retries included. The other two adapters report no cost at all.
+- **Recognizes a spent usage quota and a logged-out CLI** in the output of a run
+  that failed. A quota stop becomes `usage_limit` — no retry consumed, the task
+  waits and re-runs itself — and a logged-out CLI becomes
+  `agent_unauthenticated`, which blocks with the fix named. Codex and cursor do
+  neither: their wordings have not been captured from a real run (doing so means
+  burning a real quota window), and vincent will not guess at one, because a
+  wrong guess parks a genuinely failed task in a wait it never leaves. On those
+  two, both conditions still read as `agent_error` or `nonzero_exit`. See
+  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing).
 
 ### Mid-run questions
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -232,6 +232,8 @@ The block reason names what happened:
 | `nonzero_exit` | A command step exited non-zero |
 | `agent_error` | The agent's own event stream reported an error |
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
+| `agent_unauthenticated` | The agent CLI is installed but not logged in (see below) |
+| `usage_limit` | The agent's usage quota for the window is spent — **not** a failure; the task waits and re-runs itself (see below) |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `template_error` | A template failed to render (see above) |
@@ -245,6 +247,41 @@ The block reason names what happened:
 `check_failed` is the common and healthy one: it means a check caught something
 the agent claimed was done. Read the step's transcript, then `E` to edit the
 prompt and retry with better instructions.
+
+### `usage_limit` — do nothing
+
+The agent CLI stopped because your account's usage quota for the current window
+is spent. vincent treats this as a wait, not a failure:
+
+- the attempt is recorded `interrupted` and consumes **no** retry;
+- the task goes back to `queued` and **gives up its concurrency slot**, so other
+  work carries on;
+- the row shows the time it will resume — `queued → 14:20` on the board, and
+  `queued · usage limit → 14:20` in the detail header;
+- when that time comes the step re-runs by itself. There is nothing to press.
+
+The resume time is the reset the CLI reported. When it reported none, vincent
+waits [`usage_limit_recheck_interval`](../reference/configuration.md#usage_limit_recheck_interval)
+(default 15 minutes) and tries again, repeating until the window reopens. If you
+know your plan's window, set that knob to match it.
+
+If you would rather not wait, cancel the task, or pause and resume it to try
+again immediately — any human action drops the wait.
+
+Only the claude adapter recognizes usage-limit wording today. On codex and
+cursor a quota stop still surfaces as `agent_error` or `nonzero_exit`, because
+their wordings have not been captured from a real run and vincent will not guess
+at one: a wrong guess would park a genuinely failed task forever.
+
+### `agent_unauthenticated`
+
+The agent CLI is installed and runs, but is not logged in. This one **does**
+block — waiting cannot fix it. Log in with the CLI's own command (`claude`
+interactively, `cursor-agent login`), then `r` to retry the task.
+
+The check the daemon view shows for cursor (`logged_in`) catches most of these
+before a task is ever created; claude and codex have no cheap probe, so the first
+sign is a failed step.
 
 ### `transcript_limit`
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -60,13 +60,19 @@ One row per task: id, project, title, state, current step `k/n` with its name,
 elapsed, and cost so far. The header shows daemon status, agent availability,
 running-versus-cap counts, and how many tasks need a human.
 
-Two behaviors matter:
+Three behaviors matter:
 
 - **Tasks waiting on a human are pinned to the top** with a distinct badge —
   `awaiting_input`, `awaiting_gate` and `blocked`. `!` jumps to the next one from
   anywhere.
 - **The terminal bell rings when a task enters `awaiting_input`**, so most
   terminals flash or badge the window even when it is not focused.
+- **A task waiting on a clock says when it resumes.** A task whose agent hit a
+  usage limit is `queued` like any other, but its state cell reads
+  `queued → 14:20` — the time vincent will try it again, on its own. It holds no
+  slot and needs nothing from you; the detail header names the reason in full
+  (`queued · usage limit → 14:20`). See
+  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing).
 
 `/` filters by id, title, project or state; `tab` commits the filter, `esc`
 clears it.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -154,7 +154,14 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 Anything else returns `409` with `details.state`. See
 [Task lifecycle](task-lifecycle.md).
 
-Three details worth knowing:
+Four details worth knowing:
+
+- **A `queued` task may be waiting on a clock, not a slot.** Every task
+  representation carries `queued_reason` and `admit_not_before` (RFC3339, or
+  `null`). Both are `null` for an ordinarily queued task; `usage_limit` with a
+  timestamp means the agent's usage window is spent and vincent will try again
+  then, unattended. They are separate from `block_reason`, which still means
+  only "stopped, needs a human" — the task is not blocked.
 
 - **List rows carry the board fields** — `project_name`, `step_total`,
   `step_name`, and `cost_usd` / `input_tokens` / `output_tokens` rolled up across

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -50,6 +50,9 @@ transcript_retention_days: 90
 # Per-attempt transcript cap.
 transcript_max_bytes: 512MB
 
+# How long a quota-stopped task waits when the agent CLI named no reset time.
+usage_limit_recheck_interval: 15m
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
@@ -203,6 +206,28 @@ ends — a half-written line would turn a size failure into a parse failure for
 every later reader.
 
 `0` disables the cap.
+
+### `usage_limit_recheck_interval`
+
+```yaml
+usage_limit_recheck_interval: 15m
+```
+
+How long a task waits before vincent tries it again after its agent reported
+that the account's usage quota for the current window is spent.
+
+It applies only when the CLI named **no** reset time. When it names one, that
+timestamp is used instead and this value is unused.
+
+While it waits the task is `queued`, not `blocked`, and holds **no** concurrency
+slot — everything else keeps running, and the task recovers on its own when the
+window reopens. Nothing is retried in the meantime: a quota stop consumes none
+of the step's retry budget. See
+[Task lifecycle](task-lifecycle.md#failure-reasons).
+
+Must be positive. There is no exponential backoff; if you know your plan's
+window, set this to match it. Hot-reloaded, so a change applies to the next
+task that hits a limit.
 
 ### `log_level`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -47,7 +47,7 @@ Tasks are `queued` immediately on creation. There is no draft state.
 
 | State | Meaning | Holds a slot? |
 |---|---|---|
-| `queued` | Ready to run; waiting for scheduler admission | no |
+| `queued` | Ready to run; waiting for scheduler admission — or, when `queued_reason` is set, for something else (see below) | no |
 | `running` | A step process is executing, or about to | **yes** |
 | `awaiting_gate` | Stopped at a `manual` step, waiting for approval | no |
 | `awaiting_input` | The running agent asked a question; its process is alive and idle on stdin | **yes** |
@@ -57,7 +57,17 @@ Tasks are `queued` immediately on creation. There is no draft state.
 | `aborted` | You cancelled, or rejected terminally. Worktree and branch retained | no |
 | `archived` | Terminal. Worktree removed, branch kept, record kept | no |
 
-Two of these are worth dwelling on.
+Three of these are worth dwelling on.
+
+**`queued` covers two different waits.** Usually it means "waiting for a free
+slot". But a task whose agent hit a usage limit is also `queued` — waiting on a
+clock rather than on the queue — and says so through two fields: `queued_reason`
+(`usage_limit`) and `admit_not_before`, the instant vincent will try again. It
+holds no slot while it waits, keeps its place in the queue, and needs nothing
+from you: when the window reopens, the step re-runs on its own. The board shows
+the resume time on the row (`queued → 14:20`) and the detail header names the
+reason. Cancelling, pausing or otherwise acting on the task drops the wait
+immediately — a human action always means go.
 
 **`awaiting_input` keeps its concurrency slot.** The agent process is alive
 mid-step, idle on its stdin; killing or re-queueing it would lose the very
@@ -129,6 +139,8 @@ same thing wherever it originated.
 | `nonzero_exit` | A command step exited non-zero |
 | `agent_error` | The agent's event stream reported an error |
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
+| `agent_unauthenticated` | The agent CLI is installed but not logged in. Retries as usual, then blocks — log in and retry |
+| `usage_limit` | The agent's usage quota for the window is spent. **Not a failure:** no retry is consumed, and the task waits `queued` until the window reopens |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `input_protocol_error` | A control message the adapter could not parse — it fails, it never hangs |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -231,6 +231,21 @@ nullable — not all agents report cost), input wait time (ms spent in `awaiting
   as a fresh attempt and the task is re-queued (§12.4).
 ```
 
+**Amended 2026-08-14 (task 003): `running → queued` has a second producer.** It
+used to mean only "interrupted — a crash or a shutdown cut the step short". It now
+also means "the agent reported that its usage quota for this window is spent"
+(§7.2). Both consume no retry and both release the concurrency slot; they differ
+in that the second re-queues the task with an **admission hold** — `admit_not_before`
+plus a `queued_reason` (§11, §14) — so the scheduler does not walk it straight
+back into the same wall. A re-queued task may therefore be waiting on a clock
+rather than on a slot, which is a distinction clients render (§15).
+
+A hold describes exactly one queued period: **any** transition out of `queued`
+clears it, so admission, parking and cancel all drop it. One consequence, accepted
+rather than fixed: pausing a held task and resuming it re-admits it at once and it
+re-discovers the wall. That costs one process spawn and buys the rule this section
+already applies to every other pending flag — a human action means go.
+
 ### States
 
 | State | Meaning | Consumes a concurrency slot? |
@@ -296,6 +311,21 @@ stdout/stderr are captured to the step transcript.
 - **Interruption** (daemon crash/stop while a step runs) is *not* a failure: the
   attempt is marked `interrupted`, does **not** consume a retry, and the step is
   automatically re-run when the daemon restarts (§12.4).
+- **Usage limits are not failures either.** *Added 2026-08-14 (task 003).* When an
+  agent adapter recognizes that its CLI stopped because the account's usage quota
+  for the current window is spent, the attempt is recorded `interrupted` with
+  reason `usage_limit`, consumes **no** retry, and the task returns to `queued`
+  carrying an admission hold (§11) until the window is plausibly back. The retry
+  budget bounds genuine failure; a quota wall is not one, and with no delay
+  between attempts a walled step would otherwise spend its whole budget in
+  seconds. `usage_limit` is therefore a `queued_reason`, never a `block_reason`.
+  Recovery needs no human: the scheduler re-admits the task when the hold expires.
+- **`agent_unauthenticated` stays under the normal budget.** *Added 2026-08-14
+  (task 003).* A CLI that refuses because it is not logged in fails the attempt
+  like any other, retries as usual, and blocks when the budget is spent. Waiting
+  cannot fix it, and short-circuiting the budget would make it the only reason in
+  vincent that bypasses this section — to save one process spawn at the default
+  `max_retries: 1`. Its value is that the reason names the fix.
 
 ### 7.3 Fresh session per step
 
@@ -601,6 +631,12 @@ type RunResult struct {
     InputTokens  int64    // 0 if unreported
     OutputTokens int64
     CostUSD      *float64 // nil if unreported (e.g. codex)
+    Failure      *Failure // task 003: the adapter's verdict, nil = nothing recognized
+}
+
+type Failure struct {                // task 003, added 2026-08-14
+    Kind       FailureKind // usage_limit | unauthenticated
+    RetryAfter *time.Time  // absolute UTC; nil = the CLI reported no usable reset
 }
 
 type AgentOptions struct {
@@ -645,6 +681,28 @@ recording and discarding:
   **whole blocks**; a dialect that streams token-level deltas coalesces them
   itself and emits when the block closes. See the §9.7 amendment for why that
   constraint is the part of the original decision worth keeping.
+
+**The adapter's failure verdict (task 003, added 2026-08-14).** `RunResult`
+carries an optional `Failure`: the adapter's reading of *why* its CLI stopped,
+when the wording is one it recognizes. It rides on the result rather than behind
+a new interface method because the material — the terminal result and the stderr
+tail — already lives inside the handle, and the engine never sees either.
+
+`FailureKind` is an adapter-side enum (`usage_limit`, `unauthenticated`), **not** a
+`block_reason`: that vocabulary belongs to the engine and to worktree management,
+and the engine does the kind → reason mapping, so a reason string keeps exactly
+one source of truth. A nil `Failure` means "nothing recognized" and is every run
+that behaves as it did before this field existed.
+
+Parsing is **layered and conservative**, in the precedent §9.7's logged-out
+wording sets: recognize the documented shapes, fall through to nil for everything
+else, and never guess a reset time — an unparseable or implausible one leaves
+`RetryAfter` nil and `usage_limit_recheck_interval` (§12.3) decides instead. The
+wordings are **not fixture-verified**: capturing a genuine quota exhaustion means
+burning a real five-hour window. Claude ships patterns on that basis; **codex and
+cursor recognize nothing** and behave exactly as before, which is a deliberate
+asymmetry rather than an oversight — an adapter that guessed would send a
+genuinely failed task into a wait it never recovers from.
 
 Both ride the live stream *and* scrollback. A record that appeared only after
 a step finished would read as output that went missing while it was running,
@@ -1022,6 +1080,21 @@ would invalidate every one of them.
 - A `queued` task whose pause was requested while it was running (§6) is not admitted:
   the scheduler moves it straight to `paused` instead. A pause therefore survives a
   crash, which re-queues the task without clearing the request.
+- **Admission holds** (*added 2026-08-14, task 003*). A queued task may carry
+  `admit_not_before` — an instant before which it is not admissible — and a
+  `queued_reason` naming what it is waiting for. `usage_limit` is the only
+  producer today (§7.2); the pair is generic so the next wait-shaped case costs
+  no second mechanism. The walk applies the three checks **in this order**:
+  1. **pause** — a pending pause parks the task, held or not. This runs first
+     because a human asked for `paused`, and a task showing `queued` until a hold
+     expired would be the same lie the cap check already avoids. It is also why
+     the hold is evaluated in the walk and **not** filtered out in SQL.
+  2. **the hold** — skip and keep walking; a held task must not starve the queue.
+  3. **the caps**, as above.
+
+  No timer is needed: the scheduler's 5 s safety-net tick is what notices an
+  expired hold, since nothing commits a state change when one lapses. That is the
+  tick's second reason to exist — otherwise it normally finds nothing to do.
 
 ## 12. The daemon
 
@@ -1204,6 +1277,7 @@ defaults:
   input_timeout: 24h           # max wait in awaiting_input (§7.4)
 transcript_retention_days: 90   # transcripts of *archived* tasks older than this are pruned
 transcript_max_bytes: 512MB     # per-run transcript cap (§18); past it the step fails `transcript_limit`
+usage_limit_recheck_interval: 15m  # how long a quota-held task waits when the CLI named no reset (§11)
 log_level: info
 debug: false                 # record each step's resolved settings and full argv in its transcript
 environment:                 # what child processes inherit (T4.23)
@@ -1215,6 +1289,16 @@ agents:
   codex:  { path: "" }
   cursor: { path: "" }         # resolves `cursor-agent`, never `cursor` (§9.7)
 ```
+
+**`usage_limit_recheck_interval` (task 003, added 2026-08-14).** How long a task
+waits before being re-admitted after its agent reported a spent usage quota
+*without* a reset time; when the CLI reports one, that timestamp wins and this is
+unused. Must be positive — zero would re-admit on the very next tick, which is the
+respawn loop the hold exists to stop. 15 m bounds a five-hour window at roughly
+twenty wasted spawns, and a user who knows their plan can tighten or widen it.
+There is deliberately **no** exponential backoff: that would be per-task state the
+row has to carry and a second retry-ish concept beside §7.2's. Read per hold, so a
+hot reload reaches the next one.
 
 **`environment` (T4.23).** Governs every process the daemon spawns — agent
 steps via `RunSpec.Env` (§9.1), command steps and their checks via §8.5's
@@ -1351,7 +1435,12 @@ GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=
                                         ?archived= defaults to false: archived tasks are
                                         excluded unless asked for (?archived=true → only
                                         archived, ?archived=all → both). state=archived
-                                        still selects them explicitly
+                                        still selects them explicitly.
+                                        Every task shape (list and detail) additionally
+                                        carries admit_not_before (RFC3339 or null) and
+                                        queued_reason (task 003): a queued task waiting on
+                                        something other than a slot, per §11. Both are null
+                                        for every other task, so the pair is additive
 POST   /v1/tasks                        { project_id, workflow, title, description?, fields?,
                                           base_branch?, branch_name?, priority?, agent?,
                                           model?, effort? }
@@ -1508,6 +1597,8 @@ CREATE TABLE tasks (
   retry_cursor_at     TEXT,                   -- last human `retry`; the retry budget counts failures after it (§7.2)
   pending_override_json TEXT,                 -- edit+retry text awaiting the next attempt's step_run
   pending_input_json  TEXT,                   -- normalized InputRequest while state='awaiting_input' (§7.4)
+  admit_not_before    TEXT,                   -- §11 admission hold; NULL = admissible now (task 003)
+  queued_reason       TEXT,                   -- why a queued task waits on more than a slot; NULL = the ordinary queue
   created_at          TEXT NOT NULL,
   updated_at          TEXT NOT NULL,
   started_at          TEXT,
@@ -1561,6 +1652,15 @@ CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT
 
 WAL mode, `busy_timeout` set, all writes through the daemon's single connection pool.
 Migrations are embedded in the binary and applied at startup.
+
+*Added 2026-08-14 (task 003).* `admit_not_before` / `queued_reason` carry no index:
+`ListAdmissible` already returns the whole queued set in §11 order and the hold is
+evaluated during the walk. Both are cleared by **any** transition out of `queued`,
+in the transition itself rather than by each caller — the same construction that
+makes "`pending_input_json` non-null iff `awaiting_input`" hold. `block_reason` was
+deliberately not overloaded for this: §14 says it is set while `state='blocked'`,
+clients key off it to mean exactly that, and a queued task carrying one would break
+them.
 
 ## 15. TUI
 
@@ -1655,6 +1755,16 @@ full-screen takeovers reached from the command palette.
 The task table keeps the full §15 column set at full width. A narrow left rail
 would have to drop most of it, and cost-so-far and step `k/n` are the two columns
 a human scans to decide where to intervene.
+
+**Two kinds of `queued` (task 003, added 2026-08-14).** A task waiting on an
+agent's usage window and a task waiting for a free slot are both `queued`, and
+conflating them is what the reason exists to prevent. The **board's** state cell
+renders the resume time — `queued → 14:20` — for a task carrying an
+`admit_not_before`; the reason itself does not fit the state column's width, and
+widening it for a rare state would cost every board the columns that get shed
+first. The **detail header**, which has the room, renders the full
+`queued · usage limit → 14:20`. Band ordering is unchanged: a held task stays in
+the queued band, in normal §11 order, because that is where it will run from.
 
 **The focused panel expands; the others collapse** to their title bar plus the
 selected line. The task table never collapses below 5 rows — it is the navigation
@@ -1851,7 +1961,8 @@ currently true to show (§15 view 6).
 | Option probe fails (help unparseable) | `GET /v1/agents` serves the curated catalog with `probe_error` set; selection and free text keep working (§9.6) |
 | Model/effort unknown to the catalog | Validation warning only; the CLI is the final authority — a rejected value fails the step with the CLI's error (retry policy applies) |
 | Model *in* the catalog but rejected at run time | Real, not hypothetical, on cursor (§9.7): the step fails with the stderr tail as the message, since no `result` event arrives. Catalog membership is advisory in both directions |
-| Agent CLI installed but not authenticated | `logged_in: false` where the adapter can tell (§9.5); the new-task form flags it like an unavailable agent. Where it cannot (`null`), the step runs and fails with the CLI's auth error |
+| Agent CLI installed but not authenticated | `logged_in: false` where the adapter can tell (§9.5); the new-task form flags it like an unavailable agent. Where it cannot (`null`), the step runs and fails. *Amended 2026-08-14 (task 003):* where the adapter recognizes the CLI's auth wording, that failure is now named `agent_unauthenticated` instead of surfacing as `nonzero_exit`/`agent_error`. Everything else about the row is unchanged and deliberately so — the step still runs, the attempt still fails, the §7.2 budget still applies, and the task still ends up blocked. There is no pre-flight refusal on `logged_in: false` |
+| Agent stopped by a usage limit | *Added 2026-08-14 (task 003).* Where the adapter recognizes the wording, the attempt is recorded `interrupted` with reason `usage_limit`, consumes **no** retry (§7.2), and the task returns to `queued` with an admission hold (§11) — releasing its slot, so other work keeps running. The hold ends at the reset time the CLI reported, or `usage_limit_recheck_interval` after the stop when it reported none. Recovery is unattended: the scheduler re-admits and the step re-runs. The board says `queued` *with* its reason rather than `blocked` (§15). Where the adapter recognizes nothing — codex and cursor today (§9.1) — the run reads as `nonzero_exit`/`agent_error` exactly as before |
 | `effort` set on a step whose agent has no effort concept | Ignored by the adapter and documented as ignored (cursor, §9.7); a claude/codex effort value on a cursor step is already an §8.2 *error* — it belongs to another adapter's catalog |
 | `restricted` step on an adapter that cannot restrict on this OS | Step fails to start with `restricted_unsupported` (cursor on Windows, §9.7), under the retry policy → typically blocked. Never downgraded to full-auto, and deliberately *not* `agent_unavailable`: the CLI is installed and healthy, so "not found" would send the user to reinstall what is already there |
 | Runaway step output (agent or command) | Past `transcript_max_bytes` (§12.3) the process tree is killed and the attempt fails `transcript_limit`, under the retry policy. The line that trips the cap is written **whole** — a truncated line would turn a size failure into a parse failure for every later reader of the JSONL — and the partial transcript is kept with a closing `vincent.transcript_limit` annotation, because the lines that got there are what explain the runaway |

--- a/docs/tasks/003-usage-limit-classification.md
+++ b/docs/tasks/003-usage-limit-classification.md
@@ -1,0 +1,172 @@
+# 003 — Classify agent usage limits and auth expiry
+
+**Status:** ✅ done (7/7) · **Opened:** 2026-08-14 · Closes
+[#80](https://github.com/lezli01/vincent/issues/80)
+
+Two new reasons in the shared failure vocabulary — `usage_limit` and
+`agent_unauthenticated` — plus the machinery that makes `usage_limit` mean
+something the daemon can act on rather than a label on a `blocked` task.
+
+## The problem
+
+`classifyAgent` collapsed every adapter outcome it did not already special-case
+into `nonzero_exit` (exit ≠ 0) or `agent_error` (`IsError`). A quota-exhausted
+run and a genuinely failed run were the same row, the same board cell, the same
+block reason.
+
+That is worse than one bad error message. `runStepWithRetries` has no delay
+between attempts, so a quota-walled step spent its whole `max_retries` budget in
+seconds; and since the scheduler admits up to `max_parallel_tasks` concurrently,
+every running task on that adapter hit the same wall in the same minute. The
+board went `blocked` with a reason that sent the reader to a transcript about a
+task that was fine.
+
+The two halves have different spec status, and it matters:
+
+- **Quota was an unconsidered case.** §18's edge-case table is otherwise unusually
+  thorough — dirty worktrees, manually deleted directories, DST, gigabyte output,
+  ref-hierarchy conflicts — and "the agent ran out of quota" was not among them.
+  Nothing in the spec, `docs/history/v0-tasks.md` or `docs/tasks/` recorded a
+  decision about usage limits, retry backoff, or auto-recovery from a rate limit.
+- **Auth expiry at run time was a *stated position*.** `docs/spec.md`'s §18 auth
+  row already said that where an adapter cannot tell whether the CLI is
+  authenticated (`logged_in: null`), "the step runs and fails with the CLI's auth
+  error". Decision 4 below leaves that substantively intact and amends only the
+  name of the reason.
+
+## Decisions
+
+### 1. The admission hold is a generic pair of columns on `tasks`
+
+*2026-08-14.* Migration `0006` adds `admit_not_before TEXT` and
+`queued_reason TEXT`. The scheduler reads one timestamp and clients render one
+reason string, so the next wait-shaped case — the agent-wide hold this task
+leaves out of scope, a git backoff — costs no second migration and no second
+branch in the admission walk.
+
+**Beat:** overloading `block_reason`. §14 says it is "set while `state='blocked'`",
+and clients key off the API's `block_reason` field to mean exactly that; a queued
+task carrying one would break them. Also beat: a `usage_limit_until` column, which
+would have to be renamed or duplicated the first time anything else waits.
+
+**Clearing is not the caller's job.** `TransitionTask` NULLs both columns on any
+transition whose *from*-state is `queued` — the same construction that makes
+"`pending_input_json` non-null iff `awaiting_input`" hold. So a hold cannot
+outlive the queued period it belongs to: admission, parking and cancel all clear
+it, and no caller has to remember.
+
+One consequence, recorded rather than fixed: pausing a held task and then
+resuming it drops the hold, so the task is admitted at once and re-discovers the
+wall. That is one wasted spawn in exchange for "a human action means go", which
+is the rule §6 already applies to every other pending flag.
+
+### 2. The adapter's verdict travels on `agent.RunResult`
+
+*2026-08-14.* `RunResult` gains `Failure *agent.Failure{Kind FailureKind;
+RetryAfter *time.Time}`, populated inside each adapter's `Wait()`.
+
+**Beat:** a new `Adapter` method, `ClassifyFailure(res, stderr)`. The engine
+could not feed that signature today — it never sees stderr, only the handle
+does — so the material would have to be plumbed out of the adapter purely to be
+handed back in. `Wait()` is where the terminal result and the 64 KB stderr tail
+already are.
+
+`FailureKind` is an adapter-side enum (`usage_limit`, `unauthenticated`), **not**
+a reason string. `internal/agent` must own no entry in the `block_reason`
+vocabulary — that vocabulary is `internal/taskrun` + `internal/worktree`
+(T1.5/T1.6 decision) — and the engine does the kind → reason mapping, so there is
+no third source of truth for a reason value.
+
+**Claude ships patterns; codex and cursor recognize nothing.** The wordings are
+not fixture-verified: capturing a genuine quota exhaustion means burning a real
+five-hour window, the same impracticality `internal/agent/cursor/cursor.go`
+records for the logged-out wording. The precedent set there applies — a layered,
+conservative parse that falls through to today's reason when unsure. Extending it
+to codex and cursor without a fixture would be a guess, and a wrong guess parks a
+genuinely failed task in a wait it never recovers from. `cmd/fakeagent` carries
+the scenarios in all three dialects anyway, and the codex/cursor legs assert that
+today's behaviour is unchanged — so adding patterns later is a `classify` call
+beside an existing test.
+
+**A reset timestamp is parsed or nil, never guessed.** Anything unparseable, in
+the past, or beyond a seven-day horizon leaves `RetryAfter` nil and the interval
+takes over. A past timestamp would admit on the next tick — the exact respawn
+loop this task exists to stop.
+
+### 3. Re-check interval is a config knob, default 15 minutes
+
+*2026-08-14.* `usage_limit_recheck_interval`, used only when the CLI reported no
+reset timestamp. 15 m bounds a five-hour window at roughly twenty wasted spawns;
+a user who knows their plan can tighten or widen it. Validated positive: zero
+would re-admit on the very next tick.
+
+**Beat:** exponential backoff. That is per-task state the row would have to carry
+and a second retry-ish concept beside §7.2's, for a case where the wait length is
+knowable from the plan.
+
+**Beat:** a hardcoded constant. The gate needs a two-second interval to drive the
+whole path end to end, and a test-only override hatch is what the PR V decision
+rejected in favour of a real config field.
+
+### 4. The auth half classifies, and changes nothing else
+
+*2026-08-14.* §18's auth row stays true: the step still runs, the attempt still
+fails, the normal §7.2 budget still applies, and the task still ends up `blocked`.
+The row is amended only to name the reason `agent_unauthenticated` instead of
+"the CLI's auth error".
+
+**Beat:** a pre-flight refusal on `logged_in: false`, and short-circuiting the
+retry budget. Either would make this the first reason in vincent to bypass §7.2,
+and what it saves is one extra process spawn at the default `max_retries: 1`.
+
+### 5. The hold is evaluated in the walk, not in `ListAdmissible`'s SQL
+
+*2026-08-14.* The issue put it in SQL. The walk parks a task whose pause was
+requested while it ran, and that check has to keep running for held tasks — if
+SQL hid them, a `pause` on a quota-held task would silently not take effect until
+the hold expired, which is exactly the "showing queued while the human asked for
+paused" lie the existing comment calls out. Order in the walk: pause, then the
+hold, then the caps.
+
+No timer is needed: `tickInterval` is already 5 s, so a hold is picked up within
+5 s of expiring. That gives the tick's doc comment a second exception worth
+noting — nothing commits a state change when a hold lapses, so the tick is the
+only thing that notices.
+
+## Tasks
+
+- [x] **003.1** — `agent.Failure`/`FailureKind` on `RunResult`; claude's layered
+  parse, with codex and cursor documented as classifying nothing. ✓ 2026-08-14
+- [x] **003.2** — Migration `0006`, `store.Task`/`TaskChange` fields, and the
+  "any transition out of `queued` clears the hold" invariant. ✓ 2026-08-14
+- [x] **003.3** — Engine: `ReasonUsageLimit`/`ReasonAgentUnauthenticated`, the
+  `classifyAgent` branch, and `holdForUsageLimit`. ✓ 2026-08-14
+- [x] **003.4** — Scheduler: the hold in the walk, injected clock, pause-first
+  ordering. ✓ 2026-08-14
+- [x] **003.5** — `usage_limit_recheck_interval` in config, `GET /v1/config`, the
+  generated config file and the daemon view. ✓ 2026-08-14
+- [x] **003.6** — `admit_not_before`/`queued_reason` through the API and client;
+  the board cell and detail header. ✓ 2026-08-14
+- [x] **003.7** — `cmd/fakeagent` scenarios in all three dialects, per-package
+  tests, and `scripts/m2-gate.sh` scenario 5 driving the whole path over curl.
+  ✓ 2026-08-14
+
+## Out of scope
+
+**The agent-wide hold** — one task's `usage_limit` suppressing admission of every
+*other* queued task on that adapter — stays out, as the issue asks. Each task
+discovers the wall independently, costing N process spawns per window. It wants
+its own issue, and the generic `admit_not_before` column chosen above is what it
+will build on.
+
+**Crash recovery needs no change.** The hold is a column on the task row, so a
+crash during a wait leaves a queued task with its hold intact; the startup sweep
+only finalizes `running` step runs.
+
+## Verification
+
+- `go test ./...` and `go test -race ./...` green.
+- `go tool golangci-lint run ./...` green for `GOOS=linux`, `darwin` and
+  `windows` (the CLAUDE.md cross-platform lint).
+- `VINCENT_GATE_SCENARIO=5 ./scripts/m2-gate.sh` — held task frees its slot, the
+  second task runs, the first recovers unattended, all over curl.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -17,6 +17,7 @@ description of how the system actually behaves.
 |---|---|---|
 | [001](001-configurable-branch-names.md) | Configurable branch names | ✅ done (11/11) |
 | [002](002-homebrew-tap.md) | Homebrew tap for macOS | ✅ done (6/6) |
+| [003](003-usage-limit-classification.md) | Classify agent usage limits and auth expiry | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 )
 
 // PermissionMode selects how much autonomy the agent CLI gets (spec §9.4).
@@ -259,6 +260,49 @@ type RunResult struct {
 	InputTokens  int64  // 0 if unreported
 	OutputTokens int64
 	CostUSD      *float64 // nil if unreported (e.g. codex)
+	// Failure is the adapter's verdict about *why* the run stopped, when it
+	// recognized the reason in its own CLI's output (task 003, §9.1). nil —
+	// "nothing recognized" — is every run that behaves as it did before this
+	// field existed, which is what keeps an unrecognized failure on today's
+	// nonzero_exit/agent_error path.
+	//
+	// It rides here rather than behind a new Adapter method because this is
+	// where the material already is: the terminal result and the stderr tail
+	// live inside the handle, and the engine never sees either.
+	Failure *Failure
+}
+
+// FailureKind names a condition an adapter recognized in its CLI's output
+// (task 003, §9.1).
+//
+// It is deliberately *not* a block_reason. That vocabulary belongs to
+// internal/taskrun and internal/worktree (T1.5/T1.6 decision), and the engine
+// does the kind → reason mapping, so a reason string has exactly one source of
+// truth and internal/agent owns no entry in it.
+type FailureKind string
+
+// Recognized failure kinds (task 003).
+const (
+	// FailureUsageLimit is a run the CLI stopped because the account's usage
+	// quota for the current window is spent. It is not a failure of the work:
+	// the window reopens on its own, so the engine re-queues the task with an
+	// admission hold instead of spending a retry (§7.2, §11).
+	FailureUsageLimit FailureKind = "usage_limit"
+	// FailureUnauthenticated is a run the CLI refused because it is not
+	// logged in. Waiting cannot fix it — re-authenticating is a human action —
+	// so it stays an ordinary failure under the §7.2 budget (§18).
+	FailureUnauthenticated FailureKind = "unauthenticated"
+)
+
+// Failure is an adapter's verdict about a stopped run (task 003, §9.1).
+type Failure struct {
+	Kind FailureKind
+	// RetryAfter is when the CLI said the limit resets — absolute, UTC. nil
+	// means the CLI reported no usable reset time, and is what an unparseable
+	// or implausible one becomes: a guessed timestamp would park a task for a
+	// window nobody promised. The engine falls back to
+	// `usage_limit_recheck_interval` (§12.3) when it is nil.
+	RetryAfter *time.Time
 }
 
 // Options are the selectable models/efforts of an adapter (spec §9.1, §9.6).

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -459,6 +459,10 @@ func (r *run) Wait() (agent.RunResult, error) {
 				res.ErrorMessage += ": " + tail
 			}
 		}
+		// The adapter's verdict on *why* the run stopped (task 003, §9.1).
+		// It happens here because this is the one place that holds both the
+		// terminal result and the stderr tail; the engine sees neither.
+		res.Failure = classify(res, r.stderr.String())
 		r.waitRes = res
 	})
 	return r.waitRes, r.waitErr

--- a/internal/agent/claude/failure.go
+++ b/internal/agent/claude/failure.go
@@ -1,0 +1,101 @@
+package claude
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// resetHorizon bounds a reset timestamp the CLI reported. A quota window is
+// hours, not months, so a value beyond this is a misparse rather than a long
+// wait — and acting on it would park the task past any point a human would
+// wait for. Past timestamps are rejected for the mirror-image reason: a hold
+// that has already expired admits the task on the next tick, which is the
+// tight respawn loop this whole feature exists to stop.
+const resetHorizon = 7 * 24 * time.Hour
+
+// usageLimitMarkers are the phrasings that mean "the quota for this window is
+// spent". Matched case-insensitively against the terminal result text, the
+// error message and the stderr tail.
+//
+// **Not fixture-verified.** Capturing a genuine quota exhaustion means burning
+// a real five-hour window, the same impracticality cursor's logged-out probe
+// records (cursor.go's loggedIn). So the parse follows the precedent that set:
+// recognize the shapes that are documented, and fall through to nil for
+// everything else rather than guess. An unrecognized quota stop keeps today's
+// behaviour exactly — it fails as nonzero_exit or agent_error — which is the
+// regression that matters most here.
+var usageLimitMarkers = []string{
+	"usage limit reached",
+	"5-hour limit reached",
+	"weekly limit reached",
+}
+
+// unauthenticatedMarkers are the phrasings that mean "this CLI is not logged
+// in". Same caveat as above: layered and conservative, never a guess.
+var unauthenticatedMarkers = []string{
+	"invalid api key",
+	"please run /login",
+	"not logged in",
+	"oauth token has expired",
+	"authentication_error",
+}
+
+// resetEpochRe matches the reset time claude appends to its usage-limit
+// message as unix seconds: `Claude AI usage limit reached|1755100000`.
+var resetEpochRe = regexp.MustCompile(`limit reached\|(\d{9,11})`)
+
+// classify inspects a finished run for a condition vincent can act on: a spent
+// usage quota, which the engine turns into an admission hold (§11), or a CLI
+// that is not authenticated, which blocks under the normal retry budget (§18).
+//
+// It reads the terminal result and the stderr tail together because which one
+// carries the wording is not fixture-verified either — the same reason cursor's
+// login probe reads both of its streams.
+//
+// The order matters only for a message that somehow says both: a quota stop is
+// the recoverable one, so it wins and the task waits rather than blocking on a
+// human who has nothing to do.
+func classify(res agent.RunResult, stderr string) *agent.Failure {
+	text := strings.ToLower(strings.Join([]string{res.ErrorMessage, res.ResultText, stderr}, "\n"))
+	switch {
+	case containsAny(text, usageLimitMarkers):
+		return &agent.Failure{Kind: agent.FailureUsageLimit, RetryAfter: parseReset(text, time.Now())}
+	case containsAny(text, unauthenticatedMarkers):
+		return &agent.Failure{Kind: agent.FailureUnauthenticated}
+	default:
+		return nil
+	}
+}
+
+func containsAny(text string, markers []string) bool {
+	for _, m := range markers {
+		if strings.Contains(text, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseReset extracts the reset timestamp claude appends to its usage-limit
+// message. Anything that does not parse, or that lands outside resetHorizon in
+// either direction, yields nil — the interval fallback then decides, which is
+// the honest answer when the CLI told us nothing usable.
+func parseReset(text string, now time.Time) *time.Time {
+	m := resetEpochRe.FindStringSubmatch(text)
+	if m == nil {
+		return nil
+	}
+	secs, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return nil
+	}
+	at := time.Unix(secs, 0).UTC()
+	if !at.After(now) || at.After(now.Add(resetHorizon)) {
+		return nil
+	}
+	return &at
+}

--- a/internal/agent/claude/failure_test.go
+++ b/internal/agent/claude/failure_test.go
@@ -1,0 +1,191 @@
+package claude
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// TestClassify is the table the whole conservative-parse argument rests on.
+// The last group matters most: output the adapter does not recognize must
+// yield a nil Failure, so a run that used to fail `nonzero_exit`/`agent_error`
+// still does.
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name   string
+		res    agent.RunResult
+		stderr string
+		want   agent.FailureKind // "" = nil Failure
+	}{
+		{
+			name: "usage limit in the result text",
+			res:  agent.RunResult{IsError: true, ResultText: "Claude AI usage limit reached"},
+			want: agent.FailureUsageLimit,
+		},
+		{
+			name: "usage limit in the error message",
+			res:  agent.RunResult{IsError: true, ErrorMessage: "Claude AI usage limit reached|0"},
+			want: agent.FailureUsageLimit,
+		},
+		{
+			name:   "usage limit only on stderr",
+			res:    agent.RunResult{ExitCode: 1},
+			stderr: "5-hour limit reached, try again later",
+			want:   agent.FailureUsageLimit,
+		},
+		{
+			name: "weekly limit",
+			res:  agent.RunResult{IsError: true, ResultText: "Weekly limit reached for this account"},
+			want: agent.FailureUsageLimit,
+		},
+		{
+			name: "invalid api key",
+			res:  agent.RunResult{IsError: true, ResultText: "Invalid API key · Please run /login"},
+			want: agent.FailureUnauthenticated,
+		},
+		{
+			name:   "logged out on stderr",
+			res:    agent.RunResult{ExitCode: 1},
+			stderr: "You are not logged in.",
+			want:   agent.FailureUnauthenticated,
+		},
+		{
+			name: "expired oauth token",
+			res:  agent.RunResult{IsError: true, ErrorMessage: "OAuth token has expired"},
+			want: agent.FailureUnauthenticated,
+		},
+		{
+			// The precedence case: a quota stop is recoverable by waiting, so
+			// it wins over a phrase that would send the reader to re-login.
+			name: "both phrasings present prefers the recoverable one",
+			res:  agent.RunResult{IsError: true, ResultText: "usage limit reached; please run /login to switch accounts"},
+			want: agent.FailureUsageLimit,
+		},
+
+		// Everything below is today's behaviour, unchanged.
+		{
+			name: "an ordinary agent failure is not classified",
+			res:  agent.RunResult{IsError: true, ResultText: "the tests did not pass"},
+		},
+		{
+			name: "a plain nonzero exit is not classified",
+			res:  agent.RunResult{ExitCode: 3},
+		},
+		{
+			name:   "an unrelated rate limit is not a usage limit",
+			res:    agent.RunResult{ExitCode: 1},
+			stderr: "curl: (429) rate limit exceeded talking to api.example.com",
+		},
+		{
+			name: "a successful run is not classified",
+			res:  agent.RunResult{ResultText: "done"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classify(tc.res, tc.stderr)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("classify = %+v, want nil (unrecognized output must keep today's reason)", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("classify = nil, want kind %s", tc.want)
+			}
+			if got.Kind != tc.want {
+				t.Fatalf("kind = %s, want %s", got.Kind, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyParsesResetTime covers the RetryAfter leg: a usable timestamp is
+// parsed, and anything else stays nil so the interval fallback decides rather
+// than a guess.
+func TestClassifyParsesResetTime(t *testing.T) {
+	now := time.Now()
+	in90m := now.Add(90 * time.Minute).Truncate(time.Second)
+
+	got := classify(agent.RunResult{
+		IsError:    true,
+		ResultText: "Claude AI usage limit reached|" + strconv.FormatInt(in90m.Unix(), 10),
+	}, "")
+	if got == nil || got.RetryAfter == nil {
+		t.Fatalf("classify = %+v, want a parsed RetryAfter", got)
+	}
+	if !got.RetryAfter.Equal(in90m.UTC()) {
+		t.Errorf("RetryAfter = %s, want %s", got.RetryAfter, in90m.UTC())
+	}
+
+	unusable := map[string]string{
+		"no timestamp at all":  "Claude AI usage limit reached",
+		"not a number":         "Claude AI usage limit reached|later-today",
+		"already in the past":  "Claude AI usage limit reached|1000000000",
+		"implausibly far away": "Claude AI usage limit reached|" + strconv.FormatInt(now.Add(60*24*time.Hour).Unix(), 10),
+	}
+	for name, text := range unusable {
+		t.Run(name, func(t *testing.T) {
+			f := classify(agent.RunResult{IsError: true, ResultText: text}, "")
+			if f == nil || f.Kind != agent.FailureUsageLimit {
+				t.Fatalf("classify = %+v, want a usage-limit failure", f)
+			}
+			if f.RetryAfter != nil {
+				t.Errorf("RetryAfter = %s, want nil (never a guessed reset time)", f.RetryAfter)
+			}
+		})
+	}
+}
+
+// TestWaitClassifiesUsageLimit runs the real adapter against the fake CLI, so
+// the wiring from the stream through Wait is exercised rather than assumed.
+func TestWaitClassifiesUsageLimit(t *testing.T) {
+	h := startRun(t, "usage-limit", "FAKEAGENT_USAGE_LIMIT_RESET=600")
+	drain(t, h)
+	res, err := h.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if res.Failure == nil || res.Failure.Kind != agent.FailureUsageLimit {
+		t.Fatalf("Failure = %+v, want usage_limit", res.Failure)
+	}
+	if res.Failure.RetryAfter == nil {
+		t.Fatal("RetryAfter = nil, want the reset time the CLI reported")
+	}
+	if !res.Failure.RetryAfter.After(time.Now()) {
+		t.Errorf("RetryAfter = %s, want a future instant", res.Failure.RetryAfter)
+	}
+}
+
+// TestWaitClassifiesUnauthenticated is the same wiring check for the auth half.
+func TestWaitClassifiesUnauthenticated(t *testing.T) {
+	h := startRun(t, "unauthenticated")
+	drain(t, h)
+	res, err := h.Wait()
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if res.Failure == nil || res.Failure.Kind != agent.FailureUnauthenticated {
+		t.Fatalf("Failure = %+v, want unauthenticated", res.Failure)
+	}
+}
+
+// TestWaitLeavesOrdinaryFailuresUnclassified is the regression: the adapter
+// must not start labelling runs it has no evidence about.
+func TestWaitLeavesOrdinaryFailuresUnclassified(t *testing.T) {
+	for _, scenario := range []string{"success", "error-event", "nonzero-exit"} {
+		t.Run(scenario, func(t *testing.T) {
+			h := startRun(t, scenario)
+			drain(t, h)
+			res, err := h.Wait()
+			if err != nil {
+				t.Fatalf("Wait: %v", err)
+			}
+			if res.Failure != nil {
+				t.Errorf("Failure = %+v, want nil for scenario %s", res.Failure, scenario)
+			}
+		})
+	}
+}

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -226,6 +226,14 @@ func (r *run) PID() int { return r.cmd.Process.Pid }
 // Wait implements agent.RunHandle. It blocks until the stream is fully
 // consumed and the process has exited, then assembles the RunResult per
 // §7.1: the terminal turn event plus the exit code.
+//
+// RunResult.Failure is deliberately left nil (task 003): codex's usage-limit
+// and unauthenticated wordings are not fixture-verified, and this adapter
+// ships no guess in their place. A quota stop here therefore reads exactly as
+// it did before task 003 — nonzero_exit or agent_error — rather than as an
+// invented match. Adding it later is a `classify` beside this call and a
+// `usage-limit` case in cmd/fakeagent's codex dialect, which is already there
+// and already asserted to produce today's behaviour.
 func (r *run) Wait() (agent.RunResult, error) {
 	r.waitOnce.Do(func() {
 		<-r.readerDone

--- a/internal/agent/codex/failure_test.go
+++ b/internal/agent/codex/failure_test.go
@@ -1,0 +1,31 @@
+package codex
+
+import "testing"
+
+// TestQuotaAndAuthStopsStayUnclassified pins the codex half of task 003's
+// decision: this adapter recognizes nothing, because its usage-limit and
+// unauthenticated wordings are not fixture-verified, so a run stopped by
+// either reads exactly as it did before — an ordinary failure under §7.2.
+//
+// The test exists rather than the classification because the risk here is the
+// opposite of a missing feature: an adapter that starts guessing would send a
+// genuinely failed task into a wait it never recovers from.
+func TestQuotaAndAuthStopsStayUnclassified(t *testing.T) {
+	for _, scenario := range []string{"usage-limit", "unauthenticated"} {
+		t.Run(scenario, func(t *testing.T) {
+			h := startRun(t, scenario)
+			drain(t, h)
+			res, err := h.Wait()
+			if err != nil {
+				t.Fatalf("Wait: %v", err)
+			}
+			if res.Failure != nil {
+				t.Fatalf("Failure = %+v, want nil until a fixture exists", res.Failure)
+			}
+			if !res.IsError && res.ExitCode == 0 {
+				t.Errorf("run reported success; want the ordinary failure path (exit %d, is_error %v)",
+					res.ExitCode, res.IsError)
+			}
+		})
+	}
+}

--- a/internal/agent/cursor/cursor.go
+++ b/internal/agent/cursor/cursor.go
@@ -338,6 +338,14 @@ func (r *run) PID() int { return r.cmd.Process.Pid }
 // everyday failure, not a defensive corner: an invalid model id exits 1 with
 // `ActionRequiredError: … Model name is not valid` on stderr and emits no
 // result event at all (spec §9.7).
+//
+// RunResult.Failure is deliberately left nil (task 003), for the reason this
+// adapter already records about `status`: the wordings are not
+// fixture-verified, and probing them means signing the developer out or
+// burning a real quota window. A quota stop or an expired login therefore
+// reads exactly as it did before task 003. Note that the §9.5 `logged_in`
+// probe is unaffected and still flags an unauthenticated CLI *before* a task
+// is created — this is only about classifying a run that already failed.
 func (r *run) Wait() (agent.RunResult, error) {
 	r.waitOnce.Do(func() {
 		<-r.readerDone

--- a/internal/agent/cursor/failure_test.go
+++ b/internal/agent/cursor/failure_test.go
@@ -1,0 +1,31 @@
+package cursor
+
+import "testing"
+
+// TestQuotaAndAuthStopsStayUnclassified pins the cursor half of task 003's
+// decision, for the reason this adapter already records about `status`: the
+// wordings are not fixture-verified — probing them means signing the developer
+// out or burning a real quota window — so nothing is recognized and a run
+// stopped by either reads exactly as it did before.
+//
+// The §9.5 `logged_in` probe is unaffected: an unauthenticated cursor is still
+// flagged before a task is created. This is only about a run that has failed.
+func TestQuotaAndAuthStopsStayUnclassified(t *testing.T) {
+	for _, scenario := range []string{"usage-limit", "unauthenticated"} {
+		t.Run(scenario, func(t *testing.T) {
+			h := startRun(t, scenario)
+			drain(t, h)
+			res, err := h.Wait()
+			if err != nil {
+				t.Fatalf("Wait: %v", err)
+			}
+			if res.Failure != nil {
+				t.Fatalf("Failure = %+v, want nil until a fixture exists", res.Failure)
+			}
+			if !res.IsError && res.ExitCode == 0 {
+				t.Errorf("run reported success; want the ordinary failure path (exit %d, is_error %v)",
+					res.ExitCode, res.IsError)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -258,6 +258,7 @@ type configResponse struct {
 	Defaults                configDefaults       `json:"defaults"`
 	TranscriptRetentionDays int                  `json:"transcript_retention_days"`
 	TranscriptMaxBytes      int64                `json:"transcript_max_bytes"`
+	UsageLimitRecheck       string               `json:"usage_limit_recheck_interval"`
 	LogLevel                string               `json:"log_level"`
 	Agents                  map[string]agentPath `json:"agents"`
 }
@@ -284,6 +285,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
 		},
 		TranscriptRetentionDays: cfg.TranscriptRetentionDays,
 		TranscriptMaxBytes:      cfg.TranscriptMaxBytes.Bytes(),
+		UsageLimitRecheck:       cfg.UsageLimitRecheckInterval.String(),
 		LogLevel:                cfg.LogLevel,
 		Agents: map[string]agentPath{
 			"claude": {Path: cfg.Agents.Claude.Path},

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -66,6 +66,13 @@ type taskResponse struct {
 	// alone so the detail view can render k/n without re-parsing the snapshot.
 	StepTotal   int     `json:"step_total"`
 	BlockReason *string `json:"block_reason"`
+	// AdmitNotBefore and QueuedReason describe a queued task waiting on
+	// something other than a free slot (§11, task 003) — an agent usage window
+	// today. Both are null for every other task, so the pair is additive and
+	// changes nothing for a client that ignores it. They are deliberately not
+	// folded into block_reason, which means "set while blocked" (§14).
+	AdmitNotBefore *string `json:"admit_not_before"`
+	QueuedReason   *string `json:"queued_reason"`
 	// Warnings are non-fatal §8.2 catalog findings from creation-time
 	// validation; only the POST /v1/tasks response carries them.
 	Warnings []string `json:"warnings,omitempty"`
@@ -141,6 +148,8 @@ func toTaskResponse(t *store.Task, summary snapshotSummary) taskResponse {
 		CurrentStep:      t.CurrentStep,
 		StepTotal:        summary.stepTotal,
 		BlockReason:      nilIfEmpty(t.BlockReason),
+		AdmitNotBefore:   timePtr(t.AdmitNotBefore),
+		QueuedReason:     nilIfEmpty(t.QueuedReason),
 		PendingInput:     rawIfNotEmpty(t.PendingInputJSON),
 		PauseRequested:   t.PauseRequested,
 		AvailableActions: availableActions(t.State),

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -69,13 +69,16 @@ func (c *Client) Info(ctx context.Context) (Info, error) {
 // has it loaded, durations rendered as Go duration strings. It is read-only
 // here — the file is authoritative and the daemon hot-reloads it (§12.3).
 type Config struct {
-	Listen                  string               `json:"listen"`
-	MaxParallelTasks        int                  `json:"max_parallel_tasks"`
-	Defaults                ConfigDefaults       `json:"defaults"`
-	TranscriptRetentionDays int                  `json:"transcript_retention_days"`
-	TranscriptMaxBytes      int64                `json:"transcript_max_bytes"`
-	LogLevel                string               `json:"log_level"`
-	Agents                  map[string]AgentPath `json:"agents"`
+	Listen                  string         `json:"listen"`
+	MaxParallelTasks        int            `json:"max_parallel_tasks"`
+	Defaults                ConfigDefaults `json:"defaults"`
+	TranscriptRetentionDays int            `json:"transcript_retention_days"`
+	TranscriptMaxBytes      int64          `json:"transcript_max_bytes"`
+	// UsageLimitRecheck is how long a quota-held task waits before the
+	// scheduler tries again, when the agent CLI reported no reset time (§11).
+	UsageLimitRecheck string               `json:"usage_limit_recheck_interval"`
+	LogLevel          string               `json:"log_level"`
+	Agents            map[string]AgentPath `json:"agents"`
 }
 
 // ConfigDefaults are the §12.3 default timeouts, as duration strings.

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -38,11 +38,27 @@ type Task struct {
 	PauseRequested   bool     `json:"pause_requested"`
 	AvailableActions []string `json:"available_actions"`
 
+	// QueuedReason and AdmitNotBefore describe a queued task waiting on
+	// something other than a free slot (§11) — `usage_limit` today, with the
+	// instant the daemon will try again. Both nil is the ordinary queue.
+	QueuedReason   *string    `json:"queued_reason"`
+	AdmitNotBefore *time.Time `json:"admit_not_before"`
+
 	CreatedAt  time.Time  `json:"created_at"`
 	UpdatedAt  time.Time  `json:"updated_at"`
 	StartedAt  *time.Time `json:"started_at"`
 	FinishedAt *time.Time `json:"finished_at"`
 	ArchivedAt *time.Time `json:"archived_at"`
+}
+
+// Hold reports a queued task that is waiting on something other than a free
+// slot (§11): the reason, and when the daemon will try again. ok is false for
+// the ordinary queue, which is every task that carries no queued_reason.
+func (t Task) Hold() (reason string, until *time.Time, ok bool) {
+	if t.QueuedReason == nil || *t.QueuedReason == "" {
+		return "", nil, false
+	}
+	return *t.QueuedReason, t.AdmitNotBefore, true
 }
 
 // StepDisplay renders the k/n pair. It reports ok=false when the snapshot

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -39,6 +39,12 @@ transcript_retention_days: 90
 # transcript_limit rather than filling the disk.
 transcript_max_bytes: 512MB
 
+# How long a task waits before trying again after its agent reported that the
+# usage quota for the window is spent, when the CLI named no reset time. When
+# it does name one, that wins and this is unused. The task keeps its place in
+# the queue and holds no slot while it waits.
+usage_limit_recheck_interval: 15m
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,7 +157,17 @@ type Config struct {
 	// at the top level beside its retention sibling, not under `defaults:`,
 	// which is timeouts only (PR V decision).
 	TranscriptMaxBytes ByteSize `yaml:"transcript_max_bytes"`
-	LogLevel           string   `yaml:"log_level"`
+	// UsageLimitRecheckInterval is how long a task waits before trying again
+	// after its agent reported a spent usage quota *without* a reset time
+	// (task 003, §11). When the CLI does report one, that timestamp wins and
+	// this is unused.
+	//
+	// 15m bounds a five-hour window at roughly twenty wasted spawns, and a
+	// user who knows their plan can tighten or widen it. There is deliberately
+	// no exponential backoff: that is per-task state the row would have to
+	// carry, and a second retry-ish concept beside §7.2's.
+	UsageLimitRecheckInterval Duration `yaml:"usage_limit_recheck_interval"`
+	LogLevel                  string   `yaml:"log_level"`
 	// Debug records, in every step's transcript, the exact conditions the
 	// step ran under: the resolved agent/model/effort, the permission mode,
 	// the working directory, and the full argv of the process spawned.
@@ -210,9 +220,10 @@ func Default() Config {
 			CommandTimeout: Duration(15 * time.Minute),
 			InputTimeout:   Duration(24 * time.Hour),
 		},
-		TranscriptRetentionDays: 90,
-		TranscriptMaxBytes:      512 << 20, // 512MB (§12.3)
-		LogLevel:                "info",
+		TranscriptRetentionDays:   90,
+		TranscriptMaxBytes:        512 << 20, // 512MB (§12.3)
+		UsageLimitRecheckInterval: Duration(15 * time.Minute),
+		LogLevel:                  "info",
 		// Inherit everything: exactly what the daemon did before the policy
 		// existed, so nothing changes for anyone who does not ask.
 		Environment: Environment{Inherit: InheritAll()},
@@ -265,6 +276,12 @@ func (c Config) validate() error {
 	}
 	if c.TranscriptRetentionDays < 0 {
 		return fmt.Errorf("transcript_retention_days must not be negative, got %d", c.TranscriptRetentionDays)
+	}
+	// Positive, not merely non-negative: zero would re-admit a quota-held task
+	// on the very next tick, which is the tight respawn loop the hold exists
+	// to stop (task 003).
+	if c.UsageLimitRecheckInterval <= 0 {
+		return fmt.Errorf("usage_limit_recheck_interval must be positive, got %s", c.UsageLimitRecheckInterval)
 	}
 	switch c.LogLevel {
 	case "debug", "info", "warn", "error":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,6 +59,7 @@ defaults:
   input_timeout: 36h
 transcript_retention_days: 7
 transcript_max_bytes: 32MB
+usage_limit_recheck_interval: 2m
 log_level: warn
 agents:
   claude:
@@ -78,9 +79,10 @@ agents:
 			CommandTimeout: Duration(90 * time.Second),
 			InputTimeout:   Duration(36 * time.Hour),
 		},
-		TranscriptRetentionDays: 7,
-		TranscriptMaxBytes:      32 << 20,
-		LogLevel:                "warn",
+		TranscriptRetentionDays:   7,
+		TranscriptMaxBytes:        32 << 20,
+		UsageLimitRecheckInterval: Duration(2 * time.Minute),
+		LogLevel:                  "warn",
 		// The file omits `environment:`, so the §12.3 default survives an
 		// otherwise fully-overriding config — which is the property that
 		// keeps T4.23 invisible to anyone who does not ask for it.
@@ -97,19 +99,23 @@ agents:
 
 func TestLoadRejectsInvalid(t *testing.T) {
 	cases := map[string]string{
-		"unknown key":            "max_parallel_jobs: 5\n",
-		"unknown nested key":     "defaults:\n  agent_timeut: 60m\n",
-		"bad duration":           "defaults:\n  agent_timeout: sixty minutes\n",
-		"duration missing unit":  "defaults:\n  agent_timeout: 60\n",
-		"negative duration":      "defaults:\n  command_timeout: -5m\n",
-		"zero cap":               "max_parallel_tasks: 0\n",
-		"bad log level":          "log_level: verbose\n",
-		"non-loopback listen":    "listen: 0.0.0.0:8080\n",
-		"listen without port":    "listen: 127.0.0.1\n",
-		"bad port":               "listen: 127.0.0.1:notaport\n",
-		"negative retention":     "transcript_retention_days: -1\n",
-		"not yaml":               "{{{\n",
-		"wrong type for integer": "max_parallel_tasks: many\n",
+		"unknown key":           "max_parallel_jobs: 5\n",
+		"unknown nested key":    "defaults:\n  agent_timeut: 60m\n",
+		"bad duration":          "defaults:\n  agent_timeout: sixty minutes\n",
+		"duration missing unit": "defaults:\n  agent_timeout: 60\n",
+		"negative duration":     "defaults:\n  command_timeout: -5m\n",
+		"zero cap":              "max_parallel_tasks: 0\n",
+		"bad log level":         "log_level: verbose\n",
+		"non-loopback listen":   "listen: 0.0.0.0:8080\n",
+		"listen without port":   "listen: 127.0.0.1\n",
+		"bad port":              "listen: 127.0.0.1:notaport\n",
+		"negative retention":    "transcript_retention_days: -1\n",
+		// Zero would re-admit a quota-held task on the very next tick, which
+		// is the respawn loop the hold exists to stop (task 003).
+		"zero recheck interval":     "usage_limit_recheck_interval: 0s\n",
+		"negative recheck interval": "usage_limit_recheck_interval: -1m\n",
+		"not yaml":                  "{{{\n",
+		"wrong type for integer":    "max_parallel_tasks: many\n",
 	}
 	for name, content := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/scheduler/hold_test.go
+++ b/internal/scheduler/hold_test.go
@@ -1,0 +1,130 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// TestAdmissionHoldDefersThenReleases is the §11 hold, both legs: not
+// admitted while the clock is before the instant, admitted on the first walk
+// after it. The clock is injected rather than slept through — a test that
+// waited out a real hold would either be slow or be measuring the tick.
+func TestAdmissionHoldDefersThenReleases(t *testing.T) {
+	h := newHarness(t, 10)
+	p := h.project(t, "proj", nil)
+	task := h.task(t, p, "held", store.TaskQueued, 0, time.Minute)
+
+	start := time.Now().UTC()
+	h.clock = start
+	h.hold(t, task, start.Add(15*time.Minute), "usage_limit")
+
+	h.sched.admit(t.Context())
+	if got := h.admitter.ids(); len(got) != 0 {
+		t.Fatalf("admitted %v before the hold expired", got)
+	}
+
+	// One second before: still held. The boundary is worth pinning because
+	// an off-by-one here is a respawn loop, not a rounding error.
+	h.clock = start.Add(15*time.Minute - time.Second)
+	h.sched.admit(t.Context())
+	if got := h.admitter.ids(); len(got) != 0 {
+		t.Fatalf("admitted %v one second before the hold expired", got)
+	}
+
+	h.clock = start.Add(15 * time.Minute)
+	h.sched.admit(t.Context())
+	if got := h.admitter.ids(); len(got) != 1 || got[0] != task.ID {
+		t.Fatalf("admitted %v after the hold expired, want [%d]", got, task.ID)
+	}
+	if got := h.state(t, task.ID); got != store.TaskRunning {
+		t.Fatalf("state = %s, want running", got)
+	}
+}
+
+// TestAdmissionHoldClearsOnAdmission proves the columns do not outlive the
+// queued period they describe: the hold is dropped by the very transition
+// that admits the task, so a later re-queue starts clean.
+func TestAdmissionHoldClearsOnAdmission(t *testing.T) {
+	h := newHarness(t, 10)
+	p := h.project(t, "proj", nil)
+	task := h.task(t, p, "held", store.TaskQueued, 0, time.Minute)
+
+	start := time.Now().UTC()
+	h.clock = start
+	h.hold(t, task, start.Add(-time.Minute), "usage_limit") // already expired
+
+	h.sched.admit(t.Context())
+
+	after, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if after.AdmitNotBefore != nil || after.QueuedReason != "" {
+		t.Fatalf("hold survived admission: admit_not_before=%v queued_reason=%q",
+			after.AdmitNotBefore, after.QueuedReason)
+	}
+}
+
+// TestHeldTaskDoesNotBlockTheQueue is the point of releasing the slot: the
+// held task sorts first, and the walk must step over it rather than stop at
+// it — otherwise one quota-walled task starves everything behind it.
+func TestHeldTaskDoesNotBlockTheQueue(t *testing.T) {
+	h := newHarness(t, 10)
+	p := h.project(t, "proj", nil)
+	held := h.task(t, p, "held", store.TaskQueued, 0, 3*time.Minute)
+	next := h.task(t, p, "next", store.TaskQueued, 0, time.Minute)
+
+	start := time.Now().UTC()
+	h.clock = start
+	h.hold(t, held, start.Add(15*time.Minute), "usage_limit")
+
+	h.sched.admit(t.Context())
+
+	got := h.admitter.ids()
+	if len(got) != 1 || got[0] != next.ID {
+		t.Fatalf("admitted %v, want only [%d] — the held task must be stepped over", got, next.ID)
+	}
+}
+
+// TestPauseOnHeldTaskStillParks guards the decision to evaluate the hold in
+// the walk rather than in ListAdmissible's SQL. Filtering held tasks out of
+// the query would leave this task showing `queued` until its hold expired,
+// which is precisely the "showing queued while the human asked for paused"
+// lie the pause check exists to prevent.
+func TestPauseOnHeldTaskStillParks(t *testing.T) {
+	h := newHarness(t, 10)
+	p := h.project(t, "proj", nil)
+	task := h.task(t, p, "held", store.TaskRunning, 0, time.Minute)
+	if _, err := h.store.RequestPause(t.Context(), task.ID); err != nil {
+		t.Fatalf("RequestPause: %v", err)
+	}
+	// The engine's usage-limit re-queue: running → queued carrying the hold.
+	start := time.Now().UTC()
+	h.clock = start
+	until := start.Add(15 * time.Minute)
+	reason := "usage_limit"
+	if _, _, err := h.store.TransitionTask(t.Context(), task.ID,
+		store.TaskRunning, store.TaskQueued,
+		store.TaskChange{AdmitNotBefore: &until, QueuedReason: &reason}); err != nil {
+		t.Fatalf("re-queue with a hold: %v", err)
+	}
+
+	h.sched.admit(t.Context())
+
+	if got := h.admitter.ids(); len(got) != 0 {
+		t.Fatalf("admitted %v; a pending pause must park even a held task", got)
+	}
+	if got := h.state(t, task.ID); got != store.TaskPaused {
+		t.Fatalf("state = %s, want paused", got)
+	}
+	after, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if after.AdmitNotBefore != nil || after.QueuedReason != "" {
+		t.Errorf("hold survived parking: admit_not_before=%v queued_reason=%q",
+			after.AdmitNotBefore, after.QueuedReason)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -23,6 +23,11 @@ import (
 
 // tickInterval is the safety net. Wake drives admission in practice — every
 // committed state change fires it — so a tick normally finds nothing to do.
+//
+// It has two exceptions, and the second arrived with task 003: a task held by
+// `admit_not_before` (§11) becomes admissible with no state change to wake
+// anyone, so the tick is what picks it up — within 5 s of the hold expiring,
+// which is why the hold needs no timer of its own.
 const tickInterval = 5 * time.Second
 
 // Admitter runs a task the scheduler has admitted. The task is already in
@@ -42,6 +47,10 @@ type Deps struct {
 	Config   func() config.Config
 	Admitter Admitter
 	Logger   *slog.Logger
+	// Now is the clock the §11 admission hold is measured against; nil means
+	// time.Now. Injected by tests so "not before T, admitted after T" is
+	// assertable without sleeping (task 003).
+	Now func() time.Time
 }
 
 // Scheduler admits queued tasks within the §11 caps.
@@ -126,6 +135,7 @@ func (s *Scheduler) admit(ctx context.Context) {
 	// admitted counts this walk's own admissions per project; the candidate
 	// rows carry the counts as of the query, which predate them.
 	admitted := map[int64]int{}
+	now := s.now()
 	for i := range candidates {
 		if ctx.Err() != nil {
 			return
@@ -140,6 +150,18 @@ func (s *Scheduler) admit(ctx context.Context) {
 		// and a task showing `queued` until a slot frees would be a lie.
 		if c.Task.PauseRequested {
 			s.park(&c.Task, log)
+			continue
+		}
+		// An admission hold (§11, task 003): the task is queued and waiting on
+		// something other than a slot — an agent's usage window, today.
+		//
+		// It is checked here, in the walk, rather than filtered out in
+		// ListAdmissible's SQL, and the pause check above is why: hiding held
+		// tasks from the query would mean a `pause` on one silently did not
+		// take effect until the hold expired, which is exactly the "showing
+		// queued while the human asked for paused" lie the comment above
+		// calls out. Pause first, then the hold, then the caps.
+		if c.Task.AdmitNotBefore != nil && now.Before(*c.Task.AdmitNotBefore) {
 			continue
 		}
 		if global >= limit {
@@ -197,6 +219,14 @@ func (s *Scheduler) park(task *store.Task, log *slog.Logger) {
 		return
 	}
 	log.Info("task paused before admission; pause was requested while it ran")
+}
+
+// now returns the injected clock, defaulting to the real one.
+func (s *Scheduler) now() time.Time {
+	if s.deps.Now != nil {
+		return s.deps.Now()
+	}
+	return time.Now()
 }
 
 func (s *Scheduler) persistCtx() context.Context {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -43,6 +43,11 @@ type harness struct {
 	store    *store.Store
 	admitter *stubAdmitter
 	sched    *Scheduler
+	// clock drives the §11 admission hold. Zero means the real clock; tests
+	// that care set it, so "not before T, admitted after T" is asserted
+	// without sleeping. Read only from the test goroutine, which is the one
+	// that calls admit directly.
+	clock time.Time
 }
 
 func newHarness(t *testing.T, maxParallel int) *harness {
@@ -63,8 +68,25 @@ func newHarness(t *testing.T, maxParallel int) *harness {
 		},
 		Admitter: adm,
 		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Now: func() time.Time {
+			if h.clock.IsZero() {
+				return time.Now()
+			}
+			return h.clock
+		},
 	})
 	return h
+}
+
+// hold puts a task on an admission hold, the way the engine does when an
+// agent reports a spent usage quota (task 003).
+func (h *harness) hold(t *testing.T, task *store.Task, until time.Time, reason string) {
+	t.Helper()
+	task.AdmitNotBefore = &until
+	task.QueuedReason = reason
+	if err := h.store.UpdateTask(t.Context(), task); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
 }
 
 func (h *harness) project(t *testing.T, name string, limit *int) int64 {

--- a/internal/store/hold_test.go
+++ b/internal/store/hold_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAdmissionHoldRoundTrips asserts the 0006 columns exist on a store the
+// migrator opened and survive a write/read cycle. It is also the proof that
+// the migration applied: `openTest` runs the full chain, and every query in
+// this package selects taskColumns, which now names both columns.
+func TestAdmissionHoldRoundTrips(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "held", TaskQueued)
+	if err := s.CreateTask(ctx, task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	// A fresh task carries no hold: this is what every existing row looks
+	// like after the migration, and what every client keeps seeing.
+	fresh, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if fresh.AdmitNotBefore != nil || fresh.QueuedReason != "" {
+		t.Fatalf("new task carries a hold: %v / %q", fresh.AdmitNotBefore, fresh.QueuedReason)
+	}
+
+	until := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	task.AdmitNotBefore = &until
+	task.QueuedReason = "usage_limit"
+	if err := s.UpdateTask(ctx, task); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	got, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.AdmitNotBefore == nil || !got.AdmitNotBefore.Equal(until) {
+		t.Errorf("admit_not_before = %v, want %s", got.AdmitNotBefore, until)
+	}
+	if got.QueuedReason != "usage_limit" {
+		t.Errorf("queued_reason = %q, want usage_limit", got.QueuedReason)
+	}
+
+	// ListAdmissible is the scheduler's own read path; the hold has to reach
+	// it, since the walk — not SQL — is where it is evaluated.
+	candidates, err := s.ListAdmissible(ctx)
+	if err != nil {
+		t.Fatalf("ListAdmissible: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(candidates))
+	}
+	if candidates[0].Task.AdmitNotBefore == nil {
+		t.Error("ListAdmissible dropped admit_not_before; the scheduler would admit at once")
+	}
+}
+
+// TestTransitionWritesHoldIntoQueued covers the engine's write: the hold
+// lands atomically with the running → queued transition.
+func TestTransitionWritesHoldIntoQueued(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "work", TaskRunning)
+	if err := s.CreateTask(ctx, task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	until := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	reason := "usage_limit"
+	got, _, err := s.TransitionTask(ctx, task.ID, TaskRunning, TaskQueued,
+		TaskChange{AdmitNotBefore: &until, QueuedReason: &reason})
+	if err != nil {
+		t.Fatalf("TransitionTask: %v", err)
+	}
+	if got.AdmitNotBefore == nil || !got.AdmitNotBefore.Equal(until) {
+		t.Errorf("admit_not_before = %v, want %s", got.AdmitNotBefore, until)
+	}
+	if got.QueuedReason != reason {
+		t.Errorf("queued_reason = %q, want %q", got.QueuedReason, reason)
+	}
+	// A hold is not a block reason: clients key off block_reason to mean
+	// "stopped, needs a human", and this task is neither.
+	if got.BlockReason != "" {
+		t.Errorf("block_reason = %q, want empty for a held queued task", got.BlockReason)
+	}
+}
+
+// TestLeavingQueuedClearsHold is the invariant that makes clearing not the
+// caller's job: every way out of `queued` drops the hold, so it cannot
+// outlive the queued period it describes.
+func TestLeavingQueuedClearsHold(t *testing.T) {
+	exits := map[string]TaskState{
+		"admitted": TaskRunning,
+		"parked":   TaskPaused,
+		"canceled": TaskAborted,
+	}
+	for name, to := range exits {
+		t.Run(name, func(t *testing.T) {
+			s := openTest(t)
+			ctx := t.Context()
+			p := testProject(t, s, "p1")
+			task := newTask(p.ID, "held", TaskRunning)
+			if err := s.CreateTask(ctx, task, nil); err != nil {
+				t.Fatalf("CreateTask: %v", err)
+			}
+			until := time.Now().Add(15 * time.Minute).UTC()
+			reason := "usage_limit"
+			if _, _, err := s.TransitionTask(ctx, task.ID, TaskRunning, TaskQueued,
+				TaskChange{AdmitNotBefore: &until, QueuedReason: &reason}); err != nil {
+				t.Fatalf("re-queue with a hold: %v", err)
+			}
+
+			got, _, err := s.TransitionTask(ctx, task.ID, TaskQueued, to, TaskChange{})
+			if err != nil {
+				t.Fatalf("TransitionTask(%s): %v", to, err)
+			}
+			if got.AdmitNotBefore != nil || got.QueuedReason != "" {
+				t.Fatalf("hold survived queued → %s: %v / %q", to, got.AdmitNotBefore, got.QueuedReason)
+			}
+			reloaded, err := s.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if reloaded.AdmitNotBefore != nil || reloaded.QueuedReason != "" {
+				t.Errorf("hold still committed after queued → %s: %v / %q",
+					to, reloaded.AdmitNotBefore, reloaded.QueuedReason)
+			}
+		})
+	}
+}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 5
+const latestSchemaVersion = 6
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0006_admission_hold.sql
+++ b/internal/store/migrations/0006_admission_hold.sql
@@ -1,0 +1,19 @@
+-- 0006_admission_hold: a per-task hold on scheduler admission, and the reason
+-- a queued task is waiting (task 003, spec §11/§14).
+--
+-- The pair is deliberately generic rather than usage-limit-specific. The
+-- scheduler reads one timestamp and clients render one string, so the next
+-- wait-shaped case — an agent-wide hold, a git backoff — costs no second
+-- migration and no second branch in the admission walk.
+--
+-- `block_reason` was not overloaded for this. §14 says it is "set while
+-- state='blocked'", and clients key off the API's `block_reason` field to mean
+-- exactly that; a queued task carrying one would break them.
+--
+-- No index accompanies these. ListAdmissible already returns the whole queued
+-- set in §11 order and the hold is evaluated during the walk, next to the
+-- caps — never in SQL, because a task whose pause was requested while it ran
+-- must still be parked while it is held (see internal/scheduler).
+
+ALTER TABLE tasks ADD COLUMN admit_not_before TEXT;  -- NULL = admissible now
+ALTER TABLE tasks ADD COLUMN queued_reason TEXT;     -- NULL = waiting for a slot

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -92,11 +92,24 @@ type Task struct {
 	// awaiting_input (§7.4); "" otherwise. TransitionTask clears it on any
 	// transition out of awaiting_input.
 	PendingInputJSON string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
-	StartedAt        *time.Time
-	FinishedAt       *time.Time
-	ArchivedAt       *time.Time
+	// AdmitNotBefore holds admission until this instant (§11, task 003); nil
+	// means admissible now. Generic on purpose: the scheduler reads one
+	// timestamp whatever put it there.
+	AdmitNotBefore *time.Time
+	// QueuedReason says why a queued task is waiting for something other than
+	// a slot — `usage_limit` today. "" is the ordinary queue. It is not
+	// BlockReason: that one means "set while blocked" (§14), and a queued task
+	// carrying one would lie to every client that keys off it.
+	//
+	// Both clear on any transition *out of* queued, in TransitionTask rather
+	// than in each caller, so a hold cannot outlive the queued period it
+	// belongs to.
+	QueuedReason string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
+	ArchivedAt   *time.Time
 }
 
 // StepRun is one attempt at executing one step of one task; history is

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -15,7 +15,7 @@ import (
 const taskColumns = `id, project_id, title, description, fields_json, workflow_name, workflow_snapshot,
 	base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 	state, current_step, block_reason, pause_requested, retry_cursor_at, pending_override_json,
-	pending_input_json,
+	pending_input_json, admit_not_before, queued_reason,
 	created_at, updated_at, started_at, finished_at, archived_at`
 
 // slotStates is the set of states that occupy a concurrency slot (spec §11),
@@ -283,12 +283,14 @@ func (s *Store) UpdateTask(ctx context.Context, t *Task) error {
 			workflow_snapshot = ?, base_branch = ?, branch_name = ?, worktree_path = ?,
 			priority = ?, agent_override = ?, model_override = ?, effort_override = ?,
 			state = ?, current_step = ?, block_reason = ?,
+			admit_not_before = ?, queued_reason = ?,
 			updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
 		WHERE id = ?`,
 		t.Title, t.Description, fields, t.WorkflowName,
 		t.WorkflowSnapshot, t.BaseBranch, t.BranchName, nullString(t.WorktreePath),
 		t.Priority, nullString(t.AgentOverride), nullString(t.ModelOverride), nullString(t.EffortOverride),
 		string(t.State), t.CurrentStep, nullString(t.BlockReason),
+		formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
 		formatTime(t.UpdatedAt), formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt),
 		t.ID)
 	if err != nil {
@@ -557,6 +559,7 @@ func scanTask(r rowScanner) (*Task, error) {
 		agentOv, modelOv, effortOv  sql.NullString
 		retryCursor, pendingOv      sql.NullString
 		pendingInput                sql.NullString
+		admitNotBefore, queuedWhy   sql.NullString
 		created, updated            string
 		started, finished, archived sql.NullString
 	)
@@ -565,13 +568,14 @@ func scanTask(r rowScanner) (*Task, error) {
 		&agentOv, &modelOv, &effortOv,
 		(*string)(&t.State), &t.CurrentStep, &blockReason,
 		&t.PauseRequested, &retryCursor, &pendingOv,
-		&pendingInput,
+		&pendingInput, &admitNotBefore, &queuedWhy,
 		&created, &updated, &started, &finished, &archived); err != nil {
 		return nil, err
 	}
 	t.WorktreePath = worktree.String
 	t.BlockReason = blockReason.String
 	t.PendingInputJSON = pendingInput.String
+	t.QueuedReason = queuedWhy.String
 	t.AgentOverride = agentOv.String
 	t.ModelOverride = modelOv.String
 	t.EffortOverride = effortOv.String
@@ -590,6 +594,9 @@ func scanTask(r rowScanner) (*Task, error) {
 	}
 	var err error
 	if t.RetryCursorAt, err = parseTimePtr(retryCursor); err != nil {
+		return nil, err
+	}
+	if t.AdmitNotBefore, err = parseTimePtr(admitNotBefore); err != nil {
 		return nil, err
 	}
 	if t.CreatedAt, err = parseTime(created); err != nil {

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -76,6 +76,14 @@ type TaskChange struct {
 	// job: TransitionTask NULLs the column on any transition out of
 	// awaiting_input, so "non-null iff awaiting_input" holds by construction.
 	PendingInput *string
+	// AdmitNotBefore holds admission of the re-queued task until an instant
+	// (§11, task 003), and QueuedReason says why it is waiting. Both are
+	// written with a transition *into* queued and, by the same construction
+	// PendingInput uses, cleared by TransitionTask on any transition out of
+	// it — so admission, parking and cancel all drop the hold without a
+	// caller remembering to.
+	AdmitNotBefore *time.Time
+	QueuedReason   *string
 	// EventPayload carries extra fields into the state-change event, merged
 	// with from/to. Reserved keys (from, to) are overwritten.
 	EventPayload map[string]any
@@ -123,6 +131,19 @@ func (s *Store) TransitionTask(
 			// awaiting_input always discards the pending request.
 			t.PendingInputJSON = ""
 		}
+		if from == TaskQueued {
+			// The §11 admission-hold invariant, same construction: a hold
+			// describes *this* queued period, so leaving queued always drops
+			// it. Admission, parking and cancel are all covered by the one
+			// rule, and a caller cannot forget it.
+			//
+			// One consequence, recorded rather than fixed (task 003): pausing
+			// a held task and resuming it re-admits at once and re-discovers
+			// the wall. That costs one process spawn, and buys the rule §6
+			// already applies to every other pending flag — a human action
+			// means go.
+			t.AdmitNotBefore, t.QueuedReason = nil, ""
+		}
 		switch to {
 		case TaskRunning:
 			if t.StartedAt == nil {
@@ -147,11 +168,13 @@ func (s *Store) TransitionTask(
 			UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
 				workflow_snapshot = ?, pause_requested = ?, retry_cursor_at = ?,
 				pending_override_json = ?, pending_input_json = ?,
+				admit_not_before = ?, queued_reason = ?,
 				updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
 			WHERE id = ? AND state = ?`,
 			string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
 			t.WorkflowSnapshot, t.PauseRequested, formatTimePtr(t.RetryCursorAt), pendingOverride,
 			nullString(t.PendingInputJSON),
+			formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
 			formatTime(t.UpdatedAt),
 			formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt),
 			id, string(from))
@@ -329,6 +352,12 @@ func applyChange(t *Task, ch TaskChange) {
 	}
 	if ch.PendingInput != nil {
 		t.PendingInputJSON = *ch.PendingInput
+	}
+	if ch.AdmitNotBefore != nil {
+		t.AdmitNotBefore = ch.AdmitNotBefore
+	}
+	if ch.QueuedReason != nil {
+		t.QueuedReason = *ch.QueuedReason
 	}
 }
 

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -45,7 +45,21 @@ const (
 	// allowed to fill the disk; the partial transcript is kept, because the
 	// lines that got there are exactly what explains the runaway.
 	ReasonTranscriptLimit = "transcript_limit"
-	ReasonInternalError   = "internal_error"
+	// ReasonUsageLimit is an agent run the CLI stopped because the account's
+	// usage quota is spent (task 003, §7.2, §18). It is the one reason in this
+	// vocabulary that is *not* a failure: the attempt is recorded
+	// `interrupted`, consumes no retry, and the task returns to `queued` with
+	// an admission hold until the window is plausibly back. It therefore
+	// appears as a `queued_reason`, never as a `block_reason`.
+	ReasonUsageLimit = "usage_limit"
+	// ReasonAgentUnauthenticated is a run the CLI refused because it is not
+	// logged in (task 003, §18). An ordinary failure under §7.2's budget —
+	// waiting cannot fix it, and short-circuiting the budget would make this
+	// the first reason in vincent to bypass §7.2 to save one process spawn.
+	// The value of the reason is that it names the fix instead of sending the
+	// reader to a transcript.
+	ReasonAgentUnauthenticated = "agent_unauthenticated"
+	ReasonInternalError        = "internal_error"
 )
 
 // Durable event types the engine emits (spec §13.3). State changes emit
@@ -83,6 +97,10 @@ type stepOutcome struct {
 	output        string // tail of the attempt's output, for the retry block
 	exitCode      *int
 	checkExitCode *int
+	// retryAfter carries a reason=usage_limit outcome's reset time, when the
+	// CLI reported one (task 003). nil means it did not, and the hold falls
+	// back to `usage_limit_recheck_interval`.
+	retryAfter *time.Time
 }
 
 // execute runs one admission of a task: it walks the snapshot's steps from
@@ -139,6 +157,13 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 				env.log.Error("persist step advance", "error", err)
 			}
 		case store.StepInterrupted:
+			// A quota stop is interruption-shaped — no retry consumed, the
+			// slot released — but it must not be re-admitted immediately, or
+			// the task simply walks back into the same wall (task 003).
+			if outcome.reason == ReasonUsageLimit {
+				r.holdForUsageLimit(task, outcome.retryAfter, env.log)
+				return
+			}
 			r.interrupt(task, log)
 			return
 		case store.StepFailed, store.StepRunning, store.StepApproved, store.StepRejected, store.StepSkipped:
@@ -450,6 +475,39 @@ func (r *Runner) fail(task *store.Task, reason string, log *slog.Logger, what st
 func (r *Runner) interrupt(task *store.Task, log *slog.Logger) {
 	if r.transition(task, taskstate.Interrupt, store.TaskChange{}, log) {
 		log.Info("task interrupted; re-queued")
+	}
+}
+
+// holdForUsageLimit re-queues a task whose agent reported a spent usage quota
+// (task 003, §11). It is `interrupt` plus an admission hold: the same
+// running → queued transition, the same "consumes no retry" (the attempt is
+// already recorded `interrupted` by finishStepRun, so the timeline shows it
+// and the budget does not), and the slot is released by leaving `running`.
+//
+// Nothing sleeps here. The actor ends with the admission per the phase 2
+// decision, and the scheduler picks the task up within a tick of the hold
+// expiring — a sleeping actor would hold the slot for a whole quota window,
+// which with max_parallel_tasks slots held that way means nothing runs at all.
+func (r *Runner) holdForUsageLimit(task *store.Task, retryAfter *time.Time, log *slog.Logger) {
+	// The interval is read now rather than cached, so a config hot-reload
+	// (§12.3) reaches the next hold rather than the next daemon restart.
+	until := r.now().Add(r.deps.Config().UsageLimitRecheckInterval.Std()).UTC()
+	if retryAfter != nil {
+		until = retryAfter.UTC()
+	}
+	reason := ReasonUsageLimit
+	ch := store.TaskChange{
+		AdmitNotBefore: &until,
+		QueuedReason:   &reason,
+		EventPayload: map[string]any{
+			"queued_reason":    reason,
+			"admit_not_before": until.Format(time.RFC3339),
+		},
+	}
+	if r.transition(task, taskstate.Interrupt, ch, log) {
+		log.Info("agent usage limit reached; task re-queued until it resets",
+			"admit_not_before", until.Format(time.RFC3339),
+			"reported_by_cli", retryAfter != nil)
 	}
 }
 

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -34,6 +34,10 @@ type engineHarness struct {
 	repo      string
 	dataDir   string
 	projectID int64
+	// cfg is the daemon config both the engine and the scheduler read, so a
+	// test that shrinks a cap or an interval shrinks it for the whole
+	// admission path rather than for the engine alone.
+	cfg config.Config
 }
 
 func newEngineHarness(t *testing.T) *engineHarness { return newEngineHarnessWith(t, nil) }
@@ -75,7 +79,10 @@ func newEngineHarnessWith(t *testing.T, mutate func(*config.Config)) *engineHarn
 		DataDir: dataDir,
 		Logger:  log,
 	})
-	return &engineHarness{store: st, runner: runner, repo: repo, dataDir: dataDir, projectID: project.ID}
+	return &engineHarness{
+		store: st, runner: runner, repo: repo,
+		dataDir: dataDir, projectID: project.ID, cfg: cfg,
+	}
 }
 
 // start runs the runner and a real scheduler for the test's lifetime, so
@@ -84,7 +91,7 @@ func (h *engineHarness) start(t *testing.T) {
 	t.Helper()
 	sched := scheduler.New(scheduler.Deps{
 		Store:    h.store,
-		Config:   config.Default,
+		Config:   func() config.Config { return h.cfg },
 		Admitter: h.runner,
 		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -297,6 +297,13 @@ loop:
 // the process before the run context is canceled (§6's grace, §12.4's), so
 // an abrupt exit then is an interruption, not a failure to retry. The run
 // context's cancel cause distinguishes the engine's own kills (§7.4).
+//
+// The adapter's own verdict (res.Failure, task 003) is consulted *after* all
+// of those and *before* the generic exit-code and IsError buckets. The order
+// is the point: a cancel or a shutdown that lands on a quota-stopped run is
+// still a cancel, a step that ran past its timeout is still a timeout, and
+// only a run that would otherwise have been flattened into nonzero_exit or
+// agent_error gets the more specific reason.
 func classifyAgent(daemonCtx, runCtx context.Context, interrupting bool, res *agent.RunResult, waitErr error) stepOutcome {
 	switch {
 	case daemonCtx.Err() != nil:
@@ -313,6 +320,17 @@ func classifyAgent(daemonCtx, runCtx context.Context, interrupting bool, res *ag
 		return stepOutcome{state: store.StepInterrupted, reason: ReasonInterrupted}
 	case waitErr != nil:
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	case res.Failure != nil && res.Failure.Kind == agent.FailureUsageLimit:
+		// Interruption-shaped on purpose: runStepWithRetries returns any
+		// non-StepFailed outcome without touching the budget, which is what
+		// makes "consumes no retry" true with no change there (§7.2).
+		return stepOutcome{
+			state:      store.StepInterrupted,
+			reason:     ReasonUsageLimit,
+			retryAfter: res.Failure.RetryAfter,
+		}
+	case res.Failure != nil && res.Failure.Kind == agent.FailureUnauthenticated:
+		return stepOutcome{state: store.StepFailed, reason: ReasonAgentUnauthenticated}
 	case res.ExitCode != 0:
 		return stepOutcome{state: store.StepFailed, reason: ReasonNonzeroExit}
 	case res.IsError:

--- a/internal/taskrun/usagelimit_test.go
+++ b/internal/taskrun/usagelimit_test.go
@@ -1,0 +1,205 @@
+package taskrun
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// agentStepSnapshot is a one-step agent workflow with its retry budget stated
+// rather than defaulted, so both halves of task 003 are measured against a
+// number this file chose: a usage limit must leave all of it, and an auth
+// failure must spend all of it.
+const agentStepSnapshot = `name: quota
+steps:
+  - id: implement
+    type: agent
+    max_retries: 1
+    prompt: "Do the work"
+`
+
+// waitForHold polls until the task is queued carrying an admission hold.
+func (h *engineHarness) waitForHold(t *testing.T, id int64) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	var last *store.Task
+	for time.Now().Before(deadline) {
+		task, err := h.store.GetTask(t.Context(), id)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		last = task
+		if task.State == store.TaskQueued && task.AdmitNotBefore != nil {
+			return task
+		}
+		if task.State == store.TaskBlocked || task.State == store.TaskDone {
+			t.Fatalf("task %d reached %s (%q); want queued with an admission hold",
+				id, task.State, task.BlockReason)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never picked up an admission hold (state %s)", id, last.State)
+	return nil
+}
+
+// TestUsageLimitReQueuesAndConsumesNoRetry is the core claim of task 003: a
+// quota stop is recorded as an interrupted attempt, spends none of the retry
+// budget, and parks the task on an admission hold instead of blocking it.
+func TestUsageLimitReQueuesAndConsumesNoRetry(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		// Long enough that the hold cannot expire during the test, so what is
+		// asserted is the hold itself and not a race with the 5 s tick.
+		c.UsageLimitRecheckInterval = config.Duration(time.Hour)
+	})
+	task := h.createTask(t, agentStepSnapshot)
+	before := time.Now()
+	h.start(t)
+
+	held := h.waitForHold(t, task.ID)
+	if held.QueuedReason != ReasonUsageLimit {
+		t.Errorf("queued_reason = %q, want %s", held.QueuedReason, ReasonUsageLimit)
+	}
+	if held.BlockReason != "" {
+		t.Errorf("block_reason = %q; a held task is not blocked", held.BlockReason)
+	}
+	// No reset time was reported, so the interval decided.
+	if got := held.AdmitNotBefore.Sub(before); got < 55*time.Minute || got > 65*time.Minute {
+		t.Errorf("admit_not_before is %s away, want about the 1h recheck interval", got)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1 — a quota stop must not burn the budget", len(runs))
+	}
+	if runs[0].State != store.StepInterrupted {
+		t.Errorf("attempt state = %s, want interrupted", runs[0].State)
+	}
+	if runs[0].FailureReason != ReasonUsageLimit {
+		t.Errorf("failure_reason = %q, want %s", runs[0].FailureReason, ReasonUsageLimit)
+	}
+
+	// The budget itself, as the engine counts it: interrupted attempts are
+	// excluded, so the step still has its full max_retries for a real failure.
+	attempts, err := h.store.CountStepAttempts(t.Context(), task.ID, 0, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if attempts.Failed != 0 {
+		t.Errorf("failed attempts = %d, want 0", attempts.Failed)
+	}
+}
+
+// TestUsageLimitHonoursTheReportedResetTime: when the CLI names a reset, that
+// timestamp wins over the configured interval.
+func TestUsageLimitHonoursTheReportedResetTime(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	t.Setenv("FAKEAGENT_USAGE_LIMIT_RESET", "1800") // 30 minutes from now
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		c.UsageLimitRecheckInterval = config.Duration(4 * time.Hour)
+	})
+	task := h.createTask(t, agentStepSnapshot)
+	before := time.Now()
+	h.start(t)
+
+	held := h.waitForHold(t, task.ID)
+	got := held.AdmitNotBefore.Sub(before)
+	if got < 25*time.Minute || got > 35*time.Minute {
+		t.Errorf("admit_not_before is %s away, want ~30m from the CLI rather than the 4h interval", got)
+	}
+}
+
+// TestUsageLimitReleasesTheSlot: the whole reason the wait is not a sleep in
+// the actor. With one slot, a quota-walled task must not keep the queue from
+// moving.
+func TestUsageLimitReleasesTheSlot(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		c.MaxParallelTasks = 1
+		c.UsageLimitRecheckInterval = config.Duration(time.Hour)
+	})
+	// The walled task is older, so §11 admits it first.
+	walled := h.createTask(t, agentStepSnapshot)
+	other := h.createTask(t, "name: other\nsteps:\n"+
+		commandStep("work", script("echo second task ran", "Write-Output 'second task ran'")))
+	h.start(t)
+
+	held := h.waitForHold(t, walled.ID)
+	if held.QueuedReason != ReasonUsageLimit {
+		t.Fatalf("queued_reason = %q, want %s", held.QueuedReason, ReasonUsageLimit)
+	}
+	done := h.waitForState(t, other.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("second task = %s (%s), want done — the held task kept its slot",
+			done.State, done.BlockReason)
+	}
+}
+
+// TestUsageLimitRecoversWithoutAHuman is the end-to-end promise: the window
+// reopens, the scheduler re-admits, and the task finishes with nobody
+// pressing anything. The fake CLI owns the "has the window reopened" state via
+// a marker file, so the recovery is observed rather than staged.
+func TestUsageLimitRecoversWithoutAHuman(t *testing.T) {
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		// Effectively "as soon as the next tick comes round": the hold is
+		// what is being released here, not waited on.
+		c.UsageLimitRecheckInterval = config.Duration(time.Millisecond)
+	})
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	t.Setenv("FAKEAGENT_USAGE_LIMIT_MARKER", filepath.Join(t.TempDir(), "window-spent"))
+
+	task := h.createTask(t, agentStepSnapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done with no human action", done.State, done.BlockReason)
+	}
+	if done.QueuedReason != "" || done.AdmitNotBefore != nil {
+		t.Errorf("hold survived the run: %q / %v", done.QueuedReason, done.AdmitNotBefore)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("attempts = %d, want 2 (the walled one, then the successful re-run)", len(runs))
+	}
+	if runs[0].State != store.StepInterrupted || runs[0].FailureReason != ReasonUsageLimit {
+		t.Errorf("first attempt = %s/%q, want interrupted/%s",
+			runs[0].State, runs[0].FailureReason, ReasonUsageLimit)
+	}
+	if runs[1].State != store.StepSucceeded {
+		t.Errorf("second attempt = %s (%s), want succeeded", runs[1].State, runs[1].FailureReason)
+	}
+}
+
+// TestUnauthenticatedBlocksUnderTheNormalBudget is the auth half, which
+// deliberately changes nothing but the reason: the step still runs, the
+// attempts still fail, the §7.2 budget still applies, and the task still ends
+// up blocked — now saying what to fix instead of pointing at a transcript.
+func TestUnauthenticatedBlocksUnderTheNormalBudget(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "unauthenticated")
+	h := newEngineHarness(t)
+	task := h.createTask(t, agentStepSnapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+	if blocked.BlockReason != ReasonAgentUnauthenticated {
+		t.Fatalf("block_reason = %q, want %s", blocked.BlockReason, ReasonAgentUnauthenticated)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("attempts = %d, want 2 (max_retries 1) — the budget must not be short-circuited", len(runs))
+	}
+	for _, run := range runs {
+		if run.State != store.StepFailed || run.FailureReason != ReasonAgentUnauthenticated {
+			t.Errorf("attempt %d = %s/%q, want failed/%s",
+				run.Attempt, run.State, run.FailureReason, ReasonAgentUnauthenticated)
+		}
+	}
+}

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -600,7 +600,7 @@ func (b *board) rowsFor(tasks []apiclient.Task, set columnSet) []table.Row {
 		if d, ok := t.Elapsed(now); ok {
 			elapsed = formatElapsed(d)
 		}
-		row = append(row, t.Title, renderState(t.State), formatStep(t, set.stepName), elapsed)
+		row = append(row, t.Title, renderBoardState(t), formatStep(t, set.stepName), elapsed)
 		if set.cost {
 			row = append(row, formatCost(t.CostUSD))
 		}

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -183,6 +183,45 @@ func renderState(state string) string {
 	return label
 }
 
+// renderBoardState is the board's state cell. A queued task held by the
+// scheduler (§11) shows when it resumes — `queued → 14:20` — so it reads as
+// waiting on a clock rather than on a slot, which a bare `queued` cannot say.
+//
+// The reason itself is deliberately not in this cell: it does not fit
+// widthState, and widening the column for a rare state would cost every board
+// the columns that get shed first. The detail header, which has the width,
+// names it (renderDetailState).
+func renderBoardState(t apiclient.Task) string {
+	_, until, ok := t.Hold()
+	if !ok || until == nil {
+		return renderState(t.State)
+	}
+	return applyStateStyle(t.State, t.State+" → "+until.Local().Format("15:04"))
+}
+
+// renderDetailState is the header form: the full `queued · usage limit →
+// 14:20`, where there is room for the reason. A hold with no resume time
+// still names the reason — the engine always computes one, so this is the
+// shape a future hold-setter that does not would take.
+func renderDetailState(t apiclient.Task) string {
+	reason, until, ok := t.Hold()
+	if !ok {
+		return renderState(t.State)
+	}
+	label := t.State + " · " + strings.ReplaceAll(reason, "_", " ")
+	if until != nil {
+		label += " → " + until.Local().Format("15:04")
+	}
+	return applyStateStyle(t.State, label)
+}
+
+func applyStateStyle(state, label string) string {
+	if st, ok := stateStyles[state]; ok {
+		return st.Render(label)
+	}
+	return label
+}
+
 // formatElapsed renders a duration compactly enough for a table cell.
 func formatElapsed(d time.Duration) string {
 	switch {

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -79,6 +79,7 @@ func (d *daemonView) configLines() []string {
 				"   input "+c.Defaults.InputTimeout),
 		field("transcript retention", strconv.Itoa(c.TranscriptRetentionDays)+" days")+
 			styleDim.Render("   cap "+humanBytes(c.TranscriptMaxBytes)+" per run"),
+		field("usage limit recheck", c.UsageLimitRecheck),
 		field("log level", c.LogLevel),
 	)
 	for _, name := range sortedKeys(c.Agents) {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -184,7 +184,7 @@ func (d *detail) headerLine() string {
 	t := d.task
 	parts := []string{
 		styleTitle.Render(fmt.Sprintf(" #%d %s", t.ID, t.Title)),
-		renderState(t.State),
+		renderDetailState(t.Task),
 	}
 	if k, n, ok := t.StepDisplay(); ok {
 		parts = append(parts, fmt.Sprintf("%d/%d", k, n))

--- a/internal/tui/holdlive_test.go
+++ b/internal/tui/holdlive_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// TestBoardDistinguishesAHeldQueueFromAnOrdinaryOne drives the whole path —
+// store columns, API DTO, client, renderer — through the real handlers. The
+// point of §11's hold is unrenderable otherwise: a task waiting on a quota
+// window and a task waiting for a slot are both `queued`, and the board has
+// to say which.
+func TestBoardDistinguishesAHeldQueueFromAnOrdinaryOne(t *testing.T) {
+	h := newBoardLiveHarness(t)
+	ctx := context.Background()
+	h.createTask(t, "waiting for a slot")
+	held := h.createTask(t, "waiting on a quota")
+
+	h.p.until(20*time.Second, "both tasks to appear", func() bool {
+		got := content(h.m)
+		return strings.Contains(got, "waiting for a slot") && strings.Contains(got, "waiting on a quota")
+	})
+
+	// The engine's re-queue: running → queued carrying the hold.
+	if _, _, err := h.st.TransitionTask(
+		ctx, held.ID, store.TaskQueued, store.TaskRunning, store.TaskChange{},
+	); err != nil {
+		t.Fatalf("TransitionTask(running): %v", err)
+	}
+	until := time.Now().Add(90 * time.Minute)
+	reason := "usage_limit"
+	if _, _, err := h.st.TransitionTask(ctx, held.ID, store.TaskRunning, store.TaskQueued,
+		store.TaskChange{AdmitNotBefore: &until, QueuedReason: &reason}); err != nil {
+		t.Fatalf("TransitionTask(held): %v", err)
+	}
+
+	stamp := until.Local().Format("15:04")
+	h.p.until(20*time.Second, "the resume time to render on the held row", func() bool {
+		return strings.Contains(content(h.m), "queued → "+stamp)
+	})
+
+	// The ordinary queue is untouched: exactly one row carries the marker.
+	if got := strings.Count(content(h.m), "queued → "); got != 1 {
+		t.Errorf("%d rows render a resume time, want 1 — an unheld task must read as a bare queued", got)
+	}
+
+	// The detail header has the width the board cell does not, so it names
+	// the reason as well as the time.
+	_, cmd := h.m.Update(selectTaskMsg{id: held.ID})
+	h.p.push(cmd)
+	h.p.until(20*time.Second, "the detail header to name the hold", func() bool {
+		return strings.Contains(content(h.m), "queued · usage limit → "+stamp)
+	})
+}

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -4,10 +4,12 @@
 # remote) runs to the gate with an agent question round-tripping
 # awaiting_input → answer → resume (scenario 1), that kill -9 mid-step
 # recovers correctly (scenario 2), and that both concurrency caps hold under
-# load (scenario 3). Runs against the committed fakeagent so CI never calls a
-# real API; run manually with VINCENT_GATE_AGENT=claude to exercise the real
-# CLI (scenario 1 only — killing a paid run and 8× cap spend prove nothing
-# extra). VINCENT_GATE_SCENARIO=1|2|3|4 runs a single scenario for debugging.
+# load (scenario 3), that branch naming and its recovery path hold (scenario
+# 4), and that an agent usage limit re-queues rather than blocks and recovers
+# unattended (scenario 5). Runs against the committed fakeagent so CI never
+# calls a real API; run manually with VINCENT_GATE_AGENT=claude to exercise the
+# real CLI (scenario 1 only — killing a paid run and 8× cap spend prove nothing
+# extra). VINCENT_GATE_SCENARIO=1|2|3|4|5 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -517,6 +519,110 @@ EOF
   echo "=== scenario 4 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 5 — agent usage limits (task 003, spec §7.2/§11/§18).
+#
+# The whole path over curl: an agent that reports a spent quota must not burn
+# its retry budget, must give its slot back, and must recover with nobody
+# pressing anything. The recheck interval is squeezed to two seconds so the
+# unattended half is observable in a gate rather than in five hours.
+#
+# The global cap is 1 and the second task sleeps, so "the slot was released" is
+# a fact the scenario forces rather than infers: the sleeper can only be
+# running because the walled task stopped holding one, and the walled task can
+# only finish afterwards because the scheduler came back to it on its own.
+# ---------------------------------------------------------------------------
+scenario5() {
+  echo "=== scenario 5: usage limit — no retry burned, slot released, unattended recovery"
+  scenario_dirs s5
+
+  export FAKEAGENT_SCENARIO=usage-limit
+  # The marker is the fake CLI's own record that the window has reopened, so
+  # the recovery is the daemon's doing and not the script's.
+  export FAKEAGENT_USAGE_LIMIT_MARKER
+  FAKEAGENT_USAGE_LIMIT_MARKER="$(hostpath "$TMP/s5-window-spent")"
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+max_parallel_tasks: 1
+usage_limit_recheck_interval: 2s
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  # max_retries: 0 — so a quota stop that wrongly counted as a failure would
+  # block the task on the spot, and this scenario would fail loudly.
+  cat > "$CONFIG_DIR/workflows/m2-quota.yaml" <<EOF
+name: m2-quota
+description: M2 gate — one agent step against a quota-exhausted CLI.
+defaults:
+  agent: claude
+  max_retries: 0
+steps:
+  - id: work
+    type: agent
+    prompt: "Do the work for {{.Task.Title}}"
+EOF
+  cat > "$CONFIG_DIR/workflows/m2-sleeper.yaml" <<EOF
+name: m2-sleeper
+description: M2 gate — occupies the only slot while the held task waits.
+steps:
+  - id: nap
+    type: command
+    run: sleep 3
+EOF
+
+  daemon_up
+
+  local repo="$TMP/s5/repo" proj walled sleeper
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  # The walled task is created first, so §11 offers it the only slot first.
+  walled="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-quota\",\"title\":\"Quota walled\"}" | jq -r .id)"
+  sleeper="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-sleeper\",\"title\":\"Sleeper\"}" | jq -r .id)"
+
+  echo "== wait for the quota stop to park the task on an admission hold"
+  local task=""
+  local ok=0
+  for _ in $(seq 1 90); do
+    task="$(api GET "/tasks/$walled")"
+    if [[ "$(jq -r '.queued_reason // "null"' <<<"$task")" == "usage_limit" ]]; then ok=1; break; fi
+    [[ "$(jq -r .state <<<"$task")" == "blocked" ]] && { jq . <<<"$task" >&2; fail "task $walled blocked instead of waiting on the quota window"; }
+    sleep 1
+  done
+  (( ok )) || { jq . <<<"$task" >&2; fail "task $walled never picked up queued_reason=usage_limit"; }
+  [[ "$(jq -r .state <<<"$task")" == "queued" ]] || fail "held task is $(jq -r .state <<<"$task"), want queued"
+  [[ "$(jq -r '.admit_not_before // "null"' <<<"$task")" != "null" ]] \
+    || fail "held task carries no admit_not_before: $task"
+  [[ "$(jq -r '.block_reason // "null"' <<<"$task")" == "null" ]] \
+    || fail "a quota-held task must not carry a block_reason: $task"
+
+  echo "== assert the attempt is recorded interrupted and spent no retry"
+  local steps
+  steps="$(api GET "/tasks/$walled/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "1" ]] || fail "attempts = $(jq 'length' <<<"$steps"), want 1: $steps"
+  [[ "$(jq -r '.[0].state' <<<"$steps")" == "interrupted" ]] || fail "attempt not interrupted: $steps"
+  [[ "$(jq -r '.[0].failure_reason' <<<"$steps")" == "usage_limit" ]] \
+    || fail "attempt reason is $(jq -r '.[0].failure_reason' <<<"$steps"), want usage_limit"
+
+  echo "== the released slot lets the next task run"
+  wait_for_state "$sleeper" done 120
+
+  echo "== the held task recovers with no human action"
+  wait_for_state "$walled" done 120
+  steps="$(api GET "/tasks/$walled/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "2" ]] || fail "attempts = $(jq 'length' <<<"$steps"), want 2: $steps"
+  [[ "$(jq -r '.[1].state' <<<"$steps")" == "succeeded" ]] || fail "the re-run did not succeed: $steps"
+  [[ "$(api GET "/tasks/$walled" | jq -r '.queued_reason // "null"')" == "null" ]] \
+    || fail "the hold outlived the queued period it belonged to"
+
+  "$VINCENT" daemon stop
+  unset FAKEAGENT_SCENARIO FAKEAGENT_USAGE_LIMIT_MARKER
+  echo "=== scenario 5 PASS (task $walled recovered unattended)"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -527,7 +633,8 @@ case "$WHICH" in
   2) scenario2 ;;
   3) scenario3 ;;
   4) scenario4 ;;
-  all) scenario1; scenario2; scenario3; scenario4 ;;
+  5) scenario5 ;;
+  all) scenario1; scenario2; scenario3; scenario4; scenario5 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
## Summary

Two new reasons in the shared failure vocabulary — `usage_limit` and
`agent_unauthenticated` — plus the machinery that makes `usage_limit` mean
something the daemon can act on rather than a label on a `blocked` task.

Before this, `classifyAgent` collapsed every adapter outcome it did not already
special-case into `nonzero_exit` or `agent_error`. A quota-exhausted run and a
genuinely failed one were the same row, the same board cell, the same block
reason. That is worse than one bad error message: `runStepWithRetries` has no
delay between attempts, so a quota-walled step spent its whole `max_retries`
budget in seconds, and since the scheduler admits up to `max_parallel_tasks`
concurrently, every running task on that adapter hit the same wall in the same
minute. The board went `blocked` with a reason that sent the reader to a
transcript about a task that was fine.

**A quota stop is now a wait, not a failure.** The attempt is recorded
`interrupted` with reason `usage_limit`, **consumes no retry**, and the task
returns to `queued` carrying an admission hold — releasing its concurrency slot,
so other work carries on — until the window is plausibly back. When it is, the
scheduler re-admits and the step re-runs with **no human action**.

**The auth half classifies and changes nothing else.** §18's auth row stays true:
the step still runs, the attempt still fails, the §7.2 budget still applies, and
the task still ends up `blocked`. Only the name of the reason changes, and its
value is that it names the fix instead of pointing at a transcript.

### How it fits together

- **`agent.RunResult` gains `Failure{Kind, RetryAfter}`**, filled inside each
  adapter's `Wait()` — where the terminal result and the stderr tail already are.
  Not a new `Adapter` method: the engine never sees stderr, so
  `ClassifyFailure(res, stderr)` could not be fed without plumbing the tail out
  purely to hand it back in. `FailureKind` is an adapter-side enum, **not** a
  `block_reason`; the engine does the kind → reason mapping, so a reason string
  keeps one source of truth.
- **Migration `0006`** adds `admit_not_before` and `queued_reason` to `tasks` —
  generic on purpose, so the next wait-shaped case costs no second migration.
  `block_reason` was deliberately not overloaded: §14 says it is set while
  `state='blocked'` and clients key off it to mean that. Clearing is not the
  caller's job — `TransitionTask` NULLs both on any transition out of `queued`,
  the same construction that makes "`pending_input_json` non-null iff
  `awaiting_input`" hold.
- **The scheduler skips a held task in the walk**, after the pause check and
  before the caps — not in `ListAdmissible`'s SQL. Hiding held tasks from the
  query would make a `pause` on one silently not take effect until the hold
  expired, which is exactly the "showing queued while the human asked for paused"
  lie that check exists to prevent. There is a regression test for it.
- **Nothing sleeps in the actor.** The slot is released by leaving `running`, and
  the actor ends with the admission per the phase 2 decision. A sleeping actor
  would hold a slot for a whole quota window; with every slot held that way,
  nothing runs at all.
- **`usage_limit_recheck_interval`** (new, default `15m`, validated positive)
  decides only when the CLI reported no reset time.

### Two things a reviewer should push back on if they disagree

**Only claude classifies anything.** Codex and cursor ship no patterns and behave
exactly as before. The wordings are not fixture-verified — capturing a genuine
quota exhaustion means burning a real five-hour window, the same impracticality
`internal/agent/cursor/cursor.go` already records for the logged-out wording — and
a wrong guess parks a *genuinely failed* task in a wait it never leaves. The
fakeagent scenarios exist in all three dialects anyway, and the codex/cursor legs
assert today's behaviour is unchanged, so adding patterns later is a `classify`
call beside an existing test. The plan called for "the hook" on all three
adapters; what landed is the shared field plus a comment in each `Wait()` saying
why it stays nil and what to add — a `classify` that unconditionally returned nil
would be dead code the linter objects to.

**The board cell is shorter than the plan's example.** The plan wrote
`queued · usage limit → 14:20` "inside the existing state-cell width"; that string
is 28 characters and `widthState` is 18. Widening the column for a rare state
costs every board the columns that get shed first (cost, then step name, then
workflow), so the board renders `queued → 14:20` — the fact that it is waiting on
a clock rather than a slot, which is the distinction the issue asks for — and the
**detail header**, which has the room, renders the full
`queued · usage limit → 14:20`. Both forms are asserted in a live test against
the real handlers.

### Also here

- Spec amended in place, dated `2026-08-14`: §6, §7.2, §9.1, §11, §12.3, §13.2,
  §14, §15, and §18 (a new row for a quota stop, and the auth row amended).
- `docs/tasks/003-usage-limit-classification.md` carries the five decisions with
  the alternatives they beat; the index row lands in the same edit.
- `scripts/m2-gate.sh` scenario 5 drives the whole path over curl.

### Deliberately out of scope

The **agent-wide hold** — one task's `usage_limit` suppressing admission of every
*other* queued task on that adapter — stays out, as the issue asks. Each task
discovers the wall independently, costing N process spawns per window. The
generic `admit_not_before` column is what it will build on.

One consequence recorded rather than fixed: pausing a held task and resuming it
drops the hold, so it is admitted at once and re-discovers the wall. That is one
wasted spawn in exchange for "a human action means go", which is the rule §6
already applies to every other pending flag.

## Related

Closes #80

Closes 003.1 through 003.7 (`docs/tasks/003-usage-limit-classification.md`).

This **amends a stated position**: §18's auth row said that where an adapter
cannot tell whether the CLI is authenticated, "the step runs and fails with the
CLI's auth error". It is amended to name the reason `agent_unauthenticated` and
otherwise left intact — no pre-flight refusal on `logged_in: false`, and no
short-circuiting of the retry budget, which would make this the first reason in
vincent to bypass §7.2 in order to save one process spawn.

Usage limits, by contrast, were an **unconsidered** case, not a deferred one:
nothing in the spec, `docs/history/v0-tasks.md` or `docs/tasks/` recorded a
decision about them, retry backoff, or auto-recovery from a rate limit. No phase,
PR or task decision is relitigated here.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — adapter classification tables
      (including the regression that *unrecognized* output stays on today's
      reason), no-retry-consumed, slot-released, hold-honoured-then-released with
      an injected clock, pause-on-a-held-task-still-parks, unattended end-to-end
      recovery, auth-blocks-after-the-full-budget, store round-trip and clearing
      on every exit from `queued`, a TUI live test against the real handlers, and
      `m2-gate.sh` scenario 5. `go test ./...` and `go test -race` green;
      `golangci-lint` green for `GOOS=linux`, `darwin` and `windows`; all three
      gate scripts run locally.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated —
      `reference/configuration.md` (the new knob),
      `reference/task-lifecycle.md` (both new reasons, and the two kinds of
      `queued`), `reference/api.md` (the two new task fields),
      `guides/tui.md` (the state cell), `guides/troubleshooting.md` (what to do
      about each reason — for `usage_limit`, nothing) and `guides/agents.md` (the
      adapter capability table). No CLI page change: this adds no cobra command
      or flag.
