### PR TITLE
feat: reclaim orphaned worktrees with `vincent gc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ type — that is the exhaustive index; this is the human summary.
 
 ## [Unreleased]
 
+### Added
+
+- **`vincent gc` reclaims directories no task claims.** A worktree could outlive
+  every reference to it: deleting a project removes worktrees best-effort and
+  drops the task rows regardless, so a removal that failed — a file locked by
+  another process, a shell sitting in the directory — left a directory nothing
+  could ever name again. A crash between creating a worktree and recording its
+  path did the same, and made the task's next admission fail
+  `worktree_path_occupied` pointing at a directory the user had never been told
+  about.
+
+  `vincent gc` lists those directories with their sizes and removes them.
+  `--dry-run` prints the identical report and removes nothing. A worktree with
+  local changes (untracked files count) is skipped as `worktree_dirty`; one whose
+  repository is gone, so `git status` cannot run at all, is skipped as
+  `dirty_unknown` — the common case for a real orphan — and `--force` removes
+  both. Orphaned transcript directories are reclaimed too, since retention walks
+  task *rows* and a cascade-deleted row's transcripts are reached by no pass.
+  Nothing outside `{data_dir}/worktrees` and `{data_dir}/transcripts` is ever
+  removed, no branch is ever deleted, and no task row is modified.
+
+  New endpoints `GET /v1/maintenance/orphans` and `POST /v1/maintenance/gc`, and
+  `orphans` on `GET /v1/info`.
+
+- **The daemon reports orphans at startup and never deletes them.** One warning
+  per directory in the log, plus the count on `/v1/info` and a line in the TUI
+  daemon view naming `vincent gc`. The unattended path reports; a human deletes.
+
 ## [0.1.1] — 2026-08-15
 
 ### Added

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -171,6 +171,14 @@ A related failure is a **ref hierarchy conflict**: `feat/foo` cannot be created
 while `feat/foo/bar` exists, because git stores refs as a path hierarchy. The
 message names the branch that is in the way.
 
+`worktree_path_occupied` has a second cause with a different fix: a crash between
+creating the worktree and recording its path leaves the directory on disk while
+the task claims nothing, so every later admission finds it occupied. Run
+[`vincent gc`](../reference/cli.md#vincent-gc) — it reclaims exactly the
+directories no task claims — then retry the task. `vincent gc --dry-run` shows
+you the path first, and `--force` is needed when git cannot judge the directory
+because the repository behind it is gone.
+
 ### `base_branch_missing` / `project_path_missing`
 
 The base branch was deleted, or the repository moved. Re-point the project

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -225,6 +225,12 @@ Version, uptime, the config in effect, the adapters detected, and a live tail of
 the daemon log. The view reports, it does not act — `vincent daemon stop` owns
 stopping the daemon, and a TUI that auto-started one has no business killing it.
 
+An **orphans** line appears in the identity block when the daemon has found
+directories under its data dir that no task claims, naming the count and
+`vincent gc`. It is a pointer, not a button: for the same reason this view does
+not stop the daemon, it does not delete anything either. Nothing shows when the
+count is zero.
+
 | Key | Does |
 |---|---|
 | `R` | Re-read the daemon info, the config and the log |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -51,10 +51,12 @@ parse out of prose — an invalid state transition is always `409` with
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/v1/health` | Liveness → `{ status, version }`. **Unauthenticated** |
-| `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect |
+| `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, and `orphans` |
 | `GET` | `/v1/config` | The effective global config, read-only |
 | `GET` | `/v1/agents` | Per-adapter availability plus model/effort options. `?refresh=true` forces a re-probe |
 | `POST` | `/v1/daemon/stop` | Graceful shutdown → `202`, then the daemon exits |
+| `GET` | `/v1/maintenance/orphans` | Directories under the data dir no task claims, with sizes. Removes nothing |
+| `POST` | `/v1/maintenance/gc` | `{ force?, dry_run? }` — reclaims them. Same body shape as the list |
 
 `GET /v1/agents` is the option catalog the TUI's pickers render:
 
@@ -75,6 +77,35 @@ construction. `logged_in` is `null` where the adapter has no cheap
 authentication probe (claude, codex) and a definite boolean where it does
 (cursor) — because an installed-but-unauthenticated CLI probes as healthy and
 then fails every run.
+
+`orphans` on `GET /v1/info` counts directories under `{data_dir}/worktrees` and
+`{data_dir}/transcripts` that no task row claims. It is computed per request from
+a readdir and one id query — no size walk, no git — so it is cheap and drops the
+moment `gc` runs. It is deliberately **not** on `/v1/health`, which stays
+`{ status, version }` and is the one unauthenticated endpoint.
+
+The two maintenance endpoints share one body, so a dry run and a real run are
+compared field by field:
+
+```json
+{ "orphans": [ { "path": "/home/u/.local/share/vincent/worktrees/41",
+                 "kind": "worktree", "task_id": 41, "bytes": 13010000,
+                 "skip_reason": "dirty_unknown", "removed": false } ],
+  "mismatches": [ { "task_id": 58, "path": "…/worktrees/58", "state": "blocked" } ],
+  "bytes": 13010000, "reclaimed": 0, "reclaimed_bytes": 0,
+  "dry_run": false, "force": false }
+```
+
+`kind` is `worktree` or `transcript`. `task_id` is `null` when the directory's
+name is not an id — the claim decides, not the name. `skip_reason` is why gc
+declined (`worktree_dirty`, `dirty_unknown`, `not_a_directory`); `error` is a
+removal that was attempted and failed, and the run continues past it, so
+`reclaimed` and `reclaimed_bytes` count only what actually went. `mismatches[]`
+is the reverse case — rows whose `worktree_path` points at a directory that is
+gone — reported only; gc modifies no row and deletes nothing outside the two data
+roots.
+
+See [`vincent gc`](cli.md#vincent-gc) for the command over these endpoints.
 
 ## Projects
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,7 @@ localhost API.
 - [`vincent project`](#vincent-project)
 - [`vincent task`](#vincent-task)
 - [`vincent workflow`](#vincent-workflow)
+- [`vincent gc`](#vincent-gc)
 
 ---
 
@@ -245,6 +246,53 @@ a CI job.
 
 Exit `0` valid, `1` invalid. Warnings (a model in no catalog) print but do not
 fail the command.
+
+## `vincent gc`
+
+```sh
+vincent gc [--dry-run] [--force] [--json]
+```
+
+Reclaims directories under the data dir that **no task claims**. Two things
+produce one: deleting a project whose worktree removal failed (the task rows go
+regardless, so nothing can name the directory again), and a crash between
+creating a worktree and recording its path.
+
+```
+KIND       PATH                                  SIZE     STATUS
+worktree   ~/.local/share/vincent/worktrees/41   12.4MB   removed
+worktree   ~/.local/share/vincent/worktrees/58   3.1MB    skipped: dirty_unknown
+transcript ~/.local/share/vincent/transcripts/41 88.2KB   removed
+reclaimed 2 of 3 orphan(s), 12.5MB freed
+```
+
+| Flag | Effect |
+|---|---|
+| `--dry-run` | Prints the identical report and removes nothing |
+| `--force` | Also removes worktrees that are dirty or that git cannot judge |
+| `--json` | The raw report, including per-entry `skip_reason` and `error` |
+
+**Skip reasons.** A worktree with local changes — untracked files included, the
+same rule `git worktree remove` uses — is `worktree_dirty`. One whose repository
+has been deleted, or in which `git worktree prune` has run, is `dirty_unknown`:
+`git status` fails there, so nobody can say what is inside. That is the *common*
+case for a real orphan, so expect a plain `vincent gc` to skip most of what it
+lists and to need `--force` once you have looked at the paths. A file sitting
+directly under a data root is `not_a_directory` and is never removed.
+
+**What it never does.** It never deletes a branch, never touches a directory any
+task row claims, never removes anything outside `{data_dir}/worktrees` and
+`{data_dir}/transcripts`, and never modifies a task row. A task pointing at a
+worktree that is gone is *reported* at the end of the output and left alone —
+recover that one with a retry, which recreates the worktree from the branch.
+
+An entry that could not be removed (a file locked by another process, a
+permissions problem) is reported on its own line and the run continues; the
+reclaimed totals count only what actually went.
+
+The daemon reports the same orphans at startup — one warning per directory in
+`daemon.log`, plus a count on `GET /v1/info` and in the TUI daemon view — but it
+never deletes anything by itself.
 
 ---
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -95,6 +95,12 @@ Two rules worth internalizing:
 Your own checkout is never touched: vincent reads the repository to create
 worktrees and never modifies your working tree, current branch or stash.
 
+**What reclaims a worktree.** Archiving the task, normally. A worktree whose task
+row is gone — a deleted project whose removal failed, a crash before the path was
+recorded — is nobody's, and nothing archives it; that is what
+[`vincent gc`](cli.md#vincent-gc) is for. The daemon reports those at startup and
+counts them on the daemon view, but it never deletes one on its own.
+
 ## Transcripts
 
 ```
@@ -115,6 +121,11 @@ Two consequences of storing the raw stream rather than a parsed one:
 Transcripts are bounded by `transcript_max_bytes` per attempt and pruned for
 **archived** tasks past `transcript_retention_days` — see
 [Configuration](configuration.md).
+
+**What reclaims a transcript.** Retention, for as long as the task row exists.
+Deleting a project deletes its task rows, and retention walks rows — so those
+directories are reached by no retention pass, ever, and are reclaimed by
+[`vincent gc`](cli.md#vincent-gc) instead.
 
 They contain the rendered prompt and everything the agent did. **Read one before
 pasting it into an issue.**
@@ -147,7 +158,7 @@ vincent daemon --config-dir /srv/v-cfg --data-dir /srv/v-data
 |---|---|
 | `logs/daemon.log` | Nothing; it is recreated |
 | `transcripts/{task_id}/` | That task's output history is gone; the task record and its metrics stay |
-| `worktrees/{task_id}/` | Effectively an unregistered archive — prefer archiving the task, which does it properly |
+| `worktrees/{task_id}/` | Effectively an unregistered archive — prefer archiving the task, which does it properly. For a directory whose task no longer exists, prefer `vincent gc`, which checks it is not somebody's live worktree first |
 | `daemon.json`, `daemon.lock` | Only safe while the daemon is stopped; both are recreated |
 | `token` | Recreated at next start, and every existing client must re-read it |
 | `vincent.db` | **Everything is gone** — projects, tasks, history. Branches in your repositories survive |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1056,6 +1056,46 @@ would invalidate every one of them.
 - **Cleanup:** only on `archive`: `git worktree remove` (+ `--force` after an explicit
   dirty-worktree confirmation), then `git -C {project.path} worktree prune`. The
   branch is **never** deleted by vincent.
+
+  *Amended 2026-08-15 (task 005).* "Only on archive" was true of a **task's** worktree
+  and remains so. It left a second reclaim path missing entirely, because two things
+  produce a directory under a data root that no task will ever name again:
+  - `DELETE /v1/projects/{id}` removes worktrees best-effort by the T1.5 decision and
+    `DeleteProjectCascade` drops the rows regardless. A removal that fails — a file
+    locked by another process on Windows, a permissions problem, a shell sitting in the
+    directory — leaves the directory behind with every reference to it gone.
+  - A crash between `git worktree add` and the write that records `worktree_path`
+    leaves the directory present while the row survives claiming nothing. The task's
+    next admission then fails `worktree_path_occupied` (§18).
+
+  So **an orphan is an entry directly under a data root that no task row claims**, and
+  `vincent gc` (§12.1) reclaims them. Claim is by `worktree_path`, not by directory
+  name: the name-based reading misses the second producer, whose directory *is* named
+  after a live row. The rules:
+  - **Archive stays the only path that removes a task's worktree.** gc removes only
+    what no task claims. Making project delete's removal authoritative was rejected in
+    the same discussion: it strands the user with an undeletable project over a locked
+    file and does nothing about the crash case.
+  - **Deletion is confined to the data roots.** `{data_dir}/worktrees` and
+    `{data_dir}/transcripts` — the same containment check a forced archive uses, so a
+    `worktree_path` naming anything outside is refused whatever the database says.
+  - **A dirty worktree is skipped without `--force`,** by `Manager.IsDirty`'s rule
+    (`git status --porcelain`, untracked included). Dirtiness git cannot *determine*
+    is `dirty_unknown` (§18) and is likewise skipped: an orphan's `.git` file points
+    into a repository that is often deleted or pruned, which makes this the common
+    answer rather than the rare one, and it is reported distinctly because "you have
+    uncommitted work" and "nobody can tell" are different facts.
+  - **Non-directory entries are reported, never removed.** vincent only ever creates
+    directories under these roots.
+  - **Branches are never deleted here either.** §10's standing rule has no gc
+    exception.
+  - **The reverse mismatch is reported, not repaired:** a task row whose
+    `worktree_path` names a directory that is gone (§18's `worktree_missing` shape).
+    There is nothing to delete and no row is modified.
+  - **The unattended path never deletes.** Daemon start scans and logs (§12.4, §17);
+    the count rides `GET /v1/info`. `vincent gc` deletes by default, and the dirty
+    check, the containment rule and the printed byte report are what make that
+    acceptable when a human is behind it.
 - **Repo deletion / path moves:** if the project path disappears, affected tasks go
   `blocked` with a descriptive reason; project records can be re-pointed via
   `PATCH /v1/projects/{id}`.
@@ -1111,7 +1151,13 @@ One Go binary, `vincent`:
 | `vincent workflow ls / validate [file]` | Registry listing / YAML validation |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
 | `vincent task add / ls / show <id> / cancel <id>` | Thin API clients for scripting |
+| `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent version` | Build info |
+
+*Amended 2026-08-15 (task 005).* `gc` breaks this table's noun-verb pattern
+(`project add`, `task ls`) knowingly: `git gc` is the idiom users already have, and the
+scope spans two directory trees — worktrees and transcripts — so a `worktree` noun
+would have been wrong on the day it shipped.
 
 Single-instance enforcement: a lock file in the data dir; a second daemon exits with a
 pointer to the running instance.
@@ -1363,6 +1409,11 @@ edited via `PATCH /v1/projects/{id}`.
 - Because agent steps are fresh sessions operating on a worktree whose committed state
   survives, re-running an interrupted step is safe by construction; workflow authors
   are advised to have agents commit incrementally.
+- *Added 2026-08-15 (task 005).* Recovery reconciles **rows and processes, not
+  directories**. The directory tree is reconciled by a separate startup pass that only
+  reports (§10): it logs one warning per orphan and raises the `orphans` count on
+  `GET /v1/info`, and it deletes nothing — `vincent gc` does that, with a human behind
+  it.
 
 ## 13. HTTP API
 
@@ -1387,12 +1438,38 @@ edited via `PATCH /v1/projects/{id}`.
 
 ```
 GET    /v1/health                       liveness (also unauthenticated) → { status, version }
-GET    /v1/info                         daemon version, uptime, agent availability, caps in effect
+GET    /v1/info                         daemon version, uptime, agent availability, caps in effect,
+                                        and `orphans`: how many data-root directories no task
+                                        claims right now (§10, task 005). Computed per request
+                                        from a readdir plus the id queries — no size walk, no git —
+                                        so it is cheap and never stale after a gc run. It is here
+                                        and not on /v1/health deliberately: health is
+                                        {status, version} and is the one unauthenticated endpoint
+                                        (§13.1); the shape of a user's disk does not belong on it
 GET    /v1/config                       effective global config (read-only)
 GET    /v1/agents                       per-adapter availability + model/effort options (§9.6);
                                         ?refresh=true forces a re-probe
 POST   /v1/daemon/stop                  graceful shutdown (§12.4); 202, then the daemon exits.
                                         `vincent daemon stop` calls this and waits for exit
+
+GET    /v1/maintenance/orphans          what gc would consider, with sizes; removes nothing
+                                        (§10, task 005) → { orphans[], mismatches[], bytes,
+                                        reclaimed, reclaimed_bytes, dry_run, force }.
+                                        Each orphan: { path, kind (worktree|transcript),
+                                        task_id (null when the name is not an id), bytes,
+                                        skip_reason?, error?, removed }. skip_reason is why gc
+                                        declined (`worktree_dirty`, `dirty_unknown`,
+                                        `not_a_directory`); error is a removal that was
+                                        attempted and failed. mismatches[] are the reverse
+                                        case — rows whose worktree_path is gone (§18) —
+                                        report-only, no row modified
+POST   /v1/maintenance/gc               { force?, dry_run? } → the same body, with `removed`
+                                        set and the reclaimed totals filled in. force also
+                                        removes a worktree git calls dirty, or cannot judge;
+                                        dry_run returns the identical report and removes
+                                        nothing. The totals count only what actually went, so
+                                        a locked file is reported per path and the rest of the
+                                        run continues
 
 GET    /v1/projects                     list
 POST   /v1/projects                     { path, name?, default_branch?, default_workflow?, max_parallel_tasks? }
@@ -1725,7 +1802,10 @@ stream for the live tail.
    v1 — new files are written in the editor and appear on the next reload. §19's M3
    acceptance loop says "author workflow"; it means this edit path.
 6. **Daemon.** Version, uptime, config in effect, adapters detected, recent daemon
-   log. The view reports, it does not act: stopping the daemon from the TUI is out
+   log, and — *added 2026-08-15 (task 005)* — the `orphans` count from `/v1/info`
+   beside the words `vincent gc`, shown only when it is non-zero. It offers no way to
+   run gc, for exactly the reason it offers no way to stop the daemon.
+   The view reports, it does not act: stopping the daemon from the TUI is out
    of v1 — `vincent daemon stop` owns that, and a TUI that auto-started the daemon
    at launch has no business killing it. The log tail is read straight from
    `{data_dir}/logs/daemon.log`, the one place the TUI is not a pure API client:
@@ -1951,6 +2031,13 @@ currently true to show (§15 view 6).
   `transcript_retention_days` (default 90); DB rows kept indefinitely (rows are small,
   history is valuable).
 
+  *Amended 2026-08-15 (task 005).* Retention is about **archived rows**: the pruner
+  walks `archived_at`, so a transcript directory whose row was cascade-deleted with its
+  project is reached by no retention pass, ever. That directory is `vincent gc`'s
+  (§10), under the same claim rule as a worktree and with no dirty check — a transcript
+  is vincent's own output, not a working tree. While the row exists, its transcripts
+  stay the pruner's, archived or not.
+
 ## 18. Edge cases and errors
 
 | Case | Behavior |
@@ -1971,7 +2058,9 @@ currently true to show (§15 view 6).
 | Branch already exists (or a ref hierarchy conflict blocks the name) | Rejected at creation with `400` where the name is known then; otherwise the task blocks with `branch_exists` at admission, which stays the authority. Never reused, never auto-renamed. Recover with `retry { branch_override }` (§10, task 001) |
 | Configured branch name is not a legal git ref | `400` with `branch_name_invalid`, quoting git's own rules. Never sanitized into something legal — a branch the user did not ask for is worse than a rejection (task 001) |
 | Branch template references a field the task does not set | `400` at creation. Note that `{{.Fields.x}}` errors while `{{ index .Fields "x" }}` renders empty by design (§8.4's `missingkey=error` covers map *field* access only), and `feat/-slug` is a legal ref — so the loud form is the documented default for branch templates |
-| Worktree dir manually deleted | Next step fails → blocked with `worktree_missing`; retry recreates the worktree from the branch if it survives |
+| Worktree dir manually deleted | Next step fails → blocked with `worktree_missing`; retry recreates the worktree from the branch if it survives. *Amended 2026-08-15 (task 005):* the same mismatch found by a scan rather than by a step is **reported** — at daemon start and in `vincent gc`'s output — and no row is modified |
+| Orphaned directory under a data root | *Added 2026-08-15 (task 005).* An entry under `{data_dir}/worktrees` or `{data_dir}/transcripts` that no task row claims — left by a project delete whose worktree removal failed (the cascade drops the rows regardless, §10) or by a crash between `git worktree add` and the claim write. Daemon start logs one warning per orphan and raises `orphans` on `GET /v1/info`; it **never** deletes, for the same reason DB corruption never auto-deletes. `vincent gc` reclaims them, and only them — archive remains the only path that removes a *task's* worktree |
+| Dirtiness of an orphan cannot be determined | *Added 2026-08-15 (task 005).* An orphan's `.git` file points at `{repo}/.git/worktrees/{n}`, so a deleted or pruned repository makes `git status --porcelain` fail outright. Reported as `dirty_unknown` — distinct from `worktree_dirty`, because "git says you have local changes" and "nobody can tell what is in here" are different facts — and skipped until `vincent gc --force`. This is the *common* case where the projects really are gone, so a default run there reclaims little; that is the deliberate trade for never deleting work nobody can vouch for |
 | Project path missing | New/step-starting tasks in that project → blocked with `project_path_missing` |
 | Daemon port taken | Ephemeral port by default makes this nearly impossible; pinned-port conflict fails startup with a clear message |
 | DB corruption | Startup fails loudly, points at the file, never auto-deletes |

--- a/docs/tasks/005-orphaned-worktree-gc.md
+++ b/docs/tasks/005-orphaned-worktree-gc.md
@@ -1,0 +1,168 @@
+# 005 — Reclaim orphaned worktrees: `vincent gc` and a report-only startup reconcile
+
+**Status:** ✅ done (8/8) · **Opened:** 2026-08-15
+
+A directory under `{data_dir}/worktrees` or `{data_dir}/transcripts` could outlive
+every reference to it, and nothing in vincent would ever look at it again. `vincent gc`
+reclaims those; daemon start reports them and deletes nothing.
+
+Closes [#95](https://github.com/lezli01/vincent/issues/95).
+
+## The problem
+
+Two producers, neither reconciled by anything that already exists:
+
+- **Project delete.** `internal/api/projects.go` removes each task's worktree
+  best-effort — the T1.5 decision, spelled out in the comment — and
+  `DeleteProjectCascade` drops the rows regardless. Removal genuinely fails in
+  practice: a file locked by another process on Windows, a permissions problem, a
+  shell sitting in the directory. `DeleteProjectCascade` is also **the only path that
+  deletes task rows**, which makes it the only producer of a directory no row can ever
+  name again.
+- **The create/claim crash window.** `ensureWorktree` created the worktree and *then*
+  wrote `worktree_path`. A crash in between left `{data_dir}/worktrees/{id}` on disk
+  while the row survived claiming nothing — and the task's next admission failed
+  `worktree_path_occupied`, telling the user to "remove it manually".
+
+Nothing covered either. `Manager.prune` is `git worktree prune` inside the *project*
+repo, reachable only from `Create` and `Remove`: it deletes no directory of ours and
+never runs for a task whose row is gone. `taskrun.Recover` (§12.4) reconciles step-run
+rows and processes. `TranscriptPruner` (§17) walks archived task *rows*. `Archive`
+fails closed and is not a producer at all.
+
+Consequences: disk grows silently, invisible to the board, the CLI and the API; and a
+future task can be blocked by a directory belonging to a project that no longer exists.
+
+## Decisions
+
+### 1. An orphan is a directory **no task row claims** — by path, not by name
+
+*2026-08-15.* The claim is `worktree_path`. The issue proposed the name-based
+definition ("the name is not the id of an existing task row"), and that one misses the
+create/claim crash window entirely: the directory there *is* named after a live row, so
+a name-based scan calls it claimed and leaves the `worktree_path_occupied` block in
+place forever — one of the two problems this work exists to end. One rule covers both
+producers.
+
+**Beat:** the name-based definition. It is simpler and it fails the second acceptance
+criterion.
+
+### 2. That definition creates a race, and it is guarded at the source
+
+*2026-08-15.* Between `Manager.Create` returning and the claim being persisted, a live
+task's worktree is momentarily unclaimed, and a concurrent scan would delete a running
+task's working tree. So `Manager` grows an `RWMutex`: creation takes it shared across
+create-**and**-claim, the reclaim scan takes it exclusively across scan-**and**-remove.
+In practice `Create` gained a `claim func(path string) error` callback
+(`CreateAndClaim`) that `ensureWorktree` fills with its `SetTaskProgress` call — the
+callback is what makes the window lockable at all. `Archive`'s remove-then-clear window
+takes the same shared lock (`RemoveAndRelease`), so the reverse-mismatch report cannot
+transiently accuse a task that is being archived.
+
+**Beat:** an mtime/age heuristic ("ignore anything younger than a minute"). A timing
+guess in place of a lock, in the package whose entire subject is ownership.
+
+### 3. Dirtiness git cannot determine is `dirty_unknown`, skipped without `--force`
+
+*2026-08-15.* This is the **common** case, not the rare one. An orphan's `.git` file
+points at `{repo}/.git/worktrees/{n}`; the repository being deleted — or
+`git worktree prune` having run in it — makes `git status --porcelain` fail, so
+`Manager.IsDirty` returns an error rather than true or false. Reported distinctly from
+`worktree_dirty`, because "git says you have uncommitted work" and "nobody can tell
+what is in here" are different facts, and the second one dominates in the field.
+
+Consequence accepted deliberately: on a machine where the projects really are gone,
+most orphans need `--force`, and a default run reclaims less than the issue's prose
+implies. The alternative is deleting work nobody can vouch for.
+
+The string stays `dirty_unknown` with no `worktree_` prefix: it is a gc *skip* reason
+and never becomes a task `block_reason`, so it is not part of the block-reason
+vocabulary §18 shares with `internal/worktree`.
+
+### 4. gc reclaims orphaned transcripts as well as orphaned worktrees
+
+*2026-08-15.* Same producer, same permanence: `DeleteProjectCascade` deletes the rows,
+and the §17 pruner walks archived *rows*, so `{data_dir}/transcripts/{task_id}` for a
+deleted row is pruned by no path, ever. It costs one more readdir against the same
+task-id set — no git, no dirty check, nothing to be careful about — and it means one
+command instead of two for one leak. §17 is amended alongside §10.
+
+### 5. The command is `vincent gc`, over two maintenance endpoints
+
+*2026-08-15.* `GET /v1/maintenance/orphans` and `POST /v1/maintenance/gc`
+(`{force, dry_run}`). The name breaks §12.1's noun-verb pattern knowingly: `git gc` is
+the idiom users already have, and the scope now spans two directory trees, so a
+`worktree` noun would have been wrong on the day it shipped.
+
+### 6. The unattended path never deletes; the explicit one deletes by default
+
+*2026-08-15.* Daemon start scans, logs one warning per orphan, and leaves everything in
+place — silently removing a directory that may hold an agent's uncommitted work is what
+§18's "never auto-deletes" posture around DB corruption already rejects. `vincent gc`
+deletes by default, and the dirty check, the containment rule and the printed byte
+report are what make that acceptable with a human behind it.
+
+**Beat:** deleting automatically at startup, and making project delete's removal
+authoritative. The second is the issue's own rejected alternative and stays rejected:
+it strands the user with an undeletable project because of a locked file, and does
+nothing for orphans created by a crash.
+
+### 7. The count goes on `/v1/info`, not `/v1/health`
+
+*2026-08-15.* Health is deliberately `{status, version}` and is the one unauthenticated
+endpoint (§13.1) — disk-shape facts about the user's machine do not belong on it. The
+count is computed per request (readdir plus the id queries, **no** size walk), so it is
+never stale after a gc run and `/v1/info` stays cheap. Sizes are walked only by the
+list and reclaim endpoints, which is where the report needs them.
+
+### 8. The TUI shows the count and offers no action
+
+*2026-08-15.* §15 view 6: "the view reports, it does not act". The daemon view gains a
+line with the count and the words `vincent gc`, shown only when the count is non-zero —
+a permanent "orphans: 0" is noise on every healthy daemon. It does not run gc, for the
+same reason it cannot stop the daemon.
+
+### 9. Sizes are apparent file sizes, symlinks not followed
+
+*2026-08-15.* `filepath.WalkDir` sums regular files, reusing the pruner's `dirSize`. A
+byte figure that walked into a symlinked cache would over-report the reclaim.
+
+## Tasks
+
+- [x] **005.1** — `internal/worktree`: `Root()`, `Reclaim(path)` (today's containment
+      check exported unchanged), `ReasonDirtyUnknown`, the `RWMutex` and
+      `CreateAndClaim` / `RemoveAndRelease` / `WithReclaimLock`. ✓ 2026-08-15
+- [x] **005.2** — `internal/store`: `ListWorktreeClaims` and `ListTaskIDs`, both across
+      archived and non-archived rows. ✓ 2026-08-15
+- [x] **005.3** — `internal/taskrun/reclaim.go`: `Scan`, `Reclaim`, `Count`; wiring in
+      `engine.go` (`CreateAndClaim`) and `actions.go` (`RemoveAndRelease`).
+      ✓ 2026-08-15
+- [x] **005.4** — `internal/api/maintenance.go` + the two routes; `orphans` on
+      `/v1/info`. ✓ 2026-08-15
+- [x] **005.5** — `internal/apiclient/maintenance.go`; `Info.Orphans`. ✓ 2026-08-15
+- [x] **005.6** — `vincent gc [--dry-run] [--force] [--json]`. ✓ 2026-08-15
+- [x] **005.7** — Report-only startup reconcile in `internal/daemon`; orphan line in the
+      TUI daemon view. ✓ 2026-08-15
+- [x] **005.8** — Tests and the m1-gate leg; spec §10/§12.1/§12.4/§13.2/§15/§17/§18 and
+      the user docs. ✓ 2026-08-15
+
+## Out of scope
+
+- **Repairing the reverse mismatch.** A row whose `worktree_path` is gone is reported
+  and left alone. Clearing it is a state change to a task, which belongs to the FSM and
+  to `retry` (§18: a retry recreates the worktree from the branch if it survives), not
+  to a disk-reclaim command.
+- **A scheduled gc.** Retention has a ticker because it is a policy with a configured
+  window; gc deletes on a human's word, and a timer that deleted worktrees unattended
+  would be decision 6 in reverse.
+- **Deleting branches.** §10's standing rule, restated: vincent never deletes a branch,
+  gc included.
+
+## Verification
+
+- `go test ./...` and `go test -race ./internal/taskrun` green (2026-08-15, macOS).
+- `go tool golangci-lint run ./...` clean for `GOOS=windows`, `darwin` and `linux`.
+- `./scripts/m1-gate.sh` passes with its new gc leg: plant
+  `{data_dir}/worktrees/999999`, assert it is listed with a size, assert `--dry-run`
+  leaves it, reclaim it, and assert the real task's worktree and branch survived
+  (2026-08-15, macOS).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ description of how the system actually behaves.
 | [002](002-homebrew-tap.md) | Homebrew tap for macOS | ✅ done (6/6) |
 | [003](003-usage-limit-classification.md) | Classify agent usage limits and auth expiry | ✅ done (7/7) |
 | [004](004-go-toolchain-pin.md) | Pin the Go toolchain and automate its patch bumps | ✅ done (3/3) |
+| [005](005-orphaned-worktree-gc.md) | Reclaim orphaned worktrees: `vincent gc` and a startup reconcile | ✅ done (8/8) |
 
 ## How to add and update a task document
 

--- a/internal/api/maintenance.go
+++ b/internal/api/maintenance.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/lezli01/vincent/internal/taskrun"
+)
+
+// orphanResponse is one entry under a data root that no task row claims
+// (§10, §18). `skip` and `error` are separate on purpose: the first is gc
+// declining to act, the second is gc having tried and failed.
+type orphanResponse struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+	// TaskID is the id the directory is named after, or null when its name
+	// is not an id. Informational — a claim, not a name, is what decides.
+	TaskID  *int64 `json:"task_id"`
+	Bytes   int64  `json:"bytes"`
+	Skip    string `json:"skip_reason,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Removed bool   `json:"removed"`
+}
+
+// mismatchResponse is a task row whose worktree_path names a directory that
+// is gone (§18's `worktree_missing` shape). Report-only: gc modifies no row.
+type mismatchResponse struct {
+	TaskID int64  `json:"task_id"`
+	Path   string `json:"path"`
+	State  string `json:"state"`
+}
+
+// orphanReport is the body of both maintenance endpoints. One shape for the
+// list and the reclaim, so a `--dry-run` and a real run are compared field by
+// field rather than read as two different reports.
+type orphanReport struct {
+	Orphans        []orphanResponse   `json:"orphans"`
+	Mismatches     []mismatchResponse `json:"mismatches"`
+	Bytes          int64              `json:"bytes"`
+	Reclaimed      int                `json:"reclaimed"`
+	ReclaimedBytes int64              `json:"reclaimed_bytes"`
+	DryRun         bool               `json:"dry_run"`
+	Force          bool               `json:"force"`
+}
+
+// gcRequest is the body of POST /v1/maintenance/gc. Both fields default
+// false, so a bodyless POST is "remove the clean orphans", which is what
+// `vincent gc` sends.
+type gcRequest struct {
+	Force  bool `json:"force"`
+	DryRun bool `json:"dry_run"`
+}
+
+// handleOrphans serves GET /v1/maintenance/orphans: what gc would consider,
+// with sizes, removing nothing.
+func (s *Server) handleOrphans(w http.ResponseWriter, r *http.Request) {
+	s.serveReport(w, r, func(ctx context.Context) (taskrun.Report, error) {
+		return s.deps.Reclaimer.Scan(ctx)
+	})
+}
+
+// handleGC serves POST /v1/maintenance/gc: the same scan, followed by the
+// removal of everything eligible. The daemon owns the filesystem, so the
+// client sends two booleans and renders what comes back (§4).
+func (s *Server) handleGC(w http.ResponseWriter, r *http.Request) {
+	var req gcRequest
+	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
+		return
+	}
+	s.serveReport(w, r, func(ctx context.Context) (taskrun.Report, error) {
+		return s.deps.Reclaimer.Reclaim(ctx, req.Force, req.DryRun)
+	})
+}
+
+func (s *Server) serveReport(
+	w http.ResponseWriter, r *http.Request, run func(context.Context) (taskrun.Report, error),
+) {
+	if s.deps.Reclaimer == nil {
+		s.internalError(w, "reclaim", errors.New("no reclaimer is configured"))
+		return
+	}
+	rep, err := run(r.Context())
+	if err != nil {
+		s.internalError(w, "reclaim", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toOrphanReport(rep))
+}
+
+func toOrphanReport(rep taskrun.Report) orphanReport {
+	out := orphanReport{
+		Orphans:        make([]orphanResponse, 0, len(rep.Orphans)),
+		Mismatches:     make([]mismatchResponse, 0, len(rep.Mismatches)),
+		Bytes:          rep.Bytes,
+		Reclaimed:      rep.Reclaimed,
+		ReclaimedBytes: rep.ReclaimedBytes,
+		DryRun:         rep.DryRun,
+		Force:          rep.Force,
+	}
+	for _, o := range rep.Orphans {
+		entry := orphanResponse{
+			Path:    o.Path,
+			Kind:    o.Kind,
+			Bytes:   o.Bytes,
+			Skip:    o.Skip,
+			Error:   o.Error,
+			Removed: o.Removed,
+		}
+		if o.TaskID != 0 {
+			id := o.TaskID
+			entry.TaskID = &id
+		}
+		out.Orphans = append(out.Orphans, entry)
+	}
+	for _, m := range rep.Mismatches {
+		out.Mismatches = append(out.Mismatches, mismatchResponse{
+			TaskID: m.TaskID, Path: m.Path, State: m.State,
+		})
+	}
+	return out
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,6 +64,10 @@ type Deps struct {
 	// Broker feeds the SSE endpoints (§13.3). Nil is tolerated (tests
 	// without streaming); the endpoints then answer 500.
 	Broker *events.Broker
+	// Reclaimer serves /v1/maintenance and the /v1/info orphan count
+	// (task 005, §10). Nil is tolerated (tests without a data dir) — the
+	// maintenance endpoints then answer 500 and /v1/info reports no orphans.
+	Reclaimer *taskrun.Reclaimer
 }
 
 // AgentStatus is one adapter's availability as reported by /v1/info
@@ -136,6 +140,8 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodGet, "/v1/config", s.handleConfig)
 	rt.handle(http.MethodGet, "/v1/agents", s.handleAgents)
 	rt.handle(http.MethodPost, "/v1/daemon/stop", s.handleStop)
+	rt.handle(http.MethodGet, "/v1/maintenance/orphans", s.handleOrphans)
+	rt.handle(http.MethodPost, "/v1/maintenance/gc", s.handleGC)
 	rt.handle(http.MethodGet, "/v1/projects", s.handleProjectList)
 	rt.handle(http.MethodPost, "/v1/projects", s.handleProjectCreate)
 	rt.handle(http.MethodGet, "/v1/projects/{id}", s.handleProjectGet)
@@ -212,6 +218,13 @@ type infoResponse struct {
 	Listen           string        `json:"listen"`
 	MaxParallelTasks int           `json:"max_parallel_tasks"`
 	Agents           []AgentStatus `json:"agents"`
+	// Orphans is how many data-root directories no task row claims right now
+	// (task 005, §10). It rides /v1/info rather than /v1/health because
+	// health is deliberately {status, version} and is the one unauthenticated
+	// endpoint (§13.1) — the shape of a user's disk does not belong on it.
+	// Computed per request from a readdir and the id queries, with no size
+	// walk, so it is never stale after a gc run.
+	Orphans int `json:"orphans"`
 }
 
 func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
@@ -237,6 +250,18 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
+	// A failed count degrades to zero with a log line: /v1/info is what every
+	// client polls for daemon identity, and a readdir problem must not take
+	// the whole payload down with it.
+	orphans := 0
+	if s.deps.Reclaimer != nil {
+		n, err := s.deps.Reclaimer.Count(r.Context())
+		if err != nil {
+			s.deps.Logger.Warn("count orphans", "error", err)
+		} else {
+			orphans = n
+		}
+	}
 	writeJSON(w, http.StatusOK, infoResponse{
 		Version:          version.Version(),
 		Commit:           version.Commit(),
@@ -247,6 +272,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		Listen:           s.deps.ListenAddr,
 		MaxParallelTasks: cfg.MaxParallelTasks,
 		Agents:           agents,
+		Orphans:          orphans,
 	})
 }
 

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -38,6 +38,10 @@ type Info struct {
 	Listen           string        `json:"listen"`
 	MaxParallelTasks int           `json:"max_parallel_tasks"`
 	Agents           []AgentStatus `json:"agents"`
+	// Orphans counts data-root directories no task row claims (task 005).
+	// It is a pointer to a leak a human clears with `vincent gc`, not
+	// something a client acts on by itself.
+	Orphans int `json:"orphans"`
 }
 
 // Uptime is how long the daemon has been up as of now. It is derived from

--- a/internal/apiclient/maintenance.go
+++ b/internal/apiclient/maintenance.go
@@ -1,0 +1,75 @@
+package apiclient
+
+import "context"
+
+// Orphan kinds as the daemon names them (§10, §17).
+const (
+	OrphanWorktree   = "worktree"
+	OrphanTranscript = "transcript"
+)
+
+// Orphan is one directory under a vincent data root that no task row claims.
+//
+// SkipReason and Error are different answers: the first is gc declining to
+// remove it (`worktree_dirty`, `dirty_unknown`, `not_a_directory`), the
+// second is gc having tried and failed — a file locked by another process, a
+// permissions problem. Only the second means the leak is still there after a
+// `--force` run.
+type Orphan struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+	// TaskID is the id the directory is named after, nil when its name is
+	// not an id at all.
+	TaskID     *int64 `json:"task_id"`
+	Bytes      int64  `json:"bytes"`
+	SkipReason string `json:"skip_reason,omitempty"`
+	Error      string `json:"error,omitempty"`
+	Removed    bool   `json:"removed"`
+}
+
+// Mismatch is a task row whose worktree_path names a directory that is gone
+// (§18's `worktree_missing`). Report-only — gc modifies no row.
+type Mismatch struct {
+	TaskID int64  `json:"task_id"`
+	Path   string `json:"path"`
+	State  string `json:"state"`
+}
+
+// OrphanReport is the body of both maintenance endpoints. A dry run and a
+// real run return the same shape, so the two are compared field by field.
+type OrphanReport struct {
+	Orphans        []Orphan   `json:"orphans"`
+	Mismatches     []Mismatch `json:"mismatches"`
+	Bytes          int64      `json:"bytes"`
+	Reclaimed      int        `json:"reclaimed"`
+	ReclaimedBytes int64      `json:"reclaimed_bytes"`
+	DryRun         bool       `json:"dry_run"`
+	Force          bool       `json:"force"`
+}
+
+// Orphans lists what gc would consider, with sizes, removing nothing
+// (GET /v1/maintenance/orphans).
+func (c *Client) Orphans(ctx context.Context) (OrphanReport, error) {
+	var out OrphanReport
+	if err := c.get(ctx, "/v1/maintenance/orphans", &out); err != nil {
+		return OrphanReport{}, err
+	}
+	return out, nil
+}
+
+// GC reclaims orphaned worktree and transcript directories
+// (POST /v1/maintenance/gc). force removes a worktree git calls dirty, or
+// cannot judge; dryRun returns the identical report and removes nothing.
+func (c *Client) GC(ctx context.Context, force, dryRun bool) (OrphanReport, error) {
+	var out OrphanReport
+	body := gcRequest{Force: force, DryRun: dryRun}
+	if err := c.post(ctx, "/v1/maintenance/gc", body, &out); err != nil {
+		return OrphanReport{}, err
+	}
+	return out, nil
+}
+
+type gcRequest struct {
+	Force  bool `json:"force"`
+	DryRun bool `json:"dry_run"`
+}

--- a/internal/apiclient/maintenance_live_test.go
+++ b/internal/apiclient/maintenance_live_test.go
@@ -1,0 +1,222 @@
+package apiclient_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// gcHarness wires a client to the real maintenance handlers over a real data
+// dir — the endpoints' whole subject is what is on disk, so a fake would
+// prove nothing about the wire types.
+type gcHarness struct {
+	client  *apiclient.Client
+	dataDir string
+	st      *store.Store
+}
+
+func newGCHarness(t *testing.T) *gcHarness {
+	t.Helper()
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	worktrees := worktree.NewManager(gitx.New(), dataDir)
+	reclaimer := taskrun.NewReclaimer(taskrun.Deps{
+		Store:     st,
+		Config:    config.Default,
+		Worktrees: worktrees,
+		DataDir:   dataDir,
+		Logger:    logger,
+	})
+	s := api.New(api.Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      logger,
+		Store:       st,
+		Worktrees:   worktrees,
+		Reclaimer:   reclaimer,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return &gcHarness{client: apiclient.New(ts.URL, testToken), dataDir: dataDir, st: st}
+}
+
+// plant creates a directory under a data root with a known payload size.
+func (h *gcHarness) plant(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(h.dataDir, root, name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload"), []byte("0123456789"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return dir
+}
+
+func TestOrphansAndGCOverTheWire(t *testing.T) {
+	h := newGCHarness(t)
+	wt := h.plant(t, "worktrees", "999999")
+	ts := h.plant(t, "transcripts", "999998")
+
+	rep, err := h.client.Orphans(t.Context())
+	if err != nil {
+		t.Fatalf("Orphans: %v", err)
+	}
+	if len(rep.Orphans) != 2 {
+		t.Fatalf("orphans = %d, want 2 (%+v)", len(rep.Orphans), rep.Orphans)
+	}
+	if rep.Bytes <= 0 {
+		t.Errorf("bytes = %d, want the planted payloads' size", rep.Bytes)
+	}
+	kinds := map[string]string{}
+	for _, o := range rep.Orphans {
+		kinds[o.Path] = o.Kind
+		if o.TaskID == nil {
+			t.Errorf("orphan %s has no task_id, though its name is an id", o.Path)
+		}
+		if o.Removed {
+			t.Errorf("GET /orphans reports %s as removed", o.Path)
+		}
+	}
+	if kinds[wt] != apiclient.OrphanWorktree || kinds[ts] != apiclient.OrphanTranscript {
+		t.Errorf("kinds = %+v, want worktree and transcript", kinds)
+	}
+
+	// A dry run leaves everything where it is and says so.
+	dry, err := h.client.GC(t.Context(), false, true)
+	if err != nil {
+		t.Fatalf("GC dry run: %v", err)
+	}
+	if !dry.DryRun || dry.Reclaimed != 0 {
+		t.Errorf("dry run report = %+v, want dry_run true and nothing reclaimed", dry)
+	}
+	for _, path := range []string{wt, ts} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("dry run removed %s", path)
+		}
+	}
+
+	// The real thing. --force, because the planted worktree has no repo
+	// behind it and git therefore cannot judge it — dirty_unknown, the
+	// common case for a real orphan.
+	got, err := h.client.GC(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if got.Reclaimed != 2 || got.ReclaimedBytes <= 0 {
+		t.Fatalf("reclaimed = %d / %d bytes, want 2 and a positive size",
+			got.Reclaimed, got.ReclaimedBytes)
+	}
+	for _, path := range []string{wt, ts} {
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("%s survived gc", path)
+		}
+	}
+}
+
+// TestGCWithoutForceReportsTheSkipReason: git cannot judge a directory whose
+// repo never existed, so the default run declines and names why.
+func TestGCWithoutForceReportsTheSkipReason(t *testing.T) {
+	h := newGCHarness(t)
+	wt := h.plant(t, "worktrees", "424242")
+
+	rep, err := h.client.GC(t.Context(), false, false)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if rep.Reclaimed != 0 {
+		t.Errorf("reclaimed = %d, want 0 without force", rep.Reclaimed)
+	}
+	if len(rep.Orphans) != 1 || rep.Orphans[0].SkipReason != worktree.ReasonDirtyUnknown {
+		t.Fatalf("orphans = %+v, want one skipped %q", rep.Orphans, worktree.ReasonDirtyUnknown)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("a skipped orphan was removed: %v", err)
+	}
+}
+
+// TestInfoCarriesTheOrphanCount: the count rides /v1/info (not /v1/health,
+// which is unauthenticated and deliberately {status, version}) and is
+// computed per request, so it drops the moment gc runs.
+func TestInfoCarriesTheOrphanCount(t *testing.T) {
+	h := newGCHarness(t)
+	info, err := h.client.Info(t.Context())
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Orphans != 0 {
+		t.Fatalf("orphans = %d on a clean daemon, want 0", info.Orphans)
+	}
+	h.plant(t, "worktrees", "777")
+	if info, err = h.client.Info(t.Context()); err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Orphans != 1 {
+		t.Fatalf("orphans = %d after planting one, want 1", info.Orphans)
+	}
+	if _, err := h.client.GC(t.Context(), true, false); err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if info, err = h.client.Info(t.Context()); err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Orphans != 0 {
+		t.Errorf("orphans = %d after gc, want 0 — the count must not be cached", info.Orphans)
+	}
+}
+
+// TestClaimedDirectoryIsNeverAnOrphanOverTheWire: the claim, not the name, is
+// what protects a live task's worktree.
+func TestClaimedDirectoryIsNeverAnOrphanOverTheWire(t *testing.T) {
+	h := newGCHarness(t)
+	ctx := context.Background()
+	p := &store.Project{Name: "p", Path: t.TempDir(), DefaultBranch: "main"}
+	if err := h.st.CreateProject(ctx, p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	task := &store.Task{
+		ProjectID: p.ID, Title: "live", WorkflowName: "adhoc", WorkflowSnapshot: "x",
+		BaseBranch: "main", BranchName: "b", State: store.TaskRunning,
+	}
+	if err := h.st.CreateTask(ctx, task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	dir := h.plant(t, "worktrees", strconv.FormatInt(task.ID, 10))
+	if err := h.st.SetTaskProgress(ctx, task.ID, nil, &dir); err != nil {
+		t.Fatalf("SetTaskProgress: %v", err)
+	}
+
+	rep, err := h.client.GC(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("GC: %v", err)
+	}
+	if len(rep.Orphans) != 0 {
+		t.Fatalf("orphans = %+v, want none — the directory is claimed", rep.Orphans)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("a claimed worktree was deleted by gc: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,6 +41,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(
 		newDaemonCmd(), newVersionCmd(),
 		newProjectCmd(), newTaskCmd(), newWorkflowCmd(), newServiceCmd(),
+		newGCCmd(),
 	)
 	return root
 }

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// newGCCmd is `vincent gc` (task 005, §12.1).
+//
+// The name breaks §12.1's noun-verb pattern knowingly: `git gc` is the idiom
+// users already have, and the scope spans two directory trees, so a
+// `worktree` noun would have been wrong on the day it shipped.
+func newGCCmd() *cobra.Command {
+	var (
+		dryRun bool
+		force  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "gc",
+		Short: "Reclaim worktree and transcript directories no task claims",
+		Long: "Reclaim directories under the data dir that no task row claims — " +
+			"left behind by a project delete whose worktree removal failed, or by a " +
+			"crash between creating a worktree and recording it.\n\n" +
+			"A worktree with local changes, or one git cannot judge because its " +
+			"repository is gone, is skipped and named in the output; --force removes " +
+			"it. Branches are never deleted.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				rep, err := c.GC(ctx, force, dryRun)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), rep)
+				}
+				return renderGC(cmd.OutOrStdout(), rep)
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Report what would be reclaimed and remove nothing")
+	cmd.Flags().BoolVar(&force, "force", false, "Also remove worktrees with local changes, or ones git cannot judge")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// renderGC prints the report a human reads. Every orphan is listed whatever
+// happened to it: a run that only printed a total would leave the user with
+// no idea which directory the skipped bytes are in.
+func renderGC(w io.Writer, rep apiclient.OrphanReport) error {
+	if len(rep.Orphans) == 0 && len(rep.Mismatches) == 0 {
+		_, err := fmt.Fprintln(w, "nothing to reclaim")
+		return err
+	}
+	if len(rep.Orphans) > 0 {
+		rows := make([][]string, 0, len(rep.Orphans))
+		for _, o := range rep.Orphans {
+			rows = append(rows, []string{
+				o.Kind, o.Path, humanBytes(o.Bytes), gcStatus(o, rep.DryRun),
+			})
+		}
+		if err := table(w, []string{"KIND", "PATH", "SIZE", "STATUS"}, rows); err != nil {
+			return err
+		}
+	}
+	for _, m := range rep.Mismatches {
+		// The reverse mismatch is not a leak and nothing here removes it; it
+		// is printed because a task pointing at a directory that is gone is
+		// the other half of the same reconciliation (§18).
+		if _, err := fmt.Fprintf(w,
+			"task %d (%s) points at a worktree that is gone: %s\n",
+			m.TaskID, m.State, m.Path); err != nil {
+			return err
+		}
+	}
+	if rep.DryRun {
+		_, err := fmt.Fprintf(w, "dry run: %d orphan(s), %s — nothing removed\n",
+			len(rep.Orphans), humanBytes(rep.Bytes))
+		return err
+	}
+	_, err := fmt.Fprintf(w, "reclaimed %d of %d orphan(s), %s freed\n",
+		rep.Reclaimed, len(rep.Orphans), humanBytes(rep.ReclaimedBytes))
+	return err
+}
+
+// gcStatus is what happened to one entry, in the words the daemon used. A
+// skip reason is the daemon's reason string verbatim so the CLI, the API and
+// the docs all name it the same way.
+func gcStatus(o apiclient.Orphan, dryRun bool) string {
+	switch {
+	case o.Error != "":
+		return "failed: " + o.Error
+	case o.SkipReason != "":
+		return "skipped: " + o.SkipReason
+	case o.Removed:
+		return "removed"
+	case dryRun:
+		return "would remove"
+	default:
+		return "not removed"
+	}
+}
+
+// humanBytes renders a size for the report. Powers of 1024, one decimal past
+// KB, which is what a user comparing this against `du -h` expects.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatInt(n, 10) + "B"
+	}
+	div, exp := int64(unit), 0
+	for n/div >= unit && exp < 3 {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%s", float64(n)/float64(div), [...]string{"KB", "MB", "GB", "TB"}[exp])
+}

--- a/internal/cli/gc_e2e_test.go
+++ b/internal/cli/gc_e2e_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// TestGCAgainstLiveDaemon drives `vincent gc` through the real binary against
+// a real daemon — the whole command is a thin API client, so the only thing
+// worth proving here is that the round trip and the rendering work end to end.
+func TestGCAgainstLiveDaemon(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	t.Cleanup(func() {
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = append(os.Environ(),
+			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
+		_, _ = cmd.CombinedOutput()
+	})
+	if out, code := runVincent(t, dataDir, cfgDir, "daemon", "start"); code != 0 {
+		t.Fatalf("daemon start: code %d, out %q", code, out)
+	}
+
+	// An orphan of the exact shape a failed project delete leaves: a
+	// directory under the worktree root that no row can ever name again.
+	orphan := filepath.Join(dataDir, "worktrees", "999999")
+	if err := os.MkdirAll(orphan, 0o700); err != nil {
+		t.Fatalf("plant orphan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "payload"), []byte("0123456789"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	out, code := runVincent(t, dataDir, cfgDir, "gc", "--dry-run", "--force")
+	if code != 0 {
+		t.Fatalf("gc --dry-run: code %d, out %q", code, out)
+	}
+	if !strings.Contains(out, orphan) || !strings.Contains(out, "dry run") {
+		t.Errorf("gc --dry-run does not report the orphan:\n%s", out)
+	}
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("gc --dry-run removed the orphan: %v", err)
+	}
+
+	// --force, because git cannot judge a worktree whose repo never existed
+	// (dirty_unknown) — the common shape for a real orphan.
+	out, code = runVincent(t, dataDir, cfgDir, "gc", "--force", "--json")
+	if code != 0 {
+		t.Fatalf("gc --force --json: code %d, out %q", code, out)
+	}
+	var rep struct {
+		Reclaimed      int   `json:"reclaimed"`
+		ReclaimedBytes int64 `json:"reclaimed_bytes"`
+		Orphans        []struct {
+			Path    string `json:"path"`
+			Kind    string `json:"kind"`
+			Removed bool   `json:"removed"`
+		} `json:"orphans"`
+	}
+	if err := json.Unmarshal([]byte(out), &rep); err != nil {
+		t.Fatalf("gc --json is not JSON: %v (%q)", err, out)
+	}
+	if rep.Reclaimed != 1 || rep.ReclaimedBytes <= 0 {
+		t.Errorf("reclaimed = %d / %d bytes, want 1 and a positive size",
+			rep.Reclaimed, rep.ReclaimedBytes)
+	}
+	if len(rep.Orphans) != 1 || !rep.Orphans[0].Removed ||
+		rep.Orphans[0].Kind != "worktree" || rep.Orphans[0].Path != orphan {
+		t.Errorf("orphans = %+v, want the planted worktree removed", rep.Orphans)
+	}
+	if _, err := os.Stat(orphan); err == nil {
+		t.Error("the orphan survived gc")
+	}
+
+	out, code = runVincent(t, dataDir, cfgDir, "gc")
+	if code != 0 || !strings.Contains(out, "nothing to reclaim") {
+		t.Errorf("gc on a clean daemon: code %d, out %q", code, out)
+	}
+}
+
+// TestGCWithoutADaemon: gc behaves like every other thin client when nothing
+// is listening — exit 2 and the same message, so a script can tell "start the
+// daemon" from "fix your request" without parsing stderr (PR U decision).
+func TestGCWithoutADaemon(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	out, code := runVincent(t, dataDir, cfgDir, "gc")
+	if code != 2 {
+		t.Fatalf("gc without a daemon: code %d, want 2 (out %q)", code, out)
+	}
+	if !strings.Contains(out, "no running daemon found") {
+		t.Errorf("gc without a daemon: out %q, want the standard message", out)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -241,6 +241,14 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	// ticker is what makes retention work on a daemon that survives reboots
 	// (T4.1) rather than only on the restarts it no longer has.
 	go taskrun.NewTranscriptPruner(runnerDeps).Run(ctx)
+	// Orphan reconcile (task 005, §10). It runs after recovery, which
+	// reconciles rows and processes but never directories, and it **reports
+	// only**: silently deleting a directory that may hold an agent's
+	// uncommitted work is what §18's "never auto-deletes" posture rejects.
+	// A human runs `vincent gc`; the count also rides /v1/info so a log line
+	// nobody tails is not the whole report.
+	reclaimer := taskrun.NewReclaimer(runnerDeps)
+	reportOrphans(ctx, reclaimer, logger)
 	sched := scheduler.New(scheduler.Deps{
 		Store:    st,
 		Config:   currentConfig,
@@ -282,6 +290,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		Runner:      runner,
 		WakeRunner:  sched.Wake,
 		Broker:      broker,
+		Reclaimer:   reclaimer,
 		OnProjectsChanged: func() {
 			pctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
@@ -413,6 +422,37 @@ func syncWorkflowProjects(ctx context.Context, st *store.Store, reg *workflow.Re
 	}
 	reg.SetProjects(roots)
 	return nil
+}
+
+// reportOrphans logs the data-root directories no task row claims, one line
+// each plus a summary naming the command that clears them (task 005, §10).
+//
+// It deletes nothing, ever. The asymmetry with `vincent gc` — which deletes
+// by default — is deliberate: the explicit command has a human behind it, a
+// dirty check, a containment rule and a printed byte report, and the
+// unattended path at startup has none of those.
+//
+// A failure here is logged and dropped. Reconciling directories is
+// housekeeping, and a daemon that refuses to serve because it could not read
+// a directory has its priorities backwards.
+func reportOrphans(ctx context.Context, rc *taskrun.Reclaimer, logger *slog.Logger) {
+	rep, err := rc.Scan(ctx)
+	if err != nil {
+		logger.Error("scan for orphaned directories failed", "error", err)
+		return
+	}
+	for _, o := range rep.Orphans {
+		logger.Warn("orphaned directory: no task claims it",
+			"path", o.Path, "kind", o.Kind, "bytes", o.Bytes, "skip_reason", o.Skip)
+	}
+	for _, m := range rep.Mismatches {
+		logger.Warn("task points at a worktree that is gone",
+			"task", m.TaskID, "state", m.State, "path", m.Path)
+	}
+	if len(rep.Orphans) > 0 {
+		logger.Warn("orphaned directories found; reclaim them with `vincent gc`",
+			"orphans", len(rep.Orphans), "bytes", rep.Bytes)
+	}
 }
 
 // primeAgentCatalog fills the §9.6 cache at startup and logs each adapter's

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -395,6 +395,70 @@ func (s *Store) CountNonArchivedTasks(ctx context.Context, projectID int64) (int
 		projectID, string(TaskArchived))
 }
 
+// WorktreeClaim is one task's claim on a directory under the worktree root
+// (task 005). An empty Path means the row claims nothing — the state a task
+// is in before its first admission, and the state a crash between
+// `git worktree add` and the claim write leaves behind.
+type WorktreeClaim struct {
+	TaskID int64
+	Path   string
+	State  TaskState
+}
+
+// ListWorktreeClaims returns every task's worktree claim, archived rows
+// included. gc classifies a directory by *claim*, not by name, so this is the
+// authoritative set: a directory nothing here names is an orphan, and a claim
+// naming a directory that is gone is the reverse mismatch (§18).
+//
+// Archived rows are in deliberately. Their worktree is normally already gone
+// and their claim already cleared, but an archive interrupted between the two
+// leaves a live claim, and gc must not delete what it names.
+func (s *Store) ListWorktreeClaims(ctx context.Context) ([]WorktreeClaim, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, COALESCE(worktree_path, ''), state FROM tasks ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list worktree claims: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []WorktreeClaim
+	for rows.Next() {
+		var c WorktreeClaim
+		if err := rows.Scan(&c.TaskID, &c.Path, (*string)(&c.State)); err != nil {
+			return nil, fmt.Errorf("scan worktree claim: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate worktree claims: %w", err)
+	}
+	return out, nil
+}
+
+// ListTaskIDs returns every task id, archived rows included — what gc diffs
+// the transcript root against (task 005). A transcript directory belongs to
+// its task for as long as the row exists; §17 retention decides when an
+// *archived* row's transcripts go, and only a row that no longer exists at
+// all is gc's.
+func (s *Store) ListTaskIDs(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id FROM tasks ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list task ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan task id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate task ids: %w", err)
+	}
+	return ids, nil
+}
+
 // ArchivedTaskIDsBefore returns the ids of tasks archived before cutoff —
 // the input to transcript pruning (§17 retention).
 //

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -209,18 +209,30 @@ func (r *Runner) Archive(ctx context.Context, id int64, force bool) (*store.Task
 	if !taskstate.Can(task.State, taskstate.Archive) {
 		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Archive, State: task.State}
 	}
-	if task.WorktreePath != "" {
-		project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
-		if err != nil {
-			return nil, err
-		}
-		if err := r.deps.Worktrees.Remove(ctx, project.Path, task.WorktreePath, force); err != nil {
-			return nil, err
-		}
-	}
 	empty := ""
-	return r.transitionFrom(ctx, task, taskstate.Archive,
-		store.TaskChange{WorktreePath: &empty})
+	if task.WorktreePath == "" {
+		return r.transitionFrom(ctx, task, taskstate.Archive,
+			store.TaskChange{WorktreePath: &empty})
+	}
+	project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	// Remove-then-clear runs under the manager's claim lock, the mirror of
+	// creation's create-then-claim (task 005). Between the two the row still
+	// names a directory that is already gone, and a gc scan landing there
+	// would report the task as a reverse mismatch it never was.
+	var out *store.Task
+	if err := r.deps.Worktrees.RemoveAndRelease(ctx, project.Path, task.WorktreePath, force,
+		func() error {
+			var err error
+			out, err = r.transitionFrom(ctx, task, taskstate.Archive,
+				store.TaskChange{WorktreePath: &empty})
+			return err
+		}); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // SetPriority reorders admission without changing state (§6: queued and

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -186,7 +186,20 @@ func (r *Runner) ensureWorktree(ctx context.Context, task *store.Task, project *
 	// window is gone. Keeping the recompute would have been actively harmful once
 	// names became configurable: it produced the *built-in* name, so a task whose
 	// user chose `feat/OPS-123` would have silently run on `vincent/{id}-{slug}`.
-	path, err := r.deps.Worktrees.Create(ctx, project.Path, task.ID, task.BranchName, task.BaseBranch)
+	// CreateAndClaim rather than Create: the directory exists before the row
+	// names it, and a gc scan slipping into that window would delete a live
+	// task's working tree (task 005). The claim is what closes it.
+	path, err := r.deps.Worktrees.CreateAndClaim(ctx, project.Path, task.ID,
+		task.BranchName, task.BaseBranch, func(p string) error {
+			// A failed persist is logged and the run continues, as it always
+			// has: the worktree is real and the step can use it. What it
+			// leaves behind is an unclaimed directory, which is precisely the
+			// crash case `vincent gc` reclaims.
+			if err := r.deps.Store.SetTaskProgress(ctx, task.ID, nil, &p); err != nil {
+				log.Error("persist worktree path", "error", err)
+			}
+			return nil
+		})
 	if err != nil {
 		if ctx.Err() != nil {
 			// A shutdown mid-create is an interruption, not a git failure.
@@ -201,9 +214,6 @@ func (r *Runner) ensureWorktree(ctx context.Context, task *store.Task, project *
 		return err
 	}
 	task.WorktreePath = path
-	if err := r.deps.Store.SetTaskProgress(ctx, task.ID, nil, &path); err != nil {
-		log.Error("persist worktree path", "error", err)
-	}
 	return nil
 }
 

--- a/internal/taskrun/reclaim.go
+++ b/internal/taskrun/reclaim.go
@@ -1,0 +1,357 @@
+package taskrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// Orphan kinds — which data root the entry was found under (§10, §17).
+const (
+	KindWorktree   = "worktree"
+	KindTranscript = "transcript"
+)
+
+// SkipNotADirectory is why a stray *file* sitting directly under a data root
+// is reported and never removed (task 005). vincent only ever creates
+// directories there, so a file is something else's — an editor swap file, a
+// `.DS_Store`, a note somebody left — and deleting it would exceed what gc
+// was asked to do.
+const SkipNotADirectory = "not_a_directory"
+
+// Orphan is one entry directly under a data root that no task row claims.
+type Orphan struct {
+	// Path is absolute and always inside one of the two data roots.
+	Path string
+	Kind string
+	// TaskID is the id the entry is named after, or 0 when the name is not
+	// an id at all. It is informational: the claim decides, not the name.
+	TaskID int64
+	Bytes  int64
+	// Skip is why this orphan was left alone — worktree_dirty,
+	// dirty_unknown, not_a_directory — or "" when it is eligible.
+	Skip string
+	// Error is a removal that was attempted and failed (a file locked by
+	// another process on Windows, a permissions problem). The orphan stays
+	// reported and the totals count only what actually went.
+	Error string
+	// Removed is true when this run deleted it. A dry run leaves it false on
+	// every entry, which is the whole difference between the two reports.
+	Removed bool
+}
+
+// Mismatch is the reverse of an orphan: a task row whose worktree_path names
+// a directory that is not there (§18's `worktree_missing` shape). It is
+// report-only — there is nothing to delete, and gc modifies no row.
+type Mismatch struct {
+	TaskID int64
+	Path   string
+	State  string
+}
+
+// Report is what a scan or a reclaim run found and did.
+type Report struct {
+	Orphans    []Orphan
+	Mismatches []Mismatch
+	// Bytes is every orphan's size, eligible or not: what a full `--force`
+	// run would reclaim.
+	Bytes int64
+	// Reclaimed and ReclaimedBytes count only entries actually removed, so a
+	// failed removal never inflates the figure the user is shown.
+	Reclaimed      int
+	ReclaimedBytes int64
+	DryRun         bool
+	Force          bool
+}
+
+// Reclaimer finds and removes data-root directories no task row claims
+// (task 005; spec §10, §17).
+//
+// It lives beside the transcript pruner because it needs exactly the same
+// dependencies — Store, DataDir, Worktrees, Logger — and reclaims the same
+// two trees. The producers it exists for are the ones nothing else
+// reconciles: `DELETE /v1/projects/{id}`, whose worktree removal is
+// best-effort by the T1.5 decision while the cascade drops the rows
+// regardless, and a crash between `git worktree add` and the claim write.
+//
+// Removal is never automatic. The startup pass only reports (§18's "never
+// auto-deletes" posture); deletion happens when a human runs `vincent gc`.
+type Reclaimer struct {
+	deps Deps
+}
+
+// NewReclaimer returns a reclaimer over the runner's dependencies.
+func NewReclaimer(deps Deps) *Reclaimer { return &Reclaimer{deps: deps} }
+
+// Scan reports what gc would consider, removing nothing.
+func (rc *Reclaimer) Scan(ctx context.Context) (Report, error) {
+	return rc.run(ctx, false, true)
+}
+
+// Reclaim removes every eligible orphan and reports what went. Without force,
+// a worktree git calls dirty — or cannot judge at all — is skipped with its
+// reason. A dry run removes nothing and returns the identical report.
+func (rc *Reclaimer) Reclaim(ctx context.Context, force, dryRun bool) (Report, error) {
+	return rc.run(ctx, force, dryRun)
+}
+
+// Count is the size-free orphan count for GET /v1/info: a readdir of each
+// root plus the id queries, with no size walk and no git, so the endpoint
+// stays cheap enough to serve per request and can never be stale after a gc
+// run.
+func (rc *Reclaimer) Count(ctx context.Context) (int, error) {
+	claimed, transcripts, err := rc.claimSets(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return len(rc.strays(rc.worktreeRoot(), claimed)) +
+		len(rc.strays(rc.transcriptRoot(), transcripts)), nil
+}
+
+func (rc *Reclaimer) worktreeRoot() string   { return rc.deps.Worktrees.Root() }
+func (rc *Reclaimer) transcriptRoot() string { return filepath.Join(rc.deps.DataDir, "transcripts") }
+
+// run is the one implementation behind Scan and Reclaim: classify under the
+// manager's exclusive claim lock, then remove what is eligible without
+// releasing it. Holding the lock across the removal is what closes the
+// create-and-claim window — a task admitted mid-run waits rather than racing.
+func (rc *Reclaimer) run(ctx context.Context, force, dryRun bool) (Report, error) {
+	var rep Report
+	err := rc.deps.Worktrees.WithReclaimLock(func() error {
+		var err error
+		rep, err = rc.classify(ctx, force, dryRun)
+		if err != nil {
+			return err
+		}
+		if dryRun {
+			return nil
+		}
+		for i := range rep.Orphans {
+			o := &rep.Orphans[i]
+			if o.Skip != "" {
+				continue
+			}
+			if err := rc.remove(*o); err != nil {
+				// One undeletable entry must not strand every orphan behind
+				// it — the same rule the transcript pruner already follows,
+				// and the Windows locked-file case this feature exists for.
+				o.Error = err.Error()
+				rc.deps.Logger.Warn("reclaim orphan", "path", o.Path, "error", err)
+				continue
+			}
+			o.Removed = true
+			rep.Reclaimed++
+			rep.ReclaimedBytes += o.Bytes
+		}
+		return nil
+	})
+	if err != nil {
+		return Report{}, err
+	}
+	return rep, nil
+}
+
+// remove deletes one orphan. Worktrees go through the manager so its
+// containment check applies; transcripts get the identical check against
+// their own root, so neither kind can reach outside the data dir whatever a
+// claim says.
+func (rc *Reclaimer) remove(o Orphan) error {
+	if o.Kind == KindWorktree {
+		return rc.deps.Worktrees.Reclaim(o.Path)
+	}
+	if err := containedIn(rc.transcriptRoot(), o.Path); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(o.Path); err != nil {
+		return fmt.Errorf("remove %s: %w", o.Path, err)
+	}
+	return nil
+}
+
+// classify diffs both roots against the claim set and decides what each
+// entry is. It is the whole definition of an orphan in one place.
+func (rc *Reclaimer) classify(ctx context.Context, force, dryRun bool) (Report, error) {
+	claims, err := rc.deps.Store.ListWorktreeClaims(ctx)
+	if err != nil {
+		return Report{}, err
+	}
+	ids, err := rc.deps.Store.ListTaskIDs(ctx)
+	if err != nil {
+		return Report{}, err
+	}
+	rep := Report{DryRun: dryRun, Force: force}
+
+	wtRoot := rc.worktreeRoot()
+	for _, e := range rc.strays(wtRoot, claimedPaths(claims)) {
+		o := rc.measure(e, wtRoot, KindWorktree)
+		if o.Skip == "" && !force {
+			o.Skip = rc.dirtiness(ctx, o.Path)
+		}
+		rep.Orphans = append(rep.Orphans, o)
+	}
+	tsRoot := rc.transcriptRoot()
+	for _, e := range rc.strays(tsRoot, claimedTranscripts(tsRoot, ids)) {
+		// No dirty check: a transcript directory is vincent's own output,
+		// not a working tree, so there is nothing for git to have an opinion
+		// about.
+		rep.Orphans = append(rep.Orphans, rc.measure(e, tsRoot, KindTranscript))
+	}
+	sortOrphans(rep.Orphans)
+
+	for _, c := range claims {
+		if c.Path == "" {
+			continue
+		}
+		if _, err := os.Stat(c.Path); errors.Is(err, fs.ErrNotExist) {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{
+				TaskID: c.TaskID, Path: c.Path, State: string(c.State),
+			})
+		}
+	}
+	for _, o := range rep.Orphans {
+		rep.Bytes += o.Bytes
+	}
+	return rep, nil
+}
+
+// measure fills in an entry's size and the reason a non-directory is left
+// alone. A size that cannot be read is not a reason to hide the orphan: the
+// entry is reported with whatever bytes could be accounted for.
+func (rc *Reclaimer) measure(e os.DirEntry, root, kind string) Orphan {
+	o := Orphan{Path: filepath.Join(root, e.Name()), Kind: kind}
+	if id, err := strconv.ParseInt(e.Name(), 10, 64); err == nil {
+		o.TaskID = id
+	}
+	if !e.IsDir() {
+		o.Skip = SkipNotADirectory
+		if info, err := e.Info(); err == nil {
+			o.Bytes = info.Size()
+		}
+		return o
+	}
+	size, err := dirSize(o.Path)
+	if err != nil {
+		rc.deps.Logger.Warn("measure orphan", "path", o.Path, "error", err)
+	}
+	o.Bytes = size
+	return o
+}
+
+// dirtiness is the without-force gate on a worktree orphan. git failing
+// outright is the *common* answer here, not the exceptional one: an orphan's
+// `.git` file points at `{repo}/.git/worktrees/{n}`, and the repo being gone —
+// or `git worktree prune` having run in it — makes `git status` fail. That is
+// reported as dirty_unknown rather than folded into worktree_dirty, because
+// "you have uncommitted work" and "nobody can tell" are different facts and
+// only the first is about work that could be lost.
+func (rc *Reclaimer) dirtiness(ctx context.Context, path string) string {
+	dirty, err := rc.deps.Worktrees.IsDirty(ctx, path)
+	switch {
+	case err != nil:
+		return worktree.ReasonDirtyUnknown
+	case dirty:
+		return worktree.ReasonWorktreeDirty
+	default:
+		return ""
+	}
+}
+
+// claimSets builds both roots' claim sets in one pair of queries.
+func (rc *Reclaimer) claimSets(ctx context.Context) (worktrees, transcripts map[string]bool, err error) {
+	claims, err := rc.deps.Store.ListWorktreeClaims(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	ids, err := rc.deps.Store.ListTaskIDs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return claimedPaths(claims), claimedTranscripts(rc.transcriptRoot(), ids), nil
+}
+
+// strays lists the entries directly under root that claimed does not name. A
+// root that is not there yet has no strays and is not an error — a daemon
+// that has never run a task has no worktrees directory.
+func (rc *Reclaimer) strays(root string, claimed map[string]bool) []os.DirEntry {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			rc.deps.Logger.Warn("read data root", "path", root, "error", err)
+		}
+		return nil
+	}
+	out := make([]os.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		if claimed[filepath.Clean(filepath.Join(root, e.Name()))] {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// claimedPaths is the set of directories task rows claim.
+//
+// An empty claim is deliberately *not* in the set. That is the crash window:
+// `git worktree add` succeeded, the row's worktree_path was never written, and
+// the directory on disk belongs to nobody — which is exactly what makes the
+// task's next admission fail `worktree_path_occupied` and tell the user to
+// remove a directory by hand. A name-based definition of "orphan" would call
+// that directory claimed and leave the block in place forever.
+//
+// A claim pointing outside the worktree root stays in the set: it still means
+// a row owns it, and the containment check is what refuses to act on it.
+func claimedPaths(claims []store.WorktreeClaim) map[string]bool {
+	out := make(map[string]bool, len(claims))
+	for _, c := range claims {
+		if c.Path == "" {
+			continue
+		}
+		out[filepath.Clean(c.Path)] = true
+	}
+	return out
+}
+
+// claimedTranscripts is the transcript root's equivalent: a transcript
+// directory belongs to its task id for as long as the row exists at all.
+// §17 retention decides when an *archived* row's transcripts go; only a row
+// that no longer exists is gc's.
+func claimedTranscripts(root string, ids []int64) map[string]bool {
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		out[filepath.Clean(filepath.Join(root, strconv.FormatInt(id, 10)))] = true
+	}
+	return out
+}
+
+// containedIn refuses a path outside root — the same rule, and the same
+// reason, as the worktree manager's own containment check.
+func containedIn(root, path string) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("refusing to delete %s: outside %s", path, root)
+	}
+	return nil
+}
+
+// sortOrphans gives the report a stable order — worktrees first, then by
+// path. A report a human compares between two runs must not reorder itself,
+// and readdir promises nothing.
+func sortOrphans(o []Orphan) {
+	sort.SliceStable(o, func(i, j int) bool {
+		if o[i].Kind != o[j].Kind {
+			return o[i].Kind == KindWorktree
+		}
+		return o[i].Path < o[j].Path
+	})
+}

--- a/internal/taskrun/reclaim_test.go
+++ b/internal/taskrun/reclaim_test.go
@@ -1,0 +1,585 @@
+package taskrun
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// reclaimHarness is a store, a real git repo and a real data dir. gc is a
+// filesystem operation driven by a DB query and adjudicated by git, so all
+// three halves have to be real — a fake worktree would not reproduce the
+// dirty_unknown case, which is the common one.
+type reclaimHarness struct {
+	store     *store.Store
+	dataDir   string
+	repo      string
+	projectID int64
+	worktrees *worktree.Manager
+	rc        *Reclaimer
+}
+
+func newReclaimHarness(t *testing.T) *reclaimHarness {
+	t.Helper()
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	repo := testrepo.Init(t, "main")
+	project := &store.Project{Name: "proj", Path: repo, DefaultBranch: "main"}
+	if err := st.CreateProject(t.Context(), project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	wt := worktree.NewManager(gitx.New(), dataDir)
+	deps := Deps{
+		Store:     st,
+		Config:    config.Default,
+		Worktrees: wt,
+		DataDir:   dataDir,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return &reclaimHarness{
+		store: st, dataDir: dataDir, repo: repo, projectID: project.ID,
+		worktrees: wt, rc: NewReclaimer(deps),
+	}
+}
+
+func (h *reclaimHarness) worktreeRoot() string {
+	return filepath.Join(h.dataDir, "worktrees")
+}
+
+func (h *reclaimHarness) transcriptRoot() string {
+	return filepath.Join(h.dataDir, "transcripts")
+}
+
+// task inserts a row and returns it. It creates nothing on disk: the tests
+// decide separately what exists where, which is the whole point of a
+// claim-based definition.
+func (h *reclaimHarness) task(t *testing.T, title string) *store.Task {
+	t.Helper()
+	task := &store.Task{
+		ProjectID: h.projectID, Title: title, WorkflowName: "adhoc",
+		State: store.TaskQueued, WorkflowSnapshot: "name: adhoc\nsteps: []\n",
+		BranchName: worktree.BranchName(0, title), BaseBranch: "main",
+	}
+	if err := h.store.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	return task
+}
+
+// archive marks the row archived. The row stays, which is exactly what makes
+// its transcripts §17's business rather than gc's.
+func (h *reclaimHarness) archive(t *testing.T, task *store.Task) {
+	t.Helper()
+	now := time.Now()
+	task.State, task.ArchivedAt = store.TaskArchived, &now
+	if err := h.store.UpdateTask(t.Context(), task); err != nil {
+		t.Fatalf("UpdateTask(archived): %v", err)
+	}
+}
+
+// realWorktree creates a task with an actual git worktree, claimed by the row
+// exactly as ensureWorktree claims it.
+func (h *reclaimHarness) realWorktree(t *testing.T, title string) *store.Task {
+	t.Helper()
+	task := h.task(t, title)
+	branch := worktree.BranchName(task.ID, title)
+	path, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, task.ID, branch, "main",
+		func(p string) error {
+			return h.store.SetTaskProgress(t.Context(), task.ID, nil, &p)
+		})
+	if err != nil {
+		t.Fatalf("CreateAndClaim: %v", err)
+	}
+	task.WorktreePath = path
+	task.BranchName = branch
+	return task
+}
+
+// orphan turns a real worktree into an orphan the way a project delete does:
+// the rows go, the directory stays.
+func (h *reclaimHarness) orphan(t *testing.T, title string) string {
+	t.Helper()
+	task := h.realWorktree(t, title)
+	if err := h.store.DeleteProjectCascade(t.Context(), h.projectID); err != nil {
+		t.Fatalf("DeleteProjectCascade: %v", err)
+	}
+	// Re-register so later tasks in the same test still have a project.
+	project := &store.Project{Name: "proj", Path: h.repo, DefaultBranch: "main"}
+	if err := h.store.CreateProject(t.Context(), project); err != nil {
+		t.Fatalf("re-CreateProject: %v", err)
+	}
+	h.projectID = project.ID
+	return task.WorktreePath
+}
+
+func (h *reclaimHarness) mkdir(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "payload"), []byte("0123456789"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return path
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// find returns the orphan entry for path, or nil.
+func find(rep Report, path string) *Orphan {
+	for i := range rep.Orphans {
+		if rep.Orphans[i].Path == path {
+			return &rep.Orphans[i]
+		}
+	}
+	return nil
+}
+
+// TestScanClassifiesByClaimNotName is the definition itself: what makes a
+// directory an orphan is that no row's worktree_path names it.
+func TestScanClassifiesByClaimNotName(t *testing.T) {
+	h := newReclaimHarness(t)
+
+	live := h.realWorktree(t, "live")
+	// The crash case: `git worktree add` succeeded, worktree_path was never
+	// written. The directory is named after an existing task row, so a
+	// name-based definition would call it claimed — and the row's next
+	// admission would keep failing worktree_path_occupied forever.
+	crashed := h.task(t, "crashed")
+	crashedDir := h.mkdir(t, filepath.Join(h.worktreeRoot(), strconv.FormatInt(crashed.ID, 10)))
+	// A directory whose name is not an id at all.
+	stray := h.mkdir(t, filepath.Join(h.worktreeRoot(), "not-an-id"))
+	// A file directly under the root: reported, never removed.
+	strayFile := filepath.Join(h.worktreeRoot(), "notes.txt")
+	if err := os.WriteFile(strayFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write stray file: %v", err)
+	}
+
+	rep, err := h.rc.Scan(t.Context())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if find(rep, live.WorktreePath) != nil {
+		t.Error("a claimed worktree was reported as an orphan")
+	}
+	for _, path := range []string{crashedDir, stray, strayFile} {
+		o := find(rep, path)
+		if o == nil {
+			t.Fatalf("%s was not reported as an orphan", path)
+		}
+		if o.Kind != KindWorktree {
+			t.Errorf("%s kind = %q, want %q", path, o.Kind, KindWorktree)
+		}
+	}
+	if got := find(rep, crashedDir); got.TaskID != crashed.ID {
+		t.Errorf("crashed orphan task_id = %d, want %d", got.TaskID, crashed.ID)
+	}
+	if got := find(rep, strayFile); got.Skip != SkipNotADirectory {
+		t.Errorf("stray file skip = %q, want %q", got.Skip, SkipNotADirectory)
+	}
+	if got := find(rep, stray); got.Bytes <= 0 {
+		t.Errorf("orphan bytes = %d, want the size of its payload", got.Bytes)
+	}
+}
+
+// TestScanReportsReverseMismatchWithoutTouchingTheRow covers §18's
+// worktree_missing shape: report only, no row modified.
+func TestScanReportsReverseMismatchWithoutTouchingTheRow(t *testing.T) {
+	h := newReclaimHarness(t)
+	task := h.realWorktree(t, "gone")
+	if err := os.RemoveAll(task.WorktreePath); err != nil {
+		t.Fatalf("remove worktree: %v", err)
+	}
+
+	rep, err := h.rc.Reclaim(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	if len(rep.Mismatches) != 1 || rep.Mismatches[0].TaskID != task.ID {
+		t.Fatalf("mismatches = %+v, want the one task pointing at a missing dir", rep.Mismatches)
+	}
+	if rep.Mismatches[0].Path != task.WorktreePath {
+		t.Errorf("mismatch path = %q, want %q", rep.Mismatches[0].Path, task.WorktreePath)
+	}
+	after, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if after.WorktreePath != task.WorktreePath {
+		t.Errorf("worktree_path = %q, want it untouched (%q)", after.WorktreePath, task.WorktreePath)
+	}
+	if after.State != task.State {
+		t.Errorf("state = %q, want it untouched (%q)", after.State, task.State)
+	}
+}
+
+// TestReclaimRemovesCleanOrphanAndKeepsTheBranch is §10's standing promise:
+// vincent never deletes a branch, gc included.
+func TestReclaimRemovesCleanOrphanAndKeepsTheBranch(t *testing.T) {
+	h := newReclaimHarness(t)
+	task := h.realWorktree(t, "clean")
+	branch := task.BranchName
+	path := task.WorktreePath
+	// Drop the claim only — the directory and the repo both stay, which is
+	// the one shape where git can still judge dirtiness.
+	empty := ""
+	if err := h.store.SetTaskProgress(t.Context(), task.ID, nil, &empty); err != nil {
+		t.Fatalf("clear claim: %v", err)
+	}
+
+	rep, err := h.rc.Reclaim(t.Context(), false, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	o := find(rep, path)
+	if o == nil || !o.Removed || o.Skip != "" {
+		t.Fatalf("clean orphan not removed: %+v", o)
+	}
+	if rep.Reclaimed != 1 || rep.ReclaimedBytes <= 0 {
+		t.Errorf("reclaimed = %d / %d bytes, want 1 and a positive size",
+			rep.Reclaimed, rep.ReclaimedBytes)
+	}
+	if exists(path) {
+		t.Error("the orphan is still on disk")
+	}
+	if testrepo.Run(t, h.repo, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch) == "" {
+		t.Errorf("branch %s no longer resolves — gc must never delete a branch", branch)
+	}
+}
+
+// TestReclaimSkipsDirtyOrphanUntilForced: an untracked file is enough, the
+// same rule `git worktree remove` itself uses.
+func TestReclaimSkipsDirtyOrphanUntilForced(t *testing.T) {
+	h := newReclaimHarness(t)
+	task := h.realWorktree(t, "dirty")
+	testrepo.WriteFile(t, task.WorktreePath, "scratch.txt", "unsaved work\n")
+	empty := ""
+	if err := h.store.SetTaskProgress(t.Context(), task.ID, nil, &empty); err != nil {
+		t.Fatalf("clear claim: %v", err)
+	}
+
+	rep, err := h.rc.Reclaim(t.Context(), false, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	o := find(rep, task.WorktreePath)
+	if o == nil || o.Skip != worktree.ReasonWorktreeDirty {
+		t.Fatalf("dirty orphan skip = %+v, want %q", o, worktree.ReasonWorktreeDirty)
+	}
+	if !exists(task.WorktreePath) {
+		t.Fatal("a dirty orphan was removed without force")
+	}
+
+	forced, err := h.rc.Reclaim(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("forced Reclaim: %v", err)
+	}
+	if o := find(forced, task.WorktreePath); o == nil || !o.Removed {
+		t.Fatalf("forced run did not remove the dirty orphan: %+v", o)
+	}
+	if exists(task.WorktreePath) {
+		t.Error("the dirty orphan survived --force")
+	}
+}
+
+// TestReclaimReportsDirtyUnknownWhenTheRepoIsGone is the *common* case: an
+// orphan's .git file points into a repository that has been deleted, so
+// `git status` fails and nobody can say what is in the directory.
+func TestReclaimReportsDirtyUnknownWhenTheRepoIsGone(t *testing.T) {
+	h := newReclaimHarness(t)
+	path := h.orphan(t, "repo-gone")
+	if err := os.RemoveAll(h.repo); err != nil {
+		t.Skipf("cannot remove the test repo on this platform: %v", err)
+	}
+
+	rep, err := h.rc.Reclaim(t.Context(), false, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	o := find(rep, path)
+	if o == nil || o.Skip != worktree.ReasonDirtyUnknown {
+		t.Fatalf("skip = %+v, want %q", o, worktree.ReasonDirtyUnknown)
+	}
+	if !exists(path) {
+		t.Fatal("an unjudgeable orphan was removed without force")
+	}
+	forced, err := h.rc.Reclaim(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("forced Reclaim: %v", err)
+	}
+	if o := find(forced, path); o == nil || !o.Removed {
+		t.Fatalf("forced run did not remove it: %+v", o)
+	}
+	if exists(path) {
+		t.Error("the orphan survived --force")
+	}
+}
+
+// TestReclaimRefusesPathsOutsideTheWorktreeRoot asserts on the filesystem,
+// not on a returned error: whatever the DB says, a directory outside
+// {data_dir}/worktrees is not gc's to delete.
+func TestReclaimRefusesPathsOutsideTheWorktreeRoot(t *testing.T) {
+	h := newReclaimHarness(t)
+	outside := h.mkdir(t, filepath.Join(t.TempDir(), "precious"))
+	traversal := h.mkdir(t, filepath.Join(h.worktreeRoot(), "..", "escaped"))
+
+	for _, path := range []string{outside, traversal} {
+		if err := h.worktrees.Reclaim(path); err == nil {
+			t.Errorf("Reclaim(%s) returned no error", path)
+		}
+		if !exists(path) {
+			t.Fatalf("%s was deleted — containment failed", path)
+		}
+	}
+	// And through the whole gc path, with a row claiming the outside
+	// directory so the scan has every excuse to touch it.
+	task := h.task(t, "outside-claim")
+	if err := h.store.SetTaskProgress(t.Context(), task.ID, nil, &outside); err != nil {
+		t.Fatalf("claim outside path: %v", err)
+	}
+	if _, err := h.rc.Reclaim(t.Context(), true, false); err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	if !exists(outside) {
+		t.Error("a claimed path outside the root was deleted")
+	}
+	if !exists(traversal) {
+		t.Error("a ..-traversal path outside the root was deleted")
+	}
+}
+
+// TestDryRunMatchesTheRealReportAndRemovesNothing.
+func TestDryRunMatchesTheRealReportAndRemovesNothing(t *testing.T) {
+	h := newReclaimHarness(t)
+	a := h.mkdir(t, filepath.Join(h.worktreeRoot(), "111"))
+	b := h.mkdir(t, filepath.Join(h.transcriptRoot(), "222"))
+
+	dry, err := h.rc.Reclaim(t.Context(), true, true)
+	if err != nil {
+		t.Fatalf("dry Reclaim: %v", err)
+	}
+	if len(dry.Orphans) != 2 {
+		t.Fatalf("dry run orphans = %d, want 2", len(dry.Orphans))
+	}
+	if dry.Reclaimed != 0 || dry.ReclaimedBytes != 0 {
+		t.Errorf("dry run claims to have reclaimed %d / %d bytes",
+			dry.Reclaimed, dry.ReclaimedBytes)
+	}
+	if !dry.DryRun {
+		t.Error("dry run report does not say so")
+	}
+	for _, path := range []string{a, b} {
+		if !exists(path) {
+			t.Fatalf("dry run removed %s", path)
+		}
+	}
+
+	scan, err := h.rc.Scan(t.Context())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if scan.Bytes != dry.Bytes || len(scan.Orphans) != len(dry.Orphans) {
+		t.Errorf("scan and dry run disagree: %d/%d bytes, %d/%d orphans",
+			scan.Bytes, dry.Bytes, len(scan.Orphans), len(dry.Orphans))
+	}
+	for i := range scan.Orphans {
+		if scan.Orphans[i].Path != dry.Orphans[i].Path ||
+			scan.Orphans[i].Bytes != dry.Orphans[i].Bytes {
+			t.Errorf("entry %d differs: %+v vs %+v", i, scan.Orphans[i], dry.Orphans[i])
+		}
+	}
+}
+
+// TestReclaimTranscriptOfACascadeDeletedRow: DeleteProjectCascade drops the
+// row, so §17's pruner — which walks archived *rows* — will never look at
+// this directory again. It is gc's, and it needs no dirty check.
+func TestReclaimTranscriptOfACascadeDeletedRow(t *testing.T) {
+	h := newReclaimHarness(t)
+	deleted := h.task(t, "cascade-deleted")
+	dir := h.mkdir(t, filepath.Join(h.transcriptRoot(),
+		strconv.FormatInt(deleted.ID, 10)))
+	if err := h.store.DeleteProjectCascade(t.Context(), h.projectID); err != nil {
+		t.Fatalf("DeleteProjectCascade: %v", err)
+	}
+
+	// No force: a transcript directory is vincent's own output, so nothing
+	// here is ever skipped for dirtiness.
+	rep, err := h.rc.Reclaim(t.Context(), false, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	o := find(rep, dir)
+	if o == nil || o.Kind != KindTranscript || !o.Removed || o.Skip != "" {
+		t.Fatalf("cascade-deleted transcript not reclaimed: %+v", o)
+	}
+	if exists(dir) {
+		t.Error("the cascade-deleted transcript directory is still on disk")
+	}
+}
+
+// TestArchivedRowKeepsItsTranscript proves the other half of the split: while
+// the row exists, its transcripts belong to §17 retention, not to gc.
+func TestArchivedRowKeepsItsTranscript(t *testing.T) {
+	h := newReclaimHarness(t)
+	archived := h.task(t, "archived")
+	dir := h.mkdir(t, filepath.Join(h.transcriptRoot(),
+		strconv.FormatInt(archived.ID, 10)))
+	h.archive(t, archived)
+
+	rep, err := h.rc.Reclaim(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	if o := find(rep, dir); o != nil {
+		t.Fatalf("an archived task's transcript was treated as an orphan: %+v", o)
+	}
+	if !exists(dir) {
+		t.Error("an archived task's transcript directory was removed by gc")
+	}
+}
+
+// TestScanCannotDeleteAWorktreeBeingCreated is the race the claim-based
+// definition creates and the claim lock closes. The claim callback is the
+// seam: the scan is launched from inside it, at the exact instant the
+// directory exists and no row names it.
+func TestScanCannotDeleteAWorktreeBeingCreated(t *testing.T) {
+	h := newReclaimHarness(t)
+	task := h.task(t, "racing")
+
+	var (
+		wg       sync.WaitGroup
+		scanRep  Report
+		scanErr  error
+		inClaim  = make(chan struct{})
+		released = make(chan struct{})
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-inClaim
+		// This blocks on the claim lock until CreateAndClaim returns; the
+		// test's assertion is that it cannot observe the unclaimed window.
+		scanRep, scanErr = h.rc.Reclaim(context.Background(), true, false)
+		close(released)
+	}()
+
+	branch := worktree.BranchName(task.ID, "racing")
+	path, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, task.ID, branch, "main",
+		func(p string) error {
+			close(inClaim)
+			return h.store.SetTaskProgress(t.Context(), task.ID, nil, &p)
+		})
+	if err != nil {
+		t.Fatalf("CreateAndClaim: %v", err)
+	}
+	<-released
+	wg.Wait()
+	if scanErr != nil {
+		t.Fatalf("concurrent Reclaim: %v", scanErr)
+	}
+	if o := find(scanRep, path); o != nil {
+		t.Fatalf("the scan saw a worktree being created as an orphan: %+v", o)
+	}
+	if !exists(path) {
+		t.Fatal("a live task's worktree was deleted by a concurrent gc run")
+	}
+}
+
+// TestReclaimKeepsGoingPastAnUndeletableOrphan is the Windows locked-file
+// case — the very failure that produces these orphans in the first place. The
+// failure is reported per path and the totals count only what actually went.
+func TestReclaimKeepsGoingPastAnUndeletableOrphan(t *testing.T) {
+	h := newReclaimHarness(t)
+	locked := h.mkdir(t, filepath.Join(h.worktreeRoot(), "111"))
+	other := h.mkdir(t, filepath.Join(h.worktreeRoot(), "222"))
+
+	f, err := os.Open(filepath.Join(locked, "payload"))
+	if err != nil {
+		t.Fatalf("open payload: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	rep, err := h.rc.Reclaim(t.Context(), true, false)
+	if err != nil {
+		t.Fatalf("Reclaim: %v", err)
+	}
+	if o := find(rep, other); o == nil || !o.Removed {
+		t.Fatalf("the removable orphan was not reclaimed: %+v", o)
+	}
+	if exists(other) {
+		t.Error("a removable orphan survived a run that hit a locked one")
+	}
+	// POSIX happily unlinks an open file, so the locked leg only asserts
+	// where the OS actually refuses. Where it does refuse — Windows — the
+	// report must name the failure and the totals must not count it.
+	o := find(rep, locked)
+	if o == nil {
+		t.Fatal("the locked orphan is not in the report")
+	}
+	if o.Removed {
+		if rep.Reclaimed != 2 {
+			t.Errorf("reclaimed = %d, want 2 where the OS allows the removal", rep.Reclaimed)
+		}
+		return
+	}
+	if o.Error == "" {
+		t.Error("a failed removal is reported without an error message")
+	}
+	if rep.Reclaimed != 1 {
+		t.Errorf("reclaimed = %d, want 1 — the failed removal must not be counted", rep.Reclaimed)
+	}
+	if rep.ReclaimedBytes != o2Bytes(rep, other) {
+		t.Errorf("reclaimed_bytes = %d, want only the orphan that went", rep.ReclaimedBytes)
+	}
+}
+
+func o2Bytes(rep Report, path string) int64 {
+	if o := find(rep, path); o != nil {
+		return o.Bytes
+	}
+	return 0
+}
+
+// TestCountMatchesTheScan keeps the cheap /v1/info figure honest against the
+// full report it summarizes.
+func TestCountMatchesTheScan(t *testing.T) {
+	h := newReclaimHarness(t)
+	if n, err := h.rc.Count(t.Context()); err != nil || n != 0 {
+		t.Fatalf("Count on a clean daemon = %d, %v; want 0, nil", n, err)
+	}
+	h.mkdir(t, filepath.Join(h.worktreeRoot(), "111"))
+	h.mkdir(t, filepath.Join(h.transcriptRoot(), "222"))
+	h.realWorktree(t, "claimed")
+
+	n, err := h.rc.Count(t.Context())
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	rep, err := h.rc.Scan(t.Context())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if n != len(rep.Orphans) || n != 2 {
+		t.Errorf("Count = %d, scan orphans = %d, want 2", n, len(rep.Orphans))
+	}
+}

--- a/internal/tui/daemon_test.go
+++ b/internal/tui/daemon_test.go
@@ -335,3 +335,44 @@ func TestDaemonViewNamesAnUnpinnedAdapterPath(t *testing.T) {
 		t.Errorf("an unpinned adapter path is not explained:\n%s", out)
 	}
 }
+
+// TestDaemonViewShowsOrphansAndOffersNoAction: §15 view 6 reports, it does
+// not act. The line names the count and the command, and nothing on this view
+// runs gc — for the same reason nothing here stops the daemon.
+func TestDaemonViewShowsOrphansAndOffersNoAction(t *testing.T) {
+	d := newTestDaemonView(nil, nil)
+	info := testInfo()
+	info.Orphans = 3
+	d.update(daemonInfoMsg{info: info})
+	d.update(daemonConfigMsg{config: testConfig()})
+	out := renderDaemon(d)
+
+	if !strings.Contains(out, "orphans") || !strings.Contains(out, "3 directories") {
+		t.Errorf("the view does not report the orphan count:\n%s", out)
+	}
+	if !strings.Contains(out, "vincent gc") {
+		t.Errorf("the view does not name the command that clears them:\n%s", out)
+	}
+}
+
+// A clean daemon shows no orphan line at all: a permanent "orphans: 0" is
+// noise on every healthy daemon.
+func TestDaemonViewHidesTheOrphanLineWhenThereAreNone(t *testing.T) {
+	d := newTestDaemonView(nil, nil)
+	loadedDaemon(d)
+	if out := renderDaemon(d); strings.Contains(out, "orphans") {
+		t.Errorf("the view shows an orphan line with nothing to report:\n%s", out)
+	}
+}
+
+// The singular case reads as a sentence rather than as a count with a plural
+// bolted on.
+func TestDaemonViewSingularOrphanLine(t *testing.T) {
+	line, ok := orphanLine(1)
+	if !ok || !strings.Contains(line, "1 directory no task claims") {
+		t.Errorf("orphanLine(1) = %q, %v", line, ok)
+	}
+	if _, ok := orphanLine(0); ok {
+		t.Error("orphanLine(0) produced a line")
+	}
+}

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -58,10 +58,34 @@ func (d *daemonView) identityLines() []string {
 		field("data dir", d.dataDirOrUnknown()),
 		field("log", d.logPathOrUnknown()),
 	)
+	if line, ok := orphanLine(i.Orphans); ok {
+		out = append(out, line)
+	}
 	if line, ok := d.staleLine(d.infoErr, d.infoAt); ok {
 		out = append(out, line)
 	}
 	return out
+}
+
+// orphanLine reports directories under the data dir that no task claims
+// (task 005, §10) and names the command that clears them.
+//
+// It reports and offers no action, like the rest of this view (§15 view 6):
+// running gc from here would be the daemon-stop button this view already
+// refuses to have. A zero count prints nothing at all — a permanent "orphans:
+// 0" is noise on every healthy daemon, and the line only earns its space when
+// there is something to do about it.
+func orphanLine(n int) (string, bool) {
+	if n <= 0 {
+		return "", false
+	}
+	noun := "directories"
+	if n == 1 {
+		noun = "directory"
+	}
+	return field("orphans", styleWarn.Render(
+		fmt.Sprintf("%d %s no task claims", n, noun))+
+		styleDim.Render("   reclaim with `vincent gc`")), true
 }
 
 // configLines is the configuration the daemon actually has loaded, which is

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/lezli01/vincent/internal/gitx"
 )
@@ -27,6 +28,18 @@ const (
 	ReasonWorktreePathOccupied = "worktree_path_occupied"
 	ReasonGitError             = "git_error"
 )
+
+// ReasonDirtyUnknown is gc's answer when git cannot say whether a directory
+// holds uncommitted work (task 005) — the *common* case for an orphan, whose
+// `.git` file points into a repo that has been deleted or pruned, so
+// `git status --porcelain` fails outright.
+//
+// It is deliberately distinct from ReasonWorktreeDirty: "git says you have
+// local changes" and "nobody can tell what is in here" are different facts,
+// and only the second one is about a missing repo. It is also the one reason
+// in this file that never becomes a task `block_reason` — it is a gc *skip*
+// reason, which is why it carries no `worktree_` prefix.
+const ReasonDirtyUnknown = "dirty_unknown"
 
 // Error is a typed worktree-management failure.
 type Error struct {
@@ -94,12 +107,24 @@ func BranchName(taskID int64, title string) string {
 type Manager struct {
 	git  *gitx.Git
 	root string
+
+	// claims guards the window in which a directory exists on disk but no
+	// task row claims it yet (task 005). gc defines an orphan by claim, not
+	// by name, so that window is exactly when a live task's worktree would
+	// look reclaimable. Creation and archival take it shared; the reclaim
+	// scan takes it exclusively. An mtime/age heuristic was rejected: a
+	// timing guess has no place in the package whose subject is ownership.
+	claims sync.RWMutex
 }
 
 // NewManager returns a Manager storing worktrees under dataDir.
 func NewManager(git *gitx.Git, dataDir string) *Manager {
 	return &Manager{git: git, root: filepath.Join(dataDir, "worktrees")}
 }
+
+// Root is the directory every worktree lives under, and the only directory
+// Reclaim will delete inside (spec §10).
+func (m *Manager) Root() string { return m.root }
 
 // Path returns the worktree location for a task.
 func (m *Manager) Path(taskID int64) string {
@@ -109,7 +134,66 @@ func (m *Manager) Path(taskID int64) string {
 // Create adds branch (from base) and a worktree for it, returning the
 // worktree path. It prunes stale worktree registrations first and never
 // deletes an existing directory (prune-then-fail decision).
+//
+// Callers that persist the path afterwards must use CreateAndClaim instead,
+// so the create-then-claim window is closed against a concurrent gc scan.
 func (m *Manager) Create(ctx context.Context, projectPath string, taskID int64, branch, base string) (string, error) {
+	m.claims.RLock()
+	defer m.claims.RUnlock()
+	return m.create(ctx, projectPath, taskID, branch, base)
+}
+
+// CreateAndClaim creates the worktree and, still holding the claim lock,
+// hands the path to claim — which is where the caller records it against the
+// task row (task 005). A gc scan cannot run between the two, so a worktree is
+// never unclaimed and reclaimable at the same instant.
+//
+// A claim that fails is reported, not undone: the directory is real and the
+// engine's own error path decides what happens to the task. The next scan
+// will see it as an orphan, which is precisely the crash case gc exists for.
+func (m *Manager) CreateAndClaim(
+	ctx context.Context, projectPath string, taskID int64, branch, base string,
+	claim func(path string) error,
+) (string, error) {
+	m.claims.RLock()
+	defer m.claims.RUnlock()
+	path, err := m.create(ctx, projectPath, taskID, branch, base)
+	if err != nil {
+		return "", err
+	}
+	if claim != nil {
+		if err := claim(path); err != nil {
+			return path, err
+		}
+	}
+	return path, nil
+}
+
+// RemoveAndRelease removes the worktree and then clears the claim, both under
+// the claim lock — the mirror of CreateAndClaim. Archive is the caller: a
+// scan slipping between the removal and the cleared `worktree_path` would
+// report the row as a reverse mismatch it never was (task 005).
+func (m *Manager) RemoveAndRelease(
+	ctx context.Context, projectPath, worktreePath string, force bool, release func() error,
+) error {
+	m.claims.RLock()
+	defer m.claims.RUnlock()
+	if err := m.Remove(ctx, projectPath, worktreePath, force); err != nil {
+		return err
+	}
+	return release()
+}
+
+// WithReclaimLock runs fn with no create-or-claim in flight anywhere in the
+// daemon. gc holds it across scan **and** removal, so the claim set it
+// classifies against cannot move underneath it (task 005).
+func (m *Manager) WithReclaimLock(fn func() error) error {
+	m.claims.Lock()
+	defer m.claims.Unlock()
+	return fn()
+}
+
+func (m *Manager) create(ctx context.Context, projectPath string, taskID int64, branch, base string) (string, error) {
 	if _, err := os.Stat(projectPath); err != nil {
 		return "", &Error{
 			Reason:  ReasonProjectPathMissing,
@@ -274,6 +358,16 @@ func (m *Manager) Remove(ctx context.Context, projectPath, worktreePath string, 
 	}
 	return m.prune(ctx, projectPath)
 }
+
+// Reclaim deletes a directory under the manager's root without consulting
+// git at all — gc's removal path (task 005). An orphan has, by definition, no
+// task row and often no reachable repo, so `git worktree remove` has nothing
+// to work from; the containment check is what keeps that safe.
+//
+// It is removeDirect exported unchanged: one containment rule, one
+// implementation, so a path outside {data_dir}/worktrees is refused here for
+// the same reason it is refused during a forced archive.
+func (m *Manager) Reclaim(path string) error { return m.removeDirect(path) }
 
 // removeDirect deletes a worktree directory without git, but only inside the
 // manager's own root — nothing outside vincent's namespace is ever removed.

--- a/scripts/m1-gate.sh
+++ b/scripts/m1-gate.sh
@@ -125,6 +125,50 @@ DIFF="$(api GET "/tasks/$TASK_ID/diff")"
 grep -q 'README.md' <<<"$DIFF" || fail "diff does not mention README.md:
 $DIFF"
 
+# The gc leg rides here because this script already has the two things it
+# needs: a registered project and a task with a real worktree that must come
+# through untouched (task 005, §10).
+echo "== plant an orphaned worktree"
+ORPHAN_ID=999999
+ORPHAN="$DATA_DIR/worktrees/$ORPHAN_ID"
+mkdir -p "$ORPHAN"
+printf '0123456789\n' > "$ORPHAN/payload"
+LIVE_WORKTREE="$(api GET "/tasks/$TASK_ID" | jq -r .worktree_path)"
+[[ -d "$LIVE_WORKTREE" ]] || fail "the task's worktree is not on disk: $LIVE_WORKTREE"
+
+echo "== list orphans"
+ORPHANS="$(api GET /maintenance/orphans)"
+jq -e --argjson id "$ORPHAN_ID" \
+  '[.orphans[] | select(.task_id == $id)] | length == 1' <<<"$ORPHANS" >/dev/null \
+  || fail "the planted orphan is not listed:
+$ORPHANS"
+jq -e --argjson id "$ORPHAN_ID" \
+  '.orphans[] | select(.task_id == $id) | .kind == "worktree" and .bytes > 0' <<<"$ORPHANS" >/dev/null \
+  || fail "the orphan is listed without a kind or a size:
+$ORPHANS"
+# The live task's worktree is claimed, so it must never appear.
+jq -e --argjson id "$TASK_ID" \
+  '[.orphans[] | select(.task_id == $id)] | length == 0' <<<"$ORPHANS" >/dev/null \
+  || fail "a live task's worktree was reported as an orphan:
+$ORPHANS"
+api GET /info | jq -e '.orphans >= 1' >/dev/null || fail "/v1/info does not report the orphan"
+
+echo "== dry run removes nothing"
+api POST /maintenance/gc '{"force":true,"dry_run":true}' \
+  | jq -e '.dry_run == true and .reclaimed == 0' >/dev/null || fail "dry run reported a removal"
+[[ -d "$ORPHAN" ]] || fail "the dry run removed the orphan"
+
+# --force: the planted directory has no repository behind it, so git cannot
+# judge it and gc reports dirty_unknown rather than guessing.
+echo "== reclaim"
+GC="$(api POST /maintenance/gc '{"force":true}')"
+jq -e '.reclaimed == 1 and .reclaimed_bytes > 0' <<<"$GC" >/dev/null || fail "gc reclaimed nothing:
+$GC"
+[[ ! -e "$ORPHAN" ]] || fail "the orphan survived gc"
+[[ -d "$LIVE_WORKTREE" ]] || fail "gc removed a live task's worktree: $LIVE_WORKTREE"
+git -C "$REPO" rev-parse --verify "refs/heads/$BRANCH" >/dev/null \
+  || fail "gc deleted branch $BRANCH — branches are never deleted"
+
 echo "== stop daemon"
 "$VINCENT" daemon stop
 


### PR DESCRIPTION
## Summary

A directory under `{data_dir}/worktrees` or `{data_dir}/transcripts` could outlive every
reference to it, and nothing in vincent would ever look at it again. Two producers, and
nothing reconciled either: `DELETE /v1/projects/{id}` removes worktrees best-effort by
the T1.5 decision while `DeleteProjectCascade` drops the rows regardless, and a crash
between `git worktree add` and the `worktree_path` write left a directory claimed by
nobody — which then failed the task's next admission with `worktree_path_occupied`,
pointing at a path the user had never been told about. `Manager.prune` is git's
bookkeeping inside the *project* repo; `taskrun.Recover` reconciles rows and processes;
the §17 pruner walks archived *rows*.

**`vincent gc [--dry-run] [--force] [--json]`**, over `GET /v1/maintenance/orphans` and
`POST /v1/maintenance/gc`, reclaims them. Plus a **report-only** startup reconcile.

Four things are worth a reviewer's attention:

1. **An orphan is an entry no task row *claims* — by `worktree_path`, not by name.**
   The issue proposed the name-based definition; it calls the crash case *claimed*
   (the directory is named after a live row) and would leave that
   `worktree_path_occupied` block in place forever. One rule covers both producers.
2. **That definition opens a race, guarded at the source.** Between `Create` returning
   and the claim being persisted a live task's worktree is briefly unclaimed, and a
   concurrent scan would delete a running task's working tree. `worktree.Manager` grows
   an `RWMutex`: creation takes it shared across create-**and**-claim (`CreateAndClaim`,
   whose callback is `ensureWorktree`'s `SetTaskProgress`), archive across
   remove-**and**-clear, and the scan takes it exclusively across scan-**and**-remove.
   An mtime/age heuristic was rejected — a timing guess in the package whose subject is
   ownership.
3. **`dirty_unknown` is the common case, not an edge one.** An orphan's `.git` file
   points at `{repo}/.git/worktrees/{n}`, so a deleted or pruned repository makes
   `git status --porcelain` fail outright. It is reported distinctly from
   `worktree_dirty` and skipped without `--force`. Accepted consequence: where the
   projects really are gone, a default run reclaims less than the issue's prose
   implies.
4. **The asymmetry is deliberate.** `vincent gc` deletes by default — a human, a dirty
   check, a containment rule, a printed byte report. Daemon start only logs and raises
   the `/v1/info` count, per §18's never-auto-deletes posture.

Transcripts are in scope for the same reason worktrees are: retention walks archived
*rows*, so a cascade-deleted row's transcript directory is reached by no pass, ever. It
costs one readdir against the same id set.

Never removes anything outside the two data roots, never deletes a branch, never
modifies a task row. A row pointing at a directory that is gone (§18's
`worktree_missing` shape) is reported and left alone. A removal that fails — the locked
file on Windows that produces these orphans in the first place — is reported per path,
the run continues, and the totals count only what actually went.

**Where the code lives:** `internal/taskrun/reclaim.go` (beside `prune.go`, whose
dependency set it shares exactly), `internal/worktree` (lock, `Root`, `Reclaim`,
`ReasonDirtyUnknown`), `internal/store` (`ListWorktreeClaims`, `ListTaskIDs`),
`internal/api/maintenance.go`, `internal/apiclient/maintenance.go`,
`internal/cli/gc.go`, plus the daemon reconcile and the TUI daemon-view line.

## Related

Closes #95

Task document: [`docs/tasks/005-orphaned-worktree-gc.md`](docs/tasks/005-orphaned-worktree-gc.md)
— closes 005.1 through 005.8, and carries the nine decisions with the alternatives they
beat.

This **complements** the T1.5 best-effort decision rather than relitigating it: the
issue's own rejected alternative ("make project delete's removal authoritative") stays
rejected, since it strands the user with an undeletable project over a locked file and
does nothing for the crash case. §10's "cleanup only on archive" is amended, not
overturned — archive remains the only path that removes a *task's* worktree.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### What the tests prove

All hermetic — `internal/testrepo` for real git, `t.TempDir()` for isolation.

- **Classification** (`internal/taskrun/reclaim_test.go`) — an unclaimed directory is an
  orphan; a claimed one is never touched; a directory named after a **live row with an
  empty `worktree_path`** *is* an orphan (the criterion the name-based definition
  fails); a stray file is reported with `not_a_directory`, not deleted; a row pointing
  at a missing directory is listed and is byte-identical afterwards.
- **Dirt** — a clean orphan is removed and its branch still resolves in the project repo
  after; an orphan with only an untracked file is skipped `worktree_dirty` and removed
  under `--force`; an orphan whose repo has been deleted is skipped `dirty_unknown` and
  removed under `--force`.
- **Containment** — a claim naming a path outside `{data_dir}/worktrees`, including a
  `..` traversal, asserted **on the filesystem** rather than on a returned error.
- **Dry run** — same paths and same byte figures as the scan, everything still on disk.
- **The race** — a reclaim run launched from *inside* the claim callback, at the exact
  instant the directory exists and no row names it. The callback is the seam; no sleep.
- **Locked file** — an open handle inside an orphan. Where the OS refuses the removal
  (Windows), the failure is reported per path, the other orphan still goes, and
  `reclaimed`/`reclaimed_bytes` count only that one. POSIX unlinks an open file, so that
  leg asserts the removal instead — the branch is explicit in the test rather than a
  skip, so CI's Windows leg is what carries the criterion.
- **Transcripts** — a cascade-deleted row's directory is reclaimed with no dirty check;
  an archived-but-live row's is left to the §17 pruner.
- **Wire** (`internal/apiclient/maintenance_live_test.go`) — both endpoints and
  `Info.Orphans` through the **real** handlers over `httptest`, including that the count
  drops immediately after a gc run (it is computed per request, not cached) and that a
  claimed directory is never an orphan over the wire.
- **CLI** (`internal/cli/gc_e2e_test.go`) — `vincent gc` through the real binary against
  a real detached daemon: dry run, `--force --json`, "nothing to reclaim", and the
  daemon-unreachable path (exit 2, the same message every other thin client prints).
- **TUI** (`internal/tui/daemon_test.go`) — the daemon view shows the count and
  `vincent gc`, shows nothing at zero, and reads as a sentence in the singular.
- **Gate** — a leg appended to `scripts/m1-gate.sh`, which already registers a project
  and runs a task to a worktree over curl: plant `{data_dir}/worktrees/999999`, assert
  it is listed with a size and the live task's worktree is *not*, assert `--dry-run`
  leaves it, reclaim it, and assert the real worktree and its branch survived.

### Docs

- **`docs/spec.md`**, amended in place with dated notes in this PR, as the repository
  requires: **§10** (the second reclaim path, the orphan definition, both producers,
  `dirty_unknown`, containment, branches-never-deleted restated), **§12.1** (the
  `vincent gc` row and why the name breaks the noun-verb pattern), **§12.4** (recovery
  reconciles rows and processes, not directories), **§13.2** (both endpoints and
  `orphans` on `/v1/info`, with why it is not on `/v1/health`), **§15 view 6** (the
  count is displayed; the view still does not act), **§17** (retention is about archived
  rows; a cascade-deleted row's transcripts are gc's), **§18** (two new rows).
- **User docs**, which are derived from the source: `docs/reference/cli.md` (the cobra
  tree), `docs/reference/api.md` (the route table), `docs/reference/files.md` (both
  roots gain a "what reclaims this" note), `docs/guides/tui.md` (the daemon view),
  `docs/guides/troubleshooting.md` (`worktree_path_occupied` → run `vincent gc`).
- `docs/tasks/README.md` index row updated in the same edit as the new task document.

### Verification

- `go run mage.go test` — 1204 pass.
- `go test -race ./internal/taskrun ./internal/worktree ./internal/apiclient` — pass.
- `go run mage.go lint`, and the linter built for the host and run for
  `GOOS=windows|darwin|linux` — 0 issues on all three.
- `./scripts/m1-gate.sh` — PASS, including the new gc leg (macOS host, fake agent).

CI runs the full matrix and all three gates on Linux, macOS and Windows, which is what
carries the issue's Windows acceptance criterion.
