### PR TITLE
chore(claude): enable mattpocock-skills plugin repo-wide

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "mattpocock": {
+      "source": {
+        "source": "github",
+        "repo": "mattpocock/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "mattpocock-skills@mattpocock": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` so Matt Pocock's skills plugin is always available to anyone running Claude Code in this repository — no per-clone `/plugin marketplace add` + `/plugin install` step.

Two keys, nothing else:

- `extraKnownMarketplaces.mattpocock` registers the marketplace from `github.com/mattpocock/skills` (verified against its `.claude-plugin/marketplace.json`, which names the marketplace `mattpocock`).
- `enabledPlugins["mattpocock-skills@mattpocock"]` enables the plugin (v1.2.3 at time of writing), which contributes 25 skills across `engineering/` (`tdd`, `code-review`, `diagnosing-bugs`, `to-spec`, `to-tickets`, `domain-modeling`, `codebase-design`, `resolving-merge-conflicts`, …) and `productivity/` (`grilling`, `handoff`, `teach`, `writing-for-agents`, …).

No `ref` is pinned, so the marketplace tracks its default branch and picks up upstream skill updates. Pin a tag there if we'd rather review each bump.

Two things worth flagging, since this is a settings file that ships to every contributor:

- Settings precedence is user < project < local. A contributor who doesn't want the plugin can set `"mattpocock-skills@mattpocock": false` in their gitignored `.claude/settings.local.json`; setting it false in `~/.claude/settings.json` will *not* win against this file.
- Enabling a plugin means executing third-party skill content from a repo we don't control. That's the same trust posture as any marketplace install, just now decided centrally rather than per contributor.

## Related

No issue or `docs/tasks/` entry — repo tooling config, not product work under the spec. No recorded decision is revisited.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added/updated for behavior changes — n/a, no Go code touched; `.claude/settings.json` is agent tooling config and affects no build, test, or gate path
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — n/a, nothing about the `vincent` binary or its behavior changes
- [ ] Affected page under `docs/` updated — n/a, this touches none of `internal/config`, the cobra tree, the API route table, `internal/tui/bindings.go`, or the `Reason*` constants

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQwYHGkWNNN1HyKeMQKWKs)_