### PR TITLE
docs: relicense under PolyForm Noncommercial 1.0.0 plus a commercial license

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,7 @@ archives:
     files:
       - README.md
       - LICENSE
+      - COMMERCIAL-LICENSE.md
       - examples/*.yaml
 
 checksum:
@@ -75,7 +76,12 @@ homebrew_casks:
     directory: Casks
     homepage: "https://github.com/lezli01/vincent"
     description: "Vendor-independent control plane for executing native agent tooling"
-    license: MIT
+    # The field takes a single SPDX identifier, and the dual model has none:
+    # `PolyForm-Noncommercial-1.0.0` is the license this artifact is offered
+    # under to everyone who downloads it, and the commercial license is a
+    # separate agreement (COMMERCIAL-LICENSE.md) rather than a public grant, so
+    # it is not expressible here. Do not invent a compound identifier for it.
+    license: PolyForm-Noncommercial-1.0.0
     # An rc tag must not move the cask users install; goreleaser's `auto`
     # skips the push whenever the release is a prerelease.
     skip_upload: auto

--- a/.vincent/workflows/prepare-release.yaml
+++ b/.vincent/workflows/prepare-release.yaml
@@ -177,7 +177,7 @@ steps:
       passed && echo "ok    no uncommitted changes to tracked files"
 
       section "archive payload (.goreleaser.yaml archives.files)"
-      for f in README.md LICENSE .goreleaser.yaml cmd/vincent; do
+      for f in README.md LICENSE COMMERCIAL-LICENSE.md .goreleaser.yaml cmd/vincent; do
         [ -e "$f" ] || fail "payload: $f is missing"
       done
       # `examples/*.yaml` is an archive glob: an empty match ships an archive
@@ -187,7 +187,7 @@ steps:
       # release.yml's smoke job names this file literally; renaming it breaks
       # every published archive's smoke test and nothing before it.
       [ -f examples/cursor-review.yaml ] || fail "payload: examples/cursor-review.yaml is missing, and release.yml's smoke job runs 'workflow validate' on exactly that path"
-      passed && echo "ok    README.md, LICENSE and $n example workflow(s)"
+      passed && echo "ok    README.md, LICENSE, COMMERCIAL-LICENSE.md and $n example workflow(s)"
 
       section "module (goreleaser's before hook)"
       go mod download >"$work/mod.log" 2>&1 || fail "module: 'go mod download' failed: $(head -n 3 "$work/mod.log" | tr '\n' ' ')"
@@ -564,7 +564,7 @@ steps:
       archive=$(ls ./*_linux_amd64.tar.gz)
       mkdir -p unpacked
       tar -xzf "$archive" -C unpacked
-      for f in vincent README.md LICENSE examples/cursor-review.yaml; do
+      for f in vincent README.md LICENSE COMMERCIAL-LICENSE.md examples/cursor-review.yaml; do
         [ -e "unpacked/$f" ] || { echo "the archive is missing $f — check archives.files in .goreleaser.yaml" >&2; exit 1; }
       done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ Please pull request.
 
 ## [Unreleased]
 
+### Changed
+
+- **vincent is now source-available and dual-licensed, not MIT.** Personal and
+  non-commercial use is free under the
+  [PolyForm Noncommercial License 1.0.0](LICENSE); commercial or business use —
+  including running vincent inside a for-profit company's own development
+  workflow, without selling it — requires a separate commercial license, see
+  [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md). This is deliberately *not* an
+  OSI-approved open-source license: restricting commercial use is incompatible
+  with the Open Source Definition, so "source-available" is the accurate word.
+
+  **The change is not retroactive.** `v0.2.0` and every release before it were
+  published under the MIT License and stay usable under it forever, on the terms
+  they shipped with; no tag or published artifact is modified. The first release
+  published after this change is the first release under the new licensing, and
+  every release after it follows.
+
 ### Added
 
 - **`vincent gc` reclaims directories no task claims.** A worktree could outlive

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,59 @@
+# Commercial Licensing
+
+vincent is available under a dual-license model.
+
+For personal and non-commercial use, vincent is available under the
+[PolyForm Noncommercial License 1.0.0](LICENSE).
+
+Commercial or business use requires a separate commercial license.
+
+## What counts as commercial use
+
+Commercial use includes, but is not limited to, using vincent:
+
+- within a for-profit company or organization;
+- as part of an internal software-development or engineering workflow;
+- to operate or automate commercial AI/agentic workloads;
+- as part of a commercial product or service;
+- to provide services to customers or other third parties.
+
+Using vincent internally at a for-profit company is commercial use even when
+vincent itself is not being sold or redistributed. If your use is primarily
+intended for commercial advantage, you need a commercial license.
+
+The PolyForm Noncommercial License itself states which purposes are permitted
+without one: personal study, hobby projects, research and experiment without an
+anticipated commercial application, and use by charitable organizations,
+educational institutions, public research organizations, public safety or health
+organizations, environmental protection organizations, and government
+institutions. Read [LICENSE](LICENSE) — it governs, not this summary.
+
+## Versions and the license cutover
+
+The license change is not retroactive. Rights already granted under the MIT
+License are not revoked.
+
+| Release | License |
+|---|---|
+| `v0.2.0` (2026-08-16) and every earlier release, including `v0.1.x` and the `v0.1.0-rc*` prereleases | MIT License |
+| the first release published after this change, and every release after it | PolyForm Noncommercial 1.0.0 **or** a commercial license |
+
+If you obtained vincent at `v0.2.0` or earlier, you may keep using that version
+under the MIT License it was published under, for any purpose, forever. The
+MIT text as it applied to those releases stays in the git history at those tags.
+Upgrading to a later release means accepting the license that release ships
+under.
+
+## Getting a commercial license
+
+If you would like to use vincent commercially, please contact:
+
+**László Szabó**
+
+- Website: <https://lezli01.is-a.dev>
+- GitHub: [@lezli01](https://github.com/lezli01)
+
+Please include your company name, roughly how many developers would use
+vincent, and how you intend to use it.
+
+Commercial license terms and pricing are provided separately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,24 @@ LINT=$(go tool -n golangci-lint)
 for os in windows darwin linux; do GOOS=$os "$LINT" run ./...; done
 ```
 
+## Licensing of contributions
+
+vincent is distributed under a dual-license model consisting of a non-commercial
+source-available license ([PolyForm Noncommercial 1.0.0](LICENSE)) and separate
+commercial licenses ([COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)).
+
+By submitting a contribution, you agree that your contribution may be
+distributed by the vincent project under the project's current non-commercial
+license and under separate commercial licenses offered by the project owner.
+
+You retain copyright in your contribution unless otherwise agreed.
+
+> **Note:** this is a lightweight statement of intent, not a formal Contributor
+> License Agreement, and it is not necessarily a substitute for one. If a CLA
+> becomes necessary — for example if the project takes on contributions large
+> enough that clear relicensing rights matter — one will be added separately and
+> announced, rather than read into this paragraph.
+
 ## Pull request checklist
 
 - [ ] Commits follow Conventional Commits

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,83 @@
-MIT License
+Required Notice: Copyright © 2026 László Szabó (https://lezli01.is-a.dev)
 
-Copyright (c) 2026 László Szabó
+This license covers noncommercial use only. Commercial or business use of
+vincent requires a separate commercial license — see COMMERCIAL-LICENSE.md.
+Releases published before this license change remain available under the MIT
+License they were originally published under; see COMMERCIAL-LICENSE.md for
+the cutover.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+----------------------------------------------------------------------------
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+# PolyForm Noncommercial License 1.0.0
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 <p align="center">
   <a href="https://github.com/lezli01/vincent/actions/workflows/ci.yml"><img src="https://github.com/lezli01/vincent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-PolyForm%20Noncommercial%201.0.0-blue.svg" alt="License: PolyForm Noncommercial 1.0.0"></a>
+  <a href="COMMERCIAL-LICENSE.md"><img src="https://img.shields.io/badge/Commercial%20use-license%20required-orange.svg" alt="Commercial use: license required"></a>
   <a href="https://www.buymeacoffee.com/lezli01"><img src="https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buymeacoffee&logoColor=black" alt="Buy Me a Coffee"></a>
 </p>
 
@@ -66,9 +67,11 @@ acceptance gates that drive a real daemon over HTTP. Binaries on the
 [releases page](https://github.com/lezli01/vincent/releases) are signed,
 checksummed and attested.
 
-It is released under the [MIT License](LICENSE) and created by `lezli01` at
-[lezli01.is-a.dev](https://lezli01.is-a.dev). Contributions are welcome — see
-[Contributing](#contributing).
+It is **source-available and dual-licensed** — free for personal and
+non-commercial use under the [PolyForm Noncommercial License 1.0.0](LICENSE),
+with a [separate commercial license](COMMERCIAL-LICENSE.md) for business use —
+and created by `lezli01` at [lezli01.is-a.dev](https://lezli01.is-a.dev).
+Contributions are welcome — see [Contributing](#contributing).
 
 ## What It Does
 
@@ -442,4 +445,37 @@ rather than a public issue. See [SECURITY.md](SECURITY.md) for details.
 
 ## License
 
-vincent is released under the [MIT License](LICENSE). © 2026 lezli01.
+vincent is source-available and dual-licensed. The source is public and stays
+public; what you may do with it depends on who you are and why you are running
+it. This is **not** an OSI-approved open-source license — restricting commercial
+use is incompatible with the Open Source Definition.
+
+### Personal and non-commercial use
+
+vincent is free to use, modify, and run for personal and non-commercial purposes
+under the [PolyForm Noncommercial License 1.0.0](LICENSE). Personal projects,
+study, research and experiment, and use by charities, educational institutions,
+public research bodies and government institutions are all covered at no cost.
+
+### Commercial use
+
+Commercial or business use requires a separate commercial license.
+
+This includes using vincent as part of a company's internal software-development
+workflow, engineering processes, AI/agentic development workflows, commercial
+products, services, or other activities primarily intended for commercial
+advantage — running it internally at a for-profit company counts, even though
+vincent itself is not being sold.
+
+For commercial licensing, see [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+
+### Previously released versions
+
+Previously released versions remain available under the license under which they
+were originally published: `v0.2.0` and every earlier release were published
+under the MIT License and stay usable under it. The first release published
+after this change, and every release after it, are PolyForm Noncommercial 1.0.0
+or commercial. See [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md) for the
+cutover table.
+
+© 2026 László Szabó (`lezli01`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,10 @@ that is *not* true are stated rather than smoothed over.
   does and does not isolate, and how to tighten it.
 - [FAQ](faq.md) — the short answers.
 - [Example workflows](../examples) — four ready-to-copy files.
+- [Commercial licensing](../COMMERCIAL-LICENSE.md) — vincent is source-available
+  and dual-licensed: free for personal and non-commercial use under the
+  [PolyForm Noncommercial License 1.0.0](../LICENSE), separate license required
+  for commercial or business use.
 
 ## Design and internals
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -141,7 +141,11 @@ endpoints.
 
 ### Does it cost anything? Does it show me what a run cost?
 
-vincent is MIT-licensed and free. Your agent CLI's usage is billed by its vendor.
+vincent is source-available and dual-licensed: free for personal and
+non-commercial use under the [PolyForm Noncommercial License 1.0.0](../LICENSE),
+and a [separate commercial license](../COMMERCIAL-LICENSE.md) for business use —
+which includes running it inside a for-profit company's development workflow.
+Your agent CLI's usage is billed by its vendor.
 Claude Code reports cost, so the board's cost column sums every attempt for it;
 codex and cursor report none, and vincent shows nothing rather than guessing.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,8 +67,11 @@ named `vincent_{version}_{os}_{arch}.{tar.gz|zip}`:
 | Windows, x86-64 | `vincent_*_windows_amd64.zip` |
 | Windows, ARM64 | `vincent_*_windows_arm64.zip` |
 
-Each archive contains the binary, `LICENSE`, `README.md`, and the
-[example workflows](../../examples).
+Each archive contains the binary, `LICENSE`, `COMMERCIAL-LICENSE.md`,
+`README.md`, and the [example workflows](../../examples). vincent is
+source-available and dual-licensed: free for personal and non-commercial use
+under the PolyForm Noncommercial License 1.0.0, with a separate commercial
+license required for business use.
 
 **macOS / Linux**
 


### PR DESCRIPTION
vincent moves from MIT to a source-available, dual-license model: personal and
non-commercial use stays free under PolyForm Noncommercial 1.0.0, and commercial
or business use — including a for-profit company running vincent inside its own
development workflow, without ever selling it — needs a separate commercial
license.

LICENSE carries the official PolyForm text byte for byte (verified against
polyformproject/polyform-licenses), with the copyright as the `Required Notice:`
line the license's Notices section provides for and a header pointing at the
commercial terms. COMMERCIAL-LICENSE.md defines what commercial use covers and
how to ask for a license; it deliberately carries no pricing and no contract
terms.

The change is not retroactive. v0.2.0 and every release before it were published
under MIT and stay usable under it forever; no tag or published artifact is
touched. The first release published after this commit is the first release
under the new licensing.

"Source-available", never "open source": restricting commercial use is
incompatible with the Open Source Definition, and README says so rather than
letting a badge imply otherwise. The MIT badge is replaced by a PolyForm badge
and a commercial-use badge.

Release metadata follows: .goreleaser.yaml declares the SPDX identifier
PolyForm-Noncommercial-1.0.0 for the Homebrew cask — the commercial license is a
separate agreement, not a public grant, so no compound identifier is invented for
it — and ships COMMERCIAL-LICENSE.md in every archive, which the prepare-release
workflow's payload and dry-run checks now assert.

CONTRIBUTING gains a contributor-licensing section: contributions may be
distributed under the project's non-commercial license and under separate
commercial licenses, contributors keep their copyright, and the note says
plainly that this is not a substitute for a formal CLA.