### PR TITLE
feat(workflows): add github-bug and release workflows

### DIFF
--- a/.vincent/workflows/github-bug.yaml
+++ b/.vincent/workflows/github-bug.yaml
@@ -1,0 +1,519 @@
+# github-bug — pick up a GitHub bug issue, reproduce it, fix it, deliver it.
+#
+# Sibling of `github-enhancement.yaml`, and deliberately shaped like it: the
+# task's **title starts with the issue id** (`42`, `#42`, or the issue URL),
+# optionally followed by a short description — `42 daemon leaks the lock file`.
+# `fetch` takes the first whitespace-separated token as the id, which keeps the
+# title machine-readable while letting the rest of it feed `{{.Slug}}` and the
+# board row.
+#
+# Shape: fetch (cheap guard) → diagnose (reproduce, ask, write a failing test)
+# → triage (stop on a non-bug) → confirm-red (prove the test captures the bug)
+# → fix → verify (the expensive cross-platform legs) → gate (a human reads the
+# diff) → publish → report.
+#
+# **What makes this workflow different from its enhancement sibling is
+# `confirm-red`.** An enhancement is judged by whether the new behaviour works;
+# a bug fix is judged by whether the old behaviour is gone, and the only honest
+# evidence of that is a test that failed before the fix and passes after it.
+# So `diagnose` writes the regression test *first*, `confirm-red` runs it
+# against the unfixed code and **fails the task if it passes**, and `fix`'s
+# check re-runs that same frozen command expecting success. A green regression
+# test that was never observed red proves nothing — it may be testing the wrong
+# thing entirely, and it will keep passing after the bug comes back.
+#
+# Not every bug is reachable from a test (a TUI rendering glitch, a wrong
+# sentence in `docs/`, a platform-specific path bug on an OS this machine is
+# not). That escape hatch exists — `red-test.txt` may say `none: <reason>` —
+# but it is loud: it costs the task its automated proof, it is printed by
+# `confirm-red`, and the gate step puts it in front of the human who approves
+# the PR. Prefer a test.
+#
+# Why diagnose and fix are two steps and not one: `diagnose` runs with
+# `on_input: wait`, so it parks the task in `awaiting_input` and asks you
+# through claude's AskUserQuestion tool (§7.4). If the fix shared that step,
+# every retry after a failed check would replay the questioning and ask you the
+# same things again. `defaults.on_input: deny` makes the asymmetry explicit:
+# `diagnose` is the only step allowed to stop and ask.
+#
+# claude-only by construction, like both of its siblings. `on_input` is ignored
+# by codex and cursor (`supports_input: false`, §9.3/§9.7), so on those adapters
+# `diagnose` would silently guess at the repro instead of asking the reporter.
+#
+# POSIX-only. Every command step pins `shell: sh`; agent steps cannot pin a
+# shell at all (§8.2 rejects `shell` on an agent step), so their `check` runs
+# under the platform default and is written in `sh` regardless. On Windows the
+# whole workflow needs Git Bash's `sh` on PATH. Portability is the author's
+# problem (§8.3) and this workflow declines it deliberately.
+#
+# Requires `gh` (authenticated), `jq`, `git`, `go`, and the worktree's `origin`
+# pointing at the repo that owns the issue.
+name: github-bug
+description: Reproduce a GitHub bug issue with a failing test, fix it, and open the PR.
+
+defaults:
+  agent: claude
+  max_retries: 1
+  timeout: 30m
+  # Only `diagnose` overrides this. A fix step that stops to ask has skipped
+  # the whole point of the diagnose/fix split.
+  on_input: deny
+
+steps:
+  - id: fetch
+    name: Fetch and guard the issue
+    type: command
+    shell: sh
+    timeout: 2m
+    # A wrong id, a closed issue or a missing label is not a transient error —
+    # re-reading GitHub returns the same answer. Retrying only delays the
+    # failure.
+    max_retries: 0
+    # This step exists so that a bad id costs two seconds instead of a 45-minute
+    # agent run, and so that exactly these fields — not whatever the agent felt
+    # like fetching — are what enters the diagnosis's context.
+    run: |
+      set -e
+      # First token only: everything after it is the human-readable half of the
+      # title, which exists so the branch slug and the board row say something.
+      id=$(printf '%s' "$VINCENT_TASK_TITLE" | awk '{print $1}' | sed 's/^#//')
+      if [ -z "$id" ]; then
+        echo "task title is empty; it must start with the issue id (42, #42, or the issue URL)" >&2
+        exit 1
+      fi
+
+      mkdir -p .vincent-bug
+      # Comments matter more here than on an enhancement: a bug report's real
+      # reproduction steps, versions and "me too, but on Windows" almost always
+      # arrive in the thread rather than the body.
+      if ! gh issue view "$id" \
+        --json number,title,body,state,url,labels,comments,createdAt \
+        > .vincent-bug/issue.json; then
+        echo "no such issue: $id (the task title's first word must be the issue id)" >&2
+        exit 1
+      fi
+
+      state=$(jq -r .state .vincent-bug/issue.json)
+      if [ "$state" != "OPEN" ]; then
+        echo "issue #$id is $state; this workflow only picks up open issues" >&2
+        exit 1
+      fi
+
+      if ! jq -e '[.labels[].name] | index("bug")' \
+        .vincent-bug/issue.json > /dev/null; then
+        echo "issue #$id is not labeled 'bug'; use github-enhancement.yaml for an enhancement" >&2
+        jq -r '"labels: " + ([.labels[].name] | join(", "))' .vincent-bug/issue.json >&2
+        exit 1
+      fi
+
+      jq -r '"#\(.number) \(.title)\n\(.url)\nreported: \(.createdAt)"' .vincent-bug/issue.json
+
+  - id: diagnose
+    name: Reproduce and diagnose
+    type: agent
+    # The whole reason this step is separate: it stops and asks rather than
+    # inventing a reproduction it could not achieve.
+    on_input: wait
+    # Parking overnight while you sleep is fine. Parking forever is not.
+    input_timeout: 12h
+    timeout: 45m
+    prompt: |
+      You are diagnosing a GitHub bug report against this repository. You are
+      NOT fixing it yet: do not change a single line of non-test code.
+
+      The issue is in `.vincent-bug/issue.json` — number, title, body, state,
+      labels, creation date and every comment. Read it first, comments
+      included; reproduction details usually arrive in the thread rather than
+      the body.
+
+      You are on branch {{.Task.BranchName}}, based on {{.Task.BaseBranch}}, in
+      a dedicated worktree at {{.Worktree.Path}}.
+
+      Do this in order:
+
+      1. Establish what the *correct* behaviour is, not just the reported one.
+         This repository is spec-driven: `docs/spec.md` is the only spec and
+         its section numbers are cited from the code. Read the sections that
+         govern the reported area, read `CLAUDE.md`, and read any relevant
+         document under `docs/tasks/`. A report is a claim about a mismatch
+         between the code and the spec — find out which side is wrong before
+         you touch either.
+
+      2. Locate the defect. Read the code, follow the actual path, and name the
+         precise line or decision that produces the wrong behaviour. "Something
+         in the scheduler" is not a diagnosis.
+
+      3. Check whether it is still a bug at HEAD. The report carries a version
+         and a date; `git log` covers what has landed since. An issue that was
+         already fixed is a `reject`, not a fix — say which commit fixed it.
+
+      4. Reproduce it. Reproducing means: a command you can run in this
+         worktree that fails *because of this bug* and would pass if the bug
+         were absent. Then write that reproduction down as a **test in the
+         repository**, in the package that owns the defect, following this
+         repo's testing conventions (hermetic, no network, no real agent CLI,
+         `internal/testrepo` / `agenttest` / `cmd/fakeagent` where they apply —
+         see the testing section of `CLAUDE.md`). The test must fail right now,
+         for the reported reason and not for an unrelated one.
+
+         **You may create or modify test files only** — `*_test.go` and files
+         under a `testdata/` directory. Do not touch production code in this
+         step, and do not commit anything.
+
+      5. Use the AskUserQuestion tool when — and only when — you genuinely
+         cannot proceed without the author. The cases that warrant it:
+
+         - **You cannot reproduce it.** Ask for the missing piece: exact
+           version, OS, config, the full command, the daemon log around the
+           failure. Say what you already tried, so the answer is worth the
+           interruption.
+         - **The spec and the report disagree.** If the code does exactly what
+           `docs/spec.md` says and the reporter expected something else, the
+           bug may be in the spec. Which one changes is the author's call, not
+           yours — and if the answer is "the spec", note that the spec must be
+           amended in this same branch with a dated note.
+         - **The fix contradicts a recorded decision** — a "phase 2 decision",
+           a "T1.5/T1.6 decision", a "PR G decision", or something in
+           `docs/history/v0-tasks.md`. Those are outcomes of design sessions,
+           not incidental notes. Never relitigate one silently.
+
+         Batch related questions into as few calls as you can, with concrete
+         options where you can offer them. If the report is clear and you
+         reproduced it, ask nothing and move on.
+
+      6. Write `.vincent-bug/diagnosis.md`. Its **first line** must be exactly
+         one of:
+
+             verdict: fix
+             verdict: reject
+             verdict: needs-info
+
+         - `fix` — reproduced, understood, and worth fixing here.
+         - `reject` — this should not be fixed: it is working as specified,
+           already fixed at HEAD, a duplicate, or out of scope. You must have
+           asked the author before rejecting a report that describes real
+           surprise.
+         - `needs-info` — you asked, and what came back still is not enough to
+           reproduce it. This is not the same as `reject`: the bug may well be
+           real, and the issue stays open for a later run with better
+           information. Use it rather than guessing at a fix.
+
+         Below that first line write: what the wrong behaviour is, the exact
+         location of the defect, why it happens, which spec sections govern it,
+         which platforms are affected, what the fix should be, and any decision
+         that came out of your questions — as settled decisions in prose, not
+         as a Q&A transcript. On `reject` or `needs-info`, write why instead,
+         and what would change the answer.
+
+      7. Write `.vincent-bug/red-test.txt` — **one line**, the shell command
+         that runs your failing test and nothing else, narrow enough to be
+         fast. For example:
+
+             go test ./internal/taskrun -run TestRecoverKillsVerifiedOrphan
+
+         The next step runs this command and **fails the task if it passes**,
+         because a regression test nobody ever saw fail proves nothing.
+
+         If this bug genuinely cannot be captured by an automated test — a TUI
+         rendering artifact, a wrong sentence in `docs/`, a defect on a
+         platform this machine is not — write instead a single line:
+
+             none: <one sentence saying why no test can capture this>
+
+         Do not reach for that to save effort. It costs the fix its proof and a
+         human is shown the reason before the PR goes out.
+
+         On `reject` or `needs-info`, write `none: <verdict>` here.
+
+      Do not commit. Do not push. Do not run `gh` for anything that writes. Do
+      not modify any file outside `.vincent-bug/`, `*_test.go`, and `testdata/`.
+    # Asserts the artifacts exist and are machine-readable before later steps
+    # branch on them, that nothing was committed, and that this step really did
+    # keep its hands off production code — the last of those is what makes
+    # `confirm-red`'s verdict meaningful, since a "failing" test proves nothing
+    # if the fix already landed alongside it. A failure here retries with the
+    # reason appended (§8.4).
+    #
+    # The last clause names the offending paths on stderr rather than just
+    # exiting non-zero: a bare `test -z` prints nothing, and §8.4 hands the
+    # retry the check's *output*, so an agent told only "check failed" would
+    # have to guess which file it left behind.
+    #
+    # Written in `sh`: an agent step cannot pin a shell (§8.2).
+    check: >
+      test -s .vincent-bug/diagnosis.md &&
+      head -n 1 .vincent-bug/diagnosis.md | grep -Eq '^verdict: (fix|reject|needs-info)$' &&
+      test -s .vincent-bug/red-test.txt &&
+      git diff --cached --quiet &&
+      test "$(git rev-list --count {{.Task.BaseBranch}}..HEAD)" -eq 0 &&
+      { offenders=$( { git diff --name-only; git ls-files --others --exclude-standard; } | grep -v '^\.vincent-bug/' | grep -vE '(_test\.go$|(^|/)testdata/)' ); test -z "$offenders" || { echo 'diagnose changed files outside .vincent-bug/, *_test.go and testdata/:' >&2; echo "$offenders" >&2; false; }; }
+    check_timeout: 2m
+
+  - id: triage
+    name: Act on the verdict
+    type: command
+    shell: sh
+    timeout: 1m
+    # `reject` and `needs-info` are legitimate outcomes of `diagnose`, so
+    # `diagnose` passes its check either way. This step is what turns one into
+    # a failed task with a legible reason, instead of a pull request nobody
+    # wanted. The two are kept distinct on purpose: `reject` means never,
+    # `needs-info` means re-run this task once the thread has more in it.
+    max_retries: 0
+    run: |
+      set -e
+      verdict=$(head -n 1 .vincent-bug/diagnosis.md)
+      case "$verdict" in
+        'verdict: reject')
+          echo "diagnosis rejected this report; nothing will be fixed." >&2
+          echo "--- diagnosis.md ---" >&2
+          cat .vincent-bug/diagnosis.md >&2
+          exit 1
+          ;;
+        'verdict: needs-info')
+          echo "the report could not be reproduced with the information available." >&2
+          echo "the issue stays open; re-run this task once the thread has more in it." >&2
+          echo "--- diagnosis.md ---" >&2
+          cat .vincent-bug/diagnosis.md >&2
+          exit 1
+          ;;
+      esac
+      cat .vincent-bug/diagnosis.md
+
+  - id: confirm-red
+    name: Confirm the test fails
+    type: command
+    shell: sh
+    timeout: 15m
+    # Deterministic by construction — a second identical run is the same run.
+    max_retries: 0
+    # The load-bearing step of this workflow, and the one its enhancement
+    # sibling has no equivalent of. It proves the regression test observes the
+    # bug, in the one window where that is observable: after the test exists
+    # and before the fix does.
+    #
+    # It also *freezes* the command into `green.sh`, which is what `fix`'s
+    # check re-runs. Reading it back from `red-test.txt` there would let the
+    # fix step move its own goalposts by rewriting the file; the copy taken
+    # here was taken while the bug was still present.
+    run: |
+      set -e
+      cmd=$(head -n 1 .vincent-bug/red-test.txt)
+      if [ -z "$cmd" ]; then
+        echo ".vincent-bug/red-test.txt is empty" >&2
+        exit 1
+      fi
+
+      case "$cmd" in
+        none:*)
+          echo "NO AUTOMATED REPRODUCTION -${cmd#none:}"
+          echo "this fix ships without a regression test; the gate step is the only"
+          echo "thing standing between it and the PR."
+          printf 'exit 0\n' > .vincent-bug/green.sh
+          exit 0
+          ;;
+      esac
+
+      printf '%s\n' "$cmd" > .vincent-bug/green.sh
+      echo "--- red run: $cmd ---"
+      if sh .vincent-bug/green.sh; then
+        echo "the reproduction command passed against the unfixed code:" >&2
+        echo "  $cmd" >&2
+        echo "it does not capture the reported bug. A regression test that was never" >&2
+        echo "observed failing proves nothing about the fix." >&2
+        exit 1
+      fi
+      echo "--- confirmed red: the test fails on the unfixed code ---"
+
+  - id: fix
+    name: Fix the bug
+    type: agent
+    timeout: 45m
+    # Two attempts, not the default one: this step's check is self-healing —
+    # a still-red regression test, a failing suite or a lint finding comes back
+    # in the §8.4 failure block and the second attempt fixes it. The expensive,
+    # non-self-healing checks live in `verify` instead.
+    max_retries: 2
+    prompt: |
+      Fix the bug diagnosed in `.vincent-bug/diagnosis.md`. That diagnosis is
+      the agreed scope — the author has already answered the open questions and
+      those answers are written into it as decisions. Do not re-open them and
+      do not expand the scope. The original report is still in
+      `.vincent-bug/issue.json` for reference.
+
+      The regression test for this bug is already written and already failing;
+      it was run against the unfixed code and observed to fail, which is what
+      makes it worth anything. `.vincent-bug/green.sh` runs exactly that test.
+
+      You are on branch {{.Task.BranchName}}, based on {{.Task.BaseBranch}}, in
+      a dedicated worktree at {{.Worktree.Path}}.
+
+      Rules for the fix itself:
+
+      - **Fix the cause, not the symptom.** The diagnosis names the defect;
+        repair that. A guard added at the call site that leaves the broken
+        function broken is not a fix.
+      - **Make the smallest change that does it.** A bug fix is not the place
+        for the refactor you noticed on the way past. If you find a second,
+        unrelated bug, say so in the PR body rather than fixing it here.
+      - **Do not weaken the test to make it pass.** If the test turns out to
+        assert the wrong thing, say so explicitly in the PR body and explain
+        what you changed about it and why — silently relaxing an assertion is
+        the one failure mode this whole workflow exists to prevent.
+      - **Cross-platform is a hard requirement here** (`CLAUDE.md`): Windows,
+        macOS and Linux all run the full suite. Platform-specific code goes in
+        `_unix.go` / `_windows.go` / `_darwin.go` / `_linux.go`. Never assume a
+        POSIX shell, `/`-separated paths, or signal semantics.
+
+      **Commit the work** — the regression test and the fix, test first if you
+      split them. Commits follow Conventional Commits; a bug fix is `fix:`
+      unless it truly is not. Never add a co-author trailer.
+
+      This repository's pull request template makes four claims. Satisfy the
+      ones that apply and be honest about the ones that do not:
+
+      - Conventional Commits.
+      - Tests added or updated for behaviour changes.
+      - User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
+        a bug a user could hit belongs there.
+      - The affected page under `docs/` updated — the config reference tracks
+        `internal/config`, the CLI page the cobra tree, the API page the route
+        table in `internal/api/server.go`, the TUI key tables
+        `internal/tui/bindings.go`, the block reasons the `Reason*` constants.
+
+      If the diagnosis concluded that `docs/spec.md` is the side that was
+      wrong, amend the spec in this same branch with a dated note — that is a
+      hard rule of this repository, not a nicety.
+
+      Then write two more files:
+
+      - `.vincent-bug/pr-title.txt` — one line, Conventional Commits style, no
+        trailing prose.
+      - `.vincent-bug/pr.md` — the pull request body, following
+        `.github/PULL_REQUEST_TEMPLATE.md`. Under **Related**, write
+        `Closes #<the issue number from issue.json>` so merging the PR closes
+        the issue. Say plainly what the root cause was and how the regression
+        test would catch it coming back. Tick a checklist box only if you
+        actually did that thing; leaving a box unticked with a one-line reason
+        is the correct outcome when it does not apply.
+
+      **Never stage or commit `.vincent-bug/`.** It is scratch space for this
+      workflow and must not appear in the diff — do not `git add -A` without
+      excluding it. A later step deletes it.
+    # Cheap assertions first, so an obvious failure does not wait out a full
+    # test run: scratch stayed untracked, something was actually committed (an
+    # empty branch would only fail at `gh pr create`, after you had already
+    # approved it at the gate), the PR artifacts exist. Then the narrow
+    # regression test — the specific thing this task is for, and the fastest
+    # signal that the fix works. Then the real bar.
+    #
+    # `green.sh` was frozen by `confirm-red` while the bug was still present,
+    # so this is the same command that was observed failing.
+    check: >
+      ! git ls-files .vincent-bug | grep -q . &&
+      test "$(git rev-list --count {{.Task.BaseBranch}}..HEAD)" -gt 0 &&
+      test -s .vincent-bug/pr-title.txt &&
+      test -s .vincent-bug/pr.md &&
+      sh .vincent-bug/green.sh &&
+      go run mage.go test &&
+      go run mage.go lint
+    check_timeout: 15m
+
+  - id: verify
+    name: Verify across platforms
+    type: command
+    shell: sh
+    timeout: 20m
+    # `max_retries: 0`: nothing here is flaky in a way a second identical run
+    # fixes, and each attempt is expensive. A failure blocks the task for you
+    # to read rather than silently buying another 45-minute agent attempt.
+    max_retries: 0
+    # These are the legs CLAUDE.md requires before pushing but that are too
+    # slow to put in `fix`'s check. `testrace` needs cgo and a C compiler; on a
+    # machine without one this step fails, and that is the honest answer rather
+    # than a silently skipped race detector — which matters more for a bug fix
+    # than for a feature, since "intermittent" is how half of them are reported.
+    #
+    # The GOOS loop is not decorative: `go tool golangci-lint` cross-*builds*
+    # the linter and then cannot run it, so the linter is built for the host
+    # once and re-run per target. A host-only lint hides every finding in a
+    # build-tagged file — exactly where a platform-specific bug fix lands.
+    run: |
+      set -e
+      go run mage.go testrace
+      LINT=$(go tool -n golangci-lint)
+      for os in windows darwin linux; do
+        echo "--- golangci-lint GOOS=$os ---"
+        GOOS=$os "$LINT" run ./...
+      done
+
+  - id: gate
+    name: Approve the pull request
+    type: manual
+    instructions: |
+      Read the diff for task #{{.Task.ID}} before it goes out.
+
+      The next step pushes {{.Task.BranchName}} to `origin` and opens a public
+      pull request against {{.Task.BaseBranch}} under your account. It notifies
+      whoever watches the repository, and closing the PR afterwards does not
+      unsend that.
+
+      The worktree is {{.Worktree.Path}}. The diagnosis and the drafted PR body
+      are in `.vincent-bug/`. Tests, lint and the cross-platform legs have
+      already passed — what is left is the judgement they cannot make:
+
+      - Does the diff fix the **cause** named in the diagnosis, or guard the
+        symptom somewhere upstream of it?
+      - Is there a regression test in the diff, and does it assert the
+        behaviour that was actually broken? Read the `confirm-red` output
+        below: if it says NO AUTOMATED REPRODUCTION, this fix ships with no
+        proof at all and you are it.
+      - Did the fix stay small, or did a refactor come along for the ride?
+
+      Reproduction check:
+
+      {{(index .Steps "confirm-red").Result}}
+
+      The fix reported:
+
+      {{(index .Steps "fix").Result}}
+
+      Approve to push and open the PR. Reject if the fix is wrong, too broad,
+      or not worth shipping.
+
+  - id: publish
+    name: Push and open the PR
+    type: command
+    shell: sh
+    timeout: 5m
+    # Load-bearing. A retried `gh pr create` opens a second pull request, and
+    # nothing distinguishes "the call failed" from "the call succeeded and the
+    # response was lost".
+    max_retries: 0
+    # `--head` is passed explicitly rather than letting gh infer it: inference
+    # from the current branch is exactly the kind of thing that behaves
+    # differently inside a linked worktree.
+    run: >
+      git push -u origin {{.Task.BranchName}} &&
+      gh pr create
+      --base {{.Task.BaseBranch}}
+      --head {{.Task.BranchName}}
+      --title "$(cat .vincent-bug/pr-title.txt)"
+      --body-file .vincent-bug/pr.md
+      > .vincent-bug/url.txt
+
+  - id: report
+    name: Report the PR
+    type: command
+    shell: sh
+    timeout: 2m
+    # stdout becomes this step's Result and lands in the transcript — that is
+    # where you read the PR url. Clearing the scratch directory afterwards
+    # leaves the worktree clean, so archiving the task does not warn about a
+    # dirty tree.
+    #
+    # `&&`, not two lines: sh reports the last command's status, so an
+    # unchained `rm` would mask a failed `view` and leave the step green. It
+    # also means the drafts survive for inspection when the report fails —
+    # which is the same reason nothing deletes them if `publish` fails.
+    run: gh pr view "$(cat .vincent-bug/url.txt)" && rm -rf .vincent-bug

--- a/.vincent/workflows/prepare-release.yaml
+++ b/.vincent/workflows/prepare-release.yaml
@@ -1,0 +1,636 @@
+# prepare-release — make this repository green for the *next* Release run,
+# before any tag exists.
+#
+# The tag push is the release. `.github/workflows/release.yml` runs on it and
+# every failure it can have is discovered *after* the one-way door: a tag that
+# module proxies have already cached, pointing at a commit whose archives never
+# built. This workflow moves every one of those failures in front of the door.
+#
+# What it actually proves, in order of strength:
+#
+#   1. The **dry run**: `Release` is dispatched with `dry_run` checked and
+#      watched to completion. That is `release --snapshot --clean
+#      --skip=publish,sign` plus the whole three-OS `smoke` matrix against the
+#      archives it produced — real cross-compilation, real archives, real
+#      unpack-and-run, published nowhere. It is RELEASING.md step 4, run
+#      unconditionally rather than when someone remembers that packaging
+#      changed.
+#   2. The **audit**: the parts of a release run that a dry run cannot reach —
+#      `go mod download` (goreleaser's `before` hook), all six
+#      GOOS/GOARCH targets, the files `archives.files` promises, the three
+#      assertions `smoke` makes about the binary, and whether every third-party
+#      action `release.yml` pins still resolves.
+#   3. The **secrets and access** it cannot test without publishing:
+#      `HOMEBREW_TAP_TOKEN` and reachability of the tap. Reported, never faked.
+#
+# Shape: preflight → audit (report-only) → vuln → remediate (the only agent
+# step) → pr → merge (human) → verify-base → dry-run → inspect (human) → report.
+#
+# **Nothing here publishes anything.** No tag, no release, no cask — the one
+# outward action is dispatching a `dry_run` of `Release`, which uploads a
+# `dist` artifact and nothing else. Cutting the release is the `release`
+# workflow's job, and this workflow deliberately stops one step short of it:
+# run `release` with the version in the task title once this one reports green.
+#
+# The audit is report-only on its first pass **on purpose**. A step that fails
+# blocks the task, and a blocked task cannot then be fixed by the step after
+# it. So `audit` prints findings and exits 0, `remediate` fixes the blocking
+# ones, and the same script — re-run as that step's `check` — is what decides
+# whether the fixes worked. One script, two callers, no drift.
+#
+# The task title MAY start with the version being prepared (`v0.2.0`, or
+# `0.2.0` — the `v` is added), which buys a tag-collision check and better
+# messages; the rest of the title is prose. A title that does not start with
+# something version-shaped is fine and the workflow runs version-agnostic. A
+# title that starts with something version-*shaped* but malformed is an error,
+# because that is a typo, not a prose title.
+#
+# This workflow is specific to **this** repository: it knows the `ci` and
+# `gates` check-run names from `.github/workflows/ci.yml`, the `Release`
+# workflow file and its `dry_run` input, the six targets and the
+# `archives.files` list in `.goreleaser.yaml`, the `lezli01/homebrew-tap`
+# repository, `go run mage.go vuln`, and the exact assertions release.yml's
+# `smoke` job makes. It is not a generic release-readiness workflow.
+#
+# POSIX-only. Every command step pins `shell: sh`; agent steps cannot pin a
+# shell (§8.2 rejects `shell` on an agent step), so `remediate`'s check runs
+# under the platform default and is written in `sh` regardless. On Windows the
+# whole workflow needs Git Bash's `sh` on PATH. Portability is the author's
+# problem (§8.3) and this workflow declines it deliberately.
+#
+# Requires: `gh` authenticated with write access to this repository (dispatching
+# a workflow is a write), `git`, `go`, `awk`, `tar`, and a sha256 tool
+# (`sha256sum` or `shasum`).
+#
+# Known wart: this task's own branch carries the remediation commits, so the
+# worktree survives until you archive the task. Archive it after `report`.
+name: prepare-release
+description: Prove the Release workflow will be green — audit, fix, and dry-run it before the tag exists.
+
+defaults:
+  agent: claude
+  max_retries: 1
+  timeout: 30m
+  # The human checkpoints are the two manual steps. An agent parking the task
+  # mid-audit adds a third one nobody is watching for.
+  on_input: deny
+
+steps:
+  - id: preflight
+    name: Guard and write the audit
+    type: command
+    shell: sh
+    timeout: 10m
+    # A malformed version or a tag that already exists is not transient.
+    max_retries: 0
+    # This step writes the two scripts every later step reads, so that the
+    # audit run here, the audit re-run as `remediate`'s check, and the audit
+    # re-run in `report` are byte-identical by construction.
+    run: |
+      set -e
+      mkdir -p .vincent-prepare
+
+      # The version is optional here (unlike the `release` workflow, where it
+      # is the whole point): a dry run builds a snapshot and needs no version
+      # at all. When the title carries one, it buys the tag-collision check
+      # below and names the release in every later message.
+      raw=$(printf '%s' "$VINCENT_TASK_TITLE" | awk '{print $1}')
+      v=""
+      case "$raw" in
+        v[0-9]*|[0-9]*)
+          cand="v${raw#v}"
+          if printf '%s\n' "$cand" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            v="$cand"
+          else
+            echo "task title starts with '$raw', which looks like a version but is not vX.Y.Z (or vX.Y.Z-rc1)" >&2
+            echo "either fix it, or start the title with prose to run version-agnostic" >&2
+            exit 1
+          fi
+          ;;
+      esac
+
+      gh auth status >/dev/null 2>&1 || { echo "gh is not authenticated" >&2; exit 1; }
+      command -v go >/dev/null 2>&1 || { echo "go is not on PATH" >&2; exit 1; }
+
+      git fetch --quiet --tags origin "$VINCENT_BASE_BRANCH"
+      if [ -n "$v" ] && git ls-remote --exit-code --tags origin "refs/tags/$v" >/dev/null 2>&1; then
+        echo "tag $v already exists on origin — that release is already cut, and a published tag is never re-pointed (RELEASING.md)" >&2
+        exit 1
+      fi
+
+      # Byte-for-byte the check the `release` workflow's preflight uses, for
+      # the same reason: a commit with *no* checks yet passes the per-run rule
+      # trivially, so the count is what catches it. Called twice from here —
+      # advisory inside the audit, blocking in `verify-base`.
+      cat > .vincent-prepare/require-green.sh <<'GREEN'
+      # Usage: sh require-green.sh <sha>. Exit 0 iff every check run on the
+      # commit completed successfully and both required matrices are present.
+      set -e
+      sha="$1"
+      runs=$(gh api "repos/{owner}/{repo}/commits/$sha/check-runs?per_page=100" \
+        --jq '.check_runs[] | [.name, .status, (.conclusion // "pending")] | @tsv')
+      printf '%s\n' "$runs"
+      bad=$(printf '%s\n' "$runs" | awk -F'\t' 'NF && ($2 != "completed" || ($3 != "success" && $3 != "skipped")) { print $1 " " $3 }')
+      if [ -n "$bad" ]; then
+        echo "not green on $sha:" >&2
+        printf '%s\n' "$bad" >&2
+        exit 1
+      fi
+      for job in ci gates; do
+        n=$(printf '%s\n' "$runs" | awk -F'\t' -v j="$job" 'index($1, j " (") == 1' | wc -l | tr -d ' ')
+        if [ "$n" -ne 3 ]; then
+          echo "expected 3 '$job' checks on $sha (ubuntu, macos, windows), found $n" >&2
+          exit 1
+        fi
+      done
+      GREEN
+
+      # The audit. Deliberately **not** `set -e`: an audit that stops at the
+      # first problem makes the human run it once per problem. Every check
+      # runs, every finding prints, and the exit code is the summary.
+      #
+      #   FAIL — blocks a release and is fixable in this repository. These are
+      #          what `remediate` must clear, and what the exit code counts.
+      #   WARN — real, and not something a commit on this branch can fix
+      #          (a red base branch, a missing secret, an empty changelog).
+      #          Carried to the human at `inspect`.
+      cat > .vincent-prepare/audit.sh <<'AUDIT'
+      # Usage: sh audit.sh. Exit 1 iff there is a FAIL finding.
+      fails=0
+      mark=0
+      fail() { printf 'FAIL %s\n' "$*"; fails=$((fails + 1)); }
+      warn() { printf 'WARN %s\n' "$*"; }
+      # A section that finds nothing must still say so: a silent block reads
+      # like a block that did not run.
+      section() { echo "== $1"; mark=$fails; }
+      passed() { [ "$fails" -eq "$mark" ]; }
+
+      work=.vincent-prepare/work
+      rm -rf "$work"
+      mkdir -p "$work"
+
+      section "working tree"
+      # goreleaser builds what is committed at the tag, not what is in the
+      # working tree, so an uncommitted fix is not a fix.
+      git diff --quiet || fail "tree: tracked files have uncommitted changes; commit them or they will not be in the release"
+      git diff --cached --quiet || fail "tree: changes are staged but not committed"
+      passed && echo "ok    no uncommitted changes to tracked files"
+
+      section "archive payload (.goreleaser.yaml archives.files)"
+      for f in README.md LICENSE .goreleaser.yaml cmd/vincent; do
+        [ -e "$f" ] || fail "payload: $f is missing"
+      done
+      # `examples/*.yaml` is an archive glob: an empty match ships an archive
+      # with no examples and nothing fails until a user looks.
+      n=$(ls examples/*.yaml 2>/dev/null | wc -l | tr -d ' ')
+      [ "$n" -gt 0 ] || fail "payload: examples/*.yaml matches nothing, so the archives would ship no examples"
+      # release.yml's smoke job names this file literally; renaming it breaks
+      # every published archive's smoke test and nothing before it.
+      [ -f examples/cursor-review.yaml ] || fail "payload: examples/cursor-review.yaml is missing, and release.yml's smoke job runs 'workflow validate' on exactly that path"
+      passed && echo "ok    README.md, LICENSE and $n example workflow(s)"
+
+      section "module (goreleaser's before hook)"
+      go mod download >"$work/mod.log" 2>&1 || fail "module: 'go mod download' failed: $(head -n 3 "$work/mod.log" | tr '\n' ' ')"
+      go mod verify >>"$work/mod.log" 2>&1 || fail "module: 'go mod verify' failed: $(tail -n 3 "$work/mod.log" | tr '\n' ' ')"
+      passed && echo "ok    go mod download, go mod verify"
+
+      section "cross-compile (the six targets .goreleaser.yaml builds)"
+      for t in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+        goos=${t%/*}
+        goarch=${t#*/}
+        if CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -trimpath \
+             -o "$work/vincent-$goos-$goarch" ./cmd/vincent >"$work/build.log" 2>&1; then
+          echo "ok    $t"
+        else
+          fail "build: $t does not compile: $(head -n 3 "$work/build.log" | tr '\n' ' ')"
+        fi
+      done
+
+      section "smoke contract (what release.yml asserts about the binary)"
+      probe=v0.0.0-audit
+      if go build -trimpath \
+           -ldflags "-s -w -X github.com/lezli01/vincent/internal/version.version=$probe" \
+           -o "$work/vincent" ./cmd/vincent >"$work/probe.log" 2>&1; then
+        # smoke asserts `vincent version` reports the tag rather than "dev".
+        # It can only do that if this ldflags path still names a real symbol —
+        # a moved package or renamed variable leaves the flag silently inert.
+        if ! "$work/vincent" version 2>&1 | grep -q "$probe"; then
+          fail "smoke: the version ldflags path no longer reaches internal/version.version, so a released binary would report 'dev' and release.yml's smoke job would fail on the tag"
+        fi
+        "$work/vincent" workflow validate examples/cursor-review.yaml >"$work/validate.log" 2>&1 \
+          || fail "smoke: 'workflow validate examples/cursor-review.yaml' failed: $(tail -n 3 "$work/validate.log" | tr '\n' ' ')"
+        # smoke requires exit 2 — "no daemon answered" — with no daemon
+        # running. Isolated dirs are what make that true on a maintainer's
+        # machine, where a daemon usually *is* running.
+        VINCENT_CONFIG_DIR="$work/isolated/config" VINCENT_DATA_DIR="$work/isolated/data" \
+          "$work/vincent" task ls >/dev/null 2>&1
+        code=$?
+        [ "$code" -eq 2 ] || fail "smoke: 'task ls' with no daemon exited $code, and release.yml's smoke job requires 2"
+      else
+        fail "smoke: the host build failed: $(head -n 3 "$work/probe.log" | tr '\n' ' ')"
+      fi
+      passed && echo "ok    version reports the injected tag, 'workflow validate' runs, 'task ls' exits 2 with no daemon"
+
+      section "pinned actions in .github/workflows/release.yml"
+      # A pin that no longer resolves fails the release run at step setup,
+      # after the tag is public. `commits/{ref}` accepts a SHA or a tag, so
+      # one call covers both the SHA-pinned third-party actions and the
+      # major-tag `actions/*` ones.
+      grep -Eo 'uses: [A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+' .github/workflows/release.yml \
+        | awk '{print $2}' | sort -u > "$work/uses.txt"
+      while IFS= read -r u; do
+        [ -n "$u" ] || continue
+        repo=${u%@*}
+        ref=${u#*@}
+        if gh api "repos/$repo/commits/$ref" --jq .sha >/dev/null 2>&1; then
+          echo "ok    $u"
+        else
+          fail "action: $u does not resolve — the Release run cannot start with a dangling pin"
+        fi
+      done < "$work/uses.txt"
+
+      section "publish-time credentials (cannot be tested without publishing)"
+      if gh secret list >/dev/null 2>&1; then
+        if gh secret list | awk '{print $1}' | grep -qx HOMEBREW_TAP_TOKEN; then
+          echo "ok    HOMEBREW_TAP_TOKEN is set on this repository"
+        else
+          warn "secret: HOMEBREW_TAP_TOKEN is not set on this repository — the Homebrew cask push is the last thing a real release does, and it will fail (RELEASING.md § Repository secrets)"
+        fi
+      else
+        warn "secret: this token cannot read repository secrets; HOMEBREW_TAP_TOKEN unverified"
+      fi
+      if gh api repos/lezli01/homebrew-tap --jq .full_name >/dev/null 2>&1; then
+        echo "ok    lezli01/homebrew-tap is reachable"
+      else
+        warn "tap: lezli01/homebrew-tap is not reachable with this token — the cask push targets it"
+      fi
+
+      section "release inputs owned by other steps"
+      if awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | grep -q '[^[:space:]]'; then
+        echo "ok    CHANGELOG.md has an [Unreleased] section with content"
+      else
+        warn "changelog: the [Unreleased] section is empty — the release workflow refuses to cut a release with nothing to name"
+      fi
+
+      section "base branch"
+      git fetch --quiet --tags origin "$VINCENT_BASE_BRANCH" 2>/dev/null || true
+      base_sha=$(git rev-parse "origin/$VINCENT_BASE_BRANCH" 2>/dev/null || echo "")
+      if [ -z "$base_sha" ]; then
+        warn "base: origin/$VINCENT_BASE_BRANCH could not be resolved"
+      elif sh .vincent-prepare/require-green.sh "$base_sha" >"$work/green.log" 2>&1; then
+        echo "ok    $VINCENT_BASE_BRANCH is green at $base_sha"
+      else
+        # Advisory here and blocking in `verify-base`: the base may be red for
+        # exactly the reason this task is about to fix, and a red base at audit
+        # time is a fact to report, not a reason to refuse to look further.
+        #
+        # `NF == 1` keeps require-green's messages and drops its check-run
+        # table, whose columns are tab-separated — the table is the evidence,
+        # not the finding, and a finding has to fit on a line.
+        warn "base: $VINCENT_BASE_BRANCH is not green at $base_sha: $(awk -F'\t' 'NF == 1' "$work/green.log" | tr '\n' ' ')"
+      fi
+
+      echo
+      if [ "$fails" -gt 0 ]; then
+        echo "$fails blocking finding(s) — a Release run on this tree would not be green"
+        exit 1
+      fi
+      echo "no blocking findings"
+      AUDIT
+
+      printf '%s\n' "$v" > .vincent-prepare/version.txt
+      if [ -n "$v" ]; then
+        printf '%s\n' "$v" > .vincent-prepare/label.txt
+      else
+        printf '%s\n' "the next release" > .vincent-prepare/label.txt
+      fi
+
+      echo
+      echo "preparing:   $(cat .vincent-prepare/label.txt)"
+      echo "base branch: $VINCENT_BASE_BRANCH @ $(git rev-parse "origin/$VINCENT_BASE_BRANCH")"
+      echo "nothing in this workflow publishes anything; the tag is the release workflow's job"
+
+  - id: audit
+    name: Audit release readiness
+    type: command
+    shell: sh
+    # Six cross-compilations, a host build and a handful of API calls.
+    timeout: 20m
+    # Re-running the same audit on the same tree returns the same findings.
+    max_retries: 0
+    # Report-only by construction: `|| true` is what lets `remediate` exist.
+    # The strict run of this same script is `remediate`'s check.
+    run: |
+      sh .vincent-prepare/audit.sh 2>&1 | tee .vincent-prepare/audit.txt || true
+      exit 0
+
+  - id: vuln
+    name: Vulnerability sweep
+    type: command
+    shell: sh
+    timeout: 15m
+    # RELEASING.md step 2, unconditional. It sweeps all three GOOS values,
+    # because reachability differs per platform. A minute is not worth the
+    # judgement call about whether the last run predates a dependency change.
+    run: go run mage.go vuln
+
+  - id: remediate
+    name: Fix the blocking findings
+    type: agent
+    timeout: 45m
+    prompt: |
+      You are making this repository green for a future run of
+      `.github/workflows/release.yml`. You are NOT releasing anything: no tag,
+      no `gh release`, no `gh pr`, no `git push`. A later step handles the pull
+      request.
+
+      An audit has already run. Its findings are in `.vincent-prepare/audit.txt`
+      and the script that produced them is `.vincent-prepare/audit.sh`. Read
+      both first — the script is the exact contract you are being judged
+      against, and it will be re-run to check your work.
+
+      Findings are one per line:
+
+      - `FAIL …` — blocks a release and is fixable in this repository. Fix
+        every one of these.
+      - `WARN …` — real, but not fixable by a commit on this branch (a red base
+        branch, a missing repository secret, an empty changelog section).
+        **Leave these alone.** A human reads them at the next checkpoint.
+
+      If there is no `FAIL` line, change nothing, commit nothing, and say so.
+      That is a normal outcome, not a reason to look for work.
+
+      For the findings that do exist:
+
+      1. Read `.goreleaser.yaml`, `.github/workflows/release.yml` and
+         `RELEASING.md` before touching anything, so a fix matches what the
+         release actually does rather than what the finding's one line implies.
+      2. Fix the cause, not the audit. Never edit `.vincent-prepare/` — those
+         files are the check, and a passing audit you rewrote proves nothing.
+      3. A dangling action pin (`FAIL action: …`) is the one finding with a
+         trap in it: **do not invent a SHA.** The `# vX.Y.Z` comment beside
+         each pin names the tag it is supposed to be. Resolve that tag with
+         `gh api repos/OWNER/REPO/commits/vX.Y.Z --jq .sha` and use exactly
+         what the API returns, keeping the comment truthful. If the tag itself
+         is gone, stop and explain — a human decides what to trust, and a
+         blocked step is the correct outcome.
+      4. Keep every fix minimal and inside the repository's conventions
+         (CLAUDE.md). Cross-platform is a hard requirement: a build fix that
+         works on one OS and breaks another is not a fix.
+      5. Commit your work in logical commits with Conventional Commit
+         subjects (`fix:` for something that was broken, `chore:` for
+         packaging plumbing, `ci:` for workflow files). Do not use
+         `git add -A` or `git commit -a`; stage the files you changed.
+         Do not touch `CHANGELOG.md` — the `release` workflow owns it.
+
+      Then re-run `sh .vincent-prepare/audit.sh` yourself and iterate until it
+      prints "no blocking findings". Finish by printing the audit's final
+      output and `git log --oneline` of the commits you added.
+    # The audit, run strictly. An agent that described fixes without making
+    # them, or made them and left them uncommitted, fails here and retries
+    # with the failure block appended (§8.4).
+    check: sh .vincent-prepare/audit.sh
+    check_timeout: 20m
+
+  - id: pr
+    name: Open the fixes PR
+    type: command
+    shell: sh
+    timeout: 5m
+    # Load-bearing. A retried `gh pr create` opens a second pull request and
+    # nothing distinguishes "the call failed" from "the call succeeded and the
+    # response was lost". Re-running the step by hand is safe: it finds the
+    # pull request it already opened.
+    max_retries: 0
+    # The common case is that nothing needed fixing, so "no commits" is a
+    # normal, successful outcome rather than an error.
+    run: |
+      set -e
+      label=$(cat .vincent-prepare/label.txt)
+      if [ -z "$(git log --oneline "origin/$VINCENT_BASE_BRANCH"..HEAD)" ]; then
+        echo "no fixes were needed — nothing to open a pull request for"
+        printf '%s\n' "none" > .vincent-prepare/pr-url.txt
+        exit 0
+      fi
+      existing=$(gh pr view {{.Task.BranchName}} --json url --jq .url 2>/dev/null || true)
+      if [ -n "$existing" ]; then
+        echo "pull request already open: $existing"
+        printf '%s\n' "$existing" > .vincent-prepare/pr-url.txt
+        exit 0
+      fi
+      git push -u origin {{.Task.BranchName}}
+      gh pr create \
+        --base {{.Task.BaseBranch}} \
+        --head {{.Task.BranchName}} \
+        --title "chore: release readiness for $label" \
+        --body "Release-readiness fixes for \`$label\`, prepared by vincent task #{{.Task.ID}}.
+
+      Every commit here exists because \`.github/workflows/release.yml\` would
+      not have been green without it. The audit that found them is in the
+      task's transcript; the dry run that proves them is dispatched after this
+      lands on \`{{.Task.BaseBranch}}\`." \
+        > .vincent-prepare/pr-url.txt
+      cat .vincent-prepare/pr-url.txt
+
+  - id: merge
+    name: Merge the fixes
+    type: manual
+    instructions: |
+      Checkpoint for task #{{.Task.ID}}. Nothing has been published and nothing
+      is about to be — the step after this one dispatches a **dry run**.
+
+      Pull request: {{(index .Steps "pr").Result}}
+
+      1. If there is a pull request, review it. These are commits that change
+         how the release is built or packaged, which CI exercises less than
+         ordinary code — read them the way you would read a Makefile change.
+      2. Merge it with a **merge commit**, not a squash (CLAUDE.md § Git flow).
+      3. Wait for all six checks on {{.Task.BaseBranch}}. The next step
+         re-checks them and refuses to continue otherwise, so approving early
+         only fails that step.
+      4. If there was no pull request, nothing needed fixing — just confirm
+         {{.Task.BaseBranch}} is green and approve.
+
+      The audit said:
+
+      {{(index .Steps "audit").Result}}
+
+      Approve once {{.Task.BaseBranch}} carries the fixes and is green. Reject
+      if a fix is wrong; nothing downstream has happened yet.
+
+  - id: verify-base
+    name: Verify the commit a tag would name
+    type: command
+    shell: sh
+    timeout: 10m
+    # No retry: every failure here means "the world is not ready yet" (pull
+    # request not merged, CI still running) and there is no delay between
+    # attempts, so a retry just fails a second time a second later. Re-run the
+    # step by hand once the branch is actually green.
+    max_retries: 0
+    run: |
+      set -e
+      v=$(cat .vincent-prepare/version.txt)
+      git fetch --quiet --tags origin "$VINCENT_BASE_BRANCH"
+
+      if ! git merge-base --is-ancestor HEAD "origin/$VINCENT_BASE_BRANCH"; then
+        echo "this task's commits are not on $VINCENT_BASE_BRANCH yet — merge the pull request first" >&2
+        exit 1
+      fi
+      if [ -n "$v" ] && git ls-remote --exit-code --tags origin "refs/tags/$v" >/dev/null 2>&1; then
+        echo "tag $v appeared on origin while this task was running — stop and work out who pushed it" >&2
+        exit 1
+      fi
+
+      sha=$(git rev-parse "origin/$VINCENT_BASE_BRANCH")
+      # Blocking here, unlike the audit's advisory version: a tag on a red
+      # commit produces signed, attested, broken binaries (RELEASING.md step 1).
+      sh .vincent-prepare/require-green.sh "$sha"
+      printf '%s\n' "$sha" > .vincent-prepare/target-sha.txt
+
+      echo
+      echo "a tag would name:"
+      git log -1 --format='%H %s (%an, %ad)' --date=short "$sha"
+
+  - id: dry-run
+    name: Dry-run the Release workflow
+    type: command
+    shell: sh
+    # The run cross-compiles six archives and then smoke-tests them on three
+    # OSes; the poll for the run to appear is inside the same budget.
+    timeout: 60m
+    # Dispatching is an outward action, and a retry would start a second run
+    # while the first is still going. Re-running by hand is fine — it just
+    # dispatches a fresh run.
+    max_retries: 0
+    # RELEASING.md step 4, unconditional and watched. `--snapshot` needs no
+    # tag, `--skip=publish,sign` means nothing leaves the runner, and the
+    # `smoke` matrix still runs because it only needs the `dist` artifact.
+    # Signing, attestation, the GitHub release and the cask push are the parts
+    # this cannot exercise; `inspect` says so rather than implying otherwise.
+    run: |
+      set -e
+      label=$(cat .vincent-prepare/label.txt)
+      started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      gh workflow run release.yml --ref "$VINCENT_BASE_BRANCH" -f dry_run=true
+      echo "dispatched a dry run of Release on $VINCENT_BASE_BRANCH for $label"
+
+      # The run takes a few seconds to appear. Match on creation time as well
+      # as branch, so a dry run someone else started an hour ago is not
+      # mistaken for this one.
+      id=""
+      i=0
+      while [ "$i" -lt 20 ]; do
+        id=$(gh run list --workflow=release.yml --event=workflow_dispatch --limit 30 \
+          --json databaseId,createdAt,headBranch \
+          --jq "[.[] | select(.headBranch == \"$VINCENT_BASE_BRANCH\" and .createdAt >= \"$started\")] | sort_by(.createdAt) | .[0].databaseId // empty")
+        if [ -n "$id" ]; then break; fi
+        i=$((i + 1))
+        sleep 15
+      done
+      if [ -z "$id" ]; then
+        echo "the dispatched Release run never appeared — check Actions" >&2
+        exit 1
+      fi
+      url=$(gh run view "$id" --json url --jq .url)
+      printf '%s\n' "$url" > .vincent-prepare/dry-run-url.txt
+      echo "$url"
+      gh run watch "$id" --exit-status
+
+      # The run being green means the archives built and ran. This says what
+      # is *in* them: `archives.files` is a glob list, and a glob that stops
+      # matching ships a smaller archive without failing anything upstream.
+      rm -rf .vincent-prepare/dist
+      mkdir -p .vincent-prepare/dist
+      gh run download "$id" -n dist -D .vincent-prepare/dist
+      cd .vincent-prepare/dist
+
+      n=$(ls ./*.tar.gz ./*.zip 2>/dev/null | wc -l | tr -d ' ')
+      [ "$n" -eq 6 ] || { echo "expected 6 archives (3 OS x 2 arch), found $n" >&2; exit 1; }
+
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c checksums.txt
+      elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -c checksums.txt
+      else
+        echo "no sha256 tool found (sha256sum or shasum)" >&2
+        exit 1
+      fi
+
+      archive=$(ls ./*_linux_amd64.tar.gz)
+      mkdir -p unpacked
+      tar -xzf "$archive" -C unpacked
+      for f in vincent README.md LICENSE examples/cursor-review.yaml; do
+        [ -e "unpacked/$f" ] || { echo "the archive is missing $f — check archives.files in .goreleaser.yaml" >&2; exit 1; }
+      done
+
+      echo
+      echo "dry run green: $(cat ../dry-run-url.txt)"
+      echo "archives:"
+      ls ./*.tar.gz ./*.zip
+
+  - id: inspect
+    name: Look at what the dry run produced
+    type: manual
+    instructions: |
+      Last human pass over {{.Task.Title}}. Still nothing published.
+
+      {{(index .Steps "dry-run").Result}}
+
+      1. **Look at the artifact** (RELEASING.md step 4). The `dist` artifact
+         from the run above is also unpacked in `.vincent-prepare/dist/` inside
+         this task's worktree. Sizes, names and the unpacked layout are what a
+         user downloads.
+      2. **Read the WARN findings** from the audit, above in this task. They
+         are the release failures no commit on a branch can prevent — a missing
+         `HOMEBREW_TAP_TOKEN`, an unreachable tap, an empty `[Unreleased]`
+         section. Deal with them now, not while a tag is propagating.
+      3. **Know what the dry run did not test**: cosign signing, build
+         provenance attestation, publishing the GitHub release, and the
+         Homebrew cask push. `--skip=publish,sign` skips the first and third,
+         and attestation is `if: github.event_name == 'push'`. Those four run
+         for the first time on the real tag.
+
+      Approve when the artifact looks right and the warnings are dealt with.
+      Reject to stop — nothing here needs undoing.
+
+  - id: report
+    name: Report readiness
+    type: command
+    shell: sh
+    timeout: 20m
+    # A final audit against the merged tree, so the receipt is a fact rather
+    # than a memory of one — it is the same script, and it fails this step if
+    # anything regressed while the pull request was in review. stdout becomes
+    # the step Result and lands in the transcript. Clearing `.vincent-prepare/`
+    # afterwards leaves the worktree clean, so archiving the task does not warn
+    # about a dirty tree.
+    run: |
+      set -e
+      label=$(cat .vincent-prepare/label.txt)
+      v=$(cat .vincent-prepare/version.txt)
+      sha=$(cat .vincent-prepare/target-sha.txt)
+      url=$(cat .vincent-prepare/dry-run-url.txt)
+
+      echo "== final audit"
+      sh .vincent-prepare/audit.sh
+
+      echo
+      echo "== ready to release"
+      echo "preparing:   $label"
+      echo "base branch: $VINCENT_BASE_BRANCH @ $sha"
+      echo "dry run:     $url"
+      echo
+      if [ -n "$v" ]; then
+        echo "Next: start a task on the 'release' workflow titled '$v …'. It re-runs its"
+        echo "own preflight, writes the changelog, and pushes the tag behind a manual gate."
+      else
+        echo "Next: choose the version (CHANGELOG.md § Versioning and stability — while"
+        echo "vincent is 0.x a breaking change is a minor bump), then start a task on the"
+        echo "'release' workflow titled with it."
+      fi
+
+      rm -rf .vincent-prepare
+      echo
+      echo "worktree status (expect empty):"
+      git status --porcelain

--- a/.vincent/workflows/release.yaml
+++ b/.vincent/workflows/release.yaml
@@ -1,0 +1,514 @@
+# release — cut a vincent release, following RELEASING.md step for step.
+#
+# The task's **title starts with the version** (`v0.2.0`, or `0.2.0` — the `v`
+# is added if you leave it off), optionally followed by prose:
+# `v0.2.0 first minor after the v0 line`. `preflight` takes the first
+# whitespace-separated token as the version, which keeps the title
+# machine-readable while the rest of it feeds `{{.Slug}}` and the board row.
+# Same shape as the `github-*` workflows, which take an issue id there.
+#
+# Shape: preflight (cheap guards) → vuln → changelog (the only agent step)
+# → pr → merge (human merges, CI runs) → verify-master → gate (human) → tag
+# (**irreversible**) → watch → verify → finish (human) → report.
+#
+# **The tag push is a one-way door.** Go module proxies cache tags, and a moved
+# tag silently invalidates every checksum, cosign signature and attestation a
+# user already verified (RELEASING.md § If a release goes wrong). So the two
+# steps that cannot be undone — `pr`, which opens a pull request, and `tag`,
+# which publishes the tag — both pin `max_retries: 0`, and `tag` sits directly
+# behind a manual gate that prints the exact commit it is about to name.
+#
+# Everything after `tag` is verification, not work: the release itself is built,
+# signed, attested and published by `.github/workflows/release.yml`. Nothing in
+# this workflow ever builds an artifact — that is the property RELEASING.md
+# exists to protect ("no artifact is ever built on a maintainer's machine").
+#
+# What this workflow does NOT decide: the version number. That is a policy
+# judgement (CHANGELOG.md § Versioning and stability — while vincent is 0.x a
+# breaking change is a *minor* bump), so it comes from the task title, from a
+# human who read the policy.
+#
+# This workflow is specific to **this** repository: it knows the `ci` and
+# `gates` check-run names from `.github/workflows/ci.yml`, the `Release`
+# workflow file, `go run mage.go vuln`, and the CHANGELOG.md layout. It is not
+# a generic release workflow and will not work anywhere else unchanged.
+#
+# POSIX-only. Every command step pins `shell: sh`; agent steps cannot pin a
+# shell at all (§8.2 rejects `shell` on an agent step), so `changelog`'s check
+# runs under the platform default and is written in `sh` regardless. On Windows
+# the whole workflow needs Git Bash's `sh` on PATH. Portability is the author's
+# problem (§8.3) and this workflow declines it deliberately.
+#
+# Requires: `gh` authenticated with push access to this repository, `jq`, `git`,
+# `go`, and `awk`. `cosign` is optional — `verify` reports loudly when it is
+# missing rather than pretending the signature was checked.
+#
+# Known wart: this task's own branch is the changelog PR's branch, so the
+# worktree survives until you archive the task. Archive it after `report`.
+name: release
+description: Cut a tagged release — changelog PR, tag push, and post-release verification.
+
+defaults:
+  agent: claude
+  max_retries: 1
+  timeout: 30m
+  # No step here is allowed to stop and ask. The human checkpoints are the
+  # three manual steps; an agent parking the task mid-release just adds a
+  # fourth one nobody is watching for.
+  on_input: deny
+
+steps:
+  - id: preflight
+    name: Guard the release
+    type: command
+    shell: sh
+    timeout: 10m
+    # A bad version, a red master or an existing tag is not transient —
+    # re-running the same checks returns the same answer.
+    max_retries: 0
+    # This step exists so a typo'd version costs ten seconds instead of a merged
+    # changelog PR naming a release that cannot be cut, and so every later step
+    # reads the version from one file rather than re-parsing the title.
+    run: |
+      set -e
+      mkdir -p .vincent-release
+
+      raw=$(printf '%s' "$VINCENT_TASK_TITLE" | awk '{print $1}')
+      v="v${raw#v}"
+      if ! printf '%s\n' "$v" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+        echo "task title must start with the version to release (vX.Y.Z, or vX.Y.Z-rc1 for a pre-release); got: $raw" >&2
+        exit 1
+      fi
+      # goreleaser keys `prerelease: auto` off the hyphen, and `skip_upload:
+      # auto` skips the Homebrew cask push for one. Later steps need to know.
+      case "$v" in
+        *-*) pre=yes ;;
+        *)   pre=no ;;
+      esac
+
+      gh auth status >/dev/null 2>&1 || { echo "gh is not authenticated" >&2; exit 1; }
+
+      git fetch --quiet --tags origin "$VINCENT_BASE_BRANCH"
+      if git ls-remote --exit-code --tags origin "refs/tags/$v" >/dev/null 2>&1; then
+        echo "tag $v already exists on origin — a published tag is never re-pointed (RELEASING.md)" >&2
+        exit 1
+      fi
+
+      # The green-master check is needed twice: here, so a red branch stops the
+      # release before a changelog PR exists, and again in `verify-master` on
+      # the merge commit that actually gets tagged. Written once, to a file, so
+      # the two cannot drift.
+      cat > .vincent-release/require-green.sh <<'GREEN'
+      # Usage: sh require-green.sh <sha>. Fails unless every check run on the
+      # commit completed successfully, and both required matrices are there —
+      # a commit with *no* checks yet is green by the first rule alone, which
+      # is exactly the trap the count catches.
+      set -e
+      sha="$1"
+      runs=$(gh api "repos/{owner}/{repo}/commits/$sha/check-runs?per_page=100" \
+        --jq '.check_runs[] | [.name, .status, (.conclusion // "pending")] | @tsv')
+      printf '%s\n' "$runs"
+      # `NF &&` matters: with no check runs at all this filter must stay empty,
+      # so the failure comes from the count below with a message that names the
+      # missing matrix instead of printing a blank line.
+      bad=$(printf '%s\n' "$runs" | awk -F'\t' 'NF && ($2 != "completed" || ($3 != "success" && $3 != "skipped")) { print $1 " " $3 }')
+      if [ -n "$bad" ]; then
+        echo "not green on $sha:" >&2
+        printf '%s\n' "$bad" >&2
+        exit 1
+      fi
+      for job in ci gates; do
+        n=$(printf '%s\n' "$runs" | awk -F'\t' -v j="$job" 'index($1, j " (") == 1' | wc -l | tr -d ' ')
+        if [ "$n" -ne 3 ]; then
+          echo "expected 3 '$job' checks on $sha (ubuntu, macos, windows), found $n" >&2
+          exit 1
+        fi
+      done
+      GREEN
+      base_sha=$(git rev-parse "origin/$VINCENT_BASE_BRANCH")
+      sh .vincent-release/require-green.sh "$base_sha"
+
+      # An empty [Unreleased] section means there is nothing to name.
+      if ! awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | grep -q '[^[:space:]]'; then
+        echo "CHANGELOG.md has an empty [Unreleased] section — nothing to release" >&2
+        exit 1
+      fi
+
+      # Advisory only: the token running this may not be able to read secrets,
+      # and the cask push is the last thing the release job does. A warning
+      # here reaches the human at the `merge` gate; a hard failure would refuse
+      # to cut a release over a check that may simply be unavailable.
+      if [ "$pre" = no ]; then
+        if gh secret list >/dev/null 2>&1; then
+          if ! gh secret list | awk '{print $1}' | grep -qx HOMEBREW_TAP_TOKEN; then
+            echo "WARNING: HOMEBREW_TAP_TOKEN is not set on this repository — the Homebrew cask push will fail (RELEASING.md § Repository secrets)"
+          fi
+        else
+          echo "NOTE: cannot read repository secrets with this token; HOMEBREW_TAP_TOKEN unverified"
+        fi
+      fi
+
+      # RELEASING.md step 4: dry-run the build when the packaging changed since
+      # the last tag. Detected here, acted on by the human at `merge`.
+      last=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+      packaging=yes
+      if [ -n "$last" ] && [ -z "$(git diff --name-only "$last".."origin/$VINCENT_BASE_BRANCH" -- .goreleaser.yaml .github/workflows/release.yml)" ]; then
+        packaging=no
+      fi
+
+      printf '%s\n' "$v" > .vincent-release/version.txt
+      printf '%s\n' "$pre" > .vincent-release/prerelease.txt
+      printf '%s\n' "$packaging" > .vincent-release/dry-run-needed.txt
+      printf '%s\n' "$last" > .vincent-release/last-tag.txt
+
+      echo
+      echo "version:          $v"
+      echo "pre-release:      $pre (cask push skipped: $pre)"
+      echo "previous tag:     ${last:-none}"
+      echo "base branch:      $VINCENT_BASE_BRANCH @ $base_sha"
+      echo "goreleaser dry-run needed: $packaging"
+
+  - id: vuln
+    name: Vulnerability sweep
+    type: command
+    shell: sh
+    timeout: 15m
+    # RELEASING.md makes this conditional on "the last run predates a dependency
+    # change". Running it unconditionally costs a minute and removes the
+    # judgement call; a release is not the place to save a minute.
+    run: go run mage.go vuln
+
+  - id: changelog
+    name: Write the release changelog
+    type: agent
+    prompt: |
+      You are preparing the changelog commit for a release of this repository.
+      You are NOT tagging, publishing, or pushing anything.
+
+      The version being released is in `.vincent-release/version.txt`. Read it
+      first; call it `vX.Y.Z` below, and `X.Y.Z` where the leading `v` is
+      dropped. The previous tag is in `.vincent-release/last-tag.txt`.
+
+      Do this in order:
+
+      1. Read `CHANGELOG.md` in full, including its header and the
+         "Versioning and stability" section, so you write in its voice. Read
+         `RELEASING.md` step 3 — it specifies exactly this edit.
+
+      2. Read `git log --no-merges <previous tag>..HEAD` and the merge commits
+         alongside it. Compare what landed against what the `[Unreleased]`
+         section claims. Every user-visible change must be described there:
+         behaviour, flags, config keys, API routes, TUI bindings, block
+         reasons, platform differences. Add what is missing, in the file's
+         existing style — entries are prose paragraphs with a bold lead, not
+         one-line bullets, and they say what changed for a *user*, not which
+         function was edited. Do not invent an entry for something you cannot
+         find in the log, and do not describe internal refactors.
+
+      3. Make the release edit:
+
+         - Rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`, using an
+           em dash (—) exactly as the existing `## [0.1.0] — …` heading does,
+           and today's date from `date +%Y-%m-%d`.
+         - Insert a fresh, empty `## [Unreleased]` heading above it.
+         - Fix the two link definitions at the bottom of the file:
+
+           ```
+           [Unreleased]: https://github.com/lezli01/vincent/compare/vX.Y.Z...HEAD
+           [X.Y.Z]: https://github.com/lezli01/vincent/releases/tag/vX.Y.Z
+           ```
+
+           Keep the older versions' link definitions in place.
+
+      4. Commit **only** `CHANGELOG.md`:
+
+         ```
+         git add CHANGELOG.md
+         git commit -m "docs: changelog for vX.Y.Z"
+         ```
+
+      Do not run `git push`, `git tag`, `gh release`, or `gh pr`. Do not touch
+      any file outside `CHANGELOG.md` — in particular, leave `.vincent-release/`
+      alone; a later step reads it. Do not use `git add -A` or `git commit -a`.
+
+      Finish by printing the diff of your commit, so the reviewer sees the exact
+      text without opening the file.
+    # Proves the edit has the shape RELEASING.md step 3 specifies and that it is
+    # committed — an agent that described the change in prose without making it,
+    # or made it and left it in the working tree, fails here and retries with
+    # the failure block appended (§8.4).
+    check: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      n=${v#v}
+      grep -q "^## \[$n\] " CHANGELOG.md
+      grep -q "^## \[Unreleased\]$" CHANGELOG.md
+      grep -q "^\[$n\]: https://github.com/.*/releases/tag/$v$" CHANGELOG.md
+      grep -q "^\[Unreleased\]: https://github.com/.*/compare/$v\.\.\.HEAD$" CHANGELOG.md
+      git diff --quiet -- CHANGELOG.md
+      git diff --cached --quiet -- CHANGELOG.md
+      test -n "$(git log --oneline "origin/$VINCENT_BASE_BRANCH"..HEAD -- CHANGELOG.md)"
+    check_timeout: 2m
+
+  - id: pr
+    name: Open the changelog PR
+    type: command
+    shell: sh
+    timeout: 5m
+    # Load-bearing. A retried `gh pr create` opens a second pull request, and
+    # nothing distinguishes "the call failed" from "the call succeeded and the
+    # response was lost".
+    max_retries: 0
+    # `--head` is passed explicitly rather than letting gh infer it: inference
+    # from the current branch behaves differently inside a linked worktree.
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      git push -u origin {{.Task.BranchName}}
+      gh pr create \
+        --base {{.Task.BaseBranch}} \
+        --head {{.Task.BranchName}} \
+        --title "docs: changelog for $v" \
+        --body "Changelog for \`$v\`, prepared by vincent task #{{.Task.ID}}.
+
+      This is the last commit before the tag — merge it with a **merge commit**
+      (no squash), so the tag points at a changelog that describes the release
+      it names. \`$v\` is pushed only after this lands and CI is green on
+      \`{{.Task.BaseBranch}}\`." \
+        > .vincent-release/pr-url.txt
+      cat .vincent-release/pr-url.txt
+
+  - id: merge
+    name: Merge the changelog PR
+    type: manual
+    instructions: |
+      Review and merge the changelog PR for task #{{.Task.ID}}, then wait for
+      CI to go green on {{.Task.BaseBranch}}.
+
+      PR: {{(index .Steps "pr").Result}}
+
+      1. Read the changelog entry. It is the human summary of the release —
+         the generated commit list on the GitHub release is the exhaustive
+         index, this is not.
+      2. Merge with a **merge commit**, not a squash (CLAUDE.md § Git flow).
+      3. If the preflight below says `goreleaser dry-run needed: yes`, run it
+         now: Actions → **Release** → *Run workflow*, `dry_run` checked. Download
+         the `dist` artifact and look at it (RELEASING.md step 4).
+      4. Wait for all six checks on {{.Task.BaseBranch}}. The next step
+         re-checks them and refuses to continue otherwise, so approving early
+         only fails that step.
+
+      Preflight said:
+
+      {{(index .Steps "preflight").Result}}
+
+      Approve once the PR is merged. Reject if the changelog is wrong — the
+      release has not started yet, and nothing is published until the gate two
+      steps from here.
+
+  - id: verify-master
+    name: Verify the commit to tag
+    type: command
+    shell: sh
+    timeout: 10m
+    # No retry: every failure here means "the world is not ready yet" (PR not
+    # merged, CI still running), and there is no delay between attempts, so a
+    # retry just fails a second time a second later. Re-run the step by hand
+    # once the branch is actually green.
+    max_retries: 0
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      n=${v#v}
+      git fetch --quiet --tags origin "$VINCENT_BASE_BRANCH"
+
+      if ! git merge-base --is-ancestor HEAD "origin/$VINCENT_BASE_BRANCH"; then
+        echo "this task's changelog commit is not on $VINCENT_BASE_BRANCH yet — merge the PR first" >&2
+        exit 1
+      fi
+      if ! git show "origin/$VINCENT_BASE_BRANCH:CHANGELOG.md" | grep -q "^## \[$n\] "; then
+        echo "CHANGELOG.md on $VINCENT_BASE_BRANCH has no '## [$n]' heading" >&2
+        exit 1
+      fi
+      if git ls-remote --exit-code --tags origin "refs/tags/$v" >/dev/null 2>&1; then
+        echo "tag $v appeared on origin while this task was running — stop and work out who pushed it" >&2
+        exit 1
+      fi
+
+      sha=$(git rev-parse "origin/$VINCENT_BASE_BRANCH")
+      sh .vincent-release/require-green.sh "$sha"
+      printf '%s\n' "$sha" > .vincent-release/target-sha.txt
+
+      echo
+      echo "$v will tag:"
+      git log -1 --format='%H %s (%an, %ad)' --date=short "$sha"
+
+  - id: gate
+    name: Approve the tag push
+    type: manual
+    instructions: |
+      Final checkpoint for {{.Task.Title}}. **The next step is irreversible.**
+
+      It pushes the tag, which starts the Release workflow: cross-compilation,
+      cosign signing, build provenance, the published GitHub release, and the
+      Homebrew cask. Go module proxies cache tags aggressively, so a tag pushed
+      by mistake cannot be cleanly withdrawn — the recovery is to ship the next
+      patch, not to re-point the tag (RELEASING.md § If a release goes wrong).
+
+      Verified just now:
+
+      {{(index .Steps "verify-master").Result}}
+
+      Check the version number one more time against
+      CHANGELOG.md § Versioning and stability — while vincent is 0.x, a
+      breaking change is a minor bump, not a major one.
+
+      Approve to publish. Reject to stop; nothing has been released yet, and
+      the changelog commit on {{.Task.BaseBranch}} is harmless on its own.
+
+  - id: tag
+    name: Push the tag
+    type: command
+    shell: sh
+    timeout: 5m
+    # max_retries: 0 is not negotiable — this is the publishing step.
+    max_retries: 0
+    # Re-running by hand after a failed push is safe: an existing local tag is
+    # accepted only when it already points at the commit we verified.
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      sha=$(cat .vincent-release/target-sha.txt)
+      if git rev-parse -q --verify "refs/tags/$v" >/dev/null; then
+        existing=$(git rev-parse "refs/tags/$v^{}")
+        if [ "$existing" != "$sha" ]; then
+          echo "local tag $v points at $existing, not the verified $sha" >&2
+          exit 1
+        fi
+      else
+        git tag -a "$v" "$sha" -m "$v"
+      fi
+      git push origin "refs/tags/$v"
+      echo "pushed $v -> $sha"
+
+  - id: watch
+    name: Watch the release run
+    type: command
+    shell: sh
+    # The run cross-compiles six archives, signs, attests, publishes, and then
+    # smoke-tests the published archive on three OSes.
+    timeout: 90m
+    # Watching is idempotent, so one retry is free; a second watch of a failed
+    # run just fails again immediately.
+    max_retries: 1
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      # A tag push reports the tag as headBranch. The run takes a few seconds
+      # to appear, so poll for up to five minutes before giving up.
+      id=""
+      i=0
+      while [ "$i" -lt 20 ]; do
+        id=$(gh run list --workflow=release.yml --event=push --limit 30 \
+          --json databaseId,headBranch \
+          --jq "[.[] | select(.headBranch == \"$v\")][0].databaseId // empty")
+        if [ -n "$id" ]; then break; fi
+        i=$((i + 1))
+        sleep 15
+      done
+      if [ -z "$id" ]; then
+        echo "no Release run found for $v — check Actions" >&2
+        exit 1
+      fi
+      gh run watch "$id" --exit-status
+
+  - id: verify
+    name: Verify the published artifacts
+    type: command
+    shell: sh
+    timeout: 20m
+    # RELEASING.md step 7, as a user would run it: against the published
+    # archives, not against anything this machine built.
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+      rm -rf .vincent-release/dist
+      mkdir -p .vincent-release/dist
+      gh release download "$v" --dir .vincent-release/dist
+      cd .vincent-release/dist
+
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum -c checksums.txt
+      elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 -c checksums.txt
+      else
+        echo "no sha256 tool found (sha256sum or shasum)" >&2
+        exit 1
+      fi
+
+      # cosign is optional on a maintainer's machine, so its absence is
+      # reported rather than failed — but loudly, because a skipped signature
+      # check is not a passed one.
+      if command -v cosign >/dev/null 2>&1; then
+        cosign verify-blob checksums.txt \
+          --certificate checksums.txt.pem \
+          --signature checksums.txt.sig \
+          --certificate-identity-regexp "https://github.com/$repo/.*" \
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      else
+        echo "SKIPPED: cosign is not installed — the signature over checksums.txt was NOT verified"
+      fi
+
+      for a in *.tar.gz *.zip; do
+        # An unmatched glob arrives as its own pattern in sh.
+        [ -e "$a" ] || continue
+        gh attestation verify "$a" --repo "$repo"
+      done
+
+  - id: finish
+    name: Check the cask and the notes
+    type: manual
+    instructions: |
+      Last human pass over {{.Task.Title}} (RELEASING.md steps 8 and 9).
+
+      1. **Read the published release notes.** They are generated from the
+         commits since the last tag, with `docs:`, `test:`, `ci:`, `chore:` and
+         merge commits filtered out. A user-visible change that landed under a
+         filtered type is missing from them — fix it by hand in the notes.
+
+      2. **Check the Homebrew cask** — macOS only, and skipped entirely for a
+         pre-release, which does not publish one:
+
+         ```sh
+         git -C "$(brew --repo lezli01/tap)" pull
+         brew info lezli01/tap/vincent               # version must be the tag
+         brew reinstall lezli01/tap/vincent
+         vincent version
+         xattr -l "$(readlink -f "$(brew --prefix)/bin/vincent")"
+         ```
+
+         `com.apple.provenance` is expected; `com.apple.quarantine` is not, and
+         means the cask's `postflight` hook did not run.
+
+      Approve when both are right. Reject if the release is defective — it is
+      published, so treat that as an incident and follow RELEASING.md
+      § If a release goes wrong. Never re-point the tag.
+
+  - id: report
+    name: Report the release
+    type: command
+    shell: sh
+    timeout: 5m
+    # stdout becomes this step's Result and lands in the transcript, which is
+    # where you read it. Clearing `.vincent-release/` afterwards leaves the
+    # worktree clean, so archiving the task does not warn about a dirty tree.
+    run: |
+      set -e
+      v=$(cat .vincent-release/version.txt)
+      gh release view "$v" --json tagName,isPrerelease,url \
+        --jq '"released " + .tagName + " (prerelease: " + (.isPrerelease | tostring) + ")\n" + .url'
+      rm -rf .vincent-release
+      echo
+      echo "worktree status (expect empty):"
+      git status --porcelain


### PR DESCRIPTION
## Summary

Two project workflows for this repository, alongside the existing
`github-issue` / `github-enhancement` pair in `.vincent/workflows/`.

**`github-bug`** — picks up a labeled `bug` issue, reproduces it, fixes it,
opens the PR. Shape: `fetch` → `diagnose` → `triage` → `confirm-red` → `fix` →
`verify` → `gate` → `publish` → `report`.

What distinguishes it from its enhancement sibling is `confirm-red`. An
enhancement is judged by whether the new behavior works; a bug fix is judged by
whether the old behavior is gone, and the only honest evidence of that is a test
that failed before the fix and passes after it. So `diagnose` writes the
regression test first and touches no production code, `confirm-red` runs it
against the unfixed code and **fails the task if it passes**, and `fix`'s check
re-runs that same frozen command expecting success. The command is frozen into
`green.sh` while the bug is still present so the fix step cannot move its own
goalposts. The escape hatch (`none: <reason>` for a bug no test can capture)
exists but is loud — it is printed by `confirm-red` and put in front of the
human at the gate.

`diagnose` is split from `fix` because it runs `on_input: wait`: if the fix
shared that step, every retry after a failed check would re-ask the author the
same questions. `defaults.on_input: deny` makes the asymmetry explicit.

**`release`** — cuts a tagged release, following `RELEASING.md` step for step.
Shape: `preflight` → `vuln` → `changelog` → `pr` → `merge` (human) →
`verify-master` → `gate` (human) → `tag` → `watch` → `verify` → `finish`
(human) → `report`.

The tag push is a one-way door: module proxies cache tags, and a moved tag
invalidates every checksum, signature and attestation a user already verified.
So `pr` and `tag` pin `max_retries: 0`, and `tag` sits directly behind a manual
gate that prints the exact commit it is about to name. Nothing after `tag` does
work — the release is built, signed, attested and published by
`.github/workflows/release.yml`, and this workflow never builds an artifact,
which is the property `RELEASING.md` exists to protect. The version number is
not decided here either; it comes from the task title, from a human who read
the versioning policy.

Both are claude-only by construction — `on_input` is ignored by codex and cursor
(§9.3/§9.7), so `diagnose` would silently guess at the repro instead of asking.
Both are POSIX-only: every command step pins `shell: sh`, and on Windows they
need Git Bash's `sh` on PATH. Portability is the author's problem (§8.3) and
both decline it deliberately.

`vincent workflow validate` passes on both (9 and 12 steps, 0 warnings).

## Related

None — repo-local workflow files, no task ID.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — n/a, no code change; both files pass `vincent workflow validate`
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — n/a, these are this repo's own workflow files, not shipped behavior
- [x] Affected page under `docs/` updated — n/a, `.vincent/workflows/` is not documented under `docs/` (neither sibling is); the rationale lives in each file's header comment