### PR TITLE
feat(tui): select several tasks for one bulk action

### DIFF
--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -11,6 +11,7 @@ vincent          # opens the TUI
 - [The first run](#the-first-run)
 - [Layout](#layout)
 - [The board](#the-board)
+- [Acting on several tasks at once](#acting-on-several-tasks-at-once)
 - [Task detail](#task-detail)
 - [Answering a question](#answering-a-question)
 - [The takeover screens](#the-takeover-screens)
@@ -51,8 +52,8 @@ timeline and the output pane with it. `tab` moves focus between panels;
 `shift+tab` goes back.
 
 The other four views — new task, projects, workflows, daemon — are full-screen
-takeovers. `esc` closes one layer at a time (popup → screen → filter) and
-**never quits**.
+takeovers. `esc` closes one layer at a time (popup → screen → selection →
+filter) and **never quits**.
 
 ## The board
 
@@ -76,6 +77,12 @@ Three behaviors matter:
 
 `/` filters by id, title, project or state; `tab` commits the filter, `esc`
 clears it.
+
+Elapsed on the board is **wall clock** from the task's start. That is
+deliberate: a task idle on a human for 35 of its 40 minutes must not read as
+"5m" on the board whose job is to flag it. The per-attempt figures in the
+timeline are the other measure — active time, with the excluded wait shown
+beside it rather than silently subtracted.
 
 ### Grouping
 
@@ -110,11 +117,46 @@ Set the grouping you start with in `config.yaml`
 ([`tui.board.group_by`](../reference/configuration.md#tuiboardgroup_by)); `[]`
 gives you one flat list.
 
-Elapsed on the board is **wall clock** from the task's start. That is
-deliberate: a task idle on a human for 35 of its 40 minutes must not read as
-"5m" on the board whose job is to flag it. The per-attempt figures in the
-timeline are the other measure — active time, with the excluded wait shown
-beside it rather than silently subtracted.
+### Acting on several tasks at once
+
+Archiving yesterday's finished work one row at a time is the same keypress ten
+times with a confirmation between each. Select the tasks instead:
+
+| Key | Does |
+|---|---|
+| `space` | Select the task under the cursor (again deselects) |
+| `V` | Select every task the filter is showing — or clear that selection |
+| `esc` | Clear the selection |
+
+While anything is selected, a `✓` appears beside those rows, the panel title
+counts them (`Tasks — 5 selected`), and the **action keys act on the whole
+selection**:
+
+```
+ A archive (5) · c cancel (2)          archive · 5 of 5 · 3 branches deleted
+```
+
+The count beside each key is how many of the selected tasks that action can
+actually move — an action shows up when *some* selected task accepts it, and the
+ones that do not are left alone. So a selection holding four finished tasks and
+one still running offers `A archive (4)`, and the running one stays where it is.
+
+The rest of the behavior follows from what a selection is:
+
+- **It is a set of tasks, not of rows.** Filtering, regrouping and refreshing do
+  not change it — that is why the count is in the title, so a selected task the
+  filter is hiding still says it is coming along.
+- **One confirmation for the batch.** `A` asks once, about all of them. Behind
+  the scenes vincent sends one ordinary action per task, so the daemon sees
+  nothing special; you get one line back: how many moved, and the first refusal
+  named if any refused.
+- **Uncommitted changes still re-prompt.** A bulk archive archives the clean
+  worktrees and asks again about only the dirty ones —
+  `2 of 5 selected tasks have uncommitted changes`.
+- **What succeeded leaves the selection; what failed stays in it**, so a retry
+  needs no re-selecting.
+- **The keys work from any panel.** Whatever has focus, the footer is counting
+  the selection, so that is what `A` acts on.
 
 ## Task detail
 
@@ -168,7 +210,9 @@ activate the tab and on an explicit refresh, never on every output chunk.
 ### The action bar
 
 Below the panes, the action bar shows **exactly the actions valid in the
-current state** — the daemon computes that list, the TUI renders it.
+current state** — the daemon computes that list, the TUI renders it. With tasks
+selected on the board it acts on all of them; see
+[Acting on several tasks at once](#acting-on-several-tasks-at-once).
 
 | Key | Action | Valid from |
 |---|---|---|
@@ -307,7 +351,7 @@ Global bindings — active whenever the focused surface is not capturing text:
 | `!` | Jump to the next task needing a human |
 | `n` | New task |
 | `M` | Toggle the mouse |
-| `esc` | Close one layer: popup → screen → filter — never quits |
+| `esc` | Close one layer: popup → screen → selection → filter — never quits |
 | `q` | Quit the TUI (the daemon keeps running) |
 | `ctrl+c` | Quit |
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1990,6 +1990,10 @@ stream for the live tail.
    headers — projects, and the workflows of a project inside it — configured by
    `tui.board.group_by` (§12.3) and cycled for the session with `g`. See
    *Grouping* below.
+   **Several tasks can be selected at once (task 011, added 2026-08-16):**
+   `space` marks the row under the cursor, `V` marks everything the filter is
+   showing, and while anything is marked the task-action keys act on the whole
+   selection. See *Bulk selection* below.
 2. **Task detail.** Step timeline (every attempt, with durations, tokens, cost);
    live output tail of the running step (follow mode); scrollback into full
    transcripts of past steps. Timeline and output are **side by side, both always
@@ -2103,6 +2107,39 @@ get to bend:
 - **The panel title names the grouping only when it is not the configured one**,
   the same rule the output pane's `v` follows.
 
+**Bulk selection (task 011, added 2026-08-16).** Triage arrives in batches — a
+sweep of finished tasks to archive, a run of queued ones to cancel after a bad
+workflow edit — and one row at a time that is the same keypress N times with a
+confirmation between each, which is where a human either stops tidying up or
+stops reading the confirmations. `space` marks the row under the cursor, `V`
+marks (and unmarks) everything the filter is showing, `esc` clears the
+selection, and while anything is marked the §6 action keys act on the marked
+tasks instead of the cursor row. The rules:
+
+- **The selection is a set of tasks, not of rows.** It survives a filter, a `g`
+  regroup and a refresh, because all three are ways of *looking* at the board;
+  narrowing it to what is visible would mean typing a filter silently changes
+  what a confirmed archive destroys. The panel title carries the count
+  (`Tasks — 5 selected`), which is what keeps a marked task the filter is hiding
+  honest, and a marker column — one cell, present only while something is marked
+  — carries the per-row glyph.
+- **An action is offered when *some* marked task offers it, and the key carries
+  the count**: `A archive (7)` on nine marked rows. Requiring all of them would
+  make `archive` vanish from a sweep of finished work because one task in it is
+  still running, with nothing on screen to explain the absence. Tasks that do not
+  offer the action are left alone; the invariant is "an action that cannot happen
+  is not on screen", and one that can happen to seven of nine can happen.
+- **One confirmation for the batch, one call per task.** There is no bulk
+  endpoint: §6 lives in the API and the TUI is one of three clients, so the
+  daemon still sees an ordinary action per task, sent sequentially in board
+  order. `force` stays the dirty confirmation — a bulk archive archives the clean
+  worktrees and re-asks about exactly the refusals ("2 of 5 selected tasks have
+  uncommitted changes") — and the batch reports one line: `archive · 5 of 7`,
+  the branch cleanup, and the first refusal named.
+- **The keys work from any panel**, since the footer counts the selection
+  wherever the focus is, and **what the daemon accepted leaves the selection**
+  while refusals stay marked, so a retry needs no re-selection.
+
 **The focused panel expands; the others collapse** to their title bar plus the
 selected line. The task table never collapses below 5 rows — it is the navigation
 spine, and a spine you cannot see is a modal round-trip wearing a border.
@@ -2176,8 +2213,9 @@ Global: `:` palette · `?` help · `n` new task · `q` quit (the daemon keeps ru
 a status line reminds of the running task count on exit) · `tab`/`shift+tab` move
 focus between panels · `M` toggle mouse.
 
-Task actions act on the selected task and are offered only when the daemon reports
-them in `available_actions`: `p` pause/resume · `a` approve · `x` reject · `r`
+Task actions act on the selected task — or on the whole bulk selection when there
+is one (task 011) — and are offered only when the daemon reports them in
+`available_actions`: `p` pause/resume · `a` approve · `x` reject · `r`
 retry · `s` skip · `E` edit+retry in `$EDITOR` · `c` cancel · `A` archive. `x`
 rejects because `r` is taken; `r` doubles as *retry connecting* while disconnected,
 where no task is reachable anyway. Destructive actions confirm inline: `c` kills a
@@ -2187,7 +2225,10 @@ live process, `A` removes the worktree and a dirty one re-prompts for `force`.
 Panel-local: `/` filters **whichever list has focus** — tasks, projects, workflows
 — so one key means one thing everywhere. `g` cycles the task table's grouping
 (task 009), taking the key from the table widget's undocumented go-to-top alias,
-which `home` still is. `enter` opens or expands. `[`/`]` switch
+which `home` still is. `space` marks the row for a bulk action and `V` marks
+every row the filter is showing (task 011); neither moves the cursor, because
+marking a run of rows is the human's own `down` and auto-advancing would put an
+unmarking mis-press on the wrong row. `enter` opens or expands. `[`/`]` switch
 the output pane's tabs (`d` kept as an alias). `f`/`G` re-arm follow on a live
 tail or the daemon log. `v` cycles how much of the output pane's records show —
 compact → normal → verbose (T4.16): reasoning is hidden, truncated to its first
@@ -2202,7 +2243,8 @@ human, surfaced in the footer only when that count is non-zero — the board has
 always pinned and belled those tasks without offering any way to *go* to one.
 
 **`esc` cancels one layer per press**, by a fixed stack: popup (palette,
-confirmation, answer form) → takeover screen → active filter → nothing. It is a
+confirmation, answer form) → takeover screen → bulk selection → active filter →
+nothing. It is a
 no-op at the bottom and it **never quits** — `esc`-to-exit surprises anyone who
 pressed it meaning "back". "Back to the board" is not among its meanings any more,
 because the board is always on screen.

--- a/docs/tasks/011-bulk-task-selection.md
+++ b/docs/tasks/011-bulk-task-selection.md
@@ -1,0 +1,96 @@
+# 011 — Selecting several tasks for one action
+
+Status: **done** (5/5)
+
+The board is where triage happens, and triage arrives in batches: a sweep of
+finished tasks to archive after a morning's work, a run of queued ones to cancel
+after a bad workflow edit. Today every §6 action acts on exactly the row under
+the cursor, so a batch is the same keypress N times with a confirmation between
+each — which is where a human either stops tidying up, or stops reading the
+confirmations. Both outcomes are worse than the keystrokes saved.
+
+This adds a **selection** to the task table: `space` marks the row under the
+cursor, `V` marks everything the filter is showing, and while anything is marked
+the §6 action keys act on the whole set instead of the cursor row.
+
+## Decisions
+
+- **The selection is a set of tasks, not of rows** *(2026-08-16)*. It survives a
+  filter, a `g` regroup and a refresh, because all three are ways of *looking* at
+  the board rather than statements about what was chosen. The alternative —
+  narrowing the selection to what is currently visible — means typing a filter
+  silently changes what a confirmed archive will destroy, which is the one thing
+  a bulk action must never do. The count in the panel title (`Tasks — 5
+  selected`) is what keeps a marked-but-hidden task honest.
+- **An action is offered when *some* marked task offers it, and the key carries
+  the count** *(2026-08-16)*. `A archive (7)` on nine marked rows says both that
+  the key works and that two rows will not move. Requiring *every* marked task to
+  offer the action — the other candidate — would make `archive` vanish from a
+  sweep of finished work because one task in it is still running, with nothing on
+  screen to explain the absence. Tasks that do not offer the action are left
+  alone; the invariant §15 actually holds is "an action that cannot happen is not
+  on screen", and one that can happen to seven of nine can happen.
+- **One call per task, sequentially, from the client** *(2026-08-16)*. No bulk
+  endpoint: §6 lives in the API and the TUI is one of three clients, so a second
+  definition of what `archive` means is a second thing to keep in step. Sequential
+  rather than concurrent because N parallel archives are N worktree removals
+  racing the scheduler for the slots they free, and because the report a human
+  reads afterwards ("5 of 7") has to be built from outcomes that actually
+  happened. Each call keeps the single-action timeout; the batch as a whole is not
+  bounded, since a batch cut off halfway leaves no account of which half.
+- **`force` stays the dirty confirmation, in bulk too** *(2026-08-16)*. A bulk
+  archive that meets dirty worktrees archives the clean ones and re-asks about
+  exactly the refusals — "2 of 5 selected tasks have uncommitted changes" — the
+  same second ask a single archive already makes (§6). The alternative, failing
+  the whole batch, would make the common case (one dirty task among six) require
+  finding and de-selecting it.
+- **The selection keeps what failed** *(2026-08-16)*. Tasks the daemon accepted
+  are unmarked when the result lands; refusals stay marked, so a retry needs no
+  re-selection and the rows still on screen are the ones still to deal with.
+- **Bulk keys work from any panel** *(2026-08-16)*. The footer counts the marked
+  tasks wherever the eye is, so the shell routes action keys at the selection
+  before the focused panel sees them — otherwise `A` over the output pane would
+  archive the one task the detail panels happen to be showing while the footer
+  promised seven.
+- **`esc` clears the selection before the filter** *(2026-08-16)*, one layer per
+  press, innermost first — the selection is the more recent thing in the flow
+  that builds it.
+
+## Tasks
+
+- [x] **011.1** The selection itself: `markSet` on the board, `space` toggling
+  the cursor row, `V` marking (and unmarking) everything the filter shows, `esc`
+  clearing it, marks pruned to tasks the daemon still lists.
+  *Done when:* the set survives a refresh that reorders rows and a regroup, and a
+  task the daemon dropped leaves the set with it. ✓ 2026-08-16 —
+  `TestMarksSurviveARefreshThatReorders`,
+  `TestMarksArePrunedForTasksTheDaemonDropped`,
+  `TestMarkVisibleTakesTheFilterButTheSelectionKeepsWhatItHad`.
+- [x] **011.2** Rendering: a marker column that exists only while something is
+  marked, the count in the panel title, counts beside the action keys in the
+  action line, the footer and the palette.
+  *Done when:* the marker column costs nothing at any width when nothing is
+  marked, and `A archive (7)` renders for nine marked rows of which seven can be
+  archived. ✓ 2026-08-16 — `TestMarkerColumnExistsOnlyWhileSomethingIsMarked`,
+  `TestBoardTitleCountsTheSelection`, `TestBulkActionKeysCountTheTasksTheyMove`,
+  and the column/row agreement check in `TestGroupedRowsMatchTheColumnCount`
+  extended to the marked case.
+- [x] **011.3** Bulk dispatch: one call per task, the dirty-worktree re-ask over
+  the refusals only, and a one-line report of what happened.
+  *Done when:* a bulk archive over a mixed selection archives what it can, re-asks
+  for the dirty ones, and reports `5 of 7` with the first failure named.
+  ✓ 2026-08-16 — `TestBulkArchiveAsksOnceAndSendsOneCallPerTask`,
+  `TestBulkArchiveReAsksForTheDirtyOnesOnly`, `TestBulkReportNamesTheFirstRefusal`,
+  `TestBulkSelectionLeavesFailuresMarked`.
+- [x] **011.4** Routing: action keys retargeted at the selection from any panel
+  focus, with a pending bulk confirmation owning the keyboard.
+  *Done when:* `A` then `y` with the output pane focused archives the selection,
+  not the open task. ✓ 2026-08-16 — `TestBulkKeysWorkFromAnyPanel`,
+  `TestEscClearsTheSelectionBeforeTheFilter`, and `TestBulkArchiveLive`, which
+  drives the whole thing through the real §6 handlers.
+- [x] **011.5** Registry, help and docs: `space`/`V` in `bindings.go` with
+  probes, the spec §15 amendment, the TUI guide.
+  *Done when:* `TestEveryPanelKeyIsHandled` covers both keys and the spec
+  describes the selection as shipped. ✓ 2026-08-16 — probes added for
+  `space` and `V`; spec §15 amended (view 1, *Bulk selection*, Keys, the esc
+  stack) and `docs/guides/tui.md` grew *Acting on several tasks at once*.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -25,6 +25,7 @@ description of how the system actually behaves.
 | [008](008-archive-branch-cleanup.md) | Archive cleanup: delete a branch with no commits past its base | ✅ done (7/7) |
 | [009](009-configurable-tasks-view.md) | A configurable tasks view, grouped by project then workflow | ✅ done (6/6) |
 | [010](010-workflow-platform-restrictions.md) | Restricting a workflow to platforms (`platforms:`) | ✅ done (6/6) |
+| [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/tui/actionbar.go
+++ b/internal/tui/actionbar.go
@@ -70,15 +70,59 @@ type taskActions struct {
 	id      int64
 	state   string
 	actions []string
+	// marked is the board's bulk selection (task 011). When it is non-empty
+	// the bar acts on every marked task that offers the action, and `id` names
+	// only the row under the cursor — so a key can never act on a task the
+	// count beside it did not include.
+	marked []markedTask
 }
 
+// markedTask is one member of a bulk selection: which task, and what the
+// daemon says can be done to it.
+type markedTask struct {
+	id      int64
+	actions []string
+}
+
+// has reports the action is on offer. Under a bulk selection that means *some*
+// marked task offers it (task 011 decision): requiring all of them would make
+// `archive` vanish from a sweep of finished work because one task in it is
+// still running, with nothing on screen to explain the absence. The count
+// beside the key is what keeps that honest — `A archive (7)` on nine marked
+// rows says both that the key works and that two rows will not move.
 func (t taskActions) has(action string) bool {
+	if t.bulk() {
+		return len(t.targets(action)) > 0
+	}
 	for _, a := range t.actions {
 		if a == action {
 			return true
 		}
 	}
 	return false
+}
+
+// bulk reports that a selection, rather than the cursor row, is what the bar
+// acts on.
+func (t taskActions) bulk() bool { return len(t.marked) > 0 }
+
+// targets is the ids one action would be sent to: the marked tasks offering
+// it, or nil when nothing is marked — the single-task path uses t.id, and a
+// nil here is what distinguishes the two.
+func (t taskActions) targets(action string) []int64 {
+	out := make([]int64, 0, len(t.marked))
+	for _, m := range t.marked {
+		for _, a := range m.actions {
+			if a == action {
+				out = append(out, m.id)
+				break
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // actionBar turns key presses into daemon calls and reports what happened.
@@ -89,6 +133,13 @@ type actionBar struct {
 	// one that carries `force` after a dirty worktree refused the first.
 	pending string
 	force   bool
+	// pendingIDs pins the tasks a confirmation is for, when they are not
+	// simply "the row under the cursor": a bulk selection, and — on the force
+	// re-ask — the subset of it whose worktrees were dirty. nil means the
+	// single-task path. bulkTotal is how many the question started out about,
+	// so the re-ask can say "2 of 5".
+	pendingIDs []int64
+	bulkTotal  int
 
 	status    string
 	statusBad bool
@@ -105,11 +156,14 @@ func (a *actionBar) handleKey(key string, client *apiclient.Client, t taskAction
 	if a.pending != "" {
 		switch key {
 		case "y":
-			action, force := a.pending, a.force
-			a.pending, a.force = "", false
+			action, force, ids := a.pending, a.force, a.pendingIDs
+			a.pending, a.force, a.pendingIDs = "", false, nil
+			if len(ids) > 0 {
+				return a.dispatchBulk(client, ids, action, force), true
+			}
 			return a.dispatch(client, t.id, action, force), true
 		case "n", "esc":
-			a.pending, a.force = "", false
+			a.pending, a.force, a.pendingIDs = "", false, nil
 			a.setStatus("cancelled", false)
 			return nil, true
 		}
@@ -121,9 +175,16 @@ func (a *actionBar) handleKey(key string, client *apiclient.Client, t taskAction
 	if !ok {
 		return nil, false
 	}
+	// A selection retargets the key at every marked task offering the action;
+	// with nothing marked, targets is nil and this is the path it always was.
+	ids := t.targets(action)
 	if needsConfirm(action) {
 		a.pending, a.force = action, false
+		a.pendingIDs, a.bulkTotal = ids, len(ids)
 		return nil, true
+	}
+	if len(ids) > 0 {
+		return a.dispatchBulk(client, ids, action, false), true
 	}
 	return a.dispatch(client, t.id, action, false), true
 }
@@ -149,34 +210,41 @@ func (a *actionBar) dispatch(client *apiclient.Client, id int64, action string, 
 	}
 	a.setStatus(action+"…", false)
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
-		defer cancel()
-		var (
-			task   apiclient.Task
-			branch apiclient.BranchOutcome
-			err    error
-		)
-		switch action {
-		case apiclient.ActionCancel:
-			task, err = client.Cancel(ctx, id)
-		case apiclient.ActionPause:
-			task, err = client.Pause(ctx, id)
-		case apiclient.ActionResume:
-			task, err = client.Resume(ctx, id)
-		case apiclient.ActionRetry:
-			task, err = client.Retry(ctx, id, apiclient.Override{})
-		case apiclient.ActionSkip:
-			task, err = client.Skip(ctx, id)
-		case apiclient.ActionApprove:
-			task, err = client.Approve(ctx, id)
-		case apiclient.ActionReject:
-			task, err = client.Reject(ctx, id)
-		case apiclient.ActionArchive:
-			task, branch, err = client.Archive(ctx, id, force)
-		default:
-			err = fmt.Errorf("unknown action %q", action)
-		}
+		task, branch, err := callActionWithTimeout(client, id, action, force)
 		return actionResultMsg{taskID: id, action: action, task: task, branch: branch, err: err}
+	}
+}
+
+// callAction is the one place a §6 action becomes an HTTP call, shared by the
+// single-task path and the bulk one so the two cannot drift into meaning
+// different things by the same key.
+func callAction(ctx context.Context, client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, error) {
+	switch action {
+	case apiclient.ActionCancel:
+		task, err := client.Cancel(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionPause:
+		task, err := client.Pause(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionResume:
+		task, err := client.Resume(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionRetry:
+		task, err := client.Retry(ctx, id, apiclient.Override{})
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionSkip:
+		task, err := client.Skip(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionApprove:
+		task, err := client.Approve(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionReject:
+		task, err := client.Reject(ctx, id)
+		return task, apiclient.BranchOutcome{}, err
+	case apiclient.ActionArchive:
+		return client.Archive(ctx, id, force)
+	default:
+		return apiclient.Task{}, apiclient.BranchOutcome{}, fmt.Errorf("unknown action %q", action)
 	}
 }
 
@@ -195,13 +263,14 @@ func (a *actionBar) applyResult(msg actionResultMsg) {
 		a.setStatus(status, false)
 		return
 	}
+	if isDirtyWorktree(msg.action, msg.err) {
+		a.pending, a.force = apiclient.ActionArchive, true
+		a.pendingIDs, a.bulkTotal = nil, 0
+		a.status = ""
+		return
+	}
 	var apiErr *apiclient.Error
 	if errors.As(msg.err, &apiErr) {
-		if msg.action == apiclient.ActionArchive && apiErr.Details["reason"] == "worktree_dirty" {
-			a.pending, a.force = apiclient.ActionArchive, true
-			a.status = ""
-			return
-		}
 		if apiErr.Status == http.StatusConflict {
 			if state := apiErr.Details["state"]; state != "" {
 				a.setStatus(fmt.Sprintf("%s: the task is %s", msg.action, state), true)
@@ -219,7 +288,17 @@ func (a *actionBar) setStatus(text string, bad bool) {
 }
 
 // clear drops transient state when the bar moves to another task.
+//
+// A pending *bulk* question survives it, because it is a question about the
+// selection rather than about the row under the cursor — and the cursor moves
+// on its own exactly when one is on screen: a bulk archive that met a dirty
+// worktree has already archived the clean tasks, the refetch drops their rows,
+// and the cursor lands somewhere else. Clearing there would take the force
+// re-ask away between the two halves of one action (task 011).
 func (a *actionBar) clear() {
+	if len(a.pendingIDs) > 0 {
+		return
+	}
 	a.pending, a.force = "", false
 	a.status, a.statusBad = "", false
 }
@@ -227,6 +306,9 @@ func (a *actionBar) clear() {
 // confirmPrompt is the question a pending confirmation asks. It names the
 // consequence, not the action: "archive?" is not what a human needs to know.
 func (a *actionBar) confirmPrompt(t taskActions) string {
+	if n := len(a.pendingIDs); n > 0 {
+		return a.bulkPrompt(n)
+	}
 	switch {
 	case a.pending == apiclient.ActionArchive && a.force:
 		return fmt.Sprintf("#%d has uncommitted changes — archive anyway and lose them? (y/n)", t.id)
@@ -239,8 +321,40 @@ func (a *actionBar) confirmPrompt(t taskActions) string {
 	}
 }
 
+// bulkPrompt is the same question asked of a selection. The force re-ask names
+// the subset it is about — "2 of 5 selected tasks" — because by then the other
+// three are already archived and re-asking about all five would be a lie.
+func (a *actionBar) bulkPrompt(n int) string {
+	switch {
+	case a.pending == apiclient.ActionArchive && a.force:
+		subject := selectedNoun(n)
+		if a.bulkTotal > n {
+			subject = fmt.Sprintf("%d of %s", n, selectedNoun(a.bulkTotal))
+		}
+		return fmt.Sprintf("%s have uncommitted changes — archive anyway and lose them? (y/n)", subject)
+	case a.pending == apiclient.ActionArchive:
+		return fmt.Sprintf("archive %s? their worktrees are removed (y/n)", selectedNoun(n))
+	case a.pending == apiclient.ActionCancel:
+		return fmt.Sprintf("cancel %s? their running steps are killed (y/n)", selectedNoun(n))
+	default:
+		return fmt.Sprintf("%s %s? (y/n)", a.pending, selectedNoun(n))
+	}
+}
+
+// actionLabel names an action beside its key. Under a bulk selection it
+// carries how many of the marked tasks the key would actually move: an action
+// on offer for seven of nine says so, rather than leaving the reader to guess
+// whether the other two come along (task 011).
+func actionLabel(t taskActions, action string) string {
+	if !t.bulk() {
+		return action
+	}
+	return fmt.Sprintf("%s (%d)", action, len(t.targets(action)))
+}
+
 // render draws the bar: the pending question if there is one, otherwise the
-// keys this task actually accepts plus whatever the last action reported.
+// keys this task accepts — or, under a selection, the keys the marked tasks
+// accept — plus whatever the last action reported.
 func (a *actionBar) render(t taskActions, extra ...string) string {
 	if a.pending != "" {
 		return styleWarn.Render(" " + a.confirmPrompt(t))
@@ -248,7 +362,7 @@ func (a *actionBar) render(t taskActions, extra ...string) string {
 	parts := make([]string, 0, len(actionOrder)+2)
 	for _, o := range actionOrder {
 		if t.has(o.action) {
-			parts = append(parts, styleKey.Render(o.key)+" "+o.action)
+			parts = append(parts, styleKey.Render(o.key)+" "+actionLabel(t, o.action))
 		}
 	}
 	// `answer` has no key: it is the form, and where the form lives differs

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -73,7 +73,7 @@ var bindings = []binding{
 	// running it from the palette would paste into a field the palette just
 	// closed.
 	{key: "ctrl+v", label: "paste into the focused field (Cmd+V and the terminal's own paste work too)", scope: scopeGlobal, noPalette: true},
-	{key: "esc", label: "close one layer: popup → screen → filter — never quits", scope: scopeGlobal, noPalette: true},
+	{key: "esc", label: "close one layer: popup → screen → selection → filter — never quits", scope: scopeGlobal, noPalette: true},
 	{key: "q", label: "quit the TUI (the daemon keeps running)", scope: scopeGlobal},
 	{key: "ctrl+c", label: "quit the TUI", scope: scopeGlobal, noPalette: true},
 
@@ -103,6 +103,8 @@ var bindings = []binding{
 	{key: "enter", label: "open the selected task — or its answer form when it is asking", scope: scopePanel, context: ctxTasks, hint: "enter open", priority: 1},
 	{key: "/", label: "filter by id, title, project or state", scope: scopePanel, context: ctxTasks, hint: "/ filter", priority: 2},
 	{key: "g", label: "group the tasks: project › workflow → project → workflow → flat (config.yaml sets the one you start on)", scope: scopePanel, context: ctxTasks, hint: "g group", priority: 4},
+	{key: "space", label: "select this task for a bulk action — the action keys then act on every selected task (space again deselects, esc clears)", scope: scopePanel, context: ctxTasks, hint: "space select", priority: 5},
+	{key: "V", label: "select every task the filter is showing, or clear that selection", scope: scopePanel, context: ctxTasks, priority: 6},
 
 	// Timeline.
 	{key: "down", label: "select an attempt (↑/↓); scrollback is per attempt", scope: scopePanel, context: ctxTimeline, hint: "↑/↓ attempts", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -113,6 +113,30 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatalf("g did not change the grouping (still %s)", s.board.group.label())
 			}
 		},
+		"space": func(t *testing.T) {
+			s, _ := newShellFixture(t, task(7, stateDone))
+			s.focus = panelTasks
+			s.update(registryKey(t, "space"))
+			if !s.board.marks.has(7) {
+				t.Fatalf("space did not select the task under the cursor (marks %v)", s.board.marks)
+			}
+			s.update(registryKey(t, "space"))
+			if s.board.hasMarks() {
+				t.Fatalf("space did not deselect it again (marks %v)", s.board.marks)
+			}
+		},
+		"V": func(t *testing.T) {
+			s, _ := newShellFixture(t, task(1, stateDone), task(2, stateDone))
+			s.focus = panelTasks
+			s.update(registryKey(t, "V"))
+			if len(s.board.marks) != 2 {
+				t.Fatalf("V selected %v, want both visible tasks", s.board.marks)
+			}
+			s.update(registryKey(t, "V"))
+			if s.board.hasMarks() {
+				t.Fatalf("V did not clear the selection (marks %v)", s.board.marks)
+			}
+		},
 	},
 
 	ctxTimeline: {

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -83,6 +83,10 @@ type board struct {
 	tbl        table.Model
 	selectedID int64
 
+	// marks is the bulk selection (boardmark.go, task 011): the tasks the §6
+	// action keys act on instead of the row under the cursor.
+	marks markSet
+
 	filter    textinput.Model
 	filtering bool
 
@@ -280,24 +284,35 @@ func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
 		// the row was stale, and leaving it stale invites the same keypress.
 		b.refreshPending = false
 		return b, b.loadCmd()
+	case bulkResultMsg:
+		b.actions.applyBulkResult(msg)
+		// What the daemon accepted leaves the selection; what it refused stays
+		// marked, so a force re-ask or a retry needs no re-selection (task 011).
+		b.marks = b.marks.drop(msg.done...)
+		b.refreshPending = false
+		return b, b.loadCmd()
 	case tea.KeyPressMsg:
 		return b.updateKey(msg)
 	}
 	return b, nil
 }
 
-// target is the row under the cursor as the action bar sees it.
+// target is what the action bar acts on: the row under the cursor, carrying
+// the bulk selection when there is one (task 011). The cursor row travels even
+// then — it is what the confirmation for a single task would name, and what the
+// palette titles its action section with.
 func (b *board) target() taskActions {
+	marked := b.markedTargets()
 	id, ok := b.selected()
 	if !ok {
-		return taskActions{}
+		return taskActions{marked: marked}
 	}
 	for _, t := range b.visible() {
 		if t.ID == id {
-			return taskActions{id: t.ID, state: t.State, actions: t.AvailableActions}
+			return taskActions{id: t.ID, state: t.State, actions: t.AvailableActions, marked: marked}
 		}
 	}
-	return taskActions{id: id}
+	return taskActions{id: id, marked: marked}
 }
 
 func (b *board) updateLoaded(msg boardLoadedMsg) {
@@ -316,6 +331,11 @@ func (b *board) updateLoaded(msg boardLoadedMsg) {
 	b.lastLoad = b.now()
 	b.tasks = msg.tasks
 	b.appliedSeq = msg.seq
+	// A mark for a task the daemon no longer lists — archived away, or whose
+	// project was removed — would be counted in the panel title and dispatched
+	// to a 404. Only a *successful* load prunes: a failed refresh is not news
+	// about which tasks exist.
+	b.marks = b.marks.keep(msg.tasks)
 }
 
 // updateNote reacts to the event stream. Every task event schedules a
@@ -412,6 +432,16 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		if b.filter.Value() != "" {
 			b.filter.SetValue("")
 		}
+		return b, nil
+	case "space":
+		// Mark the row for a bulk action (§15, task 011). The cursor does not
+		// move: `space` is a statement about this row, and a human marking a
+		// run of rows presses down themselves — auto-advancing would make
+		// unmarking a mis-press land on the wrong row.
+		b.toggleMark()
+		return b, nil
+	case "V":
+		b.markVisible()
 		return b, nil
 	case "g":
 		// Cycles the grouping for the session (§15, task 009); the config
@@ -674,7 +704,7 @@ func (b *board) render(width, height int) string {
 		return sb.String()
 	}
 
-	cols, set := boardColumns(b.width, b.group)
+	cols, set := boardColumns(b.width, b.group, b.hasMarks())
 	// SetColumns re-renders the rows it already holds: when a resize crosses
 	// a column breakpoint, yesterday's wider rows meet today's narrower
 	// column set and the table indexes out of range. Clear the rows first —
@@ -752,7 +782,11 @@ func (b *board) rowsFor(rows []boardRow, set columnSet) []table.Row {
 			continue
 		}
 		t := r.task
-		row := table.Row{strconv.FormatInt(t.ID, 10)}
+		row := make(table.Row, 0, maxBoardColumns)
+		if set.mark {
+			row = append(row, b.markCell(t.ID))
+		}
+		row = append(row, strconv.FormatInt(t.ID, 10))
 		if set.project {
 			row = append(row, t.ProjectName)
 		}
@@ -777,7 +811,13 @@ func (b *board) rowsFor(rows []boardRow, set columnSet) []table.Row {
 // every other cell blank, so the header reads as a break in the list rather
 // than as a task with missing figures.
 func groupHeaderRow(r boardRow, set columnSet) table.Row {
-	row := table.Row{""}
+	row := make(table.Row, 0, maxBoardColumns)
+	if set.mark {
+		// A group is not something a bulk action can name: the marker column is
+		// blank on a header, like every other column but the label.
+		row = append(row, "")
+	}
+	row = append(row, "")
 	if set.project {
 		row = append(row, "")
 	}

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -182,7 +182,7 @@ func TestColumnsDropByPriority(t *testing.T) {
 		{85, true, false, false, false},  // then the workflow
 		{70, false, false, false, false}, // then the project
 	} {
-		got := columnsFor(tc.width, nil)
+		got := columnsFor(tc.width, nil, false)
 		if got.project != tc.project || got.workflow != tc.workflow ||
 			got.stepName != tc.stepName || got.cost != tc.cost {
 			t.Errorf("width %d = %+v, want project=%v workflow=%v stepName=%v cost=%v",
@@ -196,14 +196,25 @@ func TestColumnsDropByPriority(t *testing.T) {
 // column has to actually buy back the space — an earlier version clamped the
 // title to its minimum instead and overflowed by a character at width 80.
 func TestBoardColumnsFitWidth(t *testing.T) {
+	// 65 is the narrowest board that still fits: below it every optional column
+	// is already shed and the title is clamped at its minimum, which the
+	// columns deliberately overflow rather than hide the id or the state. A
+	// bulk selection raises that floor by exactly the marker column's three
+	// cells (task 011) — nothing is left for them to come out of.
 	for width := 65; width <= 220; width++ {
-		cols, _ := boardColumns(width, nil)
-		total := 0
-		for _, c := range cols {
-			total += c.Width + colPadding
-		}
-		if total > width {
-			t.Fatalf("width %d: columns total %d, which overflows", width, total)
+		for _, marking := range []bool{false, true} {
+			if marking && width < 68 {
+				continue
+			}
+			cols, _ := boardColumns(width, nil, marking)
+			total := 0
+			for _, c := range cols {
+				total += c.Width + colPadding
+			}
+			if total > width {
+				t.Fatalf("width %d (marking=%v): columns total %d, which overflows",
+					width, marking, total)
+			}
 		}
 	}
 }
@@ -212,7 +223,7 @@ func TestBoardColumnsFitWidth(t *testing.T) {
 // the columns you steer by survive.
 func TestBoardColumnsAlwaysKeepNavigationColumns(t *testing.T) {
 	for _, width := range []int{20, 40, 65, 120} {
-		cols, _ := boardColumns(width, nil)
+		cols, _ := boardColumns(width, nil, false)
 		titles := make([]string, 0, len(cols))
 		for _, c := range cols {
 			titles = append(titles, c.Title)

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -7,7 +7,11 @@ import (
 // Column widths. The table adds one space of padding either side of every
 // cell, so a column occupies its width plus two.
 const (
-	colPadding     = 2
+	colPadding = 2
+	// widthMark holds the bulk-selection glyph (task 011). It is one cell and
+	// it only exists while something is marked, so an unmarked board is the
+	// board every earlier version rendered, to the column.
+	widthMark      = 1
 	widthID        = 5
 	widthProject   = 14
 	widthWorkflow  = 14
@@ -19,8 +23,17 @@ const (
 	minTitle       = 16
 )
 
+// maxBoardColumns is every column the widest board can carry — the size a row
+// is built at, so rowsFor and groupHeaderRow never grow their slice mid-loop.
+const maxBoardColumns = 9
+
 // columnSet records which optional columns survived the current width.
 type columnSet struct {
+	// mark is the bulk-selection marker (task 011). Unlike the others it is
+	// not a width decision and is never shed: it is on exactly while something
+	// is marked, because a selection you cannot see is worse than a narrow
+	// title.
+	mark    bool
 	project bool
 	// workflow answers "what is this task actually running", which the step
 	// name alone cannot: "survey" means nothing without knowing it belongs to
@@ -34,6 +47,10 @@ type columnSet struct {
 func (s columnSet) fixedWidth() int {
 	total := widthID + widthState + widthElapsed
 	count := 4 // id, title, state, elapsed
+	if s.mark {
+		total += widthMark
+		count++
+	}
 	if s.project {
 		total += widthProject
 		count++
@@ -76,8 +93,12 @@ func (s columnSet) titleWidth(width int) int { return width - s.fixedWidth() }
 // spent saying what the reader just read. The width that frees goes to the
 // title, which is where a grouped board needs it — the titles are indented
 // under their headers.
-func columnsFor(width int, g grouping) columnSet {
+// The marker column is outside the shedding order entirely: it is three cells
+// wide with its padding, it exists only while a selection does, and it is the
+// one column whose absence would make the keys lie about what they act on.
+func columnsFor(width int, g grouping, marking bool) columnSet {
 	set := columnSet{
+		mark:     marking,
 		project:  !g.has(groupProject),
 		workflow: !g.has(groupWorkflow),
 		stepName: true,
@@ -104,15 +125,20 @@ func columnsFor(width int, g grouping) columnSet {
 
 // boardColumns builds the table columns for a terminal width, giving the
 // title whatever space the fixed columns leave.
-func boardColumns(width int, g grouping) ([]table.Column, columnSet) {
-	set := columnsFor(width, g)
+func boardColumns(width int, g grouping, marking bool) ([]table.Column, columnSet) {
+	set := columnsFor(width, g, marking)
 	title := max(set.titleWidth(width), minTitle)
 	stepWidth := widthStepShort
 	if set.stepName {
 		stepWidth = widthStepLong
 	}
 
-	cols := make([]table.Column, 0, 8)
+	cols := make([]table.Column, 0, maxBoardColumns)
+	if set.mark {
+		// No heading: a one-cell column has no room for one, and "✓" over a
+		// column of blanks reads as a state the rows are failing.
+		cols = append(cols, table.Column{Title: "", Width: widthMark})
+	}
 	cols = append(cols, table.Column{Title: "ID", Width: widthID})
 	if set.project {
 		cols = append(cols, table.Column{Title: "PROJECT", Width: widthProject})

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -209,15 +209,15 @@ func TestGroupCycleKeepsTheSelectedTask(t *testing.T) {
 // TestGroupedColumnsAreDropped: a level named by every header above the rows
 // does not also need a column repeating it on every row.
 func TestGroupedColumnsAreDropped(t *testing.T) {
-	full := columnsFor(160, nil)
+	full := columnsFor(160, nil, false)
 	if !full.project || !full.workflow {
 		t.Fatalf("flat at 160 = %+v, want both columns", full)
 	}
-	both := columnsFor(160, grouping{groupProject, groupWorkflow})
+	both := columnsFor(160, grouping{groupProject, groupWorkflow}, false)
 	if both.project || both.workflow {
 		t.Errorf("grouped by project and workflow = %+v, want neither column", both)
 	}
-	one := columnsFor(160, grouping{groupProject})
+	one := columnsFor(160, grouping{groupProject}, false)
 	if one.project {
 		t.Error("grouping by project kept the PROJECT column")
 	}
@@ -240,14 +240,21 @@ func TestGroupedRowsMatchTheColumnCount(t *testing.T) {
 	for _, width := range []int{40, 70, 90, 120, 200} {
 		for _, g := range []grouping{nil, {groupProject}, {groupProject, groupWorkflow}} {
 			b.group = g
-			cols, set := boardColumns(width, g)
-			for _, row := range b.rowsFor(b.rows(), set) {
-				if len(row) != len(cols) {
-					t.Fatalf("width %d, %s: row has %d cells, %d columns",
-						width, g.label(), len(row), len(cols))
+			// With and without the bulk-selection marker column (task 011):
+			// both the task rows and the group headers have to grow the extra
+			// cell, and a header that forgot it is the same panic.
+			for _, marks := range []markSet{nil, {1}} {
+				b.marks = marks
+				cols, set := boardColumns(width, g, b.hasMarks())
+				for _, row := range b.rowsFor(b.rows(), set) {
+					if len(row) != len(cols) {
+						t.Fatalf("width %d, %s, marks=%v: row has %d cells, %d columns",
+							width, g.label(), marks, len(row), len(cols))
+					}
 				}
 			}
 		}
+		b.marks = nil
 	}
 }
 

--- a/internal/tui/boardmark.go
+++ b/internal/tui/boardmark.go
@@ -1,0 +1,161 @@
+package tui
+
+import (
+	"slices"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The task table's bulk selection (§15, task 011).
+//
+// Triage is the board's job and triage arrives in batches: a sweep of finished
+// tasks to archive, a run of queued ones to cancel after a bad workflow edit.
+// One row at a time, that is the same keypress N times with a confirmation
+// between each — which is where a human either stops tidying up or stops
+// reading the confirmations.
+//
+// The selection is a set of **tasks**, not of rows: it survives a filter, a `g`
+// regroup and a refresh, because all three are ways of looking at the board
+// rather than statements about what was chosen (task 011 decision). Narrowing
+// it to what is currently visible would mean typing a filter silently changes
+// what a confirmed archive destroys. The count in the panel title is what keeps
+// a marked task the filter is hiding honest.
+
+// markSet is the marked task ids. A slice rather than a map: a selection is
+// tens of rows at most, and a stable order makes what it feeds — the targets
+// of a bulk action, and the test that pins them — deterministic.
+type markSet []int64
+
+func (m markSet) has(id int64) bool { return slices.Contains(m, id) }
+
+// toggle marks an unmarked task and unmarks a marked one.
+func (m markSet) toggle(id int64) markSet {
+	if i := slices.Index(m, id); i >= 0 {
+		return slices.Delete(slices.Clone(m), i, i+1)
+	}
+	return append(m, id)
+}
+
+// add marks every id not already marked.
+func (m markSet) add(ids ...int64) markSet {
+	for _, id := range ids {
+		if !m.has(id) {
+			m = append(m, id)
+		}
+	}
+	return m
+}
+
+// drop unmarks ids. It is what a finished bulk action does with the tasks the
+// daemon accepted: what it refused stays marked, so a retry needs no
+// re-selection and the rows still marked are the ones still to deal with.
+func (m markSet) drop(ids ...int64) markSet {
+	out := make(markSet, 0, len(m))
+	for _, id := range m {
+		if !slices.Contains(ids, id) {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// keep prunes marks for tasks the daemon no longer lists — archived away, or
+// belonging to a project that was removed. A mark for a task that is gone would
+// be counted in the panel title and dispatched to a 404.
+func (m markSet) keep(tasks []apiclient.Task) markSet {
+	if len(m) == 0 {
+		return nil
+	}
+	live := make([]int64, 0, len(tasks))
+	for _, t := range tasks {
+		live = append(live, t.ID)
+	}
+	out := make(markSet, 0, len(m))
+	for _, id := range m {
+		if slices.Contains(live, id) {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// hasMarks reports that a bulk selection is driving the board.
+func (b *board) hasMarks() bool { return len(b.marks) > 0 }
+
+// toggleMark is `space`: mark or unmark the row under the cursor. A group
+// header resolves to the first task under it the way every other key does, so
+// the press is never a silent no-op.
+func (b *board) toggleMark() {
+	id, ok := b.selected()
+	if !ok {
+		return
+	}
+	b.marks = b.marks.toggle(id)
+}
+
+// markVisible is `V`: mark every task the filter is showing, or unmark them
+// when they are all marked already. One key for "select all" and for undoing
+// it, because those are the same intention twice — and it unmarks only what is
+// visible, so a selection built before the filter was typed is not thrown away
+// by a key that was aimed at the rows on screen.
+func (b *board) markVisible() {
+	visible := b.visible()
+	if len(visible) == 0 {
+		return
+	}
+	ids := make([]int64, 0, len(visible))
+	all := true
+	for _, t := range visible {
+		ids = append(ids, t.ID)
+		if !b.marks.has(t.ID) {
+			all = false
+		}
+	}
+	if all {
+		b.marks = b.marks.drop(ids...)
+		return
+	}
+	b.marks = b.marks.add(ids...)
+}
+
+func (b *board) clearMarks() { b.marks = nil }
+
+// markedTargets is the selection as the action bar sees it: what the daemon
+// says can be done to each marked task (§6), in board order — top to bottom, so
+// a bulk action runs in the order the rows were read. Filtering is deliberately
+// not applied; the selection is not a view.
+func (b *board) markedTargets() []markedTask {
+	if len(b.marks) == 0 {
+		return nil
+	}
+	sorted := make([]apiclient.Task, len(b.tasks))
+	copy(sorted, b.tasks)
+	sortTasks(sorted)
+	out := make([]markedTask, 0, len(b.marks))
+	for _, t := range sorted {
+		if b.marks.has(t.ID) {
+			out = append(out, markedTask{id: t.ID, actions: t.AvailableActions})
+		}
+	}
+	return out
+}
+
+// markGlyph marks a selected row. A glyph rather than colour alone, so the
+// selection survives NO_COLOR and a 16-colour terminal (§15 Colour).
+const markGlyph = "✓"
+
+// markCell is the row's cell in the marker column. styleKey is reused rather
+// than duplicated: the glyph means the same thing a key hint does — this is the
+// thing the next press acts on.
+func (b *board) markCell(id int64) string {
+	if b.marks.has(id) {
+		return styleKey.Render(markGlyph)
+	}
+	return " "
+}

--- a/internal/tui/boardmark_test.go
+++ b/internal/tui/boardmark_test.go
@@ -1,0 +1,179 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Task 011: the bulk selection on the task table.
+
+// markedBoard is a flat, loaded board with the given tasks — the same fixture
+// the sorting and column tests use, since a selection is a question about
+// tasks and grouping only changes which line they land on.
+func markedBoard(tasks ...apiclient.Task) *board {
+	b := testBoard()
+	b.tasks = tasks
+	return b
+}
+
+func withActions(actions ...string) func(*apiclient.Task) {
+	return func(t *apiclient.Task) { t.AvailableActions = actions }
+}
+
+// TestMarksSurviveARefreshThatReorders is the reason the selection holds ids
+// rather than row indices: a board reorders under a running task all the time,
+// and a selection that followed the rows would silently come to mean other
+// tasks.
+func TestMarksSurviveARefreshThatReorders(t *testing.T) {
+	b := markedBoard(task(1, stateDone), task(2, stateDone), task(3, stateDone))
+	b.marks = markSet{1, 3}
+
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{
+		task(3, stateDone), task(2, stateRunning), task(1, stateDone),
+	}})
+
+	if !b.marks.has(1) || !b.marks.has(3) || b.marks.has(2) {
+		t.Fatalf("marks after a reordering refresh = %v, want exactly [1 3]", b.marks)
+	}
+}
+
+// TestMarksArePrunedForTasksTheDaemonDropped: a mark for a task that is gone
+// would be counted in the panel title and dispatched to a 404.
+func TestMarksArePrunedForTasksTheDaemonDropped(t *testing.T) {
+	b := markedBoard(task(1, stateDone), task(2, stateDone))
+	b.marks = markSet{1, 2}
+
+	// #2 archived away: the default list stops returning it.
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{task(1, stateDone)}})
+	if len(b.marks) != 1 || !b.marks.has(1) {
+		t.Fatalf("marks = %v, want just [1]", b.marks)
+	}
+
+	// A *failed* refresh says nothing about which tasks exist, so it must not
+	// prune: the rows on screen are still the last truth there was.
+	b.updateLoaded(boardLoadedMsg{err: errors.New("http 500")})
+	if !b.marks.has(1) {
+		t.Fatalf("a failed refresh dropped the selection (marks %v)", b.marks)
+	}
+}
+
+// TestMarkVisibleTakesTheFilterButTheSelectionKeepsWhatItHad: `V` acts on the
+// rows on screen, and a selection built before the filter was typed is not
+// thrown away by a key aimed at them (task 011 decision).
+func TestMarkVisibleTakesTheFilterButTheSelectionKeepsWhatItHad(t *testing.T) {
+	b := markedBoard(
+		task(1, stateDone, inProject("api")),
+		task(2, stateDone, inProject("web")),
+		task(3, stateDone, inProject("web")),
+	)
+	b.marks = markSet{1}
+	b.filter.SetValue("web")
+
+	b.markVisible()
+	for _, id := range []int64{1, 2, 3} {
+		if !b.marks.has(id) {
+			t.Fatalf("after V the selection is %v, want #%d in it", b.marks, id)
+		}
+	}
+
+	// Everything visible is marked, so the same key unmarks it — and only it.
+	b.markVisible()
+	if b.marks.has(2) || b.marks.has(3) {
+		t.Errorf("V left the filtered rows marked: %v", b.marks)
+	}
+	if !b.marks.has(1) {
+		t.Errorf("V cleared a mark the filter was hiding: %v", b.marks)
+	}
+}
+
+// TestMarkedTargetsCarryEachTaskActions: the bar decides nothing about
+// validity, so the selection has to hand it available_actions per task (§6).
+func TestMarkedTargetsCarryEachTaskActions(t *testing.T) {
+	b := markedBoard(
+		task(1, stateDone, withActions(apiclient.ActionArchive)),
+		task(2, stateRunning, withActions(apiclient.ActionCancel, apiclient.ActionPause)),
+	)
+	b.marks = markSet{2, 1}
+
+	got := b.markedTargets()
+	// Board order, not the order the marks were made: a bulk action runs the
+	// way the rows were read.
+	if len(got) != 2 || got[0].id != 2 || got[1].id != 1 {
+		t.Fatalf("targets = %+v, want #2 (running) before #1 (done)", got)
+	}
+	target := b.target()
+	if !target.has(apiclient.ActionArchive) || !target.has(apiclient.ActionCancel) {
+		t.Fatalf("a mixed selection offers %v, want both archive and cancel", target.marked)
+	}
+	if ids := target.targets(apiclient.ActionArchive); len(ids) != 1 || ids[0] != 1 {
+		t.Fatalf("archive targets = %v, want just the done task", ids)
+	}
+}
+
+// TestMarkerColumnExistsOnlyWhileSomethingIsMarked: an unmarked board is the
+// board every earlier version rendered, to the column.
+func TestMarkerColumnExistsOnlyWhileSomethingIsMarked(t *testing.T) {
+	b := markedBoard(task(1, stateDone), task(2, stateDone))
+
+	plain := b.render(160, 20)
+	if strings.Contains(ansi.Strip(plain), markGlyph) {
+		t.Fatalf("an unmarked board rendered the selection glyph:\n%s", plain)
+	}
+	// At 160 there is slack for the marker, so it is added rather than paid
+	// for by shedding — which is what makes this a count of one column.
+	cols, _ := boardColumns(160, nil, false)
+	marked, _ := boardColumns(160, nil, true)
+	if len(marked) != len(cols)+1 {
+		t.Fatalf("marking added %d columns, want exactly one", len(marked)-len(cols))
+	}
+
+	b.marks = markSet{2}
+	out := ansi.Strip(b.render(160, 20))
+	if !strings.Contains(out, markGlyph) {
+		t.Fatalf("a marked board does not show the selection:\n%s", out)
+	}
+	// One row is marked, so the glyph appears once — the marker is per row,
+	// not a mode indicator painted down the column.
+	if n := strings.Count(out, markGlyph); n != 1 {
+		t.Fatalf("the glyph renders %d times, want once (one marked row):\n%s", n, out)
+	}
+}
+
+// TestBoardTitleCountsTheSelection: the selection survives a filter, so the
+// count is the only thing that can say a hidden task is still in it.
+func TestBoardTitleCountsTheSelection(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateDone, inProject("api")), task(2, stateDone, inProject("web")))
+	s.board.marks = markSet{1, 2}
+	s.board.filter.SetValue("web")
+
+	if title := s.panelTitle(panelTasks); !strings.Contains(title, "2 selected") {
+		t.Fatalf("panel title = %q, want the selection count in it", title)
+	}
+}
+
+// TestEscClearsTheSelectionBeforeTheFilter is the §15 esc stack with the
+// selection spliced in: one layer per press, innermost first.
+func TestEscClearsTheSelectionBeforeTheFilter(t *testing.T) {
+	s, _ := newShellFixture(t, task(1, stateDone))
+	s.focus = panelTasks
+	s.board.filter.SetValue("task")
+	s.board.marks = markSet{1}
+
+	s.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if s.board.hasMarks() {
+		t.Fatal("esc did not clear the selection first")
+	}
+	if !s.board.filterActive() {
+		t.Fatal("esc took the filter with it — that is two layers for one press")
+	}
+	s.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if s.board.filterActive() {
+		t.Fatal("the second esc did not clear the filter")
+	}
+}

--- a/internal/tui/bulkaction.go
+++ b/internal/tui/bulkaction.go
@@ -1,0 +1,166 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Bulk actions (§6, task 011): one human action sent to every task in the
+// board's selection.
+//
+// There is no bulk endpoint and there is not going to be one: §6 lives in the
+// API, and the TUI is one of three clients — a second definition of what
+// `archive` means is a second thing to keep in step. So the client makes one
+// call per task, and the daemon stays the only place a transition happens.
+
+// bulkResultMsg carries the outcome of one bulk action. It is deliberately not
+// a stream of actionResultMsg: a batch is one thing a human did and gets one
+// answer, and thirty status lines racing each other is not an answer.
+type bulkResultMsg struct {
+	action string
+	force  bool
+	// total is how many tasks the batch was sent to, so the report can say
+	// "5 of 7" rather than a bare count.
+	total int
+	// done are the ids the daemon accepted; dirty are the archive targets it
+	// refused for an unclean worktree (§6), which become the force re-ask;
+	// failed carries everything else, one entry per task.
+	done   []int64
+	dirty  []int64
+	failed []bulkFailure
+	// branches counts archives that deleted the task's branch (§10, task 008)
+	// — the one consequence of an archive that is invisible afterwards.
+	branches int
+}
+
+type bulkFailure struct {
+	id  int64
+	err error
+}
+
+// dispatchBulk sends one action to every id, one at a time, in the order the
+// board handed them over.
+//
+// Sequential rather than concurrent: N parallel archives are N worktree
+// removals racing the scheduler for the slots they free, and the line a human
+// reads afterwards has to be built from outcomes that actually happened. Each
+// call carries the same timeout a single action does; the batch as a whole is
+// not bounded, because a batch cut off halfway leaves no account of which half.
+func (a *actionBar) dispatchBulk(client *apiclient.Client, ids []int64, action string, force bool) tea.Cmd {
+	if client == nil {
+		a.setStatus("not connected", true)
+		return nil
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	a.setStatus(fmt.Sprintf("%s %s…", action, selectedNoun(len(ids))), false)
+	ids = slices.Clone(ids) // the selection may change while the batch runs
+	return func() tea.Msg {
+		msg := bulkResultMsg{action: action, force: force, total: len(ids)}
+		for _, id := range ids {
+			_, branch, err := callActionWithTimeout(client, id, action, force)
+			switch {
+			case err == nil:
+				msg.done = append(msg.done, id)
+				if branch.Result == apiclient.BranchDeleted {
+					msg.branches++
+				}
+			case isDirtyWorktree(action, err):
+				msg.dirty = append(msg.dirty, id)
+			default:
+				msg.failed = append(msg.failed, bulkFailure{id: id, err: err})
+			}
+		}
+		return msg
+	}
+}
+
+func callActionWithTimeout(client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+	defer cancel()
+	return callAction(ctx, client, id, action, force)
+}
+
+// applyBulkResult records what a batch did. A dirty worktree comes back as the
+// second confirmation rather than as an error, exactly as it does for a single
+// task — `force` *is* the dirty confirmation (§6) — except that the re-ask is
+// about the refusals only: the clean ones are already archived.
+func (a *actionBar) applyBulkResult(msg bulkResultMsg) {
+	a.setStatus(bulkSummary(msg), len(msg.failed) > 0)
+	if len(msg.dirty) > 0 {
+		a.pending, a.force = apiclient.ActionArchive, true
+		a.pendingIDs = msg.dirty
+		a.bulkTotal = msg.total
+	}
+}
+
+// bulkSummary is the one line a batch reports: what was accepted, what the
+// branch cleanup did, and the *first* refusal. A list of forty errors is not a
+// status line — the board's own rows are the durable account of which tasks
+// moved.
+func bulkSummary(msg bulkResultMsg) string {
+	parts := []string{fmt.Sprintf("%s · %d of %d", msg.action, len(msg.done), msg.total)}
+	if msg.branches > 0 {
+		parts = append(parts, fmt.Sprintf("%s deleted", plural(msg.branches, "branch", "branches")))
+	}
+	if n := len(msg.dirty); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d need force", n))
+	}
+	if n := len(msg.failed); n > 0 {
+		first := msg.failed[0]
+		parts = append(parts, fmt.Sprintf("#%d: %s", first.id, actionErrString(first.err)))
+		if n > 1 {
+			parts = append(parts, fmt.Sprintf("and %d more failed", n-1))
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+// actionErrString renders one failure the way the single-task bar does: a 409
+// is the task having moved on, which is worth saying as a state rather than as
+// an HTTP code.
+func actionErrString(err error) string {
+	var apiErr *apiclient.Error
+	if errors.As(err, &apiErr) {
+		if state := apiErr.Details["state"]; state != "" {
+			return "the task is " + state
+		}
+		return apiErr.Message
+	}
+	return errString(err)
+}
+
+// isDirtyWorktree reports the daemon refused an archive because the worktree
+// has uncommitted changes (§6) — the one refusal that is a question, not a
+// failure.
+func isDirtyWorktree(action string, err error) bool {
+	if action != apiclient.ActionArchive {
+		return false
+	}
+	var apiErr *apiclient.Error
+	return errors.As(err, &apiErr) && apiErr.Details["reason"] == "worktree_dirty"
+}
+
+// selectedNoun names a count of marked tasks for a prompt or a status line.
+func selectedNoun(n int) string {
+	if n == 1 {
+		return "1 selected task"
+	}
+	return fmt.Sprintf("%d selected tasks", n)
+}
+
+// plural is the count plus the right noun, for the few lines that carry one.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, one)
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}

--- a/internal/tui/bulkaction_test.go
+++ b/internal/tui/bulkaction_test.go
@@ -1,0 +1,347 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Task 011: one §6 action sent to a whole selection.
+
+// bulkServer is a stand-in daemon that records the action calls it received
+// and answers each one from a per-task script. It is not a fake §6 — the live
+// harness covers the real handlers — it exists to prove the *client* side: one
+// call per marked task, and what the bar does with a mixed set of answers.
+type bulkServer struct {
+	ts *httptest.Server
+
+	mu sync.Mutex
+	// calls are the paths in the order they arrived, so "sequential, in board
+	// order" is an assertion rather than a hope.
+	calls  []string
+	forced []int64
+	// dirty are the ids that refuse an unforced archive, the way a task with
+	// uncommitted changes does (§6).
+	dirty map[int64]bool
+	// fail are ids that refuse outright, with a 409.
+	fail map[int64]bool
+}
+
+func newBulkServer(t *testing.T) *bulkServer {
+	t.Helper()
+	s := &bulkServer{dirty: map[int64]bool{}, fail: map[int64]bool{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/tasks/{id}/{action}", func(w http.ResponseWriter, r *http.Request) {
+		var id int64
+		if _, err := fmt.Sscanf(r.PathValue("id"), "%d", &id); err != nil {
+			http.Error(w, "bad id", http.StatusBadRequest)
+			return
+		}
+		var body struct {
+			Force bool `json:"force"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		s.mu.Lock()
+		s.calls = append(s.calls, r.PathValue("action")+" "+r.PathValue("id"))
+		if body.Force {
+			s.forced = append(s.forced, id)
+		}
+		dirty, fail := s.dirty[id] && !body.Force, s.fail[id]
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case fail:
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_state","message":"the task is running",` +
+				`"details":{"state":"running"}}}`))
+		case dirty:
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":{"code":"worktree_dirty","message":"uncommitted changes",` +
+				`"details":{"reason":"worktree_dirty"}}}`))
+		default:
+			_, _ = fmt.Fprintf(w, `{"id":%d,"state":"archived","branch":{"name":"vincent/%d","result":"deleted"}}`, id, id)
+		}
+	})
+	s.ts = httptest.NewServer(mux)
+	t.Cleanup(s.ts.Close)
+	return s
+}
+
+func (s *bulkServer) client() *apiclient.Client { return apiclient.New(s.ts.URL, "token") }
+
+func (s *bulkServer) seen() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
+}
+
+// runBulk executes the command a key produced and hands back the message it
+// resolved to, the way the runtime would.
+func runBulk(t *testing.T, cmd tea.Cmd) bulkResultMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("the key produced no command — nothing was dispatched")
+	}
+	msg := runCmd(t, cmd, 30*time.Second)
+	got, ok := msg.(bulkResultMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want a bulkResultMsg", msg)
+	}
+	return got
+}
+
+// bulkTarget is a selection of tasks that all accept `archive`.
+func bulkTarget(ids ...int64) taskActions {
+	marked := make([]markedTask, 0, len(ids))
+	for _, id := range ids {
+		marked = append(marked, markedTask{id: id, actions: []string{apiclient.ActionArchive}})
+	}
+	return taskActions{id: ids[0], state: stateDone, actions: []string{apiclient.ActionArchive}, marked: marked}
+}
+
+// TestBulkArchiveAsksOnceAndSendsOneCallPerTask: the point of the feature is
+// one confirmation for the batch, and the point of the invariant is that the
+// daemon still sees an ordinary §6 action per task.
+func TestBulkArchiveAsksOnceAndSendsOneCallPerTask(t *testing.T) {
+	srv := newBulkServer(t)
+	bar := &actionBar{}
+	target := bulkTarget(3, 5, 8)
+
+	cmd, handled := bar.handleKey("A", srv.client(), target)
+	if !handled || cmd != nil {
+		t.Fatalf("A dispatched without asking (handled=%v, cmd=%v)", handled, cmd != nil)
+	}
+	if got := bar.confirmPrompt(target); !strings.Contains(got, "3 selected tasks") {
+		t.Fatalf("prompt = %q, want it to name the whole selection", got)
+	}
+
+	cmd, handled = bar.handleKey("y", srv.client(), target)
+	if !handled {
+		t.Fatal("y was not taken as the answer to the confirmation")
+	}
+	msg := runBulk(t, cmd)
+
+	want := []string{"archive 3", "archive 5", "archive 8"}
+	if got := srv.seen(); !equalStrings(got, want) {
+		t.Fatalf("calls = %v, want one per marked task in board order: %v", got, want)
+	}
+	if len(msg.done) != 3 || msg.total != 3 {
+		t.Fatalf("result = %+v, want all three accepted", msg)
+	}
+	bar.applyBulkResult(msg)
+	if bar.status == "" || bar.statusBad {
+		t.Fatalf("status = %q (bad=%v), want a plain report", bar.status, bar.statusBad)
+	}
+	if !strings.Contains(bar.status, "3 of 3") {
+		t.Errorf("status = %q, want it to say how many of how many moved", bar.status)
+	}
+	if !strings.Contains(bar.status, "branches deleted") {
+		t.Errorf("status = %q, want the branch cleanup named (§10)", bar.status)
+	}
+}
+
+// TestBulkArchiveReAsksForTheDirtyOnesOnly: `force` *is* the dirty
+// confirmation (§6), and by the time it is asked the clean tasks are already
+// archived — so the second question is about the refusals, and says so.
+func TestBulkArchiveReAsksForTheDirtyOnesOnly(t *testing.T) {
+	srv := newBulkServer(t)
+	srv.dirty[5] = true
+	bar := &actionBar{}
+	target := bulkTarget(3, 5, 8)
+
+	bar.handleKey("A", srv.client(), target)
+	cmd, _ := bar.handleKey("y", srv.client(), target)
+	first := runBulk(t, cmd)
+	if len(first.done) != 2 || len(first.dirty) != 1 || first.dirty[0] != 5 {
+		t.Fatalf("first pass = %+v, want two archived and #5 held back", first)
+	}
+	bar.applyBulkResult(first)
+
+	if !bar.capturing() {
+		t.Fatal("a dirty worktree did not re-ask — the batch just failed")
+	}
+	prompt := bar.confirmPrompt(target)
+	if !strings.Contains(prompt, "1 of 3 selected tasks") {
+		t.Fatalf("re-ask = %q, want it scoped to the refusals", prompt)
+	}
+	if !strings.Contains(bar.status, "2 of 3") {
+		t.Errorf("status = %q, want what the first pass did to survive the re-ask", bar.status)
+	}
+
+	cmd, _ = bar.handleKey("y", srv.client(), target)
+	second := runBulk(t, cmd)
+	if len(second.done) != 1 || second.total != 1 {
+		t.Fatalf("forced pass = %+v, want just the dirty task", second)
+	}
+	srv.mu.Lock()
+	forced := append([]int64(nil), srv.forced...)
+	srv.mu.Unlock()
+	if len(forced) != 1 || forced[0] != 5 {
+		t.Fatalf("forced %v, want force on #5 alone — the clean tasks were already archived", forced)
+	}
+}
+
+// TestBulkReportNamesTheFirstRefusal: a batch that partly failed says so, with
+// one failure named. Forty error lines are not a status line — the board's own
+// rows are the durable account.
+func TestBulkReportNamesTheFirstRefusal(t *testing.T) {
+	srv := newBulkServer(t)
+	srv.fail[5], srv.fail[8] = true, true
+	bar := &actionBar{}
+	target := bulkTarget(3, 5, 8)
+
+	bar.handleKey("A", srv.client(), target)
+	cmd, _ := bar.handleKey("y", srv.client(), target)
+	msg := runBulk(t, cmd)
+	bar.applyBulkResult(msg)
+
+	if !bar.statusBad {
+		t.Errorf("status %q is not marked bad, though two tasks refused", bar.status)
+	}
+	for _, want := range []string{"1 of 3", "#5: the task is running", "and 1 more failed"} {
+		if !strings.Contains(bar.status, want) {
+			t.Errorf("status = %q, want %q in it", bar.status, want)
+		}
+	}
+}
+
+// TestBulkActionKeysCountTheTasksTheyMove: an action offered because *some*
+// marked task accepts it has to say how many, or the key is a promise about
+// nine rows that moves seven.
+func TestBulkActionKeysCountTheTasksTheyMove(t *testing.T) {
+	target := taskActions{
+		id: 1, state: stateDone, actions: []string{apiclient.ActionArchive},
+		marked: []markedTask{
+			{id: 1, actions: []string{apiclient.ActionArchive}},
+			{id: 2, actions: []string{apiclient.ActionArchive}},
+			{id: 3, actions: []string{apiclient.ActionCancel}},
+		},
+	}
+	bar := &actionBar{}
+	line := bar.render(target)
+	if !strings.Contains(line, "archive (2)") {
+		t.Errorf("action line = %q, want archive counted at 2 of the 3 marked", line)
+	}
+	if !strings.Contains(line, "cancel (1)") {
+		t.Errorf("action line = %q, want cancel offered for the one task that accepts it", line)
+	}
+}
+
+// TestBulkKeysWorkFromAnyPanel: the footer counts the selection wherever the
+// eye is, so `A` over the output pane must archive the selection rather than
+// the one task the detail panels happen to be showing.
+func TestBulkKeysWorkFromAnyPanel(t *testing.T) {
+	srv := newBulkServer(t)
+	s, _ := newShellFixture(t,
+		task(1, stateDone, withActions(apiclient.ActionArchive)),
+		task(2, stateDone, withActions(apiclient.ActionArchive)))
+	s.board.client = srv.client()
+	s.board.marks = markSet{1, 2}
+	s.focus = panelOutput
+	s.detail.taskID = 1
+
+	s.update(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	if !s.bar.capturing() {
+		t.Fatal("A over the output pane did not raise the bulk confirmation")
+	}
+	if got := s.bar.confirmPrompt(s.board.target()); !strings.Contains(got, "2 selected tasks") {
+		t.Fatalf("prompt = %q, want the selection named", got)
+	}
+
+	_, cmd := s.update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	msg := runBulk(t, cmd)
+	if len(msg.done) != 2 {
+		t.Fatalf("result = %+v, want both marked tasks archived", msg)
+	}
+	// What the daemon accepted leaves the selection; the board refetches.
+	s.update(msg)
+	if s.board.hasMarks() {
+		t.Errorf("the archived tasks stayed marked: %v", s.board.marks)
+	}
+}
+
+// TestBulkForceReAskSurvivesTheCursorMoving is the seam between the two halves
+// of a bulk archive: the clean tasks are gone from the list by the time the
+// re-ask is on screen, so the cursor lands on another row and the detail panels
+// reset the shared bar. The question is about the selection, not about the row
+// under the cursor, and it has to still be there.
+func TestBulkForceReAskSurvivesTheCursorMoving(t *testing.T) {
+	srv := newBulkServer(t)
+	srv.dirty[1] = true
+	s, _ := newShellFixture(t,
+		task(1, stateDone, withActions(apiclient.ActionArchive)),
+		task(2, stateDone, withActions(apiclient.ActionArchive)))
+	s.board.client = srv.client()
+	s.board.marks = markSet{1, 2}
+	// Finished tasks read newest first, so the cursor starts on #2 — the one
+	// that is about to be archived and disappear.
+	if s.cursor != 2 {
+		t.Fatalf("fixture cursor = #%d, want the row that this archive removes", s.cursor)
+	}
+
+	s.update(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	_, cmd := s.update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	msg := runBulk(t, cmd)
+
+	// The refetch that follows drops #2, and the cursor lands on #1.
+	s.update(msg)
+	s.update(boardLoadedMsg{tasks: []apiclient.Task{
+		task(1, stateDone, withActions(apiclient.ActionArchive)),
+	}})
+	s.render(120, 37)
+	if s.cursor != 1 {
+		t.Fatalf("cursor = #%d after the archived row went away, want it moved to #1", s.cursor)
+	}
+
+	if !s.bar.capturing() {
+		t.Fatal("the force re-ask was cleared when the cursor moved off the archived row")
+	}
+	if got := s.bar.confirmPrompt(s.board.target()); !strings.Contains(got, "uncommitted") {
+		t.Fatalf("prompt = %q, want the dirty-worktree question", got)
+	}
+}
+
+// TestBulkSelectionLeavesFailuresMarked: a retry must not need the selection
+// to be built again.
+func TestBulkSelectionLeavesFailuresMarked(t *testing.T) {
+	b := markedBoard(
+		task(1, stateDone, withActions(apiclient.ActionArchive)),
+		task(2, stateRunning, withActions(apiclient.ActionCancel)),
+	)
+	b.marks = markSet{1, 2}
+
+	b.update(bulkResultMsg{
+		action: apiclient.ActionArchive, total: 2,
+		done:   []int64{1},
+		failed: []bulkFailure{{id: 2, err: fmt.Errorf("boom")}},
+	})
+	if b.marks.has(1) {
+		t.Errorf("an archived task stayed selected: %v", b.marks)
+	}
+	if !b.marks.has(2) {
+		t.Errorf("the refusal lost its mark: %v — a retry would need re-selecting", b.marks)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/bulklive_test.go
+++ b/internal/tui/bulklive_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// TestBulkArchiveLive is task 011's done-when, against the real handlers: two
+// tasks are selected on the board, one `A` asks once, and one `y` archives
+// both. Nothing here is stubbed — the transitions are the daemon's, so this is
+// what proves the client-side fan-out is still an ordinary §6 action per task.
+func TestBulkArchiveLive(t *testing.T) {
+	h := newActionLiveHarness(t)
+	ctx := context.Background()
+
+	ids := make([]int64, 0, 2)
+	for _, title := range []string{"finished-one", "finished-two"} {
+		task := h.createTask(t, title)
+		if _, _, err := h.st.TransitionTask(ctx, task.ID,
+			store.TaskQueued, store.TaskDone, store.TaskChange{}); err != nil {
+			t.Fatalf("park %s at done: %v", title, err)
+		}
+		ids = append(ids, task.ID)
+	}
+
+	h.p.until(30*time.Second, "the board to show both finished tasks", func() bool {
+		out := content(h.m)
+		return strings.Contains(out, "finished-one") && strings.Contains(out, "finished-two")
+	})
+
+	// Select everything the board is showing, and check the offer before
+	// acting on it: the key has to say how many tasks it moves.
+	h.press(t, "V")
+	h.p.until(10*time.Second, "the selection to be counted on screen", func() bool {
+		return strings.Contains(content(h.m), "archive (2)")
+	})
+
+	h.press(t, "A")
+	if !strings.Contains(content(h.m), "2 selected tasks") {
+		t.Fatalf("A did not ask about the selection:\n%s", content(h.m))
+	}
+	h.press(t, "y")
+
+	for _, id := range ids {
+		h.p.until(60*time.Second, "both tasks to be archived", func() bool {
+			return h.state(t, id) == store.TaskArchived
+		})
+	}
+	// A finished batch hands the selection back empty: what the daemon
+	// accepted is no longer waiting to be dealt with.
+	h.p.until(30*time.Second, "the selection to empty as the archives land", func() bool {
+		return !h.m.views[viewHome].(*shell).board.hasMarks()
+	})
+}

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -142,11 +142,11 @@ func pinnedHits(x int, segs []footerSeg) []footerHit {
 // bar's last status.
 func footerLeftSegs(panelRows []binding, bar *actionBar, target taskActions, attention int, retry bool) []footerSeg {
 	segs := footerHintSegs(panelRows)
-	if bar != nil && target.id != 0 {
+	if bar != nil && (target.id != 0 || target.bulk()) {
 		for _, o := range actionOrder {
 			if target.has(o.action) {
 				segs = append(segs, footerSeg{
-					text: styleKey.Render(o.key) + " " + o.action, key: o.key,
+					text: styleKey.Render(o.key) + " " + actionLabel(target, o.action), key: o.key,
 				})
 			}
 		}

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -45,8 +45,14 @@ func newPalette(entries []paletteEntry) *palette {
 // on a task the daemon cannot see.
 func paletteEntries(ctx bindingContext, target taskActions, editable, connected bool) []paletteEntry {
 	out := make([]paletteEntry, 0, len(bindings))
-	if connected && target.id != 0 {
+	if connected && (target.id != 0 || target.bulk()) {
+		// A selection is what the keys act on, so it is what the section is
+		// titled after (task 011) — running `archive` from here with nine rows
+		// marked must not read as archiving the one row named above the list.
 		group := fmt.Sprintf("actions on #%d", target.id)
+		if target.bulk() {
+			group = "actions on " + selectedNoun(len(target.marked))
+		}
 		for _, b := range bindings {
 			if b.scope != scopeTaskAction || !target.has(b.action) {
 				continue

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -206,6 +206,9 @@ func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		}
 		return s, cmd
 	}
+	if cmd, handled := s.bulkKey(msg); handled {
+		return s, cmd
+	}
 	if s.focusedCaptures() {
 		// While the filter field is being typed into, tab commits it and
 		// moves focus (§15): the filter is view state, not a mode, and
@@ -232,10 +235,15 @@ func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		s.cycleFocus(-1)
 		return s, nil
 	case "esc":
-		// The shell's layer of the §15 esc stack: clear the active filter,
-		// from any panel focus. Below that is nothing — esc never quits,
-		// and "back to the board" is not a meaning any more because the
-		// board is always on screen; tab is the focus key.
+		// The shell's layers of the §15 esc stack, innermost first: the bulk
+		// selection, then the active filter, from any panel focus. Below that
+		// is nothing — esc never quits, and "back to the board" is not a
+		// meaning any more because the board is always on screen; tab is the
+		// focus key.
+		if s.board.hasMarks() {
+			s.board.clearMarks()
+			return s, nil
+		}
 		if s.board.filterActive() {
 			s.board.clearFilter()
 			return s, s.checkSelection()
@@ -255,6 +263,32 @@ func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return s, s.detail.update(msg)
 	}
 	return s, tea.Batch(s.routeKey(msg), s.checkSelection())
+}
+
+// bulkKey aims the §6 action keys at the board's selection, from whichever
+// panel has focus (task 011).
+//
+// It has to run before the panels see the key, for one reason: the footer
+// counts the marked tasks wherever the eye is, so `A` over the output pane must
+// archive the seven the footer promised rather than the one task the detail
+// panels happen to be showing. The same goes for the y/n underneath it — a
+// pending *bulk* confirmation is answered here, while a single-task one is left
+// to the panel that raised it.
+//
+// A key that is not an action the selection offers comes back unhandled, so
+// j/k, space and tab keep working with rows marked.
+func (s *shell) bulkKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	if s.board.filtering {
+		return nil, false // the filter field owns every key it is given
+	}
+	switch {
+	case len(s.bar.pendingIDs) > 0: // a bulk confirmation is on screen
+	case s.bar.capturing(): // a single-task confirmation: not ours
+		return nil, false
+	case !s.board.hasMarks():
+		return nil, false
+	}
+	return s.bar.handleKey(msg.String(), s.board.client, s.board.target())
 }
 
 // routeKey hands a key to the focused panel's sub-model.
@@ -534,6 +568,12 @@ func (s *shell) panelTitle(id panelID) string {
 		}
 		if v := s.board.filter.Value(); v != "" && !s.board.filtering {
 			title += " — /" + v
+		}
+		// The selection is a set of tasks, not of rows (task 011): a marked
+		// task the filter is hiding is still going to be archived, and this
+		// count is what says so.
+		if n := len(s.board.marks); n > 0 {
+			title += fmt.Sprintf(" — %d selected", n)
 		}
 		return title
 	case panelTimeline:


### PR DESCRIPTION
Triage arrives in batches — a sweep of finished tasks to archive, a run of
queued ones to cancel after a bad workflow edit — and one row at a time that
is the same keypress N times with a confirmation between each, which is where
a human either stops tidying up or stops reading the confirmations.

`space` marks the row under the cursor, `V` marks everything the filter is
showing, `esc` clears the selection, and while anything is marked the §6
action keys act on the marked tasks instead of the cursor row.

The rules the selection holds to (closes 011):

- It is a set of tasks, not of rows: it survives a filter, a `g` regroup and a
  refresh, and the panel title counts it so a marked task the filter is hiding
  still says it is coming along. Marks are pruned only by a successful load.
- An action is offered when *some* marked task offers it, and the key carries
  the count — `A archive (7)` on nine marked rows. Requiring all of them would
  make archive vanish from a sweep of finished work because one task in it is
  running, with nothing on screen to explain the absence.
- One confirmation for the batch, one ordinary §6 call per task, sequentially:
  no bulk endpoint, so the daemon stays the only definition of what an action
  means. `force` is still the dirty confirmation and re-asks about exactly the
  refusals; the batch reports `archive · 5 of 7`, the branch cleanup, and the
  first refusal named.
- The keys work from any panel, since the footer counts the selection wherever
  the focus is; what the daemon accepted leaves the selection and refusals stay
  marked, so a retry needs no re-selection.

Spec §15 amended (view 1, a new *Bulk selection* block, Keys, and the esc
stack) and the TUI guide grew *Acting on several tasks at once*.