### PR TITLE
feat(tui): configurable task-table grouping, project then workflow by default

### DIFF
--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -77,6 +77,39 @@ Three behaviors matter:
 `/` filters by id, title, project or state; `tab` commits the filter, `esc`
 clears it.
 
+### Grouping
+
+The rows are **grouped by project, and by workflow within a project**, out of
+the box:
+
+```
+▾ api  4  ! 1
+  ▾ feature-pr  3
+   12  add rate limiting        running        3/5 implement   4m09s  $0.42
+   14  ! fix the flaky test     ! awaiting_gate 2/4 review     1m02s  $0.08
+  ▾ docs-update  1
+   15  document the cache       queued         —               —      —
+▾ web  1
+  ▾ feature-pr  1
+   13  bump the design tokens   done           4/4 pr          6m11s  $0.90
+```
+
+- The header shows the group's task count, and the needs-attention badge when
+  it holds any — a group can never be the reason you missed something waiting.
+- **Grouping does not reorder anything.** The sort is what it always was, and a
+  group sits where its first task does, so the group holding the oldest thing
+  waiting on a human is the top group.
+- A grouped level loses its column — the header already names it — and the
+  width goes to the title.
+- Headers are labels: the cursor steps over them, and nothing collapses.
+
+`g` cycles project›workflow → project → workflow → flat for the session. The
+panel title names the grouping whenever it is not the configured one.
+
+Set the grouping you start with in `config.yaml`
+([`tui.board.group_by`](../reference/configuration.md#tuiboardgroup_by)); `[]`
+gives you one flat list.
+
 Elapsed on the board is **wall clock** from the task's start. That is
 deliberate: a task idle on a human for 35 of its 40 minutes must not read as
 "5m" on the board whose job is to flag it. The per-attempt figures in the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,7 +53,7 @@ parse out of prose — an invalid state transition is always `409` with
 |---|---|---|
 | `GET` | `/v1/health` | Liveness → `{ status, version }`. **Unauthenticated** |
 | `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, and `orphans` |
-| `GET` | `/v1/config` | The effective global config, read-only |
+| `GET` | `/v1/config` | The effective global config, read-only — including the `tui` section the daemon only relays |
 | `GET` | `/v1/agents` | Per-adapter availability plus model/effort options. `?refresh=true` forces a re-probe |
 | `GET` | `/v1/doctor` | The whole diagnostic report. Read-only — see [Doctor](#doctor) |
 | `POST` | `/v1/doctor/fix` | Removes orphaned worktrees and compacts the database |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -79,6 +79,11 @@ agents:
     path: ""
   cursor:
     path: ""
+
+# What clients render, not what the daemon does.
+tui:
+  board:
+    group_by: [project, workflow]
 ```
 
 ## Keys
@@ -420,6 +425,49 @@ the standing fix for a CLI the daemon cannot see.
 
 `cursor` resolves the **`cursor-agent`** binary, never `cursor` — that one is the
 editor launcher and would open a GUI.
+
+### `tui`
+
+```yaml
+tui:
+  board:
+    group_by: [project, workflow]
+```
+
+The one section the daemon does not act on. It validates it, hot-reloads it with
+everything else and serves it on `GET /v1/config`; the TUI reads it from there.
+It lives here rather than in a file of the TUI's own because the TUI is a pure
+API client — it reads no configuration from disk, and a second file would be a
+second path, a second reload story and a second `vincent doctor` line for one
+setting.
+
+#### `tui.board.group_by`
+
+How the task table is grouped, outermost level first.
+
+| Value | Board |
+|---|---|
+| `[project, workflow]` (default) | Projects, and the workflows of a project nested inside it |
+| `[project]` | One group per project |
+| `[workflow]` | One group per workflow, across every project |
+| `[]` | One flat list — the table every version before this one rendered |
+
+Accepted levels are `project` and `workflow`. An unknown level, a repeated one,
+or anything that is not a list fails the load and names the key. There is no
+`state` level on purpose: the board already orders by state and pins everything
+waiting on a human to the top, and grouping by it would fight that.
+
+Grouping never reorders tasks. They are sorted exactly as before and each group
+takes the position of its first task, so the group holding the oldest thing
+waiting on a human is the first group. Group headers carry the task count and,
+when the group holds any, the needs-attention badge and count.
+
+A grouped level costs no column — the header names it, so `PROJECT` and
+`WORKFLOW` drop out and the width goes to the title.
+
+**`g` cycles the grouping for the session** — project›workflow → project →
+workflow → flat — and never writes to this file. The Tasks panel title names the
+grouping whenever it is not the one configured here.
 
 ## Per-project settings
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1456,6 +1456,9 @@ agents:
   claude: { path: "" }         # "" = resolve from PATH
   codex:  { path: "" }
   cursor: { path: "" }         # resolves `cursor-agent`, never `cursor` (§9.7)
+tui:                           # view preference; the daemon validates and relays it (§15)
+  board:
+    group_by: [project, workflow]  # task-table grouping, outermost first; [] = flat
 ```
 
 **`usage_limit_recheck_interval` (task 003, added 2026-08-14).** How long a task
@@ -1481,6 +1484,19 @@ succeeded — and that combination is a startup/reload **warning**, not a load f
 a key that is merely unreachable is not an invalid one, and refusing the file over it
 would revert every unrelated edit in the same save. Both are read per archive, so a
 hot reload reaches the next one.
+
+**`tui` (task 009, added 2026-08-16).** The one section the daemon does not act
+on. It validates it, hot-reloads it with the rest of the file and serves it on
+`GET /v1/config`; the TUI reads it from there. It lives in this file rather than
+one of the TUI's own because the TUI is a pure API client (§15) — it reads no
+configuration from disk, and a second file would be a second path, a second
+reload story and a second `vincent doctor` line for one setting. `board.group_by`
+is the task table's grouping, outermost level first; the accepted levels are
+`project` and `workflow`, an unknown or repeated one fails the load, and `[]` is
+the flat table every version before this one rendered. `state` is deliberately
+not a level: the band sort already orders by state and pins what is waiting on a
+human above everything, and a state grouping would fight the one ordering rule
+the board is not allowed to lose.
 
 **`environment` (T4.23).** Governs every process the daemon spawns — agent
 steps via `RunSpec.Env` (§9.1), command steps and their checks via §8.5's
@@ -1924,6 +1940,10 @@ stream for the live tail.
    with a distinct badge, and the TUI rings the terminal bell when a task enters
    `awaiting_input` — most terminals flash/badge the window even unfocused
    (§7.4). OS desktop notifications remain out of v1 (§20).
+   **Grouped by default (task 009, added 2026-08-16):** the rows nest under group
+   headers — projects, and the workflows of a project inside it — configured by
+   `tui.board.group_by` (§12.3) and cycled for the session with `g`. See
+   *Grouping* below.
 2. **Task detail.** Step timeline (every attempt, with durations, tokens, cost);
    live output tail of the running step (follow mode); scrollback into full
    transcripts of past steps. Timeline and output are **side by side, both always
@@ -2010,6 +2030,33 @@ first. The **detail header**, which has the room, renders the full
 `queued · usage limit → 14:20`. Band ordering is unchanged: a held task stays in
 the queued band, in normal §11 order, because that is where it will run from.
 
+**Grouping (task 009, added 2026-08-16).** The task table nests its rows under
+group headers, `[project, workflow]` by default: a board with more than one
+repository on it is read project by project, and within one project the workflow
+is what says what a task is *doing*. It is configuration — `tui.board.group_by`,
+served on `GET /v1/config` — because the shape that suits three projects and one
+workflow is not the shape that suits one project and six; `[]` is the flat table
+of every earlier version, and `g` cycles project›workflow → project → workflow →
+flat for the session without writing to the file. The rules the grouping does not
+get to bend:
+
+- **Ordering is untouched.** The tasks are sorted by band exactly as before and
+  the groups take the order of their first task, so a group holding work that
+  needs a human is the first group, and §15's pinning rule survives grouping.
+  A header carries its task count and, when it has any, the attention badge and
+  count — a header must never be the reason someone missed a task that is
+  waiting.
+- **A grouped level costs no column.** The header names it, so `PROJECT` and
+  `WORKFLOW` drop out of the column set (the §15 shedding order is otherwise
+  unchanged) and the width goes to the title, which is where a grouped board
+  needs it — the titles are indented under their headers.
+- **A header is a label, not a row.** The cursor steps over headers in the
+  direction it was travelling, clicking one selects nothing, and nothing folds
+  away: a board whose whole job is showing you every task has no business
+  hiding rows behind a collapse.
+- **The panel title names the grouping only when it is not the configured one**,
+  the same rule the output pane's `v` follows.
+
 **The focused panel expands; the others collapse** to their title bar plus the
 selected line. The task table never collapses below 5 rows — it is the navigation
 spine, and a spine you cannot see is a modal round-trip wearing a border.
@@ -2092,7 +2139,9 @@ live process, `A` removes the worktree and a dirty one re-prompts for `force`.
 `set priority` (§6) has no key — priority is chosen in the new-task flow.
 
 Panel-local: `/` filters **whichever list has focus** — tasks, projects, workflows
-— so one key means one thing everywhere. `enter` opens or expands. `[`/`]` switch
+— so one key means one thing everywhere. `g` cycles the task table's grouping
+(task 009), taking the key from the table widget's undocumented go-to-top alias,
+which `home` still is. `enter` opens or expands. `[`/`]` switch
 the output pane's tabs (`d` kept as an alias). `f`/`G` re-arm follow on a live
 tail or the daemon log. `v` cycles how much of the output pane's records show —
 compact → normal → verbose (T4.16): reasoning is hidden, truncated to its first

--- a/docs/tasks/009-configurable-tasks-view.md
+++ b/docs/tasks/009-configurable-tasks-view.md
@@ -1,0 +1,133 @@
+# 009 — A configurable tasks view: grouped by project, then by workflow
+
+**Status:** ✅ done (6/6) · **Opened:** 2026-08-16
+
+The board's task table was one flat list, sorted by band, for any number of projects
+and workflows. This makes the table's shape **configuration** — `tui.board.group_by` in
+`config.yaml`, served on `GET /v1/config` — and changes the default to
+`[project, workflow]`: projects outermost, the workflows of a project nested inside it.
+`g` cycles the grouping for the session.
+
+## The problem
+
+Once more than one repository is registered, the board is read project by project — but
+it was rendered as one list where two projects' tasks interleave by state, and the only
+way to see one project at a time was to type its name into the filter, which hides
+everything else including work waiting on a human. Within one project, the workflow is
+what says what a task is *doing* (`survey` means nothing without knowing it belongs to
+`docs-update`), and that too was a column to scan rather than a structure to read.
+
+The shape that suits three projects with one workflow is not the shape that suits one
+project with six, which is why this is a setting rather than a nicer fixed layout.
+
+## Decisions
+
+### 1. The grouping lives in `config.yaml`, under a `tui:` section the daemon only relays
+
+*2026-08-16.* The daemon validates it, hot-reloads it with the rest of the file and
+serves it on `GET /v1/config`; the TUI reads it from there and acts on it. The daemon
+does nothing else with it.
+
+**Beat:** a preferences file of the TUI's own. The TUI is a pure API client (§15) — it
+reads no configuration from disk — so a second file would have been a second path per
+platform, a second reload story, a second `vincent doctor` line and a second thing to
+document, for one setting. Putting it in the file that already exists costs one relayed
+field and keeps strict validation, hot reload and `GET /v1/config` for free.
+
+The corollary is deliberate: a TUI that cannot reach a daemon renders the built-in
+default, because the setting arrives over the API like everything else. Before a board
+has any rows, that is invisible.
+
+### 2. Grouping is a view over the existing sort, never a second ordering
+
+*2026-08-16.* The tasks are sorted by band exactly as they always were, and each group
+takes the position of its first task. So a group holding something that needs a human is
+the first group, and §15's pinning rule — work waiting on a human is never below work
+that is not — survives grouping untouched.
+
+This was the constraint the feature was not allowed to cost. Sorting groups by name, or
+by size, would have buried a blocked task under an alphabetically luckier project.
+
+Group headers carry the task count and, when the group holds any, the needs-attention
+badge and count: a header must never be the reason someone missed a task that is
+waiting.
+
+### 3. A grouped level costs no column
+
+*2026-08-16.* The header names it, so grouping by project drops `PROJECT` and grouping
+by workflow drops `WORKFLOW`, and the freed width goes to the title — which is where a
+grouped board needs it, since the titles are indented under their headers. The §15
+shedding order (cost → step name → workflow → project) is otherwise unchanged and still
+derives its thresholds from the widths.
+
+### 4. Headers are labels: the cursor steps over them, and nothing collapses
+
+*2026-08-16.* A header has no task, so it has no state, no `available_actions` and
+nothing for the detail panels to show. `↑`/`↓` therefore step over headers in the
+direction of travel (turning around at either end), a click on one selects nothing, and
+the cursor comes up on the first *task* rather than the first row.
+
+Collapsing groups was rejected: a board whose whole job is showing you every task has no
+business hiding rows, and a collapsed group holding an `awaiting_input` task is exactly
+the failure the pinning rule and the bell exist to prevent. The `▾` glyph is a nesting
+marker, not a disclosure control.
+
+### 5. `g` cycles for the session and never writes the config
+
+*2026-08-16.* project›workflow → project → workflow → flat. The config is where the
+board *starts*; the key is a quick look at the same board another way. A refetch on
+reconnect therefore does not undo a press, and the Tasks panel title names the grouping
+whenever it is not the configured one — the same rule the output pane's `v` follows.
+
+`g` is taken from the table widget's own undocumented go-to-top alias; `home` still does
+that, and the binding registry is what the help promises.
+
+### 6. `project` and `workflow` are the whole vocabulary; `state` is deliberately absent
+
+*2026-08-16.* Grouping by state would fight the band sort, which already orders by state
+and pins what is waiting on a human — the one ordering rule decision 2 protects. Agent,
+model and priority were not offered either: none of them is how anyone reads a board,
+and each would be a level nobody can rename later without breaking a config file.
+
+An unknown or repeated level fails the load and names the key; the TUI, being a client,
+*ignores* one instead — a newer daemon may serve a level this build predates, and a
+board with one level of a two-level grouping is still a board.
+
+## Tasks
+
+- [x] **009.1** — `internal/config`: the `tui.board.group_by` key, its vocabulary,
+      validation and default; the generated `config.yaml` section. ✓ 2026-08-16
+- [x] **009.2** — `internal/api` + `internal/apiclient`: the `tui` object on
+      `GET /v1/config`, always an array so a flat table is not `null`. ✓ 2026-08-16
+- [x] **009.3** — `internal/tui/boardgroup.go`: the grouping type, the row model, group
+      building off the sorted list, header rendering. ✓ 2026-08-16
+- [x] **009.4** — `internal/tui`: the board's config fetch, header-aware selection and
+      cursor movement, `g` and its registry row, the grouped column set, the panel
+      title, the daemon view's config line. ✓ 2026-08-16
+- [x] **009.5** — Tests: grouping unit tests (nesting, group order under the band sort,
+      counts, cursor skipping, cycling, columns, row/column shape), config tests, and
+      live tests driving the real `/v1/config` handler both grouped and flat.
+      ✓ 2026-08-16
+- [x] **009.6** — Spec §12.3 and §15 amendments; `docs/reference/configuration.md`,
+      `docs/reference/api.md` and `docs/guides/tui.md`. ✓ 2026-08-16
+
+## Out of scope
+
+- **Collapsing groups** — decision 4.
+- **Grouping by state, agent, model or priority** — decision 6.
+- **Configurable columns or sort order.** This task makes the table's *shape*
+  configurable; which columns show is still derived from the terminal width (§15), and
+  the sort is the band order the pinning rule depends on.
+- **Writing the config from the TUI.** `g` is session state. The file is the daemon's,
+  and a client that edited it would need a write endpoint, a merge story for concurrent
+  edits and a reason the workflows view does not have one.
+- **Per-project or per-view saved layouts.** One setting, one board.
+
+## Verification
+
+- `go test ./...` and `go test -race ./internal/tui ./internal/config ./internal/api`
+  green (2026-08-16, Linux).
+- `go tool golangci-lint run ./...` clean for `GOOS=linux`, `windows` and `darwin`.
+- `TestBoardGroupsFromTheDaemonConfig` / `TestBoardHonoursAConfiguredFlatTable` drive
+  the real API handler, so the config → wire → client → table path is covered end to
+  end rather than by poking the model.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -23,6 +23,7 @@ description of how the system actually behaves.
 | [006](006-vincent-doctor.md) | `vincent doctor` — one diagnostic report | ✅ done (8/8) |
 | [007](007-release-please.md) | Release Please automation | ✅ done (6/6) |
 | [008](008-archive-branch-cleanup.md) | Archive cleanup: delete a branch with no commits past its base | ✅ done (7/7) |
+| [009](009-configurable-tasks-view.md) | A configurable tasks view, grouped by project then workflow | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -305,6 +305,20 @@ type configResponse struct {
 	UsageLimitRecheck           string               `json:"usage_limit_recheck_interval"`
 	LogLevel                    string               `json:"log_level"`
 	Agents                      map[string]agentPath `json:"agents"`
+	// TUI is view preference the daemon only relays (§15): it is in the file
+	// the daemon owns and hot-reloads, so this endpoint is how the TUI — which
+	// reads no configuration of its own — gets it.
+	TUI configTUI `json:"tui"`
+}
+
+type configTUI struct {
+	Board configBoard `json:"board"`
+}
+
+type configBoard struct {
+	// GroupBy is always present, empty list included: `null` would make a
+	// flat table indistinguishable from a client's own default.
+	GroupBy []string `json:"group_by"`
 }
 
 type configDefaults struct {
@@ -338,7 +352,18 @@ func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
 			"codex":  {Path: cfg.Agents.Codex.Path},
 			"cursor": {Path: cfg.Agents.Cursor.Path},
 		},
+		TUI: configTUI{Board: configBoard{GroupBy: boardGroupBy(cfg.TUI.Board.GroupBy)}},
 	})
+}
+
+// boardGroupBy renders the grouping levels as strings, never as JSON null: a
+// flat table is a configured choice and has to read as `[]`.
+func boardGroupBy(levels []config.BoardGroup) []string {
+	out := make([]string, 0, len(levels))
+	for _, l := range levels {
+		out = append(out, string(l))
+	}
+	return out
 }
 
 func (s *Server) handleStop(w http.ResponseWriter, _ *http.Request) {

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -89,6 +89,22 @@ type Config struct {
 	UsageLimitRecheck string               `json:"usage_limit_recheck_interval"`
 	LogLevel          string               `json:"log_level"`
 	Agents            map[string]AgentPath `json:"agents"`
+	// TUI is the view preference the daemon only relays (§15). It is served
+	// here rather than read from disk because the TUI is a pure API client;
+	// a client that cannot reach the daemon renders its own defaults.
+	TUI ConfigTUI `json:"tui"`
+}
+
+// ConfigTUI is the `tui` section of config.yaml as served.
+type ConfigTUI struct {
+	Board ConfigBoard `json:"board"`
+}
+
+// ConfigBoard configures the task table. GroupBy names the grouping levels,
+// outermost first; an empty list is a flat table. Unknown levels are the
+// caller's to ignore — a newer daemon may serve one this client predates.
+type ConfigBoard struct {
+	GroupBy []string `json:"group_by"`
 }
 
 // ConfigDefaults are the §12.3 default timeouts, as duration strings.

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -94,6 +94,18 @@ agents:
   # editor launcher (§9.7).
   cursor:
     path: ""
+
+# What clients render, not what the daemon does. The daemon validates these,
+# hot-reloads them and serves them on GET /v1/config; the TUI reads them from
+# there.
+#
+# group_by nests the task table under headers, outermost level first. Accepted
+# levels: project, workflow. Use [] for one flat list of tasks. A grouped
+# level drops its own column — the header already names it — and "g" cycles
+# the grouping for the session without touching this file.
+tui:
+  board:
+    group_by: [project, workflow]
 `
 
 // EnsureDefaultFile writes the commented default config.yaml into dir when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,59 @@ type Config struct {
 	// what every version before it did implicitly.
 	Environment Environment `yaml:"environment"`
 	Agents      Agents      `yaml:"agents"`
+	// TUI is view preference, not daemon behaviour: the daemon validates it,
+	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
+	// with it. It lives in this file rather than one of the TUI's own because
+	// the TUI is a pure API client (§15) — it reads no configuration from
+	// disk, and a second file would be a second path, a second reload story
+	// and a second `vincent doctor` line for one setting.
+	TUI TUI `yaml:"tui"`
+}
+
+// TUI holds the settings clients read for themselves (§15).
+type TUI struct {
+	Board BoardView `yaml:"board"`
+}
+
+// BoardView configures the task table — the board's Tasks panel.
+type BoardView struct {
+	// GroupBy nests the rows under group headers, outermost level first.
+	//
+	// The default groups by project and then by workflow: a board is read
+	// project by project, and within one project the workflow is what says
+	// what a task is *doing* — the same reason those are the two columns the
+	// width budget sheds last (boardcols.go). An empty list — `group_by: []`
+	// — is the flat table every version before this one rendered.
+	GroupBy []BoardGroup `yaml:"group_by"`
+}
+
+// BoardGroup is one grouping level of the task table.
+type BoardGroup string
+
+// The grouping vocabulary. Deliberately not `state`: the board's band sort
+// already orders by state and pins the tasks waiting on a human above
+// everything (§15), so a state grouping would fight the one ordering rule
+// the board is not allowed to lose.
+const (
+	BoardGroupProject  BoardGroup = "project"
+	BoardGroupWorkflow BoardGroup = "workflow"
+)
+
+func (b BoardView) validate() error {
+	seen := make(map[BoardGroup]bool, len(b.GroupBy))
+	for _, g := range b.GroupBy {
+		switch g {
+		case BoardGroupProject, BoardGroupWorkflow:
+		default:
+			return fmt.Errorf(
+				"tui.board.group_by: unknown level %q; want project or workflow, or [] for a flat table", g)
+		}
+		if seen[g] {
+			return fmt.Errorf("tui.board.group_by: %q listed twice", g)
+		}
+		seen[g] = true
+	}
+	return nil
 }
 
 // Defaults holds fallback step timeouts, applied when a workflow step does
@@ -249,6 +302,9 @@ func Default() Config {
 		// Inherit everything: exactly what the daemon did before the policy
 		// existed, so nothing changes for anyone who does not ask.
 		Environment: Environment{Inherit: InheritAll()},
+		TUI: TUI{Board: BoardView{
+			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
+		}},
 	}
 }
 
@@ -309,6 +365,9 @@ func (c Config) validate() error {
 	case "debug", "info", "warn", "error":
 	default:
 		return fmt.Errorf("log_level must be one of debug, info, warn, error; got %q", c.LogLevel)
+	}
+	if err := c.TUI.Board.validate(); err != nil {
+		return err
 	}
 	return c.Environment.validate()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,9 @@ agents:
 			Claude: Agent{Path: "/opt/bin/claude"},
 			Codex:  Agent{Path: `C:\tools\codex.exe`},
 		},
+		// And the same again for `tui:`: an unnamed section keeps the §15
+		// default grouping rather than flattening the board.
+		TUI: TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("got %+v, want %+v", cfg, want)
@@ -157,6 +160,39 @@ delete_remote_branch_on_archive: true
 	}
 }
 
+// TestBoardGroupingDefault pins §15's default: a board is read project by
+// project, and within a project by what each task is doing.
+func TestBoardGroupingDefault(t *testing.T) {
+	want := []BoardGroup{BoardGroupProject, BoardGroupWorkflow}
+	if got := Default().TUI.Board.GroupBy; !reflect.DeepEqual(got, want) {
+		t.Errorf("default group_by = %v, want %v", got, want)
+	}
+}
+
+// TestBoardGroupingExplicitFlat: an empty list has to survive unmarshalling
+// into Default(), or there is no way back to the flat table.
+func TestBoardGroupingExplicitFlat(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "tui:\n  board:\n    group_by: []\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.TUI.Board.GroupBy) != 0 {
+		t.Errorf("group_by = %v, want the empty list the file asked for", cfg.TUI.Board.GroupBy)
+	}
+}
+
+// TestBoardGroupingOneLevel: a single level is a whole configuration, not a
+// half-written default.
+func TestBoardGroupingOneLevel(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "tui:\n  board:\n    group_by: [workflow]\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := []BoardGroup{BoardGroupWorkflow}; !reflect.DeepEqual(cfg.TUI.Board.GroupBy, want) {
+		t.Errorf("group_by = %v, want %v", cfg.TUI.Board.GroupBy, want)
+	}
+}
+
 func TestLoadRejectsInvalid(t *testing.T) {
 	cases := map[string]string{
 		"unknown key":           "max_parallel_jobs: 5\n",
@@ -176,6 +212,9 @@ func TestLoadRejectsInvalid(t *testing.T) {
 		"negative recheck interval": "usage_limit_recheck_interval: -1m\n",
 		"not yaml":                  "{{{\n",
 		"wrong type for integer":    "max_parallel_tasks: many\n",
+		"unknown grouping level":    "tui:\n  board:\n    group_by: [project, agent]\n",
+		"repeated grouping level":   "tui:\n  board:\n    group_by: [project, project]\n",
+		"grouping is not a list":    "tui:\n  board:\n    group_by: project\n",
 	}
 	for name, content := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -102,6 +102,7 @@ var bindings = []binding{
 	{key: "down", label: "move the selection (↑/↓ — the panels follow the cursor)", scope: scopePanel, context: ctxTasks, hint: "↑/↓ select", priority: 3},
 	{key: "enter", label: "open the selected task — or its answer form when it is asking", scope: scopePanel, context: ctxTasks, hint: "enter open", priority: 1},
 	{key: "/", label: "filter by id, title, project or state", scope: scopePanel, context: ctxTasks, hint: "/ filter", priority: 2},
+	{key: "g", label: "group the tasks: project › workflow → project → workflow → flat (config.yaml sets the one you start on)", scope: scopePanel, context: ctxTasks, hint: "g group", priority: 4},
 
 	// Timeline.
 	{key: "down", label: "select an attempt (↑/↓); scrollback is per attempt", scope: scopePanel, context: ctxTimeline, hint: "↑/↓ attempts", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -104,6 +104,15 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("/ did not open the task filter")
 			}
 		},
+		"g": func(t *testing.T) {
+			s, _ := newShellFixture(t, task(1, stateRunning))
+			s.focus = panelTasks
+			s.board.group = defaultGrouping()
+			s.update(registryKey(t, "g"))
+			if s.board.group.equal(defaultGrouping()) {
+				t.Fatalf("g did not change the grouping (still %s)", s.board.group.label())
+			}
+		},
 	},
 
 	ctxTimeline: {

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -50,6 +50,13 @@ type (
 		info apiclient.Info
 		err  error
 	}
+	// boardConfigMsg carries the view preferences the daemon relays (§15,
+	// task 009). The TUI reads no configuration from disk, so this is where
+	// the task table's grouping comes from.
+	boardConfigMsg struct {
+		board apiclient.ConfigBoard
+		err   error
+	}
 	// boardTickMsg drives the elapsed column.
 	boardTickMsg time.Time
 	// selectTaskMsg asks the home shell to select a task in the table and
@@ -78,6 +85,15 @@ type board struct {
 
 	filter    textinput.Model
 	filtering bool
+
+	// group is the grouping the table is rendering (boardgroup.go);
+	// configGroup is what the daemon's config asked for. They differ once `g`
+	// has been pressed, and groupPinned is what keeps a reconnect's refetch
+	// from undoing that press — the config is the starting point, not a
+	// setting the daemon re-imposes while someone is looking at the board.
+	group       grouping
+	configGroup grouping
+	groupPinned bool
 
 	// actions drives §15's action keys against the row under the cursor.
 	// The shell shares one instance between board and detail — a pending
@@ -111,11 +127,13 @@ func newBoard() *board {
 	fi.Placeholder = "filter by id, title, project or state"
 	fi.Prompt = "/"
 	b := &board{
-		now:     time.Now,
-		filter:  fi,
-		bell:    ringBell,
-		actions: &actionBar{},
-		tbl:     table.New(table.WithFocused(true)),
+		now:         time.Now,
+		filter:      fi,
+		bell:        ringBell,
+		actions:     &actionBar{},
+		tbl:         table.New(table.WithFocused(true)),
+		group:       defaultGrouping(),
+		configGroup: defaultGrouping(),
 	}
 	b.applyStyles()
 	return b
@@ -152,7 +170,7 @@ func (b *board) title() string { return "Board" }
 // load. Called again on reconnect, which is why the tick is guarded.
 func (b *board) setClient(c *apiclient.Client) tea.Cmd {
 	b.client = c
-	cmds := []tea.Cmd{b.loadCmd(), b.infoCmd()}
+	cmds := []tea.Cmd{b.loadCmd(), b.infoCmd(), b.configCmd()}
 	if !b.ticking {
 		b.ticking = true
 		cmds = append(cmds, tickCmd())
@@ -192,6 +210,36 @@ func (b *board) infoCmd() tea.Cmd {
 	}
 }
 
+// configCmd fetches the view preferences (§12.3 `tui:`). It rides the connect
+// and every reconnect, which is also how a config the human edited while the
+// TUI was up reaches the board: the daemon hot-reloads the file but publishes
+// no event for it (§13.3), so there is nothing to subscribe to.
+func (b *board) configCmd() tea.Cmd {
+	client := b.client
+	if client == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cfg, err := client.Config(ctx)
+		return boardConfigMsg{board: cfg.TUI.Board, err: err}
+	}
+}
+
+// applyConfig installs the configured grouping. A failed fetch changes
+// nothing: the default grouping is a working board, and a config request that
+// timed out is not a statement that the human wants a flat table.
+func (b *board) applyConfig(msg boardConfigMsg) {
+	if msg.err != nil {
+		return
+	}
+	b.configGroup = parseGrouping(msg.board.GroupBy)
+	if !b.groupPinned {
+		b.group = b.configGroup
+	}
+}
+
 // scheduleRefresh opens a debounce window, or does nothing if one is open.
 func (b *board) scheduleRefresh() tea.Cmd {
 	if b.refreshPending {
@@ -213,6 +261,9 @@ func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
 		if msg.err == nil {
 			b.info, b.infoOK = msg.info, true
 		}
+		return b, nil
+	case boardConfigMsg:
+		b.applyConfig(msg)
 		return b, nil
 	case boardRefreshMsg:
 		b.refreshPending = false
@@ -362,6 +413,19 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 			b.filter.SetValue("")
 		}
 		return b, nil
+	case "g":
+		// Cycles the grouping for the session (§15, task 009); the config
+		// file stays the starting point and is never written from here. This
+		// takes `g` from the table's own undocumented go-to-top alias — `home`
+		// still does that, and the registry is what the help promises.
+		//
+		// The cursor is not touched: selectedID already names the task under
+		// it, and the next render puts the cursor back on that task wherever
+		// the new layout moved it. Re-reading the cursor here would read an
+		// index from the old layout against the new one.
+		b.group = b.group.next()
+		b.groupPinned = true
+		return b, nil
 	}
 
 	// §15's action keys act on the row under the cursor. A key the daemon
@@ -371,10 +435,51 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return b, cmd
 	}
 
+	before := b.tbl.Cursor()
 	var cmd tea.Cmd
 	b.tbl, cmd = b.tbl.Update(msg)
+	b.skipHeaders(travelDir(before, b.tbl.Cursor()))
 	b.rememberSelection()
 	return b, cmd
+}
+
+// travelDir is the direction a cursor move was going in, which is the
+// direction a group header has to be stepped over in. A move that went
+// nowhere (already at an end) reads as downward, so the first press on the
+// top row still lands on a task.
+func travelDir(before, after int) int {
+	if after < before {
+		return -1
+	}
+	return 1
+}
+
+// skipHeaders steps the cursor off a group header, carrying on in the
+// direction of travel and turning around at either end. Headers are labels:
+// resting on one would empty the detail panels and offer no actions, so j/k
+// pass over them as if they were not rows at all.
+//
+// It moves with MoveUp/MoveDown rather than SetCursor for the reason
+// clickRow does: the table's scroll offset is private and only those two keep
+// its bookkeeping consistent.
+func (b *board) skipHeaders(dir int) {
+	rows := b.rows()
+	// Bounded by the row count: a turn-around at either end must not become a
+	// loop between two headers.
+	for range rows {
+		i := b.tbl.Cursor()
+		if i < 0 || i >= len(rows) || !rows[i].header {
+			return
+		}
+		if dir > 0 {
+			b.tbl.MoveDown(1)
+		} else {
+			b.tbl.MoveUp(1)
+		}
+		if b.tbl.Cursor() == i {
+			dir = -dir // clamped at an end: the tasks are the other way
+		}
+	}
 }
 
 // clickRow selects the table row rendered at the given body line (0 = the
@@ -409,7 +514,15 @@ func (b *board) clickRow(line int) {
 	if cursorLine < 0 {
 		return
 	}
-	switch delta := line - cursorLine; {
+	delta := line - cursorLine
+	// A group header is a label, not a row: clicking one leaves the selection
+	// alone rather than jumping to a task the click did not name. The clicked
+	// row is the cursor's plus the delta — a body line cannot be indexed into
+	// the row slice directly, because the table may be scrolled.
+	if b.rowAt(b.tbl.Cursor() + delta).header {
+		return
+	}
+	switch {
 	case delta > 0:
 		b.tbl.MoveDown(delta)
 	case delta < 0:
@@ -437,26 +550,64 @@ func (b *board) wheelMove(delta int) {
 	} else {
 		b.tbl.MoveUp(-delta)
 	}
+	b.skipHeaders(delta)
 	b.rememberSelection()
 }
 
-// visible is the filtered, sorted task list currently on screen.
-func (b *board) visible() []apiclient.Task {
+// rows is the table as it is rendered: filtered, sorted, and — under a
+// grouping — interleaved with group headers (boardgroup.go). Every index into
+// the table means an index into this slice.
+func (b *board) rows() []boardRow {
 	tasks := filterTasks(b.tasks, b.filter.Value())
 	sorted := make([]apiclient.Task, len(tasks))
 	copy(sorted, tasks)
 	sortTasks(sorted)
-	return sorted
+	return groupRows(sorted, b.group)
+}
+
+// rowAt is the row at a table index, or a zero row off either end.
+func (b *board) rowAt(i int) boardRow {
+	rows := b.rows()
+	if i < 0 || i >= len(rows) {
+		return boardRow{}
+	}
+	return rows[i]
+}
+
+// visible is the tasks on screen in render order, headers dropped: the list
+// for anything that walks tasks rather than lines — the attention jump, the
+// action bar's target.
+func (b *board) visible() []apiclient.Task {
+	rows := b.rows()
+	out := make([]apiclient.Task, 0, len(rows))
+	for _, r := range rows {
+		if !r.header {
+			out = append(out, r.task)
+		}
+	}
+	return out
 }
 
 // selected reports the task id under the cursor.
+//
+// A cursor sitting on a group header resolves to the first task under it,
+// rather than to nothing. Key navigation steps over headers (skipHeaders), so
+// this is the frame between a load and the render that places the cursor —
+// and answering "no task" there would leave a freshly loaded board with its
+// detail panels empty until something moved. A header always has rows beneath
+// it, so the scan always lands.
 func (b *board) selected() (int64, bool) {
-	rows := b.visible()
+	rows := b.rows()
 	i := b.tbl.Cursor()
-	if i < 0 || i >= len(rows) {
+	if i < 0 {
 		return 0, false
 	}
-	return rows[i].ID, true
+	for ; i < len(rows); i++ {
+		if !rows[i].header {
+			return rows[i].task.ID, true
+		}
+	}
+	return 0, false
 }
 
 // hintedProject is the project of the row under the cursor, which is the
@@ -484,20 +635,22 @@ func (b *board) rememberSelection() {
 	}
 }
 
-// restoreSelection moves the cursor back onto the remembered task.
-func (b *board) restoreSelection(rows []apiclient.Task) {
-	if b.selectedID == 0 {
-		return
-	}
-	for i := range rows {
-		if rows[i].ID == b.selectedID {
-			b.tbl.SetCursor(i)
-			return
+// restoreSelection moves the cursor back onto the remembered task — after a
+// refresh that reordered the rows, and after `g` regrouped them.
+func (b *board) restoreSelection(rows []boardRow) {
+	if b.selectedID != 0 {
+		for i := range rows {
+			if !rows[i].header && rows[i].task.ID == b.selectedID {
+				b.tbl.SetCursor(i)
+				return
+			}
 		}
 	}
-	// The task is gone (archived, or filtered out): fall back to the top
-	// rather than leaving the cursor pointing at an unrelated row.
-	b.tbl.SetCursor(0)
+	// The task is gone (archived, or filtered out), or nothing has been
+	// selected yet: the first task rather than the first *row*, which under a
+	// grouping is a header — a cursor parked on one shows empty panels and no
+	// actions.
+	b.tbl.SetCursor(firstTaskRow(rows))
 }
 
 func (b *board) render(width, height int) string {
@@ -515,13 +668,13 @@ func (b *board) render(width, height int) string {
 		sb.WriteString("\n")
 	}
 
-	rows := b.visible()
+	rows := b.rows()
 	if body, ok := b.emptyBody(rows); ok {
 		sb.WriteString(body)
 		return sb.String()
 	}
 
-	cols, set := boardColumns(b.width)
+	cols, set := boardColumns(b.width, b.group)
 	// SetColumns re-renders the rows it already holds: when a resize crosses
 	// a column breakpoint, yesterday's wider rows meet today's narrower
 	// column set and the table indexes out of range. Clear the rows first —
@@ -539,7 +692,7 @@ func (b *board) render(width, height int) string {
 	// board that emptied and refilled) parks the cursor at -1; with rows on
 	// screen the cursor belongs on one.
 	if b.tbl.Cursor() < 0 && len(rows) > 0 {
-		b.tbl.SetCursor(0)
+		b.tbl.SetCursor(firstTaskRow(rows))
 	}
 	sb.WriteString(b.tbl.View())
 	sb.WriteString("\n")
@@ -585,10 +738,20 @@ func (b *board) firstRowLine() int {
 	return n
 }
 
-func (b *board) rowsFor(tasks []apiclient.Task, set columnSet) []table.Row {
+// rowsFor renders the table's cells. It and boardColumns share one shape —
+// the same optional columns in the same order — and move together; a row that
+// disagrees with the column set indexes the table out of range.
+func (b *board) rowsFor(rows []boardRow, set columnSet) []table.Row {
 	now := b.now()
-	out := make([]table.Row, 0, len(tasks))
-	for _, t := range tasks {
+	// Task titles sit under their headers, one indent per grouping level.
+	indent := strings.Repeat(groupIndent, len(b.group))
+	out := make([]table.Row, 0, len(rows))
+	for _, r := range rows {
+		if r.header {
+			out = append(out, groupHeaderRow(r, set))
+			continue
+		}
+		t := r.task
 		row := table.Row{strconv.FormatInt(t.ID, 10)}
 		if set.project {
 			row = append(row, t.ProjectName)
@@ -600,13 +763,32 @@ func (b *board) rowsFor(tasks []apiclient.Task, set columnSet) []table.Row {
 		if d, ok := t.Elapsed(now); ok {
 			elapsed = formatElapsed(d)
 		}
-		row = append(row, t.Title, renderBoardState(t), formatStep(t, set.stepName), elapsed)
+		row = append(row, indent+t.Title, renderBoardState(t), formatStep(t, set.stepName), elapsed)
 		if set.cost {
 			row = append(row, formatCost(t.CostUSD))
 		}
 		out = append(out, row)
 	}
 	return out
+}
+
+// groupHeaderRow renders a group header as a table row: the label in the
+// title column — the widest, and the only one that survives every width — and
+// every other cell blank, so the header reads as a break in the list rather
+// than as a task with missing figures.
+func groupHeaderRow(r boardRow, set columnSet) table.Row {
+	row := table.Row{""}
+	if set.project {
+		row = append(row, "")
+	}
+	if set.workflow {
+		row = append(row, "")
+	}
+	row = append(row, r.headerCell(), "", "", "")
+	if set.cost {
+		row = append(row, "")
+	}
+	return row
 }
 
 // headerLine reports what the daemon is doing overall (§15): how much work
@@ -703,7 +885,7 @@ func (b *board) staleNote() string {
 // emptyBody distinguishes "nothing exists yet" from "your filter matches
 // nothing": different problems with different ways out, and the first-run
 // case is the one moment a new user most needs pointing at what to do next.
-func (b *board) emptyBody(rows []apiclient.Task) (string, bool) {
+func (b *board) emptyBody(rows []boardRow) (string, bool) {
 	if len(rows) > 0 {
 		return "", false
 	}

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -15,11 +15,16 @@ import (
 
 var testNow = time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
 
+// testBoard is the flat table: sorting, filtering, columns and selection are
+// the same questions grouped or not, and answering them without group headers
+// in the way keeps the row index equal to the task index. Grouping has its
+// own fixture and its own file (boardgroup_test.go).
 func testBoard() *board {
 	b := newBoard()
 	b.now = func() time.Time { return testNow }
 	b.bell = func() {}
 	b.loaded = true
+	b.group, b.configGroup = nil, nil
 	return b
 }
 
@@ -177,7 +182,7 @@ func TestColumnsDropByPriority(t *testing.T) {
 		{85, true, false, false, false},  // then the workflow
 		{70, false, false, false, false}, // then the project
 	} {
-		got := columnsFor(tc.width)
+		got := columnsFor(tc.width, nil)
 		if got.project != tc.project || got.workflow != tc.workflow ||
 			got.stepName != tc.stepName || got.cost != tc.cost {
 			t.Errorf("width %d = %+v, want project=%v workflow=%v stepName=%v cost=%v",
@@ -192,7 +197,7 @@ func TestColumnsDropByPriority(t *testing.T) {
 // title to its minimum instead and overflowed by a character at width 80.
 func TestBoardColumnsFitWidth(t *testing.T) {
 	for width := 65; width <= 220; width++ {
-		cols, _ := boardColumns(width)
+		cols, _ := boardColumns(width, nil)
 		total := 0
 		for _, c := range cols {
 			total += c.Width + colPadding
@@ -207,7 +212,7 @@ func TestBoardColumnsFitWidth(t *testing.T) {
 // the columns you steer by survive.
 func TestBoardColumnsAlwaysKeepNavigationColumns(t *testing.T) {
 	for _, width := range []int{20, 40, 65, 120} {
-		cols, _ := boardColumns(width)
+		cols, _ := boardColumns(width, nil)
 		titles := make([]string, 0, len(cols))
 		for _, c := range cols {
 			titles = append(titles, c.Title)

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -71,8 +71,18 @@ func (s columnSet) titleWidth(width int) int { return width - s.fixedWidth() }
 // The workflow outranks the step name: "survey" is meaningless without
 // knowing it belongs to docs-update, while the workflow alone still tells you
 // what a task is doing.
-func columnsFor(width int) columnSet {
-	set := columnSet{project: true, workflow: true, stepName: true, cost: true}
+// A grouped level costs no column: the header above the rows already names
+// it, and repeating it down every row of the group is fourteen characters
+// spent saying what the reader just read. The width that frees goes to the
+// title, which is where a grouped board needs it — the titles are indented
+// under their headers.
+func columnsFor(width int, g grouping) columnSet {
+	set := columnSet{
+		project:  !g.has(groupProject),
+		workflow: !g.has(groupWorkflow),
+		stepName: true,
+		cost:     true,
+	}
 	for set.titleWidth(width) < minTitle {
 		switch {
 		case set.cost:
@@ -94,8 +104,8 @@ func columnsFor(width int) columnSet {
 
 // boardColumns builds the table columns for a terminal width, giving the
 // title whatever space the fixed columns leave.
-func boardColumns(width int) ([]table.Column, columnSet) {
-	set := columnsFor(width)
+func boardColumns(width int, g grouping) ([]table.Column, columnSet) {
+	set := columnsFor(width, g)
 	title := max(set.titleWidth(width), minTitle)
 	stepWidth := widthStepShort
 	if set.stepName {

--- a/internal/tui/boardgroup.go
+++ b/internal/tui/boardgroup.go
@@ -1,0 +1,269 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Grouping for the task table (§15, task 009). The board's rows are nested
+// under headers by project and then by workflow, which is how a board with
+// more than one repository on it is actually read: you look at one project,
+// and within it the workflow is what says what a task is *doing*. It is
+// configuration — `tui.board.group_by` in config.yaml, served on
+// `GET /v1/config` — because the shape that suits three projects and one
+// workflow is not the shape that suits one project and six.
+//
+// Grouping is a view over the same sorted list, never a second ordering: the
+// tasks are sorted by band exactly as they always were, and the groups take
+// the order of their first task. A group holding a task that needs a human
+// therefore rises to the top, and §15's pinning rule survives grouping —
+// which is the one property this feature was not allowed to cost.
+
+// groupKey is one grouping level. The values are the wire strings the daemon
+// serves, duplicated here rather than imported from internal/config for the
+// same reason the task states are (boardrows.go): the TUI is an API client,
+// and what it renders comes from the wire.
+type groupKey string
+
+const (
+	groupProject  groupKey = "project"
+	groupWorkflow groupKey = "workflow"
+)
+
+// grouping is the levels in effect, outermost first. Empty is a flat table —
+// exactly what every version before this one rendered.
+type grouping []groupKey
+
+// defaultGrouping is what the board renders before the daemon's config
+// arrives, and what it keeps when no daemon is reachable. It matches
+// config.Default(); boardgroup_test.go holds the two together.
+func defaultGrouping() grouping { return grouping{groupProject, groupWorkflow} }
+
+// groupingCycle is what `g` steps through: the default, each level alone,
+// then flat. A configured grouping outside this cycle (the levels reversed,
+// say) is honoured on load and cycles from the start on the first press —
+// the key is a quick look at the board another way, not an editor for the
+// config file.
+func groupingCycle() []grouping {
+	return []grouping{
+		{groupProject, groupWorkflow},
+		{groupProject},
+		{groupWorkflow},
+		{},
+	}
+}
+
+// next is the grouping `g` moves to.
+func (g grouping) next() grouping {
+	cycle := groupingCycle()
+	for i, c := range cycle {
+		if g.equal(c) {
+			return cycle[(i+1)%len(cycle)]
+		}
+	}
+	return cycle[0]
+}
+
+func (g grouping) has(k groupKey) bool {
+	for _, level := range g {
+		if level == k {
+			return true
+		}
+	}
+	return false
+}
+
+func (g grouping) equal(other grouping) bool {
+	if len(g) != len(other) {
+		return false
+	}
+	for i := range g {
+		if g[i] != other[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// label names the grouping for the panel title.
+func (g grouping) label() string {
+	if len(g) == 0 {
+		return "ungrouped"
+	}
+	parts := make([]string, 0, len(g))
+	for _, level := range g {
+		parts = append(parts, string(level))
+	}
+	return "by " + strings.Join(parts, " › ")
+}
+
+// parseGrouping reads the levels the daemon served. An unknown level is
+// dropped rather than refused: a newer daemon may serve one this TUI predates,
+// and a board that renders one level of a two-level grouping is still a board.
+// A duplicate is dropped for the same reason — the daemon rejects one at load,
+// so seeing it here means the two disagree, and repeating a level would nest a
+// group inside itself.
+func parseGrouping(levels []string) grouping {
+	out := make(grouping, 0, len(levels))
+	for _, l := range levels {
+		k := groupKey(l)
+		switch k {
+		case groupProject, groupWorkflow:
+		default:
+			continue
+		}
+		if !out.has(k) {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// boardRow is one line of the task table: a task, or the header of a group of
+// them. Headers are labels — the cursor steps over them (board.skipHeaders)
+// and they carry no actions, because a group is not something the daemon has
+// a state for.
+type boardRow struct {
+	// header marks a group header; task is the zero value on one.
+	header bool
+	task   apiclient.Task
+	// depth is the nesting level: 0 for an outermost header, len(grouping)
+	// for every task row.
+	depth int
+	// label, count and attention describe the group a header opens. The
+	// attention count is on the header so a collapsed-looking board can never
+	// hide that something is waiting on a human (§15).
+	label     string
+	count     int
+	attention int
+}
+
+// groupRows interleaves group headers into an already-sorted task list.
+// Groups appear in the order their first task does, so the band sort decides
+// group order as well as row order.
+func groupRows(tasks []apiclient.Task, g grouping) []boardRow {
+	if len(g) == 0 {
+		out := make([]boardRow, 0, len(tasks))
+		for _, t := range tasks {
+			out = append(out, boardRow{task: t})
+		}
+		return out
+	}
+	out := make([]boardRow, 0, len(tasks)+len(g))
+	var walk func(tasks []apiclient.Task, depth int)
+	walk = func(tasks []apiclient.Task, depth int) {
+		if depth == len(g) {
+			for _, t := range tasks {
+				out = append(out, boardRow{task: t, depth: depth})
+			}
+			return
+		}
+		for _, grp := range partitionTasks(tasks, g[depth]) {
+			out = append(out, boardRow{
+				header:    true,
+				depth:     depth,
+				label:     grp.key,
+				count:     len(grp.tasks),
+				attention: countAttention(grp.tasks),
+			})
+			walk(grp.tasks, depth+1)
+		}
+	}
+	walk(tasks, 0)
+	return out
+}
+
+type taskGroup struct {
+	key   string
+	tasks []apiclient.Task
+}
+
+// partitionTasks splits a sorted list by one level, preserving both the order
+// of the groups (first appearance) and the order within them.
+func partitionTasks(tasks []apiclient.Task, k groupKey) []taskGroup {
+	out := make([]taskGroup, 0, 4)
+	index := make(map[string]int, 4)
+	for _, t := range tasks {
+		key := groupValue(t, k)
+		i, ok := index[key]
+		if !ok {
+			i = len(out)
+			index[key] = i
+			out = append(out, taskGroup{key: key})
+		}
+		out[i].tasks = append(out[i].tasks, t)
+	}
+	return out
+}
+
+// groupUnnamed labels a group whose key is empty — a task the daemon reported
+// without a project name or a workflow. It is the dash the board already uses
+// for a figure nobody reported, rather than a blank header that would read as
+// a rendering bug.
+const groupUnnamed = "—"
+
+func groupValue(t apiclient.Task, k groupKey) string {
+	var v string
+	switch k {
+	case groupProject:
+		v = t.ProjectName
+	case groupWorkflow:
+		v = t.Workflow
+	}
+	if strings.TrimSpace(v) == "" {
+		return groupUnnamed
+	}
+	return v
+}
+
+// groupGlyph opens a header line. A glyph rather than colour alone, so the
+// nesting survives NO_COLOR and a 16-colour terminal (§15 Colour). It marks a
+// group, not a collapse control: nothing here folds away, because a board
+// whose whole job is showing you every task has no business hiding rows.
+const groupGlyph = "▾"
+
+// styleGroup is the header label. Bold rather than coloured: the state
+// colours are the board's colour vocabulary and a header holds no state.
+var styleGroup = lipgloss.NewStyle().Bold(true)
+
+// headerCell renders a group header into the title column — the widest column
+// and the only one guaranteed to be there at any width (boardcols.go).
+func (r boardRow) headerCell() string {
+	label := strings.Repeat(groupIndent, r.depth) + groupGlyph + " " + r.label
+	out := styleGroup.Render(label) + styleDim.Render("  "+strconv.Itoa(r.count))
+	if r.attention > 0 {
+		out += "  " + styleWarn.Render(attentionBadge+" "+strconv.Itoa(r.attention))
+	}
+	return out
+}
+
+// groupIndent is one level of nesting, for headers and for the task titles
+// under them.
+const groupIndent = "  "
+
+// firstTaskRow is the row a cursor with nothing to restore belongs on: the
+// first actual task. Zero when there is nothing at all, which is the same
+// answer the ungrouped board gave.
+func firstTaskRow(rows []boardRow) int {
+	for i := range rows {
+		if !rows[i].header {
+			return i
+		}
+	}
+	return 0
+}
+
+// groupSummary is the one-line description of a grouping for the daemon
+// view's "config in effect" block, where the levels are what the file says
+// rather than what any one client is currently showing.
+func groupSummary(levels []string) string {
+	g := parseGrouping(levels)
+	if len(g) == 0 {
+		return "off (one flat list)"
+	}
+	return g.label()
+}

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -1,0 +1,354 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// groupedBoard is the fixture for everything in this file: a board with the
+// §15 default grouping, unlike testBoard's flat table.
+func groupedBoard(tasks ...apiclient.Task) *board {
+	b := newBoard()
+	b.now = func() time.Time { return testNow }
+	b.bell = func() {}
+	b.loaded = true
+	b.updateLoaded(boardLoadedMsg{tasks: tasks})
+	return b
+}
+
+func inProject(name string) func(*apiclient.Task) {
+	return func(t *apiclient.Task) { t.ProjectName = name }
+}
+
+func inWorkflow(name string) func(*apiclient.Task) {
+	return func(t *apiclient.Task) { t.Workflow = name }
+}
+
+// rowLabels renders the row structure compactly: "▾ label" for a header at
+// its depth, "#id" for a task.
+func rowLabels(rows []boardRow) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if r.header {
+			out = append(out, strings.Repeat(" ", r.depth)+"▾ "+r.label)
+			continue
+		}
+		out = append(out, "#"+strconv.FormatInt(r.task.ID, 10))
+	}
+	return out
+}
+
+// TestDefaultGroupingMatchesTheConfigDefault holds the two definitions of
+// "default" together: the board renders grouped before any daemon answers,
+// and it must be the same grouping the daemon would have told it.
+func TestDefaultGroupingMatchesTheConfigDefault(t *testing.T) {
+	levels := make([]string, 0, 2)
+	for _, l := range config.Default().TUI.Board.GroupBy {
+		levels = append(levels, string(l))
+	}
+	if want := parseGrouping(levels); !defaultGrouping().equal(want) {
+		t.Errorf("TUI default grouping = %s, config default = %s",
+			defaultGrouping().label(), want.label())
+	}
+	if b := newBoard(); !b.group.equal(defaultGrouping()) {
+		t.Errorf("a fresh board groups %s, want %s", b.group.label(), defaultGrouping().label())
+	}
+}
+
+// TestGroupRowsNestsWorkflowInsideProject is the default the task asked for:
+// projects outermost, the workflows of one project inside it.
+func TestGroupRowsNestsWorkflowInsideProject(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateRunning, inProject("api"), inWorkflow("build"), withStarted(testNow.Add(-time.Minute))),
+		task(2, stateRunning, inProject("api"), inWorkflow("docs"), withStarted(testNow.Add(-time.Minute))),
+		task(3, stateRunning, inProject("web"), inWorkflow("build"), withStarted(testNow.Add(-time.Minute))),
+		task(4, stateRunning, inProject("api"), inWorkflow("build"), withStarted(testNow.Add(-time.Minute))),
+	)
+	got := rowLabels(b.rows())
+	want := []string{
+		"▾ api",
+		" ▾ build", "#1", "#4",
+		" ▾ docs", "#2",
+		"▾ web",
+		" ▾ build", "#3",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("rows =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+// TestGroupOrderFollowsTheBandSort is the property grouping was not allowed
+// to cost (§15): a task waiting on a human stays at the top of the board, so
+// the group holding it comes first even though its project sorts later.
+func TestGroupOrderFollowsTheBandSort(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateRunning, inProject("api"), inWorkflow("build"), withStarted(testNow.Add(-time.Hour))),
+		task(2, stateBlocked, inProject("web"), inWorkflow("deploy")),
+	)
+	rows := b.rows()
+	if rows[0].label != "web" {
+		t.Fatalf("first group = %q, want the one holding the blocked task", rows[0].label)
+	}
+	if rows[0].attention != 1 {
+		t.Errorf("group %q attention = %d, want 1 — a header must not hide that work is waiting",
+			rows[0].label, rows[0].attention)
+	}
+	cell := rows[0].headerCell()
+	if !strings.Contains(cell, attentionBadge) {
+		t.Errorf("header cell %q carries no attention badge", cell)
+	}
+	if !strings.Contains(cell, "web") {
+		t.Errorf("header cell %q does not name its group", cell)
+	}
+}
+
+// TestGroupHeaderCountsItsTasks: the count is what makes a header worth a row.
+func TestGroupHeaderCountsItsTasks(t *testing.T) {
+	// Queued, so the band sort is scheduler order — id ascending here — and
+	// the expected row order reads off the fixture.
+	b := groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("api"), inWorkflow("build")),
+		task(3, stateQueued, inProject("api"), inWorkflow("docs")),
+	)
+	rows := b.rows()
+	if rows[0].count != 3 {
+		t.Errorf("project header count = %d, want 3", rows[0].count)
+	}
+	if !strings.Contains(rows[0].headerCell(), "3") {
+		t.Errorf("project header %q does not show its count", rows[0].headerCell())
+	}
+	if rows[1].count != 2 {
+		t.Errorf("workflow header count = %d, want 2", rows[1].count)
+	}
+}
+
+// TestGroupValueFallsBackToADash: a task the daemon reported without a
+// workflow still belongs somewhere, and a blank header reads as a bug.
+func TestGroupValueFallsBackToADash(t *testing.T) {
+	b := groupedBoard(task(1, stateQueued, inProject("api")))
+	rows := b.rows()
+	if rows[1].label != groupUnnamed {
+		t.Errorf("empty workflow grouped as %q, want %q", rows[1].label, groupUnnamed)
+	}
+}
+
+// TestCursorStepsOverGroupHeaders: headers are labels. Moving through the
+// table must land on tasks only, in both directions.
+func TestCursorStepsOverGroupHeaders(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("web"), inWorkflow("build")),
+	)
+	b.render(160, 20)
+	if got, ok := b.selected(); !ok || got != 1 {
+		t.Fatalf("first render selected %d (ok=%v), want the first task", got, ok)
+	}
+	if r := b.rowAt(b.tbl.Cursor()); r.header {
+		t.Fatal("the cursor came up on a group header")
+	}
+
+	// Down crosses this group's end and the next group's two headers.
+	b.updateKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if r := b.rowAt(b.tbl.Cursor()); r.header {
+		t.Fatalf("down parked the cursor on the header %q", r.label)
+	}
+	if got, _ := b.selected(); got != 2 {
+		t.Fatalf("down selected %d, want 2", got)
+	}
+
+	// And back up, over the same two headers.
+	b.updateKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	if r := b.rowAt(b.tbl.Cursor()); r.header {
+		t.Fatalf("up parked the cursor on the header %q", r.label)
+	}
+	if got, _ := b.selected(); got != 1 {
+		t.Fatalf("up selected %d, want 1", got)
+	}
+}
+
+// TestGroupCycleKeepsTheSelectedTask: `g` is a way to look at the same board
+// differently, so the task under the cursor must survive the regrouping —
+// the row *index* certainly does not.
+func TestGroupCycleKeepsTheSelectedTask(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("web"), inWorkflow("build")),
+	)
+	b.render(160, 20)
+	b.updateKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if got, _ := b.selected(); got != 2 {
+		t.Fatalf("fixture selected %d, want 2", got)
+	}
+
+	for _, want := range []grouping{
+		{groupProject}, {groupWorkflow}, {}, {groupProject, groupWorkflow},
+	} {
+		b.updateKey(tea.KeyPressMsg{Code: 'g', Text: "g"})
+		if !b.group.equal(want) {
+			t.Fatalf("g moved to %s, want %s", b.group.label(), want.label())
+		}
+		b.render(160, 20)
+		if got, ok := b.selected(); !ok || got != 2 {
+			t.Fatalf("%s: selected %d (ok=%v), want 2 through the regrouping",
+				b.group.label(), got, ok)
+		}
+		if r := b.rowAt(b.tbl.Cursor()); r.header {
+			t.Fatalf("%s: regrouping left the cursor on a header", b.group.label())
+		}
+	}
+}
+
+// TestGroupedColumnsAreDropped: a level named by every header above the rows
+// does not also need a column repeating it on every row.
+func TestGroupedColumnsAreDropped(t *testing.T) {
+	full := columnsFor(160, nil)
+	if !full.project || !full.workflow {
+		t.Fatalf("flat at 160 = %+v, want both columns", full)
+	}
+	both := columnsFor(160, grouping{groupProject, groupWorkflow})
+	if both.project || both.workflow {
+		t.Errorf("grouped by project and workflow = %+v, want neither column", both)
+	}
+	one := columnsFor(160, grouping{groupProject})
+	if one.project {
+		t.Error("grouping by project kept the PROJECT column")
+	}
+	if !one.workflow {
+		t.Error("grouping by project dropped the WORKFLOW column, which nothing names")
+	}
+	// The width a dropped column frees goes to the title, which is where a
+	// grouped board needs it: the titles are indented under their headers.
+	if both.titleWidth(160) <= full.titleWidth(160) {
+		t.Errorf("grouped title width %d, flat %d — grouping must not cost title space",
+			both.titleWidth(160), full.titleWidth(160))
+	}
+}
+
+// TestGroupedRowsMatchTheColumnCount: a row that disagrees with the column
+// set indexes the table out of range, which is a panic, not a rendering
+// glitch.
+func TestGroupedRowsMatchTheColumnCount(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning, inProject("api"), inWorkflow("build")))
+	for _, width := range []int{40, 70, 90, 120, 200} {
+		for _, g := range []grouping{nil, {groupProject}, {groupProject, groupWorkflow}} {
+			b.group = g
+			cols, set := boardColumns(width, g)
+			for _, row := range b.rowsFor(b.rows(), set) {
+				if len(row) != len(cols) {
+					t.Fatalf("width %d, %s: row has %d cells, %d columns",
+						width, g.label(), len(row), len(cols))
+				}
+			}
+		}
+	}
+}
+
+// TestGroupHeadersRenderInTheTitleColumn: the header label has to land in the
+// one column wide enough to hold a name, at every width.
+func TestGroupHeadersRenderInTheTitleColumn(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning, inProject("api"), inWorkflow("build")))
+	for _, width := range []int{70, 120, 200} {
+		out := b.render(width, 20)
+		if !strings.Contains(out, "▾ api") {
+			t.Errorf("width %d rendered no project header:\n%s", width, out)
+		}
+		if !strings.Contains(out, "▾ build") {
+			t.Errorf("width %d rendered no workflow header:\n%s", width, out)
+		}
+	}
+}
+
+// TestConfiguredGroupingApplies is the point of the config key: the daemon's
+// file decides what the board comes up as.
+func TestConfiguredGroupingApplies(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning))
+	b.applyConfig(boardConfigMsg{board: apiclient.ConfigBoard{GroupBy: []string{"workflow"}}})
+	if want := (grouping{groupWorkflow}); !b.group.equal(want) {
+		t.Errorf("group = %s, want %s", b.group.label(), want.label())
+	}
+
+	// An empty list is a configured choice — the flat table — not a missing
+	// answer.
+	b.applyConfig(boardConfigMsg{board: apiclient.ConfigBoard{GroupBy: []string{}}})
+	if len(b.group) != 0 {
+		t.Errorf("group = %s, want the flat table the config asked for", b.group.label())
+	}
+
+	// A level this TUI predates is dropped, not fatal.
+	b.applyConfig(boardConfigMsg{board: apiclient.ConfigBoard{GroupBy: []string{"agent", "project"}}})
+	if want := (grouping{groupProject}); !b.group.equal(want) {
+		t.Errorf("group = %s, want %s — an unknown level must be ignored", b.group.label(), want.label())
+	}
+}
+
+// TestConfigFetchFailureKeepsTheGrouping: a config request that timed out is
+// not a statement about how anyone wants their board.
+func TestConfigFetchFailureKeepsTheGrouping(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning))
+	b.applyConfig(boardConfigMsg{err: errTest})
+	if !b.group.equal(defaultGrouping()) {
+		t.Errorf("group = %s after a failed fetch, want the default kept", b.group.label())
+	}
+}
+
+// TestPressedGroupingSurvivesAReconnect: the config is where the board
+// starts, not a setting the daemon re-imposes under someone's hands. A
+// reconnect refetches the config, and that must not undo a `g`.
+func TestPressedGroupingSurvivesAReconnect(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning))
+	b.render(160, 20)
+	b.updateKey(tea.KeyPressMsg{Code: 'g', Text: "g"})
+	pressed := b.group
+
+	b.applyConfig(boardConfigMsg{board: apiclient.ConfigBoard{
+		GroupBy: []string{"project", "workflow"},
+	}})
+	if !b.group.equal(pressed) {
+		t.Errorf("group = %s after a refetch, want the pressed %s",
+			b.group.label(), pressed.label())
+	}
+	if !b.configGroup.equal(defaultGrouping()) {
+		t.Errorf("configGroup = %s, want what the daemon served", b.configGroup.label())
+	}
+}
+
+// TestPanelTitleNamesAnUnconfiguredGrouping follows the `v` precedent (§15):
+// the headers say what the grouping is, the title says when it is not the one
+// the config asked for.
+func TestPanelTitleNamesAnUnconfiguredGrouping(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateRunning))
+	s.board.group, s.board.configGroup = defaultGrouping(), defaultGrouping()
+	if got := s.panelTitle(panelTasks); got != "Tasks" {
+		t.Errorf("title = %q under the configured grouping, want a plain %q", got, "Tasks")
+	}
+
+	s.board.group = grouping{groupWorkflow}
+	if got := s.panelTitle(panelTasks); !strings.Contains(got, "by workflow") {
+		t.Errorf("title = %q, want it to name the grouping in effect", got)
+	}
+
+	s.board.filter.SetValue("api")
+	got := s.panelTitle(panelTasks)
+	if !strings.Contains(got, "by workflow") || !strings.Contains(got, "/api") {
+		t.Errorf("title = %q, want both the grouping and the committed filter", got)
+	}
+}
+
+// TestGroupSummaryReadsAsASetting is the daemon view's line: what the file
+// says, in words rather than YAML.
+func TestGroupSummaryReadsAsASetting(t *testing.T) {
+	if got := groupSummary([]string{"project", "workflow"}); got != "by project › workflow" {
+		t.Errorf("summary = %q", got)
+	}
+	if got := groupSummary(nil); !strings.Contains(got, "flat") {
+		t.Errorf("summary of no grouping = %q, want it to say the list is flat", got)
+	}
+}

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -48,6 +48,15 @@ type boardLiveHarness struct {
 
 func newBoardLiveHarness(t *testing.T) *boardLiveHarness {
 	t.Helper()
+	return newBoardLiveHarnessConfig(t, config.Default)
+}
+
+// newBoardLiveHarnessConfig is the same harness against a chosen
+// configuration — the daemon serves `tui:` on /v1/config, so this is how a
+// configured board is exercised over the real handler rather than by poking
+// the model.
+func newBoardLiveHarnessConfig(t *testing.T, cfg func() config.Config) *boardLiveHarness {
+	t.Helper()
 	const token = "board-token"
 	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
@@ -60,7 +69,7 @@ func newBoardLiveHarness(t *testing.T) *boardLiveHarness {
 
 	s := api.New(api.Deps{
 		Token:       token,
-		Config:      config.Default,
+		Config:      cfg,
 		StartedAt:   time.Now(),
 		ListenAddr:  "127.0.0.1:0",
 		RequestStop: func() {},
@@ -246,4 +255,60 @@ func TestBoardEnterOpensDetail(t *testing.T) {
 	h.p.until(10*time.Second, "the detail header to render", func() bool {
 		return strings.Contains(content(h.m), want)
 	})
+}
+
+// TestBoardGroupsFromTheDaemonConfig walks the whole path the grouping takes:
+// config.yaml → GET /v1/config → apiclient → the task table. It is a live
+// test for the reason the others are — the board renders what the daemon
+// serves, and a wire type that drifted would show up here and nowhere else.
+func TestBoardGroupsFromTheDaemonConfig(t *testing.T) {
+	h := newBoardLiveHarness(t)
+	h.createTask(t, "grouped task")
+
+	h.p.until(20*time.Second, "the task to appear", func() bool {
+		return strings.Contains(content(h.m), "grouped task")
+	})
+	// The project header, then the workflow header under it — the default
+	// grouping, fetched rather than assumed.
+	h.p.until(10*time.Second, "the group headers to render", func() bool {
+		got := content(h.m)
+		return strings.Contains(got, "▾ board") && strings.Contains(got, "▾ three")
+	})
+	b := h.m.views[viewHome].(*shell).board
+	if !b.group.equal(defaultGrouping()) {
+		t.Errorf("board grouping = %s, want the configured %s",
+			b.group.label(), defaultGrouping().label())
+	}
+	// A grouped level costs no column: the header names it.
+	if strings.Contains(content(h.m), "WORKFLOW") {
+		t.Error("the WORKFLOW column is still on a board grouped by workflow")
+	}
+}
+
+// TestBoardHonoursAConfiguredFlatTable is the other end of the setting: a
+// config that asks for no grouping gets the table every version before this
+// one rendered, columns included.
+func TestBoardHonoursAConfiguredFlatTable(t *testing.T) {
+	flat := func() config.Config {
+		cfg := config.Default()
+		cfg.TUI.Board.GroupBy = nil
+		return cfg
+	}
+	h := newBoardLiveHarnessConfig(t, flat)
+	h.createTask(t, "flat task")
+
+	h.p.until(20*time.Second, "the task to appear", func() bool {
+		return strings.Contains(content(h.m), "flat task")
+	})
+	h.p.until(10*time.Second, "the configured flat table to apply", func() bool {
+		b := h.m.views[viewHome].(*shell).board
+		return len(b.group) == 0
+	})
+	got := content(h.m)
+	if strings.Contains(got, groupGlyph) {
+		t.Errorf("a flat board rendered a group header:\n%s", got)
+	}
+	if !strings.Contains(got, "WORKFLOW") {
+		t.Errorf("a flat board dropped the WORKFLOW column:\n%s", got)
+	}
 }

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -110,6 +110,9 @@ func (d *daemonView) configLines() []string {
 			styleDim.Render("   remote "+onOff(c.DeleteRemoteBranchOnArchive)),
 		field("usage limit recheck", c.UsageLimitRecheck),
 		field("log level", c.LogLevel),
+		// What the file says, which is not necessarily what the board is
+		// showing: `g` regroups for the session without writing anything.
+		field("task grouping", groupSummary(c.TUI.Board.GroupBy)),
 	)
 	for _, name := range sortedKeys(c.Agents) {
 		path := c.Agents[name].Path

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -316,7 +316,7 @@ func (s *shell) openSelected() tea.Cmd {
 // task yet; selectedID makes the next refresh put the cursor on it.
 func (s *shell) openNow(id int64) tea.Cmd {
 	s.board.selectedID = id
-	s.board.restoreSelection(s.board.visible())
+	s.board.restoreSelection(s.board.rows())
 	s.lastSel = id
 	s.focus = panelTimeline
 	return s.detail.open(id, s.stateOf(id))
@@ -524,10 +524,18 @@ func (s *shell) panelTitle(id panelID) string {
 		// A committed filter is view state, applied and named here (§15) —
 		// losing track of why rows are missing trains people to distrust
 		// the table.
-		if v := s.board.filter.Value(); v != "" && !s.board.filtering {
-			return "Tasks — /" + v
+		title := "Tasks"
+		// `g` regroups for the session, and the title names any grouping but
+		// the configured one — the rule the output pane's `v` already follows
+		// (§15). The group headers show what the grouping *is*; this says it
+		// is not the one the config asked for.
+		if !s.board.group.equal(s.board.configGroup) {
+			title += " — " + s.board.group.label()
 		}
-		return "Tasks"
+		if v := s.board.filter.Value(); v != "" && !s.board.filtering {
+			title += " — /" + v
+		}
+		return title
 	case panelTimeline:
 		if s.detail.taskID != 0 {
 			return fmt.Sprintf("Timeline — #%d", s.detail.taskID)

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -23,6 +23,10 @@ func newShellFixture(t *testing.T, tasks ...apiclient.Task) (*shell, *int) {
 	s := newShell(testCtx(t))
 	s.board.now = func() time.Time { return testNow }
 	s.board.bell = func() {}
+	// Flat, for the same reason testBoard is: these tests count rendered rows
+	// and click at line offsets, and group headers are lines that are not
+	// tasks. What grouping does to the cursor is tested in boardgroup_test.go.
+	s.board.group, s.board.configGroup = nil, nil
 	subs := new(int)
 	s.detail.openStream = func(context.Context, int64, apiclient.StreamOptions) <-chan apiclient.Note {
 		*subs++


### PR DESCRIPTION
The board's task table was one flat list for any number of projects and
workflows. It now nests its rows under group headers, `[project, workflow]`
by default: a board with more than one repository on it is read project by
project, and within a project the workflow is what says what a task is doing.

The shape is configuration — `tui.board.group_by` in config.yaml, validated
and hot-reloaded by the daemon and served on GET /v1/config, which is how the
TUI (a pure API client that reads nothing from disk) gets it. `[]` is the flat
table of every earlier version, and `g` cycles project›workflow → project →
workflow → flat for the session without writing to the file.

What grouping does not get to bend:

- Ordering. Tasks are sorted by band exactly as before and each group takes
  the position of its first task, so a group holding work that needs a human
  is the first group and §15's pinning rule survives. Headers carry the task
  count and the needs-attention badge.
- A grouped level costs no column — the header names it, so PROJECT and
  WORKFLOW drop out and the width goes to the title.
- A header is a label: the cursor steps over it, clicking one selects nothing,
  and nothing collapses.

Closes 009.1–009.6.