### PR TITLE
feat(archive): delete a task's branch when it has no commits past its base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,37 @@ Please pull request.
   then the existing GoReleaser workflow publishes signed artifacts and updates
   the stable Homebrew cask. Prerelease tags continue to skip the tap.
 
+- **Archiving a task now deletes its branch when that branch has no commits past
+  its base.** A workflow that files an issue, posts a summary or reviews
+  read-only writes nothing to the repository, but it still got a branch, and
+  archiving it left that branch behind forever — one empty `vincent/*` ref per
+  run, with no reliable glob to clean up with, since branch names are
+  configurable. The only remedy was to list the archived tasks and delete them by
+  hand.
+
+  The test is exact: `git rev-list -n 1 {base}..{branch}` must produce nothing,
+  meaning the tip is an ancestor of the base the task was cut from. **A branch
+  carrying any commit is never touched**, the delete is `git branch -d` rather
+  than `-D`, and anything git cannot answer — the base branch renamed away, the
+  repository gone — keeps the branch and is logged. A branch problem never fails
+  an archive: the task still reaches `archived`, and the branch simply survives,
+  which is what always used to happen.
+
+  Set `delete_empty_branch_on_archive: false` in `config.yaml` for the previous
+  behaviour on every path. `POST /v1/tasks/{id}/archive` reports what it did in a
+  new `branch` object beside the task, and the TUI says it in one line;
+  `DELETE /v1/projects/{id}?force` applies the same rule to every row it is about
+  to drop, because the cascade erases the branch names for good. `vincent gc` and
+  `vincent doctor --fix` still delete no branch at all — an orphaned directory has
+  no task row, so there is no base branch to judge it against.
+
+- **`delete_remote_branch_on_archive` deletes the upstream counterpart too — off
+  by default.** It runs only when you archive a task yourself, only after the
+  local branch was deleted, and only when the branch has a configured upstream;
+  a project delete never touches a remote. A rejected push, an unreachable host
+  or a timeout is logged and the archive still succeeds. It is off by default
+  because a forge is shared with other people and the deletion cannot be undone.
+
 - **codex now reports `logged_in`.** `Detect` probes `codex login status`, so
   "the CLI is installed but your session expired" is visible on the board, in
   the new-task form, in `GET /v1/agents` and in doctor — instead of first

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -110,8 +110,12 @@ What it **does not** buy you: privilege isolation. A full-auto agent runs as
 you, with your credentials and your network. See the
 [Security model](../security-model.md).
 
-Archiving a task removes its worktree and keeps the branch and the record.
-vincent never deletes a branch.
+Archiving a task removes its worktree and keeps the record. It keeps the branch
+too, unless that branch has no commits past the base it was cut from — a
+workflow that never writes to the repository leaves nothing on its branch, and
+archiving deletes it rather than leaving an empty ref behind. **A branch
+carrying any commit is never deleted.** Turn the cleanup off with
+[`delete_empty_branch_on_archive: false`](../reference/configuration.md#delete_empty_branch_on_archive).
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -248,9 +248,11 @@ Installed with Homebrew, `brew uninstall --zap vincent` does all of the above in
 one step — it unloads the LaunchAgent, removes the binary, and trashes the
 config and data directory.
 
-**Branches are never deleted by vincent.** Task branches stay in your repositories
-until you remove them. Ask vincent which ones it made — branch names are
-configurable, so a `vincent/*` glob is not guaranteed to find them all:
+**A branch with commits on it is never deleted by vincent.** Archiving a task
+deletes its branch only when that branch has no commits past its base, so
+everything vincent actually wrote for you stays in your repositories until you
+remove it. Ask vincent which branches it made — branch names are configurable, so
+a `vincent/*` glob is not guaranteed to find them all:
 
 ```sh
 vincent task ls --archived      # read the branch column

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -198,8 +198,10 @@ gh pr create --head vincent/1-add-a-version-flag-to-the-cli
 ```
 
 When you are done with the task, archive it (`A` in the TUI). That removes the
-**worktree** and keeps the record and the branch — vincent never deletes a
-branch.
+**worktree** and keeps the record. The branch you just made a PR from carries
+commits, so it is kept as well; a branch that never received a commit is deleted
+instead of accumulating as an empty ref, and the TUI says which happened. See
+[`delete_empty_branch_on_archive`](../reference/configuration.md#delete_empty_branch_on_archive).
 
 ---
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -202,9 +202,12 @@ discard, then archive again.
 ### `branch_exists` / `worktree_path_occupied`
 
 The branch this task would use, or its worktree directory, already exists from an
-earlier run. vincent **never deletes a branch**, so leftovers accumulate if you
-re-create tasks with the same title — or if a branch template has no discriminator
-in it, in which case the *second* task for the same input collides every time.
+earlier run. vincent **never deletes a branch that carries a commit**, so
+leftovers accumulate if you re-create tasks with the same title — or if a branch
+template has no discriminator in it, in which case the *second* task for the same
+input collides every time. (Archiving cleans up only the branches that received
+no commit at all, which is precisely the set that never collides with anything
+you would miss.)
 
 Most collisions are caught at creation with a `400`, but the check at creation is
 racy by nature, so this block is the authority.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -188,7 +188,12 @@ See [`vincent gc`](cli.md#vincent-gc) for the command over these endpoints.
 
 `DELETE` succeeds only when no non-archived tasks remain. `?force` archives them
 first (force-removing worktrees), and is refused while any task is running.
-**Branches are never deleted.**
+Before the rows go, every branch that has no commits past its base is deleted —
+archived rows included, because the cascade erases the branch names for good.
+**A branch carrying a commit is never deleted**, and no remote is ever touched
+here; failures are logged and the delete proceeds. Set
+[`delete_empty_branch_on_archive: false`](configuration.md#delete_empty_branch_on_archive)
+to disable the sweep.
 
 ## Workflows
 
@@ -253,6 +258,31 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 
 Anything else returns `409` with `details.state`. See
 [Task lifecycle](task-lifecycle.md).
+
+`/archive` is the one action whose response is not just the task. When it looks
+at the branch, it adds a `branch` object beside the task fields:
+
+```json
+{
+  "id": 7, "state": "archived", "…": "…",
+  "branch": {
+    "name": "vincent/7-file-an-issue",
+    "result": "deleted",
+    "remote": { "remote": "origin", "ref": "refs/heads/vincent/7-file-an-issue", "result": "deleted" }
+  }
+}
+```
+
+`result` is `deleted` (no commits past its base), `has_commits` (kept), `unknown`
+(git could not judge it — base branch renamed away, repository gone) or `error`
+(the delete itself failed), with git's message in `error` for the last two. The
+`remote` object appears only when
+[`delete_remote_branch_on_archive`](configuration.md#delete_remote_branch_on_archive)
+is on and the local delete succeeded; its `result` is `deleted`, `no_upstream` or
+`error`. The whole `branch` object is **absent** when nothing was checked — the
+cleanup is off, or the task never had a branch of its own.
+
+None of it affects the status code: a branch problem never fails an archive.
 
 Four details worth knowing:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,6 +44,18 @@ defaults:
   command_timeout: 15m
   input_timeout: 24h
 
+# Delete a task's branch when it is archived and carries no commits past the
+# base it was cut from — the branch a workflow that never writes to the
+# repository leaves behind. A branch holding any commit is always kept, and a
+# check git cannot answer keeps the branch too.
+delete_empty_branch_on_archive: true
+
+# Also delete that branch's upstream counterpart, when it has one. Off by
+# default and honoured only when a human archives the task: a forge is shared
+# with other people and the deletion cannot be undone. Nothing happens here
+# unless delete_empty_branch_on_archive is also on.
+delete_remote_branch_on_archive: false
+
 # Transcripts of archived tasks older than this many days are pruned.
 transcript_retention_days: 90
 
@@ -136,9 +148,11 @@ Available in a template:
 
 Two things to get right, because git will not catch them for you:
 
-**Put a discriminator in it.** vincent never deletes branches, so a template like
-`feat/{{.Fields.ticket}}` collides on the *second* task for the same ticket. Include
-`{{.ID}}`, or expect to name repeats by hand.
+**Put a discriminator in it.** vincent never deletes a branch that carries a
+commit, so a template like `feat/{{.Fields.ticket}}` collides on the *second* task
+for the same ticket. Include `{{.ID}}`, or expect to name repeats by hand.
+([`delete_empty_branch_on_archive`](#delete_empty_branch_on_archive) reclaims only
+branches that received no commit, which is not the case this is about.)
 
 **Prefer `{{.Fields.x}}` over `{{ index .Fields "x" }}`.** The first fails loudly when
 the field is missing; the second renders *nothing*, giving you `feat/-fix-login` — a
@@ -176,6 +190,68 @@ normal retry policy. The step clock **pauses** while a task is
 `awaiting_input`: it measures agent work, not human latency.
 
 Workflow `defaults:` and per-step fields override these.
+
+### `delete_empty_branch_on_archive`
+
+```yaml
+delete_empty_branch_on_archive: true
+```
+
+When a task is archived, delete its branch if that branch has **no commits past
+the base it was cut from**. That is the branch a workflow which never writes to
+the repository leaves behind — filing an issue, posting a summary, reviewing
+read-only — one empty ref per run, with no reliable glob to find them again since
+branch names are configurable.
+
+The test is `git rev-list -n 1 {base}..{branch}` producing nothing: the branch tip
+is an ancestor of the base. It stays correct when the base moves on after the task
+started, and it is exact — **a branch carrying any commit is never deleted**.
+
+Three refusals are deliberate, and all of them keep the branch:
+
+| Situation | What happens |
+|---|---|
+| The branch has commits | Kept, reported `has_commits` |
+| git cannot judge it — base branch renamed or deleted, repository gone | Kept, reported `unknown`, logged |
+| The delete itself fails — the branch is checked out in another worktree | Kept, reported `error`, logged. The delete is `git branch -d`, never `-D` |
+
+A branch problem never fails an archive: the task reaches `archived` either way,
+and the branch simply survives, which is what always used to happen.
+`POST /v1/tasks/{id}/archive` reports the outcome in its response and the TUI
+prints it in one line; every other path logs to `daemon.log`.
+
+The same rule runs for every task row `DELETE /v1/projects/{id}?force` is about to
+delete, archived ones included — that cascade erases the branch names for good, so
+it is the last moment they exist. `vincent gc` and `vincent doctor --fix` delete no
+branch at all: an orphaned directory has no task row, so there is no base branch to
+judge it against.
+
+Set it to `false` to keep every branch on every path, which is what vincent did
+before this key existed. Read per archive, so a hot reload applies to the next one.
+
+### `delete_remote_branch_on_archive`
+
+```yaml
+delete_remote_branch_on_archive: false
+```
+
+Also delete the upstream counterpart of a branch that qualified above. **Off by
+default**, and unlike its local sibling it is honoured only when *you* archive a
+task (`POST /v1/tasks/{id}/archive`) — deleting a branch on a forge you share with
+other people cannot be undone, so no unattended path does it. `DELETE
+/v1/projects/{id}?force` never touches a remote.
+
+It runs only after the local delete succeeded, and only when the branch has a
+configured upstream (`branch.{name}.remote` and `branch.{name}.merge`). No
+upstream means nothing was pushed as far as vincent knows, so nothing is
+attempted — and the remote name is never guessed from the local one. The push is
+`git push --delete {remote} {ref}` under a 60-second timeout; a rejection, an
+unreachable host or a timeout is logged, reported in the archive response, and
+never fails the archive.
+
+It does nothing while `delete_empty_branch_on_archive` is `false`. That
+combination still loads — a key that cannot do anything is not an invalid one —
+but the daemon logs a warning at startup and on any reload that introduces it.
 
 ### `transcript_retention_days`
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -83,9 +83,14 @@ Two rules worth internalizing:
 
 - **The worktree is disposable.** Archiving a task removes it. If it has
   uncommitted changes, archiving refuses unless forced — that work would be lost.
-- **The branch is not.** vincent never deletes a branch. Task branches accumulate
-  in your repository until you remove them. The daemon is the reliable list, since
-  a configured name need not start with `vincent/`:
+- **The branch is not — as long as it holds a commit.** vincent never deletes a
+  branch that has commits past the base it was cut from, so everything an agent
+  actually wrote accumulates in your repository until you remove it. The one
+  branch archiving does delete is one that received *no* commit at all, which is
+  what a workflow that never writes to the repository leaves behind
+  ([`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)).
+  The daemon is the reliable list, since a configured name need not start with
+  `vincent/`:
 
   ```sh
   vincent task ls --archived      # the branch column
@@ -165,8 +170,11 @@ vincent daemon --config-dir /srv/v-cfg --data-dir /srv/v-data
 | `{config_dir}/` | Your config and global workflows; defaults are rewritten at next start |
 
 To remove vincent entirely: `vincent service uninstall`, `vincent daemon stop`,
-delete the binary, delete both directories, then clean up `vincent/*` branches in
-any repository you used.
+delete the binary, delete both directories, then clean up any branches left in
+the repositories you used — the ones that carry commits, since the empty ones
+went when their tasks were archived. Take the list from `vincent task ls
+--archived` **before** deleting the database: a configured branch name need not
+start with `vincent/`.
 
 ---
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -55,7 +55,7 @@ Tasks are `queued` immediately on creation. There is no draft state.
 | `paused` | You asked it to hold; takes effect at the next step boundary | no |
 | `done` | Every step succeeded. Worktree and branch retained for inspection | no |
 | `aborted` | You cancelled, or rejected terminally. Worktree and branch retained | no |
-| `archived` | Terminal. Worktree removed, branch kept, record kept | no |
+| `archived` | Terminal. Worktree removed, record kept. The branch is kept unless it has no commits past its base, in which case it is deleted ([`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)) | no |
 
 Three of these are worth dwelling on.
 
@@ -92,7 +92,7 @@ its worktree, its branch and its transcripts while it does.
 | `approve` | awaiting_gate | Gate `approved`, advance → `queued` |
 | `reject` | awaiting_gate | Gate `rejected` → `blocked`, from which you can edit-and-retry an earlier step, skip, or abort |
 | `set priority` | queued, paused | Reorders scheduler admission |
-| `archive` | done, aborted | Removes the worktree, keeps the branch → `archived`. Refuses on a dirty worktree unless forced — uncommitted work would be lost |
+| `archive` | done, aborted | Removes the worktree → `archived`, then deletes the branch **only** if it has no commits past its base. Refuses on a dirty worktree unless forced — uncommitted work would be lost, and a refusal never reaches the branch |
 
 In the TUI these are the action bar keys (`a`, `x`, `r`, `E`, `s`, `p`, `c`,
 `A`); over the API they are `POST /v1/tasks/{id}/{action}`; from the CLI,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -258,7 +258,7 @@ already applies to every other pending flag — a human action means go.
 | `paused` | Engineer-requested soft pause (takes effect at the next step boundary) | no |
 | `done` | All steps succeeded; worktree/branch retained for inspection | no |
 | `aborted` | Engineer aborted, or rejected terminally; worktree/branch retained | no |
-| `archived` | Terminal. Worktree removed (branch retained); record kept for history | no |
+| `archived` | Terminal. Worktree removed; record kept for history. The branch is retained unless it carries no commits past its base, in which case `delete_empty_branch_on_archive` deletes it (§10, *amended 2026-08-16, task 008*) | no |
 
 ### Human actions
 
@@ -1076,7 +1076,11 @@ would invalidate every one of them.
   rest of this bullet exists. Names are configurable —
   `built-in < config.yaml < project < per-task literal` — and because vincent **never
   deletes branches**, a template without a discriminator collides on the *second* task
-  for the same input. So collision is a routine outcome, not a defensive check:
+  for the same input. (*Amended 2026-08-16, task 008:* still true of every branch that
+  carries a commit, which is the case a discriminator-less template is about — the one
+  branch archive may now delete is one that received nothing. The collision checks
+  below are unchanged, and task 001's decisions are not reopened.) So collision is a
+  routine outcome, not a defensive check:
   - **Legality** is delegated to `git check-ref-format --branch`, never a
     reimplementation of git's grammar, and a rejected name is `branch_name_invalid`
     (§18) rather than silently sanitized.
@@ -1097,8 +1101,47 @@ would invalidate every one of them.
   process-level resources (global caches, package stores, ports, docker). True
   sandboxing is out of scope for v1.
 - **Cleanup:** on `archive`: `git worktree remove` (+ `--force` after an explicit
-  dirty-worktree confirmation), then `git -C {project.path} worktree prune`. The
-  branch is **never** deleted by vincent.
+  dirty-worktree confirmation), then `git -C {project.path} worktree prune`. A branch
+  that carries **any commit past its base** is never deleted by vincent.
+
+  *Amended 2026-08-16 (task 008).* This bullet used to read "the branch is **never**
+  deleted by vincent". It has exactly one exception now: a branch with **no commits
+  past the base recorded on its task** is deleted at archive time. A workflow that
+  files an issue, posts a summary or reviews read-only writes nothing, so every run
+  used to leave a ref that holds nothing to lose, and branch names are configurable —
+  there is no `vincent/*` glob that reliably finds them again. The rules:
+  - **The test is `git rev-list -n 1 {base_branch}..{branch_name}` producing no
+    output** — the tip is an ancestor of the base. Both fields are on the task row.
+    It stays correct when the base moves forward after the task started, costs one
+    cheap git call, and **any** git failure (base renamed or deleted, repository gone)
+    reads as *cannot judge* and keeps the branch, reported as `unknown` and distinct
+    from `has_commits` the way `dirty_unknown` is from `worktree_dirty`. Deleting when
+    the *net diff* is empty was rejected: it destroys real commit objects.
+  - **`git branch -d`, never `-D`.** Its own merged check is a second belt behind the
+    rev-list, and its refusal is what covers a branch checked out in another worktree.
+  - **Ordering is worktree removal → transition → branch.** The branch is checked out
+    in the worktree until the worktree is gone, and an archive that has committed must
+    not be reversible by a branch problem. A dirty worktree refused without `force`
+    therefore never reaches the branch step at all.
+  - **`delete_empty_branch_on_archive` (§12.3), default true,** is the standing policy;
+    a per-archive flag beside `force` was rejected, since the project-delete path has
+    no human to ask. Setting it false restores this bullet's pre-008 behaviour exactly.
+  - **The remote counterpart is a separate key, `delete_remote_branch_on_archive`,
+    default false, honoured only by `POST /v1/tasks/{id}/archive`.** Deleting a branch
+    on a forge other people share is unrecoverable and outward-facing, which is further
+    than "the unattended path never deletes" (task 005) was ever written about. It runs
+    only after a local delete that succeeded, only when the branch has a configured
+    upstream (`branch.{name}.remote` + `.merge`; no upstream ⇒ nothing was pushed as
+    far as vincent knows, so nothing is attempted), and its failures — rejection,
+    unreachable host, timeout — are logged and never fail the archive.
+  - **`DELETE /v1/projects/{id}?force` sweeps every row it is about to drop,** archived
+    ones included: the cascade erases the branch names, so that is the last moment they
+    exist. Local leg only, best-effort, exactly like the worktree removal beside it.
+  - **`vincent gc` and `vincent doctor --fix` gain nothing** — see the task 005
+    amendment below.
+  - **The outcome is reported on the archive response (§13.2), not as an event.**
+    `archived` is terminal and a `block_reason` would be a lie on it; every other path
+    logs to `daemon.log`. No new event type and no migration.
 
   *Amended 2026-08-15 (task 005).* "Only on archive" was true of a **task's** worktree
   and remains so. It left a second reclaim path missing entirely, because two things
@@ -1131,7 +1174,12 @@ would invalidate every one of them.
   - **Non-directory entries are reported, never removed.** vincent only ever creates
     directories under these roots.
   - **Branches are never deleted here either.** §10's standing rule has no gc
-    exception.
+    exception. (*Confirmed 2026-08-16, task 008*, which gave archive one: no orphan has
+    a branch that is both **known** and **safe to delete**. A row-less orphan has no
+    `base_branch` and no `branch_name` to test, and usually no reachable repository to
+    test them in; the crash-window orphan is named after a **live** task row whose
+    branch must survive. A deletion path here would have no input, and a report line
+    would read the same on every row.)
   - **The reverse mismatch is reported, not repaired:** a task row whose
     `worktree_path` names a directory that is gone (§18's `worktree_missing` shape).
     There is nothing to delete and no row is modified.
@@ -1393,6 +1441,8 @@ defaults:
   agent_timeout: 60m
   command_timeout: 15m
   input_timeout: 24h           # max wait in awaiting_input (§7.4)
+delete_empty_branch_on_archive: true   # archive deletes a branch with no commits past its base (§10)
+delete_remote_branch_on_archive: false # …and its upstream counterpart; attended archive only
 transcript_retention_days: 90   # transcripts of *archived* tasks older than this are pruned
 transcript_max_bytes: 512MB     # per-run transcript cap (§18); past it the step fails `transcript_limit`
 usage_limit_recheck_interval: 15m  # how long a quota-held task waits when the CLI named no reset (§11)
@@ -1416,6 +1466,20 @@ respawn loop the hold exists to stop. 15 m bounds a five-hour window at roughly
 twenty wasted spawns, and a user who knows their plan can tighten or widen it.
 There is deliberately **no** exponential backoff: that would be per-task state the
 row has to carry and a second retry-ish concept beside §7.2's. Read per hold, so a
+hot reload reaches the next one.
+
+**`delete_empty_branch_on_archive` / `delete_remote_branch_on_archive` (task 008,
+added 2026-08-16).** The §10 branch-cleanup pair. The local key is the standing
+policy: on archive, a branch with no commits past its recorded base is deleted, and
+`false` restores the pre-008 behaviour exactly — no branch is deleted on any path.
+The remote key is deliberately **not** its default-true sibling. Everything it does
+happens on a forge shared with other people and cannot be undone, so it defaults to
+`false` and is honoured only by `POST /v1/tasks/{id}/archive`, where a human asked for
+this one task; `DELETE /v1/projects/{id}?force` never touches a remote. It is inert
+while the local key is off — the remote leg runs only after a local delete that
+succeeded — and that combination is a startup/reload **warning**, not a load failure:
+a key that is merely unreachable is not an invalid one, and refusing the file over it
+would revert every unrelated edit in the same save. Both are read per archive, so a
 hot reload reaches the next one.
 
 **`environment` (T4.23).** Governs every process the daemon spawns — agent
@@ -1568,7 +1632,10 @@ PATCH  /v1/projects/{id}                any mutable field, incl. path re-pointin
 DELETE /v1/projects/{id}                hard-deletes the project and its task history (rows);
                                         only when no non-archived tasks; ?force first archives
                                         them (worktrees force-removed; refused while any task
-                                        is running). Branches are never deleted (§10)
+                                        is running). Before the cascade, every row it drops —
+                                        archived ones too — loses its branch if that branch has
+                                        no commits past its base (§10, task 008); best-effort,
+                                        local only, never a remote
 
 GET    /v1/workflows?project_id=        merged registry view: built-in + global + that project's
                                         (shadowing applied); each entry:
@@ -1644,7 +1711,14 @@ POST   /v1/tasks/{id}/answer           { answers?, allow? }        (awaiting_inp
 POST   /v1/tasks/{id}/archive          { force? } or ?force        (done/aborted only);
                                         the worktree is removed before the transition, so a
                                         dirty worktree without force is a 409 and the task
-                                        stays done/aborted
+                                        stays done/aborted. The response is the task plus
+                                        `branch: { name, result, error?, remote? }` — result is
+                                        deleted | has_commits | unknown | error, remote is
+                                        { remote, ref, result: deleted|no_upstream|error,
+                                        error? } and rides only an opted-in remote leg. The
+                                        whole object is **absent** when the branch step did not
+                                        run, and never affects the status code: an archive is
+                                        never failed by a branch problem (§10, task 008)
 
 GET    /v1/tasks/{id}/steps             all StepRuns (every attempt)
 GET    /v1/tasks/{id}/steps/{run_id}/transcript?offset=&tail=&format=
@@ -2160,6 +2234,7 @@ currently true to show (§15 view 6).
 | Branch already exists (or a ref hierarchy conflict blocks the name) | Rejected at creation with `400` where the name is known then; otherwise the task blocks with `branch_exists` at admission, which stays the authority. Never reused, never auto-renamed. Recover with `retry { branch_override }` (§10, task 001) |
 | Configured branch name is not a legal git ref | `400` with `branch_name_invalid`, quoting git's own rules. Never sanitized into something legal — a branch the user did not ask for is worse than a rejection (task 001) |
 | Branch template references a field the task does not set | `400` at creation. Note that `{{.Fields.x}}` errors while `{{ index .Fields "x" }}` renders empty by design (§8.4's `missingkey=error` covers map *field* access only), and `feat/-slug` is a legal ref — so the loud form is the documented default for branch templates |
+| Archive-time branch delete fails | *Added 2026-08-16 (task 008).* Checked out in another worktree (`git branch -d` refuses), the base branch renamed away so the emptiness test cannot run, a remote that rejects the push or never answers inside `RemoteTimeout` — none of it fails the archive. The worktree is already gone and the task must still reach `archived`. It is logged, reported on the response as `error`/`unknown`, and the branch survives, which is the pre-008 behaviour. The remote leg cannot even be reached without a local delete that succeeded first |
 | Worktree dir manually deleted | Next step fails → blocked with `worktree_missing`; retry recreates the worktree from the branch if it survives. *Amended 2026-08-15 (task 005):* the same mismatch found by a scan rather than by a step is **reported** — at daemon start and in `vincent gc`'s output — and no row is modified |
 | Orphaned directory under a data root | *Added 2026-08-15 (task 005).* An entry under `{data_dir}/worktrees` or `{data_dir}/transcripts` that no task row claims — left by a project delete whose worktree removal failed (the cascade drops the rows regardless, §10) or by a crash between `git worktree add` and the claim write. Daemon start logs one warning per orphan and raises `orphans` on `GET /v1/info`; it **never** deletes, for the same reason DB corruption never auto-deletes. `vincent gc` reclaims them, and only them — archive remains the only path that removes a *task's* worktree |
 | Dirtiness of an orphan cannot be determined | *Added 2026-08-15 (task 005).* An orphan's `.git` file points at `{repo}/.git/worktrees/{n}`, so a deleted or pruned repository makes `git status --porcelain` fail outright. Reported as `dirty_unknown` — distinct from `worktree_dirty`, because "git says you have local changes" and "nobody can tell what is in here" are different facts — and skipped until `vincent gc --force`. This is the *common* case where the projects really are gone, so a default run there reclaims little; that is the deliberate trade for never deleting work nobody can vouch for |

--- a/docs/tasks/005-orphaned-worktree-gc.md
+++ b/docs/tasks/005-orphaned-worktree-gc.md
@@ -156,7 +156,10 @@ byte figure that walked into a symlinked cache would over-report the reclaim.
   window; gc deletes on a human's word, and a timer that deleted worktrees unattended
   would be decision 6 in reverse.
 - **Deleting branches.** §10's standing rule, restated: vincent never deletes a branch,
-  gc included.
+  gc included. (*Note 2026-08-16, [task 008](008-archive-branch-cleanup.md):* archive
+  now has one exception, for a branch carrying no commits past its base. gc still has
+  none, and for a reason specific to orphans — no orphan has a branch that is both
+  known and safe to delete.)
 
 ## Verification
 

--- a/docs/tasks/008-archive-branch-cleanup.md
+++ b/docs/tasks/008-archive-branch-cleanup.md
@@ -1,0 +1,192 @@
+# 008 — Archive cleanup: delete a task's branch when it has no commits past its base
+
+**Status:** ✅ done (7/7) · **Opened:** 2026-08-16
+
+Archiving a task removed its worktree and stopped there, so every task ever run left a
+`vincent/*` ref behind — including the workflows that never write to the repository at
+all. This adds one narrow exception to §10's standing rule: a branch with **no commits
+past its recorded base** is deleted at archive time. Nothing that carries a commit
+object is ever touched.
+
+Closes [#105](https://github.com/lezli01/vincent/issues/105).
+
+## The problem
+
+A workflow that files a GitHub issue, posts a summary or runs a read-only review still
+gets a worktree and a branch, because `git worktree add -b` makes both or neither. It
+writes nothing, so the branch it was given never receives a commit. `Runner.Archive`
+removed the worktree and released the claim; §10 then said, in as many words, that "the
+branch is **never** deleted by vincent".
+
+The remedy was manual, and `docs/getting-started/installation.md` said so: list the
+archived tasks, read the branch column, delete them by hand. Branch names are
+configurable since task 001, so there is not even a `vincent/*` glob that reliably
+finds them.
+
+## Decisions
+
+### 1. The test is `git rev-list -n 1 {base}..{branch}` producing no output
+
+*2026-08-16.* The tip is an ancestor of the base. Both fields are on the task row since
+`0001_init.sql`, so nothing has to be inferred or stored. It costs one cheap git call,
+it stays correct when the base moves forward *after* the task started, and it is exact:
+a branch that passes holds no commit object anybody could want back.
+
+Both refs are named in full (`refs/heads/…`). An ambiguous short name — a tag sharing
+the branch's name, a deleted base with a surviving remote-tracking ref — must read as
+*cannot judge* rather than quietly resolve to something else and answer confidently.
+
+**Beat:** deleting when the *net diff* against base is empty (commits that cancel out).
+That destroys real commit objects, for a case rarer than the one this is about. It was
+the issue's own rejected alternative and stays rejected.
+
+### 2. Any git failure means *cannot judge*, and keeps the branch
+
+*2026-08-16.* Base branch renamed or deleted, repository gone, git unhappy for a reason
+nobody predicted: the outcome is `unknown`, the branch survives, the error is logged.
+Deliberately distinct from `has_commits`, the same way task 005 separated
+`dirty_unknown` from `worktree_dirty` — "it has work in it" and "nobody can tell" are
+different facts, and only one of them is a judgement.
+
+`git branch -d`, never `-D`, for the same posture: its own merged check is a second
+belt behind the rev-list, and its refusal is what covers a branch checked out in
+another worktree — exactly the case where a force delete corrupts somebody's working
+tree.
+
+### 3. The remote leg gets its own key, defaults to false, and runs only on an attended archive
+
+*2026-08-16.* `delete_remote_branch_on_archive`, honoured only by
+`POST /v1/tasks/{id}/archive`. `DELETE /v1/projects/{id}?force` never touches a remote.
+
+vincent has no push, no remote refs and no credential handling anywhere in the tree
+today; the single mention of a remote is `origin/HEAD` detection at project
+registration. Deleting a branch on a forge the user shares with other people is
+unrecoverable and outward-facing — strictly further-reaching than the local directories
+task 005's "the unattended path never deletes" was written about. Opt-in and
+attended-only *extends* that rule; a local-style default-true would have contradicted
+it.
+
+It runs only after a local delete that succeeded, and only when the branch has a
+configured upstream (`branch.{name}.remote` **and** `branch.{name}.merge`). No upstream
+means nothing was pushed as far as vincent knows, so nothing is attempted — and
+guessing a remote name from a local one is exactly the inference that deletes the wrong
+ref on somebody else's forge. The upstream is read from git *config*, not from
+`@{upstream}`: a remote-tracking ref can be pruned while the configuration that named
+it survives, and the question here is "did vincent ever push this".
+
+**Beat:** the issue's "skip any branch with an upstream" — the remote counterpart is
+deletable, just not by default and not unattended.
+
+### 4. `vincent gc` and `vincent doctor --fix` are out of scope; task 005's rule stands unamended
+
+*2026-08-16.* The issue lists them. No orphan gc sees has a branch that is both **known**
+and **safe to delete**:
+
+- A row-less orphan — the project-delete leftover — has no `base_branch`, no
+  `branch_name`, and usually no reachable repository to run `rev-list` in. The
+  ancestor-of-base test has no input there.
+- The crash-window orphan is named after a **live** task row, whose branch must
+  survive.
+
+So "branches are never deleted here either" (§10, task 005) keeps its full force, gc
+gains neither a deletion path nor a report line that would read the same on every row,
+and `docs/reference/cli.md`'s "It never deletes a branch" stays true as written.
+
+### 5. `DELETE /v1/projects/{id}?force` sweeps every row it drops, archived ones included
+
+*2026-08-16.* The issue describes that endpoint as archiving its tasks; it does not. It
+force-removes worktrees best-effort and then hard-deletes the rows through
+`DeleteProjectCascade`. After the cascade the branch names are gone forever, so this is
+the last moment they exist — an archived row whose branch survived (the setting was off
+when it was archived) is reachable from nowhere else afterwards. The sweep therefore
+covers the whole `tasks` slice the handler already holds, not just the non-archived
+ones.
+
+Local-only and best-effort, exactly as the worktree removal beside it already is: a
+failure is logged and the cascade proceeds.
+
+### 6. The outcome rides the archive response; every other path logs
+
+*2026-08-16.* `archived` is terminal and a `block_reason` would be a lie on it, and no
+client renders event rows today — the TUI and CLI use SSE only to trigger refreshes. So
+`POST /v1/tasks/{id}/archive` returns `branch: { name, result, error?, remote? }` beside
+the task, and the TUI prints one line where a human asked for the action. Project delete
+and anything else writes `daemon.log` only. No new event type (§13.3 keeps its PR D
+shape) and no migration.
+
+The object is **absent**, not null-with-empty-strings, when the branch step did not run,
+so a client that predates the field sees exactly what it saw before.
+
+### 7. Ordering is worktree removal → transition → branch, and a branch problem never fails an archive
+
+*2026-08-16.* The branch is checked out in the worktree until the worktree is gone, so
+the branch work happens *after* `RemoveAndRelease` returns and never inside its
+callback. By then the archive has committed, and it must not be reversible by a git
+problem: every failure is logged and reported, and the task stays `archived`. The
+corollary is load-bearing in the other direction too — a dirty worktree refused without
+`force` never reaches the branch step at all.
+
+### 8. Two plain `bool` keys, and a warning rather than a validation error
+
+*2026-08-16.* `Load` unmarshals into `Default()`, so an absent key keeps its default and
+an explicit `false` restores the pre-008 behaviour exactly — no tri-state pointer is
+needed. A bool has no invalid value, so `validate()` gains nothing.
+
+The *pair* does: `delete_remote_branch_on_archive: true` with
+`delete_empty_branch_on_archive: false` asks for something that cannot happen, since
+the remote leg runs only after a local delete. That is a new `Config.Warnings()`,
+logged at startup and on any reload that changes it — separate from `validate()` on
+purpose, because a key that is merely unreachable is not an invalid one, and failing
+the load over it would revert every unrelated edit in the same save.
+
+### 9. `gitx.RemoteTimeout`, a third timeout constant
+
+*2026-08-16.* Neither existing one fits a network call. `QueryTimeout` (30 s) is sized
+for a local object-database read and would fail a push over a slow link; `WorktreeTimeout`
+(5 min) would park the archive's caller behind an unreachable host. 60 s, and a remote
+that does not answer inside it is logged while the branch stays deleted locally.
+
+## Tasks
+
+- [x] **008.1** — `internal/worktree/branch_delete.go`: `DeleteEmptyBranch`, the
+      outcome vocabulary, upstream resolution and `push --delete`; `gitx.RemoteTimeout`;
+      `testrepo.InitBare`. ✓ 2026-08-16
+- [x] **008.2** — `internal/config`: both keys, `Default()`, `Config.Warnings()`, the
+      generated `config.yaml` comments, and the daemon logging them at start and on
+      reload. ✓ 2026-08-16
+- [x] **008.3** — `internal/taskrun`: `Archive` returns a `worktree.BranchOutcome` and
+      runs the branch step after `RemoveAndRelease`. ✓ 2026-08-16
+- [x] **008.4** — `internal/api`: archive's own write path and response shape, the
+      pre-cascade sweep in `handleProjectDelete`, both keys on `GET /v1/config`.
+      ✓ 2026-08-16
+- [x] **008.5** — `internal/apiclient`: `Archive`'s second return, `BranchOutcome` and
+      its `Summary()`; the TUI status line and the daemon view's config lines.
+      ✓ 2026-08-16
+- [x] **008.6** — Tests: worktree table (empty, commits, base moved, base gone, checked
+      out elsewhere, ref-hierarchy neighbour, the three remote legs), taskrun, api,
+      config. ✓ 2026-08-16
+- [x] **008.7** — `scripts/m2-gate.sh` scenario 6; spec §6/§10/§12.3/§13.2/§18 and the
+      user docs. ✓ 2026-08-16
+
+## Out of scope
+
+- **`vincent gc` and `vincent doctor --fix`** — decision 4.
+- **Pushing, or any other remote write.** The one remote call this adds is a delete of a
+  ref vincent's own configuration points at, behind a key that is off by default.
+- **A per-archive flag beside `force`.** This is a standing policy, not a per-action
+  judgement, and the project-delete path has no human to ask. (The issue's own rejected
+  alternative.)
+- **Reclaiming branches for tasks archived before this shipped.** They keep their
+  branches; only `DELETE /v1/projects/{id}?force` reaches an already-archived row, and
+  only because the cascade is about to erase its name.
+
+## Verification
+
+- `go test ./...` green (2026-08-16, macOS); `go test -race ./internal/taskrun
+  ./internal/worktree ./internal/api` green.
+- `go tool golangci-lint run ./...` clean for `GOOS=windows`, `darwin` and `linux`.
+- `VINCENT_GATE_SCENARIO=6 ./scripts/m2-gate.sh` passes (2026-08-16, macOS): a
+  fake-agent task that commits nothing loses its branch and the response says
+  `deleted`; one that commits keeps its branch at the same commit and the response says
+  `has_commits`; `delete_empty_branch_on_archive: false` hot-reloads and the branch
+  survives.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -22,6 +22,7 @@ description of how the system actually behaves.
 | [005](005-orphaned-worktree-gc.md) | Reclaim orphaned worktrees: `vincent gc` and a startup reconcile | ✅ done (8/8) |
 | [006](006-vincent-doctor.md) | `vincent doctor` — one diagnostic report | ✅ done (8/8) |
 | [007](007-release-please.md) | Release Please automation | ✅ done (6/6) |
+| [008](008-archive-branch-cleanup.md) | Archive cleanup: delete a branch with no commits past its base | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -96,15 +96,78 @@ type archiveRequest struct {
 	Force bool `json:"force"`
 }
 
+// archiveResponse is the task as every other action renders it, plus what
+// archive did to the branch (§13.2, task 008). The task fields stay at the top
+// level — an archive response is still a task — and `branch` is omitted
+// entirely when the branch step did not run, so a client that predates the
+// field sees exactly what it saw before.
+//
+// It is reported here rather than as an event: `archived` is terminal, a
+// `block_reason` would be a lie on it, and this is the one path with a human
+// on the other end of the request.
+type archiveResponse struct {
+	taskResponse
+	Branch *branchResponse `json:"branch,omitempty"`
+}
+
+// branchResponse is one branch outcome. `result` is worktree's own snake_case
+// vocabulary: deleted | has_commits | unknown | error.
+type branchResponse struct {
+	Name   string                `json:"name"`
+	Result string                `json:"result"`
+	Error  string                `json:"error,omitempty"`
+	Remote *remoteBranchResponse `json:"remote,omitempty"`
+}
+
+// remoteBranchResponse is the opt-in remote leg: deleted | no_upstream | error.
+type remoteBranchResponse struct {
+	Remote string `json:"remote,omitempty"`
+	Ref    string `json:"ref,omitempty"`
+	Result string `json:"result"`
+	Error  string `json:"error,omitempty"`
+}
+
+// handleTaskArchive cannot go through runAction: that path's taskAction returns
+// a task and nothing else, and archive is the one action with a second thing to
+// say. It reuses writeActionError so the §13.1 mapping stays in one place.
 func (s *Server) handleTaskArchive(w http.ResponseWriter, r *http.Request) {
 	var req archiveRequest
 	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
 		return
 	}
 	force := req.Force || hasForce(r)
-	s.runAction(w, r, func(id int64) (*store.Task, error) {
-		return s.deps.Runner.Archive(r.Context(), id, force)
+	if s.deps.Runner == nil {
+		s.internalError(w, "task actions", errors.New("no task runner is configured"))
+		return
+	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	task, branch, err := s.deps.Runner.Archive(r.Context(), id, force)
+	if err != nil {
+		s.writeActionError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, archiveResponse{
+		taskResponse: toTaskResponse(task, s.snaps.get(task.ID, task.WorkflowSnapshot)),
+		Branch:       toBranchResponse(branch),
 	})
+}
+
+// toBranchResponse renders a branch outcome, or nil when the step never ran.
+func toBranchResponse(out worktree.BranchOutcome) *branchResponse {
+	if !out.Checked() {
+		return nil
+	}
+	b := &branchResponse{Name: out.Branch, Result: out.Result, Error: out.Error}
+	if out.Remote != nil {
+		b.Remote = &remoteBranchResponse{
+			Remote: out.Remote.Remote, Ref: out.Remote.Ref,
+			Result: out.Remote.Result, Error: out.Remote.Error,
+		}
+	}
+	return b
 }
 
 // answerRequest is the §13.2 body of POST /v1/tasks/{id}/answer (§7.4).

--- a/internal/api/actions_test.go
+++ b/internal/api/actions_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
 )
 
 // actionHarness is the task harness with no runner: tasks stay queued, so a
@@ -283,6 +284,135 @@ func TestArchiveDirtyWorktree(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("worktree %s survived the archive", path)
+	}
+}
+
+// decodeArchive reads an archive response: a task with a branch object beside
+// it (§13.2, task 008).
+func decodeArchive(t *testing.T, body []byte) archiveResponse {
+	t.Helper()
+	var out archiveResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode archive: %v (%s)", err, body)
+	}
+	return out
+}
+
+// archivableTask leaves a done task holding a real worktree cut from main.
+func archivableTask(t *testing.T, h *taskHarness) *store.Task {
+	t.Helper()
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone)
+	stored, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	path, err := h.wt.Create(t.Context(), h.repo, task.ID, stored.BranchName, stored.BaseBranch)
+	if err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if err := h.store.SetTaskProgress(t.Context(), task.ID, nil, &path); err != nil {
+		t.Fatalf("record worktree: %v", err)
+	}
+	stored.WorktreePath = path
+	return stored
+}
+
+// TestArchiveReportsTheBranchOutcome walks the three answers the endpoint can
+// give (§13.2, task 008). The branch is the one consequence of an archive that
+// is invisible afterwards — the row stops naming a worktree to go look in — so
+// the response is where it has to be said.
+func TestArchiveReportsTheBranchOutcome(t *testing.T) {
+	cases := []struct {
+		name string
+		// setup runs after the worktree exists and before the archive.
+		setup      func(t *testing.T, h *taskHarness, task *store.Task)
+		wantResult string
+		wantErrMsg bool
+		wantBranch bool // does the branch still exist afterwards?
+	}{
+		{
+			name:       "deleted",
+			setup:      func(*testing.T, *taskHarness, *store.Task) {},
+			wantResult: "deleted",
+		},
+		{
+			name: "kept because it has commits",
+			setup: func(t *testing.T, _ *taskHarness, task *store.Task) {
+				testrepo.WriteFile(t, task.WorktreePath, "work.txt", "real work\n")
+				testrepo.Run(t, task.WorktreePath, "add", ".")
+				testrepo.Run(t, task.WorktreePath, "commit", "-q", "-m", "the work")
+			},
+			wantResult: "has_commits",
+			wantBranch: true,
+		},
+		{
+			name: "kept because git cannot judge it",
+			setup: func(t *testing.T, h *taskHarness, _ *store.Task) {
+				testrepo.Run(t, h.repo, "branch", "-m", "main", "trunk")
+			},
+			wantResult: "unknown",
+			wantErrMsg: true,
+			wantBranch: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := newActionHarness(t)
+			task := archivableTask(t, h)
+			c.setup(t, h, task)
+
+			resp, body := h.doJSON(t, http.MethodPost,
+				fmt.Sprintf("/v1/tasks/%d/archive", task.ID), nil)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("archive: %d %s — a branch problem must never fail it", resp.StatusCode, body)
+			}
+			got := decodeArchive(t, body)
+			if got.State != string(store.TaskArchived) {
+				t.Errorf("state = %s, want archived", got.State)
+			}
+			if got.Branch == nil {
+				t.Fatalf("no branch object in %s", body)
+			}
+			if got.Branch.Result != c.wantResult {
+				t.Errorf("branch.result = %q, want %q", got.Branch.Result, c.wantResult)
+			}
+			if got.Branch.Name != task.BranchName {
+				t.Errorf("branch.name = %q, want %q", got.Branch.Name, task.BranchName)
+			}
+			if (got.Branch.Error != "") != c.wantErrMsg {
+				t.Errorf("branch.error = %q, want present = %v", got.Branch.Error, c.wantErrMsg)
+			}
+			// The remote leg is off by default and must not have run.
+			if got.Branch.Remote != nil {
+				t.Errorf("remote leg ran unasked: %+v", got.Branch.Remote)
+			}
+			exists := testrepo.Run(t, h.repo, "for-each-ref", "--format=%(refname:short)",
+				"refs/heads/"+task.BranchName) != ""
+			if exists != c.wantBranch {
+				t.Errorf("branch %s exists = %v, want %v", task.BranchName, exists, c.wantBranch)
+			}
+		})
+	}
+}
+
+// TestArchiveOmitsTheBranchWhenTheStepDidNotRun: a client that predates the
+// field must see exactly what it saw before, so `branch` is absent rather than
+// null-with-empty-strings when there was nothing to check.
+func TestArchiveOmitsTheBranchWhenTheStepDidNotRun(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone) // no worktree, so no branch of its own
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/archive", task.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive: %d %s", resp.StatusCode, body)
+	}
+	if got := decodeArchive(t, body); got.Branch != nil {
+		t.Errorf("branch = %+v, want absent", got.Branch)
+	}
+	if strings.Contains(string(body), `"branch"`) {
+		t.Errorf("body carries a branch key with nothing to say: %s", body)
 	}
 }
 

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -329,6 +329,7 @@ func (s *Server) handleProjectDelete(w http.ResponseWriter, r *http.Request) {
 				"task", t.ID, "worktree", t.WorktreePath, "error", err)
 		}
 	}
+	s.deleteEmptyBranches(ctx, p, tasks)
 	if err := s.deps.Store.DeleteProjectCascade(ctx, p.ID); err != nil {
 		s.internalError(w, "delete project", err)
 		return
@@ -341,6 +342,41 @@ func (s *Server) handleProjectDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	s.projectsChanged()
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteEmptyBranches applies the §10 empty-branch rule to every task row the
+// cascade is about to drop (task 008).
+//
+// It covers the whole slice, archived rows included, because after the cascade
+// the branch names are gone forever — this is the last moment they exist. An
+// archived row whose branch survived (the setting was off when it was archived)
+// is reachable from nowhere else.
+//
+// Local only: `delete_remote_branch_on_archive` is honoured by
+// POST /v1/tasks/{id}/archive alone, since §10's rule is that the unattended
+// path never deletes and a forge is further-reaching than a local directory.
+// Best-effort, exactly like the worktree removal above it: a failure is logged
+// and the cascade proceeds.
+func (s *Server) deleteEmptyBranches(ctx context.Context, p *store.Project, tasks []store.Task) {
+	if s.deps.Worktrees == nil || s.deps.Config == nil || !s.deps.Config().DeleteEmptyBranchOnArchive {
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.BranchName == "" {
+			continue
+		}
+		out, err := s.deps.Worktrees.DeleteEmptyBranch(ctx, p.Path, t.BaseBranch, t.BranchName, false)
+		if err != nil {
+			s.deps.Logger.Warn("project delete: branch kept",
+				"task", t.ID, "branch", t.BranchName, "result", out.Result, "error", err)
+			continue
+		}
+		if out.Result == worktree.BranchDeleted {
+			s.deps.Logger.Info("project delete: deleted a branch with no commits past its base",
+				"task", t.ID, "branch", t.BranchName, "base", t.BaseBranch)
+		}
+	}
 }
 
 // projectFromPath resolves the {id} path segment to a project, writing the

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -33,6 +33,13 @@ type projectHarness struct {
 
 func newProjectHarness(t *testing.T) *projectHarness {
 	t.Helper()
+	return newProjectHarnessWithConfig(t, config.Default)
+}
+
+// newProjectHarnessWithConfig is the same server with the daemon configuration
+// a test wants — the §10 branch sweep is the first thing here to read one.
+func newProjectHarnessWithConfig(t *testing.T, cfg func() config.Config) *projectHarness {
+	t.Helper()
 	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
 		t.Fatalf("open store: %v", err)
@@ -42,7 +49,7 @@ func newProjectHarness(t *testing.T) *projectHarness {
 	wt := worktree.NewManager(git, t.TempDir())
 	s := New(Deps{
 		Token:       testToken,
-		Config:      config.Default,
+		Config:      cfg,
 		StartedAt:   time.Now(),
 		ListenAddr:  "127.0.0.1:0",
 		RequestStop: func() {},
@@ -448,9 +455,103 @@ func TestProjectDelete(t *testing.T) {
 		if _, err := h.store.GetTask(ctx, taskID); !errors.Is(err, store.ErrNotFound) {
 			t.Errorf("task row survived: %v", err)
 		}
-		// The branch is never deleted (spec §10).
+		// This row's recorded branch name is not the one the worktree was cut
+		// on, so the §10 sweep cannot judge it and leaves it exactly where it
+		// is — which is also what every forced delete did before task 008.
 		testrepo.Run(t, repo, "rev-parse", "--verify", "refs/heads/vincent/"+itoa(taskID)+"-x")
 	})
+
+	// The cascade hard-deletes the rows, so this is the last moment the branch
+	// names exist: the sweep covers archived rows too, or their branches become
+	// unreachable from anywhere (task 008).
+	t.Run("force deletes branches with no commits past their base", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		p := h.mustCreate(t, map[string]any{"path": repo, "name": "sweep"})
+		id := int64(p["id"].(float64))
+
+		empty := branchedTask(t, h, id, store.TaskArchived, "vincent/empty", "main", false)
+		withWork := branchedTask(t, h, id, store.TaskQueued, "vincent/has-work", "main", true)
+		// A row whose base no longer resolves: unjudgeable, therefore kept, and
+		// the cascade must still finish around it.
+		unjudgeable := branchedTask(t, h, id, store.TaskArchived, "vincent/lost-base", "gone", false)
+
+		resp, out := h.doJSON(t, http.MethodDelete, "/v1/projects/"+itoa(id)+"?force=true", nil)
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("forced delete = %d %s — a branch problem must not fail the cascade",
+				resp.StatusCode, out)
+		}
+		if branchExists(t, repo, empty) {
+			t.Errorf("%s survived: it carried no commits past main", empty)
+		}
+		if !branchExists(t, repo, withWork) {
+			t.Errorf("%s was deleted despite carrying a commit", withWork)
+		}
+		if !branchExists(t, repo, unjudgeable) {
+			t.Errorf("%s was deleted on a check nobody could make", unjudgeable)
+		}
+	})
+
+	t.Run("force deletes no branch when the policy is off", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		h := newProjectHarnessWithConfig(t, func() config.Config {
+			c := config.Default()
+			c.DeleteEmptyBranchOnArchive = false
+			return c
+		})
+		p := h.mustCreate(t, map[string]any{"path": repo, "name": "sweep-off"})
+		id := int64(p["id"].(float64))
+		empty := branchedTask(t, h, id, store.TaskArchived, "vincent/empty", "main", false)
+
+		resp, out := h.doJSON(t, http.MethodDelete, "/v1/projects/"+itoa(id)+"?force=true", nil)
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("forced delete = %d %s", resp.StatusCode, out)
+		}
+		if !branchExists(t, repo, empty) {
+			t.Errorf("%s was deleted with delete_empty_branch_on_archive off", empty)
+		}
+	})
+}
+
+// branchedTask inserts a task row naming a branch that really exists in repo,
+// optionally carrying a commit of its own. It returns the branch name.
+func branchedTask(
+	t *testing.T, h *projectHarness, projectID int64,
+	state store.TaskState, branch, base string, withCommit bool,
+) string {
+	t.Helper()
+	repo := projectPath(t, h, projectID)
+	testrepo.Run(t, repo, "branch", branch)
+	if withCommit {
+		testrepo.Run(t, repo, "switch", "-q", branch)
+		testrepo.WriteFile(t, repo, "work.txt", "real work\n")
+		testrepo.Run(t, repo, "add", ".")
+		testrepo.Run(t, repo, "commit", "-q", "-m", "the work")
+		testrepo.Run(t, repo, "switch", "-q", "main")
+	}
+	tk := &store.Task{
+		ProjectID: projectID, Title: "t", WorkflowName: "adhoc",
+		WorkflowSnapshot: "x", BaseBranch: base, BranchName: branch, State: state,
+	}
+	if err := h.store.CreateTask(context.Background(), tk, nil); err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+	return branch
+}
+
+func projectPath(t *testing.T, h *projectHarness, id int64) string {
+	t.Helper()
+	p, err := h.store.GetProject(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	return p.Path
+}
+
+// branchExists asks the repository itself, not the code under test.
+func branchExists(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	return testrepo.Run(t, repo, "for-each-ref", "--format=%(refname:short)",
+		"refs/heads/"+branch) != ""
 }
 
 func insertTask(t *testing.T, st *store.Store, projectID int64, state store.TaskState) int64 {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -292,14 +292,19 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 // configResponse mirrors config.yaml as snake_case JSON; durations render as
 // Go duration strings (phase 1 decision).
 type configResponse struct {
-	Listen                  string               `json:"listen"`
-	MaxParallelTasks        int                  `json:"max_parallel_tasks"`
-	Defaults                configDefaults       `json:"defaults"`
-	TranscriptRetentionDays int                  `json:"transcript_retention_days"`
-	TranscriptMaxBytes      int64                `json:"transcript_max_bytes"`
-	UsageLimitRecheck       string               `json:"usage_limit_recheck_interval"`
-	LogLevel                string               `json:"log_level"`
-	Agents                  map[string]agentPath `json:"agents"`
+	Listen           string         `json:"listen"`
+	MaxParallelTasks int            `json:"max_parallel_tasks"`
+	Defaults         configDefaults `json:"defaults"`
+	// The §10 branch-cleanup pair (task 008). Both are reported because the
+	// remote one is inert without the local one, and a client showing only the
+	// key that is on would describe a policy that cannot run.
+	DeleteEmptyBranchOnArchive  bool                 `json:"delete_empty_branch_on_archive"`
+	DeleteRemoteBranchOnArchive bool                 `json:"delete_remote_branch_on_archive"`
+	TranscriptRetentionDays     int                  `json:"transcript_retention_days"`
+	TranscriptMaxBytes          int64                `json:"transcript_max_bytes"`
+	UsageLimitRecheck           string               `json:"usage_limit_recheck_interval"`
+	LogLevel                    string               `json:"log_level"`
+	Agents                      map[string]agentPath `json:"agents"`
 }
 
 type configDefaults struct {
@@ -322,10 +327,12 @@ func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
 			CommandTimeout: cfg.Defaults.CommandTimeout.String(),
 			InputTimeout:   cfg.Defaults.InputTimeout.String(),
 		},
-		TranscriptRetentionDays: cfg.TranscriptRetentionDays,
-		TranscriptMaxBytes:      cfg.TranscriptMaxBytes.Bytes(),
-		UsageLimitRecheck:       cfg.UsageLimitRecheckInterval.String(),
-		LogLevel:                cfg.LogLevel,
+		DeleteEmptyBranchOnArchive:  cfg.DeleteEmptyBranchOnArchive,
+		DeleteRemoteBranchOnArchive: cfg.DeleteRemoteBranchOnArchive,
+		TranscriptRetentionDays:     cfg.TranscriptRetentionDays,
+		TranscriptMaxBytes:          cfg.TranscriptMaxBytes.Bytes(),
+		UsageLimitRecheck:           cfg.UsageLimitRecheckInterval.String(),
+		LogLevel:                    cfg.LogLevel,
 		Agents: map[string]agentPath{
 			"claude": {Path: cfg.Agents.Claude.Path},
 			"codex":  {Path: cfg.Agents.Codex.Path},

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -158,6 +158,20 @@ func TestConfigView(t *testing.T) {
 	if _, ok := cfg.Agents["claude"]; !ok {
 		t.Error("agents.claude missing")
 	}
+	// Both halves of the §10 branch-cleanup pair, and both by name: a client
+	// showing only the key that is on would describe a policy that cannot run
+	// (task 008).
+	if cfg.DeleteEmptyBranchOnArchive != want.DeleteEmptyBranchOnArchive ||
+		cfg.DeleteRemoteBranchOnArchive != want.DeleteRemoteBranchOnArchive {
+		t.Errorf("branch cleanup = %v/%v, want %v/%v",
+			cfg.DeleteEmptyBranchOnArchive, cfg.DeleteRemoteBranchOnArchive,
+			want.DeleteEmptyBranchOnArchive, want.DeleteRemoteBranchOnArchive)
+	}
+	for _, key := range []string{"delete_empty_branch_on_archive", "delete_remote_branch_on_archive"} {
+		if !strings.Contains(string(body), key) {
+			t.Errorf("%s missing from the config view", key)
+		}
+	}
 	if !strings.Contains(string(body), "max_parallel_tasks") {
 		t.Error("response keys are not snake_case")
 	}

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -77,15 +77,91 @@ func (c *Client) Reject(ctx context.Context, id int64) (Task, error) {
 	return c.action(ctx, id, ActionReject, nil)
 }
 
-// Archive removes the worktree and archives the task. A dirty worktree is a
-// 409 carrying details.reason "worktree_dirty" unless force is set — force is
-// the confirmation, so a caller re-issues with it after asking (§6, §13.2).
-func (c *Client) Archive(ctx context.Context, id int64, force bool) (Task, error) {
-	return c.action(ctx, id, ActionArchive, archiveBody{Force: force})
+// Archive removes the worktree, archives the task, and — when
+// `delete_empty_branch_on_archive` is on — deletes the branch if it carries no
+// commits past its base (§10, task 008). The second return is what happened to
+// that branch; its zero value means the branch step did not run.
+//
+// A dirty worktree is a 409 carrying details.reason "worktree_dirty" unless
+// force is set — force is the confirmation, so a caller re-issues with it after
+// asking (§6, §13.2).
+func (c *Client) Archive(ctx context.Context, id int64, force bool) (Task, BranchOutcome, error) {
+	var out archiveResponse
+	path := fmt.Sprintf("/v1/tasks/%d/%s", id, ActionArchive)
+	if err := c.post(ctx, path, archiveBody{Force: force}, &out); err != nil {
+		return Task{}, BranchOutcome{}, err
+	}
+	if out.Branch == nil {
+		return out.Task, BranchOutcome{}, nil
+	}
+	return out.Task, *out.Branch, nil
 }
 
 type archiveBody struct {
 	Force bool `json:"force"`
+}
+
+// archiveResponse decodes the archive body, whose task fields sit at the top
+// level beside `branch` — so the task is decoded from the same object rather
+// than from a nested one.
+type archiveResponse struct {
+	Task
+	Branch *BranchOutcome `json:"branch"`
+}
+
+// Branch outcomes as the daemon names them (§10, task 008). A client renders
+// the string the daemon sends; these exist to key rendering onto.
+const (
+	BranchDeleted      = "deleted"
+	BranchHasCommits   = "has_commits"
+	BranchUnknown      = "unknown"
+	BranchDeleteFailed = "error"
+
+	RemoteBranchDeleted    = "deleted"
+	RemoteBranchNoUpstream = "no_upstream"
+	RemoteBranchFailed     = "error"
+)
+
+// BranchOutcome is what an archive did to the task's branch. A zero value means
+// the branch step never ran: the setting is off, or the task had no branch of
+// its own — which is what every archive did before task 008.
+type BranchOutcome struct {
+	Name   string               `json:"name"`
+	Result string               `json:"result"`
+	Error  string               `json:"error,omitempty"`
+	Remote *RemoteBranchOutcome `json:"remote,omitempty"`
+}
+
+// RemoteBranchOutcome is the opt-in remote leg's outcome.
+type RemoteBranchOutcome struct {
+	Remote string `json:"remote,omitempty"`
+	Ref    string `json:"ref,omitempty"`
+	Result string `json:"result"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Summary is the one line a human gets for a branch outcome, or "" when
+// nothing happened to the branch and there is nothing to say.
+func (o BranchOutcome) Summary() string {
+	switch o.Result {
+	case BranchDeleted:
+		s := "branch " + o.Name + " deleted (no commits)"
+		if o.Remote != nil {
+			switch o.Remote.Result {
+			case RemoteBranchDeleted:
+				s += ", remote too"
+			case RemoteBranchFailed:
+				s += ", remote kept: " + o.Remote.Error
+			}
+		}
+		return s
+	case BranchHasCommits:
+		return "branch " + o.Name + " kept (it has commits)"
+	case BranchUnknown, BranchDeleteFailed:
+		return "branch " + o.Name + " kept: " + o.Error
+	default:
+		return ""
+	}
 }
 
 // Answer delivers the answer to a pending input request; the run resumes in

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -73,11 +73,17 @@ func (c *Client) Info(ctx context.Context) (Info, error) {
 // has it loaded, durations rendered as Go duration strings. It is read-only
 // here — the file is authoritative and the daemon hot-reloads it (§12.3).
 type Config struct {
-	Listen                  string         `json:"listen"`
-	MaxParallelTasks        int            `json:"max_parallel_tasks"`
-	Defaults                ConfigDefaults `json:"defaults"`
-	TranscriptRetentionDays int            `json:"transcript_retention_days"`
-	TranscriptMaxBytes      int64          `json:"transcript_max_bytes"`
+	Listen           string         `json:"listen"`
+	MaxParallelTasks int            `json:"max_parallel_tasks"`
+	Defaults         ConfigDefaults `json:"defaults"`
+	// DeleteEmptyBranchOnArchive deletes a task's branch at archive time when
+	// it has no commits past its base (§10). DeleteRemoteBranchOnArchive does
+	// the same to its upstream counterpart, and is honoured only on an
+	// attended archive — it is inert while the local one is off.
+	DeleteEmptyBranchOnArchive  bool  `json:"delete_empty_branch_on_archive"`
+	DeleteRemoteBranchOnArchive bool  `json:"delete_remote_branch_on_archive"`
+	TranscriptRetentionDays     int   `json:"transcript_retention_days"`
+	TranscriptMaxBytes          int64 `json:"transcript_max_bytes"`
 	// UsageLimitRecheck is how long a quota-held task waits before the
 	// scheduler tries again, when the agent CLI reported no reset time (§11).
 	UsageLimitRecheck string               `json:"usage_limit_recheck_interval"`

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -32,6 +32,18 @@ defaults:
   command_timeout: 15m
   input_timeout: 24h
 
+# Delete a task's branch when it is archived and carries no commits past the
+# base it was cut from — the branch a workflow that never writes to the
+# repository leaves behind. A branch holding any commit is always kept, and a
+# check git cannot answer keeps the branch too.
+delete_empty_branch_on_archive: true
+
+# Also delete that branch's upstream counterpart, when it has one. Off by
+# default and honoured only when a human archives the task: a forge is shared
+# with other people and the deletion cannot be undone. Nothing happens here
+# unless delete_empty_branch_on_archive is also on.
+delete_remote_branch_on_archive: false
+
 # Transcripts of archived tasks older than this many days are pruned.
 transcript_retention_days: 90
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,9 +149,27 @@ type Config struct {
 	// as a hard failure, and on hot-reload by keeping the previous value with a
 	// warning, because a daemon that quietly ignored the configured convention
 	// would create every branch under the wrong name.
-	BranchTemplate          string   `yaml:"branch_template"`
-	Defaults                Defaults `yaml:"defaults"`
-	TranscriptRetentionDays int      `yaml:"transcript_retention_days"`
+	BranchTemplate string   `yaml:"branch_template"`
+	Defaults       Defaults `yaml:"defaults"`
+	// DeleteEmptyBranchOnArchive deletes a task's branch at archive time when
+	// it carries no commits past its recorded base (§10, task 008). Default
+	// true: a workflow that never writes to the repository leaves a ref behind
+	// on every run, and a branch whose tip is an ancestor of its base holds
+	// nothing to lose. Anything carrying a commit object is never touched.
+	//
+	// A plain bool is right here, unlike the pointer a tri-state would need:
+	// Load unmarshals into Default(), so an absent key keeps true and an
+	// explicit `false` restores the pre-008 behaviour exactly.
+	DeleteEmptyBranchOnArchive bool `yaml:"delete_empty_branch_on_archive"`
+	// DeleteRemoteBranchOnArchive additionally deletes the upstream
+	// counterpart of a branch that qualified. Default **false**, and honoured
+	// only by POST /v1/tasks/{id}/archive — a forge is shared with other
+	// people and the deletion is unrecoverable, so it happens only when a
+	// human asked for this archive and only when they opted in. It has no
+	// effect while DeleteEmptyBranchOnArchive is false: the remote leg runs
+	// after a local delete that succeeded.
+	DeleteRemoteBranchOnArchive bool `yaml:"delete_remote_branch_on_archive"`
+	TranscriptRetentionDays     int  `yaml:"transcript_retention_days"`
 	// TranscriptMaxBytes caps one attempt's transcript (§12.3, §18). Past it
 	// the step fails `transcript_limit` rather than filling the disk. It sits
 	// at the top level beside its retention sibling, not under `defaults:`,
@@ -220,10 +238,14 @@ func Default() Config {
 			CommandTimeout: Duration(15 * time.Minute),
 			InputTimeout:   Duration(24 * time.Hour),
 		},
-		TranscriptRetentionDays:   90,
-		TranscriptMaxBytes:        512 << 20, // 512MB (§12.3)
-		UsageLimitRecheckInterval: Duration(15 * time.Minute),
-		LogLevel:                  "info",
+		DeleteEmptyBranchOnArchive: true,
+		// Deliberately not defaulted true beside its local sibling: this one
+		// writes to a forge (§10, task 008).
+		DeleteRemoteBranchOnArchive: false,
+		TranscriptRetentionDays:     90,
+		TranscriptMaxBytes:          512 << 20, // 512MB (§12.3)
+		UsageLimitRecheckInterval:   Duration(15 * time.Minute),
+		LogLevel:                    "info",
 		// Inherit everything: exactly what the daemon did before the policy
 		// existed, so nothing changes for anyone who does not ask.
 		Environment: Environment{Inherit: InheritAll()},
@@ -289,6 +311,26 @@ func (c Config) validate() error {
 		return fmt.Errorf("log_level must be one of debug, info, warn, error; got %q", c.LogLevel)
 	}
 	return c.Environment.validate()
+}
+
+// Warnings are settings that parse, load and take effect, but do not do what
+// they look like they ask for. The daemon logs them at startup and on any
+// reload that changes them.
+//
+// They are separate from validate() on purpose: none of these refuses the file.
+// A key that is merely unreachable is not an invalid one, and failing the load
+// over it would revert every unrelated edit in the same save (§12.3).
+func (c Config) Warnings() []string {
+	var out []string
+	// A silent no-op key is worse than a line in the log: the remote leg runs
+	// only after a local delete that succeeded (§10, task 008), so this pair
+	// asks for something that cannot happen.
+	if c.DeleteRemoteBranchOnArchive && !c.DeleteEmptyBranchOnArchive {
+		out = append(out, "delete_remote_branch_on_archive is true while "+
+			"delete_empty_branch_on_archive is false: the remote counterpart is only "+
+			"deleted after the local branch, so no remote branch will ever be deleted")
+	}
+	return out
 }
 
 func isLoopbackHost(host string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,10 +79,14 @@ agents:
 			CommandTimeout: Duration(90 * time.Second),
 			InputTimeout:   Duration(36 * time.Hour),
 		},
-		TranscriptRetentionDays:   7,
-		TranscriptMaxBytes:        32 << 20,
-		UsageLimitRecheckInterval: Duration(2 * time.Minute),
-		LogLevel:                  "warn",
+		// Same property as `environment:` below: the file names neither branch
+		// key, so the §10 defaults survive an otherwise fully-overriding config
+		// — on locally, off for the forge (task 008).
+		DeleteEmptyBranchOnArchive: true,
+		TranscriptRetentionDays:    7,
+		TranscriptMaxBytes:         32 << 20,
+		UsageLimitRecheckInterval:  Duration(2 * time.Minute),
+		LogLevel:                   "warn",
 		// The file omits `environment:`, so the §12.3 default survives an
 		// otherwise fully-overriding config — which is the property that
 		// keeps T4.23 invisible to anyone who does not ask for it.
@@ -94,6 +98,62 @@ agents:
 	}
 	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("got %+v, want %+v", cfg, want)
+	}
+}
+
+// TestBranchCleanupDefaults pins the split default the §10 amendment rests on
+// (task 008): the local leg is on, the leg that writes to a forge is not.
+func TestBranchCleanupDefaults(t *testing.T) {
+	d := Default()
+	if !d.DeleteEmptyBranchOnArchive {
+		t.Error("delete_empty_branch_on_archive defaults to false, want true")
+	}
+	if d.DeleteRemoteBranchOnArchive {
+		t.Error("delete_remote_branch_on_archive defaults to true, want false")
+	}
+}
+
+// TestBranchCleanupExplicitFalse: a plain bool is only correct if an explicit
+// `false` in the file survives unmarshalling into Default() — that is the one
+// way back to the pre-008 behaviour.
+func TestBranchCleanupExplicitFalse(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "delete_empty_branch_on_archive: false\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DeleteEmptyBranchOnArchive {
+		t.Error("an explicit false was overwritten by the default true")
+	}
+}
+
+// TestBranchCleanupWarnsOnUnreachableRemoteLeg: the pair still loads — a key
+// that is merely unreachable is not an invalid one, and failing the file over
+// it would revert every unrelated edit in the same save — but it must not be
+// silent.
+func TestBranchCleanupWarnsOnUnreachableRemoteLeg(t *testing.T) {
+	cfg, err := Load(writeConfig(t, strings.TrimSpace(`
+delete_empty_branch_on_archive: false
+delete_remote_branch_on_archive: true
+`)))
+	if err != nil {
+		t.Fatalf("Load: %v — an unreachable key must not refuse the file", err)
+	}
+	warnings := cfg.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("Warnings() = %q, want exactly one", warnings)
+	}
+	if !strings.Contains(warnings[0], "delete_remote_branch_on_archive") {
+		t.Errorf("warning %q does not name the key it is about", warnings[0])
+	}
+	// Every workable combination stays quiet, or the log stops meaning anything.
+	for _, c := range []Config{
+		Default(),
+		{DeleteEmptyBranchOnArchive: true, DeleteRemoteBranchOnArchive: true},
+		{},
+	} {
+		if w := c.Warnings(); len(w) != 0 {
+			t.Errorf("Warnings() = %q for %+v, want none", w, c)
+		}
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -110,6 +110,13 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 			"branch_template", cfg.BranchTemplate, "error", err)
 		return fmt.Errorf("invalid branch_template: %w", err)
 	}
+	// Settings that load and take effect but cannot do what they ask for
+	// (§12.3). They never refuse the file, so the log is the only place they
+	// are ever visible; the reload path re-reports them when they change.
+	prevWarnings := cfg.Warnings()
+	for _, warning := range prevWarnings {
+		logger.Warn("config warning", "warning", warning)
+	}
 	if lvl, err := parseLevel(cfg.LogLevel); err == nil {
 		level.Set(lvl)
 	}
@@ -325,6 +332,15 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 					"effective", prev.BranchTemplate, "requested", next.BranchTemplate, "error", err)
 				next.BranchTemplate = prev.BranchTemplate
 			}
+		}
+		// Re-warned on every reload that introduces one: a warning is about the
+		// configuration now in force, and startup's copy says nothing about an
+		// edit made an hour later.
+		if warnings := next.Warnings(); !sameNames(prevWarnings, warnings) {
+			for _, warning := range warnings {
+				logger.Warn("config warning", "warning", warning)
+			}
+			prevWarnings = warnings
 		}
 		if lvl, err := parseLevel(next.LogLevel); err == nil {
 			level.Set(lvl)

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -15,11 +15,19 @@ import (
 	"time"
 )
 
-// Timeouts for the two shapes of git work vincent does (T1.5/T1.6 decision):
+// Timeouts for the shapes of git work vincent does (T1.5/T1.6 decision):
 // queries are near-instant; worktree checkouts scale with repo size.
 const (
 	QueryTimeout    = 30 * time.Second
 	WorktreeTimeout = 5 * time.Minute
+	// RemoteTimeout bounds a git call that talks to a network remote — today
+	// only `push --delete` on archive (§10, task 008). It is its own constant
+	// because neither of the others fits: a query timeout is sized for a local
+	// object-database read and would fail every push over a slow link, while a
+	// worktree timeout would park the archive's caller behind an unreachable
+	// host for five minutes. A remote that does not answer inside this is
+	// logged and the branch survives, which is the pre-008 behaviour.
+	RemoteTimeout = 60 * time.Second
 )
 
 // MinMajor and MinMinor are the git version below which the daemon warns at

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskstate"
 	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // InvalidActionError reports a human action that §6 does not allow from the
@@ -197,26 +198,41 @@ func (r *Runner) Reject(ctx context.Context, id int64) (*store.Task, error) {
 	return r.transitionFrom(ctx, task, taskstate.Reject, store.TaskChange{BlockReason: &reason})
 }
 
-// Archive removes the task's worktree and marks the record archived (§6,
-// §10). The branch is never deleted. Removal happens first: an archived task
-// still pointing at a live worktree would be a lie, so a dirty worktree
-// without force leaves the task exactly as it was.
-func (r *Runner) Archive(ctx context.Context, id int64, force bool) (*store.Task, error) {
+// Archive removes the task's worktree, marks the record archived, and then —
+// and only then — deletes the branch if it carries no commits past its base
+// (§6, §10, task 008). Removal happens first: an archived task still pointing
+// at a live worktree would be a lie, so a dirty worktree without force leaves
+// the task exactly as it was, and the branch step is unreachable.
+//
+// The returned BranchOutcome is what happened to the branch; its zero value
+// means the branch step did not run. It is never an error: the archive has
+// already committed by then, and a branch problem must not be able to reverse
+// it. Failures are logged here and reported to the caller.
+func (r *Runner) Archive(
+	ctx context.Context, id int64, force bool,
+) (*store.Task, worktree.BranchOutcome, error) {
 	task, err := r.deps.Store.GetTask(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, worktree.BranchOutcome{}, err
 	}
 	if !taskstate.Can(task.State, taskstate.Archive) {
-		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Archive, State: task.State}
+		return nil, worktree.BranchOutcome{},
+			&InvalidActionError{TaskID: id, Action: taskstate.Archive, State: task.State}
 	}
 	empty := ""
 	if task.WorktreePath == "" {
-		return r.transitionFrom(ctx, task, taskstate.Archive,
+		// No worktree ever existed, so no branch was ever created for this task
+		// either — `git worktree add -b` makes both or neither. That matters
+		// beyond tidiness: a task that blocked with `branch_exists` (§10, task
+		// 001) carries a branch_name naming *somebody else's* branch, and this
+		// is the check that keeps the branch step away from it.
+		out, err := r.transitionFrom(ctx, task, taskstate.Archive,
 			store.TaskChange{WorktreePath: &empty})
+		return out, worktree.BranchOutcome{}, err
 	}
 	project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
 	if err != nil {
-		return nil, err
+		return nil, worktree.BranchOutcome{}, err
 	}
 	// Remove-then-clear runs under the manager's claim lock, the mirror of
 	// creation's create-then-claim (task 005). Between the two the row still
@@ -230,9 +246,50 @@ func (r *Runner) Archive(ctx context.Context, id int64, force bool) (*store.Task
 				store.TaskChange{WorktreePath: &empty})
 			return err
 		}); err != nil {
-		return nil, err
+		return nil, worktree.BranchOutcome{}, err
 	}
-	return out, nil
+	// Outside the callback, not inside it: the branch is checked out in the
+	// worktree until the worktree is gone, and the archive transition must not
+	// be reversible by a branch problem.
+	return out, r.deleteArchivedBranch(ctx, task, project.Path), nil
+}
+
+// deleteArchivedBranch applies the §10 empty-branch rule to a task that has
+// just reached `archived`. The flags are read through Deps.Config, so a hot
+// reload reaches the next archive with no extra plumbing.
+func (r *Runner) deleteArchivedBranch(
+	ctx context.Context, task *store.Task, projectPath string,
+) worktree.BranchOutcome {
+	cfg := r.deps.Config()
+	if !cfg.DeleteEmptyBranchOnArchive || task.BranchName == "" {
+		return worktree.BranchOutcome{}
+	}
+	log := r.deps.Logger.With("task", task.ID, "branch", task.BranchName)
+	// The remote leg is attended-only by §10, and this is the attended path:
+	// every caller of Archive is a human asking for this one task.
+	out, err := r.deps.Worktrees.DeleteEmptyBranch(ctx, projectPath,
+		task.BaseBranch, task.BranchName, cfg.DeleteRemoteBranchOnArchive)
+	if err != nil {
+		log.Warn("archive: branch kept", "result", out.Result, "error", err)
+		return out
+	}
+	switch out.Result {
+	case worktree.BranchDeleted:
+		log.Info("archive: deleted the branch, which had no commits past its base",
+			"base", task.BaseBranch, "remote", remoteResult(out))
+	case worktree.BranchHasCommits:
+		log.Info("archive: kept the branch, which has commits past its base",
+			"base", task.BaseBranch)
+	}
+	return out
+}
+
+// remoteResult names the remote leg for a log line; "" when it did not run.
+func remoteResult(out worktree.BranchOutcome) string {
+	if out.Remote == nil {
+		return ""
+	}
+	return out.Remote.Result
 }
 
 // SetPriority reorders admission without changing state (§6: queued and

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -35,6 +35,9 @@ type actionHarness struct {
 	runner    *Runner
 	repo      string
 	projectID int64
+	// cfg is read through Deps.Config on every call, so a test can move a
+	// setting the way a hot reload does.
+	cfg config.Config
 }
 
 func newActionHarness(t *testing.T) *actionHarness {
@@ -51,14 +54,31 @@ func newActionHarness(t *testing.T) *actionHarness {
 	if err := st.CreateProject(t.Context(), project); err != nil {
 		t.Fatalf("CreateProject: %v", err)
 	}
-	runner := New(Deps{
+	h := &actionHarness{store: st, repo: repo, projectID: project.ID, cfg: config.Default()}
+	h.runner = New(Deps{
 		Store:     st,
-		Config:    config.Default,
+		Config:    func() config.Config { return h.cfg },
 		Worktrees: worktree.NewManager(git, dataDir),
 		DataDir:   dataDir,
 		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
-	return &actionHarness{store: st, runner: runner, repo: repo, projectID: project.ID}
+	return h
+}
+
+// branchExists asks the repository itself, not the manager under test.
+func (h *actionHarness) branchExists(t *testing.T, branch string) bool {
+	t.Helper()
+	return testrepo.Run(t, h.repo,
+		"for-each-ref", "--format=%(refname:short)", "refs/heads/"+branch) != ""
+}
+
+// commitInWorktree gives the task's branch a commit of its own, which is what
+// makes it worth keeping past archive.
+func (h *actionHarness) commitInWorktree(t *testing.T, path string) {
+	t.Helper()
+	testrepo.WriteFile(t, path, "work.txt", "real work\n")
+	testrepo.Run(t, path, "add", ".")
+	testrepo.Run(t, path, "commit", "-q", "-m", "the work")
 }
 
 func (h *actionHarness) task(t *testing.T, state store.TaskState) *store.Task {
@@ -112,7 +132,8 @@ func (h *actionHarness) invoke(
 	case taskstate.Reject:
 		return h.runner.Reject(ctx, id)
 	case taskstate.Archive:
-		return h.runner.Archive(ctx, id, false)
+		task, _, err := h.runner.Archive(ctx, id, false)
+		return task, err
 	default:
 		t := &InvalidActionError{TaskID: id, Action: action}
 		return nil, t
@@ -463,7 +484,7 @@ func TestArchiveRemovesWorktree(t *testing.T) {
 	task := h.task(t, store.TaskDone)
 	path := h.worktree(t, task)
 
-	got, err := h.runner.Archive(t.Context(), task.ID, false)
+	got, branch, err := h.runner.Archive(t.Context(), task.ID, false)
 	if err != nil {
 		t.Fatalf("Archive: %v", err)
 	}
@@ -472,6 +493,14 @@ func TestArchiveRemovesWorktree(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("worktree %s still exists after archiving", path)
+	}
+	// The default is on, and this task's branch never received a commit
+	// (task 008).
+	if branch.Result != worktree.BranchDeleted {
+		t.Errorf("branch outcome = %+v, want %q", branch, worktree.BranchDeleted)
+	}
+	if h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s survived an archive that reported it deleted", task.BranchName)
 	}
 }
 
@@ -483,7 +512,7 @@ func TestArchiveRefusesDirtyWorktreeWithoutForce(t *testing.T) {
 		t.Fatalf("dirty the worktree: %v", err)
 	}
 
-	if _, err := h.runner.Archive(t.Context(), task.ID, false); err == nil {
+	if _, _, err := h.runner.Archive(t.Context(), task.ID, false); err == nil {
 		t.Fatal("archived a dirty worktree without force")
 	} else if worktree.ReasonOf(err) != worktree.ReasonWorktreeDirty {
 		t.Fatalf("err = %v, want a dirty-worktree refusal", err)
@@ -493,12 +522,116 @@ func TestArchiveRefusesDirtyWorktreeWithoutForce(t *testing.T) {
 	if got := h.get(t, task.ID); got.State != store.TaskDone {
 		t.Errorf("state = %s after a refused archive, want done", got.State)
 	}
+	// And the branch step must be unreachable behind that refusal — it runs
+	// after the worktree removal, which did not happen (task 008).
+	if !h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s was deleted by an archive that was refused", task.BranchName)
+	}
 
-	if _, err := h.runner.Archive(t.Context(), task.ID, true); err != nil {
+	if _, _, err := h.runner.Archive(t.Context(), task.ID, true); err != nil {
 		t.Fatalf("Archive(force): %v", err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("worktree %s still exists after a forced archive", path)
+	}
+}
+
+// TestArchiveKeepsABranchWithCommits: the rule is about branches that hold
+// nothing, and a task that did work is the case that must never lose it.
+func TestArchiveKeepsABranchWithCommits(t *testing.T) {
+	h := newActionHarness(t)
+	task := h.task(t, store.TaskDone)
+	path := h.worktree(t, task)
+	h.commitInWorktree(t, path)
+
+	got, branch, err := h.runner.Archive(t.Context(), task.ID, false)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if got.State != store.TaskArchived {
+		t.Errorf("state = %s, want archived", got.State)
+	}
+	if branch.Result != worktree.BranchHasCommits {
+		t.Errorf("branch outcome = %+v, want %q", branch, worktree.BranchHasCommits)
+	}
+	if !h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s was deleted despite carrying a commit", task.BranchName)
+	}
+}
+
+// TestArchiveWithBranchCleanupOff asserts the pre-008 behaviour directly: with
+// the setting off, no path deletes anything and the outcome says nothing.
+func TestArchiveWithBranchCleanupOff(t *testing.T) {
+	h := newActionHarness(t)
+	h.cfg.DeleteEmptyBranchOnArchive = false
+	task := h.task(t, store.TaskDone)
+	h.worktree(t, task)
+
+	got, branch, err := h.runner.Archive(t.Context(), task.ID, false)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if got.State != store.TaskArchived {
+		t.Errorf("state = %s, want archived", got.State)
+	}
+	if branch.Checked() {
+		t.Errorf("branch outcome = %+v, want the zero value", branch)
+	}
+	if !h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s was deleted with delete_empty_branch_on_archive off", task.BranchName)
+	}
+}
+
+// TestArchiveSurvivesABranchFailure: every branch-side failure still lands the
+// task in `archived` and reports what happened. Here the base branch is gone,
+// so git cannot judge the branch at all.
+func TestArchiveSurvivesABranchFailure(t *testing.T) {
+	h := newActionHarness(t)
+	task := h.task(t, store.TaskDone)
+	h.worktree(t, task)
+	// The recorded base no longer resolves: renamed out from under the task.
+	testrepo.Run(t, h.repo, "branch", "-m", "main", "trunk")
+
+	got, branch, err := h.runner.Archive(t.Context(), task.ID, false)
+	if err != nil {
+		t.Fatalf("Archive: %v — a branch problem must never fail the archive", err)
+	}
+	if got.State != store.TaskArchived {
+		t.Errorf("state = %s, want archived", got.State)
+	}
+	if branch.Result != worktree.BranchUnknown {
+		t.Errorf("branch outcome = %+v, want %q", branch, worktree.BranchUnknown)
+	}
+	if branch.Error == "" {
+		t.Error("an unknown outcome carries no error text to log")
+	}
+	if !h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s was deleted on a check nobody could make", task.BranchName)
+	}
+}
+
+// TestArchiveWithoutAWorktreeTouchesNoBranch: a task that never got a worktree
+// never got a branch either, and its branch_name may name somebody else's —
+// that is exactly what a `branch_exists` block records (task 001).
+func TestArchiveWithoutAWorktreeTouchesNoBranch(t *testing.T) {
+	h := newActionHarness(t)
+	task := h.task(t, store.TaskAborted)
+	// A branch of that name exists, put there by something other than this
+	// task. Nothing may touch it.
+	testrepo.Run(t, h.repo, "branch", task.BranchName)
+
+	got, branch, err := h.runner.Archive(t.Context(), task.ID, false)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if got.State != store.TaskArchived {
+		t.Errorf("state = %s, want archived", got.State)
+	}
+	if branch.Checked() {
+		t.Errorf("branch outcome = %+v, want the zero value", branch)
+	}
+	if !h.branchExists(t, task.BranchName) {
+		t.Errorf("branch %s was deleted although this task never created it", task.BranchName)
 	}
 }
 

--- a/internal/testrepo/testrepo.go
+++ b/internal/testrepo/testrepo.go
@@ -48,6 +48,22 @@ func InitEmpty(t *testing.T, branch string) string {
 	return dir
 }
 
+// InitBare creates a temp bare repository — something a test can push to and
+// then inspect with `rev-parse`, which is the only way to prove the remote leg
+// of archive's branch cleanup (§10, task 008) without a network.
+func InitBare(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := filepath.Join(t.TempDir(), "remote.git")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	Run(t, dir, "init", "-q", "--bare", "-b", "main")
+	return dir
+}
+
 // WriteFile writes content under dir, creating parents.
 func WriteFile(t *testing.T, dir, name, content string) {
 	t.Helper()

--- a/internal/tui/actionbar.go
+++ b/internal/tui/actionbar.go
@@ -22,6 +22,11 @@ type actionResultMsg struct {
 	taskID int64
 	action string
 	task   apiclient.Task
+	// branch is what an archive did to the task's branch (§10, task 008); its
+	// zero value means the branch step did not run, and no other action sets
+	// it. It rides the result rather than an event because `archived` is
+	// terminal and this is the one place a human is waiting for the answer.
+	branch apiclient.BranchOutcome
 	err    error
 }
 
@@ -147,8 +152,9 @@ func (a *actionBar) dispatch(client *apiclient.Client, id int64, action string, 
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
 		var (
-			task apiclient.Task
-			err  error
+			task   apiclient.Task
+			branch apiclient.BranchOutcome
+			err    error
 		)
 		switch action {
 		case apiclient.ActionCancel:
@@ -166,11 +172,11 @@ func (a *actionBar) dispatch(client *apiclient.Client, id int64, action string, 
 		case apiclient.ActionReject:
 			task, err = client.Reject(ctx, id)
 		case apiclient.ActionArchive:
-			task, err = client.Archive(ctx, id, force)
+			task, branch, err = client.Archive(ctx, id, force)
 		default:
 			err = fmt.Errorf("unknown action %q", action)
 		}
-		return actionResultMsg{taskID: id, action: action, task: task, err: err}
+		return actionResultMsg{taskID: id, action: action, task: task, branch: branch, err: err}
 	}
 }
 
@@ -179,7 +185,14 @@ func (a *actionBar) dispatch(client *apiclient.Client, id int64, action string, 
 // dirty confirmation (§6) and re-asking is what a human expects to be asked.
 func (a *actionBar) applyResult(msg actionResultMsg) {
 	if msg.err == nil {
-		a.setStatus(msg.action+" · now "+msg.task.State, false)
+		status := msg.action + " · now " + msg.task.State
+		// The branch is the one consequence of an archive that is invisible
+		// afterwards — the task row no longer names a worktree to go look in —
+		// so it is said here or nowhere (§10, task 008).
+		if line := msg.branch.Summary(); line != "" {
+			status += " · " + line
+		}
+		a.setStatus(status, false)
 		return
 	}
 	var apiErr *apiclient.Error

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -103,6 +103,11 @@ func (d *daemonView) configLines() []string {
 				"   input "+c.Defaults.InputTimeout),
 		field("transcript retention", strconv.Itoa(c.TranscriptRetentionDays)+" days")+
 			styleDim.Render("   cap "+humanBytes(c.TranscriptMaxBytes)+" per run"),
+		// Both halves of the §10 pair on one line: the remote one is inert
+		// while the local one is off, so showing either alone would describe a
+		// policy that cannot run.
+		field("delete empty branch", onOff(c.DeleteEmptyBranchOnArchive))+
+			styleDim.Render("   remote "+onOff(c.DeleteRemoteBranchOnArchive)),
 		field("usage limit recheck", c.UsageLimitRecheck),
 		field("log level", c.LogLevel),
 	)
@@ -166,6 +171,15 @@ func (d *daemonView) adapterLines() []string {
 		out = append(out, row)
 	}
 	return out
+}
+
+// onOff renders a boolean setting. "on"/"off" rather than "true"/"false":
+// the view reports a policy in effect, not the YAML literal behind it.
+func onOff(v bool) string {
+	if v {
+		return "on"
+	}
+	return "off"
 }
 
 // humanBytes renders a byte count the way the config file spells it, so the

--- a/internal/worktree/branch_delete.go
+++ b/internal/worktree/branch_delete.go
@@ -1,0 +1,234 @@
+package worktree
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/lezli01/vincent/internal/gitx"
+)
+
+// Outcomes of the archive-time branch check (§10, task 008). They are the same
+// snake_case vocabulary as the Reason constants above — one word means the same
+// thing wherever it surfaces — but they are *results*, not failures: three of
+// the four describe a branch that is still there, which is the pre-008
+// behaviour and not an error in itself.
+const (
+	// BranchDeleted: the branch had no commits past its base and is gone.
+	BranchDeleted = "deleted"
+	// BranchHasCommits: the branch carries work, so it was left alone. Nothing
+	// that holds a commit object is ever deleted.
+	BranchHasCommits = "has_commits"
+	// BranchUnknown: git could not say whether the branch is empty — the base
+	// branch was renamed or deleted, the repository is gone. Read as *cannot
+	// judge*, which keeps the branch, deliberately distinct from
+	// BranchHasCommits the way ReasonDirtyUnknown is from ReasonWorktreeDirty.
+	BranchUnknown = "unknown"
+	// BranchDeleteFailed: the branch qualified but `git branch -d` refused or
+	// failed. It survives.
+	BranchDeleteFailed = "error"
+)
+
+// Outcomes of the remote leg, which only runs on an attended archive with
+// delete_remote_branch_on_archive on (§10, task 008).
+const (
+	// RemoteBranchDeleted: `git push --delete` succeeded.
+	RemoteBranchDeleted = "deleted"
+	// RemoteBranchNoUpstream: the local branch had no configured upstream, so
+	// nothing was pushed as far as vincent knows and nothing was attempted.
+	RemoteBranchNoUpstream = "no_upstream"
+	// RemoteBranchFailed: the push was rejected, the host was unreachable, or
+	// the call timed out. The local branch is already gone and the archive
+	// still succeeded.
+	RemoteBranchFailed = "error"
+)
+
+// BranchOutcome is what archive did to a task's branch. A zero value means the
+// branch step never ran — the policy is off, or the task had no branch of its
+// own to judge — which is what every path before task 008 did unconditionally.
+type BranchOutcome struct {
+	// Branch is the local branch this is about; empty when nothing was checked.
+	Branch string
+	// Result is one of the Branch* constants, or "" when nothing was checked.
+	Result string
+	// Error carries git's own message when Result is BranchUnknown or
+	// BranchDeleteFailed. It is reported, never acted on: an archive is never
+	// failed by a branch problem.
+	Error string
+	// Remote is the remote leg's outcome, non-nil only when it ran.
+	Remote *RemoteBranchOutcome
+}
+
+// Checked reports whether the branch step ran at all.
+func (o BranchOutcome) Checked() bool { return o.Result != "" }
+
+// RemoteBranchOutcome is what the opt-in remote leg did.
+type RemoteBranchOutcome struct {
+	// Remote is the configured remote name (`branch.{name}.remote`), empty
+	// when there was no upstream to resolve.
+	Remote string
+	// Ref is the full ref deleted on that remote (`branch.{name}.merge`).
+	Ref string
+	// Result is one of the RemoteBranch* constants.
+	Result string
+	// Error carries git's own message when Result is RemoteBranchFailed.
+	Error string
+}
+
+// upstream is a branch's configured push target, read from git config rather
+// than from `@{upstream}`: the remote-tracking ref can be pruned while the
+// configuration that named it survives, and the question here is "did vincent
+// ever push this", which the configuration answers and a pruned ref does not.
+type upstream struct {
+	remote string
+	ref    string
+}
+
+// DeleteEmptyBranch deletes branch when it carries no commits past base, and
+// reports what happened (§10, task 008). It is the *one* exception to §10's
+// rule that vincent never deletes a branch: a branch whose tip is an ancestor
+// of its base holds nothing a user could want back.
+//
+// The test is `git rev-list -n 1 base..branch` producing no output. It stays
+// correct when the base moves forward after the task started — the tip is
+// still an ancestor — and costs one cheap git call. Any git failure is read as
+// *cannot judge* and leaves the branch alone.
+//
+// It never fails a caller: the error is returned for logging, and the outcome
+// says what the repository now looks like. Archive has already happened by the
+// time this runs, and a branch problem must not be able to reverse it.
+//
+// deleteRemote additionally deletes the branch's upstream counterpart, and is
+// honoured only on an attended archive (§10): deleting a branch on a forge
+// other people share is unrecoverable and outward-facing, so the unattended
+// paths never pass true.
+func (m *Manager) DeleteEmptyBranch(
+	ctx context.Context, projectPath, base, branch string, deleteRemote bool,
+) (BranchOutcome, error) {
+	out := BranchOutcome{Branch: branch}
+	if branch == "" {
+		return BranchOutcome{}, nil
+	}
+	if _, err := os.Stat(projectPath); err != nil {
+		e := &Error{
+			Reason:  ReasonProjectPathMissing,
+			Message: fmt.Sprintf("project path %s does not exist", projectPath), Err: err,
+		}
+		out.Result, out.Error = BranchUnknown, e.Error()
+		return out, e
+	}
+	empty, err := m.branchIsEmpty(ctx, projectPath, base, branch)
+	if err != nil {
+		out.Result, out.Error = BranchUnknown, err.Error()
+		return out, err
+	}
+	if !empty {
+		out.Result = BranchHasCommits
+		return out, nil
+	}
+	// Resolved *before* the delete, though it is only used after one that
+	// succeeds: `git branch -d` drops the branch's own config section, taking
+	// `branch.{name}.remote` with it, so asking afterwards always answers "no
+	// upstream". The ordering the outcome describes is unchanged — no push is
+	// attempted unless the local delete worked.
+	var up upstream
+	var hasUpstream bool
+	if deleteRemote {
+		up, hasUpstream = m.branchUpstream(ctx, projectPath, branch)
+	}
+	if err := m.deleteLocalBranch(ctx, projectPath, branch); err != nil {
+		out.Result, out.Error = BranchDeleteFailed, err.Error()
+		return out, err
+	}
+	out.Result = BranchDeleted
+	if !deleteRemote {
+		return out, nil
+	}
+	if !hasUpstream {
+		out.Remote = &RemoteBranchOutcome{Result: RemoteBranchNoUpstream}
+		return out, nil
+	}
+	rem := &RemoteBranchOutcome{Remote: up.remote, Ref: up.ref, Result: RemoteBranchDeleted}
+	out.Remote = rem
+	if err := m.pushDeleteBranch(ctx, projectPath, up); err != nil {
+		rem.Result, rem.Error = RemoteBranchFailed, err.Error()
+		return out, err
+	}
+	return out, nil
+}
+
+// branchIsEmpty reports whether branch's tip is an ancestor of base. Both refs
+// are named in full: an ambiguous short name (a tag sharing the branch's name,
+// a deleted base branch with a surviving remote-tracking ref) must read as
+// *cannot judge* rather than resolve to something else and answer confidently.
+func (m *Manager) branchIsEmpty(ctx context.Context, repo, base, branch string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, gitx.QueryTimeout)
+	defer cancel()
+	out, err := m.git.Run(ctx, repo, "rev-list", "-n", "1",
+		"refs/heads/"+base+"..refs/heads/"+branch)
+	if err != nil {
+		return false, &Error{
+			Reason:  ReasonGitError,
+			Message: fmt.Sprintf("git rev-list %s..%s failed", base, branch), Err: err,
+		}
+	}
+	return out == "", nil
+}
+
+// deleteLocalBranch runs `git branch -d`, never `-D`. The lower-case form
+// carries its own merged-into-HEAD check, which is a second belt behind the
+// rev-list, and its refusal is what covers a branch still checked out in
+// another worktree — the case where a force delete would corrupt somebody's
+// working tree.
+func (m *Manager) deleteLocalBranch(ctx context.Context, repo, branch string) error {
+	ctx, cancel := context.WithTimeout(ctx, gitx.WorktreeTimeout)
+	defer cancel()
+	if _, err := m.git.Run(ctx, repo, "branch", "-d", branch); err != nil {
+		return &Error{
+			Reason:  ReasonGitError,
+			Message: fmt.Sprintf("git branch -d %s failed", branch), Err: err,
+		}
+	}
+	return nil
+}
+
+// branchUpstream reads the branch's configured push target. Both halves must be
+// present: a `branch.{name}.remote` with no `branch.{name}.merge` names no ref
+// to delete, and guessing the remote name from the local one is exactly the
+// kind of inference that deletes the wrong ref on somebody else's forge.
+func (m *Manager) branchUpstream(ctx context.Context, repo, branch string) (upstream, bool) {
+	remote, ok := m.gitConfig(ctx, repo, "branch."+branch+".remote")
+	if !ok {
+		return upstream{}, false
+	}
+	ref, ok := m.gitConfig(ctx, repo, "branch."+branch+".merge")
+	if !ok {
+		return upstream{}, false
+	}
+	return upstream{remote: remote, ref: ref}, true
+}
+
+// gitConfig reads one config key; a missing key is exit 1, not a failure.
+func (m *Manager) gitConfig(ctx context.Context, repo, key string) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, gitx.QueryTimeout)
+	defer cancel()
+	out, err := m.git.Run(ctx, repo, "config", "--get", key)
+	if err != nil || out == "" {
+		return "", false
+	}
+	return out, true
+}
+
+// pushDeleteBranch deletes the upstream counterpart. The full ref is pushed as
+// git recorded it, so nothing here has to reconstruct the remote's naming.
+func (m *Manager) pushDeleteBranch(ctx context.Context, repo string, up upstream) error {
+	ctx, cancel := context.WithTimeout(ctx, gitx.RemoteTimeout)
+	defer cancel()
+	if _, err := m.git.Run(ctx, repo, "push", "--delete", up.remote, up.ref); err != nil {
+		return &Error{
+			Reason:  ReasonGitError,
+			Message: fmt.Sprintf("git push --delete %s %s failed", up.remote, up.ref), Err: err,
+		}
+	}
+	return nil
+}

--- a/internal/worktree/branch_delete_test.go
+++ b/internal/worktree/branch_delete_test.go
@@ -1,0 +1,347 @@
+package worktree
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// branchExists asks the repository directly rather than through the Manager,
+// so a test can never pass because the code under test and the assertion share
+// a bug.
+func branchExists(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	out := testrepo.Run(t, repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/"+branch)
+	return out != ""
+}
+
+// commitInRepo advances whatever the main checkout has checked out.
+func commitInRepo(t *testing.T, repo, file, content string) {
+	t.Helper()
+	testrepo.WriteFile(t, repo, file, content)
+	testrepo.Run(t, repo, "add", ".")
+	testrepo.Run(t, repo, "commit", "-q", "-m", "commit "+file)
+}
+
+// TestDeleteEmptyBranch walks the whole rule in one table: a branch is deleted
+// only when its tip is an ancestor of its recorded base, and every other answer
+// — including every answer git refuses to give — keeps it (§10, task 008).
+func TestDeleteEmptyBranch(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup returns the base and branch names to judge, having arranged
+		// the repository however the case needs.
+		setup      func(t *testing.T, m *Manager, repo string) (base, branch string)
+		wantResult string
+		wantErr    bool
+		wantGone   bool
+		// wantAlive are branches that must still exist afterwards, whatever
+		// happened to the one under test.
+		wantAlive []string
+	}{
+		{
+			name: "no commits past base is deleted",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				if _, err := m.Create(t.Context(), repo, 1, "vincent/1-empty", "main"); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				if err := m.Remove(t.Context(), repo, m.Path(1), false); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+				return "main", "vincent/1-empty"
+			},
+			wantResult: BranchDeleted,
+			wantGone:   true,
+		},
+		{
+			name: "one commit past base survives",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				path, err := m.Create(t.Context(), repo, 2, "vincent/2-work", "main")
+				if err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				testrepo.WriteFile(t, path, "work.txt", "real work\n")
+				testrepo.Run(t, path, "add", ".")
+				testrepo.Run(t, path, "commit", "-q", "-m", "the work")
+				if err := m.Remove(t.Context(), repo, path, false); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+				return "main", "vincent/2-work"
+			},
+			wantResult: BranchHasCommits,
+		},
+		{
+			name: "base moving forward afterwards still reads as empty",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				if _, err := m.Create(t.Context(), repo, 3, "vincent/3-empty", "main"); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				if err := m.Remove(t.Context(), repo, m.Path(3), false); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+				// main gains work the task never saw. The tip is still an
+				// ancestor of it, which is the whole point of testing against
+				// the base rather than against the fork point.
+				commitInRepo(t, repo, "later.txt", "moved on\n")
+				return "main", "vincent/3-empty"
+			},
+			wantResult: BranchDeleted,
+			wantGone:   true,
+		},
+		{
+			name: "base branch that no longer resolves cannot be judged",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				if _, err := m.Create(t.Context(), repo, 4, "vincent/4-empty", "main"); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				if err := m.Remove(t.Context(), repo, m.Path(4), false); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+				return "gone-forever", "vincent/4-empty"
+			},
+			wantResult: BranchUnknown,
+			wantErr:    true,
+		},
+		{
+			name: "a branch checked out in another worktree is refused",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				// The worktree is deliberately *not* removed: `git branch -d`
+				// is the belt that covers this, and it must refuse.
+				if _, err := m.Create(t.Context(), repo, 5, "vincent/5-live", "main"); err != nil {
+					t.Fatalf("create: %v", err)
+				}
+				return "main", "vincent/5-live"
+			},
+			wantResult: BranchDeleteFailed,
+			wantErr:    true,
+		},
+		{
+			// git stores refs as a path hierarchy, which is why creating
+			// `feat/foo` beside `feat/foo/bar` is impossible in the first
+			// place (§10, task 001). What *is* reachable is two branches
+			// sharing a ref directory, and deleting one must not take the
+			// directory — and its neighbour — with it.
+			name: "a ref hierarchy neighbour is not collaterally removed",
+			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
+				for id, name := range map[int64]string{6: "feat/foo/bar", 7: "feat/foo/baz"} {
+					if _, err := m.Create(t.Context(), repo, id, name, "main"); err != nil {
+						t.Fatalf("create %s: %v", name, err)
+					}
+					if err := m.Remove(t.Context(), repo, m.Path(id), false); err != nil {
+						t.Fatalf("remove %s: %v", name, err)
+					}
+				}
+				return "main", "feat/foo/bar"
+			},
+			wantResult: BranchDeleted,
+			wantGone:   true,
+			wantAlive:  []string{"feat/foo/baz"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := testrepo.Init(t, "main")
+			m := newManager(t)
+			base, branch := tt.setup(t, m, repo)
+
+			out, err := m.DeleteEmptyBranch(t.Context(), repo, base, branch, false)
+			if tt.wantErr && err == nil {
+				t.Fatalf("DeleteEmptyBranch(%s..%s) returned no error", base, branch)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("DeleteEmptyBranch(%s..%s): %v", base, branch, err)
+			}
+			if out.Result != tt.wantResult {
+				t.Errorf("result = %q, want %q (error %v)", out.Result, tt.wantResult, err)
+			}
+			if out.Branch != branch {
+				t.Errorf("outcome names branch %q, want %q", out.Branch, branch)
+			}
+			if tt.wantErr && out.Error == "" {
+				t.Error("an outcome that failed carries no error text")
+			}
+			if got := branchExists(t, repo, branch); got == tt.wantGone {
+				t.Errorf("branch %s exists = %v, want %v", branch, got, !tt.wantGone)
+			}
+			for _, alive := range tt.wantAlive {
+				if !branchExists(t, repo, alive) {
+					t.Errorf("branch %s was removed alongside %s", alive, branch)
+				}
+			}
+			if out.Remote != nil {
+				t.Errorf("remote leg ran without being asked: %+v", out.Remote)
+			}
+		})
+	}
+}
+
+// TestDeleteEmptyBranchKeepsTheCommitObject: a branch with work survives *and*
+// its commit stays reachable. "The branch is still listed" would pass even if
+// the objects had been pruned out from under it.
+func TestDeleteEmptyBranchKeepsTheCommitObject(t *testing.T) {
+	repo := testrepo.Init(t, "main")
+	m := newManager(t)
+	path, err := m.Create(t.Context(), repo, 1, "vincent/1-work", "main")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	testrepo.WriteFile(t, path, "work.txt", "real work\n")
+	testrepo.Run(t, path, "add", ".")
+	testrepo.Run(t, path, "commit", "-q", "-m", "the work")
+	sha := testrepo.Run(t, path, "rev-parse", "HEAD")
+	if err := m.Remove(t.Context(), repo, path, false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	out, err := m.DeleteEmptyBranch(t.Context(), repo, "main", "vincent/1-work", false)
+	if err != nil {
+		t.Fatalf("DeleteEmptyBranch: %v", err)
+	}
+	if out.Result != BranchHasCommits {
+		t.Fatalf("result = %q, want %q", out.Result, BranchHasCommits)
+	}
+	if got := testrepo.Run(t, repo, "rev-parse", "refs/heads/vincent/1-work"); got != sha {
+		t.Errorf("branch tip = %s, want the commit %s", got, sha)
+	}
+	if got := testrepo.Run(t, repo, "cat-file", "-t", sha); got != "commit" {
+		t.Errorf("commit %s is no longer a reachable commit object (%s)", sha, got)
+	}
+}
+
+// TestDeleteEmptyBranchMissingProjectPath: the repository is gone, so nothing
+// can be judged and nothing is attempted.
+func TestDeleteEmptyBranchMissingProjectPath(t *testing.T) {
+	m := newManager(t)
+	out, err := m.DeleteEmptyBranch(
+		t.Context(), filepath.Join(t.TempDir(), "not-here"), "main", "vincent/1-x", false)
+	wantReason(t, err, ReasonProjectPathMissing)
+	if out.Result != BranchUnknown {
+		t.Errorf("result = %q, want %q", out.Result, BranchUnknown)
+	}
+}
+
+// TestDeleteEmptyBranchNoBranch: a task with no branch name is not a check that
+// fails, it is a check that never happens.
+func TestDeleteEmptyBranchNoBranch(t *testing.T) {
+	repo := testrepo.Init(t, "main")
+	m := newManager(t)
+	out, err := m.DeleteEmptyBranch(t.Context(), repo, "main", "", false)
+	if err != nil {
+		t.Fatalf("DeleteEmptyBranch: %v", err)
+	}
+	if out.Checked() {
+		t.Errorf("outcome = %+v, want the zero value", out)
+	}
+}
+
+// pushedRepo is a repo whose task branch has been pushed to a bare remote with
+// an upstream set, which is the only state in which the remote leg does
+// anything. vincent never pushes; a user's workflow step does.
+func pushedRepo(t *testing.T, m *Manager, branch string) (repo, remote string) {
+	t.Helper()
+	repo = testrepo.Init(t, "main")
+	remote = testrepo.InitBare(t)
+	testrepo.Run(t, repo, "remote", "add", "origin", remote)
+	testrepo.Run(t, repo, "push", "-q", "-u", "origin", "main")
+	path, err := m.Create(t.Context(), repo, 1, branch, "main")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	testrepo.Run(t, path, "push", "-q", "-u", "origin", branch)
+	if err := m.Remove(t.Context(), repo, path, false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	return repo, remote
+}
+
+func TestDeleteEmptyBranchRemote(t *testing.T) {
+	const branch = "vincent/1-pushed"
+	m := newManager(t)
+	repo, remote := pushedRepo(t, m, branch)
+	if !branchExists(t, remote, branch) {
+		t.Fatalf("fixture is wrong: %s never reached the remote", branch)
+	}
+
+	out, err := m.DeleteEmptyBranch(t.Context(), repo, "main", branch, true)
+	if err != nil {
+		t.Fatalf("DeleteEmptyBranch: %v", err)
+	}
+	if out.Result != BranchDeleted {
+		t.Fatalf("result = %q, want %q", out.Result, BranchDeleted)
+	}
+	if out.Remote == nil || out.Remote.Result != RemoteBranchDeleted {
+		t.Fatalf("remote outcome = %+v, want %q", out.Remote, RemoteBranchDeleted)
+	}
+	if out.Remote.Remote != "origin" || out.Remote.Ref != "refs/heads/"+branch {
+		t.Errorf("remote outcome names %s %s, want origin refs/heads/%s",
+			out.Remote.Remote, out.Remote.Ref, branch)
+	}
+	if branchExists(t, remote, branch) {
+		t.Errorf("branch %s survived on the remote", branch)
+	}
+}
+
+// TestDeleteEmptyBranchRemoteNoUpstream: with nothing recorded as pushed, no
+// push is attempted at all — vincent does not guess a remote name.
+func TestDeleteEmptyBranchRemoteNoUpstream(t *testing.T) {
+	repo := testrepo.Init(t, "main")
+	remote := testrepo.InitBare(t)
+	testrepo.Run(t, repo, "remote", "add", "origin", remote)
+	testrepo.Run(t, repo, "push", "-q", "origin", "main")
+	m := newManager(t)
+	if _, err := m.Create(t.Context(), repo, 1, "vincent/1-local", "main"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := m.Remove(t.Context(), repo, m.Path(1), false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// A branch with the same name on the remote, put there by something other
+	// than this task. Nothing may touch it, because nothing recorded it as
+	// this branch's upstream.
+	testrepo.Run(t, remote, "branch", "vincent/1-local", "main")
+
+	out, err := m.DeleteEmptyBranch(t.Context(), repo, "main", "vincent/1-local", true)
+	if err != nil {
+		t.Fatalf("DeleteEmptyBranch: %v", err)
+	}
+	if out.Result != BranchDeleted {
+		t.Fatalf("result = %q, want %q", out.Result, BranchDeleted)
+	}
+	if out.Remote == nil || out.Remote.Result != RemoteBranchNoUpstream {
+		t.Fatalf("remote outcome = %+v, want %q", out.Remote, RemoteBranchNoUpstream)
+	}
+	if !branchExists(t, remote, "vincent/1-local") {
+		t.Error("a remote branch vincent never pushed was deleted anyway")
+	}
+}
+
+// TestDeleteEmptyBranchRemoteRejected: a push that cannot happen leaves the
+// local branch deleted and reports the failure. The archive above it succeeds
+// either way — that is asserted in internal/taskrun.
+func TestDeleteEmptyBranchRemoteRejected(t *testing.T) {
+	const branch = "vincent/1-pushed"
+	m := newManager(t)
+	repo, remote := pushedRepo(t, m, branch)
+	// Point origin at nothing. Deleting the bare repo is the cheapest
+	// unreachable remote there is, and needs no network.
+	testrepo.Run(t, repo, "remote", "set-url", "origin", filepath.Join(remote, "..", "vanished.git"))
+
+	out, err := m.DeleteEmptyBranch(t.Context(), repo, "main", branch, true)
+	if err == nil {
+		t.Fatal("a failed push reported no error")
+	}
+	if out.Result != BranchDeleted {
+		t.Errorf("result = %q, want the local branch still deleted (%q)", out.Result, BranchDeleted)
+	}
+	if branchExists(t, repo, branch) {
+		t.Error("the local branch survived a remote failure")
+	}
+	if out.Remote == nil || out.Remote.Result != RemoteBranchFailed {
+		t.Fatalf("remote outcome = %+v, want %q", out.Remote, RemoteBranchFailed)
+	}
+	if !strings.Contains(out.Remote.Error, "push") {
+		t.Errorf("remote error %q does not name the failing command", out.Remote.Error)
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -307,8 +307,13 @@ func (m *Manager) IsDirty(ctx context.Context, worktreePath string) (bool, error
 // worktree directory that is already gone prunes and succeeds. Without force
 // a dirty worktree (untracked included) is refused with ReasonWorktreeDirty.
 // With force, when git itself cannot remove (project path gone, locked
-// worktree), a directory under the manager's root is removed directly. The
-// branch is never deleted (spec §10).
+// worktree), a directory under the manager's root is removed directly.
+//
+// Remove never touches the branch. That is a statement about this function,
+// not the standing rule it used to restate: since task 008 archive may delete a
+// branch that carries no commits past its base, through DeleteEmptyBranch,
+// after this returns (spec §10). Ordering matters — the branch is checked out
+// in the worktree until the worktree is gone.
 func (m *Manager) Remove(ctx context.Context, projectPath, worktreePath string, force bool) error {
 	projectMissing := false
 	if _, err := os.Stat(projectPath); err != nil {

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -5,11 +5,13 @@
 # awaiting_input → answer → resume (scenario 1), that kill -9 mid-step
 # recovers correctly (scenario 2), and that both concurrency caps hold under
 # load (scenario 3), that branch naming and its recovery path hold (scenario
-# 4), and that an agent usage limit re-queues rather than blocks and recovers
-# unattended (scenario 5). Runs against the committed fakeagent so CI never
-# calls a real API; run manually with VINCENT_GATE_AGENT=claude to exercise the
-# real CLI (scenario 1 only — killing a paid run and 8× cap spend prove nothing
-# extra). VINCENT_GATE_SCENARIO=1|2|3|4|5 runs a single scenario for debugging.
+# 4), that an agent usage limit re-queues rather than blocks and recovers
+# unattended (scenario 5), and that archiving deletes a branch that carries no
+# commits past its base while keeping every branch that does (scenario 6). Runs
+# against the committed fakeagent so CI never calls a real API; run manually
+# with VINCENT_GATE_AGENT=claude to exercise the real CLI (scenario 1 only —
+# killing a paid run and 8× cap spend prove nothing extra).
+# VINCENT_GATE_SCENARIO=1|2|3|4|5|6 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -662,6 +664,125 @@ EOF
   echo "=== scenario 5 PASS (task $walled recovered unattended)"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 6 — archive-time branch cleanup (task 008, spec §10/§13.2).
+#
+# The one exception to "vincent never deletes a branch", proven against a real
+# daemon on all three platforms: a task that never commits anything leaves no
+# ref behind, a task that commits keeps every one of them, and the escape hatch
+# actually reaches the running daemon. The two workflows differ in exactly one
+# thing — whether a commit is made — so a difference in the outcome can only
+# come from the rule under test.
+# ---------------------------------------------------------------------------
+scenario6() {
+  echo "=== scenario 6: archive deletes a branch with no commits past its base"
+  scenario_dirs s6
+
+  export FAKEAGENT_SCENARIO=success
+  export FAKEAGENT_EDIT_FILE=README.md
+
+  # No delete_empty_branch_on_archive line: the default is what ships, and the
+  # default is what this asserts.
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-idle.yaml" <<EOF
+name: m2-idle
+description: M2 gate — a workflow that never writes to the repository.
+steps:
+  - id: nap
+    type: command
+    run: sleep 1
+EOF
+  cat > "$CONFIG_DIR/workflows/m2-commits.yaml" <<EOF
+name: m2-commits
+description: M2 gate — the same shape, but it commits.
+defaults:
+  agent: claude
+  max_retries: 0
+steps:
+  - id: edit
+    type: agent
+    prompt: "Edit README.md for {{.Task.Title}}"
+  - id: commit
+    type: command
+    run: 'git add -A && git commit -m "m2 gate: real work"'
+EOF
+
+  daemon_up
+
+  echo "== both keys are visible in the config view, with the shipped defaults"
+  local cfg
+  cfg="$(api GET /config)"
+  [[ "$(jq -r .delete_empty_branch_on_archive <<<"$cfg")" == "true" ]] \
+    || fail "delete_empty_branch_on_archive is not true by default: $cfg"
+  [[ "$(jq -r .delete_remote_branch_on_archive <<<"$cfg")" == "false" ]] \
+    || fail "delete_remote_branch_on_archive is not false by default: $cfg"
+
+  local repo="$TMP/s6/repo" proj
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  echo "== a task that commits nothing loses its branch on archive"
+  local idle idle_branch body
+  idle="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-idle\",\"title\":\"Idle\"}" | jq -r .id)"
+  idle_branch="$(api GET "/tasks/$idle" | jq -r .branch_name)"
+  wait_for_state "$idle" done 90
+  git -C "$repo" rev-parse --verify --quiet "refs/heads/$idle_branch" >/dev/null \
+    || fail "the branch was never created, so archiving proves nothing"
+  body="$(api POST "/tasks/$idle/archive")"
+  [[ "$(jq -r .state <<<"$body")" == "archived" ]] || fail "archive did not archive: $body"
+  [[ "$(jq -r '.branch.result' <<<"$body")" == "deleted" ]] \
+    || fail "archive reported $(jq -c .branch <<<"$body"), want result deleted"
+  git -C "$repo" rev-parse --verify --quiet "refs/heads/$idle_branch" >/dev/null \
+    && fail "branch $idle_branch survived an archive that reported it deleted"
+
+  echo "== a task that commits keeps its branch, and the commit with it"
+  local work work_branch tip
+  work="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-commits\",\"title\":\"Work\"}" | jq -r .id)"
+  work_branch="$(api GET "/tasks/$work" | jq -r .branch_name)"
+  wait_for_state "$work" done 180
+  tip="$(git -C "$repo" rev-parse "refs/heads/$work_branch")"
+  body="$(api POST "/tasks/$work/archive")"
+  [[ "$(jq -r '.branch.result' <<<"$body")" == "has_commits" ]] \
+    || fail "archive reported $(jq -c .branch <<<"$body"), want result has_commits"
+  [[ "$(git -C "$repo" rev-parse "refs/heads/$work_branch")" == "$tip" ]] \
+    || fail "branch $work_branch did not survive the archive at the same commit"
+
+  echo "== delete_empty_branch_on_archive: false restores the pre-008 behaviour"
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+delete_empty_branch_on_archive: false
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+  local reloaded=0
+  for _ in $(seq 1 30); do
+    [[ "$(api GET /config | jq -r .delete_empty_branch_on_archive)" == "false" ]] \
+      && { reloaded=1; break; }
+    sleep 1
+  done
+  (( reloaded )) || fail "the daemon never picked up the edited config"
+
+  local kept kept_branch
+  kept="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-idle\",\"title\":\"Kept\"}" | jq -r .id)"
+  kept_branch="$(api GET "/tasks/$kept" | jq -r .branch_name)"
+  wait_for_state "$kept" done 90
+  body="$(api POST "/tasks/$kept/archive")"
+  [[ "$(jq -r '.branch // "null"' <<<"$body")" == "null" ]] \
+    || fail "the branch step ran with the policy off: $(jq -c .branch <<<"$body")"
+  git -C "$repo" rev-parse --verify --quiet "refs/heads/$kept_branch" >/dev/null \
+    || fail "branch $kept_branch was deleted with delete_empty_branch_on_archive off"
+
+  "$VINCENT" daemon stop
+  unset FAKEAGENT_SCENARIO FAKEAGENT_EDIT_FILE
+  echo "=== scenario 6 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -673,7 +794,8 @@ case "$WHICH" in
   3) scenario3 ;;
   4) scenario4 ;;
   5) scenario5 ;;
-  all) scenario1; scenario2; scenario3; scenario4; scenario5 ;;
+  6) scenario6 ;;
+  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
## Summary

Every task gets a branch, whether or not its workflow ever writes to the
repository. Filing an issue, posting a summary, running a read-only review: each
one left an empty `vincent/*` ref behind at archive time, and since branch names
are configurable there is not even a glob that reliably finds them again. The
documented remedy was `vincent task ls --archived`, read the branch column,
delete by hand.

Archive now deletes the branch when it has **no commits past its recorded base** —
`git rev-list -n 1 {base}..{branch}` produces nothing, so the tip is an ancestor
of the base. The test is exact, costs one cheap git call, and stays correct when
the base moves forward after the task started. **A branch carrying any commit is
never touched.**

Every refusal keeps the branch, and none of them fails the archive:

- git cannot judge it — base renamed or deleted, repository gone — is `unknown`,
  deliberately distinct from `has_commits` the way task 005 separated
  `dirty_unknown` from `worktree_dirty`.
- The delete is `git branch -d`, never `-D`. Its own merged check is a second
  belt behind the rev-list, and its refusal is what covers a branch checked out
  in another worktree.
- Ordering is worktree removal → transition → branch, outside the
  `RemoveAndRelease` callback: the branch is checked out until the worktree is
  gone, and an archive that has committed must not be reversible by a git
  problem. A dirty worktree refused without `force` never reaches the branch step
  at all.

**Configuration.** `delete_empty_branch_on_archive` (default `true`) is the
standing policy; `false` restores the pre-PR behaviour on every path.
`delete_remote_branch_on_archive` (default **false**) deletes the upstream
counterpart, and only `POST /v1/tasks/{id}/archive` honours it — a forge is
shared with other people and the deletion cannot be undone, so no unattended path
does it. It runs only after a local delete that succeeded and only when the
branch has a configured upstream (`branch.{name}.remote` **and** `.merge`); the
remote name is never guessed from the local one. Remote-on/local-off **warns**
at startup and on reload rather than failing the load — a key that is merely
unreachable is not an invalid one, and refusing the file would revert every
unrelated edit in the same save.

**Scope decisions**, all recorded in
[`docs/tasks/007-archive-branch-cleanup.md`](docs/tasks/007-archive-branch-cleanup.md)
with the alternatives they beat:

- `DELETE /v1/projects/{id}?force` sweeps **every** row it is about to drop,
  archived ones included — the cascade erases the branch names, so that is the
  last moment they exist. Local only, best-effort, exactly like the worktree
  removal beside it.
- `vincent gc` and `vincent doctor --fix` gain nothing, and §10's task 005 rule
  is **confirmed rather than amended**: no orphan has a branch that is both known
  and safe to delete. A row-less orphan has no `base_branch`, no `branch_name`
  and usually no reachable repository; the crash-window orphan is named after a
  *live* task row whose branch must survive. `docs/reference/cli.md`'s "It never
  deletes a branch" stays true as written.
- The outcome rides the archive response (`branch: { name, result, error?,
  remote? }`, **absent** when nothing was checked) rather than an event:
  `archived` is terminal, a `block_reason` would be a lie on it, and no client
  renders event rows today. No new event type and no migration.

Also new: `gitx.RemoteTimeout` (60 s) for the push — a query timeout would fail
every push over a slow link, and a worktree timeout would park the archive's
caller behind an unreachable host for five minutes — and `testrepo.InitBare`, so
the remote leg is tested against a real bare repo with no network.

## Related

Closes #105 · closes 007.1–007.7
([`docs/tasks/007-archive-branch-cleanup.md`](docs/tasks/007-archive-branch-cleanup.md)).

This changes a standing rule, so the spec is amended in this PR: §10's cleanup
bullet ("the branch is **never** deleted by vincent") gains its one exception,
dated 2026-08-16, with the four decisions above. §10's task 001 amendment gains a
clause — "because vincent never deletes branches, a template without a
discriminator collides on the second task" still holds for every branch that
carries a commit, and task 001's decisions are **not** reopened. §10's task 005
amendment is confirmed with its reason, likewise not reopened. §6's state table,
§12.3, §13.2 and §18 follow.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

**Tests.** `internal/worktree` is table-driven against real repos: empty branch
deleted, a branch with one commit survives *and* its commit object stays
reachable, a base that moved forward still reads as empty, a base that no longer
resolves is kept with an error, a branch checked out in another worktree is
refused, and a ref-hierarchy neighbour (`feat/foo/baz` beside `feat/foo/bar`) is
not collaterally removed. The remote leg proves all three of its outcomes against
a bare repo — pushed-with-upstream is deleted, no-upstream attempts no push even
when a same-named branch exists on the remote, and a rejected push leaves the
local branch deleted. `internal/taskrun` asserts archived-plus-deleted,
archived-plus-kept, the flag off (the pre-PR behaviour, asserted directly), a
branch failure that still archives, a dirty worktree that 409s and deletes
nothing, and a task with no worktree whose `branch_name` may name somebody else's
branch. `internal/api` covers the three response shapes, the object's absence,
the project-delete sweep across archived and non-archived rows including one that
cannot be judged, and both keys on `GET /v1/config`. `internal/config` pins the
split default, an explicit `false`, and the warning.

`scripts/m2-gate.sh` gains scenario 6, which proves it against a real daemon on
all three platforms: a fake-agent task that commits nothing loses its branch and
the response says `deleted`, one that commits keeps its branch at the same commit
and says `has_commits`, and `delete_empty_branch_on_archive: false` hot-reloads
and the branch survives.

**Docs.** `docs/reference/configuration.md` gains a section per key (that page
tracks `internal/config`); `docs/reference/api.md` documents the archive response
and the project-delete sweep (it tracks the route table);
`docs/reference/task-lifecycle.md`, `docs/reference/files.md`,
`docs/getting-started/concepts.md`, `quickstart.md`, `installation.md` and
`docs/guides/troubleshooting.md` each carried a "vincent never deletes a branch"
claim that is now narrower.

**Not applicable, deliberately:** no CLI or TUI key changed, so the cobra tree
and `internal/tui/bindings.go` — and their pages — are untouched. `vincent` has
no `task archive` subcommand and renders no config, so `docs/reference/cli.md`
needed only verification: gc's "It never deletes a branch" is still true.
No new `Reason*` constant either — the outcomes are results, not block reasons,
and never become a task's `block_reason`.

**Verified:** `go test ./...` and `go test -race` on the four touched packages
green; `go tool golangci-lint run ./...` clean for `GOOS=windows`, `darwin` and
`linux`; `VINCENT_GATE_SCENARIO=6 ./scripts/m2-gate.sh` passes (macOS,
2026-08-16).
