### PR TITLE
feat(workflow): restrict a workflow to platforms with `platforms:`

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -153,6 +153,27 @@ The step fails rather than running unrestricted, which is deliberate — a
 restricted mode that quietly isn't restricted is worse than none. Use claude or
 codex for that step on Windows, or drop the step to `full-auto` **knowingly**.
 
+### A workflow is listed but cannot be selected — `platform_unsupported`
+
+The workflow declares a `platforms:` list this host is not in
+([schema](../reference/workflow-schema.md#platforms)). `vincent workflow ls`
+shows it with status `unsupported` and the platforms it needs, the TUI's
+workflow view says "not on this platform", and the new-task picker refuses it —
+creating the task would only produce a run that fails at the first `cat` or
+`Get-ChildItem`.
+
+Three honest fixes, in order of preference:
+
+1. run the task on a host the workflow names;
+2. widen the list, if the workflow really is portable — `[posix, windows]` is
+   the same as removing the key;
+3. write a host-specific copy under the project scope, which shadows the
+   global one by name.
+
+The block reason `platform_unsupported` on an existing task means the task was
+created elsewhere and its data directory has since moved between machines. The
+snapshot is fine; it is the host that changed.
+
 ### Every cursor tool call is blocked on Windows
 
 If cursor steps run, produce no edits, and report blocked tool calls, check
@@ -305,6 +326,7 @@ The block reason names what happened:
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `template_error` | A template failed to render (see above) |
 | `restricted_unsupported` | The adapter cannot restrict on this platform |
+| `platform_unsupported` | The workflow's `platforms:` list does not admit this host |
 | `transcript_limit` | The attempt's transcript hit `transcript_max_bytes` |
 | `rejected` | You rejected a manual gate |
 | `shell_unavailable` | The requested shell is not installed |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -267,6 +267,21 @@ Pin one explicitly with `shell: sh | pwsh | cmd` when a step is only ever meant
 to run one way. vincent makes no attempt to translate between them: cross-OS
 portability of command steps is the author's job.
 
+**Or say you did not do that job.** A workflow written against `cat`, `grep`
+and pipes is a POSIX workflow, and pretending otherwise only moves the failure
+to run time. Declare it once at the top of the file:
+
+```yaml
+name: posix-tools
+platforms: [posix]        # every non-Windows host; or [linux, darwin], [windows]
+```
+
+On a host the list does not admit, the workflow is still listed with the
+platforms it needs, but nothing will offer it: the new-task picker refuses it
+and the API rejects a task naming it. Omitting the key means "runs anywhere",
+which is the right answer for most files — see the
+[schema reference](../reference/workflow-schema.md#platforms).
+
 Every command and check step runs with cwd set to the worktree, inherits the
 daemon's environment, and additionally gets:
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -74,6 +74,13 @@ workflow is meant to run on Windows and on POSIX, write commands that work in
 both — `&&` chaining is fine everywhere, `test -f` is not — or pin the shell and
 accept that the workflow is platform-specific.
 
+A workflow that is platform-specific should say so with
+[`platforms:`](../reference/workflow-schema.md#platforms). A file declaring
+`platforms: [posix]` is listed here with status `unsupported` and is never
+offered by the new-task picker, instead of being offered and then failing at
+its first `cat`. The reverse works too: `platforms: [windows]` for a workflow
+built around PowerShell.
+
 Paths in templates come from the daemon and are Windows paths; a command step
 that hard-codes `/` separators will not do what you expect.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -204,7 +204,14 @@ to disable the sweep.
 | `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort?, title?, fields?, base_branch?, branch_name? }` → resolution per step, plus the previewed branch name |
 
 Registry entries carry
-`{ name, scope, project_id, file, description, steps[], errors[]?, warnings[]?, error? }`.
+`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, errors[]?, warnings[]?, error? }`.
+
+`platforms[]` is the entry's [platform restriction](workflow-schema.md#platforms)
+as the file declares it, and `platform_supported` is **the daemon's own verdict**
+on it — the daemon is the process that would run the steps, so clients report
+that flag rather than comparing the list to their own OS. An entry with
+`platform_supported: false` is listed like any other, but `POST /v1/tasks`
+rejects a task naming it with a `400`.
 
 `POST /v1/resolve` applies the [resolution order](workflow-schema.md#resolution-order)
 to every step under a candidate task-level override, returning `{ value, source }`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -299,6 +299,11 @@ validation status. **Add `--project` to include that repository's
 `.vincent/workflows/`**, with shadowing applied; without it you see global scope
 only.
 
+The `PLATFORMS` column is the workflow's
+[platform restriction](workflow-schema.md#platforms); status `unsupported`
+means this host is not in it, so the workflow is listed but cannot back a task
+here.
+
 Needs a daemon: only the daemon knows which projects exist.
 
 ### `vincent workflow validate`

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -151,6 +151,7 @@ same thing wherever it originated.
 | `rejected` | You rejected a manual gate |
 | `canceled` | You cancelled the task |
 | `invalid_snapshot` | The task's stored workflow snapshot is unusable |
+| `platform_unsupported` | The workflow is restricted to platforms this host is not (`platforms:`). Only reachable for a task created on another OS |
 | `interrupted` | The daemon stopped mid-step — not a failure |
 | `internal_error` | A bug. Please [report it](https://github.com/lezli01/vincent/issues/new/choose) |
 

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -9,6 +9,7 @@ becoming a setting that silently never applied.
 
 - [File structure](#file-structure)
 - [Top level](#top-level)
+- [`platforms`](#platforms)
 - [`defaults`](#defaults)
 - [Step fields](#step-fields)
 - [Template context](#template-context)
@@ -47,8 +48,47 @@ built-in workflow, `adhoc`, is always present: a single agent step.
 |---|---|---|---|
 | `name` | string | ✅ | How tasks refer to it. Unique per scope |
 | `description` | string | | Shown in the TUI's workflow picker |
+| `platforms` | list | | Where this workflow may run. Empty means anywhere — see [`platforms`](#platforms) |
 | `defaults` | map | | Inherited by every step |
 | `steps` | list | ✅ | Runs in order, top to bottom. Must be non-empty |
+
+## `platforms`
+
+vincent never translates a command step between shells, so a workflow that
+pipes `cat` into `wc` is a POSIX workflow. Declaring that keeps it from being
+offered on a host it cannot run on:
+
+```yaml
+name: posix-tools
+platforms: [posix]
+```
+
+| Token | Matches |
+|---|---|
+| `linux` | Linux |
+| `darwin` | macOS |
+| `windows` | Windows |
+| `posix` | Every non-Windows host — the shorthand for "needs a POSIX shell" |
+
+Any combination is allowed: `[linux, darwin]` is `[posix]` spelled out,
+`[posix, windows]` is the same as omitting the key. Tokens are matched exactly
+— `macos` and `Linux` are validation errors, not silent non-matches.
+
+On a host the list does not admit:
+
+- the workflow is still **listed** — by `vincent workflow ls` (status
+  `unsupported`) and in the TUI's workflow view, with the platforms it needs;
+- it cannot be **selected**: the new-task picker refuses it and
+  `POST /v1/tasks` rejects it with a 400;
+- a task that somehow already carries it — a data directory moved between
+  machines — blocks at admission with `platform_unsupported`, before any step
+  runs.
+
+`vincent workflow validate` checks the tokens but never the host, so a
+POSIX-only workflow validates the same on a Windows CI runner as it does on
+Linux.
+
+The restriction covers the whole workflow; there is no per-step `platforms`.
 
 ## `defaults`
 
@@ -254,6 +294,8 @@ network, no agent CLI installed.
 
 - `steps` non-empty; step `id`s unique; `type` known.
 - Every template parses.
+- `platforms` entries are known tokens, with no duplicates. The list is checked
+  for shape, never against the validating host.
 - Durations parse as Go durations; `on_input` is `wait` or `deny`.
 - Unknown keys are errors.
 - `agent` names a known adapter.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -410,6 +410,7 @@ permission mode.
 
 name: feature-pr                      # required; unique per scope; project shadows global
 description: Implement, test, review, then push and open a PR.
+platforms: [posix]                    # optional; where this workflow may run (§8.1.1)
 
 defaults:                             # optional; per-step values override
   agent: claude                       # claude | codex
@@ -461,6 +462,42 @@ steps:
     max_retries: 0
 ```
 
+#### 8.1.1 Platform restriction (`platforms:`)
+
+*Added 2026-08-16 (task 010).* A workflow may declare the platforms it is
+written for. §8.3 leaves cross-OS portability of command steps to the author;
+this is how an author says they did not attempt it, instead of shipping a
+workflow that pipes `cat` into `wc` and fails wherever it is offered on
+Windows.
+
+```yaml
+platforms: [posix]           # or: [linux, darwin] · [windows] · [posix, windows]
+```
+
+- Tokens are GOOS values — `linux`, `darwin`, `windows` — plus one group
+  token, `posix`, which matches **every non-Windows host**. Matching is exact:
+  `macos` or `Linux` is a typo that fails validation, the way every other enum
+  in the schema does.
+- Omitted or empty means every platform. Nothing changes for a workflow that
+  does not declare it, which is the majority.
+- The restriction is judged against the **daemon's** host, because the daemon
+  is what runs the steps. Clients do not re-derive it: `GET /v1/workflows`
+  serves `platforms[]` and the daemon's own verdict as `platform_supported`
+  (§13.2).
+- A restricted workflow that does not match stays in the registry and is still
+  listed, with its reason — the same rule that keeps an invalid file visible
+  (§5.2). It is *offering* that stops: the TUI's new-task picker refuses it,
+  and `POST /v1/tasks` rejects it with a 400 naming the restriction and the
+  host.
+- A task already holding such a snapshot — a data directory carried to another
+  OS, or a workflow narrowed after the task was queued — is blocked at
+  admission with `platform_unsupported` (§18), before any step runs. That is
+  distinct from `invalid_snapshot`: the snapshot is valid, just not here.
+
+The restriction is **whole-workflow**. A per-step `platforms:` was considered
+and deferred: it needs an answer to "what does a skipped step do to `.Steps`
+and to the task's success", which is a lifecycle question, not a schema one.
+
 ### 8.2 Step types and fields
 
 Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
@@ -477,6 +514,10 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
 - `steps` non-empty; step ids unique; templates must parse; `type` known; durations
   parse as Go durations; `on_input` is `wait` or `deny`; unknown keys are errors
   (strict decoding) to catch typos.
+- `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
+  list is checked for *shape*, never against the validating host: a POSIX-only
+  workflow validates on a Windows CI runner exactly as it does on Linux, or
+  `vincent workflow validate` could not be a portable pre-commit check.
 - `agent` values must name a known adapter. Each step's resolved
   (agent, model, effort) triple (§8.6) is checked against that adapter's option
   catalog (§9.6). The rule is cross-catalog: a value present in the resolved
@@ -499,6 +540,8 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
 
 A step may pin `shell: sh | pwsh | cmd` explicitly. Cross-OS portability of command
 steps is the workflow author's responsibility; the spec makes no attempt to translate.
+*Amended 2026-08-16 (task 010):* an author who did not attempt it says so with
+`platforms:` (§8.1.1), which is enforced rather than translated.
 
 ### 8.4 Template context
 
@@ -1655,7 +1698,10 @@ DELETE /v1/projects/{id}                hard-deletes the project and its task hi
 
 GET    /v1/workflows?project_id=        merged registry view: built-in + global + that project's
                                         (shadowing applied); each entry:
-                                        { name, scope, project_id, file, description, steps[], errors[]?, warnings[]?, error? }
+                                        { name, scope, project_id, file, description, steps[],
+                                          platforms[]?, platform_supported, errors[]?, warnings[]?, error? }
+                                        platform_supported is this daemon's own verdict on the
+                                        entry's §8.1.1 restriction (task 010, added 2026-08-16)
 POST   /v1/workflows/validate           { yaml } → { valid, errors[], warnings[] }
 POST   /v1/resolve                      { workflow, project_id?, agent?, model?, effort?,
                                           title?, fields?, base_branch?, branch_name? } →
@@ -2277,6 +2323,7 @@ currently true to show (§15 view 6).
 | Agent stopped by a usage limit | *Added 2026-08-14 (task 003).* Where the adapter recognizes the wording, the attempt is recorded `interrupted` with reason `usage_limit`, consumes **no** retry (§7.2), and the task returns to `queued` with an admission hold (§11) — releasing its slot, so other work keeps running. The hold ends at the reset time the CLI reported, or `usage_limit_recheck_interval` after the stop when it reported none. Recovery is unattended: the scheduler re-admits and the step re-runs. The board says `queued` *with* its reason rather than `blocked` (§15). Where the adapter recognizes nothing — codex and cursor today (§9.1) — the run reads as `nonzero_exit`/`agent_error` exactly as before |
 | `effort` set on a step whose agent has no effort concept | Ignored by the adapter and documented as ignored (cursor, §9.7); a claude/codex effort value on a cursor step is already an §8.2 *error* — it belongs to another adapter's catalog |
 | `restricted` step on an adapter that cannot restrict on this OS | Step fails to start with `restricted_unsupported` (cursor on Windows, §9.7), under the retry policy → typically blocked. Never downgraded to full-auto, and deliberately *not* `agent_unavailable`: the CLI is installed and healthy, so "not found" would send the user to reinstall what is already there |
+| Workflow restricted to platforms this host is not | *Added 2026-08-16 (task 010).* Creation is refused with a `400` naming the restriction and the host (§8.1.1); the entry stays listed and says why, and the TUI's picker will not select it. A task that *already* holds such a snapshot — the data directory moved to another OS, or the workflow narrowed after the task was queued — blocks at admission with `platform_unsupported`, before a worktree or any step. Not `invalid_snapshot`: the snapshot is valid, just not here |
 | Runaway step output (agent or command) | Past `transcript_max_bytes` (§12.3) the process tree is killed and the attempt fails `transcript_limit`, under the retry policy. The line that trips the cap is written **whole** — a truncated line would turn a size failure into a parse failure for every later reader of the JSONL — and the partial transcript is kept with a closing `vincent.transcript_limit` annotation, because the lines that got there are what explain the runaway |
 | Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). DB rows are never deleted; retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |
 | Base branch doesn't exist | Task creation fails fast |

--- a/docs/tasks/010-workflow-platform-restrictions.md
+++ b/docs/tasks/010-workflow-platform-restrictions.md
@@ -1,0 +1,134 @@
+# 010 — Restricting a workflow to platforms
+
+**Status:** ✅ done (6/6) · **Opened:** 2026-08-16
+
+A workflow may now declare where it is allowed to run:
+
+```yaml
+name: posix-tools
+platforms: [posix]
+```
+
+On a host the list does not admit, the workflow stays visible but is never
+*offered*: the new-task picker refuses it, `POST /v1/tasks` rejects it with a
+400, and a task that somehow already carries such a snapshot blocks at
+admission with `platform_unsupported`.
+
+## The problem
+
+§8.3 has always said cross-OS portability of command steps is the author's
+responsibility, and vincent has always refused to translate between `/bin/sh`
+and `pwsh`. What it lacked was a way for an author to **say** they had not
+attempted it. A workflow built around `cat`, pipes and `test -f` was offered
+identically on Windows, where the only feedback was a task that ran, failed at
+its first command step, consumed its retries and blocked — a run-time discovery
+of a fact the author knew when they wrote the file.
+
+The same gap in reverse: a PowerShell-shaped workflow is just as broken on
+Linux, and nothing in the schema could express it.
+
+## Decisions
+
+### 1. The restriction is on the workflow, not on the step
+
+*2026-08-16.* One `platforms:` key at the top level, covering the whole file.
+
+**Beat:** a per-step `platforms:`, which is the more flexible design and the
+one that quietly changes the task lifecycle. A step that does not apply here is
+either skipped — and then `.Steps` has a hole, `{{.Steps.build.Result}}`
+renders nothing on one OS and something on another, and "did the task succeed"
+depends on how many steps were skipped — or it fails, which is exactly what the
+workflow-level restriction already achieves with none of that. That is a §6/§8.4
+question, not a schema one, and it is not worth answering for a feature whose
+motivating case ("this file is POSIX") is whole-file by nature.
+
+Deferred rather than rejected: if a real workflow turns up that is portable
+except for one step, the answer is likely two workflows, and the shadowing rule
+(§5.2) already makes a project-scoped host-specific copy cheap.
+
+### 2. `posix` is a token, and the only group token
+
+*2026-08-16.* The accepted set is `linux`, `darwin`, `windows` — GOOS values —
+plus `posix`, which matches every non-Windows host.
+
+The motivating sentence is "this needs a POSIX shell", and spelling that
+`[linux, darwin]` is both longer and *wrong on the machine that matters*: it
+excludes a host vincent builds for but the author did not enumerate. Defining
+`posix` as `GOOS != "windows"` rather than as a fixed list means a future
+platform inherits the right answer without touching any workflow file.
+
+No negation syntax (`!windows`), and no second group token. One group is what
+the problem needs; a second would start a taxonomy.
+
+**Tokens match exactly.** `macos`, `Linux` and `win` are validation errors, not
+near-misses that silently never match. That is the same rule every other enum
+in §8.2 follows, and the failure mode it avoids is the worst one available
+here: a restriction that appears to be set and admits nothing, or everything.
+
+### 3. The daemon decides, and clients report
+
+*2026-08-16.* `GET /v1/workflows` serves both `platforms[]` and
+`platform_supported` — the daemon's verdict on its own host. No client compares
+the list to its own `runtime.GOOS`.
+
+**Beat:** letting the TUI derive it, which is free today because the API is
+localhost-only (§13.1). It is free right up until it isn't, and the property
+worth keeping is the one PR L already established for §8.6 resolution: the
+process that would *run* the thing is the one that says whether it can. The
+client-side field is a `*bool` treating "absent" as "supported", so a `vincent`
+CLI talking to an older daemon degrades to today's behavior rather than
+declaring every workflow unrunnable.
+
+### 4. Unsupported means "not offered", never "not shown"
+
+*2026-08-16.* The entry stays in the registry, stays in `GET /v1/workflows`,
+stays in `vincent workflow ls` (status `unsupported`) and stays in the TUI's
+workflow view with the platforms it needs. Only *selection* stops.
+
+This is §5.2's existing rule for an invalid file, applied unchanged: a workflow
+that disappears when you look at it from the wrong machine looks like a
+workflow you lost, and the first thing a user would do is re-create it. The
+project-default picker goes one step further and keeps such a workflow
+*selectable*, because a project's default is repository configuration that may
+well be shared with hosts where it does run.
+
+### 5. A restricted snapshot blocks at admission, with its own reason
+
+*2026-08-16.* `platform_unsupported`, distinct from `invalid_snapshot`.
+
+Creation already refuses these, so the engine check is only reachable when the
+task and its host parted company — a data directory carried to another OS, or a
+workflow narrowed after the task was queued. Reporting it as `invalid_snapshot`
+would send the reader to look for a broken file that parses perfectly.
+
+## Tasks
+
+- [x] **010.1 — `platforms:` in the schema, with validation.** ✓ 2026-08-16
+  `Workflow.Platforms`, the four tokens, `SupportsPlatform`/`SupportsHost`/
+  `PlatformMismatch`, and §8.2 validation of unknown and duplicate tokens with
+  the offending index located in the source (`platforms[1]`).
+- [x] **010.2 — Registry and API.** ✓ 2026-08-16 `Entry.RunsHere`, plus
+  `platforms[]` and `platform_supported` on `GET /v1/workflows`.
+- [x] **010.3 — `POST /v1/tasks` refuses a workflow this host cannot run.**
+  ✓ 2026-08-16 400 naming both the restriction and the host.
+- [x] **010.4 — The engine blocks a restricted snapshot.** ✓ 2026-08-16
+  `platform_unsupported`, before the worktree and before any step run.
+- [x] **010.5 — Clients.** ✓ 2026-08-16 TUI: picker disables it with the
+  reason, the default selection skips it, `submit` refuses it locally, the
+  workflow view and the new-task summary say why. CLI: `workflow ls` gains a
+  `PLATFORMS` column and the `unsupported` status; `workflow validate` reports
+  the declared platforms without judging the host.
+- [x] **010.6 — Docs.** ✓ 2026-08-16 Spec §8.1.1 (new), §8.2, §8.3, §13.2 and
+  §18; the workflow-schema, api, cli, task-lifecycle, workflows-guide,
+  troubleshooting and Windows pages.
+
+## Verification
+
+- `go test ./...` green, including the new cases: platform matching (table,
+  every token against every GOOS), token validation and its source line,
+  snapshot round-trip through `Marshal`, the registry/API verdict, the task
+  creation 400, the engine's `platform_unsupported` block with **no** step run
+  recorded, and the two TUI paths (picker refusal, registry row).
+- The new tests pick their "foreign" platform from `runtime.GOOS`, so they
+  assert the same thing on all three CI legs rather than passing vacuously on
+  two of them.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -24,6 +24,7 @@ description of how the system actually behaves.
 | [007](007-release-please.md) | Release Please automation | ✅ done (6/6) |
 | [008](008-archive-branch-cleanup.md) | Archive cleanup: delete a branch with no commits past its base | ✅ done (7/7) |
 | [009](009-configurable-tasks-view.md) | A configurable tasks view, grouped by project then workflow | ✅ done (6/6) |
+| [010](010-workflow-platform-restrictions.md) | Restricting a workflow to platforms (`platforms:`) | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -323,6 +323,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("workflow %q is invalid: %s", workflowName, entry.Errors.Error()))
 		return
 	}
+	// Platform restriction (§8.1.1, task 010). Rejected at creation rather than
+	// at admission: a task that can never run should not reach the board, and
+	// the human asking for it is right here to be told why.
+	if mismatch := entry.Workflow.PlatformMismatch(workflow.HostPlatform()); mismatch != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("workflow %q cannot run here: %s", workflowName, mismatch))
+		return
+	}
 	baseBranch := project.DefaultBranch
 	if req.BaseBranch != nil && strings.TrimSpace(*req.BaseBranch) != "" {
 		baseBranch = strings.TrimSpace(*req.BaseBranch)

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -19,7 +19,13 @@ type workflowResponse struct {
 	File        string                 `json:"file,omitempty"`
 	Description string                 `json:"description"`
 	Steps       []workflowStepResponse `json:"steps"`
-	Errors      []workflow.Error       `json:"errors,omitempty"`
+	// Platforms is the §8.1.1 restriction as the file declares it; empty
+	// means the workflow runs anywhere. PlatformSupported is the daemon's verdict
+	// on its own host — the client never re-derives it, because the daemon is
+	// the process that would run the steps (task 010).
+	Platforms         []string         `json:"platforms,omitempty"`
+	PlatformSupported bool             `json:"platform_supported"`
+	Errors            []workflow.Error `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []workflow.Error `json:"warnings,omitempty"`
 	Error    *string          `json:"error"`
@@ -34,10 +40,11 @@ type workflowStepResponse struct {
 
 func toWorkflowResponse(e workflow.Entry) workflowResponse {
 	out := workflowResponse{
-		Name:  e.Name,
-		Scope: string(e.Scope),
-		File:  e.File,
-		Steps: []workflowStepResponse{},
+		Name:              e.Name,
+		Scope:             string(e.Scope),
+		File:              e.File,
+		Steps:             []workflowStepResponse{},
+		PlatformSupported: e.RunsHere(),
 	}
 	if e.ProjectID != 0 {
 		id := e.ProjectID
@@ -45,6 +52,7 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 	}
 	if e.Workflow != nil {
 		out.Description = e.Workflow.Description
+		out.Platforms = e.Workflow.Platforms
 		for _, st := range e.Workflow.Steps {
 			out.Steps = append(out.Steps, workflowStepResponse{
 				ID:    st.ID,

--- a/internal/api/workflows_test.go
+++ b/internal/api/workflows_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,7 +100,9 @@ type workflowEntryBody struct {
 		Type  string `json:"type"`
 		Agent string `json:"agent"`
 	} `json:"steps"`
-	Error *string `json:"error"`
+	Platforms         []string `json:"platforms"`
+	PlatformSupported bool     `json:"platform_supported"`
+	Error             *string  `json:"error"`
 }
 
 type workflowListBody struct {
@@ -181,6 +185,94 @@ func TestWorkflowListShowsBrokenEntry(t *testing.T) {
 	if broken.Error == nil {
 		t.Fatal("broken workflow has no error field")
 	}
+}
+
+// foreignPlatform names a platform this test process is not running on, so
+// the "restricted elsewhere" cases mean the same thing on all three CI legs.
+func foreignPlatform() string {
+	if runtime.GOOS == workflow.PlatformWindows {
+		return workflow.PlatformLinux
+	}
+	return workflow.PlatformWindows
+}
+
+// TestWorkflowListPlatformRestriction covers the §8.1 restriction as the
+// registry reports it: a workflow this host cannot run stays listed (it is
+// not broken, just not here) and says so, and one that names this host is
+// indistinguishable from an unrestricted entry (task 010).
+func TestWorkflowListPlatformRestriction(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "elsewhere",
+		"name: elsewhere\nplatforms: ["+foreignPlatform()+"]\n"+
+			"steps:\n  - {id: gate, type: manual, instructions: hi}\n")
+	writeWorkflowFile(t, h.globalDir, "here",
+		"name: here\nplatforms: ["+runtime.GOOS+"]\n"+
+			"steps:\n  - {id: gate, type: manual, instructions: hi}\n")
+	h.reg.ReloadGlobal()
+
+	list := decodeWorkflowList(t, mustGet(t, h, "/v1/workflows"))
+
+	elsewhere := findWorkflow(t, list, "elsewhere")
+	if elsewhere.Error != nil {
+		t.Errorf("a platform-restricted workflow is not invalid: %v", *elsewhere.Error)
+	}
+	if elsewhere.PlatformSupported {
+		t.Errorf("entry restricted to %q claims to run on %q", foreignPlatform(), runtime.GOOS)
+	}
+	if len(elsewhere.Platforms) != 1 || elsewhere.Platforms[0] != foreignPlatform() {
+		t.Errorf("platforms = %v, want [%s]", elsewhere.Platforms, foreignPlatform())
+	}
+
+	here := findWorkflow(t, list, "here")
+	if !here.PlatformSupported {
+		t.Errorf("entry restricted to %q does not run on it", runtime.GOOS)
+	}
+
+	adhoc := findWorkflow(t, list, "adhoc")
+	if !adhoc.PlatformSupported || len(adhoc.Platforms) != 0 {
+		t.Errorf("unrestricted built-in = %+v, want no platforms and supported", adhoc)
+	}
+}
+
+// TestTaskCreateRejectsForeignPlatform is the enforcement half: the entry is
+// listed, but a task naming it is refused here (§8.1, task 010).
+func TestTaskCreateRejectsForeignPlatform(t *testing.T) {
+	h := newWorkflowHarness(t)
+	repo := testrepo.Init(t, "main")
+	writeWorkflowFile(t, h.globalDir, "elsewhere",
+		"name: elsewhere\nplatforms: ["+foreignPlatform()+"]\n"+
+			"steps:\n  - {id: gate, type: manual, instructions: hi}\n")
+	h.reg.ReloadGlobal()
+	p := h.mustCreate(t, map[string]any{"path": repo})
+	id := int64(p["id"].(float64))
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": id, "title": "no", "workflow": "elsewhere",
+	})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	for _, want := range []string{"cannot run here", foreignPlatform(), runtime.GOOS} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("message %s missing %q", body, want)
+		}
+	}
+
+	// The unrestricted built-in still creates, so the check refuses the one
+	// workflow and not the endpoint.
+	resp, body = h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": id, "title": "yes", "workflow": workflow.AdhocName,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("adhoc task: %d %s", resp.StatusCode, body)
+	}
+}
+
+func mustGet(t *testing.T, h *workflowHarness, path string) []byte {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, path, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: %d %s", path, resp.StatusCode, body)
+	}
+	return body
 }
 
 func TestWorkflowListBadProjectID(t *testing.T) {

--- a/internal/apiclient/workflows.go
+++ b/internal/apiclient/workflows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // WorkflowEntry is one row of GET /v1/workflows (§13.2): the merged registry
@@ -17,6 +18,13 @@ type WorkflowEntry struct {
 	File        string              `json:"file,omitempty"`
 	Description string              `json:"description"`
 	Steps       []WorkflowEntryStep `json:"steps"`
+
+	// Platforms is the workflow's §8.1.1 platform restriction, empty when it
+	// runs anywhere. PlatformSupported is the daemon's verdict for its own
+	// host; nil means the daemon predates the field, which is
+	// indistinguishable from "unrestricted" and treated as such.
+	Platforms         []string `json:"platforms,omitempty"`
+	PlatformSupported *bool    `json:"platform_supported,omitempty"`
 
 	Errors []WorkflowFinding `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
@@ -45,6 +53,23 @@ type WorkflowFinding struct {
 // Valid reports whether this entry can back a task. An invalid entry is
 // listed for display only: POST /v1/tasks rejects it.
 func (e WorkflowEntry) Valid() bool { return len(e.Errors) == 0 }
+
+// RunsHere reports whether the daemon's host satisfies this workflow's
+// platform restriction (§8.1.1). A workflow that does not run here is listed
+// but cannot back a task: POST /v1/tasks rejects it the way it rejects an
+// invalid one.
+func (e WorkflowEntry) RunsHere() bool {
+	return e.PlatformSupported == nil || *e.PlatformSupported
+}
+
+// PlatformNote describes the restriction for one picker row: "needs linux,
+// darwin". It is empty when the workflow declares none.
+func (e WorkflowEntry) PlatformNote() string {
+	if len(e.Platforms) == 0 {
+		return ""
+	}
+	return "needs " + strings.Join(e.Platforms, ", ")
+}
 
 // FirstError returns the leading validation failure, which is what a picker
 // row has room for. It is empty for a valid entry.

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -54,16 +55,20 @@ func newWorkflowLsCmd() *cobra.Command {
 					switch {
 					case len(e.Errors) > 0 || e.Error != nil:
 						status = "invalid"
+					case !e.RunsHere():
+						// Ranked above warnings: a workflow this host cannot
+						// run is the more actionable fact about it (task 010).
+						status = "unsupported"
 					case len(e.Warnings) > 0:
 						status = "warnings"
 					}
 					rows = append(rows, []string{
-						e.Name, e.Scope, status,
-						strconv.Itoa(len(e.Steps)), dash(e.Description),
+						e.Name, e.Scope, status, strconv.Itoa(len(e.Steps)),
+						dash(strings.Join(e.Platforms, ",")), dash(e.Description),
 					})
 				}
 				return table(cmd.OutOrStdout(),
-					[]string{"NAME", "SCOPE", "STATUS", "STEPS", "DESCRIPTION"}, rows)
+					[]string{"NAME", "SCOPE", "STATUS", "STEPS", "PLATFORMS", "DESCRIPTION"}, rows)
 			})
 		},
 	}
@@ -77,12 +82,16 @@ func newWorkflowLsCmd() *cobra.Command {
 // API, and borrowing a server type would tie a local command to a remote
 // contract it never speaks.
 type validateResult struct {
-	File     string    `json:"file"`
-	Valid    bool      `json:"valid"`
-	Name     string    `json:"name,omitempty"`
-	Steps    int       `json:"steps"`
-	Errors   []finding `json:"errors"`
-	Warnings []finding `json:"warnings"`
+	File  string `json:"file"`
+	Valid bool   `json:"valid"`
+	Name  string `json:"name,omitempty"`
+	Steps int    `json:"steps"`
+	// Platforms is the §8.1.1 restriction the file declares. It is reported,
+	// never judged: validation is host-independent by design, so a POSIX-only
+	// workflow validates on a Windows CI runner exactly as it does on Linux.
+	Platforms []string  `json:"platforms,omitempty"`
+	Errors    []finding `json:"errors"`
+	Warnings  []finding `json:"warnings"`
 }
 
 type finding struct {
@@ -113,7 +122,7 @@ func newWorkflowValidateCmd() *cobra.Command {
 				Warnings: []finding{},
 			}
 			if wf != nil {
-				res.Name, res.Steps = wf.Name, len(wf.Steps)
+				res.Name, res.Steps, res.Platforms = wf.Name, len(wf.Steps), wf.Platforms
 			}
 			var errs workflow.Errors
 			if parseErr != nil {
@@ -161,8 +170,12 @@ func printValidation(cmd *cobra.Command, res validateResult) error {
 		_, err := fmt.Fprintf(out, "%s: invalid (%d error(s))\n", res.File, len(res.Errors))
 		return err
 	}
-	_, err := fmt.Fprintf(out, "%s: ok — %s, %d step(s), %d warning(s)\n",
-		res.File, res.Name, res.Steps, len(res.Warnings))
+	platforms := ""
+	if len(res.Platforms) > 0 {
+		platforms = fmt.Sprintf(", platforms: %s", strings.Join(res.Platforms, ", "))
+	}
+	_, err := fmt.Fprintf(out, "%s: ok — %s, %d step(s), %d warning(s)%s\n",
+		res.File, res.Name, res.Steps, len(res.Warnings), platforms)
 	return err
 }
 

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -3,6 +3,7 @@ package taskrun
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -59,7 +60,14 @@ const (
 	// The value of the reason is that it names the fix instead of sending the
 	// reader to a transcript.
 	ReasonAgentUnauthenticated = "agent_unauthenticated"
-	ReasonInternalError        = "internal_error"
+	// ReasonPlatformUnsupported is a snapshot whose `platforms:` list does not
+	// admit this host (§8.1.1, task 010). Task creation rejects that outright,
+	// so reaching it here means the task and its daemon parted company — a
+	// data directory carried to another OS, or a workflow edited to exclude
+	// this one after the task was queued. Distinct from invalid_snapshot: the
+	// snapshot is perfectly valid, just not here.
+	ReasonPlatformUnsupported = "platform_unsupported"
+	ReasonInternalError       = "internal_error"
 )
 
 // Durable event types the engine emits (spec §13.3). State changes emit
@@ -120,6 +128,14 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		// The snapshot validated at creation, so this is corruption or a
 		// vincent downgrade — either way the task cannot run.
 		r.fail(task, ReasonInvalidSnapshot, log, "parse workflow snapshot", err)
+		return
+	}
+	if mismatch := wf.PlatformMismatch(workflow.HostPlatform()); mismatch != "" {
+		// Creation refuses this (§8.1.1), so the task outlived the host it was
+		// created on. Blocking names the reason; the human moves it back or
+		// widens the workflow.
+		r.fail(task, ReasonPlatformUnsupported, log, "workflow platform restriction",
+			errors.New(mismatch))
 		return
 	}
 	if err := r.ensureWorktree(ctx, task, project, log); err != nil {

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -460,6 +460,31 @@ func TestEngineCommandTimeoutKills(t *testing.T) {
 	}
 }
 
+// TestEnginePlatformRestrictedSnapshotBlocks covers the §8.1 restriction on
+// the run path (task 010). The API refuses to create such a task here, so the
+// only way to hold one is to have moved the data directory to another OS —
+// which the fixture reproduces by inserting the snapshot directly.
+func TestEnginePlatformRestrictedSnapshotBlocks(t *testing.T) {
+	foreign := workflow.PlatformWindows
+	if runtime.GOOS == workflow.PlatformWindows {
+		foreign = workflow.PlatformLinux
+	}
+	h := newEngineHarness(t)
+	snapshot := "name: elsewhere\nplatforms: [" + foreign + "]\nsteps:\n" +
+		commandStep("noop", script("true", "Write-Output ok"))
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonPlatformUnsupported {
+		t.Fatalf("task = %s/%q, want blocked/%s",
+			blocked.State, blocked.BlockReason, ReasonPlatformUnsupported)
+	}
+	if runs := h.stepRuns(t, task.ID); len(runs) != 0 {
+		t.Errorf("step runs = %d, want none — the restriction is judged before any step", len(runs))
+	}
+}
+
 // TestEngineStepResultsFlowIntoTemplates covers §8.4's `.Steps`: a later
 // step reads an earlier step's result.
 func TestEngineStepResultsFlowIntoTemplates(t *testing.T) {

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -508,7 +508,7 @@ func (n *newTask) selectDefaultWorkflow() {
 		return
 	}
 	for _, e := range n.workflows {
-		if e.Valid() {
+		if e.Valid() && e.RunsHere() {
 			n.workflow = e.Name
 			return
 		}
@@ -736,8 +736,13 @@ func (n *newTask) submit() tea.Cmd {
 	if n.titleText() == "" {
 		n.rowErr[ntTitle] = "a title is required"
 	}
-	if e := n.workflowEntry(n.workflow); n.workflow != "" && e != nil && !e.Valid() {
-		n.rowErr[ntWorkflow] = "this workflow does not validate: " + e.FirstError()
+	if e := n.workflowEntry(n.workflow); n.workflow != "" && e != nil {
+		switch {
+		case !e.Valid():
+			n.rowErr[ntWorkflow] = "this workflow does not validate: " + e.FirstError()
+		case !e.RunsHere():
+			n.rowErr[ntWorkflow] = "this workflow does not run on this platform — it " + e.PlatformNote()
+		}
 	}
 	if len(n.rowErr) > 0 {
 		return nil

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -356,6 +356,55 @@ func TestNewTaskRefusesToSelectAnInvalidWorkflow(t *testing.T) {
 	}
 }
 
+// A workflow restricted to other platforms (§8.1, task 010) is listed with
+// the reason and refused, the way an invalid one is: the daemon would 400 it,
+// and "it vanished" is a worse answer than "it needs linux".
+func TestNewTaskRefusesAWorkflowThatDoesNotRunHere(t *testing.T) {
+	n := newNewTask()
+	no := false
+	n.update(ntLoadedMsg{
+		projects: []apiclient.Project{{ID: 1, Name: "vincent", DefaultBranch: "main"}},
+		workflows: []apiclient.WorkflowEntry{
+			{Name: "adhoc", Scope: "builtin"},
+			{
+				Name: "posix-tools", Scope: "global",
+				Platforms: []string{"linux", "darwin"}, PlatformSupported: &no,
+			},
+		},
+	})
+	// The default lands on a workflow that can actually run.
+	if n.workflow != "adhoc" {
+		t.Errorf("default workflow = %q, want the one that runs here", n.workflow)
+	}
+
+	var restricted pickerOption
+	for _, o := range n.workflowOptions() {
+		if o.value == "posix-tools" {
+			restricted = o
+		}
+	}
+	if restricted.value == "" {
+		t.Fatal("the restricted workflow is not listed at all")
+	}
+	if !restricted.disabled {
+		t.Error("the restricted workflow is selectable; create would 400")
+	}
+	if !strings.Contains(restricted.note, "linux, darwin") {
+		t.Errorf("note = %q, want the platforms it needs", restricted.note)
+	}
+
+	// Reaching it another way (a project default, say) still fails locally
+	// rather than travelling to the daemon.
+	n.workflow = "posix-tools"
+	n.titleIn.SetValue("something")
+	if cmd := n.submit(); cmd != nil {
+		t.Error("submit posted a task the daemon would refuse")
+	}
+	if got := n.rowErr[ntWorkflow]; !strings.Contains(got, "platform") {
+		t.Errorf("row error = %q, want it to name the platform restriction", got)
+	}
+}
+
 func TestNewTaskAgentSwitchResetsModelAndEffort(t *testing.T) {
 	n := loadedForm(t)
 	n.applyPick(ntAgent, "claude")

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -392,6 +392,12 @@ func (n *newTask) workflowOptions() []pickerOption {
 		if !e.Valid() {
 			opt.disabled = true
 			opt.note = "invalid: " + e.FirstError()
+		} else if !e.RunsHere() {
+			// Offered but not selectable: the workflow exists and the human
+			// may well be looking for it, so the row says why it is out of
+			// reach rather than vanishing (§8.1.1, task 010).
+			opt.disabled = true
+			opt.note = "not on this platform · " + e.PlatformNote()
 		} else if bad := n.unavailableSteps(e); len(bad) > 0 {
 			opt.note = fmt.Sprintf("%s · ⚠ %d step(s) need an unavailable agent", e.Scope, len(bad))
 		}

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -141,6 +141,9 @@ func (n *newTask) workflowSummary() string {
 	if !e.Valid() {
 		return out + "  " + styleBad.Render("✗ invalid")
 	}
+	if !e.RunsHere() {
+		return out + "  " + styleBad.Render("✗ "+e.PlatformNote())
+	}
 	if bad := n.unavailableSteps(*e); len(bad) > 0 {
 		out += "  " + styleWarn.Render(fmt.Sprintf("⚠ %d unavailable", len(bad)))
 	}

--- a/internal/tui/projectform.go
+++ b/internal/tui/projectform.go
@@ -314,6 +314,12 @@ func (f *projectForm) workflowOptions() []pickerOption {
 		if !e.Valid() {
 			opt.disabled = true
 			opt.note = "invalid: " + e.FirstError()
+		} else if !e.RunsHere() {
+			// Selectable, unlike in the new-task picker: a project's default
+			// is repository configuration that may well be shared with hosts
+			// where the workflow does run. It is only a task created *here*
+			// that the restriction refuses (task 010).
+			opt.note = e.Scope + " · ⚠ not on this platform, " + e.PlatformNote()
 		}
 		out = append(out, opt)
 	}

--- a/internal/tui/workflowrender.go
+++ b/internal/tui/workflowrender.go
@@ -78,6 +78,11 @@ func (w *workflowsView) renderLine(i int, line wfLine) string {
 	switch {
 	case !e.Valid():
 		parts = append(parts, styleBad.Render("invalid: "+e.FirstError()))
+	case !e.RunsHere():
+		// A platform-restricted workflow stays listed where the registry is
+		// browsed — "where did it go?" is a worse answer than "not here, and
+		// here is what it needs" (task 010).
+		parts = append(parts, styleWarn.Render("not on this platform · "+e.PlatformNote()))
 	case e.File == "":
 		parts = append(parts, styleDim.Render("built-in"))
 	case len(e.Warnings) > 0:
@@ -115,6 +120,14 @@ func (w *workflowsView) renderSteps(line wfLine) []string {
 	}
 	if e.File != "" {
 		out = append(out, styleDim.Render("      "+e.File))
+	}
+	if note := e.PlatformNote(); note != "" {
+		row := "      platforms: " + strings.TrimPrefix(note, "needs ")
+		if e.RunsHere() {
+			out = append(out, styleDim.Render(row))
+		} else {
+			out = append(out, styleWarn.Render(row+" — not this one"))
+		}
 	}
 	for _, f := range e.Errors {
 		out = append(out, styleBad.Render("      ⚠ "+findingText(f)))

--- a/internal/tui/workflows_test.go
+++ b/internal/tui/workflows_test.go
@@ -128,6 +128,27 @@ func TestWorkflowsRenderABrokenEntryInPlace(t *testing.T) {
 	}
 }
 
+// A workflow this host cannot run (§8.1, task 010) is listed like any other,
+// with the platforms it needs — the registry view is where a human goes to
+// find out why a workflow is missing from the new-task picker.
+func TestWorkflowsRenderAPlatformRestrictedEntry(t *testing.T) {
+	e := globalEntry("posix-tools")
+	no := false
+	e.Platforms, e.PlatformSupported = []string{"linux", "darwin"}, &no
+	w := newWorkflowsView()
+	loadedWorkflows(w, wfBlock{name: "global", entries: []apiclient.WorkflowEntry{e}})
+	out := w.render(120, 24)
+	if !strings.Contains(out, "posix-tools") {
+		t.Fatalf("render = %q, want the restricted entry listed", out)
+	}
+	if !strings.Contains(out, "not on this platform") {
+		t.Errorf("render = %q, want the restriction stated", out)
+	}
+	if !strings.Contains(out, "linux, darwin") {
+		t.Errorf("render = %q, want the platforms it needs", out)
+	}
+}
+
 // One unreadable project degrades its own block and nothing else.
 func TestWorkflowsIsolateAFailedProjectFetch(t *testing.T) {
 	w := newWorkflowsView()

--- a/internal/workflow/platform.go
+++ b/internal/workflow/platform.go
@@ -1,0 +1,103 @@
+package workflow
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// Platform tokens a workflow's `platforms:` list may carry (spec §8.1.1).
+// They are Go's GOOS values, plus one group token: a workflow whose command
+// steps lean on `sh`, `cat` and friends says `posix` rather than enumerating
+// every Unix vincent might ever run on.
+const (
+	PlatformLinux   = "linux"
+	PlatformDarwin  = "darwin"
+	PlatformWindows = "windows"
+	// PlatformPosix matches every non-Windows host — the set where a POSIX
+	// shell and the usual coreutils are a safe assumption.
+	PlatformPosix = "posix"
+)
+
+// platformTokens is the accepted set, in the order error messages list it.
+var platformTokens = []string{PlatformLinux, PlatformDarwin, PlatformWindows, PlatformPosix}
+
+// HostPlatform is the GOOS of the machine this process runs on. It is the
+// platform every restriction is judged against: the daemon is the only thing
+// that runs a workflow, and clients speak to it over localhost (§13.1).
+func HostPlatform() string { return runtime.GOOS }
+
+// SupportsPlatform reports whether the workflow may run on the given GOOS.
+// An empty `platforms:` list means every platform, which is why the field is
+// optional and why nothing changes for a workflow that omits it (§8.1.1).
+func (w *Workflow) SupportsPlatform(goos string) bool {
+	if w == nil || len(w.Platforms) == 0 {
+		return true
+	}
+	for _, p := range w.Platforms {
+		if platformMatches(p, goos) {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportsHost is SupportsPlatform for the host this process runs on.
+func (w *Workflow) SupportsHost() bool { return w.SupportsPlatform(HostPlatform()) }
+
+// PlatformSummary renders the restriction for a human: "linux, darwin". It is
+// empty for an unrestricted workflow.
+func (w *Workflow) PlatformSummary() string {
+	if w == nil {
+		return ""
+	}
+	return strings.Join(w.Platforms, ", ")
+}
+
+// PlatformMismatch explains why the workflow cannot run on goos, in one
+// clause the API's 400 and the engine's failure both embed. It is empty when
+// the workflow does run there, so callers branch on the string.
+func (w *Workflow) PlatformMismatch(goos string) string {
+	if w.SupportsPlatform(goos) {
+		return ""
+	}
+	return fmt.Sprintf("workflow is restricted to %s and this host is %s",
+		w.PlatformSummary(), goos)
+}
+
+// platformMatches resolves one token against a GOOS. Only `posix` covers more
+// than itself; every other token is a GOOS compared literally.
+func platformMatches(token, goos string) bool {
+	if token == PlatformPosix {
+		return goos != PlatformWindows
+	}
+	return token == goos
+}
+
+func isPlatform(s string) bool {
+	for _, p := range platformTokens {
+		if s == p {
+			return true
+		}
+	}
+	return false
+}
+
+// validatePlatforms checks the `platforms:` list (§8.1.1, §8.2). Tokens are
+// matched exactly, the way every other enum in the schema is: `Linux` or
+// `macos` is a typo that fails at load rather than a restriction that silently
+// never matched.
+func validatePlatforms(wf *Workflow, add func(string, string, ...any)) {
+	seen := make(map[string]bool, len(wf.Platforms))
+	for i, p := range wf.Platforms {
+		path := fmt.Sprintf("platforms[%d]", i)
+		switch {
+		case !isPlatform(p):
+			add(path, "unknown platform %q (one of %s)", p, strings.Join(platformTokens, ", "))
+		case seen[p]:
+			add(path, "duplicate platform %q", p)
+		default:
+			seen[p] = true
+		}
+	}
+}

--- a/internal/workflow/platform_test.go
+++ b/internal/workflow/platform_test.go
@@ -1,0 +1,160 @@
+package workflow
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const platformSource = `name: posix-tools
+platforms: [posix]
+steps:
+  - id: report
+    type: command
+    run: cat README.md | wc -l
+`
+
+func TestParsePlatforms(t *testing.T) {
+	wf, _, err := Parse([]byte(platformSource), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(wf.Platforms) != 1 || wf.Platforms[0] != PlatformPosix {
+		t.Fatalf("platforms = %v, want [posix]", wf.Platforms)
+	}
+	if got := wf.PlatformSummary(); got != "posix" {
+		t.Errorf("PlatformSummary = %q, want posix", got)
+	}
+}
+
+func TestSupportsPlatform(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms []string
+		goos      string
+		want      bool
+	}{
+		{"unrestricted runs anywhere", nil, "windows", true},
+		{"empty list runs anywhere", []string{}, "windows", true},
+		{"posix admits linux", []string{PlatformPosix}, "linux", true},
+		{"posix admits darwin", []string{PlatformPosix}, "darwin", true},
+		{"posix admits an unlisted unix", []string{PlatformPosix}, "freebsd", true},
+		{"posix refuses windows", []string{PlatformPosix}, "windows", false},
+		{"explicit pair admits a member", []string{"linux", "darwin"}, "darwin", true},
+		{"explicit pair refuses a stranger", []string{"linux", "darwin"}, "windows", false},
+		{"windows-only refuses linux", []string{PlatformWindows}, "linux", false},
+		{"mixed list admits either side", []string{PlatformPosix, PlatformWindows}, "windows", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := &Workflow{Platforms: tc.platforms}
+			if got := wf.SupportsPlatform(tc.goos); got != tc.want {
+				t.Errorf("SupportsPlatform(%q) with %v = %v, want %v",
+					tc.goos, tc.platforms, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSupportsHostMatchesRuntime(t *testing.T) {
+	wf := &Workflow{Platforms: []string{runtime.GOOS}}
+	if !wf.SupportsHost() {
+		t.Errorf("a workflow naming %q does not support its own host", runtime.GOOS)
+	}
+	if HostPlatform() != runtime.GOOS {
+		t.Errorf("HostPlatform = %q, want %q", HostPlatform(), runtime.GOOS)
+	}
+}
+
+func TestPlatformMismatch(t *testing.T) {
+	wf := &Workflow{Platforms: []string{PlatformLinux, PlatformDarwin}}
+	if got := wf.PlatformMismatch("linux"); got != "" {
+		t.Errorf("PlatformMismatch on a supported host = %q, want empty", got)
+	}
+	got := wf.PlatformMismatch("windows")
+	for _, want := range []string{"linux, darwin", "windows"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PlatformMismatch = %q, want it to mention %q", got, want)
+		}
+	}
+}
+
+func TestValidatePlatformsRejectsUnknownTokens(t *testing.T) {
+	src := `name: broken
+platforms: [linux, macos]
+steps:
+  - id: s
+    type: command
+    run: echo hi
+`
+	_, _, err := Parse([]byte(src), Options{})
+	var errs Errors
+	if !asErrors(err, &errs) {
+		t.Fatalf("Parse = %v, want validation errors", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("errors = %v, want exactly one", errs)
+	}
+	if errs[0].Path != "platforms[1]" || !strings.Contains(errs[0].Message, `unknown platform "macos"`) {
+		t.Errorf("error = %+v, want the unknown token located at platforms[1]", errs[0])
+	}
+	if errs[0].Line != 2 {
+		t.Errorf("error line = %d, want 2 — the platforms list", errs[0].Line)
+	}
+}
+
+func TestValidatePlatformsRejectsDuplicates(t *testing.T) {
+	src := `name: dup
+platforms: [linux, linux]
+steps:
+  - id: s
+    type: command
+    run: echo hi
+`
+	_, _, err := Parse([]byte(src), Options{})
+	var errs Errors
+	if !asErrors(err, &errs) {
+		t.Fatalf("Parse = %v, want validation errors", err)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Message, `duplicate platform "linux"`) {
+		t.Fatalf("errors = %v, want one duplicate-platform error", errs)
+	}
+}
+
+// A restriction survives the snapshot round-trip, which is what `edit + retry`
+// rewrites and what the engine re-reads at admission (§5.3).
+func TestMarshalKeepsPlatforms(t *testing.T) {
+	wf, _, err := Parse([]byte(platformSource), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	back, _, err := Parse(out, Options{})
+	if err != nil {
+		t.Fatalf("re-parse: %v\n%s", err, out)
+	}
+	if len(back.Platforms) != 1 || back.Platforms[0] != PlatformPosix {
+		t.Errorf("platforms after round-trip = %v, want [posix]", back.Platforms)
+	}
+}
+
+func TestEntryRunsHere(t *testing.T) {
+	other := PlatformWindows
+	if runtime.GOOS == PlatformWindows {
+		other = PlatformLinux
+	}
+	if e := (Entry{Workflow: &Workflow{Platforms: []string{other}}}); e.RunsHere() {
+		t.Errorf("entry restricted to %q claims to run on %q", other, runtime.GOOS)
+	}
+	if e := (Entry{Workflow: &Workflow{}}); !e.RunsHere() {
+		t.Error("unrestricted entry does not run here")
+	}
+	// An unparsed entry is rejected for its errors, not for a platform it
+	// never got to declare.
+	if e := (Entry{Errors: Errors{{Message: "boom"}}}); !e.RunsHere() {
+		t.Error("invalid entry should not also claim a platform mismatch")
+	}
+}

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -51,6 +51,12 @@ type Entry struct {
 // Valid reports whether the entry parsed and validated.
 func (e Entry) Valid() bool { return e.Workflow != nil }
 
+// RunsHere reports whether the entry's `platforms:` restriction (§8.1.1) admits
+// this host. An entry that failed to parse answers true: its errors are
+// already the reason it cannot back a task, and a second one would only make
+// the message wrong.
+func (e Entry) RunsHere() bool { return e.Workflow == nil || e.Workflow.SupportsHost() }
+
 // Registry holds the parsed workflows of every scope and reloads them when
 // their files change (§5.2).
 type Registry struct {

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -45,10 +45,13 @@ const (
 
 // Workflow is a parsed workflow definition (spec §8.1).
 type Workflow struct {
-	Name        string   `yaml:"name"`
-	Description string   `yaml:"description"`
-	Defaults    Defaults `yaml:"defaults"`
-	Steps       []Step   `yaml:"steps"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	// Platforms restricts where the workflow may run (§8.1.1, task 010).
+	// Empty means every platform; see platform.go for the token set.
+	Platforms []string `yaml:"platforms,omitempty"`
+	Defaults  Defaults `yaml:"defaults"`
+	Steps     []Step   `yaml:"steps"`
 }
 
 // Defaults are the workflow-level fallbacks for step fields. Pointer fields
@@ -210,6 +213,7 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 	} else if strings.ContainsAny(wf.Name, " \t/\\") {
 		add("name", "name %q must not contain whitespace or path separators", wf.Name)
 	}
+	validatePlatforms(wf, add)
 	validateDefaults(wf, opts, add)
 
 	if len(wf.Steps) == 0 {

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -7,11 +7,12 @@
 # load (scenario 3), that branch naming and its recovery path hold (scenario
 # 4), that an agent usage limit re-queues rather than blocks and recovers
 # unattended (scenario 5), and that archiving deletes a branch that carries no
-# commits past its base while keeping every branch that does (scenario 6). Runs
-# against the committed fakeagent so CI never calls a real API; run manually
-# with VINCENT_GATE_AGENT=claude to exercise the real CLI (scenario 1 only —
-# killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1|2|3|4|5|6 runs a single scenario for debugging.
+# commits past its base while keeping every branch that does (scenario 6), and
+# that a workflow restricted to other platforms is listed but never offered here
+# (scenario 7). Runs against the committed fakeagent so CI never calls a real
+# API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
+# (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
+# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -783,6 +784,81 @@ EOF
   echo "=== scenario 6 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 7 — a workflow restricted to other platforms (§8.1.1, task 010) is
+# listed with the daemon's verdict, refused at task creation, and does not
+# stop the same registry serving a workflow that does run here. The "foreign"
+# platform is chosen from the host, so this asserts the same thing on all
+# three CI legs instead of passing vacuously on two of them.
+# ---------------------------------------------------------------------------
+scenario7() {
+  echo "=== scenario 7: platform-restricted workflows are listed, not offered"
+  scenario_dirs s7
+
+  local here foreign
+  if [[ "${OS:-}" == "Windows_NT" ]]; then here=windows; foreign=posix; else here=posix; foreign=windows; fi
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-elsewhere.yaml" <<EOF
+name: m2-elsewhere
+description: M2 gate — restricted to a platform this host is not.
+platforms: [$foreign]
+steps:
+  - id: gate
+    type: manual
+    instructions: never reached
+EOF
+  cat > "$CONFIG_DIR/workflows/m2-here.yaml" <<EOF
+name: m2-here
+description: M2 gate — restricted to this very host.
+platforms: [$here]
+steps:
+  - id: nap
+    type: command
+    run: sleep 1
+EOF
+
+  daemon_up
+
+  local repo="$TMP/s7/repo" proj list
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  echo "== the registry lists both, with the daemon's own verdict on each"
+  list="$(api GET "/workflows?project_id=$proj")"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-elsewhere") | .platform_supported' <<<"$list")" == "false" ]] \
+    || fail "the foreign-platform workflow is not marked unsupported: $list"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-elsewhere") | .platforms[0]' <<<"$list")" == "$foreign" ]] \
+    || fail "the entry does not carry its platforms: $list"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-elsewhere") | .error' <<<"$list")" == "null" ]] \
+    || fail "a platform restriction was reported as a validation error: $list"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-here") | .platform_supported' <<<"$list")" == "true" ]] \
+    || fail "a workflow naming this host is not supported on it: $list"
+
+  echo "== creating a task on it is refused with 400"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d "{\"project_id\":$proj,\"workflow\":\"m2-elsewhere\",\"title\":\"Nope\"}" \
+    "$BASE/tasks")"
+  [[ "$status" == "400" ]] \
+    || fail "a workflow this host cannot run should be 400 at creation, got $status"
+
+  echo "== the workflow restricted to this host runs to completion"
+  local ok
+  ok="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-here\",\"title\":\"Yes\"}" | jq -r .id)"
+  wait_for_state "$ok" done 90
+
+  "$VINCENT" daemon stop
+  echo "=== scenario 7 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -795,7 +871,8 @@ case "$WHICH" in
   4) scenario4 ;;
   5) scenario5 ;;
   6) scenario6 ;;
-  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6 ;;
+  7) scenario7 ;;
+  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
A workflow may now declare where it is allowed to run:

    name: posix-tools
    platforms: [posix]        # or [linux, darwin], [windows], …

§8.3 has always left cross-OS portability of command steps to the author
and refused to translate between /bin/sh and pwsh; what was missing was a
way to *say* the attempt was not made. A workflow built on `cat`, pipes
and `test -f` was offered identically on Windows, where the only feedback
was a task that ran, failed at its first command step, burned its retries
and blocked.

Tokens are GOOS values — linux, darwin, windows — plus `posix`, which
matches every non-Windows host. Matching is exact, so `macos` is a
validation error rather than a restriction that silently never matches.
Omitting the key means "runs anywhere", which is unchanged behaviour for
every existing file.

On a host the list does not admit, the workflow stays *listed* — the §5.2
rule that keeps a broken file visible — but is never *offered*:

- GET /v1/workflows carries `platforms[]` and `platform_supported`, the
  daemon's own verdict, so no client re-derives it;
- POST /v1/tasks rejects it with a 400 naming the restriction and the host;
- the TUI picker disables it with the reason, the default selection skips
  it, and the workflow view says what it needs;
- `vincent workflow ls` gains a PLATFORMS column and an `unsupported`
  status; `workflow validate` reports the platforms without judging the
  host, so a POSIX workflow validates the same on a Windows CI runner;
- a task already holding such a snapshot — a data directory carried to
  another OS — blocks at admission with `platform_unsupported`, before a
  worktree or any step run.

Spec §8.1.1 is new; §8.2, §8.3, §13.2 and §18 amended in place. m2-gate
scenario 7 proves the listing, the 400 and an admitted workflow end to
end against a real daemon, picking its "foreign" platform from the host
so all three CI legs assert the same thing.

closes 010.1, 010.2, 010.3, 010.4, 010.5, 010.6