### PR TITLE
fix(tui): wrap the answer form instead of truncating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,20 @@ type — that is the exhaustive index; this is the human summary.
 - Third-party actions in the release workflow are pinned to commit SHAs; every
   job carries a `timeout-minutes`.
 
+### Fixed
+
+- **The TUI answer form no longer truncates what it asks you**
+  ([#83](https://github.com/lezli01/vincent/issues/83)). A question, an option
+  label or a permission summary longer than the popup's inner width was cut with
+  an `…` and there was no way to see the rest from inside the form — no wrap, no
+  scroll, no expand — and because the popup is capped at 76 columns, a wider
+  terminal did not help. That hid the end of an agent's question, the
+  `(Recommended)` suffix agents put at the *end* of an option label, and, in
+  `restricted` mode, the tail of the command you were being asked to approve.
+  Rows now wrap inside the popup, with continuation lines indented under the
+  marker so a wrapped option still reads as one option; `up`/`down` still move a
+  whole option at a time, and the focused row is kept fully on screen.
+
 ## [0.1.0] — 2026-08-12
 
 First release. All 70 tasks of the

--- a/internal/tui/answerform.go
+++ b/internal/tui/answerform.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -284,23 +285,21 @@ func (f *answerForm) submit(client *apiclient.Client, taskID int64) tea.Cmd {
 	}
 }
 
-// height is how many lines the form wants, capped by the caller.
-func (f *answerForm) height() int { return len(f.rows) + 2 }
+// height is how many lines the form wants at the width it will be drawn at,
+// capped by the caller. Rows wrap, so this cannot be counted from the number
+// of rows alone.
+func (f *answerForm) height(width int) int {
+	lines, _, _ := f.layout(width)
+	return len(lines) + 2
+}
 
 // render draws the form, windowed around the cursor when it does not fit —
 // a question that scrolls out of reach is worse than one that scrolls.
-func (f *answerForm) render(height int) string {
-	lines := make([]string, 0, len(f.rows)+2)
-	cursorLine := 0
-	for i, row := range f.rows {
-		if i == f.cursor && row.kind != rowHeader {
-			cursorLine = len(lines)
-		}
-		lines = append(lines, f.renderRow(i, row))
-	}
+func (f *answerForm) render(width, height int) string {
+	lines, from, to := f.layout(width)
 	if f.editing {
 		lines = append(lines, "  "+f.input.View())
-		cursorLine = len(lines) - 1
+		from, to = len(lines)-1, len(lines)
 	}
 	switch {
 	case f.err != "":
@@ -311,18 +310,105 @@ func (f *answerForm) render(height int) string {
 		lines = append(lines, styleDim.Render(
 			"  space select · e type an answer · enter submit · esc leave the form"))
 	}
-	return strings.Join(window(lines, cursorLine, height), "\n")
+	return strings.Join(windowRange(lines, from, to, height), "\n")
 }
 
-func (f *answerForm) renderRow(i int, row formRow) string {
+// layout wraps every row to width and reports the line range the focused row
+// occupies, so windowing can keep the whole of it on screen. Rows stay the
+// unit the cursor moves in; only their mapping to lines is many-to-one.
+func (f *answerForm) layout(width int) (lines []string, from, to int) {
+	lines = make([]string, 0, len(f.rows)+2)
+	for i, row := range f.rows {
+		rendered := f.renderRow(i, row, width)
+		if i == f.cursor && row.kind != rowHeader {
+			from, to = len(lines), len(lines)+len(rendered)
+		}
+		lines = append(lines, rendered...)
+	}
+	return lines, from, to
+}
+
+// headerPrefix is the question marker; its width is also the hanging indent
+// a wrapped question continues under.
+const headerPrefix = "  ? "
+
+// renderRow lays one row out across width, wrapping rather than letting the
+// tail run into frame's truncation (§15 wraps the output pane for the same
+// reason). Continuation lines are indented to the row's marker column, so a
+// wrapped option still reads as one option.
+func (f *answerForm) renderRow(i int, row formRow, width int) []string {
 	if row.kind == rowHeader {
-		return styleAsk.Render("  ? " + row.text)
+		out := wrapPlain(row.text, width-cols(headerPrefix))
+		for j := range out {
+			prefix := headerPrefix
+			if j > 0 {
+				prefix = strings.Repeat(" ", cols(headerPrefix))
+			}
+			out[j] = styleAsk.Render(prefix + out[j])
+		}
+		return out
 	}
 	cursor := "  "
 	if i == f.cursor && !f.editing {
 		cursor = styleFocus.Render("› ")
 	}
-	return cursor + "  " + f.marker(row) + " " + row.text
+	prefix := cursor + "  " + f.marker(row) + " "
+	// The prefix is already styled, so its width is measured, not counted.
+	indent := ansi.StringWidth(prefix)
+	out := wrapPlain(row.text, width-indent)
+	for j := range out {
+		if j == 0 {
+			out[j] = prefix + out[j]
+			continue
+		}
+		out[j] = strings.Repeat(" ", indent) + out[j]
+	}
+	return out
+}
+
+// wrapPlain lays plain text out in lines of at most width columns, splitting
+// words the way the §15 output pane does so an over-long one is hard-split
+// rather than left to overflow. The text is plain and the caller styles the
+// lines it gets back: a break can then never land inside an escape sequence.
+func wrapPlain(text string, width int) []string {
+	if width < 8 {
+		// Too narrow to lay anything out; frame's truncation is what is left
+		// at this width, and it is still a better line than one column.
+		width = 8
+	}
+	var out []string
+	var cur strings.Builder
+	col := 0
+	pendingSpace := false
+	for _, tok := range splitWords(text, width) {
+		if tok == " " {
+			// Held rather than written: a separator emitted before a word that
+			// turns out not to fit leaves the line ending in whitespace.
+			pendingSpace = col > 0
+			continue
+		}
+		need := cols(tok)
+		if pendingSpace {
+			need++
+		}
+		if col+need > width && col > 0 {
+			out = append(out, cur.String())
+			cur.Reset()
+			col = 0
+			pendingSpace = false
+			need = cols(tok)
+		}
+		if pendingSpace {
+			cur.WriteString(" ")
+			pendingSpace = false
+		}
+		cur.WriteString(tok)
+		col += need
+	}
+	if col > 0 || len(out) == 0 {
+		out = append(out, cur.String())
+	}
+	return out
 }
 
 // marker shows what is selected: a checkbox for multi-select, a radio for

--- a/internal/tui/answerform_test.go
+++ b/internal/tui/answerform_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -79,7 +80,7 @@ func TestFreeTextIsAlwaysAccepted(t *testing.T) {
 	if got := f.answers["Which color?"]; len(got) != 1 || got[0] != "teal" {
 		t.Errorf("answers = %v, want the typed value", got)
 	}
-	if !strings.Contains(f.render(20), "teal") {
+	if !strings.Contains(f.render(74, 20), "teal") {
 		t.Error("the typed answer is not shown back")
 	}
 }
@@ -94,7 +95,7 @@ func TestSubmitBlockedUntilEveryQuestionIsAnswered(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("an incomplete answer was submitted")
 	}
-	if f.err == "" || !strings.Contains(f.render(20), "⚠") {
+	if f.err == "" || !strings.Contains(f.render(74, 20), "⚠") {
 		t.Errorf("no reason shown for the blocked submit (err %q)", f.err)
 	}
 	if f.submitting {
@@ -109,7 +110,7 @@ func TestPermissionRendersADecision(t *testing.T) {
 		Kind:       apiclient.InputKindPermission,
 		Permission: &apiclient.InputPermission{Tool: "Bash", Summary: "rm -rf build"},
 	})
-	view := f.render(10)
+	view := f.render(74, 10)
 	if !strings.Contains(view, "Bash") || !strings.Contains(view, "allow") || !strings.Contains(view, "deny") {
 		t.Fatalf("permission form = %q, want the tool and both decisions", view)
 	}
@@ -135,6 +136,89 @@ func TestEscLeavesTheFormWithoutAnswering(t *testing.T) {
 	if !exit || cmd != nil {
 		t.Errorf("esc: exit = %v, cmd = %v; want a plain exit", exit, cmd != nil)
 	}
+}
+
+// openPopupWith puts req on a task that is waiting on input and opens the
+// answer popup the way a human does, returning the rendered screen with the
+// styling stripped. The popup is sized by the shell (§15), so this is the
+// only place the form meets the width it is actually drawn at.
+func openPopupWith(t *testing.T, req apiclient.InputRequest) string {
+	t.Helper()
+	s, _ := newShellFixture(t, task(3, stateAwaitingInput))
+	s.settle()
+	s.detail.form = newAnswerForm(req)
+	s.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !s.popup {
+		t.Fatal("enter did not open the answer popup")
+	}
+	return ansi.Strip(s.render(120, 37))
+}
+
+// TestFormPopupShowsLongTextInFull is issue #83: the popup is capped at 76
+// columns and every content line is truncated to fit it, so a question, an
+// option label or a permission summary longer than the inner width loses its
+// tail — and there is no wrap, scroll or expand to get it back. §7.4 and §15
+// describe the form as the surface a human answers from; text that cannot be
+// read cannot be answered.
+func TestFormPopupShowsLongTextInFull(t *testing.T) {
+	t.Run("question and option", func(t *testing.T) {
+		const question = "Should the scheduler admit the re-queued step ahead of newly created tasks, or hold it behind them for fairness?"
+		const option = "No — re-queue at the tail so one project's quota stop cannot starve the others (Recommended)"
+
+		view := openPopupWith(t, apiclient.InputRequest{
+			Kind: apiclient.InputKindQuestion,
+			Questions: []apiclient.InputQuestion{{
+				Header:  "Approach",
+				Text:    question,
+				Options: []string{option, "Yes — keep its original queue position"},
+			}},
+		})
+
+		// The tail of the question: the last words are what a 76-column popup
+		// drops first, and they carry the actual choice being asked about.
+		if !strings.Contains(view, "hold it behind them for fairness?") {
+			t.Errorf("the end of the question is not on screen; the popup renders:\n%s", popupOf(view))
+		}
+		// An agent puts "(Recommended)" at the end of a label, which is exactly
+		// what a truncating renderer removes.
+		if !strings.Contains(view, "(Recommended)") {
+			t.Errorf("the end of the option label is not on screen; the popup renders:\n%s", popupOf(view))
+		}
+	})
+
+	t.Run("permission summary", func(t *testing.T) {
+		const summary = "rm -rf ./build && ./scripts/publish.sh --channel=stable --yes"
+
+		view := openPopupWith(t, apiclient.InputRequest{
+			Kind:       apiclient.InputKindPermission,
+			Permission: &apiclient.InputPermission{Tool: "Bash", Summary: summary},
+		})
+
+		// Approving a command whose tail is hidden is approving something else.
+		if !strings.Contains(view, "--channel=stable --yes") {
+			t.Errorf("the end of the permission summary is not on screen; the popup renders:\n%s", popupOf(view))
+		}
+	})
+}
+
+// popupOf pulls the answer popup out of a rendered screen so a failure shows
+// the box the assertion is about rather than the whole terminal.
+func popupOf(view string) string {
+	var out []string
+	in := false
+	for _, line := range strings.Split(view, "\n") {
+		switch {
+		case strings.Contains(line, "Answer — #"):
+			in = true
+			out = append(out, line)
+		case in:
+			out = append(out, line)
+			if strings.Contains(line, "└") {
+				return strings.Join(out, "\n")
+			}
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // TestSameRequestSurvivesARefresh: the detail view refetches constantly, and

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -339,6 +339,22 @@ func window(lines []string, focus, height int) []string {
 	return lines[start : start+height]
 }
 
+// windowRange returns at most height lines, keeping the whole of the focused
+// [from,to) range on screen — a row that wraps is one thing to read, and half
+// of it is not readable. A range taller than the window is anchored at its
+// first line: what a wrapped option starts with is what identifies it.
+func windowRange(lines []string, from, to, height int) []string {
+	if height <= 0 || len(lines) <= height {
+		return lines
+	}
+	start := windowStart(len(lines), from, height)
+	if to > start+height {
+		start = min(to-height, from)
+	}
+	start = max(min(start, len(lines)-height), 0)
+	return lines[start : start+height]
+}
+
 // windowStart is where a height-line window over n lines begins so the
 // focused line stays visible.
 func windowStart(n, focus, height int) int {

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -575,9 +575,12 @@ func (s *shell) overlayPopup(bg string) string {
 	if pw < 20 {
 		pw = s.bodyW
 	}
-	ph := min(form.height()+2, max(s.bodyH-4, 6))
+	// The form lays itself out at the width it will be drawn at, so a long
+	// question wraps inside the popup instead of losing its tail to frame.
+	inner := pw - 2
+	ph := min(form.height(inner)+2, max(s.bodyH-4, 6))
 	title := fmt.Sprintf("Answer — #%d", s.detail.taskID)
-	popup := frame(title, form.render(ph-2), pw, ph, true)
+	popup := frame(title, form.render(inner, ph-2), pw, ph, true)
 	x := max((s.bodyW-pw)/2, 0)
 	y := max((s.bodyH-ph)/3, 1)
 	return overlay(bg, popup, x, y)


### PR DESCRIPTION
## Summary

The §7.4 answer popup dropped the tail of any line longer than the popup's inner
width and replaced it with `…`, and nothing inside the form got it back — no wrap,
no horizontal scroll, no expand. Because the popup is capped at 76 columns
(`shell.go`'s `pw := min(s.bodyW-6, 76)`), a wider terminal did not help either.
What disappeared was the end of the agent's question, the `(Recommended)` suffix
agents put at the *end* of an option label, and — in `restricted` mode — the tail
of the command a permission request was asking you to approve.

**Root cause.** The form was width-blind, and the truncation was only where the
damage showed. `answerForm.render` took a **height and no width**; `renderRow`
emitted exactly one line per row; `height()` was `len(f.rows) + 2`. One row = one
line was baked into rendering *and* sizing, so there was no point in the form at
which wrapping could happen. `overlayPopup` then passed the popup's width only to
`frame`, whose `ansi.Truncate` — correct in itself, it is what stops a panel
leaking into its neighbour — is where the text was lost.

**The fix** threads the width in and wraps inside the existing popup:

- `render(width, height)` and `height(width)` — the form lays itself out at the
  width it will actually be drawn at; `overlayPopup` passes `pw-2`.
- `renderRow` returns lines, wrapping each row's **plain** text and styling the
  produced lines afterwards — the same order `internal/tui/outputlines.go`'s
  `wrapLine` uses for the §15 output pane, so a break never lands inside an escape
  sequence. Over-long words are hard-split through that pane's own `splitWords`,
  so nothing overflows back into `frame`'s truncation.
- Continuation lines are indented to the row's marker column, so a wrapped option
  still reads as one option.
- Rows stay the unit the cursor moves in. `layout` reports the line range the
  focused row occupies and `windowRange` keeps the *whole* of it on screen,
  anchoring its first line when a single row is taller than the popup.
  `nextSelectable` and `f.cursor` are untouched — only the row→line mapping is new.

`frame`'s `ansi.Truncate` is deliberately left alone: it is the safety net, not the
bug. The popup keeps its size and its focus behaviour, so the PR P / T3.10 decision
("the answer form is an interrupt, so it is a popup that never steals focus") is
preserved — this widens nothing and promotes nothing to a takeover.

Rendered at the default width, the permission case now reads:

```text
┌─ ▸ Answer — #3 ──────────────────────────────────────────────────────────┐
│  ? Bash wants to run: rm -rf ./build && ./scripts/publish.sh             │
│    --channel=stable --yes                                                │
│›   ( ) allow                                                             │
│    ( ) deny                                                              │
│  space select · e type an answer · enter submit · esc leave the form     │
└──────────────────────────────────────────────────────────────────────────┘
```

## Related

Closes #83

Spec: none needed. §7.4 makes the form the surface a human answers from and §15
makes it a popup; neither describes or permits truncation, so the spec was not the
side that was wrong. §15 already records the identical decision for the output pane
("wraps its own lines, with a hanging indent the width of the gutter"), so wrapping
the form applies a decision the spec has already made. No `docs/tasks/` entry covers
this area, and no recorded decision is revisited.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [ ] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons) —
      nothing tracked changed: no key binding (`internal/tui/bindings.go`), route,
      config key, cobra command or `Reason*` constant moved, and no page documented
      the truncation. `docs/guides/tui.md`'s "Answering a question" section is a key
      table plus the never-steals-focus rule, both still exactly true.

## Test

`internal/tui/answerform_test.go` — `TestFormPopupShowsLongTextInFull`, which was
written and observed failing against the unfixed code. It drives the **real shell**
(`newShellFixture`, `enter` to open the popup) rather than the form in isolation, so
it sees the width the popup is actually sized at — the only place the defect is
visible. Two subtests, asserting on the ANSI-stripped screen:

- *question and option*: the question's closing words (`hold it behind them for
  fairness?`) and an option's `(Recommended)` suffix are both on screen.
- *permission summary*: `--channel=stable --yes` is on screen; before the fix the
  popup cut it at `--channel=s…`.

Both assert on the **tail** of the text, which is precisely what a re-introduced
truncation removes first, so a regression fails the test rather than shifting where
it cuts. The assertions were not weakened; the three pre-existing `f.render(20)` /
`f.render(10)` call sites became `f.render(74, 20)` / `f.render(74, 10)` for the new
signature, with no assertion changed.

`go test ./...` (1183 tests) and `go test -race ./internal/tui` pass;
`golangci-lint run ./...` is clean for `GOOS=linux`, `darwin` and `windows`. The
change is in shared render code with no build tags and no platform-specific path.

## Noted, not fixed here

While reading `renderRow`: a **free-text row** puts the echo of what you typed in
the marker column (`marker()` returns `"✎ " + typed`), so a long typed answer still
runs off the row and is cut by `frame` — the prefix, not the wrapped text, is what
overflows. It is a different defect from #83 (which is about the question, the
option labels and the permission summary) and fixing it means restructuring that
row, so it is left out of this PR rather than smuggled in.
