### PR TITLE
docs: open task 013 — gating workflows that require mid-run interaction

### DIFF
--- a/.vincent/workflows/github-bug.yaml
+++ b/.vincent/workflows/github-bug.yaml
@@ -40,6 +40,11 @@
 # by codex and cursor (`supports_input: false`, §9.3/§9.7), so on those adapters
 # `diagnose` would silently guess at the repro instead of asking the reporter.
 #
+# Left on `wait` rather than `on_input: require` (task 013): `require` would
+# refuse those adapters outright, and degrading is what these files have
+# always documented as intended. Add it per file if you would rather the
+# workflow refuse than guess.
+#
 # POSIX-only. Every command step pins `shell: sh`; agent steps cannot pin a
 # shell at all (§8.2 rejects `shell` on an agent step), so their `check` runs
 # under the platform default and is written in `sh` regardless. On Windows the

--- a/.vincent/workflows/github-enhancement.yaml
+++ b/.vincent/workflows/github-enhancement.yaml
@@ -25,6 +25,11 @@
 # those adapters `digest` would silently skip the part that makes this workflow
 # worth running and implement whatever it guessed.
 #
+# Left on `wait` rather than `on_input: require` (task 013): `require` would
+# refuse those adapters outright, and degrading is what these files have
+# always documented as intended. Add it per file if you would rather the
+# workflow refuse than guess.
+#
 # POSIX-only. Every command step pins `shell: sh`; agent steps cannot pin a
 # shell at all (§8.2 rejects `shell` on an agent step), so their `check` runs
 # under the platform default and is written in `sh` regardless. On Windows the

--- a/.vincent/workflows/github-issue.yaml
+++ b/.vincent/workflows/github-issue.yaml
@@ -11,6 +11,11 @@
 # (`supports_input: false`, §9.3/§9.7), so on those adapters the questioning
 # step would silently skip the part that makes this workflow worth running.
 #
+# Left on `wait` rather than `on_input: require` (task 013): `require` would
+# refuse those adapters outright, and degrading is what these files have
+# always documented as intended. Add it per file if you would rather the
+# workflow refuse than guess.
+#
 # POSIX-only. Every command step pins `shell: sh` and the draft check uses
 # `test`; on Windows this needs Git Bash's `sh` on PATH, and fails loudly
 # rather than being reinterpreted by pwsh (§8.3 — portability is the author's

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -84,6 +84,11 @@ against real captured runs. Outside that range the adapter reports
 `supports_input: false` and runs exactly as it otherwise would — no input flags,
 plain-text prompt. Nothing degrades silently.
 
+A workflow that *needs* the conversation says `on_input: require`, and then a
+claude outside the verified family is refused for that step rather than run
+unattended — `GET /v1/agents` reports `input_verdict: "unsupported"` for it, and
+a step that reaches the engine anyway fails with `input_unsupported`.
+
 ## Codex
 
 **Binary:** `codex`. **Workflow value:** `agent: codex`.
@@ -99,7 +104,9 @@ plain-text prompt. Nothing degrades silently.
   another — so pickers offer free text and the CLI's own default. A model you
   type is passed through with a warning, not rejected.
 - **No cost reporting**, and `supports_input: false`: a codex step never enters
-  `awaiting_input`, and `on_input` has no effect on it.
+  `awaiting_input`, and `on_input: wait|deny` has no effect on it. `on_input:
+  require` is the one that does: a step declaring it cannot use codex at all,
+  and a workflow pinning `agent: codex` on such a step fails validation.
 - **Reasoning is surfaced.** Codex emits whole reasoning blocks, which the TUI
   shows at the `normal` and `verbose` output levels (`v` cycles them) and the
   transcript records as `agent.thinking`. Whether any are emitted depends on
@@ -125,7 +132,9 @@ and would open a GUI. **Workflow value:** `agent: cursor`.
   question.
 - vincent's own worktree flags are never passed to it. Cursor has a worktree
   feature; worktrees belong to vincent, and two owners of one concept is a defect.
-- Reports token usage but **no cost**, and `supports_input: false`.
+- Reports token usage but **no cost**, and `supports_input: false` — so, like
+  codex, cursor cannot back a step declaring `on_input: require`, and pinning it
+  on one is a validation error.
 - Errors do not arrive in the stream — an invalid model id exits 1 with a message
   on stderr and no result line — so the adapter reports "stream ended without a
   result event" plus the stderr tail, which is what makes an everyday typo

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -174,6 +174,31 @@ The block reason `platform_unsupported` on an existing task means the task was
 created elsewhere and its data directory has since moved between machines. The
 snapshot is fine; it is the host that changed.
 
+### An agent cannot be picked for a workflow — `input_unsupported`
+
+The workflow has a step declaring
+[`on_input: require`](../reference/workflow-schema.md#type-agent): it needs an
+agent that can stop mid-run and ask you something. Codex and cursor never can —
+neither CLI has a control channel — and claude can only inside the CLI version
+family vincent has verified the protocol against.
+
+Where you meet it:
+
+- **The new-task picker greys the agent out**, and `POST /v1/tasks` answers
+  `400` naming the step. Pick an agent whose `input_verdict` in
+  `vincent agents` (or `GET /v1/agents`) is `supported`.
+- **The workflow fails to validate** when a step pins `agent: codex` or
+  `agent: cursor` outright. Change the pin, or drop `require` back to `wait` if
+  the questions are optional after all.
+- **A task blocks with `input_unsupported`** when the answer changed after the
+  task was created — almost always a claude upgrade past the verified family.
+  Check `vincent agents`; the fix is on the machine, not in the workflow, and
+  `retry` refuses until it is done rather than reproducing the block.
+
+An agent that is **not installed** never triggers any of this: an unknown
+verdict is not a refusal, and you get `agent_unavailable` at run time instead if
+it is still missing.
+
 ### Every cursor tool call is blocked on Windows
 
 If cursor steps run, produce no edits, and report blocked tool calls, check
@@ -327,6 +352,7 @@ The block reason names what happened:
 | `template_error` | A template failed to render (see above) |
 | `restricted_unsupported` | The adapter cannot restrict on this platform |
 | `platform_unsupported` | The workflow's `platforms:` list does not admit this host |
+| `input_unsupported` | A step needs an agent that can answer questions mid-run, and this one cannot (see below) |
 | `transcript_limit` | The attempt's transcript hit `transcript_max_bytes` |
 | `rejected` | You rejected a manual gate |
 | `shell_unavailable` | The requested shell is not installed |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -251,8 +251,50 @@ defaults:
 window. On expiry the process is killed and the attempt fails under the normal
 retry policy.
 
+- **`require`** — `wait`, plus a promise that a human is part of the run. The
+  step will only run on an agent that can stop and ask; one that cannot is
+  refused rather than left to guess.
+
 Adapters that report `supports_input: false` (codex, cursor) never produce input
-requests, and `on_input` has no effect on their steps.
+requests, and `wait` and `deny` have no effect on their steps.
+
+### When the conversation *is* the workflow
+
+`wait` and `deny` both degrade quietly on an agent with no control channel: the
+step runs, nothing is ever asked, and the agent decides alone. That is usually
+what you want — but not for a workflow built around asking you which of three
+designs to take. There, an agent that cannot ask does not degrade, it guesses,
+and nothing in the run says so.
+
+`on_input: require` makes that explicit:
+
+```yaml
+steps:
+  - id: clarify
+    type: agent
+    on_input: require
+    prompt: Ask me whatever you need before you start, then implement it.
+```
+
+What it changes, and where you notice:
+
+- **In the file.** Pinning `agent: codex` (or `cursor`) on a requiring step is
+  a validation error — those CLIs have no control channel in any version, so
+  the file could never work. `vincent workflow validate` catches it.
+- **When creating a task.** The new-task agent picker greys out an agent that
+  cannot answer questions, and `POST /v1/tasks` refuses one with a 400 naming
+  the step. A workflow whose requiring steps leave their agent to the task is
+  marked `needs an interactive agent` in the picker.
+- **Never on a guess.** An agent that is not installed, or whose probe did not
+  answer, is *unknown* — and unknown never refuses anything. You are only ever
+  blocked by a definite "this one cannot".
+- **At run time.** If the answer changes under you — claude upgraded past the
+  version family vincent has verified the protocol against — the step fails
+  with `input_unsupported` instead of running an unattended conversation.
+
+A step's own `on_input` still wins over `defaults:`, so a mostly-interactive
+workflow can mark one long cleanup step `on_input: deny` and leave it to run
+unattended.
 
 ## Writing portable command steps
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -66,7 +66,7 @@ parse out of prose — an invalid state transition is always `409` with
 ```json
 { "agents": [ {
     "name": "claude", "available": true, "path": "…", "version": "2.1.224",
-    "supports_input": true, "logged_in": null,
+    "supports_input": true, "input_verdict": "supported", "logged_in": null,
     "models":  [ { "value": "sonnet", "source": "cli" } ],
     "efforts": [ { "value": "max",    "source": "cli" } ],
     "default_model": "", "default_effort": "",
@@ -204,7 +204,7 @@ to disable the sweep.
 | `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort?, title?, fields?, base_branch?, branch_name? }` → resolution per step, plus the previewed branch name |
 
 Registry entries carry
-`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, errors[]?, warnings[]?, error? }`.
+`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, requires_input, errors[]?, warnings[]?, error? }`.
 
 `platforms[]` is the entry's [platform restriction](workflow-schema.md#platforms)
 as the file declares it, and `platform_supported` is **the daemon's own verdict**
@@ -212,6 +212,14 @@ on it — the daemon is the process that would run the steps, so clients report
 that flag rather than comparing the list to their own OS. An entry with
 `platform_supported: false` is listed like any other, but `POST /v1/tasks`
 rejects a task naming it with a `400`.
+
+`requires_input` marks an entry with a step declaring
+[`on_input: require`](workflow-schema.md#type-agent) that leaves its agent to
+the task — the agent chosen for a task on it must be one that can stop and ask
+mid-run, or `POST /v1/tasks` rejects it with a `400` naming the step. Each
+adapter's `input_verdict` in `GET /v1/agents` (`supported`, `unsupported`,
+`unknown`) is the verdict that gate uses; only `unsupported` refuses anything,
+so an agent that is not installed never blocks a task.
 
 `POST /v1/resolve` applies the [resolution order](workflow-schema.md#resolution-order)
 to every step under a candidate task-level override, returning `{ value, source }`

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -152,6 +152,7 @@ same thing wherever it originated.
 | `canceled` | You cancelled the task |
 | `invalid_snapshot` | The task's stored workflow snapshot is unusable |
 | `platform_unsupported` | The workflow is restricted to platforms this host is not (`platforms:`). Only reachable for a task created on another OS |
+| `input_unsupported` | The step declares `on_input: require` and its agent cannot take mid-run input. Refused at task creation, so only reachable when the agent changed underneath the task |
 | `interrupted` | The daemon stopped mid-step — not a failure |
 | `internal_error` | A bug. Please [report it](https://github.com/lezli01/vincent/issues/new/choose) |
 

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -100,7 +100,7 @@ Every key here is also settable per step, where it wins.
 | `model` | string | adapter default | agent steps |
 | `effort` | string | adapter default | agent steps (**ignored by cursor**) |
 | `permission_mode` | `full-auto` \| `restricted` | `full-auto` | agent steps |
-| `on_input` | `wait` \| `deny` | `wait` | agent steps on input-capable adapters |
+| `on_input` | `wait` \| `deny` \| `require` | `wait` | agent steps; `require` also gates which agents may run the step |
 | `input_timeout` | duration | `24h` (config) | agent steps |
 | `max_retries` | int | `1` | all steps |
 | `timeout` | duration | `60m` agent / `15m` command (config) | all steps |
@@ -133,7 +133,7 @@ Runs an agent CLI headlessly in the worktree.
 | `model` | string | | Adapter-native id or alias |
 | `effort` | string | | Adapter-native. Cursor has none — it lives in the model id |
 | `permission_mode` | string | | `full-auto` (default) or `restricted` |
-| `on_input` | string | | `wait` (default) or `deny`. No effect on codex or cursor |
+| `on_input` | string | | `wait` (default), `deny`, or `require`. `wait`/`deny` have no effect on codex or cursor; `require` refuses them |
 | `input_timeout` | duration | | Bounds each wait in `awaiting_input`, per request |
 | `check` | string | | Shell command that must exit 0 for the attempt to succeed |
 | `check_timeout` | duration | | Defaults to the command timeout |
@@ -296,9 +296,12 @@ network, no agent CLI installed.
 - Every template parses.
 - `platforms` entries are known tokens, with no duplicates. The list is checked
   for shape, never against the validating host.
-- Durations parse as Go durations; `on_input` is `wait` or `deny`.
+- Durations parse as Go durations; `on_input` is `wait`, `deny` or `require`.
 - Unknown keys are errors.
 - `agent` names a known adapter.
+- A step with `on_input: require` does not resolve to an adapter that can
+  never take mid-run input (codex, cursor). The error points at the `agent`
+  field that supplied the value — the step's own, or `defaults.agent`.
 - The resolved `(agent, model, effort)` triple is checked **cross-catalog**:
   - a value in the resolved adapter's own catalog → valid;
   - a value found only in **another** adapter's catalog → **error** (claude's

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -388,6 +388,38 @@ vincent immediately auto-responds through the adapter's `Respond()` — question
 get a canned "no user is available; decide with your best judgment" answer,
 permission requests are denied — and the task never leaves `running`.
 
+`on_input: require` (workflow `defaults` or per step, added 2026-08-17, task
+013) is `wait` plus a **precondition**: the step will only run on an adapter
+that can stop and take a human answer. It is for a workflow whose point is the
+conversation — an agent that cannot ask does not degrade there, it guesses.
+
+The requirement is enforced at three layers, and only ever on a *positive*
+"this adapter cannot":
+
+- **Load (§8.2).** A requiring step resolving to an adapter that can never take
+  input — codex, cursor: no control channel exists in any version — is a
+  validation error, attributed to the `agent` field that supplied the value.
+  claude is not judged here: its support is a version question (§9.3) that only
+  a probe answers, and validation never spawns a process.
+- **Task creation (§13.2).** `POST /v1/tasks` resolves every requiring step
+  against the task's agent override (§8.6) and refuses a selection the daemon
+  knows cannot ask. An absent binary or a probe that did not answer is
+  *unknown*, and unknown never refuses — §9.6's degrade-never-block rule
+  outranks this gate. `GET /v1/workflows` reports `requires_input` for a
+  workflow whose requiring steps leave their agent to the task, and
+  `GET /v1/agents` reports each adapter's `input_verdict`
+  (`supported` | `unsupported` | `unknown`), so a client marks its picker
+  without re-deriving the asymmetry.
+- **Run (§7.2).** The engine re-checks before spawning, and fails the attempt
+  with `input_unsupported` when the answer is now no — the task and its daemon
+  having parted company is the only way to get here.
+
+A step's own `on_input` wins over `defaults:` as every other field does, so
+`defaults: {on_input: require}` with one step's `on_input: deny` leaves that
+step deliberately unattended. `require` changes nothing else: `input_timeout`
+keeps its meaning and its three levels, and once the step is running `require`
+and `wait` are the same thing.
+
 Adapters without mid-run input support (`supports_input: false`, §9.5 — codex in
 v1) never produce input requests; their steps behave exactly as today. Requests
 and answers are appended to the step transcript as namespaced `vincent.*` lines;
@@ -417,7 +449,7 @@ defaults:                             # optional; per-step values override
   model: ""                           # adapter-native id/alias (e.g. sonnet); options via GET /v1/agents (§9.6)
   effort: ""                          # adapter-native effort (claude: low…max; codex: minimal…high) (§8.6)
   permission_mode: full-auto          # full-auto | restricted   (§9.4)
-  on_input: wait                      # wait | deny — agent input requests (§7.4)
+  on_input: wait                      # wait | deny | require — agent input requests (§7.4)
   input_timeout: 24h                  # max wait in awaiting_input (§7.4)
   max_retries: 1
   timeout: 60m
@@ -512,7 +544,7 @@ Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
 Constraints (validated on load and via `POST /v1/workflows/validate`):
 
 - `steps` non-empty; step ids unique; templates must parse; `type` known; durations
-  parse as Go durations; `on_input` is `wait` or `deny`; unknown keys are errors
+  parse as Go durations; `on_input` is `wait`, `deny` or `require`; unknown keys are errors
   (strict decoding) to catch typos.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
@@ -530,6 +562,14 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   can soften but never harden). Warnings surface structurally: `warnings[]`
   beside `errors[]` on registry entries and the validate response (§13.2),
   `warnings[]` on the task-creation response, and the daemon log.
+- A step declaring `on_input: require` (§7.4, added 2026-08-17, task 013) must
+  resolve to an adapter that can take mid-run input. Only the *static* half is
+  judged here — an adapter with no control channel in any version (codex,
+  cursor) is an error; claude, whose support is version-gated (§9.3), is left
+  to the creation-time and run-time checks, since deciding it would mean
+  probing. The finding is attributed to the `agent` field that supplied the
+  value: the step's own when it pins one, `defaults.agent` otherwise, reported
+  once however many steps inherit it.
 
 ### 8.3 Command steps and shells
 
@@ -921,12 +961,20 @@ defaults:
 ```json
 { "agents": [ {
     "name": "claude", "available": true, "path": "…", "version": "2.1.224",
-    "supports_input": true, "logged_in": null,
+    "supports_input": true, "input_verdict": "supported", "logged_in": null,
     "models":  [ { "value": "sonnet", "source": "cli" }, { "value": "opus", "source": "cli" } ],
     "efforts": [ { "value": "low", "source": "cli" }, { "value": "max", "source": "cli" } ],
     "default_model": "", "default_effort": "",
     "probed_at": "2026-08-07T10:00:00Z", "probe_error": null } ] }
 ```
+
+- **`input_verdict`** (added 2026-08-17, task 013) is the daemon's answer to
+  whether this adapter may back an `on_input: require` step (§7.4):
+  `supported`, `unsupported`, or `unknown`. It is not derivable from
+  `supports_input` alone — `false` there means "no" for an installed binary and
+  "nobody can say" for an absent one, and only the first refuses anything — so
+  the daemon publishes the verdict its own gate uses rather than leaving each
+  client to re-derive the asymmetry.
 
 - **Always dynamic, never slow:** probes run on demand and results are cached
   keyed by *binary identity* (resolved path + mtime + version). Help output is
@@ -1699,9 +1747,13 @@ DELETE /v1/projects/{id}                hard-deletes the project and its task hi
 GET    /v1/workflows?project_id=        merged registry view: built-in + global + that project's
                                         (shadowing applied); each entry:
                                         { name, scope, project_id, file, description, steps[],
-                                          platforms[]?, platform_supported, errors[]?, warnings[]?, error? }
+                                          platforms[]?, platform_supported, requires_input,
+                                          errors[]?, warnings[]?, error? }
                                         platform_supported is this daemon's own verdict on the
-                                        entry's §8.1.1 restriction (task 010, added 2026-08-16)
+                                        entry's §8.1.1 restriction (task 010, added 2026-08-16);
+                                        requires_input marks an entry whose §7.4 `require` steps
+                                        leave their agent to the task, so the agent picked for a
+                                        task must be one that can ask (task 013, added 2026-08-17)
 POST   /v1/workflows/validate           { yaml } → { valid, errors[], warnings[] }
 POST   /v1/resolve                      { workflow, project_id?, agent?, model?, effort?,
                                           title?, fields?, base_branch?, branch_name? } →
@@ -2407,6 +2459,7 @@ currently true to show (§15 view 6).
 | Agent stopped by a usage limit | *Added 2026-08-14 (task 003).* Where the adapter recognizes the wording, the attempt is recorded `interrupted` with reason `usage_limit`, consumes **no** retry (§7.2), and the task returns to `queued` with an admission hold (§11) — releasing its slot, so other work keeps running. The hold ends at the reset time the CLI reported, or `usage_limit_recheck_interval` after the stop when it reported none. Recovery is unattended: the scheduler re-admits and the step re-runs. The board says `queued` *with* its reason rather than `blocked` (§15). Where the adapter recognizes nothing — codex and cursor today (§9.1) — the run reads as `nonzero_exit`/`agent_error` exactly as before |
 | `effort` set on a step whose agent has no effort concept | Ignored by the adapter and documented as ignored (cursor, §9.7); a claude/codex effort value on a cursor step is already an §8.2 *error* — it belongs to another adapter's catalog |
 | `restricted` step on an adapter that cannot restrict on this OS | Step fails to start with `restricted_unsupported` (cursor on Windows, §9.7), under the retry policy → typically blocked. Never downgraded to full-auto, and deliberately *not* `agent_unavailable`: the CLI is installed and healthy, so "not found" would send the user to reinstall what is already there |
+| Step declaring `on_input: require` on an agent that cannot ask | *Added 2026-08-17 (task 013).* A workflow pinning an adapter with no control channel (codex, cursor) fails §8.2 validation outright. Otherwise creation is refused with a `400` naming the step and the agent, and the TUI's picker will not select that agent; `GET /v1/agents` publishes the `input_verdict` the gate uses. A task that reaches the engine anyway — claude upgraded past the §9.3 ceiling, a data directory moved — fails the attempt with `input_unsupported` under the §7.2 budget, before anything is spawned. Only a positive "cannot" refuses: an absent or unprobed binary is unknown, and unknown never blocks (§9.6) |
 | Workflow restricted to platforms this host is not | *Added 2026-08-16 (task 010).* Creation is refused with a `400` naming the restriction and the host (§8.1.1); the entry stays listed and says why, and the TUI's picker will not select it. A task that *already* holds such a snapshot — the data directory moved to another OS, or the workflow narrowed after the task was queued — blocks at admission with `platform_unsupported`, before a worktree or any step. Not `invalid_snapshot`: the snapshot is valid, just not here |
 | Runaway step output (agent or command) | Past `transcript_max_bytes` (§12.3) the process tree is killed and the attempt fails `transcript_limit`, under the retry policy. The line that trips the cap is written **whole** — a truncated line would turn a size failure into a parse failure for every later reader of the JSONL — and the partial transcript is kept with a closing `vincent.transcript_limit` annotation, because the lines that got there are what explain the runaway |
 | Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). DB rows are never deleted; retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |

--- a/docs/tasks/013-interactive-workflow-agent-gating.md
+++ b/docs/tasks/013-interactive-workflow-agent-gating.md
@@ -1,0 +1,250 @@
+# 013 — Gating workflows that require mid-run interaction
+
+**Status:** 📋 planned (0/8) · **Opened:** 2026-08-17
+
+An agent step may now declare that it *needs* a human mid-run:
+
+```yaml
+steps:
+  - id: clarify
+    type: agent
+    on_input: require
+    prompt: Ask me whatever you need before you start.
+```
+
+A step that says `require` will only ever run on an adapter that can stop the
+run and wait for an answer. A workflow pinning an adapter that can never do so
+fails to load; a task whose agent selection cannot satisfy such a step is
+refused at creation; a snapshot that somehow reaches the engine anyway fails the
+step with `input_unsupported`.
+
+## The problem
+
+§7.4 defines `on_input: wait | deny` as *the step's reaction to a mid-run input
+request*, and §9.5 makes `supports_input` a per-adapter fact — true for claude
+inside the verified version family, permanently false for codex and cursor,
+which have no control channel at all. The two never meet: `on_input` is
+"ignored by adapters without input support", so a workflow whose whole point is
+a conversation runs silently non-conversationally on two of three adapters.
+
+The author of such a workflow has no way to *say* that the conversation is the
+point. The three shipped GitHub workflows document the gap in comments — "this
+is ignored by codex and cursor, so on those adapters the questioning step just
+proceeds" — which is the right call for those files and the wrong one for a
+workflow that exists to ask you which of three designs you want. There, an
+agent that cannot ask does not degrade; it guesses, and the run is worthless in
+a way nothing reports.
+
+This is the same shape as 010: a fact the author knows when writing the file,
+discoverable today only by watching a run not do what it was for.
+
+## Decisions
+
+### 1. One capability, not a vocabulary
+
+*2026-08-17.* `on_input: require` gates on exactly one thing: whether the
+adapter can pause the run and take a human answer. No `requires:` list, no
+capability tokens.
+
+**Beat:** a general `requires: [input, cost_reporting, thinking]` mechanism.
+Adapters differ in several documented ways (§9.3, §9.7 — codex reports no cost,
+cursor has no effort concept), so a vocabulary is imaginable. None of those
+differences can make a run *worthless*, which is the property that earns a
+gate, and `supports_input` is the only capability `Availability` actually
+carries. A second capability can generalize this later; designing tokens for
+facts no code consumes is how a schema grows a taxonomy nobody uses.
+
+Question-kind and permission-kind requests are one capability, not two: they
+ride the same control channel, and no adapter has one without the other. So
+there is nothing finer to gate on — "can it stop and ask me" is the whole
+question, and the structured-question modal is what it drives.
+
+### 2. A third value on `on_input`, per step
+
+*2026-08-17.* `require` joins `wait` and `deny` on the existing field, settable
+on a step and in `defaults:`.
+
+**Beat (a):** a separate `requires_input: true` boolean, which keeps
+`on_input`'s definition as a pure reaction. It is the more honest reading —
+`require` is a precondition, and only a reaction *after* the run starts — but it
+costs a second key plus a contradiction check between the two, to express what
+one enum value expresses with neither.
+
+**Beat (b):** a file-level `requires_input:` mirroring `platforms:`. 010's
+restriction is whole-file *by nature* ("this file is POSIX"); "this step asks
+questions" is not. Agent selection already resolves per step (step → task
+override → defaults), so a per-step declaration composes with the resolution
+that actually happens: a workflow can run its build on codex and its design
+review on claude, and only the second one constrains anything.
+
+### 3. The capability is static in the catalog, and detected at probe time
+
+*2026-08-17.* `agent.Options` gains `InputSupport`: `never` (codex, cursor — no
+control channel exists, ever) or `detected` (claude — the §9.5 version gate
+decides). `Curated()` returns it without probing, which is what §8.2 validation
+already reads.
+
+Two values, not three. There is no adapter that supports input regardless of
+version, so an `always` would be a value nothing sets.
+
+**Beat:** a new `Adapter.Capabilities()` method. §8.2 already reads `Curated()`
+and deliberately never spawns a process; putting the fact where the validator
+is already looking costs no new interface surface. It does not reach the wire —
+`agentResponse` copies `Models`/`Efforts`/defaults field by field, so
+`GET /v1/agents` keeps answering the live question with `supports_input` alone.
+
+### 4. Load time decides what is decidable there
+
+*2026-08-17.* A step that both requires input and pins (or inherits) an adapter
+whose `InputSupport` is `never` is a §8.2 **error**. A step resolving to an
+adapter whose support is `detected` is not judged at load: the answer depends on
+the installed binary, and the validation path never probes.
+
+This is the cross-catalog rule (§8.2) applied unchanged — a value belonging to
+another adapter is an error, a value nobody knows about passes with the CLI as
+final authority. A workflow that can never work should fail where its author is
+looking at the file.
+
+The error points at the **agent** field, not at `on_input`: `steps[2].agent`
+when the step pins it, `defaults.agent` when it inherits, collapsing duplicates
+the way `findingPath` already does for catalog findings. The requirement is what
+the author meant; the agent is what is wrong.
+
+### 5. Creation refuses a *known* incapable selection, never an unknown one
+
+*2026-08-17.* `POST /v1/tasks` consults the binary-identity cache
+(`CatalogCache.Entry`) and rejects only on a positive "this adapter does not
+support input" verdict. An absent binary, a failed probe or an unparseable
+version allows the task through; the run-time gate is the backstop.
+
+**Beat:** strict rejection on anything short of a positive yes. §9.6's
+degrade-never-block rule exists because one cold-logon probe timeout made a
+healthy CLI look dead for a whole daemon lifetime (T4.22); paying for that with
+refused task creation is worse than a step that blocks at run time naming its
+reason. A missing agent binary is already not a creation-time error.
+
+### 6. Only steps that would actually use the picked agent constrain the picker
+
+*2026-08-17.* The task-level agent choice is restricted only when at least one
+requiring step leaves its `agent:` unpinned — i.e. when the choice being made is
+the one that step will resolve to. A workflow whose requiring steps all pin a
+capable adapter imposes no restriction at all.
+
+The gate matches real §8.6 resolution rather than a conservative approximation
+of it. Restricting the picker because of a step that ignores the picker refuses
+a task that would have run perfectly, which is the one outcome a gate must never
+produce. The same rule feeds the creation-time 400 and the `requires_input` flag
+on the workflow entry.
+
+### 7. `deny` still overrides an inherited `require`
+
+*2026-08-17.* `defaults.on_input: require` with a step's `on_input: deny` is
+legal, and the step wins.
+
+Every field in `defaults:` works this way; a special case here would make this
+the only field in the schema a step cannot override. The combination is also
+meaningful on its own — a long unattended cleanup step inside an otherwise
+interactive workflow.
+
+`require` and `deny` cannot contradict each other *within* a step, because
+decision 2 made them values of one field rather than two fields.
+
+### 8. Run time: a pre-flight in the engine, failing the step
+
+*2026-08-17.* The runner gains the `*agent.CatalogCache` in its `Deps`, checks
+before `Start`, and returns `stepFailed` with the new reason
+`input_unsupported`. `require` reaches the adapter as `InputWait`;
+`agent.InputPolicy` stays two-valued and the `Adapter` contract is untouched.
+
+`require` is a *scheduling* precondition. Once a step is running, `require` and
+`wait` are the same behaviour, so the adapter has no reason to know which one it
+was given.
+
+**Beat (a):** an `agent.ErrRestrictedUnsupported`-shaped sentinel returned from
+`Start`. That pattern earns its place for `restricted` because only the adapter
+knows its own platform story; here the daemon already holds the answer in a
+cache it shares with the API and with task creation.
+
+**Beat (b):** blocking the task outright without spending the §7.2 budget, on
+the grounds that a retry cannot change a capability. It ends in the same blocked
+state with the same reason, one attempt later, and the codebase has already
+refused this trade once: the `agent_unauthenticated` note rejects
+short-circuiting §7.2 "to save one process spawn" — and here the check precedes
+`Start`, so there is not even a spawn to save.
+
+Reaching this at all means the task and its daemon parted company: claude
+upgraded past the version ceiling, a data directory moved between machines, or a
+workflow edited after the task was queued. Distinct from `agent_unavailable` on
+the same grounds `restricted_unsupported` is: the CLI is installed and healthy.
+
+### 9. `require` does not change how long a human has
+
+*2026-08-17.* `input_timeout` keeps its §7.4 meaning and its three levels (step,
+defaults, daemon). Requiring input does not imply a longer or unbounded wait.
+
+A workflow that wants to wait all day says so in the field named for it.
+Coupling the bound to the capability gate would give `require` two unrelated
+meanings and make the timeout unpredictable from the field that sets it.
+
+### 10. The shipped workflows stay on `wait`
+
+*2026-08-17.* `github-issue.yaml`, `github-bug.yaml` and
+`github-enhancement.yaml` keep `on_input: wait`; only their comments are updated
+to mention that `require` now exists.
+
+Those files degrade deliberately — the comments document it as intended — and
+flipping them would make three shipped workflows unusable on two of three
+adapters as a side effect of adding a feature. Adopting `require` there is a
+per-file decision, not part of this work.
+
+## Tasks
+
+- [ ] **013.1 — Schema and static capability.** `on_input: require` accepted on
+  agent steps and in `defaults:`; `agent.Options.InputSupport` (`never` |
+  `detected`) set by all three adapters' curated catalogs; §8.2 errors on a
+  requiring step resolving to a `never` adapter, attributed per decision 4.
+- [ ] **013.2 — Registry and API.** A computed `requires_input` on the
+  `GET /v1/workflows` entry, derived by the decision-6 rule (daemon decides,
+  clients report — 010.2's precedent, including the `*bool`-style tolerance for
+  an older daemon).
+- [ ] **013.3 — `POST /v1/tasks` refuses a known-incapable selection.**
+  Depends: 013.1, 013.2. 400 naming the step, the agent, and why; unknown and
+  absent probes pass through (decision 5).
+- [ ] **013.4 — `edit + retry` re-validates.** Depends: 013.3. The snapshot edit
+  re-runs the creation-time check, so the repair path cannot land a task back
+  into the same block.
+- [ ] **013.5 — Engine pre-flight.** Depends: 013.1. `*agent.CatalogCache` in
+  `taskrun.Deps`, the check before `Start`, `ReasonInputUnsupported =
+  "input_unsupported"` in the §18 vocabulary.
+- [ ] **013.6 — Clients.** Depends: 013.2, 013.3. TUI: the agent picker
+  annotates an incapable adapter with the reason and refuses it on select
+  (010.5's `opt.note` + row-error pattern); the new-task summary says why. CLI
+  relays the API's 400 with no client-side rule of its own.
+- [ ] **013.7 — Docs.** Depends: all. Spec §7.4 (the third value), §8.2 (the
+  new rule), §9.5/§9.6 (the static capability), §13.2 (the entry field) and §18
+  (the reason), amended in place with dated notes; user-facing
+  `reference/workflow-schema.md`, `guides/workflows.md`, `guides/agents.md`,
+  `reference/api.md` and the block-reason table; comments in the three shipped
+  workflows (decision 10).
+- [ ] **013.8 — Gate leg.** Depends: 013.3. One `m2-gate.sh` scenario asserting
+  the creation-time 400 against a fake agent presenting as a `never` adapter.
+  The run-time block stays in `engine_test.go`, where 010 put its equivalent:
+  reaching it requires manufacturing a snapshot/daemon mismatch, which a curl
+  script should not be in the business of staging.
+
+## Verification
+
+Planned, not yet run:
+
+- `go test ./...` and `go test -race ./...` green, including: the schema table
+  (`require` accepted on agent steps and defaults, rejected on command and
+  manual steps), the §8.2 error and its attribution to both `steps[N].agent` and
+  `defaults.agent`, the decision-6 picker rule across pinned/unpinned steps, the
+  creation-time 400 and the three "unknown" paths that must *not* 400, the
+  `edit + retry` re-validation, the engine's `input_unsupported` step failure,
+  and the TUI picker's note and refusal.
+- `go run mage.go lint` for `linux`, `darwin` and `windows` from a host-built
+  linter, per CLAUDE.md — the engine change touches `taskrun.Deps` wiring, which
+  every platform compiles.
+- `./scripts/m2-gate.sh` on all three CI legs, with the new scenario committed
+  executable.

--- a/docs/tasks/013-interactive-workflow-agent-gating.md
+++ b/docs/tasks/013-interactive-workflow-agent-gating.md
@@ -1,6 +1,6 @@
 # 013 — Gating workflows that require mid-run interaction
 
-**Status:** 📋 planned (0/8) · **Opened:** 2026-08-17
+**Status:** ✅ done (8/8) · **Opened:** 2026-08-17
 
 An agent step may now declare that it *needs* a human mid-run:
 
@@ -197,36 +197,67 @@ flipping them would make three shipped workflows unusable on two of three
 adapters as a side effect of adding a feature. Adopting `require` there is a
 per-file decision, not part of this work.
 
+### 11. The daemon publishes the verdict; no client re-derives it
+
+*2026-08-17, during implementation.* `GET /v1/agents` gained
+`input_verdict`: `supported` | `unsupported` | `unknown`.
+
+Decision 3 established that the static capability need not reach the wire, and
+that remains true — what reaches it is the *verdict*, which is a different
+thing. It had to, because the refusal rule is asymmetric (decision 5) and
+`supports_input` alone cannot express it: `false` there means "no" for an
+installed binary and "nobody can say" for an absent one, and only the first
+refuses anything. A client re-deriving that from `available` + `supports_input`
+would get the codex-not-installed case wrong and grey out nothing where the
+daemon greys out an agent. Publishing the verdict keeps 010.3's rule intact —
+the process that would run the thing is the one that says whether it can.
+
+### 12. `edit + retry` cannot change an agent, so the gate lives on `retry`
+
+*2026-08-17, correcting the premise of 013.4.* The plan assumed the repair for
+an `input_unsupported` block was to edit the step's `agent:` in the task's
+snapshot. It is not: `POST /v1/tasks/{id}/retry` overrides `prompt` and `run`
+only (`store.Override`), and no endpoint changes `agent_override` after
+creation. There was no agent edit to re-validate.
+
+The real repair is environmental — install the agent, or bring claude back
+inside the verified family — so the check moved onto the retry action itself,
+against the task's own snapshot: a retry that would only reproduce the block is
+refused with the reason, and once the environment is fixed the same retry
+passes. That makes the check *more* useful than the planned one, not less; it
+is also the only place the asymmetry pays off twice, since an agent uninstalled
+between the block and the retry reads as unknown and is let through.
+
 ## Tasks
 
-- [ ] **013.1 — Schema and static capability.** `on_input: require` accepted on
+- [x] **013.1 — Schema and static capability.** ✓ 2026-08-17 `on_input: require` accepted on
   agent steps and in `defaults:`; `agent.Options.InputSupport` (`never` |
   `detected`) set by all three adapters' curated catalogs; §8.2 errors on a
   requiring step resolving to a `never` adapter, attributed per decision 4.
-- [ ] **013.2 — Registry and API.** A computed `requires_input` on the
+- [x] **013.2 — Registry and API.** ✓ 2026-08-17 A computed `requires_input` on the
   `GET /v1/workflows` entry, derived by the decision-6 rule (daemon decides,
   clients report — 010.2's precedent, including the `*bool`-style tolerance for
   an older daemon).
-- [ ] **013.3 — `POST /v1/tasks` refuses a known-incapable selection.**
+- [x] **013.3 — `POST /v1/tasks` refuses a known-incapable selection.** ✓ 2026-08-17
   Depends: 013.1, 013.2. 400 naming the step, the agent, and why; unknown and
   absent probes pass through (decision 5).
-- [ ] **013.4 — `edit + retry` re-validates.** Depends: 013.3. The snapshot edit
+- [x] **013.4 — `retry` re-validates.** ✓ 2026-08-17 Depends: 013.3. The snapshot edit
   re-runs the creation-time check, so the repair path cannot land a task back
   into the same block.
-- [ ] **013.5 — Engine pre-flight.** Depends: 013.1. `*agent.CatalogCache` in
+- [x] **013.5 — Engine pre-flight.** ✓ 2026-08-17 Depends: 013.1. `*agent.CatalogCache` in
   `taskrun.Deps`, the check before `Start`, `ReasonInputUnsupported =
   "input_unsupported"` in the §18 vocabulary.
-- [ ] **013.6 — Clients.** Depends: 013.2, 013.3. TUI: the agent picker
+- [x] **013.6 — Clients.** ✓ 2026-08-17 Depends: 013.2, 013.3. TUI: the agent picker
   annotates an incapable adapter with the reason and refuses it on select
   (010.5's `opt.note` + row-error pattern); the new-task summary says why. CLI
   relays the API's 400 with no client-side rule of its own.
-- [ ] **013.7 — Docs.** Depends: all. Spec §7.4 (the third value), §8.2 (the
+- [x] **013.7 — Docs.** ✓ 2026-08-17 Depends: all. Spec §7.4 (the third value), §8.2 (the
   new rule), §9.5/§9.6 (the static capability), §13.2 (the entry field) and §18
   (the reason), amended in place with dated notes; user-facing
   `reference/workflow-schema.md`, `guides/workflows.md`, `guides/agents.md`,
   `reference/api.md` and the block-reason table; comments in the three shipped
   workflows (decision 10).
-- [ ] **013.8 — Gate leg.** Depends: 013.3. One `m2-gate.sh` scenario asserting
+- [x] **013.8 — Gate leg.** ✓ 2026-08-17 Depends: 013.3. One `m2-gate.sh` scenario asserting
   the creation-time 400 against a fake agent presenting as a `never` adapter.
   The run-time block stays in `engine_test.go`, where 010 put its equivalent:
   reaching it requires manufacturing a snapshot/daemon mismatch, which a curl
@@ -234,17 +265,26 @@ per-file decision, not part of this work.
 
 ## Verification
 
-Planned, not yet run:
+*2026-08-17, all run:*
 
-- `go test ./...` and `go test -race ./...` green, including: the schema table
-  (`require` accepted on agent steps and defaults, rejected on command and
-  manual steps), the §8.2 error and its attribution to both `steps[N].agent` and
-  `defaults.agent`, the decision-6 picker rule across pinned/unpinned steps, the
-  creation-time 400 and the three "unknown" paths that must *not* 400, the
-  `edit + retry` re-validation, the engine's `input_unsupported` step failure,
-  and the TUI picker's note and refusal.
-- `go run mage.go lint` for `linux`, `darwin` and `windows` from a host-built
-  linter, per CLAUDE.md — the engine change touches `taskrun.Deps` wiring, which
-  every platform compiles.
-- `./scripts/m2-gate.sh` on all three CI legs, with the new scenario committed
-  executable.
+- `go run mage.go test` and `go run mage.go testrace` green, including the new
+  cases: `require` accepted on agent steps and in `defaults:` and rejected on
+  command steps, the unknown-value error naming all three, the §8.2 capability
+  error and its attribution to both `steps[N].agent` and a collapsed
+  `defaults.agent`, claude deliberately *not* judged at load, the decision-6
+  derivation across pinned/unpinned steps, `InputMismatch` resolving through
+  §8.6 overrides, the seven-case `InputVerdict` table (including both
+  not-installed cases, which must answer unknown), the three adapters' curated
+  `InputSupport`, the creation-time 400 plus the uninstalled-agent case that
+  must *not* 400, the retry refusal, the engine's `input_unsupported` block
+  with no pid recorded, the capable-agent run that still succeeds, and the two
+  TUI paths (picker note and disablement, agent-row error on submit).
+- `go tool golangci-lint run ./...` clean for `GOOS=linux`, `darwin` and
+  `windows` from a host-built linter, per CLAUDE.md.
+- `./scripts/m2-gate.sh` green, scenario 8 included: the impossible workflow
+  listed with its error pointing at `steps[0].agent`, `requires_input` true on
+  the runnable one and false on `adhoc`, `input_verdict` published per adapter,
+  the 400 on a codex task, and the same workflow running to `done` on claude.
+
+The gate script's new scenario is committed executable, and its dispatcher
+accepts `VINCENT_GATE_SCENARIO=8`.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -27,6 +27,7 @@ description of how the system actually behaves.
 | [010](010-workflow-platform-restrictions.md) | Restricting a workflow to platforms (`platforms:`) | ✅ done (6/6) |
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
+| [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | 📋 planned (0/8) |
 
 ## How to add and update a task document
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,28 @@ const (
 	SourceCurated = "curated" // catalog shipped with vincent
 )
 
+// InputSupport is what an adapter can *ever* do about mid-run input, known
+// without probing (spec §9.5, task 013). It is the static half of
+// Availability.SupportsInput, which is the same question answered about the
+// binary actually installed.
+//
+// It exists so §8.2 validation — which never spawns a process — can reject a
+// workflow that requires interaction on an adapter where interaction is
+// impossible, at the moment its author is looking at the file.
+type InputSupport string
+
+// Input support levels (task 013). There are two: no adapter supports input
+// regardless of version, so an "always" would be a value nothing sets.
+const (
+	// InputNever is an adapter with no control channel at all — codex and
+	// cursor. No version of the CLI can ask a question mid-run.
+	InputNever InputSupport = "never"
+	// InputDetected is an adapter whose support depends on the installed
+	// binary — claude, gated to the fixture-verified version family (§9.3).
+	// Only a probe can answer, so §8.2 does not judge it.
+	InputDetected InputSupport = "detected"
+)
+
 // ErrRestrictedUnsupported is returned by Start when the adapter cannot
 // honor PermissionMode Restricted on this platform (spec §9.4). It lives here
 // rather than in an adapter package so the engine can recognize the condition
@@ -311,7 +333,19 @@ type Options struct {
 	Efforts       []Option // adapter-native effort levels
 	DefaultModel  string   // "" = the CLI decides
 	DefaultEffort string   // "" = the CLI decides
+	// InputSupport is the adapter's static mid-run input capability (task
+	// 013). It rides in the catalog rather than behind a new Adapter method
+	// because §8.2 validation already reads Curated() and must not probe.
+	// The zero value is deliberately not a level: an adapter that says
+	// nothing is treated as InputDetected — unjudged — so a catalog built by
+	// a test or a future adapter never gates a workflow by accident.
+	InputSupport InputSupport
 }
+
+// InputEverPossible reports whether an adapter with these options could ever
+// take mid-run input. Only InputNever answers false; an unset level is
+// unjudged, which is what keeps validation from gating on silence.
+func (o Options) InputEverPossible() bool { return o.InputSupport != InputNever }
 
 // Option is one selectable value with provenance (spec §9.6).
 type Option struct {

--- a/internal/agent/catalog.go
+++ b/internal/agent/catalog.go
@@ -56,6 +56,17 @@ func (c Catalogs) Check(sel Selection) (errs, warns []Finding) {
 	return errs, warns
 }
 
+// InputEverPossible reports whether the named adapter could ever take mid-run
+// input (task 013). An adapter missing from the catalogs answers true: unknown
+// agents are someone else's check, the same rule Check applies.
+func (c Catalogs) InputEverPossible(name string) bool {
+	opts, known := c[name]
+	if !known {
+		return true
+	}
+	return opts.InputEverPossible()
+}
+
 // ownerOf names an adapter other than exclude whose catalog contains value.
 func (c Catalogs) ownerOf(list func(Options) []Option, value, exclude string) string {
 	for name, opts := range c {
@@ -75,6 +86,42 @@ func containsOption(opts []Option, value string) bool {
 	return false
 }
 
+// InputVerdict is what the daemon knows *right now* about an adapter's
+// ability to stop a run and take a human answer (task 013). It is the one
+// answer the creation-time gate and the engine's pre-flight both consult, so
+// "can this agent be asked a question" has a single source.
+type InputVerdict string
+
+// Input verdicts (task 013).
+const (
+	// InputUnknown is "nobody can say": the binary is not installed, the
+	// probe did not answer, or the adapter is not registered. Callers must
+	// let the work through — §9.6's degrade-never-block rule outranks a gate
+	// built on a probe that failed.
+	InputUnknown InputVerdict = "unknown"
+	// InputSupported is an installed binary that reported input support.
+	InputSupported InputVerdict = "supported"
+	// InputUnsupported is a positive no: an adapter that can never support
+	// input, or an installed one whose version falls outside the verified
+	// family. Only this verdict refuses anything.
+	InputUnsupported InputVerdict = "unsupported"
+)
+
+// InputVerdict reports whether the named adapter can take mid-run input,
+// combining the static catalog capability with what the last probe saw
+// (task 013). The static "never" is decisive without an installed binary;
+// everything else needs one, and an absent or unprobed binary is unknown.
+func (c *CatalogCache) InputVerdict(ctx context.Context, name string) InputVerdict {
+	if c == nil {
+		return InputUnknown
+	}
+	e, ok := c.Entry(ctx, name, false)
+	if !ok {
+		return InputUnknown
+	}
+	return e.InputVerdict()
+}
+
 // CatalogEntry is one adapter's cached probe result (spec §9.6): the §9.5
 // availability plus the merged option catalog.
 type CatalogEntry struct {
@@ -82,6 +129,24 @@ type CatalogEntry struct {
 	Options      Options
 	ProbedAt     time.Time
 	ProbeError   string // "" = clean probe
+}
+
+// InputVerdict is this entry's answer to "can this adapter be asked a
+// question" (task 013). The static catalog level is decisive without an
+// installed binary — an adapter with no control channel has none whether or
+// not it is on this machine — and everything else needs one: an absent or
+// unprobed binary is unknown, never a refusal.
+func (e CatalogEntry) InputVerdict() InputVerdict {
+	switch {
+	case !e.Options.InputEverPossible():
+		return InputUnsupported
+	case !e.Availability.Found:
+		return InputUnknown
+	case e.Availability.SupportsInput:
+		return InputSupported
+	default:
+		return InputUnsupported
+	}
 }
 
 // catalogKey is the binary identity a cache entry is keyed by: resolved path

--- a/internal/agent/catalog_test.go
+++ b/internal/agent/catalog_test.go
@@ -277,3 +277,64 @@ func TestCatalogsPrimedOrCurated(t *testing.T) {
 		t.Errorf("primed catalog has %d models, want the probed 2", got)
 	}
 }
+
+// TestInputVerdict covers the asymmetry the whole gate rests on: only a
+// positive "cannot" refuses anything, so an absent or unprobed binary is
+// unknown rather than a refusal (task 013).
+func TestInputVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		entry CatalogEntry
+		want  InputVerdict
+	}{
+		{"never adapter, installed", CatalogEntry{
+			Options:      Options{InputSupport: InputNever},
+			Availability: Availability{Found: true},
+		}, InputUnsupported},
+		{"never adapter, not installed — still never", CatalogEntry{
+			Options: Options{InputSupport: InputNever},
+		}, InputUnsupported},
+		{"detected adapter, installed and supporting", CatalogEntry{
+			Options:      Options{InputSupport: InputDetected},
+			Availability: Availability{Found: true, SupportsInput: true},
+		}, InputSupported},
+		{"detected adapter, installed but out of the version family", CatalogEntry{
+			Options:      Options{InputSupport: InputDetected},
+			Availability: Availability{Found: true},
+		}, InputUnsupported},
+		{"detected adapter, not installed", CatalogEntry{
+			Options:      Options{InputSupport: InputDetected},
+			Availability: Availability{Error: "not found"},
+		}, InputUnknown},
+		{"catalog that says nothing is unjudged", CatalogEntry{
+			Availability: Availability{Found: true, SupportsInput: true},
+		}, InputSupported},
+		{"catalog that says nothing, absent binary", CatalogEntry{}, InputUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.entry.InputVerdict(); got != tc.want {
+				t.Errorf("InputVerdict() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A nil cache must answer unknown rather than panic: taskrun tolerates one.
+func TestNilCatalogCacheInputVerdict(t *testing.T) {
+	var c *CatalogCache
+	if got := c.InputVerdict(context.Background(), "claude"); got != InputUnknown {
+		t.Errorf("nil cache verdict = %q, want %q", got, InputUnknown)
+	}
+}
+
+// An adapter nobody registered is someone else's check, the same rule
+// Catalogs.Check applies to models and efforts.
+func TestCatalogsInputEverPossibleUnknownAgent(t *testing.T) {
+	c := Catalogs{"codex": {InputSupport: InputNever}}
+	if c.InputEverPossible("codex") {
+		t.Error("codex reported as input-capable")
+	}
+	if !c.InputEverPossible("nobody") {
+		t.Error("unknown agent judged; unknown agents are not this check's business")
+	}
+}

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -288,3 +288,11 @@ func TestRespondNoPending(t *testing.T) {
 	drain(t, h)
 	_, _ = h.Wait()
 }
+
+// claude's support is a version question Detect answers, so the catalog says
+// only that the answer is worth asking — §8.2 must not judge it (task 013).
+func TestCuratedInputSupportIsDetected(t *testing.T) {
+	if got := New(nil).Curated().InputSupport; got != agent.InputDetected {
+		t.Errorf("InputSupport = %q, want %q", got, agent.InputDetected)
+	}
+}

--- a/internal/agent/claude/options.go
+++ b/internal/agent/claude/options.go
@@ -44,6 +44,10 @@ func mergeOptions(cliModels, cliEfforts []string) agent.Options {
 	return agent.Options{
 		Models:  mergeValues(cliModels, curatedModels),
 		Efforts: mergeValues(cliEfforts, curatedEfforts),
+		// Whether *this* claude can take mid-run input is a version question
+		// Detect answers (§9.3); the catalog only says the answer is worth
+		// asking, so §8.2 leaves a requiring step alone (task 013).
+		InputSupport: agent.InputDetected,
 	}
 }
 

--- a/internal/agent/codex/codex_test.go
+++ b/internal/agent/codex/codex_test.go
@@ -302,3 +302,11 @@ func TestRespondUnsupported(t *testing.T) {
 	drain(t, h)
 	_, _ = h.Wait()
 }
+
+// The curated catalog carries the static capability the §8.2 gate reads: no
+// version of `codex exec` can stop to ask (task 013).
+func TestCuratedInputSupportIsNever(t *testing.T) {
+	if got := New(nil).Curated().InputSupport; got != agent.InputNever {
+		t.Errorf("InputSupport = %q, want %q", got, agent.InputNever)
+	}
+}

--- a/internal/agent/codex/options.go
+++ b/internal/agent/codex/options.go
@@ -31,5 +31,12 @@ func (a *Adapter) Curated() agent.Options {
 	for _, v := range curatedEfforts {
 		efforts = append(efforts, agent.Option{Value: v, Source: agent.SourceCurated})
 	}
-	return agent.Options{Models: []agent.Option{}, Efforts: efforts}
+	return agent.Options{
+		Models:  []agent.Option{},
+		Efforts: efforts,
+		// `codex exec` is strictly non-interactive (§9.3): no version of it
+		// can stop to ask, so a workflow step requiring input is refused
+		// against this adapter at load time (task 013).
+		InputSupport: agent.InputNever,
+	}
 }

--- a/internal/agent/cursor/cursor_test.go
+++ b/internal/agent/cursor/cursor_test.go
@@ -361,3 +361,11 @@ func TestRespondUnsupported(t *testing.T) {
 	drain(t, h)
 	_, _ = h.Wait()
 }
+
+// cursor-agent has no control channel in any version (§9.7), which is what
+// lets §8.2 refuse a requiring step without probing (task 013).
+func TestCuratedInputSupportIsNever(t *testing.T) {
+	if got := New(nil).Curated().InputSupport; got != agent.InputNever {
+		t.Errorf("InputSupport = %q, want %q", got, agent.InputNever)
+	}
+}

--- a/internal/agent/cursor/options.go
+++ b/internal/agent/cursor/options.go
@@ -72,6 +72,9 @@ func mergeOptions(cliModels []string) agent.Options {
 		Models:       models,
 		Efforts:      []agent.Option{},
 		DefaultModel: defaultModel,
+		// cursor-agent has no input-format flag and no control channel
+		// (§9.7); no version of it can stop to ask (task 013).
+		InputSupport: agent.InputNever,
 	}
 }
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -78,6 +78,15 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// The `on_input: require` gate again (§7.4, task 013), against the task's
+	// own snapshot. Retry is the one action that re-admits a task, and the
+	// repair for an `input_unsupported` block is environmental — install the
+	// agent, or upgrade it back inside the verified family — so the verdict
+	// is re-taken here rather than assumed from creation time. A retry that
+	// would block again identically is refused with the reason instead.
+	if !s.checkRetryInput(w, r) {
+		return
+	}
 	s.runAction(w, r, func(id int64) (*store.Task, error) {
 		t, err := s.deps.Runner.Retry(r.Context(), id,
 			store.Override{Prompt: req.PromptOverride, Run: req.RunOverride})

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -11,11 +11,18 @@ import (
 // agentResponse is one adapter in GET /v1/agents (spec §9.6): the §9.5
 // availability plus the provenance-tagged option catalog.
 type agentResponse struct {
-	Name          string         `json:"name"`
-	Available     bool           `json:"available"`
-	Path          string         `json:"path,omitempty"`
-	Version       string         `json:"version,omitempty"`
-	SupportsInput bool           `json:"supports_input"`
+	Name          string `json:"name"`
+	Available     bool   `json:"available"`
+	Path          string `json:"path,omitempty"`
+	Version       string `json:"version,omitempty"`
+	SupportsInput bool   `json:"supports_input"`
+	// InputVerdict is the daemon's answer to whether this adapter may back a
+	// step declaring `on_input: require` (§7.4, task 013): supported,
+	// unsupported, or unknown. It is not derivable from supports_input alone —
+	// a false there is "no" for an installed binary and "nobody can say" for
+	// an absent one — so the daemon publishes the verdict its own gate uses
+	// rather than leaving each client to re-derive the asymmetry.
+	InputVerdict  string         `json:"input_verdict"`
 	LoggedIn      *bool          `json:"logged_in"` // null = the adapter cannot tell (§9.5)
 	Error         string         `json:"error,omitempty"`
 	Models        []agent.Option `json:"models"`
@@ -49,6 +56,7 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 			Path:          e.Availability.Path,
 			Version:       e.Availability.Version,
 			SupportsInput: e.Availability.SupportsInput,
+			InputVerdict:  string(e.InputVerdict()),
 			LoggedIn:      e.Availability.LoggedIn,
 			Error:         e.Availability.Error,
 			Models:        e.Options.Models,

--- a/internal/api/input_test.go
+++ b/internal/api/input_test.go
@@ -1,0 +1,201 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/agent/codex"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// newInputHarness is a workflow harness whose registry and catalog are both
+// live, which is what the task-013 gate needs: §8.2 reads the catalogs and
+// POST /v1/tasks reads the probed verdict. claudePath decides what the probe
+// finds — the fake agent (input supported) or nothing at all (unknown).
+func newInputHarness(t *testing.T, claudePath string) *workflowHarness {
+	t.Helper()
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	git := gitx.New()
+	wt := worktree.NewManager(git, t.TempDir())
+	globalDir := filepath.Join(t.TempDir(), "workflows")
+	reg := agent.NewRegistry(
+		claude.New(func() string { return claudePath }),
+		codex.New(func() string { return "/nonexistent/codex-not-here" }),
+	)
+	cache := agent.NewCatalogCache(reg)
+	wfreg := workflow.NewRegistry(globalDir, workflow.Options{
+		KnownAgents: reg.Names(),
+		Catalogs:    cache.Catalogs,
+	}, nil)
+	s := New(Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+		Git:         git,
+		Worktrees:   wt,
+		Workflows:   wfreg,
+		Agents:      reg,
+		Catalog:     cache,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return &workflowHarness{
+		projectHarness: &projectHarness{ts: ts, store: st, wt: wt},
+		reg:            wfreg,
+		globalDir:      globalDir,
+	}
+}
+
+// requiringWorkflow leaves its requiring step's agent to the task, which is
+// what makes the task-level choice the thing being gated (decision 6).
+const requiringWorkflow = "name: interactive\n" +
+	"steps:\n" +
+	"  - {id: ask, type: agent, on_input: require, prompt: what should I build?}\n"
+
+// TestWorkflowListReportsRequiresInput is the reporting half: the daemon
+// derives the flag, the client reads it (§13.2, task 013).
+func TestWorkflowListReportsRequiresInput(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "interactive", requiringWorkflow)
+	writeWorkflowFile(t, h.globalDir, "pinned",
+		"name: pinned\nsteps:\n"+
+			"  - {id: ask, type: agent, agent: claude, on_input: require, prompt: hi}\n")
+	h.reg.ReloadGlobal()
+
+	list := decodeWorkflowList(t, mustGet(t, h, "/v1/workflows"))
+	if !findWorkflow(t, list, "interactive").RequiresInput {
+		t.Error("a workflow with an unpinned requiring step does not report requires_input")
+	}
+	// Its requiring step pins a capable agent, so the task's choice is
+	// unconstrained and the flag must stay off.
+	if findWorkflow(t, list, "pinned").RequiresInput {
+		t.Error("a workflow whose requiring step pins its own agent constrains the picker")
+	}
+	if findWorkflow(t, list, "adhoc").RequiresInput {
+		t.Error("the built-in adhoc workflow reports requires_input")
+	}
+}
+
+// TestTaskCreateRefusesIncapableAgent is the enforcement half: the workflow
+// is listed and valid, and only the agent override makes it unrunnable.
+func TestTaskCreateRefusesIncapableAgent(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "interactive", requiringWorkflow)
+	h.reg.ReloadGlobal()
+	p := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+	id := int64(p["id"].(float64))
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": id, "title": "no", "workflow": "interactive", "agent": "codex",
+	})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	for _, want := range []string{"ask", "codex", "mid-run input"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("message %s missing %q", body, want)
+		}
+	}
+
+	// The same workflow on the capable agent creates, so the gate refuses one
+	// selection rather than the workflow.
+	resp, body = h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": id, "title": "yes", "workflow": "interactive", "agent": "claude",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("claude task: %d %s", resp.StatusCode, body)
+	}
+}
+
+// TestTaskCreateAllowsUnknownVerdict is decision 5: a probe that cannot
+// answer is not evidence, and §9.6's degrade-never-block rule outranks the
+// gate. claude resolves to nothing here, so its support is unknowable.
+func TestTaskCreateAllowsUnknownVerdict(t *testing.T) {
+	h := newInputHarness(t, "/nonexistent/claude-not-here")
+	writeWorkflowFile(t, h.globalDir, "interactive", requiringWorkflow)
+	h.reg.ReloadGlobal()
+	p := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+	id := int64(p["id"].(float64))
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": id, "title": "maybe", "workflow": "interactive", "agent": "claude",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("uninstalled agent refused at creation: %d %s", resp.StatusCode, body)
+	}
+}
+
+// A workflow pinning an adapter that can never take input fails §8.2, so it
+// never reaches the creation gate at all — it is listed with its error.
+func TestRequireOnIncapableAgentFailsValidation(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "broken",
+		"name: broken\nsteps:\n"+
+			"  - {id: ask, type: agent, agent: codex, on_input: require, prompt: hi}\n")
+	h.reg.ReloadGlobal()
+
+	entry := findWorkflow(t, decodeWorkflowList(t, mustGet(t, h, "/v1/workflows")), "broken")
+	if entry.Error == nil {
+		t.Fatal("require on codex validated clean")
+	}
+	if !strings.Contains(*entry.Error, "mid-run input") {
+		t.Errorf("error %q does not explain the capability", *entry.Error)
+	}
+}
+
+// TestRetryRefusesIncapableAgent is the repair-path half (task 013): a task
+// blocked with input_unsupported is refused a retry that would only reproduce
+// the block, and the message names what to fix. The environment is the repair
+// — install or downgrade the agent — so the verdict is re-taken per retry.
+func TestRetryRefusesIncapableAgent(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	task := &store.Task{
+		ProjectID:        h.mustProjectID(t),
+		Title:            "blocked",
+		WorkflowName:     "interactive",
+		WorkflowSnapshot: requiringWorkflow,
+		AgentOverride:    "codex",
+		BaseBranch:       "main",
+		BranchName:       "vincent/1-blocked",
+		State:            store.TaskBlocked,
+		BlockReason:      "input_unsupported",
+	}
+	if err := h.store.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	resp, body := h.doJSON(t, http.MethodPost,
+		"/v1/tasks/"+strconv.FormatInt(task.ID, 10)+"/retry", nil)
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(body), "codex") {
+		t.Errorf("message %s does not name the agent to change", body)
+	}
+}
+
+// mustProjectID registers a throwaway repo and returns its project id.
+func (h *workflowHarness) mustProjectID(t *testing.T) int64 {
+	t.Helper()
+	p := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+	return int64(p["id"].(float64))
+}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -384,6 +384,13 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, cerr)
 		return
 	}
+	// The `on_input: require` gate (§7.4, task 013), after the catalog check
+	// so a task with two problems reports the model one first — that is the
+	// field the human just typed.
+	if mismatch := s.inputMismatch(ctx, entry.Workflow, &t); mismatch != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
+		return
+	}
 	// Branch naming (§5.3, task 001): `default < config.yaml < project < literal`.
 	// Resolve before the insert so a bad name is a 400 rather than a task that
 	// blocks later, and so the git-side checks run with no transaction open.
@@ -463,6 +470,61 @@ func (s *Server) checkTaskCatalog(wf *workflow.Workflow, t *store.Task) (warning
 		}
 	}
 	return warnings, ""
+}
+
+// inputMismatch applies the `on_input: require` gate to a task about to be
+// created or edited (§7.4, task 013): every step that requires mid-run input
+// must resolve to an agent that can provide it.
+//
+// The verdict is the probed one, so claude's version gate counts — but only a
+// *positive* "does not support input" refuses anything. A missing binary or a
+// probe that did not answer lets the task through, because §9.6's
+// degrade-never-block rule outranks this gate: one cold-logon probe timeout
+// must not start refusing task creation against a healthy CLI (T4.22). The
+// engine's pre-flight is the backstop for what a probe could not say here.
+func (s *Server) inputMismatch(ctx context.Context, wf *workflow.Workflow, t *store.Task) string {
+	if s.deps.Catalog == nil || wf == nil {
+		return ""
+	}
+	override := agent.Level{Agent: t.AgentOverride, Model: t.ModelOverride, Effort: t.EffortOverride}
+	return wf.InputMismatch(override, func(name string) bool {
+		return s.deps.Catalog.InputVerdict(ctx, name) == agent.InputUnsupported
+	})
+}
+
+// checkRetryInput re-applies the task-013 gate before a retry re-admits a
+// task, reading the agent selection out of the task's own snapshot (§5.3).
+// It writes the error and returns false when the retry would only reproduce
+// an `input_unsupported` block; a task whose snapshot no longer parses is
+// left alone, because the engine reports that as `invalid_snapshot` and two
+// errors for one cause is one too many.
+func (s *Server) checkRetryInput(w http.ResponseWriter, r *http.Request) bool {
+	if s.deps.Catalog == nil {
+		return true
+	}
+	ctx := r.Context()
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return false
+	}
+	task, err := s.deps.Store.GetTask(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, fmt.Sprintf("task %d not found", id))
+		return false
+	}
+	if err != nil {
+		s.internalError(w, "get task", err)
+		return false
+	}
+	wf, _, perr := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if perr != nil {
+		return true
+	}
+	if mismatch := s.inputMismatch(ctx, wf, task); mismatch != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
+		return false
+	}
+	return true
 }
 
 func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -23,9 +23,15 @@ type workflowResponse struct {
 	// means the workflow runs anywhere. PlatformSupported is the daemon's verdict
 	// on its own host — the client never re-derives it, because the daemon is
 	// the process that would run the steps (task 010).
-	Platforms         []string         `json:"platforms,omitempty"`
-	PlatformSupported bool             `json:"platform_supported"`
-	Errors            []workflow.Error `json:"errors,omitempty"`
+	Platforms         []string `json:"platforms,omitempty"`
+	PlatformSupported bool     `json:"platform_supported"`
+	// RequiresInput reports that some step declares `on_input: require` and
+	// leaves its agent to the task, so the agent picked for a task must be one
+	// that can stop and ask (§7.4, task 013). Derived by the daemon for the
+	// same reason platform_supported is: the process that would run the steps
+	// is the one that says what they need.
+	RequiresInput bool             `json:"requires_input"`
+	Errors        []workflow.Error `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []workflow.Error `json:"warnings,omitempty"`
 	Error    *string          `json:"error"`
@@ -45,6 +51,7 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 		File:              e.File,
 		Steps:             []workflowStepResponse{},
 		PlatformSupported: e.RunsHere(),
+		RequiresInput:     e.NeedsInputAgent(),
 	}
 	if e.ProjectID != 0 {
 		id := e.ProjectID

--- a/internal/api/workflows_test.go
+++ b/internal/api/workflows_test.go
@@ -102,6 +102,7 @@ type workflowEntryBody struct {
 	} `json:"steps"`
 	Platforms         []string `json:"platforms"`
 	PlatformSupported bool     `json:"platform_supported"`
+	RequiresInput     bool     `json:"requires_input"`
 	Error             *string  `json:"error"`
 }
 

--- a/internal/apiclient/agents.go
+++ b/internal/apiclient/agents.go
@@ -28,6 +28,11 @@ type Agent struct {
 	Path          string `json:"path,omitempty"`
 	Version       string `json:"version,omitempty"`
 	SupportsInput bool   `json:"supports_input"`
+	// InputVerdict is the daemon's verdict on backing an `on_input: require`
+	// step (§7.4, task 013): "supported", "unsupported" or "unknown". Empty
+	// means the daemon predates the field, which is treated as unknown —
+	// nothing is refused on the strength of a field that was never sent.
+	InputVerdict string `json:"input_verdict,omitempty"`
 	// LoggedIn is nil when the adapter cannot cheaply tell (§9.5); false
 	// means installed but unauthenticated, which fails every run.
 	LoggedIn *bool `json:"logged_in"`
@@ -71,6 +76,19 @@ func (a Agent) NotAuthenticated() bool {
 // present but unauthenticated. The two are one question for a caller deciding
 // whether to warn, and two different sentences when it explains why.
 func (a Agent) Unusable() bool { return !a.Available || a.NotAuthenticated() }
+
+// InputVerdict values as GET /v1/agents reports them (§7.4, task 013).
+const (
+	InputVerdictSupported   = "supported"
+	InputVerdictUnsupported = "unsupported"
+	InputVerdictUnknown     = "unknown"
+)
+
+// CannotTakeInput reports an adapter the daemon would refuse for a step
+// declaring `on_input: require`. Only a positive verdict counts: unknown, and
+// a daemon too old to send one, both answer false, exactly as the daemon's own
+// gate does.
+func (a Agent) CannotTakeInput() bool { return a.InputVerdict == InputVerdictUnsupported }
 
 // Unavailable reports whether name is a known adapter that is not usable
 // right now. An unknown name is not "unavailable" — the catalog simply has

--- a/internal/apiclient/workflows.go
+++ b/internal/apiclient/workflows.go
@@ -26,6 +26,12 @@ type WorkflowEntry struct {
 	Platforms         []string `json:"platforms,omitempty"`
 	PlatformSupported *bool    `json:"platform_supported,omitempty"`
 
+	// RequiresInput reports that some step needs an agent able to stop and
+	// ask mid-run, and leaves the choice of agent to the task (§7.4, task
+	// 013). Absent means the daemon predates the field, which is
+	// indistinguishable from "no such step" and treated as such.
+	RequiresInput bool `json:"requires_input,omitempty"`
+
 	Errors []WorkflowFinding `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []WorkflowFinding `json:"warnings,omitempty"`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -238,6 +238,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		Config:    currentConfig,
 		Worktrees: worktrees,
 		Agents:    agents,
+		Catalog:   catalog,
 		Shells:    shells,
 		DataDir:   dirs.Data,
 		Logger:    logger,

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -67,7 +67,16 @@ const (
 	// this one after the task was queued. Distinct from invalid_snapshot: the
 	// snapshot is perfectly valid, just not here.
 	ReasonPlatformUnsupported = "platform_unsupported"
-	ReasonInternalError       = "internal_error"
+	// ReasonInputUnsupported is a step declaring `on_input: require` whose
+	// resolved adapter cannot stop and ask (§7.4, task 013). Task creation
+	// refuses these, so reaching it here means the task and its daemon parted
+	// company: claude upgraded past the §9.3 version ceiling, a data directory
+	// carried to a machine where that agent is a different build, or a
+	// workflow edited after the task was queued. Distinct from
+	// agent_unavailable on the same grounds restricted_unsupported is — the
+	// CLI is installed and healthy, just not able to hold a conversation.
+	ReasonInputUnsupported = "input_unsupported"
+	ReasonInternalError    = "internal_error"
 )
 
 // Durable event types the engine emits (spec §13.3). State changes emit

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -67,15 +67,20 @@ func newEngineHarnessWith(t *testing.T, mutate func(*config.Config)) *engineHarn
 	if mutate != nil {
 		mutate(&cfg)
 	}
+	agents := agent.NewRegistry(
+		claude.New(func() string { return fake }),
+		codex.New(func() string { return fake }),
+		cursor.New(func() string { return fake }),
+	)
 	runner := New(Deps{
 		Store:     st,
 		Config:    func() config.Config { return cfg },
 		Worktrees: worktree.NewManager(git, dataDir),
-		Agents: agent.NewRegistry(
-			claude.New(func() string { return fake }),
-			codex.New(func() string { return fake }),
-			cursor.New(func() string { return fake }),
-		),
+		Agents:    agents,
+		// Wired as the daemon wires it, so the §7.4 `require` pre-flight is
+		// live. It costs nothing for a step that does not require input: the
+		// policy is checked before the catalog is consulted.
+		Catalog: agent.NewCatalogCache(agents),
 		DataDir: dataDir,
 		Logger:  log,
 	})
@@ -482,6 +487,51 @@ func TestEnginePlatformRestrictedSnapshotBlocks(t *testing.T) {
 	}
 	if runs := h.stepRuns(t, task.ID); len(runs) != 0 {
 		t.Errorf("step runs = %d, want none — the restriction is judged before any step", len(runs))
+	}
+}
+
+// TestEngineRequireOnIncapableAgentBlocks covers the §7.4 `require`
+// pre-flight (task 013). Creation refuses such a task, so the only way to
+// hold one is for the task and its daemon to have parted company — which the
+// fixture reproduces by inserting the snapshot directly, the way the platform
+// restriction's test does.
+func TestEngineRequireOnIncapableAgentBlocks(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := "name: interactive\nsteps:\n" +
+		"  - id: ask\n    type: agent\n    agent: codex\n    on_input: require\n" +
+		"    max_retries: 0\n    prompt: what should I build?\n"
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonInputUnsupported {
+		t.Fatalf("task = %s/%q, want blocked/%s",
+			blocked.State, blocked.BlockReason, ReasonInputUnsupported)
+	}
+	// The attempt is recorded — this is a step failure under §7.2, not a
+	// pre-admission refusal — but no process ran.
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("step runs = %d, want the one failed attempt", len(runs))
+	}
+	if runs[0].PID != nil {
+		t.Errorf("pid = %d, want none: the check precedes Start", *runs[0].PID)
+	}
+}
+
+// The same step on an adapter that *can* ask runs normally, so the pre-flight
+// gates on the capability rather than on the policy.
+func TestEngineRequireOnCapableAgentRuns(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := "name: interactive\nsteps:\n" +
+		"  - id: ask\n    type: agent\n    agent: claude\n    on_input: require\n" +
+		"    max_retries: 0\n    prompt: what should I build?\n"
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
 	}
 }
 

--- a/internal/taskrun/resolve.go
+++ b/internal/taskrun/resolve.go
@@ -35,6 +35,11 @@ func resolvePermission(step workflow.Step, defaults workflow.Defaults) agent.Per
 
 // resolveInputPolicy resolves the step's reaction to an input request
 // (§7.4): step field, then workflow defaults, then wait.
+//
+// `require` resolves to wait. It differs from wait only in what must be true
+// before the step starts (task 013), and the pre-flight that enforces that has
+// already run by the time this value reaches an adapter — so InputPolicy stays
+// two-valued and no adapter learns a third.
 func resolveInputPolicy(step workflow.Step, defaults workflow.Defaults) agent.InputPolicy {
 	switch firstNonEmpty(step.OnInput, defaults.OnInput) {
 	case workflow.InputDeny:

--- a/internal/taskrun/runner.go
+++ b/internal/taskrun/runner.go
@@ -49,9 +49,14 @@ type Deps struct {
 	Config    func() config.Config
 	Worktrees *worktree.Manager
 	Agents    *agent.Registry
-	Shells    *Shells
-	DataDir   string
-	Logger    *slog.Logger
+	// Catalog answers the §7.4 `require` pre-flight: can this adapter stop
+	// and ask (task 013). It is the same binary-identity cache /v1/agents and
+	// task creation read, so one probe result serves all three. Nil is
+	// tolerated — an unknown verdict never blocks a step.
+	Catalog *agent.CatalogCache
+	Shells  *Shells
+	DataDir string
+	Logger  *slog.Logger
 	// Events receives live output chunks for the per-task SSE stream
 	// (§13.3). Nil is tolerated (tests without streaming); the transcript
 	// stays the durable copy either way.

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -40,6 +40,21 @@ func (r *Runner) runAgentStep(
 	inputTimeout := resolveInputTimeout(env.step, env.wf.Defaults, r.deps.Config())
 	onInput := resolveInputPolicy(env.step, env.wf.Defaults)
 
+	// The §7.4 `require` pre-flight (task 013). It runs before Start rather
+	// than as an adapter error because `require` is a precondition, not a
+	// behaviour: once the process is up, `require` and `wait` are the same
+	// thing, so the adapter has no reason to know which it was given. Only a
+	// positive "cannot" fails the step — an absent binary is
+	// agent_unavailable's business, and an unprobed one is nobody's.
+	if env.wf.StepRequiresInput(env.step) &&
+		r.deps.Catalog.InputVerdict(ctx, sel.Agent) == agent.InputUnsupported {
+		tr.Note("error", map[string]any{
+			"error": "agent " + sel.Agent + " cannot take mid-run input, which this step requires",
+		})
+		env.log.Error("step requires mid-run input", "agent", sel.Agent)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInputUnsupported}
+	}
+
 	// The step clock is actor-managed (input.go) so it can pause while the
 	// task waits in awaiting_input (§7.4); a plain context deadline can't.
 	// Cancel causes tell classifyAgent why the tree was killed.

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -525,6 +525,14 @@ func (n *newTask) project() (apiclient.Project, bool) {
 	return apiclient.Project{}, false
 }
 
+// workflowNeedsInputAgent reports whether the selected workflow constrains the
+// agent choice: some step declares `on_input: require` and leaves its agent to
+// the task (§7.4, task 013). The daemon derives it; this only reads the flag.
+func (n *newTask) workflowNeedsInputAgent() bool {
+	e := n.workflowEntry(n.workflow)
+	return e != nil && e.Valid() && e.RequiresInput
+}
+
 func (n *newTask) workflowEntry(name string) *apiclient.WorkflowEntry {
 	for i := range n.workflows {
 		if n.workflows[i].Name == name {
@@ -742,6 +750,15 @@ func (n *newTask) submit() tea.Cmd {
 			n.rowErr[ntWorkflow] = "this workflow does not validate: " + e.FirstError()
 		case !e.RunsHere():
 			n.rowErr[ntWorkflow] = "this workflow does not run on this platform — it " + e.PlatformNote()
+		}
+	}
+	// The §7.4 `require` gate, checked locally so the message lands on the
+	// agent row rather than arriving as a create error with nowhere to point
+	// (task 013). The daemon re-checks it: this is a courtesy, not the gate.
+	if n.workflowNeedsInputAgent() && n.agent != "" {
+		if a, ok := n.agents.Find(n.agent); ok && a.CannotTakeInput() {
+			n.rowErr[ntAgent] = "this workflow needs an agent that can answer questions mid-run; " +
+				n.agent + " cannot"
 		}
 	}
 	if len(n.rowErr) > 0 {

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -751,3 +751,72 @@ func TestNewTaskWarningsReachTheDetailView(t *testing.T) {
 		t.Error("the warning renders as an error; the task exists and will run")
 	}
 }
+
+// An agent that cannot stop and ask is listed but not selectable while the
+// chosen workflow requires one (§7.4, task 013) — the same posture as a
+// foreign-platform workflow, and for the same reason: the daemon would 400 it,
+// and "codex vanished" is a worse answer than "codex cannot answer questions".
+func TestNewTaskRefusesAnAgentThatCannotTakeInput(t *testing.T) {
+	n := newNewTask()
+	n.update(ntLoadedMsg{
+		projects: []apiclient.Project{{ID: 1, Name: "vincent", DefaultBranch: "main"}},
+		workflows: []apiclient.WorkflowEntry{
+			{Name: "interactive", Scope: "global", RequiresInput: true},
+		},
+		agents: apiclient.Agents{
+			{Name: "claude", Available: true, InputVerdict: apiclient.InputVerdictSupported},
+			{Name: "codex", Available: true, InputVerdict: apiclient.InputVerdictUnsupported},
+			{Name: "cursor", InputVerdict: apiclient.InputVerdictUnknown},
+		},
+	})
+	n.workflow = "interactive"
+
+	opts := map[string]pickerOption{}
+	for _, o := range n.agentOptions() {
+		opts[o.value] = o
+	}
+	if opts["codex"].value == "" {
+		t.Fatal("the incapable agent is not listed at all")
+	}
+	if !opts["codex"].disabled {
+		t.Error("the incapable agent is selectable; create would 400")
+	}
+	if !strings.Contains(opts["codex"].note, "questions") {
+		t.Errorf("note = %q, want the capability it lacks", opts["codex"].note)
+	}
+	if opts["claude"].disabled {
+		t.Error("the capable agent is disabled")
+	}
+	// Decision 5's asymmetry reaches the picker too: an unknown verdict is not
+	// evidence, so an uninstalled adapter stays selectable.
+	if opts["cursor"].disabled {
+		t.Error("an unknown verdict disabled an agent; only a positive no refuses")
+	}
+
+	// Submitting with the incapable agent reports on the agent row rather than
+	// waiting for the daemon's 400.
+	n.agent = "codex"
+	n.titleIn.SetValue("t")
+	n.projectID = 1
+	n.submit()
+	if !strings.Contains(n.rowErr[ntAgent], "codex") {
+		t.Errorf("agent row error = %q, want one naming codex", n.rowErr[ntAgent])
+	}
+}
+
+// With a workflow that requires nothing, the same agent list is unconstrained.
+func TestNewTaskAgentPickerUnconstrainedWithoutRequire(t *testing.T) {
+	n := newNewTask()
+	n.update(ntLoadedMsg{
+		projects:  []apiclient.Project{{ID: 1, Name: "vincent", DefaultBranch: "main"}},
+		workflows: []apiclient.WorkflowEntry{{Name: "adhoc", Scope: "builtin"}},
+		agents: apiclient.Agents{
+			{Name: "codex", Available: true, InputVerdict: apiclient.InputVerdictUnsupported},
+		},
+	})
+	for _, o := range n.agentOptions() {
+		if o.value == "codex" && o.disabled {
+			t.Error("codex disabled for a workflow that never asks a question")
+		}
+	}
+}

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -415,9 +415,17 @@ func (n *newTask) agentOptions() []pickerOption {
 		label: "(workflow default)",
 		note:  strings.TrimPrefix(n.resolvedAgents(), " → "),
 	}}
+	needsInput := n.workflowNeedsInputAgent()
 	for _, a := range n.agents {
 		opt := pickerOption{value: a.Name, label: a.Name}
 		switch {
+		case needsInput && a.CannotTakeInput():
+			// Offered but not selectable, the way a foreign-platform workflow
+			// is (task 010): the adapter exists and the human may be reaching
+			// for it, so the row says why it is out of reach for *this*
+			// workflow rather than vanishing (§7.4, task 013).
+			opt.disabled = true
+			opt.note = "cannot answer questions · this workflow requires it"
 		case !a.Available:
 			opt.note = "⚠ unavailable: " + firstNonEmpty(a.Error, "not found")
 		case a.NotAuthenticated():

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -147,6 +147,11 @@ func (n *newTask) workflowSummary() string {
 	if bad := n.unavailableSteps(*e); len(bad) > 0 {
 		out += "  " + styleWarn.Render(fmt.Sprintf("⚠ %d unavailable", len(bad)))
 	}
+	if e.RequiresInput {
+		// Said on the workflow row because it is a fact about the workflow;
+		// the agent row is where it becomes an error (§7.4, task 013).
+		out += "  " + styleDim.Render("· needs an interactive agent")
+	}
 	return out
 }
 

--- a/internal/workflow/catalog_test.go
+++ b/internal/workflow/catalog_test.go
@@ -18,8 +18,14 @@ func testCatalogs() agent.Catalogs {
 		return out
 	}
 	return agent.Catalogs{
-		"claude": {Models: opt("sonnet", "opus", "haiku"), Efforts: opt("low", "medium", "high", "xhigh", "max")},
-		"codex":  {Efforts: opt("minimal", "low", "medium", "high", "xhigh")},
+		"claude": {
+			Models: opt("sonnet", "opus", "haiku"), Efforts: opt("low", "medium", "high", "xhigh", "max"),
+			InputSupport: agent.InputDetected,
+		},
+		"codex": {
+			Efforts:      opt("minimal", "low", "medium", "high", "xhigh"),
+			InputSupport: agent.InputNever,
+		},
 	}
 }
 

--- a/internal/workflow/input.go
+++ b/internal/workflow/input.go
@@ -1,0 +1,91 @@
+package workflow
+
+// The `on_input: require` gate (spec §7.4, §8.2 — task 013). A step that
+// requires mid-run input runs only on an adapter that can stop and wait for a
+// human answer; this file owns the resolution and the mismatch clause every
+// enforcement point embeds, the way platform.go owns the §8.1.1 one.
+
+import (
+	"fmt"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// InputPolicy resolves a step's `on_input` (§7.4): the step's own field, then
+// workflow defaults, then `wait`. It is exported because the API's gate and
+// the engine's pre-flight must read the same value the engine runs under.
+func (w *Workflow) InputPolicy(step Step) string {
+	if w == nil {
+		return firstNonEmptyString(step.OnInput, InputWait)
+	}
+	return firstNonEmptyString(step.OnInput, w.Defaults.OnInput, InputWait)
+}
+
+// StepRequiresInput reports whether the step resolves to `require`.
+//
+// A step's own `on_input` wins over `defaults:` like every other field, so
+// `defaults.on_input: require` with a step's `on_input: deny` leaves that one
+// step unattended — deliberate, and the only way to say it (task 013
+// decision 7).
+func (w *Workflow) StepRequiresInput(step Step) bool {
+	return step.Type == StepAgent && w.InputPolicy(step) == InputRequire
+}
+
+// RequiresInput reports whether the *task-level* agent choice is constrained
+// by this workflow: some step requires mid-run input and does not pin its own
+// `agent:`, so the agent it runs on is the one the task picks (§8.6 level 2).
+//
+// A workflow whose requiring steps all pin a capable agent constrains nothing
+// — restricting the picker on account of a step that ignores the picker would
+// refuse a task that runs perfectly (task 013 decision 6).
+func (w *Workflow) RequiresInput() bool {
+	if w == nil {
+		return false
+	}
+	for _, step := range w.Steps {
+		if w.StepRequiresInput(step) && step.Agent == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// InputMismatch explains why this workflow cannot run under the given task
+// overrides, in one clause the API's 400 and the TUI's row error both embed.
+// It is empty when every requiring step resolves to an agent that can ask.
+//
+// incapable answers "this adapter is known not to support mid-run input" —
+// a *positive* no. An unknown answer must be false: a probe that could not
+// speak is not evidence (task 013 decision 5).
+func (w *Workflow) InputMismatch(override agent.Level, incapable func(string) bool) string {
+	if w == nil || incapable == nil {
+		return ""
+	}
+	defaults := agent.Level{Agent: w.Defaults.Agent, Model: w.Defaults.Model, Effort: w.Defaults.Effort}
+	for _, step := range w.Steps {
+		if !w.StepRequiresInput(step) {
+			continue
+		}
+		sel := agent.Resolve(
+			agent.Level{Agent: step.Agent, Model: step.Model, Effort: step.Effort},
+			override, defaults,
+		)
+		if incapable(sel.Agent) {
+			return fmt.Sprintf(
+				"step %q requires mid-run input and agent %q cannot provide it",
+				step.DisplayName(), sel.Agent)
+		}
+	}
+	return ""
+}
+
+// firstNonEmptyString is the local copy of the resolver's helper; workflow
+// resolves two of its own fields and does not otherwise depend on taskrun.
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/workflow/input_test.go
+++ b/internal/workflow/input_test.go
@@ -1,0 +1,256 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// TestRequirePolicyParses covers the §7.4 third value on every level that may
+// carry it, and its rejection on the step types that may not.
+func TestRequirePolicyParses(t *testing.T) {
+	src := `
+name: interactive
+defaults:
+  on_input: require
+steps:
+  - id: ask
+    type: agent
+    prompt: what should I build?
+  - id: quiet
+    type: agent
+    on_input: deny
+    prompt: build it
+`
+	wf, _, err := Parse([]byte(src), Options{KnownAgents: []string{"claude"}})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !wf.StepRequiresInput(wf.Steps[0]) {
+		t.Error("step inheriting defaults.on_input: require does not require input")
+	}
+	// Decision 7: a step's own policy wins over the default, so `deny` inside
+	// a `require` workflow leaves that one step unattended.
+	if wf.StepRequiresInput(wf.Steps[1]) {
+		t.Error("step with on_input: deny requires input; the step must win over defaults")
+	}
+	if got := wf.InputPolicy(wf.Steps[1]); got != InputDeny {
+		t.Errorf("InputPolicy = %q, want %q", got, InputDeny)
+	}
+}
+
+func TestRequireRejectedOnNonAgentSteps(t *testing.T) {
+	src := `
+name: bad
+steps:
+  - id: build
+    type: command
+    on_input: require
+    run: make
+`
+	if _, _, err := Parse([]byte(src), Options{}); err == nil {
+		t.Fatal("on_input accepted on a command step")
+	}
+}
+
+func TestUnknownInputPolicyNamesAllThree(t *testing.T) {
+	src := `
+name: bad
+steps:
+  - id: ask
+    type: agent
+    on_input: sometimes
+    prompt: hi
+`
+	_, _, err := Parse([]byte(src), Options{})
+	if err == nil {
+		t.Fatal("unknown on_input value accepted")
+	}
+	for _, want := range []string{InputWait, InputDeny, InputRequire} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not offer %q", err, want)
+		}
+	}
+}
+
+// TestRequireOnIncapableAgentIsALoadError is the §8.2 half of the gate: a
+// requiring step pinned to an adapter with no control channel is broken on
+// every host, and is decidable without probing.
+func TestRequireOnIncapableAgentIsALoadError(t *testing.T) {
+	src := `
+name: bad
+steps:
+  - id: ask
+    type: agent
+    agent: codex
+    on_input: require
+    prompt: what should I build?
+`
+	_, _, err := Parse([]byte(src), catalogOpts())
+	if err == nil {
+		t.Fatal("require on codex parsed clean")
+	}
+	var errs Errors
+	if !asErrors(err, &errs) {
+		t.Fatalf("error is not workflow.Errors: %T", err)
+	}
+	if errs[0].Path != "steps[0].agent" {
+		t.Errorf("path = %q, want steps[0].agent — the field to change", errs[0].Path)
+	}
+	if !strings.Contains(errs[0].Message, "codex") {
+		t.Errorf("message %q does not name the agent", errs[0].Message)
+	}
+}
+
+// The finding is attributed to whichever level supplied the agent, and a
+// default inherited by many steps is reported once.
+func TestRequireFindingAttributedToDefaults(t *testing.T) {
+	src := `
+name: bad
+defaults:
+  agent: codex
+  on_input: require
+steps:
+  - id: one
+    type: agent
+    prompt: a
+  - id: two
+    type: agent
+    prompt: b
+`
+	_, _, err := Parse([]byte(src), catalogOpts())
+	if err == nil {
+		t.Fatal("require on a codex default parsed clean")
+	}
+	var errs Errors
+	if !asErrors(err, &errs) {
+		t.Fatalf("error is not workflow.Errors: %T", err)
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1 collapsed onto defaults: %v", len(errs), errs)
+	}
+	if errs[0].Path != "defaults.agent" {
+		t.Errorf("path = %q, want defaults.agent", errs[0].Path)
+	}
+}
+
+// claude's support is a version question only a probe can answer, so §8.2
+// must not judge it.
+func TestRequireOnDetectedAgentIsNotALoadError(t *testing.T) {
+	src := `
+name: fine
+steps:
+  - id: ask
+    type: agent
+    agent: claude
+    on_input: require
+    prompt: what should I build?
+`
+	if _, _, err := Parse([]byte(src), catalogOpts()); err != nil {
+		t.Fatalf("require on claude rejected at load: %v", err)
+	}
+}
+
+// TestRequiresInputDerivation covers decision 6: only a requiring step that
+// leaves its agent to the task constrains the task's agent choice.
+func TestRequiresInputDerivation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"unpinned requiring step constrains", `
+name: w
+steps:
+  - id: ask
+    type: agent
+    on_input: require
+    prompt: a
+`, true},
+		{"pinned requiring step does not", `
+name: w
+steps:
+  - id: ask
+    type: agent
+    agent: claude
+    on_input: require
+    prompt: a
+`, false},
+		{"no requiring step", `
+name: w
+steps:
+  - id: ask
+    type: agent
+    prompt: a
+`, false},
+		{"a pinned requiring step does not excuse an unpinned one", `
+name: w
+steps:
+  - id: pinned
+    type: agent
+    agent: claude
+    on_input: require
+    prompt: a
+  - id: loose
+    type: agent
+    on_input: require
+    prompt: b
+`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wf, _, err := Parse([]byte(tc.src), Options{KnownAgents: []string{"claude"}})
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got := wf.RequiresInput(); got != tc.want {
+				t.Errorf("RequiresInput() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInputMismatchResolvesThroughOverrides is the clause the API's 400 and
+// the engine's pre-flight both embed: it must follow §8.6 resolution, not a
+// conservative approximation of it.
+func TestInputMismatchResolvesThroughOverrides(t *testing.T) {
+	src := `
+name: w
+defaults:
+  agent: claude
+steps:
+  - id: build
+    type: agent
+    agent: codex
+    prompt: build
+  - id: ask
+    type: agent
+    on_input: require
+    prompt: ask
+`
+	wf, _, err := Parse([]byte(src), Options{KnownAgents: []string{"claude", "codex"}})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	incapable := func(name string) bool { return name == "codex" }
+
+	// No override: the requiring step inherits defaults.agent (claude).
+	if got := wf.InputMismatch(agent.Level{}, incapable); got != "" {
+		t.Errorf("mismatch with a capable default = %q, want none", got)
+	}
+	// The task override reaches the unpinned step and breaks it — while the
+	// pinned codex step, which never asks, stays irrelevant.
+	got := wf.InputMismatch(agent.Level{Agent: "codex"}, incapable)
+	if got == "" {
+		t.Fatal("codex override on a requiring step reported no mismatch")
+	}
+	for _, want := range []string{"ask", "codex"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("mismatch %q does not name %q", got, want)
+		}
+	}
+	// An unknown verdict is not evidence: nothing is refused on it.
+	if got := wf.InputMismatch(agent.Level{Agent: "codex"}, func(string) bool { return false }); got != "" {
+		t.Errorf("mismatch with an unknown verdict = %q, want none", got)
+	}
+}

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -57,6 +57,12 @@ func (e Entry) Valid() bool { return e.Workflow != nil }
 // the message wrong.
 func (e Entry) RunsHere() bool { return e.Workflow == nil || e.Workflow.SupportsHost() }
 
+// NeedsInputAgent reports whether picking an agent for a task built on this
+// entry is constrained by `on_input: require` (task 013). A broken entry
+// answers false for the same reason RunsHere answers true: its errors are
+// already why it cannot back a task.
+func (e Entry) NeedsInputAgent() bool { return e.Workflow != nil && e.Workflow.RequiresInput() }
+
 // Registry holds the parsed workflows of every scope and reloads them when
 // their files change (§5.2).
 type Registry struct {

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -30,10 +30,12 @@ const (
 	PermissionRestricted = "restricted"
 )
 
-// Input policies (spec §7.4).
+// Input policies (spec §7.4). `require` is `wait` plus a precondition: the
+// step will only run on an adapter that can stop and ask (task 013).
 const (
-	InputWait = "wait"
-	InputDeny = "deny"
+	InputWait    = "wait"
+	InputDeny    = "deny"
+	InputRequire = "require"
 )
 
 // Shells a command step may pin (spec §8.3).
@@ -261,6 +263,17 @@ func validateCatalogs(wf *Workflow, opts Options, loc *locator, add func(string,
 			agent.Level{},
 			agent.Level{Agent: wf.Defaults.Agent, Model: wf.Defaults.Model, Effort: wf.Defaults.Effort},
 		)
+		// The §8.2 capability check (task 013): a step that requires mid-run
+		// input on an adapter that can never provide it is broken on every
+		// host, forever, and is decidable here — InputSupport is curated, so
+		// no probe is involved. claude's version gate is *not* judged: only a
+		// probe can answer it, and this path must not spawn.
+		if wf.StepRequiresInput(step) && !catalogs.InputEverPossible(sel.Agent) {
+			if path, dup := findingPath(step, "agent", i, seen); !dup {
+				add(path, "agent %q can never take mid-run input, which step %q requires (on_input: %s)",
+					sel.Agent, step.DisplayName(), InputRequire)
+			}
+		}
 		cerrs, cwarns := catalogs.Check(sel)
 		for _, f := range cerrs {
 			path, dup := findingPath(step, f.Field, i, seen)
@@ -284,9 +297,14 @@ func validateCatalogs(wf *Workflow, opts Options, loc *locator, add func(string,
 // set the value, else the defaults field — reported once however many steps
 // inherit it.
 func findingPath(step Step, field string, index int, seen map[string]bool) (string, bool) {
-	stepValue := step.Model
-	if field == "effort" {
+	var stepValue string
+	switch field {
+	case "effort":
 		stepValue = step.Effort
+	case "agent":
+		stepValue = step.Agent
+	default:
+		stepValue = step.Model
 	}
 	if stepValue != "" {
 		return fmt.Sprintf("steps[%d].%s", index, field), false
@@ -309,7 +327,8 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 			PermissionFullAuto, PermissionRestricted, d.PermissionMode)
 	}
 	if d.OnInput != "" && !isInputPolicy(d.OnInput) {
-		add("defaults.on_input", "on_input must be %q or %q, got %q", InputWait, InputDeny, d.OnInput)
+		add("defaults.on_input", "on_input must be %q, %q or %q, got %q",
+			InputWait, InputDeny, InputRequire, d.OnInput)
 	}
 	if d.MaxRetries != nil && *d.MaxRetries < 0 {
 		add("defaults.max_retries", "max_retries must not be negative, got %d", *d.MaxRetries)
@@ -340,7 +359,8 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 				PermissionFullAuto, PermissionRestricted, step.PermissionMode)
 		}
 		if step.OnInput != "" && !isInputPolicy(step.OnInput) {
-			add(base+".on_input", "on_input must be %q or %q, got %q", InputWait, InputDeny, step.OnInput)
+			add(base+".on_input", "on_input must be %q, %q or %q, got %q",
+				InputWait, InputDeny, InputRequire, step.OnInput)
 		}
 		rejectFields(step, base, add, "run", "shell", "env", "instructions")
 	case StepCommand:
@@ -422,7 +442,9 @@ func knownAgent(name string, known []string) bool {
 
 func isPermissionMode(s string) bool { return s == PermissionFullAuto || s == PermissionRestricted }
 
-func isInputPolicy(s string) bool { return s == InputWait || s == InputDeny }
+func isInputPolicy(s string) bool {
+	return s == InputWait || s == InputDeny || s == InputRequire
+}
 
 func isShell(s string) bool { return s == ShellSh || s == ShellPwsh || s == ShellCmd }
 

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -9,10 +9,11 @@
 # unattended (scenario 5), and that archiving deletes a branch that carries no
 # commits past its base while keeping every branch that does (scenario 6), and
 # that a workflow restricted to other platforms is listed but never offered here
-# (scenario 7). Runs against the committed fakeagent so CI never calls a real
+# (scenario 7), and that a step requiring mid-run interaction refuses an agent
+# that cannot provide it (scenario 8). Runs against the committed fakeagent so CI never calls a real
 # API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
 # (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7 runs a single scenario for debugging.
+# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7|8 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -859,6 +860,100 @@ EOF
   echo "=== scenario 7 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 8 (task 013): a step declaring `on_input: require` only runs on an
+# agent that can stop and ask. Three layers, one daemon: the workflow pinning
+# codex fails §8.2 validation outright, the unpinned one advertises
+# requires_input, and a task naming codex on it is refused with 400 while the
+# same workflow on claude runs to completion.
+# ---------------------------------------------------------------------------
+scenario8() {
+  echo "=== scenario 8: workflows that require mid-run interaction gate their agent"
+  scenario_dirs s8
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+  codex:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  # The requiring step leaves its agent to the task, which is what makes the
+  # task's choice the thing being gated.
+  cat > "$CONFIG_DIR/workflows/m2-interactive.yaml" <<'EOF'
+name: m2-interactive
+description: M2 gate — a step that needs a human mid-run.
+steps:
+  - id: ask
+    type: agent
+    on_input: require
+    max_retries: 0
+    prompt: Decide what to build.
+EOF
+  # Pinned to an adapter with no control channel: broken on every host, and
+  # decidable at load without probing anything.
+  cat > "$CONFIG_DIR/workflows/m2-impossible.yaml" <<'EOF'
+name: m2-impossible
+description: M2 gate — requires input from an agent that can never give it.
+steps:
+  - id: ask
+    type: agent
+    agent: codex
+    on_input: require
+    prompt: Decide what to build.
+EOF
+
+  export FAKEAGENT_SCENARIO=success
+  daemon_up
+
+  local repo="$TMP/s8/repo" proj list
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  echo "== the impossible workflow is listed with a validation error naming the agent"
+  list="$(api GET "/workflows?project_id=$proj")"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-impossible") | .error' <<<"$list")" != "null" ]] \
+    || fail "require on codex validated clean: $list"
+  jq -e '.workflows[] | select(.name=="m2-impossible") | .errors[0].path == "steps[0].agent"' \
+    <<<"$list" >/dev/null \
+    || fail "the finding does not point at the agent field: $list"
+
+  echo "== the runnable one advertises that it needs an interactive agent"
+  [[ "$(jq -r '.workflows[] | select(.name=="m2-interactive") | .requires_input' <<<"$list")" == "true" ]] \
+    || fail "a workflow with an unpinned requiring step does not report requires_input: $list"
+  [[ "$(jq -r '.workflows[] | select(.name=="adhoc") | .requires_input' <<<"$list")" == "false" ]] \
+    || fail "the built-in adhoc workflow reports requires_input: $list"
+
+  echo "== /v1/agents publishes the verdict the gate uses"
+  local agents
+  agents="$(api GET /agents)"
+  [[ "$(jq -r '.agents[] | select(.name=="codex") | .input_verdict' <<<"$agents")" == "unsupported" ]] \
+    || fail "codex does not report an unsupported input verdict: $agents"
+  [[ "$(jq -r '.agents[] | select(.name=="claude") | .input_verdict' <<<"$agents")" == "supported" ]] \
+    || fail "the fake claude does not report a supported input verdict: $agents"
+
+  echo "== a task picking codex for it is refused with 400"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d "{\"project_id\":$proj,\"workflow\":\"m2-interactive\",\"title\":\"Nope\",\"agent\":\"codex\"}" \
+    "$BASE/tasks")"
+  [[ "$status" == "400" ]] \
+    || fail "an agent that cannot answer questions should be 400 at creation, got $status"
+
+  echo "== the same workflow on an agent that can ask runs to completion"
+  local ok
+  ok="$(api POST /tasks \
+    "{\"project_id\":$proj,\"workflow\":\"m2-interactive\",\"title\":\"Yes\",\"agent\":\"claude\"}" | jq -r .id)"
+  wait_for_state "$ok" done 90
+
+  unset FAKEAGENT_SCENARIO
+  "$VINCENT" daemon stop
+  echo "=== scenario 8 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -872,7 +967,8 @@ case "$WHICH" in
   5) scenario5 ;;
   6) scenario6 ;;
   7) scenario7 ;;
-  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7 ;;
+  8) scenario8 ;;
+  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
Records the design for `on_input: require`: an agent step that declares it
needs a human mid-run, and the gate that keeps such a step off adapters with
no control channel.

Ten decisions, each with the alternative it beat: one capability rather than
a `requires:` vocabulary, a third value on the existing per-step field rather
than a new key or a file-level flag, a static `InputSupport` in the curated
catalog so §8.2 can hard-error on codex and cursor without probing, creation
refusing only a positive incapable verdict (§9.6 degrade-never-block), the
picker constrained only by steps that would actually use the picked agent,
and a run-time pre-flight failing the step with `input_unsupported` under the
§7.2 budget rather than bypassing it.

No code yet — 013.1 through 013.8 are unstarted.