### PR TITLE
chore: pin go toolchain to go1.26.6 and automate patch bumps

### DIFF
--- a/.github/workflows/go-toolchain.yml
+++ b/.github/workflows/go-toolchain.yml
@@ -1,0 +1,129 @@
+name: Go toolchain
+
+# The single most common way the Vulnerabilities workflow goes red is a stdlib
+# advisory that is already fixed in a Go patch release we have not adopted:
+# nothing in vincent changes, only the toolchain underneath it. Since go.mod
+# pins that toolchain exactly (004.1), adopting the patch is a one-line diff —
+# this job writes it, proves it, and opens the pull request.
+#
+# Patch releases only. The candidate is constrained to the minor series named by
+# the `go` directive, which this job never touches: a 1.26 → 1.27 move is a
+# language-version change with its own review, not something a schedule opens.
+on:
+  # Mondays, an hour ahead of the 06:17 vuln sweep, so the bump pull request is
+  # already sitting next to the failure it explains.
+  schedule:
+    - cron: "23 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # push the bump branch
+      pull-requests: write # open the pull request
+    steps:
+      - uses: actions/checkout@v7
+        # Unlike every other workflow here, this one pushes, so the token has to
+        # stay in the local git config for `git push` to authenticate.
+        with:
+          persist-credentials: true
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # go.dev/dl is the release list itself, not a mirror of it. `include=all`
+      # keeps older minors visible after a new one ships; the `stable` filter
+      # drops release candidates. Versions sort with `sort -V` because 1.26.0
+      # is published as plain "go1.26" and would otherwise outrank "go1.26.10".
+      - id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          minor=$(go mod edit -json | jq -r '.Go')
+          current=$(go mod edit -json | jq -r '.Toolchain // empty')
+          latest=go$(curl -fsSL 'https://go.dev/dl/?mode=json&include=all' \
+            | jq -r --arg m "go${minor}" \
+                '.[] | select(.stable) | .version | select(. == $m or startswith($m + "."))' \
+            | sed 's/^go//' | sort -V | tail -1)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          if [ "$current" = "$latest" ]; then
+            echo "toolchain $current is the newest $minor patch; nothing to do"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "toolchain $current -> $latest"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # No second setup-go: with the directive rewritten, GOTOOLCHAIN=auto makes
+      # the go command fetch and re-exec the pinned toolchain by itself. That is
+      # exactly what a developer hits locally after pulling the merged PR, so
+      # this job proves the path they will actually take.
+      - if: steps.resolve.outputs.changed == 'true'
+        shell: bash
+        run: go mod edit -toolchain=${{ steps.resolve.outputs.latest }}
+
+      # Gate the PR on build and test. A bump that does not compile or does not
+      # pass is not worth a reviewer's attention.
+      - if: steps.resolve.outputs.changed == 'true'
+        run: go run mage.go build
+
+      - if: steps.resolve.outputs.changed == 'true'
+        run: go run mage.go test
+
+      # govulncheck is reported, not gated: an advisory with no patch released
+      # yet fails here and the bump is still worth landing — it is a decision
+      # for the reviewer, which is why the outcome goes into the PR body.
+      - id: vuln
+        if: steps.resolve.outputs.changed == 'true'
+        continue-on-error: true
+        run: go run mage.go vuln
+
+      - if: steps.resolve.outputs.changed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT: ${{ steps.resolve.outputs.current }}
+          LATEST: ${{ steps.resolve.outputs.latest }}
+          VULN: ${{ steps.vuln.outcome }}
+        run: |
+          set -euo pipefail
+          branch="chore/go-toolchain-${LATEST#go}"
+          if [ -n "$(gh pr list --head "$branch" --state open --json number -q '.[].number')" ]; then
+            echo "a pull request for $branch is already open"
+            exit 0
+          fi
+          case "$VULN" in
+            success) vuln_line='✅ `go run mage.go vuln` is clean on linux, darwin and windows.' ;;
+            *)       vuln_line="⚠️ \`go run mage.go vuln\` still reports findings on ${LATEST} — read this job's log before merging." ;;
+          esac
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # printf rather than a heredoc: the terminator of an indented heredoc
+          # would have to sit at column 0, which YAML's block scalar forbids.
+          printf '%s\n\n' \
+            "Adopts the newest patch release in the \`go\` directive's minor series." \
+            "\`toolchain ${CURRENT}\` → \`toolchain ${LATEST}\`" \
+            "${vuln_line}" \
+            "\`go run mage.go build\` and \`go run mage.go test\` passed on \`ubuntu-latest\` in [the job that opened this pull request](${run_url})." \
+            "> A pull request opened with \`GITHUB_TOKEN\` does not trigger workflow runs. To get CI and the gates on all three platforms, close and reopen this pull request, or push an empty commit to the branch." \
+            > /tmp/pr-body.md
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git commit -am "chore: bump go toolchain to ${LATEST}"
+          # The branch belongs to this job alone, so a leftover from a closed PR
+          # is overwritten rather than reconciled.
+          git push -f -u origin "$branch"
+          gh pr create \
+            --title "chore: bump go toolchain to ${LATEST}" \
+            --body-file /tmp/pr-body.md

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ Full documentation lives in **[docs/](docs/README.md)**.
 ## Build & Test
 
 vincent is a single Go module; Go 1.26 or newer is the only prerequisite.
+`go.mod` pins an exact patch toolchain that the default `GOTOOLCHAIN=auto`
+fetches on the first build ([004](docs/tasks/004-go-toolchain-pin.md)).
 Build targets run via [mage](https://magefile.org/) with zero install — CI
 runs exactly these targets (list them all with `go run mage.go -l`):
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -184,8 +184,10 @@ Then go run something: [Quickstart](quickstart.md).
 
 ## Build from source
 
-Go 1.26 or newer is the only prerequisite. Build targets run through
-[mage](https://magefile.org/) with zero install:
+Go 1.26 or newer is the only prerequisite. `go.mod` also pins an exact patch
+toolchain, which the default `GOTOOLCHAIN=auto` downloads on the first build;
+`GOTOOLCHAIN=local` builds with the Go you already have instead. Build targets
+run through [mage](https://magefile.org/) with zero install:
 
 ```sh
 git clone https://github.com/lezli01/vincent

--- a/docs/tasks/004-go-toolchain-pin.md
+++ b/docs/tasks/004-go-toolchain-pin.md
@@ -1,0 +1,139 @@
+# 004 — Pin the Go toolchain and automate its patch bumps
+
+**Status:** ✅ done (3/3) · **Opened:** 2026-08-15
+
+`go.mod` names an exact patch toolchain, and a scheduled workflow opens the pull
+request that moves it. The Vulnerabilities workflow's most common failure needs
+no vincent code change — only a Go patch release we had no mechanism to adopt.
+
+## The problem
+
+Eight consecutive runs of `.github/workflows/vuln.yml` failed on `master` with
+five reachable findings, every one of them in the standard library and every one
+of them `Fixed in: …@go1.26.6`:
+
+| Advisory | Package | Reached from |
+|---|---|---|
+| GO-2026-6218 | `net/url` | `apiclient.Client.Diff` → `http.Client.Do` |
+| GO-2026-6090 | `crypto/tls` | `api.Server.Serve` → `http.Server.Serve` |
+| GO-2026-6089 | `net/http` | `api.Server.Serve` |
+| GO-2026-5972 | `encoding/asn1` | `claude.run.Wait` |
+| GO-2026-5026 | `net/http` (x/net/idna) | `apiclient.Client.Diff` |
+
+The runner was on go1.26.5. `go.mod` said `go 1.26` with no patch, and
+`actions/setup-go` defaults to `check-latest: false` — its log reads
+`Setup go version spec 1.26` then `Found in cache @ /opt/hostedtoolcache/go/1.26.5/x64`.
+A version spec with no patch is satisfied by whatever patch the runner image
+already carries, so a released fix is adopted only when GitHub rebuilds the
+image. go1.26.6 had been stable and present in the setup-go manifest for days.
+
+The scoreboard was the smaller half of this. `release.yml` sets Go up the same
+way, so the signed, attested binaries vincent publishes were being linked
+against a standard library with five known holes in the code paths the daemon
+actually runs — its HTTP server and its API client.
+
+## Decisions
+
+### 1. An exact `toolchain` directive, not `check-latest: true`
+
+*2026-08-15.* `go.mod` gains `toolchain go1.26.6`. `actions/setup-go@v7` reads
+the `toolchain` directive when one is present and falls back to `go` otherwise,
+so every workflow already passing `go-version-file: go.mod` picks it up with no
+edit, and `GOTOOLCHAIN=auto` makes a developer's local `go run mage.go vuln`
+resolve the same toolchain the runners use.
+
+**Beat:** `check-latest: true` on the setup-go steps. It is one line shorter and
+strictly worse: it fixes only what runs on a runner, leaves a local govulncheck
+reporting five findings CI does not see, and — because `release.yml` would also
+follow "latest" — makes the toolchain a published binary was built with a
+property of the day it was built rather than of the commit it was built from.
+That is the opposite of what the attestation in `release.yml` exists to promise.
+
+The `go` directive stays at `1.26`. It states the language version vincent
+requires; the toolchain states what builds it. Conflating them would make every
+patch bump a claim about the minimum Go a consumer needs.
+
+### 2. This supersedes the v0 "bumped manually each Go release" decision
+
+*2026-08-15.* `docs/history/v0-tasks.md` records: "*Go version:* latest stable
+minor, minor-only directive (`go 1.26`); CI reads `go-version-file: go.mod`;
+bumped manually each Go release." Half of that stands — latest stable minor,
+`go-version-file: go.mod`, no version matrix. The other half is amended here,
+explicitly rather than by drift: the directive is no longer minor-only, and the
+bump is no longer manual.
+
+What changed since v0 is that a scheduled govulncheck now exists. Manual bumps
+were adequate when nothing failed in between; with a weekly sweep, "we adopt
+patches when someone notices" is a workflow that goes red for days at a time
+over a fix that shipped upstream and has a one-line diff. The v0 ledger is
+frozen and is not edited — this document is where the amendment lives.
+
+### 3. The bump is an in-repo scheduled workflow, not a bot
+
+*2026-08-15.* `.github/workflows/go-toolchain.yml` resolves the newest stable
+patch in the `go` directive's minor series from `go.dev/dl`, rewrites the
+directive with `go mod edit -toolchain=`, and opens the pull request.
+
+**Beat:** Dependabot, which cannot do it — `gomod` updates module requirements
+only, and `dependabot-core#13520`, "Bump Go toolchain directive in go.mod
+files", is still open. The existing `gomod` entry in `.github/dependabot.yml`
+remains the right tool for the three non-reachable findings in required modules
+that the same scan reported; it is simply not a tool that can touch this.
+
+**Beat:** Renovate, which *can* — its `gomod` manager updates `go` and
+`toolchain` via the `golang-version` datasource. It would mean a second update
+bot, an app installation, and a config file, to own one line of one file that a
+thirty-line workflow already owns. If Renovate is ever adopted for other
+reasons, this workflow should be deleted in favour of it.
+
+### 4. Patch releases only, gated on build and test, reporting govulncheck
+
+*2026-08-15.* The candidate is constrained to the minor series named by the `go`
+directive, which the job never edits: 1.26 → 1.27 changes the language version
+and the minimum Go a consumer needs, and belongs to a human. Within a series,
+`go run mage.go build` and `go run mage.go test` gate the pull request — a bump
+that does not compile is not worth a reviewer.
+
+`go run mage.go vuln` runs `continue-on-error` and its outcome goes into the
+pull request body instead of gating. An advisory whose fix has not been released
+yet fails that step, and the bump is still worth landing; whether to merge it
+anyway is exactly the judgement the body is written to inform.
+
+### 5. The pull request does not trigger CI, and says so
+
+*2026-08-15.* GitHub does not run workflows for a pull request opened with
+`GITHUB_TOKEN`, so this one arrives with no checks. Rather than add a PAT secret
+— a token with write scope, held for a cosmetic gain — the job runs build, test
+and the govulncheck sweep itself before opening the pull request, links its own
+run, and tells the reviewer to close-and-reopen or push an empty commit to get
+the full three-platform matrix. The evidence is present either way; only its
+placement differs.
+
+## Tasks
+
+- [x] **004.1** — `toolchain go1.26.6` in `go.mod`. ✓ 2026-08-15
+- [x] **004.2** — `.github/workflows/go-toolchain.yml`: weekly patch resolution,
+      `go mod edit`, build/test gate, govulncheck report, pull request. ✓ 2026-08-15
+- [x] **004.3** — The build-from-source prerequisite in `README.md` and
+      `docs/getting-started/installation.md` states the pin. ✓ 2026-08-15
+
+## Out of scope
+
+- **Minor-version upgrades** (1.26 → 1.27). Decision 4; still manual, still a
+  judgement about the language version vincent requires.
+- **Suppressing advisories.** govulncheck has no allowlist file; filtering would
+  mean parsing `-json` in the `Vuln` mage target and carrying OSV IDs in-repo.
+  Nothing yet needs it, and a suppression that outlives its reason is worse than
+  a red workflow.
+- **The three non-reachable module findings** the same scan reported. Dependabot's
+  weekly `gomod` pass owns those.
+
+## Verification
+
+- `go run mage.go vuln` on go1.26.6, all three GOOS values: "No vulnerabilities
+  found." (2026-08-15, macOS host; the same sweep on go1.26.5 reported the five
+  findings in the table above.)
+- `actionlint` clean on `.github/workflows/go-toolchain.yml`.
+- The resolve step's `go.dev/dl` query, run against the live release list, picks
+  `go1.26.6` for `go 1.26` and reports `changed=false` against the new pin — the
+  no-op path a Monday with no new patch takes.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ description of how the system actually behaves.
 | [001](001-configurable-branch-names.md) | Configurable branch names | ✅ done (11/11) |
 | [002](002-homebrew-tap.md) | Homebrew tap for macOS | ✅ done (6/6) |
 | [003](003-usage-limit-classification.md) | Classify agent usage limits and auth expiry | ✅ done (7/7) |
+| [004](004-go-toolchain-pin.md) | Pin the Go toolchain and automate its patch bumps | ✅ done (3/3) |
 
 ## How to add and update a task document
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/lezli01/vincent
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8


### PR DESCRIPTION
The Vulnerabilities workflow has failed eight consecutive runs on `master` with
five reachable findings, every one in the standard library and every one
`Fixed in: …@go1.26.6`:

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-6218 | `net/url` | `apiclient.Client.Diff` → `http.Client.Do` |
| GO-2026-6090 | `crypto/tls` | `api.Server.Serve` → `http.Server.Serve` |
| GO-2026-6089 | `net/http` | `api.Server.Serve` |
| GO-2026-5972 | `encoding/asn1` | `claude.run.Wait` |
| GO-2026-5026 | `net/http` (x/net/idna) | `apiclient.Client.Diff` |

No vincent code is implicated. The runner was on go1.26.5: `go.mod` said
`go 1.26` with no patch, and `actions/setup-go` defaults to
`check-latest: false`, so its log reads `Setup go version spec 1.26` then
`Found in cache @ /opt/hostedtoolcache/go/1.26.5/x64`. A patch-less spec is
satisfied by whatever the runner image already carries, so a released fix lands
only when GitHub rebuilds the image. go1.26.6 had been stable, and in the
setup-go manifest, for days.

The scoreboard is the smaller half. `release.yml` sets Go up the same way, so
the signed and attested binaries were being linked against a standard library
with five known holes in the paths the daemon actually runs — its HTTP server
and its API client.

## What this does

- **`go.mod` gains `toolchain go1.26.6`.** setup-go v7 reads the `toolchain`
  directive when present, so all four workflows pick it up with no edit, and
  `GOTOOLCHAIN=auto` resolves the same toolchain for a local
  `go run mage.go vuln`. The `go` directive stays at `1.26` — it states the
  language version vincent requires, not what builds it.
- **`.github/workflows/go-toolchain.yml` keeps it fresh.** Weekly (Mondays, an
  hour ahead of the vuln sweep) plus `workflow_dispatch`: it resolves the newest
  stable patch in the `go` directive's minor series from `go.dev/dl`, rewrites
  the directive with `go mod edit -toolchain=`, gates on `build` and `test`,
  reports the govulncheck sweep in the pull request body rather than gating on
  it, and opens the pull request.

Dependabot cannot bump the directive — `gomod` updates module requirements only,
and `dependabot-core#13520` is still open. Renovate could, at the cost of a
second update bot for one line of one file. Rationale for both, plus the
rejected `check-latest: true` alternative, is in
[004](docs/tasks/004-go-toolchain-pin.md).

This amends the v0 decision "*Go version:* latest stable minor, minor-only
directive (`go 1.26`) … bumped manually each Go release". Latest stable minor,
`go-version-file: go.mod` and no version matrix all stand; the minor-only
directive and the manual bump do not. The v0 ledger is frozen and unedited — the
amendment lives in 004, decision 2.

## Verification

- `go run mage.go vuln` on go1.26.6, all three GOOS values: **No vulnerabilities
  found.** The same sweep on go1.26.5 reports the five findings above.
- `go run mage.go build` and `go run mage.go test` pass.
- `go tool golangci-lint run ./...` — 0 issues for `GOOS=windows`, `darwin` and
  `linux`.
- `actionlint` clean on every workflow.
- The new job's resolve step, run against the live release list, picks
  `go1.26.6` for `go 1.26` and reports `changed=false` against the new pin — the
  no-op path a Monday with no new patch takes.

## One thing to know

GitHub does not run workflows for a pull request opened with `GITHUB_TOKEN`, so
the bump pull requests will arrive with no checks. Rather than hold a PAT with
write scope for a cosmetic gain, the job runs build, test and the govulncheck
sweep itself before opening, links its own run, and tells the reviewer to
close-and-reopen or push an empty commit for the full three-platform matrix.

Closes 004.1, 004.2, 004.3.
