### PR TITLE
feat: parallel steps and workflow fan-out (task 014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,11 +87,3 @@ jobs:
       - name: M5 gate (fake agent)
         shell: bash
         run: ./scripts/m5-gate.sh
-
-      # M6: parallel step groups and workflow fan-out (task 014). It runs on
-      # all three OSes because the merge half is where platform differences
-      # actually bite — git's behaviour on Windows is the thing a gate should
-      # prove rather than assume.
-      - name: M6 gate (parallel and fan-out)
-        shell: bash
-        run: ./scripts/m6-gate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,11 @@ jobs:
       - name: M5 gate (fake agent)
         shell: bash
         run: ./scripts/m5-gate.sh
+
+      # M6: parallel step groups and workflow fan-out (task 014). It runs on
+      # all three OSes because the merge half is where platform differences
+      # actually bite — git's behaviour on Windows is the thing a gate should
+      # prove rather than assume.
+      - name: M6 gate (parallel and fan-out)
+        shell: bash
+        run: ./scripts/m6-gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,41 @@ Please pull request.
 
 ## [Unreleased]
 
+### Added
+
+- **`type: parallel` — sub-steps that run at once.** A group runs its
+  sub-steps concurrently in the task's one worktree: one step, one index, one
+  concurrency slot, no branch and no merge. It succeeds when every sub-step
+  does, a failure does not cancel its siblings, and a retry re-runs only what
+  failed. `parallel.max_parallel` (default 4) bounds it, and is a **second
+  concurrency dimension your task caps do not govern** — a board reading "1
+  running" can be a machine running four compilers. `manual`, nested groups
+  and `on_input: require` are refused inside a group.
+- **`type: fan_out` — lanes as real child tasks.** Each lane becomes an
+  ordinary task with its own worktree, branch, retries, gates and blocks, and
+  their branches are merged back (`--no-ff`, in declared order) into the
+  branch the task already owns, so one branch is still delivered. A lane is a
+  named workflow or inline steps, resolved into the task's snapshot at
+  creation; lanes may nest to any depth, bounded by `fan_out.max_depth` (3)
+  and `fan_out.max_tasks` (64), both checked at creation with a `400` naming
+  what is wrong.
+
+  A merge conflict blocks the task with `merge_conflict` and leaves the
+  worktree conflicted so you resolve it in place, stage, and retry;
+  `merge: {on_conflict: agent}` opts into an agent attempt first. A lane that
+  is cancelled or ends without finishing blocks with `lane_failed` and merges
+  **nothing**.
+
+  Two things worth knowing before you use it: a fan-out **fills** your
+  concurrency caps rather than exceeding them, and N lanes leave N worktrees
+  on disk until the tree is archived.
+
+  New `awaiting_children` task state (holds no slot), `?parent_id=` and
+  `?include_children=` on `GET /v1/tasks`, a `children` rollup on the task
+  detail, the `task.children_changed` event, `vincent task ls
+  --include-children/--parent`, and `L` in the TUI to drill into a fan-out's
+  lanes.
+
 ### Changed
 
 - **vincent is now source-available and dual-licensed, not MIT.** Personal and

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -126,6 +126,7 @@ times with a confirmation between each. Select the tasks instead:
 |---|---|
 | `space` | Select the task under the cursor (again deselects) |
 | `V` | Select every task the filter is showing — or clear that selection |
+| `L` | Drill into the selected fan-out's lanes, or back out. Lanes are hidden from the board otherwise |
 | `esc` | Clear the selection |
 
 While anything is selected, a `✓` appears beside those rows, the panel title

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -10,7 +10,9 @@ Four ready-to-copy workflows live in [`examples/`](../../examples). Start there.
 
 - [Where files live](#where-files-live)
 - [The shape of a file](#the-shape-of-a-file)
-- [Three step types](#three-step-types)
+- [Five step types](#five-step-types)
+- [Parallel verification](#verification-is-where-parallel-pays)
+- [Fan-out](#fan-out-is-for-deliverables-that-are-several-disjoint-pieces)
 - [Checks](#checks-are-how-you-stop-an-agent-grading-its-own-homework)
 - [Templates](#templates)
 - [Retries and timeouts](#retries-and-timeouts)
@@ -73,7 +75,7 @@ steps:                           # required; runs in order, top to bottom
 Unknown keys are rejected rather than ignored, so a typo is an error at
 validation time instead of a setting that silently never applied.
 
-## Three step types
+## Five step types
 
 **`agent`** runs an agent CLI headlessly in the worktree. Needs `prompt`.
 
@@ -121,6 +123,17 @@ validation time instead of a setting that silently never applied.
       - { id: typecheck, type: command, run: go vet ./... }
 ```
 
+**`fan_out`** turns each lane into a real child task and merges their branches
+back into this task's own. Needs `lanes`.
+
+```yaml
+  - id: build
+    type: fan_out
+    lanes:
+      - { id: api,  workflow: implement-module, fields: { module: api } }
+      - { id: docs, steps: [ { id: write, type: agent, prompt: "Document the API." } ] }
+```
+
 `check` is a **field** on agent and command steps, not a step of its own — see
 below.
 
@@ -151,6 +164,55 @@ group lives inside a single task, which has a single state:
 Sub-steps share one working tree, so two of them writing the same file is a
 bug in the workflow. Worktrees isolate tasks from each other, not the
 processes inside one task.
+
+## Fan-out is for deliverables that are several disjoint pieces
+
+Some work is one deliverable whose parts have no reason to wait for each
+other — two modules that do not touch, or code in one place and docs in
+another. A single task cannot do that: it has one worktree, one branch and one
+cursor. `fan_out` gives each lane its own task, and merges the branches back
+at the end of the same step, so you still get **one branch** to review.
+
+A lane is either a named workflow or inline steps. Naming one is the point —
+it is how a workflow becomes reusable as a piece of a bigger one:
+
+```yaml
+  - id: build
+    type: fan_out
+    lanes:
+      - { id: api,  workflow: implement-module, fields: { module: api } }
+      - { id: web,  workflow: implement-module, fields: { module: web } }
+```
+
+Each lane becomes an ordinary task: its own worktree, branch, retries, gates
+and blocks, visible with `vincent task ls --include-children` or by pressing
+`L` on the parent in the TUI. The parent shows `awaiting_children (2 blocked)`
+while they run — lanes are hidden from the board by default, and that summary
+is how you find out one of them needs you.
+
+### Three things to know before you use it
+
+**It fills your caps, it does not exceed them.** Every lane is a task
+competing for `max_parallel_tasks`. Fan-out buys you parallelism you would
+otherwise start by hand; it does not buy you more of the machine.
+
+**N lanes leave N worktrees** until someone archives the tree. `vincent gc`
+and `vincent doctor` exist for this, and if you fan out routinely you will
+meet it early.
+
+**Conflicts stop, they do not get guessed.** Two lanes touching the same file
+end with the task blocked on `merge_conflict` and the worktree left conflicted
+for you to fix, stage, and retry. You can opt into an agent attempt first with
+`merge: {on_conflict: agent, agent: {...}}` — gated by that step's own
+`check` — but the default is deliberately to stop, because a semantic conflict
+resolved silently and merged unread is the one outcome that turns this feature
+into a liability.
+
+If a lane is cancelled or ends without finishing, the join blocks with
+`lane_failed` and merges **nothing**. Fix the lane — it is an ordinary task,
+so retry it — then retry the parent. There is deliberately no "merge the rest
+anyway" button: a partial merge looks exactly like a complete one to
+everything downstream.
 
 ## Checks are how you stop an agent grading its own homework
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -108,8 +108,49 @@ validation time instead of a setting that silently never applied.
       Read the diff for #{{.Task.ID}} before it ships.
 ```
 
-There is no fourth type. `check` is a **field** on agent and command steps,
-not a step of its own — see below.
+**`parallel`** runs several sub-steps at once, in the same worktree. Needs
+`steps`.
+
+```yaml
+  - id: verify
+    type: parallel
+    max_parallel: 4
+    steps:
+      - { id: test,      type: command, run: go test ./... }
+      - { id: lint,      type: command, run: golangci-lint run }
+      - { id: typecheck, type: command, run: go vet ./... }
+```
+
+`check` is a **field** on agent and command steps, not a step of its own — see
+below.
+
+## Verification is where parallel pays
+
+Tests, a linter and a type check do not interact: they read the worktree and
+report an exit code. Run in sequence they cost the sum of three waits; in a
+`parallel` group they cost the longest one.
+
+The group is still **one step**. One index in the timeline, one concurrency
+slot, one thing to retry. It succeeds when every sub-step succeeds, and when
+one fails the others still run to completion — you get all three verdicts, not
+just the first bad one. Retrying re-runs only what failed, so a passing test
+suite is not re-run because the linter was unhappy.
+
+Three things a sub-step cannot be, all for the same underlying reason — the
+group lives inside a single task, which has a single state:
+
+- `manual`, because a gate releases the task's slot and waits for a human;
+- another `parallel`, because groups do not nest;
+- `on_input: require`, because the task holds one pending question at a time.
+
+> **Sizing it.** `max_parallel` (default 4) is *not* covered by your
+> `max_parallel_tasks` caps — those count tasks, and the whole group is inside
+> one. A board showing "1 running" can be a machine running four compilers.
+> Set it for the hardware.
+
+Sub-steps share one working tree, so two of them writing the same file is a
+bug in the workflow. Worktrees isolate tasks from each other, not the
+processes inside one task.
 
 ## Checks are how you stop an agent grading its own homework
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -251,7 +251,7 @@ rather than inventing a model name.
 
 | Method | Path | Notes |
 |---|---|---|
-| `GET` | `/v1/tasks?project_id=&state=&archived=&limit=&offset=` | List |
+| `GET` | `/v1/tasks?project_id=&state=&archived=&limit=&offset=&parent_id=&include_children=` | List. Fan-out lanes are **excluded** by default — `parent_id` lists one parent's lanes in merge order, `include_children=true` the flat everything |
 | `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort? }` — `branch_name` is used verbatim and wins over any template |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
@@ -312,6 +312,24 @@ Four details worth knowing:
   `step_name`, and `cost_usd` / `input_tokens` / `output_tokens` rolled up across
   every attempt — so a board renders without an N+1. Those are list-only;
   `GET /v1/tasks/{id}` serves the same numbers per attempt in `steps[]`.
+
+Every task shape carries `parent_task_id`, `lane_id` and `lane_order`, all null
+for a root task. `GET /v1/tasks/{id}` additionally carries `children` whenever
+the task has lanes:
+
+```json
+"children": {
+  "total": 4, "settled": 2,
+  "by_state": {"done": 2, "blocked": 1, "running": 1},
+  "blocked": [17], "awaiting_gate": []
+}
+```
+
+It covers the **whole subtree**, not just direct lanes, and is computed per
+request from one recursive CTE rather than stored — a counter would be a second
+truth that drifts from the rows it counts. `blocked` and `awaiting_gate` are
+ids: fetch the ones you decide to show. This is what pays for hiding lanes from
+the list, since a blocked lane would otherwise be invisible.
 - **`?archived=` defaults to false.** `true` selects only archived tasks, `all`
   returns both.
 - **Every task representation carries `available_actions`** (the actions valid
@@ -366,8 +384,8 @@ a client reconnecting with `Last-Event-ID` misses nothing.
 
 ```
 task.created            task.state_changed      task.priority_changed
-task.step_advanced      project.*               workflow.registry_changed
-daemon.shutting_down
+task.step_advanced      task.children_changed   project.*
+workflow.registry_changed                       daemon.shutting_down
 ```
 
 Payloads carry ids and the new state, not full objects — clients re-fetch what
@@ -383,6 +401,11 @@ they need.
 - `task.step_advanced` carries `{ current_step }` when the engine moves the
   cursor without a state change, so a board's `k/n` tracks a run instead of
   freezing.
+- `task.children_changed` carries `{ task_id, child_id, to_state }` and is
+  emitted on **every** fan-out ancestor when a descendant is created or
+  transitions — re-fetch the `children` rollup when you see one. It exists
+  because the per-task stream filters on `task_id` alone, so a root's stream
+  would otherwise never see a depth-2 transition.
 
 ### Live output — ephemeral
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -250,14 +250,19 @@ rejected with exit 1.
 
 ```sh
 vincent task ls [--project ID] [--state STATE] [--archived] [--limit N] [--json]
+                [--include-children] [--parent ID]
 ```
 
 Lists tasks. Archived tasks are excluded unless `--archived` is passed. Rows
 carry the board fields — project name, step progress, and cost and token totals
 rolled up across every attempt.
 
-Valid states: `queued`, `running`, `awaiting_gate`, `awaiting_input`, `blocked`,
-`paused`, `done`, `aborted`, `archived` — see
+Fan-out lanes are excluded too: the list is the work you asked for, and a
+64-task tree would bury it. `--parent ID` lists one fan-out task's lanes in
+merge order, and `--include-children` lists everything flat.
+
+Valid states: `queued`, `running`, `awaiting_gate`, `awaiting_input`,
+`awaiting_children`, `blocked`, `paused`, `done`, `aborted`, `archived` — see
 [Task lifecycle](task-lifecycle.md).
 
 ### `vincent task show`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -69,6 +69,11 @@ usage_limit_recheck_interval: 15m
 parallel:
   max_parallel: 4
 
+# Bounds on a `type: fan_out` tree, checked at task creation.
+fan_out:
+  max_depth: 3
+  max_tasks: 64
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
@@ -333,6 +338,27 @@ for the hardware, not for the board.
 Read when a group starts, so a reload governs the next group rather than
 resizing one already running. See
 [Workflow schema](workflow-schema.md#type-parallel).
+
+### `fan_out`
+
+```yaml
+fan_out:
+  max_depth: 3
+  max_tasks: 64
+```
+
+Bounds on a `type: fan_out` tree, both checked when a task is created and both
+reported as a `400` naming the bound crossed. `max_tasks` counts the child
+tasks one creation would produce, **not** counting the root.
+
+They are enforced at creation because the whole tree's shape is known there —
+lane lists live in the task's snapshot — which is what turns a depth-3
+explosion into an error in front of the person typing rather than two hundred
+worktrees discovered six hours later.
+
+Depth is unlimited by design and bounded by a default: a deeper tree is a
+config edit, not a code change. See
+[Workflow schema](workflow-schema.md#type-fan_out).
 
 ### `log_level`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,6 +65,10 @@ transcript_max_bytes: 512MB
 # How long a quota-stopped task waits when the agent CLI named no reset time.
 usage_limit_recheck_interval: 15m
 
+# Sub-steps of one `parallel` step group running at once.
+parallel:
+  max_parallel: 4
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
@@ -309,6 +313,26 @@ of the step's retry budget. See
 Must be positive. There is no exponential backoff; if you know your plan's
 window, set this to match it. Hot-reloaded, so a change applies to the next
 task that hits a limit.
+
+### `parallel`
+
+```yaml
+parallel:
+  max_parallel: 4
+```
+
+How many sub-steps of a `type: parallel` step group run at once, when the group
+does not set its own `max_parallel:`. Must be at least 1.
+
+**This is a second concurrency dimension, and your task caps do not cover it.**
+`max_parallel_tasks` counts *tasks* in a slot-holding state; a group runs
+inside one such task, so one running task can keep four processes busy. A board
+reading "1 running" is not a promise about the load on the machine — size this
+for the hardware, not for the board.
+
+Read when a group starts, so a reload governs the next group rather than
+resizing one already running. See
+[Workflow schema](workflow-schema.md#type-parallel).
 
 ### `log_level`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -51,6 +51,7 @@ Tasks are `queued` immediately on creation. There is no draft state.
 | `running` | A step process is executing, or about to | **yes** |
 | `awaiting_gate` | Stopped at a `manual` step, waiting for approval | no |
 | `awaiting_input` | The running agent asked a question; its process is alive and idle on stdin | **yes** |
+| `awaiting_children` | A `fan_out` step's lanes are running as child tasks; this task owns no process | no |
 | `blocked` | A step failed and retries are exhausted; waiting for a human | no |
 | `paused` | You asked it to hold; takes effect at the next step boundary | no |
 | `done` | Every step succeeded. Worktree and branch retained for inspection | no |
@@ -69,6 +70,19 @@ the resume time on the row (`queued → 14:20`) and the detail header names the
 reason. Cancelling, pausing or otherwise acting on the task drops the wait
 immediately — a human action always means go.
 
+**`awaiting_children` holds no slot, and offers only `cancel`.** A fan-out
+parent waiting on its lanes owns no process, so keeping a slot would starve
+the queue for hours — and it is what makes fan-out deadlock-free at any depth,
+since a parent releases its slot before its children need one. It is not a
+reuse of `awaiting_gate` because approve, reject and skip would all be
+meaningless while children are still running: the states differ in what a
+human can do about them, which is the only thing the lifecycle is for.
+
+The parent resumes on its own once every lane has settled — finished or ended.
+A lane that is `blocked`, at a gate, or paused holds the join open until you
+deal with it; the `children` rollup on `GET /v1/tasks/{id}` (and the TUI's
+`awaiting_children (2 blocked)` row) is where you see that.
+
 **`awaiting_input` keeps its concurrency slot.** The agent process is alive
 mid-step, idle on its stdin; killing or re-queueing it would lose the very
 session the answer belongs to. So a forgotten question does occupy a slot, until
@@ -82,7 +96,7 @@ its worktree, its branch and its transcripts while it does.
 
 | Action | Valid from | Effect |
 |---|---|---|
-| `cancel` | queued, running, awaiting_input, awaiting_gate, blocked, paused | Kills any running process — graceful termination, then a kill after 10s — and moves to `aborted` |
+| `cancel` | queued, running, awaiting_input, awaiting_gate, awaiting_children, blocked, paused | Kills any running process — graceful termination, then a kill after 10s — and moves to `aborted`. From `awaiting_children` it cascades to every unfinished lane, whose branches and worktrees survive |
 | `pause` | queued, running | From `running`, finishes the current step then holds. The request is persisted, so it survives a daemon crash; any other action clears it |
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step as a fresh attempt with the retry counter reset → `queued` |
@@ -153,6 +167,8 @@ same thing wherever it originated.
 | `invalid_snapshot` | The task's stored workflow snapshot is unusable |
 | `platform_unsupported` | The workflow is restricted to platforms this host is not (`platforms:`). Only reachable for a task created on another OS |
 | `input_unsupported` | The step declares `on_input: require` and its agent cannot take mid-run input. Refused at task creation, so only reachable when the agent changed underneath the task |
+| `merge_conflict` | A fan-out lane's merge conflicted. The worktree is left conflicted on purpose: resolve it, stage the files, and retry — the join commits your resolution and merges the rest |
+| `lane_failed` | A fan-out lane was cancelled or ended without finishing. **Nothing is merged** — a partial merge looks exactly like a complete one downstream. Fix the lane (it is an ordinary task), then retry the parent |
 | `interrupted` | The daemon stopped mid-step — not a failure |
 | `internal_error` | A bug. Please [report it](https://github.com/lezli01/vincent/issues/new/choose) |
 

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -118,7 +118,7 @@ Common to every step:
 |---|---|---|---|
 | `id` | slug | ✅ | Unique within the file, sub-steps included. How `.Steps` addresses it |
 | `name` | string | | Display name; defaults to `id` |
-| `type` | `agent` \| `command` \| `manual` \| `parallel` | ✅ | `check` is a *field*, not a type |
+| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
 | `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group, bounds the whole group |
 
@@ -245,6 +245,85 @@ Sub-steps share a working tree. Two of them writing the same file is a bug in
 your workflow — vincent isolates worktrees between *tasks*, not processes
 inside one.
 
+### `type: fan_out`
+
+Turns each lane into a **real child task** with its own worktree and branch,
+then merges those branches back into this task's own.
+
+| Key | Type | Required |
+|---|---|---|
+| `lanes` | list of lanes | ✅ |
+| `merge` | map | — |
+
+```yaml
+  - id: build
+    type: fan_out
+    merge:
+      on_conflict: block          # block (default) | agent
+    lanes:
+      - id: api
+        workflow: implement-module   # a registry workflow
+        fields: { module: api }
+      - id: docs
+        steps:                        # …or inline steps
+          - { id: write, type: agent, prompt: "Document the API." }
+```
+
+A **lane** carries `id` and exactly one of `workflow` or `steps`, plus:
+
+| Key | Type | Notes |
+|---|---|---|
+| `fields` | map | Merged over the parent task's fields; the lane wins |
+| `agent` / `model` / `effort` | string | Override the inherited selection for this lane's whole subtree |
+| `priority` | int | Same, for scheduler priority |
+
+A lane's workflow may itself contain a `fan_out`, to any depth. The bounds are
+`fan_out.max_depth` (3) and `fan_out.max_tasks` (64), both checked when the
+task is created — a cycle or an oversized tree is a `400` naming what is
+wrong, not something you discover as two hundred worktrees.
+
+**What a lane inherits.** Its base branch is the parent's branch, which is how
+the work lands where it belongs. Priority and the agent overrides propagate
+too — a fan-out inside an urgent task would otherwise queue behind unrelated
+work and make the urgent task *slower* than not fanning out.
+
+**One branch is still delivered.** The step does not finish until every lane is
+merged, `--no-ff`, in the order the lanes are declared.
+
+#### `merge` and conflicts
+
+| Key | Type | Notes |
+|---|---|---|
+| `on_conflict` | `block` \| `agent` | Default `block` |
+| `agent` | agent step | Required by, and only valid with, `on_conflict: agent` |
+
+`block` stops the task with `merge_conflict` and leaves the worktree
+conflicted, so you resolve it in place, stage the files, and retry — the join
+commits your resolution and merges what is left.
+
+`agent` tries an agent first. It is an ordinary agent step, `check` and all,
+and the conflicted files are in its template context as `{{.Conflicts}}`. If
+it fails, or its check fails, or conflict markers survive it, you get the same
+block.
+
+```yaml
+    merge:
+      on_conflict: agent
+      agent:
+        id: resolve
+        prompt: |
+          Resolve the merge conflict in: {{ range .Conflicts }}{{.}} {{ end }}
+        check: go build ./... && go test ./...
+```
+
+> **A fan-out fills your caps, it does not exceed them.** Each lane is a task
+> and competes for `max_parallel_tasks` like any other. What it buys is
+> parallelism you would otherwise have to start by hand.
+
+> **N lanes leave N worktrees** on disk until someone archives the tree. That
+> is what `vincent gc` and `vincent doctor` are for, and you will meet it
+> before you meet anything else in this feature.
+
 ### `check` is a field, not a step type
 
 It runs after the step body, in the worktree, with the same environment as a
@@ -342,6 +421,10 @@ network, no agent CLI installed.
 - A `parallel` group has at least one sub-step and a `max_parallel` of at
   least 1; its sub-steps are not `manual`, not `parallel`, and do not
   resolve to `on_input: require`.
+- A `fan_out` step has at least one lane; lane ids are unique within the step;
+  each lane has exactly one of `workflow` and `steps`. `merge.agent` is
+  required by, and only valid with, `on_conflict: agent`. A lane's inline
+  steps have their own id namespace, because each lane becomes its own task.
 - Every template parses.
 - `platforms` entries are known tokens, with no duplicates. The list is checked
   for shape, never against the validating host.

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -116,11 +116,11 @@ Common to every step:
 
 | Key | Type | Required | Notes |
 |---|---|---|---|
-| `id` | slug | ✅ | Unique within the file. How `.Steps` addresses it |
+| `id` | slug | ✅ | Unique within the file, sub-steps included. How `.Steps` addresses it |
 | `name` | string | | Display name; defaults to `id` |
-| `type` | `agent` \| `command` \| `manual` | ✅ | There is no fourth type |
+| `type` | `agent` \| `command` \| `manual` \| `parallel` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
-| `timeout` | duration | | Per attempt; overrides `defaults` |
+| `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group, bounds the whole group |
 
 ### `type: agent`
 
@@ -199,6 +199,51 @@ Stops and waits for a person.
 
 The task enters `awaiting_gate` and **releases its concurrency slot**. Approving
 advances; rejecting moves the task to `blocked`.
+
+### `type: parallel`
+
+Runs its sub-steps at the same time, in the task's one worktree.
+
+| Key | Type | Required |
+|---|---|---|
+| `steps` | list of steps | ✅ |
+| `max_parallel` | int | — (default `parallel.max_parallel`, 4) |
+
+```yaml
+  - id: verify
+    type: parallel
+    max_parallel: 4
+    timeout: 30m          # bounds the whole group
+    steps:
+      - { id: test,      type: command, run: go test ./... }
+      - { id: lint,      type: command, run: golangci-lint run }
+      - { id: typecheck, type: command, run: go vet ./... }
+```
+
+Sub-steps are ordinary `agent` and `command` steps: each has its own `check`,
+`timeout`, `max_retries` and agent selection, resolved exactly as at the top
+level. What they may **not** be:
+
+- `manual` — a gate releases the task's slot, and there is no such thing as
+  half a task waiting at a gate;
+- another `parallel` — groups do not nest;
+- `on_input: require` — the task has one pending question at a time, so a
+  group of agents that each want to ask has nowhere to put the answers.
+
+The group is one step: one index, one slot, one entry in the timeline. It
+succeeds when every sub-step succeeds. A failure does **not** cancel the
+others — the group waits for everything it started, then blocks with the first
+failure in declaration order. A retry re-runs only what failed, including
+after a human retry: sub-steps that already succeeded are not run again.
+
+> **`max_parallel` is not governed by your concurrency caps.** Those count
+> *tasks* (`max_parallel_tasks`, §11); a group runs inside one of them. One
+> task at `max_parallel: 8` will happily start eight compilers while the board
+> shows a single running task. Size it for the machine, not for the board.
+
+Sub-steps share a working tree. Two of them writing the same file is a bug in
+your workflow — vincent isolates worktrees between *tasks*, not processes
+inside one.
 
 ### `check` is a field, not a step type
 
@@ -292,7 +337,11 @@ re-derives it.
 `vincent workflow validate <file>` checks all of this locally — no daemon, no
 network, no agent CLI installed.
 
-- `steps` non-empty; step `id`s unique; `type` known.
+- `steps` non-empty; step `id`s unique **across the whole file**, sub-steps
+  of a `parallel` group included; `type` known.
+- A `parallel` group has at least one sub-step and a `max_parallel` of at
+  least 1; its sub-steps are not `manual`, not `parallel`, and do not
+  resolve to `on_input: require`.
 - Every template parses.
 - `platforms` entries are known tokens, with no duplicates. The list is checked
   for shape, never against the validating host.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -53,7 +53,9 @@ steps.
 - Multi-user / remote access / multi-host orchestration.
 - OS desktop notifications.
 - LLM-as-judge step verification.
-- Workflow branching, conditionals, or parallel steps within one task.
+- Workflow branching or conditionals within one task. *Amended 2026-08-17
+  (task 014): parallel steps and step fan-out are no longer deferred —
+  see §7.5 and §20.*
 - Sandboxing agents beyond worktree isolation (a worktree is not a security boundary).
 - Secret management (daemon inherits the user's environment).
 
@@ -284,6 +286,12 @@ Steps execute strictly in order. Executing step *i* means: render templates → 
 step body → evaluate success → on success advance to step *i+1* (or `done` if last) →
 persist → repeat.
 
+*Amended 2026-08-17 (task 014).* Order is still strict **between** steps; a
+`parallel` step is one step whose body runs several sub-steps at once. It
+occupies one index, holds one scheduler slot, and the cursor advances past it
+only when it succeeds, so nothing above changes. What the sub-steps do inside
+it is described in §7.5.
+
 ### 7.1 Success criteria
 
 A step **succeeds** iff:
@@ -432,6 +440,52 @@ Full-auto note: in `full-auto`, permission prompts are bypassed at the CLI level
 so `permission` requests should not occur; `question` requests can occur in any
 permission mode.
 
+### 7.5 Parallel step groups
+
+*Added 2026-08-17 (task 014).* A `parallel` step runs its sub-steps
+concurrently in the task's **one** worktree. It creates no branch, no child
+task and nothing to merge — that is `fan_out` (§7.6), a different mechanism
+that happens to share the word.
+
+```yaml
+- id: verify
+  type: parallel
+  max_parallel: 4
+  steps:
+    - { id: test,  type: command, run: go test ./... }
+    - { id: lint,  type: command, run: golangci-lint run }
+```
+
+- **Sub-steps are ordinary steps.** `agent` and `command` only, each with its
+  own `check`, `timeout`, `max_retries` and agent selection, resolved exactly
+  as they would be at the top level. `manual` is rejected: a gate ends the
+  actor goroutine and releases the slot (§6), and no state means "one sub-step
+  is gated". `on_input: require` is rejected for the same reason —
+  `awaiting_input` holds one pending request for the whole task (§7.4).
+  Groups do not nest.
+- **Rows.** One `step_runs` row per sub-step, all sharing the group's
+  `step_index` and told apart by `step_id`. The group has no row of its own;
+  its outcome is derived. Attempt numbers and retry budgets are per sub-step,
+  and a sub-step's transcript is
+  `{step_index}-{step_id}-{attempt}.jsonl` (§12.2).
+- **Success** is every sub-step succeeding. A failure does **not** cancel its
+  siblings: the group waits for everything it started, then blocks with the
+  first failure in declaration order, so the same failures always produce the
+  same `block_reason`. A group-level `timeout:` bounds the whole group and
+  fails it with `timeout`.
+- **Retry** re-runs only what did not succeed, within an admission and across
+  one: a re-admitted group skips sub-steps whose latest attempt succeeded,
+  derived from the rows rather than from a stored cursor.
+- **Concurrency.** `max_parallel` (default `parallel.max_parallel`, 4) bounds
+  how many run at once. It is a **second concurrency dimension**: the §11 caps
+  count tasks in slot-holding states, and a group runs inside one such task,
+  so one task can keep `max_parallel` processes busy while the board reads a
+  single running task. See §11.
+- **Concurrent writes are undefined.** The sub-steps share one working tree.
+  §10 isolates working trees between tasks, not processes within one; a group
+  whose sub-steps write the same files is a workflow bug, not something the
+  daemon arbitrates.
+
 ## 8. Workflow definition (YAML)
 
 ### 8.1 File format
@@ -540,12 +594,21 @@ Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
 | `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `on_input`, `input_timeout`, `check`, `check_timeout` |
 | `command` | `run` | `shell`, `env` (map), `check`, `check_timeout` |
 | `manual` | `instructions` | — |
+| `parallel` | `steps` | `max_parallel` |
+
+*`parallel` added 2026-08-17 (task 014); see §7.5 for what it does.*
 
 Constraints (validated on load and via `POST /v1/workflows/validate`):
 
 - `steps` non-empty; step ids unique; templates must parse; `type` known; durations
   parse as Go durations; `on_input` is `wait`, `deny` or `require`; unknown keys are errors
   (strict decoding) to catch typos.
+- *Amended 2026-08-17 (task 014).* Step ids are unique across the **whole**
+  workflow, sub-steps included: a `parallel` group's sub-steps share the
+  group's `step_index` and are told apart by id alone (§7.5). A group needs at
+  least one sub-step and a `max_parallel` of at least 1; its sub-steps may not
+  be `manual`, may not be `parallel`, and may not resolve to
+  `on_input: require`.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
   workflow validates on a Windows CI runner exactly as it does on Linux, or
@@ -1309,7 +1372,13 @@ would invalidate every one of them.
   - **per-project** `max_parallel_tasks` (project setting, default unlimited).
 - A `queued` task is admitted when both caps have headroom. Admission order:
   `priority` DESC, then `created_at` ASC (FIFO within a priority).
-- One task runs at most one step process at a time.
+- One task runs at most one step process at a time. *Amended 2026-08-17
+  (task 014):* a `parallel` step (§7.5) runs up to `max_parallel` processes
+  inside that one task's single slot. This is a **second concurrency
+  dimension the caps above do not govern** — they count tasks, not
+  processes — so a board reading "1 running" may be a machine running four
+  compilers. `parallel.max_parallel` (config, default 4) is what bounds it,
+  and a group's own `max_parallel:` overrides that per group.
 - `awaiting_gate`, `blocked`, and `paused` tasks hold **no** slot — a gate can wait
   hours without starving the queue. After approve/retry/skip/resume, the task
   re-enters `queued` and competes under the normal ordering (its original
@@ -1520,6 +1589,7 @@ platform the standing answer to an agent that will not resolve is the §12.3
   tui.json                   # TUI-local state (the §16 first-run acknowledgment)
   worktrees/{task_id}/
   transcripts/{task_id}/{step_index}-{attempt}.jsonl
+  transcripts/{task_id}/{step_index}-{step_id}-{attempt}.jsonl  # sub-step of a parallel group (§7.5)
   logs/daemon.log            # rotated, size-capped
 ```
 
@@ -1537,6 +1607,8 @@ delete_remote_branch_on_archive: false # …and its upstream counterpart; attend
 transcript_retention_days: 90   # transcripts of *archived* tasks older than this are pruned
 transcript_max_bytes: 512MB     # per-run transcript cap (§18); past it the step fails `transcript_limit`
 usage_limit_recheck_interval: 15m  # how long a quota-held task waits when the CLI named no reset (§11)
+parallel:
+  max_parallel: 4            # sub-steps of one `parallel` group at once (§7.5); the §11 caps do not see these
 log_level: info
 debug: false                 # record each step's resolved settings and full argv in its transcript
 environment:                 # what child processes inherit (T4.23)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -88,6 +88,9 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 21 | Agent/model/effort selection | Adapter-native values; per-step resolution `step > task override > workflow defaults > adapter default` with agent-scoped inheritance; options probed ad hoc from the installed CLIs, merged with a curated catalog, free text always allowed (§8.6, §9.6) |
 | 22 | Agent input requests | Structured requests only (`question`/`permission`); new `awaiting_input` state that keeps its slot; step clock pauses, bounded by `input_timeout` (default 24h); normalized schema + raw passthrough; `POST /v1/tasks/{id}/answer`; per-adapter capability (claude yes, codex no); `on_input: wait\|deny` opt-out; TUI-level alerts only (§6, §7.4, §13.2, §15) |
 
+| 23 | Parallel steps | `type: parallel` runs sub-steps concurrently in the task's one worktree: one step, one index, one slot, no branch and no merge. `manual`, nested groups and `on_input: require` are refused inside one; `max_parallel` (default 4) is a second concurrency dimension the §11 caps do not govern (§7.5, task 014) |
+| 24 | Workflow fan-out | `type: fan_out` makes each lane a real child task with its own worktree and branch, merged back `--no-ff` in declared order at the end of the same step. The parent parks in `awaiting_children` holding no slot, so no depth deadlocks; a conflict blocks by default, a lane that did not finish blocks the join, and the tree's bounds are checked at creation (§7.6, task 014) |
+
 ## 4. Architecture
 
 ```
@@ -188,6 +191,14 @@ A unit of work delivered by running a workflow against a project.
 | `current_step` | index into the snapshot's step list |
 | `pending_input` | normalized InputRequest (§7.4) while state is `awaiting_input`; cleared on answer, timeout, or process exit |
 
+
+*Amended 2026-08-17 (task 014).* A snapshot may carry a whole fan-out tree: a
+`fan_out` step's lanes are resolved through the registry at creation and
+written in, so later edits to a lane's workflow file never reach a task that
+already exists. Nesting lives only at authoring time — each lane's steps become
+a **child task's own flat snapshot** when it is spawned, so `edit + retry`,
+`Marshal` and the locator never meet a nested workflow.
+
 ### 5.4 StepRun
 
 One attempt at executing one step of one task. Every attempt (including retries and
@@ -256,6 +267,7 @@ already applies to every other pending flag — a human action means go.
 | `running` | A step process is executing (or about to) | **yes** |
 | `awaiting_gate` | Paused at a `manual` step, waiting for approval | no |
 | `awaiting_input` | The running agent emitted a structured input request (§7.4); its live process is idle, waiting for the answer | **yes** |
+| `awaiting_children` | A `fan_out` step's lanes are running as child tasks (§7.6, *added 2026-08-17, task 014*); the parent owns no process. Cancel is the only human action — approve/reject/skip would be meaningless, which is why this is not a reuse of `awaiting_gate` | no |
 | `blocked` | A step failed and retries are exhausted; waiting for a human decision | no |
 | `paused` | Engineer-requested soft pause (takes effect at the next step boundary) | no |
 | `done` | All steps succeeded; worktree/branch retained for inspection | no |
@@ -266,7 +278,7 @@ already applies to every other pending flag — a human action means go.
 
 | Action | Valid from | Effect |
 |---|---|---|
-| `cancel` (abort) | queued, running, awaiting_input, awaiting_gate, blocked, paused | Kills any running process (graceful term, then kill after 10 s; `taskkill /T /F` on Windows); → `aborted` |
+| `cancel` (abort) | queued, running, awaiting_input, awaiting_gate, awaiting_children, blocked, paused | Kills any running process (graceful term, then kill after 10 s; `taskkill /T /F` on Windows); → `aborted`. *Amended 2026-08-17 (task 014): from `awaiting_children` it cascades to every unsettled descendant, whose branches and worktrees survive.* |
 | `pause` | queued, running | `running`: finishes the current step, then holds; → `paused`. The request is persisted, so it survives a daemon crash; every other human action clears it |
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step (fresh attempt, retry counter reset); → `queued` |
@@ -486,6 +498,77 @@ that happens to share the word.
   whose sub-steps write the same files is a workflow bug, not something the
   daemon arbitrates.
 
+### 7.6 Fan-out steps
+
+*Added 2026-08-17 (task 014).* A `fan_out` step turns each of its lanes into
+a **real child task** — its own row, worktree, branch, scheduler slot, gates,
+blocks, transcripts and recovery — and merges their branches back into the
+branch this task already owns. One branch is still delivered, because the step
+does not finish until every lane is merged.
+
+```yaml
+- id: build
+  type: fan_out
+  merge:
+    on_conflict: block        # block (default) | agent
+  lanes:
+    - { id: api,  workflow: implement-module, fields: { module: api } }
+    - { id: docs, steps: [ { id: write, type: agent, prompt: "Document the API." } ] }
+```
+
+- **A lane is a named workflow or inline steps**, exactly one. A named lane is
+  resolved through the usual builtin < global < project shadowing at **task
+  creation** and written into the task's snapshot — never read from the
+  registry again (§5.3). A lane's workflow may itself fan out, to any depth.
+- **Creation-time checks**, possible because the whole tree's shape is static
+  once lane lists are in the snapshot: a cycle is a `400` naming the path, and
+  so is a tree past `fan_out.max_depth` (3) or `fan_out.max_tasks` (64,
+  counting descendants). A depth explosion is refused in front of the person
+  typing rather than discovered as two hundred worktrees six hours later.
+- **Inheritance.** A child's base branch is the parent's branch; its
+  `agent`/`model`/`effort` overrides and its priority propagate, and its
+  fields merge with the parent's, the lane winning. A lane spec overrides any
+  of them for its own subtree. Priority inheritance is load-bearing: admission
+  is `priority DESC, created_at ASC` and descendants are created late, so
+  priority-0 children of a priority-5 root would queue behind unrelated work.
+- **Parking.** After spawning, the parent moves to `awaiting_children`, which
+  holds **no** slot (§6, §11). That is what makes fan-out deadlock-free at any
+  depth: a parent releases its slot *before* its children need one, so there
+  is no hold-and-wait anywhere in the chain under any cap. A fan-out is not a
+  way to exceed the caps — it is a way to fill them.
+- **Resuming.** The scheduler returns the parent to the queue once every
+  descendant has *settled* (`done` or `aborted`). A `blocked`, `awaiting_gate`
+  or `paused` lane holds the join open until a human resolves it; the §13.2
+  `children` rollup is what makes that visible.
+- **The join** merges each lane branch with `git merge --no-ff` in **declared**
+  lane order, message `Merge lane '{lane_id}' of task {child_id}`, stopping at
+  the first conflict. Declared rather than completion order is what makes a
+  re-run conflict identically. Git identity is the user's own: vincent runs as
+  the invoking user (§16) and invents no author.
+- **A conflict blocks** with `merge_conflict`, leaving the worktree conflicted
+  so a human resolves in place. `on_conflict: agent` opts into an agent
+  attempt first — a full agent step, gated by its own `check` — falling back
+  to the block. Blocking by default is §7.2's posture: a human decides what a
+  machine could not.
+- **A lane that settles without finishing** blocks the join with
+  `lane_failed`, and **nothing** is merged. A partial merge is
+  indistinguishable downstream from a complete one. `retry` re-checks the
+  lanes; the remedy is to fix the child, which is an ordinary task. `skip`
+  keeps its meaning — it skips the whole join — and is deliberately not a
+  "proceed without that lane" button.
+- **Re-entry** into a half-merged join is disambiguated by the previous
+  attempt's outcome, with no merge cursor persisted: which lanes are already
+  merged is a fact git holds, and an already-merged lane re-merges as a no-op.
+  A crash aborts the in-progress merge and re-merges from the top; a human
+  retry after `merge_conflict` commits their resolution and continues. Only
+  the crash may abort — see §12.4.
+- **Cancel cascades** to every unsettled descendant, keeping their branches
+  and worktrees: the work is stopped, not destroyed. **Archive refuses** while
+  any descendant is unfinished, then cascades, each child under §10's ordinary
+  dirty-worktree rules.
+- **Cost.** N lanes leave N worktrees on disk until someone archives them.
+  That is what `vincent gc` and `vincent doctor` are for, and it will be felt.
+
 ## 8. Workflow definition (YAML)
 
 ### 8.1 File format
@@ -595,8 +678,15 @@ Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
 | `command` | `run` | `shell`, `env` (map), `check`, `check_timeout` |
 | `manual` | `instructions` | — |
 | `parallel` | `steps` | `max_parallel` |
+| `fan_out` | `lanes` | `merge` |
 
-*`parallel` added 2026-08-17 (task 014); see §7.5 for what it does.*
+*`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.*
+
+A lane carries `id` plus exactly one of `workflow` (a registry name) or
+`steps` (inline), and optionally `fields`, `agent`, `model`, `effort` and
+`priority`, which override the inherited values for that lane's subtree.
+`merge` carries `on_conflict` (`block` | `agent`) and, for the latter, an
+`agent` step.
 
 Constraints (validated on load and via `POST /v1/workflows/validate`):
 
@@ -607,8 +697,11 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   workflow, sub-steps included: a `parallel` group's sub-steps share the
   group's `step_index` and are told apart by id alone (§7.5). A group needs at
   least one sub-step and a `max_parallel` of at least 1; its sub-steps may not
-  be `manual`, may not be `parallel`, and may not resolve to
-  `on_input: require`.
+  be `manual`, may not be `parallel`, may not be `fan_out`, and may not
+  resolve to `on_input: require`. A `fan_out` step needs at least one lane;
+  lane ids are unique within the step, and a lane's inline steps have their
+  own id namespace because each lane becomes a separate task. `merge.agent`
+  is required by, and only valid with, `on_conflict: agent`.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
   workflow validates on a Windows CI runner exactly as it does on Linux, or
@@ -1254,6 +1347,15 @@ would invalidate every one of them.
   tree and index, but share the object store and refs — and **do not** isolate
   process-level resources (global caches, package stores, ports, docker). True
   sandboxing is out of scope for v1.
+
+  *Amended 2026-08-17 (task 014).* This now cuts two ways. A `parallel` group
+  runs several processes inside **one** worktree (§7.5), so its sub-steps are
+  not isolated from each other at all — concurrent writes to the same file are
+  undefined, and that is a workflow bug rather than something the daemon
+  arbitrates. A `fan_out` lane, being a real task, gets the ordinary isolation
+  (§7.6) — and leaves its own worktree behind until someone archives it, so an
+  N-lane fan-out costs N worktrees on disk. `vincent gc` and `vincent doctor`
+  are what that pressure is for.
 - **Cleanup:** on `archive`: `git worktree remove` (+ `--force` after an explicit
   dirty-worktree confirmation), then `git -C {project.path} worktree prune`. A branch
   that carries **any commit past its base** is never deleted by vincent.
@@ -1730,6 +1832,15 @@ edited via `PATCH /v1/projects/{id}`.
   `GET /v1/info`, and it deletes nothing — `vincent gc` does that, with a human behind
   it.
 
+*Amended 2026-08-17 (task 014).* A `fan_out` join interrupted mid-merge is
+recovered the same way any step is — the attempt is `interrupted` and re-runs
+— with one extra move: if a merge is still in progress in the worktree, it is
+aborted before the lanes are re-merged from the top, which is a no-op for the
+ones already in. Recovery is the **only** path allowed to abort. A human retry
+after a `merge_conflict` block finds the same in-progress merge and must
+commit their resolution instead; the two are told apart by how the previous
+attempt ended, read before the new attempt's row exists.
+
 ## 13. HTTP API
 
 ### 13.1 Transport and auth
@@ -1845,7 +1956,7 @@ POST   /v1/resolve                      { workflow, project_id?, agent?, model?,
                                         Resolution is server-side only: clients report it,
                                         never re-derive it (§8.6).
 
-GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=
+GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=&parent_id=&include_children=
                                         list rows additionally carry the §15 board fields:
                                         project_name, step_total, step_name, and cost_usd /
                                         input_tokens / output_tokens rolled up across every
@@ -1861,6 +1972,19 @@ GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=
                                         queued_reason (task 003): a queued task waiting on
                                         something other than a slot, per §11. Both are null
                                         for every other task, so the pair is additive
+                                        Amended 2026-08-17 (task 014): fan-out lanes are
+                                        excluded by default — the list is the work someone
+                                        asked for, and a 64-task tree would bury it.
+                                        ?parent_id= lists one parent's lanes in merge order;
+                                        ?include_children=true is the flat everything. Every
+                                        task shape carries parent_task_id / lane_id /
+                                        lane_order (null for a root), and GET /v1/tasks/{id}
+                                        carries a `children` rollup — subtree counts by
+                                        state plus the ids of blocked and awaiting-gate
+                                        descendants — whenever the task has lanes at all.
+                                        Derived per request from one recursive CTE, never
+                                        stored: a counter would be a second truth that
+                                        drifts from the rows it counts.
 POST   /v1/tasks                        { project_id, workflow, title, description?, fields?,
                                           base_branch?, branch_name?, priority?, agent?,
                                           model?, effort? }
@@ -1951,7 +2075,16 @@ Two kinds of streams:
    emitted as SSE with `id:` set, so clients reconnect with `Last-Event-ID` and miss
    nothing. Types:
    `task.created`, `task.state_changed`, `task.priority_changed`, `task.step_advanced`,
-   `project.*`, `workflow.registry_changed`, `daemon.shutting_down`.
+   `task.children_changed`, `project.*`, `workflow.registry_changed`,
+   `daemon.shutting_down`.
+   (`task.children_changed` — *added 2026-08-17, task 014* — carries
+   `{task_id, child_id, to_state}` and is emitted on **every** fan-out ancestor
+   when a descendant is created or transitions, so a client re-fetches the
+   §13.2 rollup. It exists because the per-task stream filters on `task_id`
+   alone: a root's stream would otherwise never see a depth-2 transition. The
+   alternative — widening that filter to a subtree test — fails because the
+   subtree is not fixed at subscribe time, since children appear as fan-outs
+   fire. The cost is bounded: at most `max_depth` extra rows per transition.)
    (`step.started`, `step.finished`, `step.retrying` and `gate.waiting` were listed
    here through M2 but were never emitted — PR D completed the vocabulary without
    them, since a step's lifecycle is reconstructable from `GET /v1/tasks/{id}/steps`
@@ -2026,6 +2159,13 @@ CREATE TABLE tasks (
   pending_input_json  TEXT,                   -- normalized InputRequest while state='awaiting_input' (§7.4)
   admit_not_before    TEXT,                   -- §11 admission hold; NULL = admissible now (task 003)
   queued_reason       TEXT,                   -- why a queued task waits on more than a slot; NULL = the ordinary queue
+  -- Fan-out lane link (§7.6, task 014, migration 0007). All NULL for a root
+  -- task; set together for a lane. lane_order is the *declared* order, which
+  -- is the order the join merges in — spawn order coincides only by luck.
+  parent_task_id      INTEGER REFERENCES tasks(id),
+  parent_step_index   INTEGER,                -- the fan_out step's index in the parent
+  lane_id             TEXT,                   -- the lane's id in that step
+  lane_order          INTEGER,
   created_at          TEXT NOT NULL,
   updated_at          TEXT NOT NULL,
   started_at          TEXT,
@@ -2033,6 +2173,7 @@ CREATE TABLE tasks (
   archived_at         TEXT
 );
 CREATE INDEX idx_tasks_sched ON tasks(state, priority DESC, created_at);
+CREATE INDEX idx_tasks_parent ON tasks(parent_task_id, lane_order);  -- §7.6 subtree walks (task 014)
 
 CREATE TABLE step_runs (
   id                  INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2524,6 +2665,10 @@ currently true to show (§15 view 6).
 | Workflow file edited mid-task | Irrelevant — execution uses the task's snapshot |
 | Workflow deleted before task creation | Creation fails: `workflow_not_found` |
 | Agent CLI missing at step start | Step fails (retry policy applies) with a `agent_unavailable` reason; typically → blocked |
+| A fan-out lane's merge conflicts | The join stops at that lane and the task blocks `merge_conflict`, with the worktree left conflicted so a human resolves in place (*added 2026-08-17, task 014*). `on_conflict: agent` tries a resolver first, gated by its `check`, and falls back to the same block. Archive gets no special case: a conflicted worktree is dirty by construction and §10 already refuses a dirty worktree without confirmation |
+| A fan-out lane ends without finishing | The join blocks `lane_failed` and merges **nothing** — a partial merge is indistinguishable downstream from a complete one. `retry` re-checks the lanes; the remedy is to fix the child, which is an ordinary task (*added 2026-08-17, task 014*) |
+| A fan-out tree is cyclic or too large | Refused at task creation with a `400` naming the cycle path or the bound crossed (`fan_out.max_depth`, `fan_out.max_tasks`). Possible because the whole tree's shape is static once lane lists are in the snapshot (*added 2026-08-17, task 014*) |
+| Two sub-steps of a `parallel` group write the same file | Undefined: the group shares one worktree, and §10 isolates working trees between *tasks*, not processes within one. A workflow bug, documented as such rather than arbitrated (*added 2026-08-17, task 014*) |
 | Option probe fails (help unparseable) | `GET /v1/agents` serves the curated catalog with `probe_error` set; selection and free text keep working (§9.6) |
 | Model/effort unknown to the catalog | Validation warning only; the CLI is the final authority — a rejected value fails the step with the CLI's error (retry policy applies) |
 | Model *in* the catalog but rejected at run time | Real, not hypothetical, on cursor (§9.7): the step fails with the stderr tail as the message, since no `result` event arrives. Catalog membership is advisory in both directions |
@@ -2620,7 +2765,9 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
 - OS desktop notifications (blocked / gate / awaiting input / done) — natural M4+1.
 - ~~More adapters~~ — **Cursor promoted out of future work to M5, 2026-08-11**
   (§9.7). Gemini CLI, opencode, and adapter capability flags remain here.
-- Workflow branching/conditionals, parallel steps, and step fan-out.
+- ~~parallel steps and step fan-out~~ — **promoted out of future work,
+  2026-08-17** (§7.5, §7.6, task 014). Workflow branching/conditionals remains
+  here.
 - LLM-as-judge verification as an optional third success layer.
 - Multi-user / remote daemons / fleet view across hosts.
 - Task templates & recurring tasks; issue-tracker ingestion (Jira → task).

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (3/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (4/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -617,7 +617,7 @@ for workflow content.
   synthetic `workflow_name` for inline lanes; cycle detection with the path in
   the `400`; `fan_out.max_depth` and `fan_out.max_tasks` computed and enforced
   in the insert path; the registry-load §8.2 cycle **warning**.
-- [ ] **014.7 — FSM.** `awaiting_children` in `taskstate`, its three table rows,
+- [x] **014.7 — FSM.** ✓ 2026-08-17 `awaiting_children` in `taskstate`, its three table rows,
   `HoldsSlot` false, the new `Settled()` predicate with `Terminal()` left alone
   (decision 20), and the §6 human-action table (cancel only).
 - [ ] **014.8 — Spawn and resume.** Depends: 014.4, 014.6, 014.7. The `fan_out`

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 📋 planned (0/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (0/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -365,6 +365,208 @@ transition.
   resources — faking a sandbox here would be the same dishonesty as faking an
   adapter capability.
 
+---
+
+Decisions 16 onwards come from the delivery-planning session held the same day,
+which walked the design against the code rather than against itself. They are
+the questions decisions 1–15 left open — several of them only visible once the
+existing store, FSM and validation code was read.
+
+### 16. Sub-steps share the group's `step_index`, and three keyed mechanisms widen to take a `step_id`
+
+*2026-08-17.* 014.2's "one `step_runs` row per sub-step sharing the group's
+`step_index` and keyed by `step_id`" collides with three mechanisms that key on
+`(task_id, step_index)` alone: `store.CountStepAttempts` (attempt numbering),
+`store.LastFailedStepRun` (which seeds `.LastFailure` for the §8.4 failure
+block), and transcript filenames `{step_index}-{attempt}.jsonl`. All three widen
+to take an optional step id; transcripts become
+`{step_index}-{step_id}-{attempt}.jsonl`.
+
+**Beat (a):** giving each sub-step its own `step_index`. `tasks.current_step` is
+one `INTEGER` and the group must stay addressable as one step — this is
+decision 1's trap in miniature, re-cutting an invariant to avoid widening two
+queries.
+
+**Beat (b):** a `sub_step_id` column keyed as a triple. It stores what the
+existing `step_id` column already holds.
+
+This extends rather than overturns the phase 2 decision recorded at
+`store/transitions.go:301`: attempt numbers stay monotonic over a step's whole
+history, now per sub-step, so transcript files still never collide or truncate.
+
+### 17. A `parallel` group has no `step_runs` row of its own
+
+*2026-08-17.* Only sub-steps get rows. The group's state is derived: it
+succeeded iff every sub-step succeeded, it is running while any sub-step is.
+
+**Beat:** a group row carrying its own state and timestamps. It is a second copy
+of a fact the sub-step rows already hold — the same reason decisions 9 and 13
+derive rather than store. The TUI folds sub-steps under their group on
+`step_index`, which it already has.
+
+### 18. A failing sub-step does not cancel its siblings; the retry budget is per sub-step
+
+*2026-08-17.* Siblings run to completion, then the group fails. `max_retries` on
+a sub-step governs that sub-step, falling back to the group's, and a retry
+re-runs only the failed sub-step (014.2).
+
+**Beat:** cancelling siblings at the first failure. It discards work that was
+about to succeed, and it does so in the most expensive way available: a killed
+sub-step records an `interrupted` attempt, which consumes no retry (§7.2), so
+the retry re-runs it from scratch. A failed linter should not throw away a test
+run whose output is the thing the human wants to read.
+
+### 19. `on_input: require` is rejected inside a `parallel` group
+
+*2026-08-17.* Validation rejects it alongside `manual` (014.1). `check`,
+`timeout` and `max_retries` are legal per sub-step, and the group itself may
+carry a `timeout` bounding the whole group.
+
+The reasoning 014.1 gives for `manual` applies unchanged: `awaiting_input` is
+one task state carrying one pending request (§7.4), and there is no state
+meaning "one sub-step of one group is waiting on a human" any more than there is
+one meaning "one sub-step is gated". Task 013 made this reachable, so it needs
+saying.
+
+**Beat:** serializing input requests from N concurrent agents. It defines an
+answering order nobody asked for and leaves the other agents idle holding the
+one slot.
+
+### 20. `Settled()` is a new predicate; `Terminal()` is left alone
+
+*2026-08-17.* Decision 6 says the parent re-queues when the last descendant
+reaches "a terminal state". Read against the code that is wrong:
+`taskstate.Terminal()` is `archived` **only**, which no child reaches on its
+own. The join waits on a new `Settled()` = `done | aborted`.
+
+A `blocked`, `awaiting_gate` or `paused` child therefore holds the join open —
+which is what decision 13's rollup exists to surface, and the two decisions
+should be read together.
+
+**Beat (a):** widening `Terminal()`. It means "no further transition is
+possible", and for a `done` task archival is still possible, so the widening
+would be a lie told to every other caller.
+
+**Beat (b):** treating any slot-free state as settled. It wakes the parent over
+a blocked lane and merges a branch missing that lane's work, with nothing in the
+result saying so.
+
+### 21. A lane that settles as `aborted` blocks the join with `lane_failed`
+
+*2026-08-17.* New block reason `lane_failed` in the shared `Reason*` vocabulary.
+The parent blocks and merges **nothing** — not even the lanes that succeeded.
+
+This is decision 8's posture applied to the other way a fan-out fails to
+converge. Merging the successful subset delivers an incomplete deliverable on a
+branch that looks finished, which is the same correctness liability decision 8
+refuses for conflicts.
+
+**Beat:** merging what succeeded and reporting the rest. A partial merge is
+indistinguishable, downstream, from a complete one.
+
+### 22. `retry` on a `lane_failed` parent re-checks; `skip` keeps its existing meaning
+
+*2026-08-17.* Retry re-evaluates every lane's state. If any lane is not `done`,
+it blocks again with `lane_failed`. The remedy is to fix the **child** — an
+ordinary task, with the ordinary retry — and then retry the parent.
+
+`skip` on the parent is unchanged and skips the whole join: no lanes are merged.
+It is deliberately **not** a "proceed without that lane" button, and there is no
+such button. Anything else would need a merge subset to be expressible, which
+decision 21 just refused.
+
+**Beat:** retry re-spawning aborted lanes as fresh children. It creates a second
+spawn path and a "which child is the current attempt at lane X" question that
+`lane_id` cannot answer without becoming versioned.
+
+### 23. A child's title is `{parent title} — {lane id}`, and its branch is named the ordinary way
+
+*2026-08-17.* Nothing about child branch naming is special-cased: a child is an
+ordinary task, so `ResolveBranchName` runs with the child's own id, slug,
+project and fields, through whatever template the project or global config sets
+(task 001). The title is the only new input, and `Slug` derives from it.
+
+**Beat:** a `title:` field on the lane spec. 014.5 enumerates `Lane` as `ID`,
+`Workflow`, `Steps`, `Fields`; a fifth field earns its place only once someone
+wants a title that the parent's own title does not imply.
+
+### 24. `on_conflict.agent` is a full agent `Step`
+
+*2026-08-17.* The value is a `workflow.Step` of type `agent`, validated by the
+existing `validateStep` and executed by the existing agent executor in the
+parent's worktree, with the conflicted file list available to the prompt
+template. `prompt`, `check`, `check_timeout`, `timeout`, `max_retries` and the
+`agent`/`model`/`effort` triple all behave exactly as they do anywhere else.
+`max_retries` defaults to 0: one attempt, then the block.
+
+This makes decision 8's "gated by a `check` the way any agent step is" literally
+true rather than approximately true.
+
+**Beat:** a bespoke struct with a hand-picked subset of those fields. It is a
+second agent-step vocabulary that will drift from the first one field at a time.
+
+### 25. The scheduler performs `ChildrenSettled`
+
+*2026-08-17.* The scheduler transitions a parked parent, woken by
+`task.children_changed` (decision 14) rather than by new polling.
+
+**Beat:** the last child's `taskrun` actor doing it. Two children settling
+concurrently both believe they are last, or neither does; and an actor writing
+another task's state breaks the sole-writer invariant outright. The scheduler is
+already the single serialized decision point that exists so admission is
+unraced, and this is the same kind of decision wearing a different name.
+
+### 26. `task.children_changed` fires on child creation too
+
+*2026-08-17.* Emitted on every fan-out ancestor when a descendant is created as
+well as when one transitions. Creation changes the rollup's counts exactly as a
+transition does, and a root whose depth-2 subtree is still being spawned is
+precisely when a live count is worth having. Step-level activity stays out: that
+is the per-task stream's job, unchanged.
+
+### 27. The `children` rollup is present whenever a task has children
+
+*2026-08-17.* Not only in `awaiting_children`. A parent mid-join, or one already
+`done`, still wants its lane ids reachable from one `GET`.
+
+**Beat:** gating the field on the state, as decision 13 words it. That forces a
+client to know the state in order to know whether to look, and the rollup's
+whole purpose is to answer "what is going on down there" in one request. The
+cost of the general form is one indexed existence check on tasks with no
+children.
+
+### 28. `fan_out.max_tasks` counts descendants only
+
+*2026-08-17.* Across the whole resolved tree, excluding the root. The bound
+exists to cap what a fan-out *creates*; counting the root makes the configured
+number off by one against the sentence that explains it.
+
+### 29. A lane's `fields:` merge with the parent's, lane wins
+
+*2026-08-17.* Decision 4 gives a lane `fields:` and decision 10 inherits
+overrides and priority, but fields were left unstated. They inherit the same
+way: the subtree gets the root's context and overrides what it needs.
+
+**Beat:** replacement. A lane that had to restate every field the parent set
+would make `fields: { module: api }` unwritable in any workflow that uses fields
+for anything else.
+
+### 30. Two config blocks, read at the point of use
+
+*2026-08-17.* `config.yaml` gains `parallel: { max_parallel: 4 }` and
+`fan_out: { max_depth: 3, max_tasks: 64 }` — a block per step type, named the
+way this document names them.
+
+**Beat:** folding all three into `defaults:`. What lives there today is timeouts
+a step may override per-step; these three are not step-overridable, so they
+would be misfiled next to things that look like them and behave differently.
+
+All three are read **when they are used** — `max_parallel` when a group starts,
+the two bounds in the task-creation path — so a hot reload (§12) governs the
+next group and the next task and never resizes something already running. That
+also keeps daemon configuration out of the workflow snapshot, which §5.3 reserves
+for workflow content.
+
 ## Tasks
 
 ### Phase 1 — `type: parallel`
@@ -373,21 +575,26 @@ transition.
   `max_parallel:`; sub-steps validated by the existing `validateStep`, with
   `manual` rejected inside a group — a gate ends the actor goroutine and
   releases the slot (§6), and there is no state meaning "one sub-step of one
-  group is gated"; `rejectFields` for everything that is not
-  `steps`/`max_parallel`; the `parallel.max_parallel` daemon default in
-  `internal/config`.
+  group is gated" — and `on_input: require` rejected for the same reason
+  (decision 19); `check`, `timeout` and `max_retries` legal per sub-step, plus a
+  group-level `timeout`; `rejectFields` for everything that is not
+  `steps`/`max_parallel`/`timeout`; the `parallel.max_parallel` daemon default in
+  `internal/config` (decision 30).
 - [ ] **014.2 — Engine.** Depends: 014.1. Concurrent execution inside the task's
   actor goroutine, bounded by `max_parallel`; one `step_runs` row per sub-step
-  sharing the group's `step_index` and keyed by `step_id`; per-sub-step attempt
-  numbering; a retry re-runs only the failed sub-step; the group succeeds iff
-  every sub-step does. The actor remains the sole writer — it forks, collects,
-  and writes the rows itself.
+  sharing the group's `step_index` and keyed by `step_id`, with no row for the
+  group itself (decision 17); `CountStepAttempts`, `LastFailedStepRun` and
+  transcript naming widened to take a step id (decision 16); per-sub-step attempt
+  numbering and retry budget; a retry re-runs only the failed sub-step; a failure
+  does not cancel siblings (decision 18); the group succeeds iff every sub-step
+  does. The actor remains the sole writer — it forks, collects, and writes the
+  rows itself.
 - [ ] **014.3 — Clients and docs for phase 1.** Depends: 014.2. TUI step list
   renders a group and its sub-steps with independent live output (`run_id` on
   every chunk already disambiguates, §13.3 unchanged); spec §7, §8.2 and §11
   amended in place, including the explicit note that `max_parallel` is a second
   concurrency dimension the caps do not govern; `reference/workflow-schema.md`,
-  `guides/workflows.md`, `reference/config.md`.
+  `guides/workflows.md`, `reference/configuration.md`.
 
 ### Phase 2 — `type: fan_out`
 
@@ -405,42 +612,59 @@ transition.
   the `400`; `fan_out.max_depth` and `fan_out.max_tasks` computed and enforced
   in the insert path; the registry-load §8.2 cycle **warning**.
 - [ ] **014.7 — FSM.** `awaiting_children` in `taskstate`, its three table rows,
-  `HoldsSlot` false, and the §6 human-action table (cancel only).
+  `HoldsSlot` false, the new `Settled()` predicate with `Terminal()` left alone
+  (decision 20), and the §6 human-action table (cancel only).
 - [ ] **014.8 — Spawn and resume.** Depends: 014.4, 014.6, 014.7. The `fan_out`
-  step creates its children (base branch = parent's branch, fields from the lane
-  spec, overrides and priority per decision 10), parks the parent, and the
-  scheduler re-queues it via `ChildrenSettled` when the last descendant reaches
-  a terminal state.
+  step creates its children (base branch = parent's branch, title
+  `{parent} — {lane}` and the ordinary branch template per decision 23, fields
+  merged with the parent's per decision 29, overrides and priority per
+  decision 10), parks the parent, and the scheduler — not the last child's actor
+  (decision 25) — re-queues it via `ChildrenSettled` once every descendant is
+  `Settled()`.
 - [ ] **014.9 — The join.** Depends: 014.8. Sequential `--no-ff` merges in
-  `lane_order`; `ReasonMergeConflict = "merge_conflict"` in the §18 vocabulary;
-  `on_conflict: {agent: …}` with its `check`; the decision-9 re-entry rules for
-  both `interrupted` and `blocked`, wired into `taskrun/recover.go`.
+  `lane_order`; `ReasonMergeConflict = "merge_conflict"` and
+  `ReasonLaneFailed = "lane_failed"` in the §18 vocabulary; `on_conflict: {agent: …}`
+  as a full agent `Step` (decision 24); the decision-9 re-entry rules for both
+  `interrupted` and `blocked`, plus decision 22's re-check on a `lane_failed`
+  retry, wired into `taskrun/recover.go`.
 - [ ] **014.10 — Lifecycle.** Depends: 014.8. Cascading cancel; archive refusing
   a non-terminal descendant then cascading with per-child dirty confirmation;
   `gc` and `doctor` seeing lane worktrees as the ordinary task worktrees they
   are.
 - [ ] **014.11 — API and events.** Depends: 014.4, 014.8. List filters
   (`?parent_id=`, `?include_children=`), the `children` rollup on
-  `GET /v1/tasks/{id}`, and `task.children_changed` emitted post-commit on every
-  fan-out ancestor.
+  `GET /v1/tasks/{id}` whenever the task has children rather than only in
+  `awaiting_children` (decision 27), and `task.children_changed` emitted
+  post-commit on every fan-out ancestor, on child creation as well as on every
+  descendant state change (decision 26).
 - [ ] **014.12 — TUI.** Depends: 014.11. A parent row reading
   `awaiting_children (2 blocked)`; drilling from a parent into its lanes and
   back; the new state in the board's colour and action-bar tables
   (`internal/tui/bindings.go` key table updated with it).
-- [ ] **014.13 — Docs.** Depends: all. Spec §5.3, §6, §10, §11, §13.2, §13.3 and
-  §18 amended in place with dated notes; §20 amended to promote fan-out out of
-  future work the way cursor was; decision-record row 23; user-facing
-  `reference/workflow-schema.md`, `reference/api.md`, `reference/config.md`,
-  `guides/workflows.md` and the block-reason table — including, stated plainly,
-  that a fan-out fills the caps rather than exceeding them, and that N lanes
-  leave N worktrees until archived.
-- [ ] **014.14 — Gate.** Depends: 014.9, 014.10. New `scripts/m6-gate.sh`,
-  committed executable via `git update-index --chmod=+x` — a non-executable gate
-  passes on Windows and exits 126 on both POSIX legs. Scenarios: happy-path
-  two-lane merge; an induced conflict reaching `merge_conflict`, resolved by
-  hand, retried, remaining lanes merged; a crash mid-merge recovering by
-  `--abort` and idempotent re-merge; one depth-2 tree; and both creation-time
-  `400`s (cycle, `max_tasks`).
+- [ ] **014.13 — Docs.** Depends: all. Spec §5.3, §6, §10, §11, §12.4, §13.2,
+  §13.3, §14 and §18 amended in place with dated notes — §12.4 and §14 because
+  recovery aborting a merge and the new `tasks` columns are exactly what those
+  sections describe; §20 amended to promote parallel steps and fan-out out of
+  future work the way cursor was, leaving branching/conditionals there;
+  decision-record rows **23 and 24**, one per step type, because decision 2
+  separated the two mechanisms and one row would re-merge them; user-facing
+  `reference/workflow-schema.md`, `reference/api.md`,
+  `reference/configuration.md`, `reference/task-lifecycle.md`,
+  `guides/workflows.md` and the block-reason table — no new page, the caveats
+  landing next to the schema that causes them — including, stated plainly, that
+  a fan-out fills the caps rather than exceeding them, and that N lanes leave N
+  worktrees until archived.
+- [ ] **014.14 — Gate.** Depends: 014.2, 014.9, 014.10. New `scripts/m6-gate.sh`
+  covering **both** phases, committed executable via `git update-index --chmod=+x`
+  — a non-executable gate passes on Windows and exits 126 on both POSIX legs —
+  and wired into CI on all three platforms, merge behaviour on Windows being
+  the thing a gate should prove rather than assume. Scenarios: a `parallel`
+  happy path; a failing sub-step; a retry re-running only the failed sub-step;
+  happy-path two-lane merge; an induced conflict reaching `merge_conflict`,
+  resolved by hand, retried, remaining lanes merged; a crash mid-merge
+  recovering by `--abort` and idempotent re-merge; one depth-2 tree; a lane
+  aborted reaching `lane_failed`; and both creation-time `400`s (cycle,
+  `max_tasks`).
 
 ## Verification
 

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (11/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (12/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -665,7 +665,7 @@ an `agent:` the policy will never run.
   `awaiting_children` (decision 27), and `task.children_changed` emitted
   post-commit on every fan-out ancestor, on child creation as well as on every
   descendant state change (decision 26).
-- [ ] **014.12 — TUI.** Depends: 014.11. A parent row reading
+- [x] **014.12 — TUI.** ✓ 2026-08-17 Depends: 014.11. A parent row reading
   `awaiting_children (2 blocked)`; drilling from a parent into its lanes and
   back; the new state in the board's colour and action-bar tables
   (`internal/tui/bindings.go` key table updated with it).

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (12/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (13/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -682,7 +682,7 @@ an `agent:` the policy will never run.
   landing next to the schema that causes them — including, stated plainly, that
   a fan-out fills the caps rather than exceeding them, and that N lanes leave N
   worktrees until archived.
-- [ ] **014.14 — Gate.** Depends: 014.2, 014.9, 014.10. New `scripts/m6-gate.sh`
+- [x] **014.14 — Gate.** ✓ 2026-08-17 Depends: 014.2, 014.9, 014.10. New `scripts/m6-gate.sh`
   covering **both** phases, committed executable via `git update-index --chmod=+x`
   — a non-executable gate passes on Windows and exits 126 on both POSIX legs —
   and wired into CI on all three platforms, merge behaviour on Windows being

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (0/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (1/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -571,7 +571,7 @@ for workflow content.
 
 ### Phase 1 — `type: parallel`
 
-- [ ] **014.1 — Schema and validation.** `type: parallel` with inline `steps:` and
+- [x] **014.1 — Schema and validation.** ✓ 2026-08-17 `type: parallel` with inline `steps:` and
   `max_parallel:`; sub-steps validated by the existing `validateStep`, with
   `manual` rejected inside a group — a gate ends the actor goroutine and
   releases the slot (§6), and there is no state meaning "one sub-step of one

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (2/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (3/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -595,7 +595,7 @@ for workflow content.
   does not cancel siblings (decision 18); the group succeeds iff every sub-step
   does. The actor remains the sole writer — it forks, collects, and writes the
   rows itself.
-- [ ] **014.3 — Clients and docs for phase 1.** Depends: 014.2. TUI step list
+- [x] **014.3 — Clients and docs for phase 1.** ✓ 2026-08-17 Depends: 014.2. TUI step list
   renders a group and its sub-steps with independent live output (`run_id` on
   every chunk already disambiguates, §13.3 unchanged); spec §7, §8.2 and §11
   amended in place, including the explicit note that `max_parallel` is a second

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (5/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (6/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -573,6 +573,28 @@ next group and the next task and never resizes something already running. That
 also keeps daemon configuration out of the workflow snapshot, which §5.3 reserves
 for workflow content.
 
+### 31. `merge:` carries the policy and the resolver as two fields
+
+*2026-08-17, during implementation.* This document spells the conflict
+setting two ways: the opening example writes `merge: { on_conflict: block }`,
+and decision 8 writes `on_conflict: {agent: …}`. They cannot both be the
+schema. The reconciliation keeps the opening example's shape:
+
+```yaml
+merge:
+  on_conflict: agent      # block (default) | agent
+  agent: { id: resolve, prompt: …, check: … }
+```
+
+**Beat:** a YAML union — `on_conflict` being either the string `block` or a
+mapping carrying an agent. It needs a custom unmarshaller, it reports type
+errors as decode failures rather than as the located §8.2 errors every other
+field gets, and it buys one line of brevity in the case nobody writes.
+
+Splitting the setting means the two halves can disagree, so validation makes
+that an error in both directions: `on_conflict: agent` with no `agent:`, and
+an `agent:` the policy will never run.
+
 ## Tasks
 
 ### Phase 1 — `type: parallel`
@@ -608,7 +630,7 @@ for workflow content.
   `parent_step_index`, `lane_id`, `lane_order`, `idx_tasks_parent`. Typed CRUD
   for the parent link, the recursive-CTE subtree query, and the list filters
   from decision 13.
-- [ ] **014.5 — Lane schema.** Depends: 014.1. `type: fan_out` with `lanes:`,
+- [x] **014.5 — Lane schema.** ✓ 2026-08-17 Depends: 014.1. `type: fan_out` with `lanes:`,
   `merge:`, `on_conflict:`; the `Lane` type (`ID`, `Workflow`, `Steps`,
   `Fields`) with `workflow` and `steps` mutually exclusive and exactly one
   required; recursive validation; `Marshal` round-trip.

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (4/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (5/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -604,7 +604,7 @@ for workflow content.
 
 ### Phase 2 — `type: fan_out`
 
-- [ ] **014.4 — Migration and store.** `0007_fan_out.sql`: `parent_task_id`,
+- [x] **014.4 — Migration and store.** ✓ 2026-08-17 `0007_fan_out.sql`: `parent_task_id`,
   `parent_step_index`, `lane_id`, `lane_order`, `idx_tasks_parent`. Typed CRUD
   for the parent link, the recursive-CTE subtree query, and the list filters
   from decision 13.

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (7/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (11/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -642,24 +642,24 @@ an `agent:` the policy will never run.
 - [x] **014.7 — FSM.** ✓ 2026-08-17 `awaiting_children` in `taskstate`, its three table rows,
   `HoldsSlot` false, the new `Settled()` predicate with `Terminal()` left alone
   (decision 20), and the §6 human-action table (cancel only).
-- [ ] **014.8 — Spawn and resume.** Depends: 014.4, 014.6, 014.7. The `fan_out`
+- [x] **014.8 — Spawn and resume.** ✓ 2026-08-17 Depends: 014.4, 014.6, 014.7. The `fan_out`
   step creates its children (base branch = parent's branch, title
   `{parent} — {lane}` and the ordinary branch template per decision 23, fields
   merged with the parent's per decision 29, overrides and priority per
   decision 10), parks the parent, and the scheduler — not the last child's actor
   (decision 25) — re-queues it via `ChildrenSettled` once every descendant is
   `Settled()`.
-- [ ] **014.9 — The join.** Depends: 014.8. Sequential `--no-ff` merges in
+- [x] **014.9 — The join.** ✓ 2026-08-17 Depends: 014.8. Sequential `--no-ff` merges in
   `lane_order`; `ReasonMergeConflict = "merge_conflict"` and
   `ReasonLaneFailed = "lane_failed"` in the §18 vocabulary; `on_conflict: {agent: …}`
   as a full agent `Step` (decision 24); the decision-9 re-entry rules for both
   `interrupted` and `blocked`, plus decision 22's re-check on a `lane_failed`
   retry, wired into `taskrun/recover.go`.
-- [ ] **014.10 — Lifecycle.** Depends: 014.8. Cascading cancel; archive refusing
+- [x] **014.10 — Lifecycle.** ✓ 2026-08-17 Depends: 014.8. Cascading cancel; archive refusing
   a non-terminal descendant then cascading with per-child dirty confirmation;
   `gc` and `doctor` seeing lane worktrees as the ordinary task worktrees they
   are.
-- [ ] **014.11 — API and events.** Depends: 014.4, 014.8. List filters
+- [x] **014.11 — API and events.** ✓ 2026-08-17 Depends: 014.4, 014.8. List filters
   (`?parent_id=`, `?include_children=`), the `children` rollup on
   `GET /v1/tasks/{id}` whenever the task has children rather than only in
   `awaiting_children` (decision 27), and `task.children_changed` emitted

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (6/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (7/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -634,7 +634,7 @@ an `agent:` the policy will never run.
   `merge:`, `on_conflict:`; the `Lane` type (`ID`, `Workflow`, `Steps`,
   `Fields`) with `workflow` and `steps` mutually exclusive and exactly one
   required; recursive validation; `Marshal` round-trip.
-- [ ] **014.6 — Creation-time tree resolution.** Depends: 014.5. Resolve every
+- [x] **014.6 — Creation-time tree resolution.** ✓ 2026-08-17 Depends: 014.5. Resolve every
   named lane workflow through registry shadowing into the parent's snapshot;
   synthetic `workflow_name` for inline lanes; cycle detection with the path in
   the `400`; `fan_out.max_depth` and `fan_out.max_tasks` computed and enforced

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (1/14) · **Opened:** 2026-08-17
+**Status:** 🚧 in progress (2/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -378,9 +378,15 @@ existing store, FSM and validation code was read.
 `step_index` and keyed by `step_id`" collides with three mechanisms that key on
 `(task_id, step_index)` alone: `store.CountStepAttempts` (attempt numbering),
 `store.LastFailedStepRun` (which seeds `.LastFailure` for the §8.4 failure
-block), and transcript filenames `{step_index}-{attempt}.jsonl`. All three widen
-to take an optional step id; transcripts become
-`{step_index}-{step_id}-{attempt}.jsonl`.
+block), and transcript filenames `{step_index}-{attempt}.jsonl`. The two
+queries take a step id; transcripts take one **only for a sub-step**, which
+becomes `{step_index}-{step_id}-{attempt}.jsonl`.
+
+*Amended during implementation, 2026-08-17:* the transcript rename was written
+here as unconditional. Applying it only where it is needed leaves §12.2 true
+for every workflow that does not use a group, and confines a path change to
+the case that actually collides. Step ids are slugs, so nothing in a name can
+escape the transcript directory.
 
 **Beat (a):** giving each sub-step its own `step_index`. `tasks.current_step` is
 one `INTEGER` and the group must stay addressable as one step — this is
@@ -580,7 +586,7 @@ for workflow content.
   group-level `timeout`; `rejectFields` for everything that is not
   `steps`/`max_parallel`/`timeout`; the `parallel.max_parallel` daemon default in
   `internal/config` (decision 30).
-- [ ] **014.2 — Engine.** Depends: 014.1. Concurrent execution inside the task's
+- [x] **014.2 — Engine.** ✓ 2026-08-17 Depends: 014.1. Concurrent execution inside the task's
   actor goroutine, bounded by `max_parallel`; one `step_runs` row per sub-step
   sharing the group's `step_index` and keyed by `step_id`, with no row for the
   group itself (decision 17); `CountStepAttempts`, `LastFailedStepRun` and

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -1,6 +1,6 @@
 # 014 — Parallel steps and workflow fan-out
 
-**Status:** 🚧 in progress (13/14) · **Opened:** 2026-08-17
+**Status:** ✅ done (14/14) · **Opened:** 2026-08-17
 
 Two features that let one task do several things at once, shipped in that order.
 
@@ -669,7 +669,7 @@ an `agent:` the policy will never run.
   `awaiting_children (2 blocked)`; drilling from a parent into its lanes and
   back; the new state in the board's colour and action-bar tables
   (`internal/tui/bindings.go` key table updated with it).
-- [ ] **014.13 — Docs.** Depends: all. Spec §5.3, §6, §10, §11, §12.4, §13.2,
+- [x] **014.13 — Docs.** ✓ 2026-08-17 Depends: all. Spec §5.3, §6, §10, §11, §12.4, §13.2,
   §13.3, §14 and §18 amended in place with dated notes — §12.4 and §14 because
   recovery aborting a merge and the new `tasks` columns are exactly what those
   sections describe; §20 amended to promote parallel steps and fan-out out of
@@ -696,4 +696,30 @@ an `agent:` the policy will never run.
 
 ## Verification
 
-Not started.
+*2026-08-17.* All 14 subtasks delivered.
+
+- `go run mage.go build test testrace lint`, plus `golangci-lint` cross-built
+  for `windows`, `darwin` and `linux` — a host-only lint hides findings in
+  build-tagged files.
+- Gates: `m1`, `m2` and `m5` re-run to prove no regression; the new `m6` passes
+  all nine scenarios, and is wired into CI on all three platforms.
+
+Three bugs the work surfaced, each recorded where it was found:
+
+1. **A resolved lane could not carry both `workflow:` and `steps:`.** They are
+   mutually exclusive in an authored file, so the resolved snapshot no longer
+   parsed. The name moved to `resolved_from:` (014.6).
+2. **A child's snapshot could not be named `{parent}/{step}/{lane}`.** The
+   engine re-parses the snapshot on every admission and validation rejects `/`
+   in a workflow name, so every child blocked with `invalid_snapshot` on its
+   first admission. The synthetic name belongs to the `workflow_name` *column*
+   — where its `/` is exactly what makes it collision-proof — and the snapshot
+   is named after where its steps came from (014.8).
+3. **Decision 9's re-entry rule read the wrong thing.** Whether a join was
+   resuming from a hand resolution or from a crash was read from the task's
+   state, which cannot answer it: the scheduler moves a retried task out of
+   `blocked` before the engine sees it. It is read from the previous attempt's
+   outcome instead — and must be read *before* the new attempt's row exists,
+   or that row is the latest one and hides the evidence. The symptom was the
+   worst case the decision exists to prevent: `git merge --abort` over a
+   resolution somebody had just finished. Caught by the `m6` gate (014.14).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (2/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (3/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (7/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (11/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (5/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (6/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (6/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (7/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (0/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (1/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -27,7 +27,7 @@ description of how the system actually behaves.
 | [010](010-workflow-platform-restrictions.md) | Restricting a workflow to platforms (`platforms:`) | ✅ done (6/6) |
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
-| [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | 📋 planned (0/8) |
+| [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
 | [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (0/14) |
 
 ## How to add and update a task document

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | 📋 planned (0/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 📋 planned (0/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (0/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (3/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (4/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (12/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (13/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (11/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (12/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (1/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (2/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (4/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (5/14) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -28,7 +28,7 @@ description of how the system actually behaves.
 | [011](011-bulk-task-selection.md) | Selecting several tasks for one action | ✅ done (5/5) |
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
-| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | 🚧 in progress (13/14) |
+| [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | ✅ done (14/14) |
 
 ## How to add and update a task document
 

--- a/internal/api/fanout_test.go
+++ b/internal/api/fanout_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// fanOutProject spins up a harness with a project and returns its id.
+func fanOutProject(t *testing.T, h *workflowHarness) int64 {
+	t.Helper()
+	p := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+	return int64(p["id"].(float64))
+}
+
+// TestTaskCreateResolvesLaneWorkflows is decision 4 at the seam that matters:
+// the registry is read once, at creation, and what it said is frozen into the
+// task's snapshot. Editing the lane's file afterwards must not reach the task.
+func TestTaskCreateResolvesLaneWorkflows(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "module",
+		"name: module\nsteps:\n  - {id: impl, type: command, run: make original}\n")
+	writeWorkflowFile(t, h.globalDir, "root",
+		"name: root\nsteps:\n  - {id: build, type: fan_out, lanes: [{id: api, workflow: module}]}\n")
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": projectID, "title": "fan out", "workflow": "root",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d %s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Rewrite the lane's workflow. The snapshot already taken must not move.
+	writeWorkflowFile(t, h.globalDir, "module",
+		"name: module\nsteps:\n  - {id: impl, type: command, run: make edited}\n")
+	h.reg.ReloadGlobal()
+
+	task, err := h.store.GetTask(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	lane := wf.Steps[0].Lanes[0]
+	if len(lane.Steps) != 1 {
+		t.Fatalf("lane steps = %+v, want the registry's inlined at creation", lane.Steps)
+	}
+	if got := lane.Steps[0].Run; !strings.Contains(got, "original") {
+		t.Errorf("lane run = %q; a later edit to the lane's file reached an existing task", got)
+	}
+	if lane.ResolvedFrom != "module" {
+		t.Errorf("lane resolved_from = %q, want the child's workflow_name recorded", lane.ResolvedFrom)
+	}
+}
+
+// TestTaskCreateRejectsCyclicLanes: an infinite spawn is a 400 in front of
+// the person typing, and the message names the path rather than sending them
+// to grep every workflow file they own.
+func TestTaskCreateRejectsCyclicLanes(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "alpha",
+		"name: alpha\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: beta}]}\n")
+	writeWorkflowFile(t, h.globalDir, "beta",
+		"name: beta\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: alpha}]}\n")
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": projectID, "title": "loop", "workflow": "alpha",
+	})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	for _, want := range []string{"cycle", "alpha", "beta"} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("message %s missing %q", body, want)
+		}
+	}
+}
+
+// TestTaskCreateRejectsTreePastMaxTasks: the bound is enforced where the tree
+// is still a document, not after N worktrees exist. It runs against the real
+// configured default (64), so the test also proves creation reads the config
+// rather than a constant.
+func TestTaskCreateRejectsTreePastMaxTasks(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	src := "name: wide\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n"
+	for i := range config.Default().FanOut.MaxTasks + 1 {
+		src += fmt.Sprintf("      - {id: l%d, steps: [{id: s%d, type: command, run: make}]}\n", i, i)
+	}
+	writeWorkflowFile(t, h.globalDir, "wide", src)
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": projectID, "title": "too wide", "workflow": "wide",
+	})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(body), "max_tasks") {
+		t.Errorf("message %s does not name the bound it crossed", body)
+	}
+}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -294,8 +294,10 @@ func (s *Server) handleProjectDelete(w http.ResponseWriter, r *http.Request) {
 	// ArchivedAll is explicit: this handler classifies archived vs not
 	// itself, and must not silently inherit the list default (which excludes
 	// archives for the board's benefit, §13.2).
+	// ChildrenInclude for the same reason: deleting a project must account
+	// for every task in it, lanes included (task 014).
 	tasks, err := s.deps.Store.ListTasks(ctx,
-		store.TaskFilter{ProjectID: p.ID, Archived: store.ArchivedAll})
+		store.TaskFilter{ProjectID: p.ID, Archived: store.ArchivedAll, Children: store.ChildrenInclude})
 	if err != nil {
 		s.internalError(w, "list tasks", err)
 		return

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -76,6 +76,15 @@ type taskResponse struct {
 	// Warnings are non-fatal §8.2 catalog findings from creation-time
 	// validation; only the POST /v1/tasks response carries them.
 	Warnings []string `json:"warnings,omitempty"`
+	// ParentTaskID, LaneID and LaneOrder identify a fan-out lane (§7.6, task
+	// 014). All null for a root task, which is every task that is not a lane.
+	ParentTaskID *int64  `json:"parent_task_id"`
+	LaneID       *string `json:"lane_id"`
+	LaneOrder    *int    `json:"lane_order"`
+	// Children is the §13.2 subtree rollup, present on the detail endpoint
+	// whenever the task has lanes. Derived per request from one recursive
+	// CTE, never stored: a counter would be a second truth that drifts.
+	Children *childrenResponse `json:"children,omitempty"`
 	// PendingInput is the normalized §7.4 input request while the task is
 	// awaiting_input — embedded verbatim as the engine persisted it.
 	PendingInput json.RawMessage `json:"pending_input,omitempty"`
@@ -130,7 +139,16 @@ func workflowSteps(summary snapshotSummary) []snapshotStepResponse {
 }
 
 func toTaskResponse(t *store.Task, summary snapshotSummary) taskResponse {
+	var laneID *string
+	var laneOrder *int
+	if t.ParentTaskID != nil {
+		id, order := t.LaneID, t.LaneOrder
+		laneID, laneOrder = &id, &order
+	}
 	return taskResponse{
+		ParentTaskID:     t.ParentTaskID,
+		LaneID:           laneID,
+		LaneOrder:        laneOrder,
 		ID:               t.ID,
 		ProjectID:        t.ProjectID,
 		Title:            t.Title,
@@ -565,6 +583,40 @@ func (s *Server) checkRetryInput(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
+// childrenResponse is the fan-out subtree rollup (§13.2, task 014
+// decision 13). Ids rather than objects for the blocked and gated lanes,
+// which is how §13.3 hands out everything else: the client re-fetches what it
+// decides it needs.
+type childrenResponse struct {
+	Total   int            `json:"total"`
+	Settled int            `json:"settled"`
+	ByState map[string]int `json:"by_state"`
+	// Blocked and AwaitingGate are the lanes holding the join open on a
+	// human — the cost paid for hiding lanes from the task list.
+	Blocked      []int64 `json:"blocked"`
+	AwaitingGate []int64 `json:"awaiting_gate"`
+}
+
+func toChildrenResponse(r store.ChildrenRollup) *childrenResponse {
+	out := &childrenResponse{
+		Total:        r.Total,
+		Settled:      r.Settled,
+		ByState:      make(map[string]int, len(r.ByState)),
+		Blocked:      r.Blocked,
+		AwaitingGate: r.AwaitingGate,
+	}
+	for state, n := range r.ByState {
+		out.ByState[string(state)] = n
+	}
+	if out.Blocked == nil {
+		out.Blocked = []int64{}
+	}
+	if out.AwaitingGate == nil {
+		out.AwaitingGate = []int64{}
+	}
+	return out
+}
+
 func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	filter := store.TaskFilter{State: store.TaskState(q.Get("state"))}
@@ -586,6 +638,27 @@ func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		filter.ProjectID = id
+	}
+	// Fan-out lanes are excluded by default (§13.2, task 014 decision 13): a
+	// list is the work someone asked for, and a 64-task tree would bury it.
+	// `parent_id` drills into one parent's lanes; `include_children` is the
+	// flat everything.
+	if v := q.Get("parent_id"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, "parent_id must be an integer")
+			return
+		}
+		filter.ParentID = id
+	}
+	switch v := q.Get("include_children"); v {
+	case "", "false":
+	case "true":
+		filter.Children = store.ChildrenInclude
+	default:
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"include_children must be true or false")
+		return
 	}
 	switch v := q.Get("archived"); v {
 	case "", "false":
@@ -675,6 +748,16 @@ func (s *Server) handleTaskGet(w http.ResponseWriter, r *http.Request) {
 	// than making each client join it back (T4.4 walkthrough finding).
 	if p, err := s.deps.Store.GetProject(r.Context(), t.ProjectID); err == nil {
 		resp.ProjectName = p.Name
+	}
+	// The children rollup (§13.2, task 014 decisions 13, 27). Present
+	// whenever the task has lanes, in any state — a parent mid-join, or one
+	// already done, still wants its lane ids reachable from one GET, and
+	// gating the field on a state would force a client to know the state to
+	// know whether to look.
+	if rollup, err := s.deps.Store.ChildrenOf(r.Context(), t.ID); err != nil {
+		s.deps.Logger.Error("children rollup", "task", t.ID, "error", err)
+	} else if rollup.Total > 0 {
+		resp.Children = toChildrenResponse(rollup)
 	}
 	resp.Steps = make([]stepRunResponse, 0, len(runs))
 	for i := range runs {

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -357,11 +357,34 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Fan-out tree resolution (§7.6, task 014 decisions 4, 5). Every lane
+	// naming a registry workflow is resolved into the snapshot **now**, so
+	// the tree's shape is fixed at creation and later edits to those files
+	// cannot mutate this task. The bounds are checked here for the same
+	// reason: a depth-3 explosion should be a 400 in front of the person
+	// typing, not two hundred worktrees discovered six hours later.
+	snapshot := entry.Source
+	if workflow.HasFanOut(entry.Workflow) {
+		cfg := s.deps.Config()
+		resolved, _, terr := workflow.ResolveTree(entry.Workflow, s.laneLookup(project.ID),
+			workflow.Limits{MaxDepth: cfg.FanOut.MaxDepth, MaxTasks: cfg.FanOut.MaxTasks})
+		if terr != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, terr.Error())
+			return
+		}
+		out, merr := workflow.Marshal(resolved)
+		if merr != nil {
+			s.internalError(w, "re-encode resolved fan-out snapshot", merr)
+			return
+		}
+		snapshot = string(out)
+	}
+
 	t := store.Task{
 		ProjectID:        project.ID,
 		Title:            title,
 		WorkflowName:     entry.Name,
-		WorkflowSnapshot: entry.Source,
+		WorkflowSnapshot: snapshot,
 		BaseBranch:       baseBranch,
 		Fields:           req.Fields,
 		AgentOverride:    agentOverride,
@@ -482,6 +505,21 @@ func (s *Server) checkTaskCatalog(wf *workflow.Workflow, t *store.Task) (warning
 // degrade-never-block rule outranks this gate: one cold-logon probe timeout
 // must not start refusing task creation against a healthy CLI (T4.22). The
 // engine's pre-flight is the backstop for what a probe could not say here.
+// laneLookup resolves a lane's workflow name through the registry, applying
+// the same builtin < global < project shadowing every other lookup does
+// (§5.2). An invalid workflow is reported as not found: a lane cannot be cut
+// from a file that does not parse, and the registry's own errors are already
+// visible on GET /v1/workflows.
+func (s *Server) laneLookup(projectID int64) workflow.LookupFunc {
+	return func(name string) (*workflow.Workflow, bool) {
+		entry, ok := s.deps.Workflows.Lookup(projectID, name)
+		if !ok || !entry.Valid() {
+			return nil, false
+		}
+		return entry.Workflow, true
+	}
+}
+
 func (s *Server) inputMismatch(ctx context.Context, wf *workflow.Workflow, t *store.Task) string {
 	if s.deps.Catalog == nil || wf == nil {
 		return ""

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -3,6 +3,7 @@ package apiclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strconv"
 	"time"
@@ -33,6 +34,16 @@ type Task struct {
 	CostUSD      *float64 `json:"cost_usd"`
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
+
+	// ParentTaskID, LaneID and LaneOrder identify a fan-out lane (§7.6, task
+	// 014); all nil for a root task.
+	ParentTaskID *int64  `json:"parent_task_id"`
+	LaneID       *string `json:"lane_id"`
+	LaneOrder    *int    `json:"lane_order"`
+	// Children is the subtree rollup, served on the detail endpoint whenever
+	// the task has lanes. Lanes are hidden from the task list by design, and
+	// this is what pays for that: it is where a blocked lane becomes visible.
+	Children *ChildrenRollup `json:"children,omitempty"`
 
 	BlockReason      *string  `json:"block_reason"`
 	PauseRequested   bool     `json:"pause_requested"`
@@ -117,6 +128,12 @@ type ListTasksOptions struct {
 	Archived  ArchivedScope
 	Limit     int
 	Offset    int
+	// ParentID lists one fan-out parent's lanes, in merge order (§7.6, task
+	// 014). Lanes are excluded from every other listing by default, so this
+	// is how a client drills into a subtree.
+	ParentID int64
+	// IncludeChildren asks for the flat everything, lanes included.
+	IncludeChildren bool
 }
 
 func (o ListTasksOptions) query() string {
@@ -129,6 +146,12 @@ func (o ListTasksOptions) query() string {
 	}
 	if o.Archived != ArchivedExclude {
 		q.Set("archived", string(o.Archived))
+	}
+	if o.ParentID != 0 {
+		q.Set("parent_id", strconv.FormatInt(o.ParentID, 10))
+	}
+	if o.IncludeChildren {
+		q.Set("include_children", "true")
 	}
 	if o.Limit > 0 {
 		q.Set("limit", strconv.Itoa(o.Limit))
@@ -199,6 +222,34 @@ func (s StepRun) Duration(now time.Time) (time.Duration, bool) {
 // Live reports whether this attempt is still producing output, which is what
 // makes follow mode meaningful (a finished attempt will never gain a line).
 func (s StepRun) Live() bool { return s.FinishedAt == nil && s.State == "running" }
+
+// ChildrenRollup summarizes a fan-out subtree (§13.2, task 014). Blocked and
+// AwaitingGate are ids: the client re-fetches whichever it decides to show,
+// the way §13.3 hands out everything else.
+type ChildrenRollup struct {
+	Total        int            `json:"total"`
+	Settled      int            `json:"settled"`
+	ByState      map[string]int `json:"by_state"`
+	Blocked      []int64        `json:"blocked"`
+	AwaitingGate []int64        `json:"awaiting_gate"`
+}
+
+// Summary is the short form a board row shows beside `awaiting_children` —
+// "2 blocked", "3/5 done". It names what a human has to act on first, since
+// that is the whole reason the rollup exists.
+func (r *ChildrenRollup) Summary() string {
+	if r == nil || r.Total == 0 {
+		return ""
+	}
+	switch {
+	case len(r.Blocked) > 0:
+		return fmt.Sprintf("%d blocked", len(r.Blocked))
+	case len(r.AwaitingGate) > 0:
+		return fmt.Sprintf("%d at a gate", len(r.AwaitingGate))
+	default:
+		return fmt.Sprintf("%d/%d done", r.Settled, r.Total)
+	}
+}
 
 // TaskDetail is GET /v1/tasks/{id}: the task plus every attempt of every
 // step it has run.

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -105,10 +105,12 @@ func newTaskAddCmd() *cobra.Command {
 
 func newTaskLsCmd() *cobra.Command {
 	var (
-		projectID int64
-		state     string
-		archived  bool
-		limit     int
+		projectID       int64
+		state           string
+		archived        bool
+		includeChildren bool
+		parentID        int64
+		limit           int
 	)
 	cmd := &cobra.Command{
 		Use:   "ls",
@@ -116,7 +118,12 @@ func newTaskLsCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
-				opts := apiclient.ListTasksOptions{ProjectID: projectID, State: state, Limit: limit}
+				opts := apiclient.ListTasksOptions{
+					ProjectID: projectID, State: state, Limit: limit,
+					// Fan-out lanes are hidden by default (§13.2): the list is
+					// the work someone asked for, and a 64-task tree buries it.
+					IncludeChildren: includeChildren, ParentID: parentID,
+				}
 				if archived {
 					opts.Archived = apiclient.ArchivedAll
 				}
@@ -146,6 +153,10 @@ func newTaskLsCmd() *cobra.Command {
 	cmd.Flags().Int64Var(&projectID, "project", 0, "Only tasks in this project")
 	cmd.Flags().StringVar(&state, "state", "", "Only tasks in this state")
 	cmd.Flags().BoolVar(&archived, "archived", false, "Include archived tasks")
+	cmd.Flags().BoolVar(&includeChildren, "include-children", false,
+		"Include fan-out lanes, which are hidden by default")
+	cmd.Flags().Int64Var(&parentID, "parent", 0,
+		"List one fan-out task's lanes, in merge order")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum rows")
 	jsonFlag(cmd)
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,12 @@ type Config struct {
 	// what every version before it did implicitly.
 	Environment Environment `yaml:"environment"`
 	Agents      Agents      `yaml:"agents"`
+	// Parallel bounds a `type: parallel` step group (task 014). It sits in its
+	// own block rather than under `defaults:`, which holds timeouts a step may
+	// override per-step; this one is not step-overridable in the same sense —
+	// a group's `max_parallel:` replaces it outright rather than inheriting
+	// from it (task 014 decision 30).
+	Parallel Parallel `yaml:"parallel"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -266,6 +272,17 @@ type Defaults struct {
 	InputTimeout Duration `yaml:"input_timeout"`
 }
 
+// Parallel configures `type: parallel` step groups (spec §7, §11 — task 014).
+//
+// MaxParallel is a genuine second concurrency dimension: a group runs its
+// sub-steps inside **one** task's slot, and the §11 caps count tasks in
+// slot-holding states, so they never see it. One task can therefore keep
+// MaxParallel processes busy while the board reads a single running task —
+// which is why this has a default at all rather than being unbounded.
+type Parallel struct {
+	MaxParallel int `yaml:"max_parallel"`
+}
+
 // Agents configures how agent CLIs are located.
 type Agents struct {
 	Claude Agent `yaml:"claude"`
@@ -302,6 +319,10 @@ func Default() Config {
 		// Inherit everything: exactly what the daemon did before the policy
 		// existed, so nothing changes for anyone who does not ask.
 		Environment: Environment{Inherit: InheritAll()},
+		// Four independent verifications is the shape this feature was
+		// designed around (test, lint, typecheck, build); past that a group
+		// is competing with the task caps for the same cores.
+		Parallel: Parallel{MaxParallel: 4},
 		TUI: TUI{Board: BoardView{
 			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
 		}},
@@ -351,6 +372,9 @@ func (c Config) validate() error {
 	}
 	if c.Defaults.InputTimeout <= 0 {
 		return fmt.Errorf("defaults.input_timeout must be positive, got %s", c.Defaults.InputTimeout)
+	}
+	if c.Parallel.MaxParallel < 1 {
+		return fmt.Errorf("parallel.max_parallel must be at least 1, got %d", c.Parallel.MaxParallel)
 	}
 	if c.TranscriptRetentionDays < 0 {
 		return fmt.Errorf("transcript_retention_days must not be negative, got %d", c.TranscriptRetentionDays)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,10 @@ type Config struct {
 	// a group's `max_parallel:` replaces it outright rather than inheriting
 	// from it (task 014 decision 30).
 	Parallel Parallel `yaml:"parallel"`
+	// FanOut bounds a `type: fan_out` tree (task 014). Both values are read
+	// in the task-creation path, so a reload governs the next task rather
+	// than anything already running (decision 30).
+	FanOut FanOut `yaml:"fan_out"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -283,6 +287,23 @@ type Parallel struct {
 	MaxParallel int `yaml:"max_parallel"`
 }
 
+// FanOut configures `type: fan_out` step trees (spec §7.6 — task 014).
+//
+// Both bounds are enforced at task creation, which is possible because the
+// whole tree's shape is static there: lane lists live in the snapshot. That
+// is what turns a depth-3 explosion into a 400 in front of the person typing
+// rather than two hundred worktrees discovered six hours later.
+//
+// Depth is unlimited by design and bounded by a default: deeper trees are a
+// config edit, not a code change.
+type FanOut struct {
+	// MaxDepth is how many fan-out levels one tree may have.
+	MaxDepth int `yaml:"max_depth"`
+	// MaxTasks bounds the child tasks one creation may produce, excluding
+	// the root itself.
+	MaxTasks int `yaml:"max_tasks"`
+}
+
 // Agents configures how agent CLIs are located.
 type Agents struct {
 	Claude Agent `yaml:"claude"`
@@ -323,6 +344,11 @@ func Default() Config {
 		// designed around (test, lint, typecheck, build); past that a group
 		// is competing with the task caps for the same cores.
 		Parallel: Parallel{MaxParallel: 4},
+		// Three levels is deep enough to compose real workflows and shallow
+		// enough that a mistake is visible; 64 descendants is more than the
+		// caps will run concurrently anyway, so it bounds the explosion
+		// rather than the throughput.
+		FanOut: FanOut{MaxDepth: 3, MaxTasks: 64},
 		TUI: TUI{Board: BoardView{
 			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
 		}},
@@ -375,6 +401,12 @@ func (c Config) validate() error {
 	}
 	if c.Parallel.MaxParallel < 1 {
 		return fmt.Errorf("parallel.max_parallel must be at least 1, got %d", c.Parallel.MaxParallel)
+	}
+	if c.FanOut.MaxDepth < 1 {
+		return fmt.Errorf("fan_out.max_depth must be at least 1, got %d", c.FanOut.MaxDepth)
+	}
+	if c.FanOut.MaxTasks < 1 {
+		return fmt.Errorf("fan_out.max_tasks must be at least 1, got %d", c.FanOut.MaxTasks)
 	}
 	if c.TranscriptRetentionDays < 0 {
 		return fmt.Errorf("transcript_retention_days must not be negative, got %d", c.TranscriptRetentionDays)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,7 @@ agents:
 		// keeps its default rather than collapsing to a zero value — a
 		// max_parallel of 0 would refuse to run any sub-step at all.
 		Parallel: Parallel{MaxParallel: 4},
+		FanOut:   FanOut{MaxDepth: 3, MaxTasks: 64},
 		TUI:      TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,9 +95,11 @@ agents:
 			Claude: Agent{Path: "/opt/bin/claude"},
 			Codex:  Agent{Path: `C:\tools\codex.exe`},
 		},
-		// And the same again for `tui:`: an unnamed section keeps the §15
-		// default grouping rather than flattening the board.
-		TUI: TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
+		// And the same again for `parallel:` and `tui:`: an unnamed section
+		// keeps its default rather than collapsing to a zero value — a
+		// max_parallel of 0 would refuse to run any sub-step at all.
+		Parallel: Parallel{MaxParallel: 4},
+		TUI:      TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("got %+v, want %+v", cfg, want)
@@ -113,6 +115,25 @@ func TestBranchCleanupDefaults(t *testing.T) {
 	}
 	if d.DeleteRemoteBranchOnArchive {
 		t.Error("delete_remote_branch_on_archive defaults to true, want false")
+	}
+}
+
+// TestParallelMaxParallel pins the task 014 default and the floor under it: a
+// group bounded at zero would deadlock rather than run serially, so the value
+// is rejected at load time instead of being quietly clamped.
+func TestParallelMaxParallel(t *testing.T) {
+	if got := Default().Parallel.MaxParallel; got != 4 {
+		t.Errorf("parallel.max_parallel default = %d, want 4", got)
+	}
+	cfg, err := Load(writeConfig(t, "parallel:\n  max_parallel: 8\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Parallel.MaxParallel != 8 {
+		t.Errorf("parallel.max_parallel = %d, want the configured 8", cfg.Parallel.MaxParallel)
+	}
+	if _, err := Load(writeConfig(t, "parallel:\n  max_parallel: 0\n")); err == nil {
+		t.Error("max_parallel: 0 loaded without error, want a validation failure")
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -220,7 +221,23 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	// The broker is the post-commit fan-out (§13.3): SSE subscribers and the
 	// scheduler's wake all hang off the store's single event hook through it.
 	broker := events.New()
-	st.SetEventHook(broker.Publish)
+	// Fan-out ancestors are notified through the same hook (§13.3, task 014
+	// decision 14). The relay runs post-commit like every other subscriber,
+	// and the events it appends come back through this hook themselves — no
+	// recursion, because children_changed is not one of the types it reacts
+	// to.
+	st.SetEventHook(func(e *store.Event) {
+		broker.Publish(e)
+		if e == nil || e.TaskID == nil {
+			return
+		}
+		if e.Type != store.EventTaskStateChanged && e.Type != store.EventTaskCreated {
+			return
+		}
+		if err := st.EmitChildrenChanged(ctx, *e.TaskID, store.TaskState(stateOfEvent(e))); err != nil {
+			logger.Error("notify fan-out ancestors", "task", *e.TaskID, "error", err)
+		}
+	})
 
 	// Crash recovery runs before anything can admit or execute (§12.4): it
 	// belongs to neither the scheduler nor the runner. Orphans are killed
@@ -492,4 +509,21 @@ func primeAgentCatalog(ctx context.Context, logger *slog.Logger, catalog *agent.
 			logger.Warn("agent not available", "agent", name, "error", av.Error)
 		}
 	}
+}
+
+// stateOfEvent reads the `to` field a task.state_changed event carries, so
+// the children_changed relay can pass it on. A task.created event has none —
+// the task is queued by definition — and an unreadable payload yields "",
+// which a client treats as "re-fetch the rollup", which it does anyway.
+func stateOfEvent(e *store.Event) string {
+	var payload struct {
+		To string `json:"to"`
+	}
+	if err := json.Unmarshal(e.Payload, &payload); err != nil {
+		return ""
+	}
+	if payload.To == "" && e.Type == store.EventTaskCreated {
+		return string(store.TaskQueued)
+	}
+	return payload.To
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -120,6 +120,9 @@ func (s *Scheduler) admit(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
+	// Fan-out parents whose subtrees have finished come back to the queue
+	// first, so this same walk can admit them (§7.6, task 014 decision 25).
+	s.resumeSettledParents(ctx)
 	limit := s.deps.Config().MaxParallelTasks
 	global, err := s.deps.Store.CountSlotHolders(ctx)
 	if err != nil {
@@ -234,6 +237,46 @@ func (s *Scheduler) persistCtx() context.Context {
 		return context.Background()
 	}
 	return s.persist
+}
+
+// resumeSettledParents returns every parent parked in `awaiting_children` to
+// the queue once each of its descendants has settled (task 014).
+//
+// This is the scheduler's job rather than the last child's actor for the
+// reason admission itself is: two children settling concurrently would both
+// believe they were last, or neither would, and an actor writing another
+// task's state breaks the sole-writer invariant outright. Here it is one
+// goroutine making one decision, which is the property the whole package
+// exists to provide.
+func (s *Scheduler) resumeSettledParents(ctx context.Context) {
+	parents, err := s.deps.Store.ListTasks(ctx, store.TaskFilter{
+		State: store.TaskAwaitingChildren, Children: store.ChildrenInclude,
+	})
+	if err != nil {
+		s.deps.Logger.Error("admission: list parked parents", "error", err)
+		return
+	}
+	for _, parent := range parents {
+		rollup, err := s.deps.Store.ChildrenOf(ctx, parent.ID)
+		if err != nil {
+			s.deps.Logger.Error("admission: roll up children", "task", parent.ID, "error", err)
+			continue
+		}
+		if !rollup.Done() {
+			continue
+		}
+		if _, _, err := s.deps.Store.TransitionTask(ctx, parent.ID,
+			store.TaskAwaitingChildren, store.TaskQueued, store.TaskChange{}); err != nil {
+			if _, conflict := store.AsStateConflict(err); conflict {
+				// A human cancelled it between the list and the write.
+				continue
+			}
+			s.deps.Logger.Error("admission: resume parent", "task", parent.ID, "error", err)
+			continue
+		}
+		s.deps.Logger.Info("fan-out children settled; parent re-queued",
+			"task", parent.ID, "children", rollup.Total)
+	}
 }
 
 // WakeOn reports whether an event should trigger re-evaluation. Only two

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 6
+const latestSchemaVersion = 7
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0007_fan_out.sql
+++ b/internal/store/migrations/0007_fan_out.sql
@@ -1,0 +1,32 @@
+-- 0007_fan_out: the parent↔child link a `type: fan_out` step creates
+-- (task 014, spec §7.6/§14).
+--
+-- A lane is a real task, not a row shape of its own: it has its own worktree,
+-- branch, scheduler slot, gates, blocks, transcripts and recovery, and these
+-- four columns are the entire difference between it and a hand-created task
+-- (decision 1). Everything else about fan-out is behaviour over rows that
+-- already existed.
+--
+-- All four are NULL for a root task, and set together for a lane. They are not
+-- one JSON column because parent_task_id is walked by a recursive CTE (the
+-- §13.2 children rollup) and lane_order is an ORDER BY — both of which want
+-- real columns.
+--
+-- lane_order is the *declared* order of the lane in its step, kept because the
+-- join merges in that order rather than in completion order: a re-run must
+-- conflict identically for recovery to be idempotent (decisions 7, 9). It
+-- cannot be derived from created_at, which is spawn order and coincides only
+-- by luck.
+--
+-- No foreign key from lane_id or parent_step_index back to the snapshot: the
+-- snapshot is text, and the child is deliberately indistinguishable from a
+-- hand-created task once it exists (decision 4).
+
+ALTER TABLE tasks ADD COLUMN parent_task_id INTEGER REFERENCES tasks(id);
+ALTER TABLE tasks ADD COLUMN parent_step_index INTEGER;  -- the fan_out step's index in the parent
+ALTER TABLE tasks ADD COLUMN lane_id TEXT;               -- the lane's id in that step
+ALTER TABLE tasks ADD COLUMN lane_order INTEGER;         -- declared position, the merge order
+
+-- The list filters and the subtree CTE both walk children by parent
+-- (decision 13); without this each level of a tree is a table scan.
+CREATE INDEX idx_tasks_parent ON tasks(parent_task_id, lane_order);

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -21,11 +21,14 @@ const (
 	TaskRunning       = taskstate.Running
 	TaskAwaitingGate  = taskstate.AwaitingGate
 	TaskAwaitingInput = taskstate.AwaitingInput
-	TaskBlocked       = taskstate.Blocked
-	TaskPaused        = taskstate.Paused
-	TaskDone          = taskstate.Done
-	TaskAborted       = taskstate.Aborted
-	TaskArchived      = taskstate.Archived
+	// TaskAwaitingChildren is a fan-out parent waiting on its lanes (§7.6,
+	// task 014). It holds no slot.
+	TaskAwaitingChildren = taskstate.AwaitingChildren
+	TaskBlocked          = taskstate.Blocked
+	TaskPaused           = taskstate.Paused
+	TaskDone             = taskstate.Done
+	TaskAborted          = taskstate.Aborted
+	TaskArchived         = taskstate.Archived
 )
 
 // StepRunState enumerates step-run attempt states (spec §5.4).
@@ -105,11 +108,25 @@ type Task struct {
 	// than in each caller, so a hold cannot outlive the queued period it
 	// belongs to.
 	QueuedReason string
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
-	ArchivedAt   *time.Time
+	// ParentTaskID links a lane to the task whose `fan_out` step spawned it
+	// (task 014, §7.6); nil for a root task. ParentStepIndex, LaneID and
+	// LaneOrder are set with it and nil/empty without it: the step it came
+	// from, the lane's id in that step, and the lane's **declared** position,
+	// which is the order the join merges in — completion order would make a
+	// re-run conflict differently and break recovery's idempotence
+	// (decisions 7, 9).
+	//
+	// A lane is otherwise an ordinary task in every respect. These four
+	// columns are the whole difference (decision 1).
+	ParentTaskID    *int64
+	ParentStepIndex *int
+	LaneID          string
+	LaneOrder       int
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	StartedAt       *time.Time
+	FinishedAt      *time.Time
+	ArchivedAt      *time.Time
 }
 
 // StepRun is one attempt at executing one step of one task; history is

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -144,11 +144,15 @@ func (s *Store) GetStepRun(ctx context.Context, id int64) (*StepRun, error) {
 // nil when the step has none. It seeds `.LastFailure` when an admission
 // starts on a step whose earlier attempts failed under a previous actor —
 // the human-retry path, where the §8.4 failure block matters most.
-func (s *Store) LastFailedStepRun(ctx context.Context, taskID int64, stepIndex int) (*StepRun, error) {
+//
+// stepID narrows it to one member of a `parallel` group, for the reason
+// CountStepAttempts gives (task 014 decision 16): the failure block a
+// sub-step retries under must be its own, not a sibling's.
+func (s *Store) LastFailedStepRun(ctx context.Context, taskID int64, stepIndex int, stepID string) (*StepRun, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT `+stepRunColumns+` FROM step_runs
-		WHERE task_id = ? AND step_index = ? AND state = ?
+		WHERE task_id = ? AND step_index = ? AND step_id = ? AND state = ?
 		ORDER BY attempt DESC, id DESC LIMIT 1`,
-		taskID, stepIndex, string(StepFailed))
+		taskID, stepIndex, stepID, string(StepFailed))
 	r, err := scanStepRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -157,6 +161,42 @@ func (s *Store) LastFailedStepRun(ctx context.Context, taskID int64, stepIndex i
 		return nil, fmt.Errorf("last failed step run: %w", err)
 	}
 	return r, nil
+}
+
+// LatestStepStates returns, for one step index, the state of the most recent
+// attempt of each distinct step id. It exists for `parallel` groups (task
+// 014): a group re-admitted after a block must re-run only the sub-steps that
+// did not already succeed, and that fact is derived from these rows rather
+// than stored on the group — which has no row of its own (decision 17).
+//
+// The map is keyed by step id. An index with no rows yields an empty map, not
+// an error: a group running for the first time has no history.
+func (s *Store) LatestStepStates(ctx context.Context, taskID int64, stepIndex int) (map[string]StepRunState, error) {
+	// The join picks the highest attempt per step id — MAX(attempt) alone
+	// would pair a maximum with an arbitrary row's state.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT r.step_id, r.state FROM step_runs r
+		JOIN (SELECT step_id, MAX(attempt) AS attempt FROM step_runs
+			WHERE task_id = ? AND step_index = ? GROUP BY step_id) m
+		ON r.step_id = m.step_id AND r.attempt = m.attempt
+		WHERE r.task_id = ? AND r.step_index = ?`,
+		taskID, stepIndex, taskID, stepIndex)
+	if err != nil {
+		return nil, fmt.Errorf("latest step states: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]StepRunState)
+	for rows.Next() {
+		var id, state string
+		if err := rows.Scan(&id, &state); err != nil {
+			return nil, fmt.Errorf("scan latest step state: %w", err)
+		}
+		out[id] = StepRunState(state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("latest step states: %w", err)
+	}
+	return out, nil
 }
 
 // ListStepRuns returns every attempt of every step of the task, ordered by

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -199,6 +199,29 @@ func (s *Store) LatestStepStates(ctx context.Context, taskID int64, stepIndex in
 	return out, nil
 }
 
+// LatestStepRun returns the newest attempt of one step, or nil when it has
+// none.
+//
+// It exists for the fan-out join's re-entry rule (task 014 decision 9): a
+// merge in progress means a crash or a human's resolution, and the two are
+// told apart by how the last attempt ended. The task's live state cannot
+// answer it — by the time the engine runs, the scheduler has already moved a
+// retried task out of `blocked`.
+func (s *Store) LatestStepRun(ctx context.Context, taskID int64, stepIndex int, stepID string) (*StepRun, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+stepRunColumns+` FROM step_runs
+		WHERE task_id = ? AND step_index = ? AND step_id = ?
+		ORDER BY attempt DESC, id DESC LIMIT 1`,
+		taskID, stepIndex, stepID)
+	r, err := scanStepRun(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("latest step run: %w", err)
+	}
+	return r, nil
+}
+
 // ListStepRuns returns every attempt of every step of the task, ordered by
 // step index, then attempt.
 func (s *Store) ListStepRuns(ctx context.Context, taskID int64) ([]StepRun, error) {

--- a/internal/store/subtree.go
+++ b/internal/store/subtree.go
@@ -1,0 +1,164 @@
+package store
+
+// The fan-out subtree (task 014, spec §7.6/§13.2). A parent parked in
+// `awaiting_children` needs two questions answered about work that is not on
+// its own row: is everything settled, and what is a human being asked for.
+//
+// Both are answered by walking `parent_task_id` with one recursive CTE, and
+// neither is stored. A denormalized counter would be a second truth that
+// drifts from the rows it counts, and this daemon's whole shape is one truth
+// (decision 13). The walk is bounded by `fan_out.max_depth`, enforced when
+// the tree is created.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// ChildrenRollup summarizes a task's descendants: how many are in each state,
+// and the ids of the ones a human has to do something about.
+//
+// Total counts every descendant at any depth, not just direct lanes — a root
+// whose lane fanned out again is still waiting on the whole subtree.
+type ChildrenRollup struct {
+	Total int
+	// ByState counts descendants per state. States with no descendants are
+	// absent rather than zero, so a client can range over what is there.
+	ByState map[TaskState]int
+	// Blocked and AwaitingGate are the descendants holding the join open on a
+	// human. Ids, not objects: §13.3's convention is that a client re-fetches
+	// what it decides it needs.
+	Blocked      []int64
+	AwaitingGate []int64
+	// Settled is how many descendants have reached a state the join can
+	// proceed from (§6 `Settled`). The parent may resume when it equals
+	// Total.
+	Settled int
+}
+
+// Done reports whether every descendant has settled — the condition the
+// scheduler re-queues a parked parent on (decision 25).
+//
+// A subtree with no descendants at all is done: a fan_out step that spawned
+// nothing has nothing to wait for.
+func (r ChildrenRollup) Done() bool { return r.Settled == r.Total }
+
+// ChildrenOf returns the rollup for one task's whole subtree.
+//
+// The CTE walks children rather than ancestors because that is the direction
+// the index runs (idx_tasks_parent). Archived descendants are counted like
+// any other: an archived lane has certainly settled, and excluding them would
+// make Total disagree with the rows a client can list.
+func (s *Store) ChildrenOf(ctx context.Context, taskID int64) (ChildrenRollup, error) {
+	out := ChildrenRollup{ByState: map[TaskState]int{}}
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE subtree(id, state) AS (
+			SELECT id, state FROM tasks WHERE parent_task_id = ?
+			UNION ALL
+			SELECT t.id, t.state FROM tasks t JOIN subtree ON t.parent_task_id = subtree.id
+		)
+		SELECT id, state FROM subtree`, taskID)
+	if err != nil {
+		return out, fmt.Errorf("children of task %d: %w", taskID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int64
+		var state string
+		if err := rows.Scan(&id, &state); err != nil {
+			return out, fmt.Errorf("scan subtree row: %w", err)
+		}
+		st := TaskState(state)
+		out.Total++
+		out.ByState[st]++
+		switch st {
+		case TaskBlocked:
+			out.Blocked = append(out.Blocked, id)
+		case TaskAwaitingGate:
+			out.AwaitingGate = append(out.AwaitingGate, id)
+		}
+		if taskstate.Settled(st) {
+			out.Settled++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("children of task %d: %w", taskID, err)
+	}
+	return out, nil
+}
+
+// FanOutAncestors returns the ids of every ancestor of a task, nearest first.
+//
+// It exists for `task.children_changed` (decision 14): a descendant's
+// transition has to reach every fan-out ancestor's rollup, and the per-task
+// SSE stream filters on task_id alone, so the event is emitted once per
+// ancestor rather than the subscription growing a subtree test.
+func (s *Store) FanOutAncestors(ctx context.Context, taskID int64) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE ancestors(id, parent_task_id, depth) AS (
+			SELECT id, parent_task_id, 0 FROM tasks WHERE id = ?
+			UNION ALL
+			SELECT t.id, t.parent_task_id, a.depth + 1
+				FROM tasks t JOIN ancestors a ON t.id = a.parent_task_id
+		)
+		SELECT id FROM ancestors WHERE depth > 0 ORDER BY depth ASC`, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("ancestors of task %d: %w", taskID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan ancestor: %w", err)
+		}
+		out = append(out, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ancestors of task %d: %w", taskID, err)
+	}
+	return out, nil
+}
+
+// ListChildren returns one task's direct lanes in merge order. The join reads
+// them this way, and so does a client drilling into a parent.
+func (s *Store) ListChildren(ctx context.Context, parentID int64) ([]Task, error) {
+	return s.queryTasks(ctx, `SELECT `+taskColumns+` FROM tasks
+		WHERE parent_task_id = ? ORDER BY lane_order ASC, id ASC`, parentID)
+}
+
+// NonTerminalDescendants returns the ids of descendants that have not settled
+// — what a cascading cancel walks and what archive refuses on (decision 11).
+// Depth-first, deepest first, so a caller cancelling in order never cancels a
+// parent before its own children.
+func (s *Store) NonTerminalDescendants(ctx context.Context, taskID int64) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE subtree(id, state, depth) AS (
+			SELECT id, state, 1 FROM tasks WHERE parent_task_id = ?
+			UNION ALL
+			SELECT t.id, t.state, subtree.depth + 1
+				FROM tasks t JOIN subtree ON t.parent_task_id = subtree.id
+		)
+		SELECT id, state FROM subtree ORDER BY depth DESC, id ASC`, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("descendants of task %d: %w", taskID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		var state string
+		if err := rows.Scan(&id, &state); err != nil {
+			return nil, fmt.Errorf("scan descendant: %w", err)
+		}
+		if !taskstate.Settled(TaskState(state)) {
+			out = append(out, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("descendants of task %d: %w", taskID, err)
+	}
+	return out, nil
+}

--- a/internal/store/subtree.go
+++ b/internal/store/subtree.go
@@ -12,6 +12,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/lezli01/vincent/internal/taskstate"
@@ -161,4 +162,45 @@ func (s *Store) NonTerminalDescendants(ctx context.Context, taskID int64) ([]int
 		return nil, fmt.Errorf("descendants of task %d: %w", taskID, err)
 	}
 	return out, nil
+}
+
+// EventTaskChildrenChanged tells a fan-out ancestor that something in its
+// subtree moved (§13.3, task 014 decision 14). Payload is
+// {task_id, child_id, to_state}; a client re-fetches the rollup rather than
+// reading state out of the event, which is how §13.3 hands out everything
+// else.
+const EventTaskChildrenChanged = "task.children_changed"
+
+// EmitChildrenChanged appends one children_changed event per fan-out ancestor
+// of childID.
+//
+// Emitting is what the per-task SSE stream needs: it filters on `task_id = ?`,
+// so a root's stream never sees a depth-2 transition and its rollup could not
+// update live. Widening that filter to a subtree-membership test was the
+// alternative, and it fails because the subtree is not fixed at subscribe
+// time — children appear as fan-outs fire — so the subscription would have to
+// grow itself by watching task.created from inside the fan-out. The cost here
+// is bounded and explicit: at most max_depth extra rows per transition.
+//
+// A task with no ancestors — every ordinary task — writes nothing.
+func (s *Store) EmitChildrenChanged(ctx context.Context, childID int64, toState TaskState) error {
+	ancestors, err := s.FanOutAncestors(ctx, childID)
+	if err != nil {
+		return err
+	}
+	for _, ancestorID := range ancestors {
+		payload, err := json.Marshal(map[string]any{
+			"task_id": ancestorID, "child_id": childID, "to_state": string(toState),
+		})
+		if err != nil {
+			return fmt.Errorf("marshal children_changed: %w", err)
+		}
+		id := ancestorID
+		if err := s.AppendEvent(ctx, &Event{
+			Type: EventTaskChildrenChanged, TaskID: &id, Payload: payload,
+		}); err != nil {
+			return fmt.Errorf("append children_changed for %d: %w", ancestorID, err)
+		}
+	}
+	return nil
 }

--- a/internal/store/subtree_test.go
+++ b/internal/store/subtree_test.go
@@ -1,0 +1,197 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+// lane inserts a child task of parent, in the given state.
+func lane(t *testing.T, s *Store, projectID, parentID int64, laneID string, order int, state TaskState) *Task {
+	t.Helper()
+	task := newTask(projectID, "lane "+laneID, state)
+	task.ParentTaskID = &parentID
+	idx := 0
+	task.ParentStepIndex = &idx
+	task.LaneID = laneID
+	task.LaneOrder = order
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask(%s): %v", laneID, err)
+	}
+	return task
+}
+
+// TestFanOutColumnsRoundTrip: the four columns are the entire difference
+// between a lane and a hand-created task, so they had better survive a write
+// and a read.
+func TestFanOutColumnsRoundTrip(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskRunning)
+	if err := s.CreateTask(t.Context(), root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	child := lane(t, s, p.ID, root.ID, "api", 2, TaskQueued)
+
+	got, err := s.GetTask(t.Context(), child.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.ParentTaskID == nil || *got.ParentTaskID != root.ID {
+		t.Errorf("parent_task_id = %v, want %d", got.ParentTaskID, root.ID)
+	}
+	if got.ParentStepIndex == nil || *got.ParentStepIndex != 0 {
+		t.Errorf("parent_step_index = %v, want 0", got.ParentStepIndex)
+	}
+	if got.LaneID != "api" || got.LaneOrder != 2 {
+		t.Errorf("lane = %q/%d, want api/2", got.LaneID, got.LaneOrder)
+	}
+
+	// A root carries none of it, and must not come back with zero values
+	// that look like lane 0 of step 0.
+	gotRoot, err := s.GetTask(t.Context(), root.ID)
+	if err != nil {
+		t.Fatalf("GetTask(root): %v", err)
+	}
+	if gotRoot.ParentTaskID != nil || gotRoot.ParentStepIndex != nil || gotRoot.LaneID != "" {
+		t.Errorf("root carries lane columns: %+v", gotRoot)
+	}
+}
+
+// TestListTasksExcludesLanesByDefault is decision 13: a list is the work
+// someone asked for, and a 64-task tree would bury it.
+func TestListTasksExcludesLanesByDefault(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskAwaitingChildren)
+	if err := s.CreateTask(ctx, root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	docs := lane(t, s, p.ID, root.ID, "docs", 1, TaskQueued)
+	api := lane(t, s, p.ID, root.ID, "api", 0, TaskRunning)
+
+	roots, err := s.ListTasks(ctx, TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(roots) != 1 || roots[0].ID != root.ID {
+		t.Fatalf("default list = %d tasks, want only the root", len(roots))
+	}
+
+	all, err := s.ListTasks(ctx, TaskFilter{Children: ChildrenInclude})
+	if err != nil {
+		t.Fatalf("ListTasks(include): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("include_children list = %d tasks, want 3", len(all))
+	}
+
+	// One parent's lanes come back in *merge* order, not newest-first:
+	// that is the order the join will merge them in.
+	lanes, err := s.ListTasks(ctx, TaskFilter{ParentID: root.ID})
+	if err != nil {
+		t.Fatalf("ListTasks(parent): %v", err)
+	}
+	gotIDs := []int64{}
+	for _, l := range lanes {
+		gotIDs = append(gotIDs, l.ID)
+	}
+	if want := []int64{api.ID, docs.ID}; !reflect.DeepEqual(gotIDs, want) {
+		t.Errorf("lanes = %v, want %v in lane_order", gotIDs, want)
+	}
+}
+
+// TestChildrenOfWalksTheWholeSubtree: the rollup counts descendants at every
+// depth, because a root whose lane fanned out again is still waiting on all
+// of it.
+func TestChildrenOfWalksTheWholeSubtree(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskAwaitingChildren)
+	if err := s.CreateTask(ctx, root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	mid := lane(t, s, p.ID, root.ID, "mid", 0, TaskAwaitingChildren)
+	done := lane(t, s, p.ID, root.ID, "done", 1, TaskDone)
+	deepBlocked := lane(t, s, p.ID, mid.ID, "deep", 0, TaskBlocked)
+
+	got, err := s.ChildrenOf(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("ChildrenOf: %v", err)
+	}
+	if got.Total != 3 {
+		t.Errorf("Total = %d, want 3 (depth 2 included)", got.Total)
+	}
+	if got.ByState[TaskDone] != 1 || got.ByState[TaskBlocked] != 1 {
+		t.Errorf("ByState = %v, want one done and one blocked", got.ByState)
+	}
+	if !reflect.DeepEqual(got.Blocked, []int64{deepBlocked.ID}) {
+		t.Errorf("Blocked = %v, want the depth-2 lane %d", got.Blocked, deepBlocked.ID)
+	}
+	if got.Settled != 1 || got.Done() {
+		t.Errorf("Settled = %d of %d, Done = %v; a blocked lane holds the join open",
+			got.Settled, got.Total, got.Done())
+	}
+	if got.ByState[TaskDone] != 1 {
+		t.Errorf("the done lane %d is missing from %v", done.ID, got.ByState)
+	}
+
+	// A task with no children is trivially done: a fan_out that spawned
+	// nothing has nothing to wait for.
+	leaf, err := s.ChildrenOf(ctx, deepBlocked.ID)
+	if err != nil {
+		t.Fatalf("ChildrenOf(leaf): %v", err)
+	}
+	if !leaf.Done() || leaf.Total != 0 {
+		t.Errorf("leaf rollup = %+v, want an empty, done rollup", leaf)
+	}
+}
+
+// TestFanOutAncestorsNearestFirst: children_changed is emitted on every
+// ancestor, so the walk has to reach past the immediate parent.
+func TestFanOutAncestorsNearestFirst(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskAwaitingChildren)
+	if err := s.CreateTask(ctx, root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	mid := lane(t, s, p.ID, root.ID, "mid", 0, TaskAwaitingChildren)
+	deep := lane(t, s, p.ID, mid.ID, "deep", 0, TaskRunning)
+
+	got, err := s.FanOutAncestors(ctx, deep.ID)
+	if err != nil {
+		t.Fatalf("FanOutAncestors: %v", err)
+	}
+	if want := []int64{mid.ID, root.ID}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ancestors = %v, want %v (nearest first)", got, want)
+	}
+	if got, err := s.FanOutAncestors(ctx, root.ID); err != nil || len(got) != 0 {
+		t.Errorf("ancestors of a root = %v (err %v), want none", got, err)
+	}
+}
+
+// TestNonTerminalDescendantsDeepestFirst: a cascading cancel must not cancel
+// a parent before its own children.
+func TestNonTerminalDescendantsDeepestFirst(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskAwaitingChildren)
+	if err := s.CreateTask(ctx, root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	mid := lane(t, s, p.ID, root.ID, "mid", 0, TaskAwaitingChildren)
+	deep := lane(t, s, p.ID, mid.ID, "deep", 0, TaskRunning)
+	lane(t, s, p.ID, root.ID, "finished", 1, TaskDone) // settled: not cancelled
+
+	got, err := s.NonTerminalDescendants(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("NonTerminalDescendants: %v", err)
+	}
+	if want := []int64{deep.ID, mid.ID}; !reflect.DeepEqual(got, want) {
+		t.Errorf("descendants = %v, want %v (deepest first, settled excluded)", got, want)
+	}
+}

--- a/internal/store/subtree_test.go
+++ b/internal/store/subtree_test.go
@@ -195,3 +195,49 @@ func TestNonTerminalDescendantsDeepestFirst(t *testing.T) {
 		t.Errorf("descendants = %v, want %v (deepest first, settled excluded)", got, want)
 	}
 }
+
+// TestEmitChildrenChangedReachesEveryAncestor is decision 14: the per-task
+// SSE stream filters on task_id alone, so a root's stream would never see a
+// depth-2 transition unless the event is emitted on the root too.
+func TestEmitChildrenChangedReachesEveryAncestor(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	root := newTask(p.ID, "root", TaskAwaitingChildren)
+	if err := s.CreateTask(ctx, root, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	mid := lane(t, s, p.ID, root.ID, "mid", 0, TaskAwaitingChildren)
+	deep := lane(t, s, p.ID, mid.ID, "deep", 0, TaskRunning)
+
+	if err := s.EmitChildrenChanged(ctx, deep.ID, TaskDone); err != nil {
+		t.Fatalf("EmitChildrenChanged: %v", err)
+	}
+	events, err := s.ListEvents(ctx, EventFilter{Types: []string{EventTaskChildrenChanged}})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	got := map[int64]bool{}
+	for _, e := range events {
+		if e.TaskID != nil {
+			got[*e.TaskID] = true
+		}
+	}
+	if !got[mid.ID] || !got[root.ID] {
+		t.Errorf("children_changed reached %v, want both %d and %d", got, mid.ID, root.ID)
+	}
+	if len(events) != 2 {
+		t.Errorf("emitted %d events, want one per ancestor", len(events))
+	}
+
+	// A task with no ancestors writes nothing: every ordinary task takes
+	// this path, and it must cost one indexed lookup and no rows.
+	before := len(events)
+	if err := s.EmitChildrenChanged(ctx, root.ID, TaskDone); err != nil {
+		t.Fatalf("EmitChildrenChanged(root): %v", err)
+	}
+	after, _ := s.ListEvents(ctx, EventFilter{Types: []string{EventTaskChildrenChanged}})
+	if len(after) != before {
+		t.Errorf("a root emitted %d children_changed events, want none", len(after)-before)
+	}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -16,6 +16,7 @@ const taskColumns = `id, project_id, title, description, fields_json, workflow_n
 	base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 	state, current_step, block_reason, pause_requested, retry_cursor_at, pending_override_json,
 	pending_input_json, admit_not_before, queued_reason,
+	parent_task_id, parent_step_index, lane_id, lane_order,
 	created_at, updated_at, started_at, finished_at, archived_at`
 
 // slotStates is the set of states that occupy a concurrency slot (spec §11),
@@ -81,12 +82,14 @@ func (s *Store) CreateTask(ctx context.Context, t *Task, resolveBranch func(id i
 			INSERT INTO tasks (project_id, title, description, fields_json, workflow_name, workflow_snapshot,
 				base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 				state, current_step, block_reason,
+				parent_task_id, parent_step_index, lane_id, lane_order,
 				created_at, updated_at, started_at, finished_at, archived_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			t.ProjectID, t.Title, t.Description, fields, t.WorkflowName, t.WorkflowSnapshot,
 			t.BaseBranch, t.BranchName, nullString(t.WorktreePath), t.Priority,
 			nullString(t.AgentOverride), nullString(t.ModelOverride), nullString(t.EffortOverride),
 			string(t.State), t.CurrentStep, nullString(t.BlockReason),
+			t.ParentTaskID, t.ParentStepIndex, nullString(t.LaneID), t.LaneOrder,
 			formatTime(t.CreatedAt), formatTime(t.UpdatedAt),
 			formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt))
 		if err != nil {
@@ -198,7 +201,24 @@ type TaskFilter struct {
 	Archived  ArchivedFilter
 	Limit     int // 0 = unlimited
 	Offset    int
+	// Children decides whether fan-out lanes appear (task 014 decision 13).
+	// The zero value is ChildrenExclude: a list is the work someone asked
+	// for, and a 64-task tree would bury it.
+	Children ChildrenFilter
+	// ParentID lists exactly one parent's lanes, in merge order. It implies
+	// nothing about Children — naming a parent *is* asking for children.
+	ParentID int64
 }
+
+// ChildrenFilter decides whether fan-out lanes are listed (task 014).
+type ChildrenFilter int
+
+const (
+	// ChildrenExclude returns root tasks only — parent_task_id IS NULL.
+	ChildrenExclude ChildrenFilter = iota
+	// ChildrenInclude returns the flat everything, roots and lanes alike.
+	ChildrenInclude
+)
 
 // ListTasks returns tasks matching f, newest first.
 func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
@@ -212,6 +232,15 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 	if f.State != "" {
 		where = append(where, "state = ?")
 		args = append(args, string(f.State))
+	}
+	switch {
+	case f.ParentID != 0:
+		// Asking for one parent's lanes is asking for children, so the
+		// Children filter does not also apply here.
+		where = append(where, "parent_task_id = ?")
+		args = append(args, f.ParentID)
+	case f.Children == ChildrenExclude:
+		where = append(where, "parent_task_id IS NULL")
 	}
 	// An explicit State always wins: asking for state=archived and getting
 	// nothing back because the default excludes archives would be absurd.
@@ -229,7 +258,14 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
-	q += " ORDER BY id DESC"
+	// Lanes of one parent read in merge order — the order the join will
+	// merge them, which is what someone drilling into a fan-out is looking
+	// at. Everything else is newest first.
+	if f.ParentID != 0 {
+		q += " ORDER BY lane_order ASC, id ASC"
+	} else {
+		q += " ORDER BY id DESC"
+	}
 	if f.Limit > 0 || f.Offset > 0 {
 		limit := f.Limit
 		if limit == 0 {
@@ -678,6 +714,9 @@ func scanTask(r rowScanner) (*Task, error) {
 		retryCursor, pendingOv      sql.NullString
 		pendingInput                sql.NullString
 		admitNotBefore, queuedWhy   sql.NullString
+		parentID, parentStep        sql.NullInt64
+		laneID                      sql.NullString
+		laneOrder                   sql.NullInt64
 		created, updated            string
 		started, finished, archived sql.NullString
 	)
@@ -687,9 +726,20 @@ func scanTask(r rowScanner) (*Task, error) {
 		(*string)(&t.State), &t.CurrentStep, &blockReason,
 		&t.PauseRequested, &retryCursor, &pendingOv,
 		&pendingInput, &admitNotBefore, &queuedWhy,
+		&parentID, &parentStep, &laneID, &laneOrder,
 		&created, &updated, &started, &finished, &archived); err != nil {
 		return nil, err
 	}
+	if parentID.Valid {
+		id := parentID.Int64
+		t.ParentTaskID = &id
+	}
+	if parentStep.Valid {
+		idx := int(parentStep.Int64)
+		t.ParentStepIndex = &idx
+	}
+	t.LaneID = laneID.String
+	t.LaneOrder = int(laneOrder.Int64)
 	t.WorktreePath = worktree.String
 	t.BlockReason = blockReason.String
 	t.PendingInputJSON = pendingInput.String

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -300,7 +300,12 @@ type StepAttempts struct {
 // never bounded: attempt numbers must stay monotonic over the step's whole
 // history, or `{step_index}-{attempt}.jsonl` transcript names would collide
 // and truncate earlier attempts (phase 2 decision).
-func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex int, since time.Time) (StepAttempts, error) {
+//
+// stepID narrows the count to one member of a `parallel` group, whose
+// sub-steps all share the group's stepIndex and are told apart by id alone
+// (task 014 decision 16). For an ordinary step it is that step's own id and
+// the filter changes nothing — one step owns the index.
+func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex int, stepID string, since time.Time) (StepAttempts, error) {
 	var (
 		out    StepAttempts
 		last   sql.NullInt64
@@ -314,8 +319,8 @@ func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex i
 	}
 	q := `SELECT MAX(attempt),
 			SUM(CASE WHEN state = ? AND started_at > ? THEN 1 ELSE 0 END)
-		FROM step_runs WHERE task_id = ? AND step_index = ?`
-	args := []any{string(StepFailed), sinceArg, taskID, stepIndex}
+		FROM step_runs WHERE task_id = ? AND step_index = ? AND step_id = ?`
+	args := []any{string(StepFailed), sinceArg, taskID, stepIndex, stepID}
 	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&last, &failed); err != nil {
 		return out, fmt.Errorf("count step attempts: %w", err)
 	}

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -153,7 +153,7 @@ func (s *Store) TransitionTask(
 			t.FinishedAt = &now
 		case TaskArchived:
 			t.ArchivedAt = &now
-		case TaskQueued, TaskAwaitingGate, TaskAwaitingInput, TaskBlocked, TaskPaused:
+		case TaskQueued, TaskAwaitingGate, TaskAwaitingInput, TaskAwaitingChildren, TaskBlocked, TaskPaused:
 			// No timestamp of their own; updated_at covers them.
 		}
 		if to != TaskBlocked {

--- a/internal/store/transitions_test.go
+++ b/internal/store/transitions_test.go
@@ -211,7 +211,7 @@ func TestCountStepAttemptsCursorBoundsOnlyFailures(t *testing.T) {
 	}
 
 	cursor := base.Add(2*time.Minute + 30*time.Second) // after attempt 2, before 3
-	got, err := s.CountStepAttempts(ctx, task.ID, 0, cursor)
+	got, err := s.CountStepAttempts(ctx, task.ID, 0, "step", cursor)
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestCountStepAttemptsCursorBoundsOnlyFailures(t *testing.T) {
 		t.Errorf("Failed = %d, want 1 — only failures after the cursor count", got.Failed)
 	}
 
-	all, err := s.CountStepAttempts(ctx, task.ID, 0, time.Time{})
+	all, err := s.CountStepAttempts(ctx, task.ID, 0, "step", time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts (zero cursor): %v", err)
 	}

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -368,11 +368,11 @@ func (r *Runner) recordStepDecision(
 		// here would record a decision that is about to lose its CAS.
 		return nil
 	}
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, task.ID, task.CurrentStep, time.Time{})
+	stepID, stepType := describeStep(task, task.CurrentStep)
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, task.ID, task.CurrentStep, stepID, time.Time{})
 	if err != nil {
 		return err
 	}
-	stepID, stepType := describeStep(task, task.CurrentStep)
 	now := time.Now()
 	run := &store.StepRun{
 		TaskID: task.ID, StepIndex: task.CurrentStep, StepID: stepID, StepType: stepType,

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -46,6 +46,10 @@ func (r *Runner) Cancel(ctx context.Context, id int64) (*store.Task, error) {
 		return nil, err
 	}
 	log := r.deps.Logger.With("task", id)
+	// A fan-out's lanes are cancelled with it (decision 11): nothing should
+	// keep burning agent time for a join that will never happen. Their
+	// branches and worktrees survive — they are stopped, not erased.
+	r.cascadeCancel(ctx, id)
 	if lr, ok := r.lookupRun(id); ok {
 		// Tearing the process tree down takes up to the §6 grace period, and
 		// the caller has already got its answer: the task is durably aborted.
@@ -218,6 +222,16 @@ func (r *Runner) Archive(
 	if !taskstate.Can(task.State, taskstate.Archive) {
 		return nil, worktree.BranchOutcome{},
 			&InvalidActionError{TaskID: id, Action: taskstate.Archive, State: task.State}
+	}
+	// Archiving a fan-out parent archives its whole subtree, so it refuses
+	// while any lane is still working — pulling a worktree out from under a
+	// running lane is not something `force` should be able to ask for
+	// (decision 11).
+	if err := r.refuseUnfinishedDescendants(ctx, id); err != nil {
+		return nil, worktree.BranchOutcome{}, err
+	}
+	if err := r.cascadeArchive(ctx, id, force); err != nil {
+		return nil, worktree.BranchOutcome{}, err
 	}
 	empty := ""
 	if task.WorktreePath == "" {

--- a/internal/taskrun/cascade.go
+++ b/internal/taskrun/cascade.go
@@ -1,0 +1,121 @@
+package taskrun
+
+// Lifecycle over a fan-out subtree (spec §7.6, §10, task 014 decision 11).
+//
+// Cancel cascades; archive refuses while anything is unfinished and then
+// cascades. Both walk depth-first, deepest first, so a parent is never ended
+// before its own children are.
+//
+// Neither destroys work. A cancelled lane keeps its branch and its worktree —
+// it is stopped, not erased — and archive removes worktrees under exactly the
+// rules §10 already applies to any task, dirty-worktree confirmation
+// included.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// UnfinishedDescendantsError reports an archive refused because part of the
+// subtree is still working. It is its own type because the API answers 409
+// with the ids: "this task has two lanes still running" is something the
+// caller can act on, unlike a bare conflict.
+type UnfinishedDescendantsError struct {
+	TaskID int64
+	IDs    []int64
+}
+
+func (e *UnfinishedDescendantsError) Error() string {
+	return fmt.Sprintf("task %d has %d unfinished fan-out %s: %v",
+		e.TaskID, len(e.IDs), plural("lane", len(e.IDs)), e.IDs)
+}
+
+func plural(word string, n int) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}
+
+// AsUnfinishedDescendants extracts an *UnfinishedDescendantsError from err.
+func AsUnfinishedDescendants(err error) (*UnfinishedDescendantsError, bool) {
+	var e *UnfinishedDescendantsError
+	return e, errors.As(err, &e)
+}
+
+// cascadeCancel cancels every unsettled descendant of a task, deepest first.
+//
+// Nothing should keep burning agent time for a join that will never happen.
+// The branches and worktrees survive, so no work is destroyed — only stopped.
+func (r *Runner) cascadeCancel(ctx context.Context, id int64) {
+	ids, err := r.deps.Store.NonTerminalDescendants(ctx, id)
+	if err != nil {
+		r.deps.Logger.Error("cancel: list descendants", "task", id, "error", err)
+		return
+	}
+	for _, childID := range ids {
+		if _, err := r.Cancel(r.persistCtx(), childID); err != nil {
+			if _, invalid := AsInvalidAction(err); invalid {
+				continue // it settled between the list and the write
+			}
+			r.deps.Logger.Error("cancel: cascade to lane", "task", id, "child", childID, "error", err)
+			continue
+		}
+		r.deps.Logger.Info("cancelled fan-out lane", "parent", id, "child", childID)
+	}
+}
+
+// refuseUnfinishedDescendants reports an error when any descendant is still
+// working, which is what archive checks before it touches anything.
+//
+// Archive of a parent is archive of its whole subtree, and a lane still
+// running would have its worktree pulled out from under it.
+func (r *Runner) refuseUnfinishedDescendants(ctx context.Context, id int64) error {
+	ids, err := r.deps.Store.NonTerminalDescendants(ctx, id)
+	if err != nil {
+		return err
+	}
+	if len(ids) > 0 {
+		return &UnfinishedDescendantsError{TaskID: id, IDs: ids}
+	}
+	return nil
+}
+
+// cascadeArchive archives every settled descendant, deepest first, with the
+// same `force` the parent's archive was given.
+//
+// Per-child dirty confirmation is not re-implemented here: each child goes
+// through the ordinary Archive, so §10's refusal of a dirty worktree without
+// explicit confirmation applies to each of them exactly as it does to any
+// task. A conflict-blocked lane is dirty by construction, and that is the
+// correct behaviour rather than a case to carve out (decision 8).
+func (r *Runner) cascadeArchive(ctx context.Context, id int64, force bool) error {
+	children, err := r.deps.Store.ListChildren(ctx, id)
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		// Depth first: a lane that fanned out again owns its own subtree.
+		if err := r.cascadeArchive(ctx, child.ID, force); err != nil {
+			return err
+		}
+		if child.State == store.TaskArchived {
+			continue
+		}
+		if !taskstate.Can(child.State, taskstate.Archive) {
+			// Refused earlier by refuseUnfinishedDescendants; reaching here
+			// means it moved in between, and stopping is better than
+			// archiving half a tree.
+			return &UnfinishedDescendantsError{TaskID: id, IDs: []int64{child.ID}}
+		}
+		if _, _, err := r.Archive(ctx, child.ID, force); err != nil {
+			return fmt.Errorf("archive lane %d: %w", child.ID, err)
+		}
+		r.deps.Logger.Info("archived fan-out lane", "parent", id, "child", child.ID)
+	}
+	return nil
+}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -97,12 +97,18 @@ const resultSummaryLimit = 4096
 const outputTailLines = 200
 
 // stepEnv is everything one step needs to run.
+//
+// A member of a `parallel` group gets its own stepEnv carrying the group's
+// index and its own step, with inGroup set — the flag decides transcript
+// naming and nothing else, because in every other respect a sub-step runs
+// exactly like the step it would have been on its own (task 014).
 type stepEnv struct {
 	task    *store.Task
 	project *store.Project
 	wf      *workflow.Workflow
 	step    workflow.Step
 	index   int
+	inGroup bool
 	log     *slog.Logger
 }
 
@@ -173,7 +179,15 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			r.enterGate(ctx, env)
 			return
 		}
-		outcome := r.runStepWithRetries(ctx, env)
+		// A group has no attempt of its own to retry: each sub-step carries its
+		// own budget, so the group's outcome is the collected one rather than
+		// anything runStepWithRetries could produce (task 014 decisions 17, 18).
+		outcome := stepOutcome{}
+		if env.step.Type == workflow.StepParallel {
+			outcome = r.runGroup(ctx, env)
+		} else {
+			outcome = r.runStepWithRetries(ctx, env)
+		}
 		switch outcome.state {
 		case store.StepSucceeded:
 			task.CurrentStep = index + 1
@@ -252,7 +266,7 @@ func (r *Runner) runStepWithRetries(ctx context.Context, env *stepEnv) stepOutco
 	if env.task.RetryCursorAt != nil {
 		since = *env.task.RetryCursorAt
 	}
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, since)
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, since)
 	if err != nil {
 		env.log.Error("count step attempts", "error", err)
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
@@ -293,7 +307,7 @@ func (r *Runner) previousFailure(ctx context.Context, env *stepEnv, lastAttempt 
 	if lastAttempt == 0 {
 		return stepOutcome{}
 	}
-	prev, err := r.deps.Store.LastFailedStepRun(ctx, env.task.ID, env.index)
+	prev, err := r.deps.Store.LastFailedStepRun(ctx, env.task.ID, env.index, env.step.ID)
 	if err != nil {
 		env.log.Warn("previous failure unavailable for retry context", "error", err)
 		return stepOutcome{}
@@ -328,7 +342,7 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		run.Agent, run.Model, run.Effort = sel.Agent, sel.Model, sel.Effort
 	}
 
-	tr, err := openTranscript(r.deps.DataDir, env.task.ID, env.index, attempt)
+	tr, err := openTranscript(r.deps.DataDir, env.task.ID, env.index, attempt, subStepIDOf(env))
 	if err != nil {
 		env.log.Error("open transcript", "error", err)
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
@@ -437,7 +451,7 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 // entry so the gate's wait is visible in the timeline, and the task gives up
 // its concurrency slot until a human approves or rejects (§6, §11).
 func (r *Runner) enterGate(ctx context.Context, env *stepEnv) {
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, time.Time{})
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, time.Time{})
 	if err != nil {
 		env.log.Error("count gate attempts", "error", err)
 		r.fail(env.task, ReasonInternalError, env.log, "count gate attempts", err)

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -109,7 +109,16 @@ type stepEnv struct {
 	step    workflow.Step
 	index   int
 	inGroup bool
-	log     *slog.Logger
+	// conflicts are the files a fan_out join is asking an `on_conflict:
+	// agent` resolver to fix (§7.6, task 014 decision 24). Empty everywhere
+	// else.
+	conflicts []string
+	// resumedFromConflict marks a join re-entered by a human retry after a
+	// merge_conflict block, as opposed to after a crash. Only the crash may
+	// run `git merge --abort` — aborting over a conflict somebody spent an
+	// hour resolving is the failure decision 9 exists to prevent.
+	resumedFromConflict bool
+	log                 *slog.Logger
 }
 
 // stepOutcome is the result of one attempt.
@@ -173,6 +182,12 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		env := &stepEnv{
 			task: task, project: project, wf: wf,
 			step: wf.Steps[index], index: index,
+			// A human retry off a merge_conflict block is the one re-entry
+			// that must not abort the merge in progress (decision 9). It is
+			// read from the state this admission started in, before anything
+			// below overwrites it.
+			resumedFromConflict: task.State == store.TaskBlocked &&
+				task.BlockReason == ReasonMergeConflict,
 			log: log.With("step", wf.Steps[index].ID, "step_index", index),
 		}
 		if env.step.Type == workflow.StepManual {
@@ -183,9 +198,19 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		// own budget, so the group's outcome is the collected one rather than
 		// anything runStepWithRetries could produce (task 014 decisions 17, 18).
 		outcome := stepOutcome{}
-		if env.step.Type == workflow.StepParallel {
+		switch env.step.Type {
+		case workflow.StepParallel:
 			outcome = r.runGroup(ctx, env)
-		} else {
+		case workflow.StepFanOut:
+			// Spawning parks the task and ends this goroutine; joining
+			// returns an ordinary outcome the switch below acts on
+			// (§7.6, decision 3).
+			var stop bool
+			outcome, stop = r.runFanOut(ctx, env)
+			if stop {
+				return
+			}
+		default:
 			outcome = r.runStepWithRetries(ctx, env)
 		}
 		switch outcome.state {
@@ -384,6 +409,12 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		outcome = r.runAgentStep(ctx, env, sel, rc, run, tr)
 	case workflow.StepCommand:
 		outcome = r.runCommandStep(ctx, env, rc, run, tr)
+	case workflow.StepFanOut:
+		// The join, reached only on a re-admission: the spawn parked the task
+		// before this path could run (§7.6, decision 3). Going through
+		// runAttempt gives it the row, transcript and events every other step
+		// has, rather than a merge that happens invisibly.
+		outcome = r.runJoinStep(ctx, env, tr)
 	default:
 		outcome = stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
 	}
@@ -444,6 +475,7 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 		Steps:       steps,
 		Worktree:    workflow.WorktreeContext{Path: env.task.WorktreePath},
 		LastFailure: workflow.Failure{Reason: previous.reason, Output: previous.output},
+		Conflicts:   env.conflicts,
 	}, nil
 }
 

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -117,6 +117,10 @@ type stepEnv struct {
 	// merge_conflict block, as opposed to after a crash. Only the crash may
 	// run `git merge --abort` — aborting over a conflict somebody spent an
 	// hour resolving is the failure decision 9 exists to prevent.
+	//
+	// It is set by runFanOut *before* the attempt row is created, because the
+	// evidence is the previous attempt's outcome and creating this attempt's
+	// row hides it.
 	resumedFromConflict bool
 	log                 *slog.Logger
 }
@@ -182,12 +186,6 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		env := &stepEnv{
 			task: task, project: project, wf: wf,
 			step: wf.Steps[index], index: index,
-			// A human retry off a merge_conflict block is the one re-entry
-			// that must not abort the merge in progress (decision 9). It is
-			// read from the state this admission started in, before anything
-			// below overwrites it.
-			resumedFromConflict: task.State == store.TaskBlocked &&
-				task.BlockReason == ReasonMergeConflict,
 			log: log.With("step", wf.Steps[index].ID, "step_index", index),
 		}
 		if env.step.Type == workflow.StepManual {

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -139,7 +139,19 @@ func (h *engineHarness) createTask(t *testing.T, snapshot string) *store.Task {
 // waitForState polls until the task reaches one of want, or the test fails.
 func (h *engineHarness) waitForState(t *testing.T, id int64, want ...store.TaskState) *store.Task {
 	t.Helper()
-	deadline := time.Now().Add(60 * time.Second)
+	return h.waitForStateWithin(t, id, 60*time.Second, want...)
+}
+
+// waitForStateWithin is waitForState with an explicit budget, for the tests
+// that legitimately need more wall clock than a single task's run: a fan-out
+// costs a parent admission, N child admissions, N git worktrees and a merge,
+// and the scheduler's safety-net tick is 5s. Under `-race` with the whole
+// package running, 60s has proved to be not quite enough for that chain.
+func (h *engineHarness) waitForStateWithin(
+	t *testing.T, id int64, budget time.Duration, want ...store.TaskState,
+) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(budget)
 	var last *store.Task
 	for time.Now().Before(deadline) {
 		task, err := h.store.GetTask(t.Context(), id)

--- a/internal/taskrun/fanout.go
+++ b/internal/taskrun/fanout.go
@@ -54,6 +54,8 @@ func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutco
 		// retry can fix. An automatic second merge would abort the first,
 		// hit the same conflict, and block anyway.
 		joinEnv := *env
+		// Asked before the attempt row exists: see resumedFromConflict.
+		joinEnv.resumedFromConflict = r.resumedFromConflict(ctx, env)
 		if joinEnv.step.MaxRetries == nil {
 			zero := 0
 			joinEnv.step.MaxRetries = &zero

--- a/internal/taskrun/fanout.go
+++ b/internal/taskrun/fanout.go
@@ -1,0 +1,226 @@
+package taskrun
+
+// The fan-out half of a `fan_out` step (spec §7.6, task 014 — phase 2). The
+// join is in join.go; the two are one step (decision 3) but they run in
+// different admissions, separated by the parent parking.
+//
+// The shape is: spawn every lane as a real child task, park the parent in
+// `awaiting_children` releasing its slot, and end the actor goroutine. The
+// scheduler brings the parent back once every descendant has settled
+// (decision 25), and the second admission runs the join.
+//
+// A child is an ordinary task in every respect (decision 1): its own row,
+// worktree, branch, slot, gates, blocks, transcripts, recovery, gc and doctor
+// coverage. The only difference is four columns saying where it came from.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// runFanOut spawns a fan_out step's lanes and parks the parent, or — if the
+// lanes already exist, which is what a re-admission after ChildrenSettled
+// means — runs the join.
+//
+// It reports whether the actor should stop. Spawning always stops it: the
+// parent holds no slot while its children work.
+func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutcome, stop bool) {
+	existing, err := r.deps.Store.ListChildren(ctx, env.task.ID)
+	if err != nil {
+		env.log.Error("list lanes", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}, false
+	}
+	// Lanes of *this* step. A workflow may fan out more than once, and the
+	// earlier step's children are none of this one's business.
+	mine := make([]store.Task, 0, len(existing))
+	for _, c := range existing {
+		if c.ParentStepIndex != nil && *c.ParentStepIndex == env.index {
+			mine = append(mine, c)
+		}
+	}
+	if len(mine) > 0 {
+		// The children exist, so this admission is the join (decision 3). It
+		// runs through the ordinary attempt path, which gives it a
+		// step_runs row like any other step.
+		//
+		// The budget is one attempt unless the author asked for more: the two
+		// ways a join fails — a conflict and a lane that did not finish — are
+		// both "a human decides", and §7.2 reserves retries for failures a
+		// retry can fix. An automatic second merge would abort the first,
+		// hit the same conflict, and block anyway.
+		joinEnv := *env
+		if joinEnv.step.MaxRetries == nil {
+			zero := 0
+			joinEnv.step.MaxRetries = &zero
+		}
+		return r.runStepWithRetries(ctx, &joinEnv), false
+	}
+
+	if err := r.spawnLanes(ctx, env); err != nil {
+		// A partial spawn is not left behind: the lanes that were created are
+		// cancelled, so a retry starts from a clean slate rather than
+		// half a tree.
+		r.abandonPartialSpawn(ctx, env)
+		env.log.Error("spawn lanes", "error", err)
+		r.fail(env.task, ReasonInternalError, env.log, "spawn lanes", err)
+		return stepOutcome{}, true
+	}
+	// Park: the slot is released before the children need one, which is what
+	// makes this deadlock-free at any depth (decision 6).
+	if r.transition(env.task, taskstate.FanOut, store.TaskChange{}, env.log) {
+		env.log.Info("fan-out spawned; awaiting children", "step", env.step.ID)
+	}
+	return stepOutcome{}, true
+}
+
+// spawnLanes creates one child task per lane, in declared order.
+//
+// Everything a lane inherits is decision 10: the parent's branch is the
+// child's base branch, its overrides and priority propagate, and a lane spec
+// may override any of them for its own subtree. Fields merge with the
+// parent's, the lane winning (decision 29).
+func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv) error {
+	project, err := r.deps.Store.GetProject(ctx, env.task.ProjectID)
+	if err != nil {
+		return fmt.Errorf("load project: %w", err)
+	}
+	for order, lane := range env.step.Lanes {
+		child, err := r.laneTask(env, lane, order)
+		if err != nil {
+			return err
+		}
+		// The child's branch is resolved inside the insert's own transaction,
+		// exactly as any other task's is (task 001) — a lane is not a special
+		// case in the one place branch names are decided.
+		spec := worktree.BranchSpec{
+			ProjectTemplate: project.BranchTemplate,
+			ConfigTemplate:  r.deps.Config().BranchTemplate,
+		}
+		bctx := worktree.NewBranchContext(child.Title, child.BaseBranch, child.Fields,
+			worktree.BranchProject{
+				Name: project.Name, Path: project.Path, DefaultBranch: project.DefaultBranch,
+			})
+		resolve := func(id int64) (string, error) {
+			name, _, err := worktree.ResolveBranchName(spec, bctx.WithID(id))
+			return name, err
+		}
+		if err := r.deps.Store.CreateTask(r.persistCtx(), child, resolve); err != nil {
+			return fmt.Errorf("create lane %q: %w", lane.ID, err)
+		}
+		env.log.Info("lane spawned", "lane", lane.ID, "child", child.ID, "branch", child.BranchName)
+	}
+	return nil
+}
+
+// laneTask builds the child task row for one lane, without inserting it.
+func (r *Runner) laneTask(env *stepEnv, lane workflow.Lane, order int) (*store.Task, error) {
+	// The child's snapshot is the lane's steps as a flat workflow of its own.
+	// After this it is indistinguishable from a hand-created task: edit+retry,
+	// Marshal and the locator never meet a nested workflow, because nesting
+	// exists at authoring time only (decision 4).
+	// Two different names, and conflating them does not work. The *column*
+	// gets the synthetic {parent}/{step}/{lane}, whose `/` is what proves it
+	// cannot collide with a registry name (decision 4). The *snapshot* cannot:
+	// the engine re-parses it on every admission, and validation rejects `/`
+	// in a workflow name — the child would block with invalid_snapshot on its
+	// first admission. So the snapshot is named after where its steps came
+	// from: the registry workflow for a resolved lane, the lane id for an
+	// inline one. That is also what `.Workflow.Name` should render to.
+	laneName := lane.ResolvedFrom
+	if laneName == "" {
+		laneName = lane.ID
+	}
+	body := &workflow.Workflow{
+		Name:     laneName,
+		Defaults: env.wf.Defaults,
+		Steps:    lane.Steps,
+	}
+	snapshot, err := workflow.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encode lane %q snapshot: %w", lane.ID, err)
+	}
+
+	index := env.index
+	child := &store.Task{
+		ProjectID:   env.task.ProjectID,
+		Title:       fmt.Sprintf("%s — %s", env.task.Title, lane.ID),
+		Description: env.task.Description,
+		Fields:      mergeFields(env.task.Fields, lane.Fields),
+		// workflow_name records where the lane came from: the registry name
+		// for a resolved lane, the synthetic path for an inline one.
+		WorkflowName:     workflow.LaneWorkflowName(lane, env.wf.Name, env.step.ID),
+		WorkflowSnapshot: string(snapshot),
+		// The parent's branch, not the project's default: that is what makes
+		// the lanes' work land on the branch the task already owns.
+		BaseBranch:      env.task.BranchName,
+		Priority:        env.task.Priority,
+		AgentOverride:   env.task.AgentOverride,
+		ModelOverride:   env.task.ModelOverride,
+		EffortOverride:  env.task.EffortOverride,
+		State:           store.TaskQueued,
+		ParentTaskID:    &env.task.ID,
+		ParentStepIndex: &index,
+		LaneID:          lane.ID,
+		LaneOrder:       order,
+	}
+	// A lane spec overrides the inheritance for its own subtree.
+	if lane.Agent != "" {
+		child.AgentOverride = lane.Agent
+	}
+	if lane.Model != "" {
+		child.ModelOverride = lane.Model
+	}
+	if lane.Effort != "" {
+		child.EffortOverride = lane.Effort
+	}
+	if lane.Priority != nil {
+		child.Priority = *lane.Priority
+	}
+	return child, nil
+}
+
+// mergeFields merges a lane's fields over the parent's, the lane winning
+// (decision 29). Neither input is modified.
+func mergeFields(parent, lane map[string]string) map[string]string {
+	if len(parent) == 0 && len(lane) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(parent)+len(lane))
+	for k, v := range parent {
+		out[k] = v
+	}
+	for k, v := range lane {
+		out[k] = v
+	}
+	return out
+}
+
+// abandonPartialSpawn cancels lanes created before a spawn failed part-way.
+//
+// Without it a retry would create a second set of lanes beside the first, and
+// the join would merge a mixture of the two. Cancelling rather than deleting
+// keeps the rule that nothing destroys work: the branches and worktrees of
+// anything that started survive (decision 11).
+func (r *Runner) abandonPartialSpawn(ctx context.Context, env *stepEnv) {
+	children, err := r.deps.Store.ListChildren(ctx, env.task.ID)
+	if err != nil {
+		env.log.Error("list lanes to abandon", "error", err)
+		return
+	}
+	for _, c := range children {
+		if c.ParentStepIndex == nil || *c.ParentStepIndex != env.index {
+			continue
+		}
+		if taskstate.Settled(c.State) {
+			continue
+		}
+		if _, err := r.Cancel(r.persistCtx(), c.ID); err != nil {
+			env.log.Error("abandon partial lane", "child", c.ID, "error", err)
+		}
+	}
+}

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/lezli01/vincent/internal/store"
 )
 
+// fanOutBudget is how long a fan-out test waits. It is larger than the
+// default because a fan-out is a chain of admissions — parent, then each lane,
+// then the parent again — with a git worktree per lane and a merge at the
+// end, paced by the scheduler's 5s safety tick.
+const fanOutBudget = 150 * time.Second
+
 // laneStepIndent shifts a commandStep block (written at the top level's two
 // spaces) under a lane's `steps:`, which sits four levels in.
 const laneStepIndent = "        "
@@ -45,7 +51,7 @@ func fanOutSnapshot(merge string, lanes ...[2]string) string {
 // waitForChildren polls until the parent has the expected number of lanes.
 func (h *engineHarness) waitForChildren(t *testing.T, parentID int64, want int) []store.Task {
 	t.Helper()
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(fanOutBudget)
 	for time.Now().Before(deadline) {
 		kids, err := h.store.ListChildren(t.Context(), parentID)
 		if err != nil {
@@ -88,7 +94,7 @@ func TestFanOutSpawnsLanesAndMerges(t *testing.T) {
 		}
 	}
 
-	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	done := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskDone, store.TaskBlocked)
 	if done.State != store.TaskDone {
 		t.Fatalf("parent state = %s (block_reason %q), want done", done.State, done.BlockReason)
 	}
@@ -120,7 +126,7 @@ func TestFanOutParentHoldsNoSlotWhileWaiting(t *testing.T) {
 
 	// Under a cap of 1 this can only finish if the parked parent stopped
 	// counting against it.
-	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	done := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskDone, store.TaskBlocked)
 	if done.State != store.TaskDone {
 		t.Fatalf("parent state = %s (%q); a parked parent still held its slot",
 			done.State, done.BlockReason)
@@ -136,7 +142,7 @@ func TestFanOutBlocksOnMergeConflict(t *testing.T) {
 	task := h.createTask(t, fanOutSnapshot("",
 		[2]string{"api", "shared.txt"}, [2]string{"docs", "shared.txt"}))
 
-	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	blocked := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskBlocked, store.TaskDone)
 	if blocked.State != store.TaskBlocked {
 		t.Fatalf("parent state = %s, want blocked on the conflict", blocked.State)
 	}
@@ -177,7 +183,7 @@ func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
 		}
 	}
 
-	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	blocked := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskBlocked, store.TaskDone)
 	if blocked.State != store.TaskBlocked {
 		t.Fatalf("parent state = %s, want blocked", blocked.State)
 	}

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -1,0 +1,214 @@
+package taskrun
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// laneStepIndent shifts a commandStep block (written at the top level's two
+// spaces) under a lane's `steps:`, which sits four levels in.
+const laneStepIndent = "        "
+
+// writeFileStep is a command step that writes one file, so a lane produces a
+// commit the join has something to merge.
+func writeFileStep(id, file, content string) string {
+	return commandStep(id, script(
+		fmt.Sprintf("printf '%s\\n' > %s && git add -A && git commit -m %s", content, file, id),
+		fmt.Sprintf("Set-Content -Path %s -Value '%s'; git add -A; git commit -m %s", file, content, id),
+	), "max_retries: 0")
+}
+
+// fanOutSnapshot builds a workflow whose only step fans out into inline
+// lanes, each writing a file. The content is the lane id, so two lanes given
+// the same filename produce a real conflict rather than an identical blob git
+// merges without noticing.
+func fanOutSnapshot(merge string, lanes ...[2]string) string {
+	var sb strings.Builder
+	sb.WriteString("name: root\nsteps:\n  - id: build\n    type: fan_out\n")
+	if merge != "" {
+		sb.WriteString(merge)
+	}
+	sb.WriteString("    lanes:\n")
+	for _, lane := range lanes {
+		fmt.Fprintf(&sb, "      - id: %s\n        steps:\n", lane[0])
+		sb.WriteString(indent(writeFileStep("write-"+lane[0], lane[1], lane[0]), laneStepIndent))
+	}
+	return sb.String()
+}
+
+// waitForChildren polls until the parent has the expected number of lanes.
+func (h *engineHarness) waitForChildren(t *testing.T, parentID int64, want int) []store.Task {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		kids, err := h.store.ListChildren(t.Context(), parentID)
+		if err != nil {
+			t.Fatalf("ListChildren: %v", err)
+		}
+		if len(kids) >= want {
+			return kids
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never spawned %d lanes", parentID, want)
+	return nil
+}
+
+// TestFanOutSpawnsLanesAndMerges is the whole of phase 2 in one pass: the
+// parent spawns real child tasks, parks without holding a slot, and — once
+// they finish — merges both branches into its own.
+func TestFanOutSpawnsLanesAndMerges(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, fanOutSnapshot("", [2]string{"api", "api.txt"}, [2]string{"docs", "docs.txt"}))
+
+	lanes := h.waitForChildren(t, task.ID, 2)
+	// A lane is an ordinary task carrying four extra columns (decision 1).
+	for i, lane := range lanes {
+		if lane.ParentTaskID == nil || *lane.ParentTaskID != task.ID {
+			t.Errorf("lane %d has no parent link", lane.ID)
+		}
+		if lane.LaneOrder != i {
+			t.Errorf("lane %q order = %d, want %d — declared order is the merge order", lane.LaneID, lane.LaneOrder, i)
+		}
+		if lane.BaseBranch != task.BranchName {
+			t.Errorf("lane base_branch = %q, want the parent's branch %q", lane.BaseBranch, task.BranchName)
+		}
+		if lane.BranchName == task.BranchName {
+			t.Errorf("lane %q shares the parent's branch; it needs its own", lane.LaneID)
+		}
+		if !strings.Contains(lane.Title, lane.LaneID) {
+			t.Errorf("lane title %q does not name the lane", lane.Title)
+		}
+	}
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("parent state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	// One branch is delivered: both lanes' files are on the parent's branch.
+	for _, file := range []string{"api.txt", "docs.txt"} {
+		if !h.fileOnBranch(t, task.BranchName, file) {
+			t.Errorf("%s is missing from the parent's branch after the join", file)
+		}
+	}
+	// And the join is visible as a step, not an invisible git operation.
+	var sawJoin bool
+	for _, run := range h.stepRuns(t, task.ID) {
+		if run.StepID == "build" && run.State == store.StepSucceeded {
+			sawJoin = true
+		}
+	}
+	if !sawJoin {
+		t.Error("the fan_out step recorded no successful step run")
+	}
+}
+
+// TestFanOutParentHoldsNoSlotWhileWaiting is what makes deep fan-out
+// deadlock-free: the parent releases its slot before its children need one.
+// With a global cap of 1, a lane can only run if the parent gave up its slot.
+func TestFanOutParentHoldsNoSlotWhileWaiting(t *testing.T) {
+	h := newEngineHarnessWith(t, func(c *config.Config) { c.MaxParallelTasks = 1 })
+	h.start(t)
+	task := h.createTask(t, fanOutSnapshot("", [2]string{"api", "api.txt"}))
+
+	// Under a cap of 1 this can only finish if the parked parent stopped
+	// counting against it.
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("parent state = %s (%q); a parked parent still held its slot",
+			done.State, done.BlockReason)
+	}
+}
+
+// TestFanOutBlocksOnMergeConflict: two lanes writing the same file conflict,
+// and the default is to stop and leave the worktree conflicted for a human —
+// not to guess (decision 8).
+func TestFanOutBlocksOnMergeConflict(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, fanOutSnapshot("",
+		[2]string{"api", "shared.txt"}, [2]string{"docs", "shared.txt"}))
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("parent state = %s, want blocked on the conflict", blocked.State)
+	}
+	if blocked.BlockReason != ReasonMergeConflict {
+		t.Fatalf("block_reason = %q, want %q", blocked.BlockReason, ReasonMergeConflict)
+	}
+	// The worktree is left conflicted on purpose: that is what a human
+	// resolves in place.
+	inMerge, err := h.runner.deps.Worktrees.InMerge(t.Context(), blocked.WorktreePath)
+	if err != nil {
+		t.Fatalf("InMerge: %v", err)
+	}
+	if !inMerge {
+		t.Error("the conflicted merge was cleaned up; there is nothing left to resolve")
+	}
+}
+
+// TestFanOutBlocksWhenALaneDidNotFinish is decision 21: a cancelled lane
+// settles, but the join must not merge around it and deliver a branch missing
+// that lane's work with nothing saying so.
+func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// The slow lane is cancelled while it runs; the quick one finishes.
+	snapshot := "name: root\nsteps:\n  - id: build\n    type: fan_out\n    lanes:\n" +
+		"      - id: quick\n        steps:\n" +
+		indent(writeFileStep("write-quick", "quick.txt", "quick"), laneStepIndent) +
+		"      - id: slow\n        steps:\n" +
+		indent(commandStep("wait", sleepCmd(30), "max_retries: 0"), laneStepIndent)
+	task := h.createTask(t, snapshot)
+
+	lanes := h.waitForChildren(t, task.ID, 2)
+	for _, lane := range lanes {
+		if lane.LaneID == "slow" {
+			if _, err := h.runner.Cancel(t.Context(), lane.ID); err != nil {
+				t.Fatalf("cancel slow lane: %v", err)
+			}
+		}
+	}
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("parent state = %s, want blocked", blocked.State)
+	}
+	if blocked.BlockReason != ReasonLaneFailed {
+		t.Errorf("block_reason = %q, want %q", blocked.BlockReason, ReasonLaneFailed)
+	}
+	// Nothing was merged: a partial merge is indistinguishable downstream
+	// from a complete one.
+	if h.fileOnBranch(t, task.BranchName, "quick.txt") {
+		t.Error("the successful lane was merged anyway; the branch now looks complete")
+	}
+}
+
+// indent shifts a block of YAML right by prefix.
+func indent(block, prefix string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(block, "\n"), "\n") {
+		sb.WriteString(prefix + line + "\n")
+	}
+	return sb.String()
+}
+
+// fileOnBranch reports whether a path exists in a branch's tip tree.
+func (h *engineHarness) fileOnBranch(t *testing.T, branch, file string) bool {
+	t.Helper()
+	out, err := h.git().Run(t.Context(), h.repo, "ls-tree", "--name-only", branch, file)
+	if err != nil {
+		t.Fatalf("ls-tree %s %s: %v", branch, file, err)
+	}
+	return strings.TrimSpace(out) != ""
+}
+
+// git is a handle for reading the repository the test asserts against.
+func (h *engineHarness) git() *gitx.Git { return gitx.New() }

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -1,0 +1,168 @@
+package taskrun
+
+// Parallel step groups (spec §7, task 014 — phase 1). A `type: parallel` step
+// runs its sub-steps concurrently in the task's one worktree: no branch, no
+// child task, no merge. Everything that makes a step a step — retries,
+// timeouts, checks, transcripts, live output — is the ordinary machinery,
+// reached once per sub-step instead of once per step.
+//
+// Two properties are worth stating because the rest of the file assumes them:
+//
+//   - The group holds **one** scheduler slot however many sub-steps it runs,
+//     so `max_parallel` is a second concurrency dimension the §11 caps do not
+//     see (decision 30). That is why it has a configured default.
+//   - The group itself owns no `step_runs` row (decision 17). Its outcome is
+//     collected from its sub-steps' rows, and a re-admission derives what is
+//     left to do from those same rows rather than from a stored cursor.
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// runGroup executes one `parallel` step and returns the outcome the engine's
+// step loop acts on, exactly as if the group had been a single step.
+//
+// Sub-steps run in goroutines forked from the actor's own, bounded by
+// `max_parallel`. Each owns its `step_runs` rows exclusively — no row has two
+// writers, and nothing here touches the *task* row, which stays the actor's
+// alone (the invariant in CLAUDE.md).
+func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
+	subs, skipped, err := r.pendingSubSteps(ctx, env)
+	if err != nil {
+		env.log.Error("read group history", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	if len(subs) == 0 {
+		// Every sub-step already succeeded under an earlier admission. The
+		// group is done, and re-running it would discard work a human may
+		// have waited an hour for.
+		env.log.Info("parallel group already complete", "sub_steps", skipped)
+		return stepOutcome{state: store.StepSucceeded}
+	}
+
+	// A group-level `timeout:` bounds the whole group; each sub-step still
+	// has its own. Expiry cancels the sub-steps, which end as interruptions —
+	// the group turns that back into a failure below, because the work ran
+	// out of the time the workflow gave it rather than stopping for the
+	// daemon's sake (§7.2).
+	groupCtx, cancel := context.WithCancel(ctx)
+	if env.step.Timeout != nil {
+		groupCtx, cancel = context.WithTimeout(ctx, env.step.Timeout.Std())
+	}
+	defer cancel()
+
+	limit := r.groupLimit(env.step)
+	env.log.Info("parallel group started",
+		"sub_steps", len(subs), "already_succeeded", skipped, "max_parallel", limit)
+
+	outcomes := make([]stepOutcome, len(subs))
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for i, sub := range subs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			// A sibling's failure does not cancel this one (decision 18): the
+			// group waits for everything it started, so a nearly-finished test
+			// run is not thrown away by a linter that failed first.
+			subEnv := &stepEnv{
+				task: env.task, project: env.project, wf: env.wf,
+				step: sub, index: env.index, inGroup: true,
+				log: env.log.With("sub_step", sub.ID),
+			}
+			outcomes[i] = r.runStepWithRetries(groupCtx, subEnv)
+		}()
+	}
+	wg.Wait()
+
+	// The group's own deadline, not the daemon's: a shutdown cancels the
+	// parent context too, and that one must stay an interruption so the task
+	// is re-admitted rather than blocked.
+	if errors.Is(groupCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+		env.log.Warn("parallel group timed out", "timeout", env.step.Timeout)
+		return stepOutcome{state: store.StepFailed, reason: ReasonTimeout}
+	}
+	return collectGroup(outcomes)
+}
+
+// pendingSubSteps is the sub-steps this admission must actually run, in
+// declaration order, plus how many were skipped as already done.
+//
+// A human retry re-admits the task at the group's index, and a sub-step whose
+// latest attempt succeeded must not run again — 014.2's "a retry re-runs only
+// the failed sub-step". The fact is derived from the rows rather than stored,
+// for the reason decisions 9 and 13 give: a second copy can disagree.
+func (r *Runner) pendingSubSteps(ctx context.Context, env *stepEnv) (subs []workflow.Step, skipped int, err error) {
+	latest, err := r.deps.Store.LatestStepStates(ctx, env.task.ID, env.index)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, sub := range env.step.Steps {
+		if latest[sub.ID] == store.StepSucceeded {
+			skipped++
+			continue
+		}
+		subs = append(subs, sub)
+	}
+	return subs, skipped, nil
+}
+
+// subStepIDOf names the transcript of an attempt: empty for an ordinary step,
+// whose index already identifies it, and the step id for a member of a group,
+// whose siblings share that index (decision 16).
+func subStepIDOf(env *stepEnv) string {
+	if env.inGroup {
+		return env.step.ID
+	}
+	return ""
+}
+
+// groupLimit resolves how many sub-steps run at once: the group's own
+// `max_parallel:`, else the daemon default. Read here rather than cached, so
+// a hot reload governs the next group (decision 30).
+func (r *Runner) groupLimit(step workflow.Step) int {
+	if step.MaxParallel != nil && *step.MaxParallel > 0 {
+		return *step.MaxParallel
+	}
+	if n := r.deps.Config().Parallel.MaxParallel; n > 0 {
+		return n
+	}
+	return 1
+}
+
+// collectGroup reduces the sub-step outcomes to the group's own, in
+// declaration order so the same set of failures always reports the same
+// reason.
+//
+// Precedence is interruption, then failure, then success. An interruption
+// means the daemon is stopping or a quota is spent: that attempt consumed no
+// retry and the task will be re-admitted, so reporting a sibling's failure
+// instead would block a task that is only paused.
+func collectGroup(outcomes []stepOutcome) stepOutcome {
+	var failure *stepOutcome
+	for i := range outcomes {
+		switch outcomes[i].state {
+		case store.StepInterrupted:
+			return outcomes[i]
+		case store.StepFailed:
+			if failure == nil {
+				failure = &outcomes[i]
+			}
+		case store.StepSucceeded, store.StepRunning, store.StepApproved,
+			store.StepRejected, store.StepSkipped:
+		}
+	}
+	if failure != nil {
+		return *failure
+	}
+	// Every sub-step succeeded, so the group did: that is the whole of its
+	// success condition (014.2).
+	return stepOutcome{state: store.StepSucceeded}
+}

--- a/internal/taskrun/group_test.go
+++ b/internal/taskrun/group_test.go
@@ -1,0 +1,268 @@
+package taskrun
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// groupSnapshot builds a workflow whose only step is a parallel group holding
+// the given sub-steps, already indented one level deeper than commandStep
+// writes them.
+func groupSnapshot(groupFields string, subSteps ...string) string {
+	var sb strings.Builder
+	sb.WriteString("name: verify\nsteps:\n  - id: group\n    type: parallel\n")
+	if groupFields != "" {
+		for _, line := range strings.Split(groupFields, "\n") {
+			fmt.Fprintf(&sb, "    %s\n", line)
+		}
+	}
+	sb.WriteString("    steps:\n")
+	for _, sub := range subSteps {
+		for _, line := range strings.Split(strings.TrimRight(sub, "\n"), "\n") {
+			fmt.Fprintf(&sb, "  %s\n", line)
+		}
+	}
+	return sb.String()
+}
+
+// sleepCmd is a portable "take about a second".
+func sleepCmd(seconds int) string {
+	return script(
+		fmt.Sprintf("sleep %d", seconds),
+		fmt.Sprintf("Start-Sleep -Seconds %d", seconds),
+	)
+}
+
+// subRuns indexes a task's step runs by sub-step id.
+func subRuns(runs []store.StepRun) map[string][]store.StepRun {
+	out := map[string][]store.StepRun{}
+	for _, r := range runs {
+		out[r.StepID] = append(out[r.StepID], r)
+	}
+	return out
+}
+
+// TestParallelGroupRunsConcurrently is the point of the feature: three
+// one-second sub-steps finish in about a second, not three. It also pins the
+// row shape — one row per sub-step, all sharing the group's step_index, told
+// apart by step_id (task 014 decision 16) — and that the group itself writes
+// no row of its own (decision 17).
+func TestParallelGroupRunsConcurrently(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 3",
+		commandStep("one", sleepCmd(1)),
+		commandStep("two", sleepCmd(1)),
+		commandStep("three", sleepCmd(1)),
+	)
+	task := h.createTask(t, snapshot)
+
+	started := time.Now()
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	elapsed := time.Since(started)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	// Serial execution takes at least three seconds. The margin is wide
+	// because CI is shared, but it cannot reach three without the sub-steps
+	// having queued behind each other.
+	if elapsed > 2500*time.Millisecond {
+		t.Errorf("group took %s for 3x1s sub-steps, want well under the 3s a serial run costs", elapsed)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 3 {
+		t.Fatalf("step runs = %d, want 3 — one per sub-step and none for the group", len(runs))
+	}
+	for _, r := range runs {
+		if r.StepIndex != 0 {
+			t.Errorf("sub-step %q step_index = %d, want the group's 0", r.StepID, r.StepIndex)
+		}
+		if r.State != store.StepSucceeded {
+			t.Errorf("sub-step %q state = %s, want succeeded", r.StepID, r.State)
+		}
+		if r.StepID == "group" {
+			t.Error("the group wrote a step_runs row of its own; its outcome is derived")
+		}
+	}
+	if got := len(subRuns(runs)); got != 3 {
+		t.Errorf("distinct sub-step ids = %d, want 3", got)
+	}
+}
+
+// TestParallelGroupMaxParallelBounds: the same three sub-steps under
+// max_parallel 1 must queue, which is what makes the knob real rather than
+// advisory.
+func TestParallelGroupMaxParallelBounds(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 1",
+		commandStep("one", sleepCmd(1)),
+		commandStep("two", sleepCmd(1)),
+	)
+	task := h.createTask(t, snapshot)
+
+	started := time.Now()
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	elapsed := time.Since(started)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	if elapsed < 2*time.Second {
+		t.Errorf("group took %s for 2x1s sub-steps at max_parallel 1, want at least 2s", elapsed)
+	}
+}
+
+// TestParallelGroupFailureDoesNotCancelSiblings covers decision 18: the group
+// fails, but only after every sub-step it started has finished on its own.
+func TestParallelGroupFailureDoesNotCancelSiblings(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 3",
+		commandStep("fails", script("exit 3", "exit 3"), "max_retries: 0"),
+		commandStep("slow", sleepCmd(1), "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked on the failing sub-step", blocked.State)
+	}
+	if blocked.BlockReason != ReasonNonzeroExit {
+		t.Errorf("block_reason = %q, want %q", blocked.BlockReason, ReasonNonzeroExit)
+	}
+	by := subRuns(h.stepRuns(t, task.ID))
+	if len(by["slow"]) != 1 || by["slow"][0].State != store.StepSucceeded {
+		t.Errorf("sibling runs = %+v, want one succeeded row — a failure must not cancel it", by["slow"])
+	}
+	if len(by["fails"]) != 1 || by["fails"][0].State != store.StepFailed {
+		t.Errorf("failing runs = %+v, want one failed row", by["fails"])
+	}
+}
+
+// TestParallelGroupRetriesOnlyTheFailedSubStep covers the per-sub-step retry
+// budget: the flaky sub-step burns its own retry while its siblings run once.
+func TestParallelGroupRetriesOnlyTheFailedSubStep(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// Succeeds on the second attempt: the first creates the marker and fails,
+	// the second finds it.
+	flaky := script(
+		"if [ -f marker ]; then exit 0; fi; touch marker; exit 1",
+		"if (Test-Path marker) { exit 0 }; New-Item -ItemType File marker | Out-Null; exit 1",
+	)
+	snapshot := groupSnapshot("max_parallel: 2",
+		commandStep("flaky", flaky, "max_retries: 1"),
+		commandStep("steady", script("true", "Write-Output ok"), "max_retries: 1"),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done after the retry", done.State, done.BlockReason)
+	}
+	by := subRuns(h.stepRuns(t, task.ID))
+	if len(by["flaky"]) != 2 {
+		t.Errorf("flaky attempts = %d, want 2", len(by["flaky"]))
+	}
+	if len(by["steady"]) != 1 {
+		t.Errorf("steady attempts = %d, want 1 — a sibling's retry is not its own", len(by["steady"]))
+	}
+	// Attempt numbers are per sub-step, not per index: both start at 1.
+	for id, runs := range by {
+		if runs[0].Attempt != 1 {
+			t.Errorf("sub-step %q first attempt = %d, want 1", id, runs[0].Attempt)
+		}
+	}
+}
+
+// TestParallelGroupRetryDoesNotRerunSucceededSubSteps is the re-admission
+// half of "a retry re-runs only the failed sub-step": a human retry after a
+// block must not redo work that already succeeded, which the engine derives
+// from the rows rather than from a stored cursor.
+func TestParallelGroupRetryDoesNotRerunSucceededSubSteps(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// Fails on the first attempt only, so the human retry can succeed.
+	oncePerTask := script(
+		"if [ -f marker ]; then exit 0; fi; touch marker; exit 1",
+		"if (Test-Path marker) { exit 0 }; New-Item -ItemType File marker | Out-Null; exit 1",
+	)
+	snapshot := groupSnapshot("max_parallel: 2",
+		commandStep("fails", oncePerTask, "max_retries: 0"),
+		commandStep("succeeds", script("true", "Write-Output ok"), "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	if blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone); blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked before the retry", blocked.State)
+	}
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+
+	by := subRuns(h.stepRuns(t, task.ID))
+	if len(by["succeeds"]) != 1 {
+		t.Errorf("already-succeeded sub-step ran %d times, want 1 — a retry re-runs only what failed",
+			len(by["succeeds"]))
+	}
+	if len(by["fails"]) != 2 {
+		t.Errorf("failed sub-step attempts = %d, want 2 (the failure and the retry)", len(by["fails"]))
+	}
+}
+
+// TestParallelGroupTimeoutFails: a group-level timeout bounds the whole
+// group, and its expiry is a failure rather than an interruption — an
+// interruption would re-queue the task and run straight back into it.
+func TestParallelGroupTimeoutFails(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 2\ntimeout: 1s",
+		commandStep("slow", sleepCmd(30), "max_retries: 0"),
+		commandStep("quick", script("true", "Write-Output ok"), "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked on the group timeout", blocked.State)
+	}
+	if blocked.BlockReason != ReasonTimeout {
+		t.Errorf("block_reason = %q, want %q", blocked.BlockReason, ReasonTimeout)
+	}
+}
+
+// TestParallelSubStepTranscriptsDoNotCollide: sub-steps share a step_index,
+// so their transcript names must not be built from the index alone.
+func TestParallelSubStepTranscriptsDoNotCollide(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 2",
+		commandStep("alpha", script("echo alpha", "Write-Output alpha")),
+		commandStep("beta", script("echo beta", "Write-Output beta")),
+	)
+	task := h.createTask(t, snapshot)
+	if done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked); done.State != store.TaskDone {
+		t.Fatalf("task state = %s, want done", done.State)
+	}
+
+	seen := map[string]string{}
+	for _, r := range h.stepRuns(t, task.ID) {
+		if r.TranscriptPath == "" {
+			t.Errorf("sub-step %q recorded no transcript path", r.StepID)
+			continue
+		}
+		if other, dup := seen[r.TranscriptPath]; dup {
+			t.Errorf("sub-steps %q and %q share transcript %s", other, r.StepID, r.TranscriptPath)
+		}
+		seen[r.TranscriptPath] = r.StepID
+	}
+}

--- a/internal/taskrun/join.go
+++ b/internal/taskrun/join.go
@@ -1,0 +1,229 @@
+package taskrun
+
+// The join half of a `fan_out` step (spec §7.6, task 014 decisions 3, 7, 8,
+// 9, 21, 22). The parent has woken from `awaiting_children` and now merges
+// every lane's branch into the branch it already owns, so that one branch is
+// still delivered at the end.
+//
+// Merges are sequential, `--no-ff`, in **declared** lane order, stopping at
+// the first conflict. Declared rather than completion order is what makes a
+// re-run conflict identically, which the idempotent recovery below depends
+// on.
+//
+// Nothing here persists a merge cursor. Which lanes are already merged is a
+// fact git holds authoritatively — an already-merged lane re-merges as
+// "Already up to date" — and a stored copy can disagree with the repository
+// after a human runs `git merge --abort` themselves (decision 9).
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// ReasonLaneFailed is a fan-out whose lane did not finish its work: it was
+// cancelled, or it failed and a human ended it (§18, task 014 decision 21).
+// Nothing is merged — a partial merge is indistinguishable, downstream, from
+// a complete one.
+const ReasonLaneFailed = "lane_failed"
+
+// ReasonMergeConflict re-exports the worktree taxonomy's name so the engine's
+// vocabulary stays one list (T1.5/T1.6 decision).
+const ReasonMergeConflict = worktree.ReasonMergeConflict
+
+// runJoinStep is the fan_out step's executor on a re-admission: it loads the
+// lanes this step spawned and merges them.
+func (r *Runner) runJoinStep(ctx context.Context, env *stepEnv, tr *transcript) stepOutcome {
+	children, err := r.deps.Store.ListChildren(ctx, env.task.ID)
+	if err != nil {
+		env.log.Error("list lanes", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	lanes := make([]store.Task, 0, len(children))
+	for _, c := range children {
+		if c.ParentStepIndex != nil && *c.ParentStepIndex == env.index {
+			lanes = append(lanes, c)
+		}
+	}
+	tr.Note("join_started", map[string]any{"lanes": len(lanes), "step_id": env.step.ID})
+	outcome := r.runJoin(ctx, env, lanes)
+	tr.Note("join_finished", map[string]any{
+		"state": string(outcome.state), "reason": outcome.reason,
+	})
+	return outcome
+}
+
+// runJoin merges every lane of one fan_out step into the parent's branch.
+func (r *Runner) runJoin(ctx context.Context, env *stepEnv, lanes []store.Task) stepOutcome {
+	// Every lane must have *finished its work*, not merely settled: an
+	// aborted lane settled too, and merging around it would deliver a branch
+	// missing that lane with nothing saying so (decision 21).
+	for _, lane := range lanes {
+		if lane.State != store.TaskDone {
+			env.log.Warn("lane did not finish", "lane", lane.LaneID, "child", lane.ID, "state", lane.State)
+			return stepOutcome{
+				state:  store.StepFailed,
+				reason: ReasonLaneFailed,
+				output: fmt.Sprintf("lane %q (task %d) is %s, not done", lane.LaneID, lane.ID, lane.State),
+			}
+		}
+	}
+
+	// Re-entry (decision 9). A merge already in progress means one of two
+	// very different things, and only one of them may abort.
+	if outcome, handled := r.resumeMerge(ctx, env); handled {
+		return outcome
+	}
+
+	for _, lane := range lanes {
+		result, err := r.deps.Worktrees.MergeLane(ctx, env.task.WorktreePath,
+			lane.BranchName, lane.LaneID, lane.ID)
+		if err != nil {
+			reason := worktree.ReasonOf(err)
+			if reason == "" {
+				reason = worktree.ReasonGitError
+			}
+			env.log.Error("merge lane", "lane", lane.LaneID, "error", err)
+			return stepOutcome{state: store.StepFailed, reason: reason, output: err.Error()}
+		}
+		if result == worktree.MergeConflicted {
+			resolved, outcome := r.handleConflict(ctx, env, lane)
+			if !resolved {
+				return outcome
+			}
+			// The resolver fixed it and the merge is committed, so the join
+			// carries on with the remaining lanes in the same admission.
+		}
+		env.log.Info("lane merged", "lane", lane.LaneID, "child", lane.ID, "branch", lane.BranchName)
+	}
+	return stepOutcome{state: store.StepSucceeded, result: fmt.Sprintf("merged %d lanes", len(lanes))}
+}
+
+// resumeMerge handles a join re-entered with a merge already in progress. It
+// reports whether it took over — when it did, the caller must not start
+// merging from the top.
+//
+// The task's own state is what disambiguates, which is why no cursor is
+// stored:
+//
+//   - `blocked` with merge_conflict is a human who has just resolved by hand
+//     and hit retry. A clean index means commit and carry on with the
+//     remaining lanes; a still-conflicted one means block again.
+//   - anything else is a crash between two lanes. Recovery aborts and
+//     re-merges every lane from the top, which is a no-op for the ones
+//     already in.
+//
+// The failure this distinction exists to prevent is specific and expensive:
+// recovery running `--abort` over a conflict a human spent an hour resolving.
+func (r *Runner) resumeMerge(ctx context.Context, env *stepEnv) (stepOutcome, bool) {
+	inMerge, err := r.deps.Worktrees.InMerge(ctx, env.task.WorktreePath)
+	if err != nil {
+		env.log.Error("check merge state", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: worktree.ReasonGitError}, true
+	}
+	if !inMerge {
+		return stepOutcome{}, false
+	}
+
+	if env.resumedFromConflict {
+		conflicted, err := r.deps.Worktrees.IndexConflicted(ctx, env.task.WorktreePath)
+		if err != nil {
+			env.log.Error("check index", "error", err)
+			return stepOutcome{state: store.StepFailed, reason: worktree.ReasonGitError}, true
+		}
+		if conflicted {
+			env.log.Warn("retry with the conflict still unresolved")
+			return stepOutcome{
+				state:  store.StepFailed,
+				reason: ReasonMergeConflict,
+				output: "the merge is still conflicted; resolve and stage the files, then retry",
+			}, true
+		}
+		if err := r.deps.Worktrees.CommitMerge(ctx, env.task.WorktreePath); err != nil {
+			env.log.Error("commit resolved merge", "error", err)
+			return stepOutcome{state: store.StepFailed, reason: worktree.ReasonGitError}, true
+		}
+		env.log.Info("resolved merge committed; continuing with the remaining lanes")
+		// Fall through to the ordinary loop: the merged lanes are now
+		// "Already up to date" no-ops and the rest merge normally.
+		return stepOutcome{}, false
+	}
+
+	// A crash mid-merge. Abort, then re-merge from the top.
+	if err := r.deps.Worktrees.AbortMerge(ctx, env.task.WorktreePath); err != nil {
+		env.log.Error("abort interrupted merge", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: worktree.ReasonGitError}, true
+	}
+	env.log.Info("aborted a merge interrupted mid-join; re-merging every lane")
+	return stepOutcome{}, false
+}
+
+// handleConflict applies the step's `on_conflict:` policy to a conflicted
+// merge. The default blocks; `agent` tries a resolver first and falls back to
+// the block when it or its check fails.
+//
+// Blocking by default is §7.2's posture applied unchanged: retries are for
+// failures a retry can fix, and a human decides what a machine could not. The
+// alternative default — an agent silently resolving a semantic conflict and
+// the merge commit landing unread — is the one outcome that turns a
+// time-saving feature into a correctness liability.
+// It reports whether the conflict was resolved, so the caller can continue
+// with the remaining lanes rather than restarting the join.
+func (r *Runner) handleConflict(
+	ctx context.Context, env *stepEnv, lane store.Task,
+) (resolved bool, outcome stepOutcome) {
+	paths, err := r.deps.Worktrees.ConflictedPaths(ctx, env.task.WorktreePath)
+	if err != nil {
+		env.log.Error("list conflicted paths", "error", err)
+	}
+	blocked := stepOutcome{
+		state:  store.StepFailed,
+		reason: ReasonMergeConflict,
+		output: fmt.Sprintf("lane %q (task %d) conflicts in:\n%s",
+			lane.LaneID, lane.ID, strings.Join(paths, "\n")),
+	}
+	if env.step.ConflictPolicy() != workflow.ConflictAgent || env.step.Merge.Agent == nil {
+		env.log.Warn("merge conflict; blocking for a human",
+			"lane", lane.LaneID, "files", len(paths))
+		return false, blocked
+	}
+
+	env.log.Info("merge conflict; trying the agent resolver", "lane", lane.LaneID, "files", len(paths))
+	resolver := *env.step.Merge.Agent
+	resolver.Type = workflow.StepAgent
+	// The resolver is an ordinary agent step, run by the ordinary executor in
+	// the parent's worktree, with the conflicted files in its context
+	// (decision 24).
+	resolverEnv := &stepEnv{
+		task: env.task, project: env.project, wf: env.wf,
+		step: resolver, index: env.index, inGroup: true,
+		conflicts: paths,
+		log:       env.log.With("merge_resolver", resolver.ID),
+	}
+	attempt := r.runStepWithRetries(ctx, resolverEnv)
+	if attempt.state != store.StepSucceeded {
+		env.log.Warn("agent resolver did not resolve the conflict; blocking",
+			"reason", attempt.reason)
+		return false, blocked
+	}
+	// The agent may have edited without staging. Staging here rather than
+	// requiring it of the prompt keeps the contract "leave the files right".
+	if err := r.deps.Worktrees.StageAll(ctx, env.task.WorktreePath); err != nil {
+		env.log.Error("stage resolver output", "error", err)
+		return false, blocked
+	}
+	if conflicted, cErr := r.deps.Worktrees.IndexConflicted(ctx, env.task.WorktreePath); cErr != nil || conflicted {
+		env.log.Warn("conflict markers survived the resolver; blocking")
+		return false, blocked
+	}
+	if err := r.deps.Worktrees.CommitMerge(ctx, env.task.WorktreePath); err != nil {
+		env.log.Error("commit resolver merge", "error", err)
+		return false, blocked
+	}
+	env.log.Info("agent resolved the merge conflict", "lane", lane.LaneID)
+	return true, stepOutcome{}
+}

--- a/internal/taskrun/join.go
+++ b/internal/taskrun/join.go
@@ -162,6 +162,30 @@ func (r *Runner) resumeMerge(ctx context.Context, env *stepEnv) (stepOutcome, bo
 	return stepOutcome{}, false
 }
 
+// resumedFromConflict reports whether this admission follows a human
+// resolving a merge conflict by hand, as opposed to a crash mid-join.
+//
+// It is read from the step's own history rather than from the task's state,
+// which cannot answer it: the scheduler moves a retried task out of `blocked`
+// before the engine ever sees it, so by here every re-entry looks alike. The
+// last attempt does distinguish them — a conflict block leaves a `failed` row
+// with reason merge_conflict, and a crash leaves an `interrupted` one.
+//
+// The caller must ask **before** creating this attempt's row, which would
+// otherwise be the latest one and hide the evidence.
+//
+// Getting this wrong in the safe direction costs a re-merge; getting it wrong
+// in the other direction runs `git merge --abort` over an hour of somebody's
+// hand resolution, which is the failure decision 9 exists to prevent.
+func (r *Runner) resumedFromConflict(ctx context.Context, env *stepEnv) bool {
+	last, err := r.deps.Store.LatestStepRun(ctx, env.task.ID, env.index, env.step.ID)
+	if err != nil {
+		env.log.Error("read the join's last attempt", "error", err)
+		return false
+	}
+	return last != nil && last.State == store.StepFailed && last.FailureReason == ReasonMergeConflict
+}
+
 // handleConflict applies the step's `on_conflict:` policy to a conflicted
 // merge. The default blocks; `agent` tries a resolver first and falls back to
 // the block when it or its check fails.

--- a/internal/taskrun/recover.go
+++ b/internal/taskrun/recover.go
@@ -55,7 +55,11 @@ func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error
 		if !ok {
 			continue // the FSM defines Interrupt from both; belt and braces
 		}
-		tasks, err := st.ListTasks(ctx, store.TaskFilter{State: state})
+		// ChildrenInclude explicitly: recovery is about every task the daemon
+		// left running, and a fan-out lane is one of those (task 014). The
+		// list default hides lanes for the board's benefit, which is exactly
+		// the wrong behaviour here.
+		tasks, err := st.ListTasks(ctx, store.TaskFilter{State: state, Children: store.ChildrenInclude})
 		if err != nil {
 			return requeued, err
 		}

--- a/internal/taskrun/recover_test.go
+++ b/internal/taskrun/recover_test.go
@@ -121,7 +121,7 @@ func TestRecoverRequeuesThroughTheFSM(t *testing.T) {
 	}
 
 	// An interruption consumes no retry (§7.2).
-	attempts, err := st.CountStepAttempts(ctx, running.ID, 0, time.Time{})
+	attempts, err := st.CountStepAttempts(ctx, running.ID, 0, "s", time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -12,7 +12,9 @@ import (
 )
 
 // transcript is one attempt's transcript file (spec §12.2:
-// {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl). Agent
+// {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl, with a
+// sub-step of a `parallel` group taking {step_index}-{step_id}-{attempt}).
+// Agent
 // stream lines are written verbatim so the file stays replayable; vincent's
 // own annotations are namespaced `vincent.*` (phase 1 decision).
 type transcript struct {
@@ -31,12 +33,22 @@ type transcript struct {
 }
 
 // openTranscript creates the transcript file for one attempt.
-func openTranscript(dataDir string, taskID int64, stepIndex, attempt int) (*transcript, error) {
+//
+// subStepID is empty for an ordinary step, whose index owns its name. A
+// member of a `parallel` group shares its group's index with its siblings, so
+// its id joins the name — `{step_index}-{step_id}-{attempt}.jsonl` — or three
+// concurrent sub-steps would open, and truncate, one file (task 014 decision
+// 16). Ids are slugs, so nothing here can escape the directory.
+func openTranscript(dataDir string, taskID int64, stepIndex, attempt int, subStepID string) (*transcript, error) {
 	dir := filepath.Join(dataDir, "transcripts", strconv.FormatInt(taskID, 10))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create transcript dir: %w", err)
 	}
-	path := filepath.Join(dir, fmt.Sprintf("%d-%d.jsonl", stepIndex, attempt))
+	name := fmt.Sprintf("%d-%d.jsonl", stepIndex, attempt)
+	if subStepID != "" {
+		name = fmt.Sprintf("%d-%s-%d.jsonl", stepIndex, subStepID, attempt)
+	}
+	path := filepath.Join(dir, name)
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("create transcript: %w", err)

--- a/internal/taskrun/transcript_test.go
+++ b/internal/taskrun/transcript_test.go
@@ -10,7 +10,7 @@ import (
 
 func openTestTranscript(t *testing.T, limit int64) *transcript {
 	t.Helper()
-	tr, err := openTranscript(t.TempDir(), 1, 0, 1)
+	tr, err := openTranscript(t.TempDir(), 1, 0, 1, "")
 	if err != nil {
 		t.Fatalf("openTranscript: %v", err)
 	}

--- a/internal/taskrun/usagelimit_test.go
+++ b/internal/taskrun/usagelimit_test.go
@@ -84,7 +84,7 @@ func TestUsageLimitReQueuesAndConsumesNoRetry(t *testing.T) {
 
 	// The budget itself, as the engine counts it: interrupted attempts are
 	// excluded, so the step still has its full max_retries for a real failure.
-	attempts, err := h.store.CountStepAttempts(t.Context(), task.ID, 0, time.Time{})
+	attempts, err := h.store.CountStepAttempts(t.Context(), task.ID, 0, "implement", time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -15,16 +15,27 @@ const (
 	Running       State = "running"
 	AwaitingGate  State = "awaiting_gate"
 	AwaitingInput State = "awaiting_input"
-	Blocked       State = "blocked"
-	Paused        State = "paused"
-	Done          State = "done"
-	Aborted       State = "aborted"
-	Archived      State = "archived"
+	// AwaitingChildren is a `fan_out` step's parent waiting for its lanes
+	// (§7.6, task 014). It holds **no** slot: the actor invariant says a
+	// gate, a block or a pause releases the slot and ends the goroutine, and
+	// a parent that kept one for hours while its children worked is the exact
+	// starvation awaiting_gate exists to avoid.
+	//
+	// It is a state of its own rather than a reuse of awaiting_gate because
+	// the two differ in what a human can do about them, which is the only
+	// thing §6 is for: awaiting_gate offers approve/reject/skip, and none of
+	// the three mean anything while children are still running.
+	AwaitingChildren State = "awaiting_children"
+	Blocked          State = "blocked"
+	Paused           State = "paused"
+	Done             State = "done"
+	Aborted          State = "aborted"
+	Archived         State = "archived"
 )
 
 // All lists every state, in the order §6 documents them.
 var All = []State{
-	Queued, Running, AwaitingGate, AwaitingInput,
+	Queued, Running, AwaitingGate, AwaitingInput, AwaitingChildren,
 	Blocked, Paused, Done, Aborted, Archived,
 }
 
@@ -45,6 +56,21 @@ func HoldsSlot(s State) bool { return s == Running || s == AwaitingInput }
 
 // Terminal reports whether no further transition is possible.
 func Terminal(s State) bool { return s == Archived }
+
+// Settled reports whether a task has finished in the sense a fan-out join
+// needs: it is done, or it ended without finishing (§6, task 014 decision
+// 20). A parent resumes when every descendant is settled.
+//
+// This is deliberately **not** Terminal, which means "no further transition
+// is possible" and is true of `archived` alone — a `done` task can still be
+// archived. Nor is it "holds no slot": `blocked`, `awaiting_gate` and
+// `paused` hold none, and a join that proceeded over a blocked lane would
+// merge a branch missing that lane's work with nothing in the result saying
+// so. Those three hold the join open until a human resolves them, which is
+// what the §13.2 children rollup exists to surface.
+//
+// `archived` counts as settled: it is reachable only from done or aborted.
+func Settled(s State) bool { return s == Done || s == Aborted || s == Archived }
 
 // Action is something that moves a task between states: either a human
 // action (§6) or an engine event.
@@ -87,6 +113,12 @@ const (
 	InputClosed Action = "input_closed"
 	// Park is a requested pause taking effect at the step boundary (§6).
 	Park Action = "park"
+	// FanOut is a fan_out step parking its parent after spawning its lanes
+	// (§7.6, task 014).
+	FanOut Action = "fan_out"
+	// ChildrenSettled is every descendant of a parked parent having settled,
+	// which returns it to the queue to run its join.
+	ChildrenSettled Action = "children_settled"
 )
 
 // humanActions is the set of actions a client may invoke, in the order §6
@@ -117,12 +149,13 @@ type Transition struct {
 // Every allowed transition in vincent appears here exactly once.
 var table = map[Action]map[State]Transition{
 	Cancel: {
-		Queued:        {To: Aborted},
-		Running:       {To: Aborted},
-		AwaitingInput: {To: Aborted},
-		AwaitingGate:  {To: Aborted},
-		Blocked:       {To: Aborted},
-		Paused:        {To: Aborted},
+		Queued:           {To: Aborted},
+		Running:          {To: Aborted},
+		AwaitingInput:    {To: Aborted},
+		AwaitingGate:     {To: Aborted},
+		AwaitingChildren: {To: Aborted},
+		Blocked:          {To: Aborted},
+		Paused:           {To: Aborted},
 	},
 	Pause: {
 		Queued: {To: Paused},
@@ -145,6 +178,17 @@ var table = map[Action]map[State]Transition{
 	Interrupt:    {Running: {To: Queued}, AwaitingInput: {To: Queued}},
 	InputClosed:  {AwaitingInput: {To: Running}},
 	Park:         {Running: {To: Paused}},
+
+	// Fan-out (task 014). A parent parks in awaiting_children when its
+	// fan_out step has spawned its lanes, and the scheduler — the one place
+	// admission decisions are unraced — re-queues it once every descendant
+	// has Settled.
+	//
+	// There is deliberately no Pause row: pause is valid from queued and
+	// running, and a parent that owns nothing running has nothing to pause.
+	// Its children are ordinary tasks and pause individually.
+	FanOut:          {Running: {To: AwaitingChildren}},
+	ChildrenSettled: {AwaitingChildren: {To: Queued}},
 }
 
 // Next returns the transition for applying a to a task in state from. ok is

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -9,6 +9,7 @@ import (
 var allActions = []Action{
 	Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive,
 	Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
+	FanOut, ChildrenSettled,
 }
 
 // wantTransitions is the §6 transition table restated independently of the
@@ -25,6 +26,7 @@ var wantTransitions = map[State]map[Action]State{
 		Pause:        Running, // deferred to the step boundary
 		Gate:         AwaitingGate,
 		RequestInput: AwaitingInput,
+		FanOut:       AwaitingChildren,
 		Complete:     Done,
 		Fail:         Blocked,
 		Interrupt:    Queued,
@@ -42,6 +44,15 @@ var wantTransitions = map[State]map[Action]State{
 		Fail:        Blocked,
 		Interrupt:   Queued,
 		InputClosed: Running, // unanswered wait, retries remaining (§7.4)
+	},
+	// A parked fan-out parent: cancel is the only human action, and the
+	// scheduler's ChildrenSettled is the only other way out (task 014).
+	// Notably absent is Pause — a parent owning nothing running has nothing
+	// to pause — and the approve/reject/skip trio, which is why this is not
+	// awaiting_gate.
+	AwaitingChildren: {
+		Cancel:          Aborted,
+		ChildrenSettled: Queued,
 	},
 	Blocked: {
 		Cancel: Aborted,
@@ -168,7 +179,8 @@ func TestHumanActionsFrom(t *testing.T) {
 // event must never be reachable through the API.
 func TestHumanClassification(t *testing.T) {
 	human := []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
-	engine := []Action{Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park}
+	engine := []Action{Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
+		FanOut, ChildrenSettled}
 	for _, a := range human {
 		if !Human(a) {
 			t.Errorf("Human(%s) = false", a)
@@ -182,6 +194,46 @@ func TestHumanClassification(t *testing.T) {
 	if len(human)+len(engine) != len(allActions) {
 		t.Errorf("action classification covers %d actions, allActions has %d",
 			len(human)+len(engine), len(allActions))
+	}
+}
+
+// TestSettledIsNotTerminal pins task 014 decision 20: the join's wait
+// condition is its own predicate, and widening Terminal to mean it would lie
+// to every other caller — a done task can still be archived.
+func TestSettledIsNotTerminal(t *testing.T) {
+	for _, s := range []State{Done, Aborted, Archived} {
+		if !Settled(s) {
+			t.Errorf("Settled(%s) = false, want true", s)
+		}
+	}
+	// The three that hold no slot but still need a human: a join must wait
+	// for them rather than merge around them.
+	for _, s := range []State{Blocked, AwaitingGate, Paused, Queued, Running, AwaitingChildren, AwaitingInput} {
+		if Settled(s) {
+			t.Errorf("Settled(%s) = true; a join would merge over unfinished work", s)
+		}
+	}
+	if Terminal(Done) || Terminal(Aborted) {
+		t.Error("Terminal widened to mean Settled; it must stay 'no further transition possible'")
+	}
+}
+
+// TestAwaitingChildrenHoldsNoSlot is what makes fan-out deadlock-free at any
+// depth: a parent releases its slot *before* its children need one, so there
+// is no hold-and-wait anywhere in the chain, under any cap.
+func TestAwaitingChildrenHoldsNoSlot(t *testing.T) {
+	if HoldsSlot(AwaitingChildren) {
+		t.Error("awaiting_children holds a slot; a deep fan-out would deadlock under the caps")
+	}
+}
+
+// TestAwaitingChildrenOffersOnlyCancel is the reason it is not a reuse of
+// awaiting_gate: approve, reject and skip would be actions the API accepts
+// and the TUI renders while they mean nothing.
+func TestAwaitingChildrenOffersOnlyCancel(t *testing.T) {
+	got := HumanActionsFrom(AwaitingChildren)
+	if len(got) != 1 || got[0] != Cancel {
+		t.Errorf("HumanActionsFrom(awaiting_children) = %v, want [cancel]", got)
 	}
 }
 

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -179,8 +179,10 @@ func TestHumanActionsFrom(t *testing.T) {
 // event must never be reachable through the API.
 func TestHumanClassification(t *testing.T) {
 	human := []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
-	engine := []Action{Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
-		FanOut, ChildrenSettled}
+	engine := []Action{
+		Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
+		FanOut, ChildrenSettled,
+	}
 	for _, a := range human {
 		if !Human(a) {
 			t.Errorf("Human(%s) = false", a)

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -106,6 +106,7 @@ var bindings = []binding{
 	{key: "g", label: "group the tasks: project › workflow → project → workflow → flat (config.yaml sets the one you start on)", scope: scopePanel, context: ctxTasks, hint: "g group", priority: 4},
 	{key: "space", label: "select this task for a bulk action — the action keys then act on every selected task (space again deselects, esc clears)", scope: scopePanel, context: ctxTasks, hint: "space select", priority: 5},
 	{key: "V", label: "select every task the filter is showing, or clear that selection", scope: scopePanel, context: ctxTasks, priority: 6},
+	{key: "L", label: "drill into the selected fan-out's lanes, or back out (lanes are hidden from the board otherwise)", scope: scopePanel, context: ctxTasks, hint: "L lanes", priority: 7},
 
 	// Timeline.
 	{key: "down", label: "select an attempt (↑/↓); scrollback is per attempt", scope: scopePanel, context: ctxTimeline, hint: "↑/↓ attempts", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -151,6 +151,25 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatalf("V did not clear the selection (marks %v)", s.board.marks)
 			}
 		},
+		"L": func(t *testing.T) {
+			s, _ := newShellFixture(t, task(4, stateAwaitingChildren))
+			s.focus = panelTasks
+			s.update(registryKey(t, "L"))
+			if s.board.laneParent != 4 {
+				t.Fatalf("L did not drill into the fan-out (laneParent %d, want 4)", s.board.laneParent)
+			}
+			s.update(registryKey(t, "L"))
+			if s.board.laneParent != 0 {
+				t.Fatalf("L did not back out (laneParent %d, want 0)", s.board.laneParent)
+			}
+			// A task that is not a fan-out has no lanes to drill into.
+			s2, _ := newShellFixture(t, task(5, stateRunning))
+			s2.focus = panelTasks
+			s2.update(registryKey(t, "L"))
+			if s2.board.laneParent != 0 {
+				t.Fatalf("L drilled into a task with no lanes (laneParent %d)", s2.board.laneParent)
+			}
+		},
 	},
 
 	ctxTimeline: {

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -82,6 +82,12 @@ type board struct {
 
 	tbl        table.Model
 	selectedID int64
+	// laneParent drills the board into one fan-out parent's lanes (§7.6,
+	// task 014). Zero is the ordinary board, which hides lanes entirely
+	// (decision 13); non-zero shows exactly that parent's lanes, in merge
+	// order. It is a lens on the same table rather than a second view: the
+	// rows are ordinary tasks and every action key means what it always does.
+	laneParent int64
 
 	// marks is the bulk selection (boardmark.go, task 011): the tasks the §6
 	// action keys act on instead of the row under the cursor.
@@ -193,10 +199,11 @@ func (b *board) loadCmd() tea.Cmd {
 	}
 	b.loadSeq++
 	seq := b.loadSeq
+	parent := b.laneParent
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		tasks, err := client.ListTasks(ctx, apiclient.ListTasksOptions{})
+		tasks, err := client.ListTasks(ctx, apiclient.ListTasksOptions{ParentID: parent})
 		return boardLoadedMsg{seq: seq, tasks: tasks, err: err}
 	}
 }
@@ -442,6 +449,25 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return b, nil
 	case "V":
 		b.markVisible()
+		return b, nil
+	case "L":
+		// Drill into the selected fan-out parent's lanes, or back out.
+		// Lanes are hidden from the board by design; this is the way in.
+		if b.laneParent != 0 {
+			parent := b.laneParent
+			b.laneParent = 0
+			b.selectedID = parent
+			return b, b.loadCmd()
+		}
+		if id, ok := b.selected(); ok {
+			for _, t := range b.tasks {
+				if t.ID == id && t.State == stateAwaitingChildren {
+					b.laneParent = id
+					b.selectedID = 0
+					return b, b.loadCmd()
+				}
+			}
+		}
 		return b, nil
 	case "g":
 		// Cycles the grouping for the session (§15, task 009); the config

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -20,11 +20,16 @@ const (
 	stateRunning       = "running"
 	stateAwaitingGate  = "awaiting_gate"
 	stateAwaitingInput = "awaiting_input"
-	stateBlocked       = "blocked"
-	statePaused        = "paused"
-	stateDone          = "done"
-	stateAborted       = "aborted"
-	stateArchived      = "archived"
+	// stateAwaitingChildren is a fan-out parent waiting on its lanes (§7.6,
+	// task 014). It is *not* an attention state: nobody is being asked for
+	// anything by the parent itself — though a blocked lane inside it is,
+	// which is what the rollup in its row says.
+	stateAwaitingChildren = "awaiting_children"
+	stateBlocked          = "blocked"
+	statePaused           = "paused"
+	stateDone             = "done"
+	stateAborted          = "aborted"
+	stateArchived         = "archived"
 )
 
 // needsAttention reports whether a task is waiting on a human (§15). These
@@ -53,7 +58,10 @@ func band(state string) int {
 	switch {
 	case needsAttention(state):
 		return bandAttention
-	case state == stateRunning:
+	case state == stateRunning, state == stateAwaitingChildren:
+		// A parked parent bands with running work: its subtree is running,
+		// and sorting it down among terminal tasks would hide an active
+		// fan-out at the bottom of the board.
 		return bandRunning
 	case state == stateQueued:
 		return bandQueued
@@ -161,11 +169,13 @@ var stateStyles = map[string]lipgloss.Style{
 	stateQueued:        lipgloss.NewStyle().Faint(true),
 	stateAwaitingInput: lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true),
 	stateAwaitingGate:  lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
-	stateBlocked:       lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true),
-	statePaused:        lipgloss.NewStyle().Foreground(lipgloss.Color("5")),
-	stateDone:          lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
-	stateAborted:       lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
-	stateArchived:      lipgloss.NewStyle().Faint(true),
+	// Cyan like running: the subtree is working, just not on this row.
+	stateAwaitingChildren: lipgloss.NewStyle().Foreground(lipgloss.Color("6")),
+	stateBlocked:          lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true),
+	statePaused:           lipgloss.NewStyle().Foreground(lipgloss.Color("5")),
+	stateDone:             lipgloss.NewStyle().Foreground(lipgloss.Color("2")),
+	stateAborted:          lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+	stateArchived:         lipgloss.NewStyle().Faint(true),
 }
 
 // attentionBadge marks a row waiting on a human. It is a glyph rather than
@@ -192,6 +202,15 @@ func renderState(state string) string {
 // the columns that get shed first. The detail header, which has the width,
 // names it (renderDetailState).
 func renderBoardState(t apiclient.Task) string {
+	// A fan-out parent says what its subtree is doing, because its own state
+	// says nothing a reader can act on (task 014). A blocked lane is
+	// invisible in the task list by design (decision 13), and this is what
+	// pays for that.
+	if t.State == stateAwaitingChildren && t.Children != nil {
+		if label := t.Children.Summary(); label != "" {
+			return applyStateStyle(t.State, t.State+" ("+label+")")
+		}
+	}
 	_, until, ok := t.Hold()
 	if !ok || until == nil {
 		return renderState(t.State)

--- a/internal/tui/boardrows_test.go
+++ b/internal/tui/boardrows_test.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// TestBoardStateShowsChildrenRollup is what pays for hiding lanes from the
+// board (task 014 decision 13): a blocked lane is invisible in the list, so
+// the parent's row has to say it is there.
+func TestBoardStateShowsChildrenRollup(t *testing.T) {
+	parent := apiclient.Task{ID: 1, State: stateAwaitingChildren}
+	if got := renderBoardState(parent); !strings.Contains(got, stateAwaitingChildren) {
+		t.Errorf("state cell = %q, want it to name the state", got)
+	}
+
+	parent.Children = &apiclient.ChildrenRollup{Total: 3, Settled: 1, Blocked: []int64{7, 8}}
+	if got := renderBoardState(parent); !strings.Contains(got, "2 blocked") {
+		t.Errorf("state cell = %q, want the blocked lanes surfaced", got)
+	}
+
+	// With nothing waiting on a human, progress is the useful thing to say.
+	parent.Children = &apiclient.ChildrenRollup{Total: 4, Settled: 3}
+	if got := renderBoardState(parent); !strings.Contains(got, "3/4 done") {
+		t.Errorf("state cell = %q, want progress", got)
+	}
+}
+
+// TestAwaitingChildrenBandsWithRunningWork: a parked parent's subtree is
+// working, so sorting it among terminal tasks would hide an active fan-out at
+// the bottom of the board. It is also not an attention state — nobody is
+// being asked for anything by the parent itself.
+func TestAwaitingChildrenBandsWithRunningWork(t *testing.T) {
+	if band(stateAwaitingChildren) != bandRunning {
+		t.Errorf("awaiting_children bands as %d, want bandRunning", band(stateAwaitingChildren))
+	}
+	if needsAttention(stateAwaitingChildren) {
+		t.Error("awaiting_children reads as needing attention; the parent asks for nothing")
+	}
+}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -722,18 +723,41 @@ func (d *detail) moveSelection(delta int) tea.Cmd {
 	return d.syncOutput()
 }
 
-// attempts returns every attempt in timeline order: by step, then by attempt
-// within the step.
+// attempts returns every attempt in timeline order: by step, then — inside a
+// `parallel` group, whose sub-steps share one step index (task 014) — by
+// sub-step, then by attempt. Without the middle tier a group's attempts
+// interleave by number and no sub-step reads as a unit.
+//
+// The order within a group is the server's: ListStepRuns returns rows by
+// index, attempt and id, so the first row of each sub-step appears in the
+// order the sub-steps started. A stable sort keeps that, which is as close to
+// declaration order as the rows can honestly report.
 func (d *detail) attempts() []apiclient.StepRun {
 	runs := make([]apiclient.StepRun, len(d.task.Steps))
 	copy(runs, d.task.Steps)
+	order := map[string]int{}
+	for _, r := range runs {
+		key := stepRunKey(r)
+		if _, seen := order[key]; !seen {
+			order[key] = len(order)
+		}
+	}
 	sort.SliceStable(runs, func(i, j int) bool {
 		if runs[i].StepIndex != runs[j].StepIndex {
 			return runs[i].StepIndex < runs[j].StepIndex
 		}
+		if runs[i].StepID != runs[j].StepID {
+			return order[stepRunKey(runs[i])] < order[stepRunKey(runs[j])]
+		}
 		return runs[i].Attempt < runs[j].Attempt
 	})
 	return runs
+}
+
+// stepRunKey identifies one step's run history within a task: the index alone
+// is not enough once a group's sub-steps share it.
+func stepRunKey(r apiclient.StepRun) string {
+	return strconv.Itoa(r.StepIndex) + "/" + r.StepID
 }
 
 func (d *detail) runIndex(id int64) int {

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -83,6 +83,66 @@ func TestDetailTimelineRendersAttempts(t *testing.T) {
 	}
 }
 
+// TestDetailTimelineRendersParallelGroup: a group's sub-steps share one step
+// index (task 014), so the timeline needs a tier the old renderer had no room
+// for — one header naming the group, then each sub-step with its own
+// attempts. Without it the attempts of three sub-steps interleave under one
+// sub-step's name.
+func TestDetailTimelineRendersParallelGroup(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 9
+
+	// Two sub-steps at index 1, the lint one having taken a second attempt.
+	test1 := attempt(1, 1, 1, "test", "succeeded", false)
+	lint1 := attempt(2, 1, 1, "lint", "failed", false)
+	lint1.FailureReason = ptr("nonzero_exit")
+	lint2 := attempt(3, 1, 2, "lint", "succeeded", false)
+	build := attempt(4, 0, 1, "build", "succeeded", false)
+
+	d.applyLoaded(detailLoadedMsg{
+		id: d.taskID,
+		task: apiclient.TaskDetail{
+			Task:  apiclient.Task{ID: d.taskID, Title: "grouped", State: stateRunning, StepTotal: 2},
+			Steps: []apiclient.StepRun{build, test1, lint1, lint2},
+			WorkflowSteps: []apiclient.WorkflowStep{
+				{Index: 0, ID: "build", Type: "command"},
+				{Index: 1, ID: "verify", Type: "parallel"},
+			},
+		},
+	})
+
+	got := d.timelinePanel(30)
+	for _, want := range []string{
+		"1 build",             // the ordinary step is unchanged
+		"2 verify (parallel)", // the group is named from the snapshot, not from a row
+		"· test",              // each sub-step gets its own tier
+		"· lint",
+		"nonzero_exit", // and its own failure
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timeline missing %q:\n%s", want, got)
+		}
+	}
+
+	// Attempts must sit under their own sub-step rather than interleaving by
+	// number: lint's two attempts are adjacent, after test's one.
+	var order []string
+	for _, line := range strings.Split(got, "\n") {
+		switch {
+		case strings.Contains(line, "· test"):
+			order = append(order, "test")
+		case strings.Contains(line, "· lint"):
+			order = append(order, "lint")
+		case strings.Contains(line, "a1 "), strings.Contains(line, "a2 "):
+			order = append(order, "attempt")
+		}
+	}
+	const want = "attempt test attempt lint attempt attempt"
+	if got := strings.Join(order, " "); got != want {
+		t.Errorf("timeline order = %q, want %q — a sub-step's attempts belong under it", got, want)
+	}
+}
+
 // TestDetailSelectionFollowsOnlyTheLiveAttempt is the rollover rule: live
 // movement never overrides a user who is browsing history.
 func TestDetailSelectionFollowsOnlyTheLiveAttempt(t *testing.T) {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -35,7 +35,8 @@ func (d *detail) timelinePanel(height int) string {
 	}
 	if height <= 1 {
 		if run := d.runByID(d.selectedRun); run.ID != 0 {
-			return d.attemptLine(run)
+			// The collapsed band has no header above it to indent under.
+			return d.attemptLine(run, false)
 		}
 		return d.headerLine()
 	}
@@ -239,18 +240,35 @@ func (d *detail) renderTimeline(height int) string {
 		return styleDim.Render("  queued — no attempts yet")
 	}
 
+	// A `parallel` group's sub-steps all carry the group's step index (task
+	// 014), so the header for that index names the group and each sub-step
+	// gets a tier of its own beneath it. Outside a group the shape is
+	// unchanged: one header, then its attempts.
+	groups := groupedIndexes(runs)
 	lines := make([]string, 0, len(runs)*2)
 	ids := make([]int64, 0, len(runs)*2)
 	cursorLine := 0
 	lastStep := -1
+	lastSub := ""
 	for _, r := range runs {
+		grouped := groups[r.StepIndex]
 		if r.StepIndex != lastStep {
 			lastStep = r.StepIndex
+			lastSub = ""
+			label := stepLabel(r)
+			if grouped {
+				label = d.groupLabel(r.StepIndex)
+			}
 			lines = append(lines, styleStepHeader.Render(
-				fmt.Sprintf("  %d %s", r.StepIndex+1, stepLabel(r))))
+				fmt.Sprintf("  %d %s", r.StepIndex+1, label)))
 			ids = append(ids, 0)
 		}
-		line := d.attemptLine(r)
+		if grouped && r.StepID != lastSub {
+			lastSub = r.StepID
+			lines = append(lines, styleDim.Render("    · "+stepLabel(r)))
+			ids = append(ids, 0)
+		}
+		line := d.attemptLine(r, grouped)
 		if r.ID == d.selectedRun {
 			cursorLine = len(lines)
 			line = styleSelected.Render(line)
@@ -268,6 +286,40 @@ func (d *detail) renderTimeline(height int) string {
 	return strings.Join(lines[start:end], "\n")
 }
 
+// groupedIndexes reports which step indexes hold more than one distinct step
+// id — which is exactly the `parallel` groups, since every other step type
+// owns its index alone.
+//
+// Derived from the rows rather than read from the snapshot so the timeline
+// renders correctly even before workflow_steps arrives, and for a task whose
+// snapshot no longer parses.
+func groupedIndexes(runs []apiclient.StepRun) map[int]bool {
+	seen := map[int]map[string]bool{}
+	for _, r := range runs {
+		if seen[r.StepIndex] == nil {
+			seen[r.StepIndex] = map[string]bool{}
+		}
+		seen[r.StepIndex][r.StepID] = true
+	}
+	out := make(map[int]bool, len(seen))
+	for index, ids := range seen {
+		out[index] = len(ids) > 1
+	}
+	return out
+}
+
+// groupLabel names a group from the task's snapshot, since the group writes
+// no step_runs row to take a name from (task 014 decision 17). A snapshot
+// that has not loaded yet falls back to the type name, which is still true.
+func (d *detail) groupLabel(index int) string {
+	for _, s := range d.task.WorkflowSteps {
+		if s.Index == index {
+			return fmt.Sprintf("%s (parallel)", s.ID)
+		}
+	}
+	return "(parallel)"
+}
+
 func stepLabel(r apiclient.StepRun) string {
 	name := r.StepName
 	if name == "" {
@@ -281,12 +333,19 @@ func stepLabel(r apiclient.StepRun) string {
 
 // attemptLine is one attempt: what it did, how long it actually worked, and
 // what it cost.
-func (d *detail) attemptLine(r apiclient.StepRun) string {
+// indented is true for an attempt inside a `parallel` group, which sits one
+// tier deeper because its sub-step header is already at the attempt's usual
+// indent.
+func (d *detail) attemptLine(r apiclient.StepRun, indented bool) string {
 	mark := " "
 	if r.PromptOverride || r.RunOverride {
 		mark = editedBadge
 	}
-	fields := []string{fmt.Sprintf("    a%d %s %-9s", r.Attempt, mark, r.State)}
+	indent := "    "
+	if indented {
+		indent = "      "
+	}
+	fields := []string{fmt.Sprintf("%sa%d %s %-9s", indent, r.Attempt, mark, r.State)}
 	if dur, ok := r.Duration(d.now()); ok {
 		fields = append(fields, formatElapsed(dur))
 	}

--- a/internal/workflow/fanout.go
+++ b/internal/workflow/fanout.go
@@ -1,0 +1,234 @@
+package workflow
+
+// Creation-time resolution of a fan-out tree (spec §7.6, task 014
+// decisions 4, 5, 28).
+//
+// A `fan_out` lane may name a registry workflow. That name is resolved
+// **once**, when the task is created, and the resulting steps are written
+// into the task's own snapshot — never read from the registry again. §5.3
+// says execution always uses the snapshot precisely so that later edits to
+// workflow files cannot mutate an in-flight task, and a lane read from the
+// registry six hours into a run would be exactly that mutation, in the one
+// place nobody would look for it.
+//
+// Resolving here is also what makes the tree's shape static: lane lists are
+// in the snapshot, so the whole tree is computable in the insert path. That
+// is what turns a depth-3 explosion into a 400 in front of the person typing
+// rather than two hundred worktrees discovered six hours later.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Limits bound a resolved fan-out tree (config `fan_out.*`, decisions 5, 28).
+type Limits struct {
+	// MaxDepth is how many fan-out levels a tree may have. A root with a
+	// fan_out step produces depth-1 children; their fan_out steps produce
+	// depth 2.
+	MaxDepth int
+	// MaxTasks bounds the **descendants** a creation may produce, excluding
+	// the root (decision 28).
+	MaxTasks int
+}
+
+// LookupFunc resolves a lane's workflow name through the registry's usual
+// builtin < global < project shadowing. ok is false when no such workflow is
+// visible to this project.
+type LookupFunc func(name string) (wf *Workflow, ok bool)
+
+// TreeError is a fan-out tree that cannot be created: a lane naming an
+// unknown or invalid workflow, a cycle, or a tree past its configured bounds.
+// It is a 400 — every case is something the person creating the task can act
+// on.
+type TreeError struct {
+	// Path is the YAML path of the offending lane, when one node is at fault.
+	Path string
+	// Message says what is wrong, including the workflow path for a cycle.
+	Message string
+}
+
+func (e *TreeError) Error() string {
+	if e.Path == "" {
+		return e.Message
+	}
+	return e.Path + ": " + e.Message
+}
+
+// ResolveTree resolves every named lane in wf into inline steps, in place on
+// a copy, and returns the resolved workflow together with how many
+// descendants creating it would produce.
+//
+// A resolved lane has its `workflow:` name moved to `resolved_from:` and the
+// steps that name resolved to written into `steps:`. The move matters: the
+// two fields are mutually exclusive in an authored file, so a lane keeping
+// both would produce a snapshot that no longer parses. An inline lane is
+// already resolved and is only descended into.
+func ResolveTree(wf *Workflow, lookup LookupFunc, limits Limits) (*Workflow, int, error) {
+	if wf == nil {
+		return nil, 0, &TreeError{Message: "no workflow to resolve"}
+	}
+	out := *wf
+	r := &treeResolver{lookup: lookup, limits: limits}
+	steps, err := r.steps(wf.Steps, "steps", 0, []string{wf.Name})
+	if err != nil {
+		return nil, 0, err
+	}
+	out.Steps = steps
+	return &out, r.tasks, nil
+}
+
+type treeResolver struct {
+	lookup LookupFunc
+	limits Limits
+	// tasks counts descendants resolved so far, checked against MaxTasks as
+	// it grows rather than at the end — a cyclic-looking-but-legal tree
+	// should fail on the bound it actually crossed.
+	tasks int
+}
+
+// steps resolves the fan_out steps in one workflow body. `path` is the YAML
+// path of the list, `depth` how many fan-out levels are already above it, and
+// `stack` the workflow names on the current path, for cycle detection.
+func (r *treeResolver) steps(in []Step, path string, depth int, stack []string) ([]Step, error) {
+	out := make([]Step, len(in))
+	copy(out, in)
+	for i := range out {
+		if out[i].Type != StepFanOut {
+			continue
+		}
+		stepPath := fmt.Sprintf("%s[%d]", path, i)
+		if depth+1 > r.limits.MaxDepth {
+			return nil, &TreeError{
+				Path: stepPath,
+				Message: fmt.Sprintf(
+					"fan-out nests %d levels deep, past fan_out.max_depth (%d)",
+					depth+1, r.limits.MaxDepth),
+			}
+		}
+		lanes := make([]Lane, len(out[i].Lanes))
+		copy(lanes, out[i].Lanes)
+		for j := range lanes {
+			resolved, err := r.lane(lanes[j], fmt.Sprintf("%s.lanes[%d]", stepPath, j), depth+1, stack)
+			if err != nil {
+				return nil, err
+			}
+			lanes[j] = resolved
+		}
+		out[i].Lanes = lanes
+	}
+	return out, nil
+}
+
+// lane resolves one lane: its own task, its steps, and whatever they fan out
+// into.
+func (r *treeResolver) lane(lane Lane, path string, depth int, stack []string) (Lane, error) {
+	r.tasks++
+	if r.tasks > r.limits.MaxTasks {
+		return lane, &TreeError{
+			Path: path,
+			Message: fmt.Sprintf("fan-out would create more than fan_out.max_tasks (%d) child tasks",
+				r.limits.MaxTasks),
+		}
+	}
+
+	body := lane.Steps
+	next := stack
+	if lane.Workflow != "" {
+		// A cycle is workflow A naming B as a lane while B names A: an
+		// infinite spawn, and the one failure here that no bound would catch
+		// in a useful way. The path is named because "there is a cycle" sends
+		// the reader to grep every workflow file they own.
+		if idx := indexOf(stack, lane.Workflow); idx >= 0 {
+			return lane, &TreeError{
+				Path: path,
+				Message: fmt.Sprintf("workflow cycle: %s",
+					strings.Join(append(append([]string{}, stack[idx:]...), lane.Workflow), " → ")),
+			}
+		}
+		if r.lookup == nil {
+			return lane, &TreeError{Path: path, Message: "lane workflows cannot be resolved here"}
+		}
+		target, ok := r.lookup(lane.Workflow)
+		if !ok {
+			return lane, &TreeError{
+				Path:    path,
+				Message: fmt.Sprintf("lane workflow %q not found", lane.Workflow),
+			}
+		}
+		body = target.Steps
+		next = append(append([]string{}, stack...), lane.Workflow)
+		lane.ResolvedFrom, lane.Workflow = lane.Workflow, ""
+	}
+
+	resolved, err := r.steps(body, path+".steps", depth, next)
+	if err != nil {
+		return lane, err
+	}
+	lane.Steps = resolved
+	return lane, nil
+}
+
+func indexOf(names []string, want string) int {
+	for i, n := range names {
+		if n == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// HasFanOut reports whether a workflow contains a fan_out step at its top
+// level. Callers use it to skip tree resolution entirely for the workflows
+// that are the overwhelming majority.
+func HasFanOut(wf *Workflow) bool {
+	if wf == nil {
+		return false
+	}
+	for _, s := range wf.Steps {
+		if s.Type == StepFanOut {
+			return true
+		}
+	}
+	return false
+}
+
+// LaneWorkflowName is the workflow_name a lane's child task carries: the
+// registry name a named lane resolved from, and a synthetic path for an
+// inline one (decision 4).
+//
+// The synthetic form provably cannot collide with a registry name, because
+// validation rejects `/` in a workflow name.
+func LaneWorkflowName(lane Lane, parentWorkflow, stepID string) string {
+	if lane.ResolvedFrom != "" {
+		return lane.ResolvedFrom
+	}
+	if lane.Workflow != "" {
+		return lane.Workflow
+	}
+	return fmt.Sprintf("%s/%s/%s", parentWorkflow, stepID, lane.ID)
+}
+
+// LaneCycleWarnings reports fan-out cycles reachable from a workflow, for the
+// §8.2 registry-load warning (decision 5).
+//
+// A warning rather than an error, and only at load: a cycle between two files
+// is real only once a task picks a root, and shadowing decides which files
+// those even are — a project workflow may shadow the very name that closed
+// the loop. Task creation is where it becomes a 400.
+func LaneCycleWarnings(wf *Workflow, lookup LookupFunc) []string {
+	if wf == nil || lookup == nil {
+		return nil
+	}
+	// A generous depth: this is a cycle probe, not a bound check, and the
+	// bounds are enforced at creation where the config is in hand.
+	r := &treeResolver{lookup: lookup, limits: Limits{MaxDepth: 16, MaxTasks: 1 << 20}}
+	if _, err := r.steps(wf.Steps, "steps", 0, []string{wf.Name}); err != nil {
+		var te *TreeError
+		if errors.As(err, &te) && strings.Contains(te.Message, "cycle") {
+			return []string{te.Error()}
+		}
+	}
+	return nil
+}

--- a/internal/workflow/fanout_test.go
+++ b/internal/workflow/fanout_test.go
@@ -1,0 +1,194 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// registry builds a LookupFunc over parsed sources, standing in for the real
+// registry's shadowing.
+func registry(t *testing.T, sources map[string]string) LookupFunc {
+	t.Helper()
+	parsed := map[string]*Workflow{}
+	for name, src := range sources {
+		wf, _, err := Parse([]byte(src), Options{})
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		parsed[name] = wf
+	}
+	return func(name string) (*Workflow, bool) {
+		wf, ok := parsed[name]
+		return wf, ok
+	}
+}
+
+func mustParse(t *testing.T, src string) *Workflow {
+	t.Helper()
+	wf, _, err := Parse([]byte(src), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return wf
+}
+
+const rootFanOut = `
+name: root
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - { id: api,  workflow: module }
+      - { id: docs, steps: [{ id: write, type: command, run: make docs }] }
+`
+
+// TestResolveTreeInlinesNamedLanes is decision 4: the registry is read once,
+// at creation, and what it said is written into the snapshot. The lane's
+// workflow name moves to resolved_from — it is still the child's
+// workflow_name — because a lane carrying both a name and steps would not
+// re-parse.
+func TestResolveTreeInlinesNamedLanes(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"module": "name: module\nsteps:\n  - {id: impl, type: command, run: make}\n",
+	})
+	got, tasks, err := ResolveTree(mustParse(t, rootFanOut), lookup, Limits{MaxDepth: 3, MaxTasks: 64})
+	if err != nil {
+		t.Fatalf("ResolveTree: %v", err)
+	}
+	if tasks != 2 {
+		t.Errorf("descendants = %d, want 2", tasks)
+	}
+	api := got.Steps[0].Lanes[0]
+	if api.ResolvedFrom != "module" || api.Workflow != "" {
+		t.Errorf("lane provenance = resolved_from %q / workflow %q, want the name moved aside "+
+			"so the snapshot still parses", api.ResolvedFrom, api.Workflow)
+	}
+	if len(api.Steps) != 1 || api.Steps[0].ID != "impl" {
+		t.Errorf("named lane steps = %+v, want the registry's inlined", api.Steps)
+	}
+	// The inline lane is untouched, and the original workflow is not mutated.
+	if got.Steps[0].Lanes[1].Steps[0].ID != "write" {
+		t.Error("the inline lane lost its steps")
+	}
+	if src := mustParse(t, rootFanOut); len(src.Steps[0].Lanes[0].Steps) != 0 {
+		t.Error("ResolveTree mutated its input")
+	}
+}
+
+// TestResolveTreeDetectsCycles: A naming B while B names A is an infinite
+// spawn, and the error names the path — "there is a cycle" would send the
+// reader to grep every workflow file they own.
+func TestResolveTreeDetectsCycles(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"verify": "name: verify\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: build}]}\n",
+		"build":  "name: build\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: verify}]}\n",
+	})
+	root := mustParse(t, "name: build\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: verify}]}\n")
+	_, _, err := ResolveTree(root, lookup, Limits{MaxDepth: 8, MaxTasks: 64})
+	if err == nil {
+		t.Fatal("ResolveTree accepted a cycle")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %q, want it to say cycle", err)
+	}
+	for _, name := range []string{"build", "verify"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error = %q, want the path to name %q", err, name)
+		}
+	}
+}
+
+// TestResolveTreeEnforcesMaxDepth: depth is unlimited by design and bounded
+// by a config default, so the bound is what reports, naming the key to edit.
+func TestResolveTreeEnforcesMaxDepth(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"a": "name: a\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: b}]}\n",
+		"b": "name: b\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: c}]}\n",
+		"c": "name: c\nsteps:\n  - {id: s, type: command, run: make}\n",
+	})
+	root := mustParse(t, "name: root\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: a}]}\n")
+
+	if _, _, err := ResolveTree(root, lookup, Limits{MaxDepth: 3, MaxTasks: 64}); err != nil {
+		t.Fatalf("depth 3 refused at max_depth 3: %v", err)
+	}
+	_, _, err := ResolveTree(root, lookup, Limits{MaxDepth: 2, MaxTasks: 64})
+	if err == nil {
+		t.Fatal("ResolveTree accepted a tree past max_depth")
+	}
+	if !strings.Contains(err.Error(), "max_depth") {
+		t.Errorf("error = %q, want it to name fan_out.max_depth", err)
+	}
+}
+
+// TestResolveTreeEnforcesMaxTasks counts descendants only (decision 28): the
+// bound caps what a fan-out creates, and counting the root would put the
+// number off by one against the sentence explaining it.
+func TestResolveTreeEnforcesMaxTasks(t *testing.T) {
+	src := "name: root\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n"
+	for _, id := range []string{"a", "b", "c"} {
+		src += "      - {id: " + id + ", steps: [{id: s" + id + ", type: command, run: make}]}\n"
+	}
+	root := mustParse(t, src)
+
+	if _, tasks, err := ResolveTree(root, nil, Limits{MaxDepth: 3, MaxTasks: 3}); err != nil || tasks != 3 {
+		t.Fatalf("three lanes at max_tasks 3: tasks=%d err=%v", tasks, err)
+	}
+	_, _, err := ResolveTree(root, nil, Limits{MaxDepth: 3, MaxTasks: 2})
+	if err == nil {
+		t.Fatal("ResolveTree accepted more lanes than max_tasks")
+	}
+	if !strings.Contains(err.Error(), "max_tasks") {
+		t.Errorf("error = %q, want it to name fan_out.max_tasks", err)
+	}
+}
+
+// TestResolveTreeUnknownLaneWorkflow: a lane naming a workflow this project
+// cannot see is a 400 at creation, not a failure hours later.
+func TestResolveTreeUnknownLaneWorkflow(t *testing.T) {
+	root := mustParse(t, "name: root\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: nope}]}\n")
+	_, _, err := ResolveTree(root, registry(t, nil), Limits{MaxDepth: 3, MaxTasks: 64})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err = %v, want a not-found naming the lane workflow", err)
+	}
+	if !strings.Contains(err.Error(), "lanes[0]") {
+		t.Errorf("err = %q, want the offending lane's path", err)
+	}
+}
+
+// TestLaneWorkflowNameCannotCollide: an inline lane's child needs a
+// workflow_name for a NOT NULL column, and the synthetic one is safe because
+// validation rejects `/` in a real workflow name.
+func TestLaneWorkflowNameCannotCollide(t *testing.T) {
+	name := LaneWorkflowName(Lane{ID: "api"}, "root", "build")
+	if name != "root/build/api" {
+		t.Errorf("synthetic name = %q, want root/build/api", name)
+	}
+	// A resolved lane carries the registry name it came from instead.
+	if got := LaneWorkflowName(Lane{ID: "api", ResolvedFrom: "module"}, "root", "build"); got != "module" {
+		t.Errorf("resolved lane name = %q, want module", got)
+	}
+	src := "name: " + name + "\nsteps:\n  - {id: s, type: command, run: make}\n"
+	if _, _, err := Parse([]byte(src), Options{}); err == nil {
+		t.Error("a workflow could be named root/build/api; the synthetic name can collide")
+	}
+}
+
+// TestLaneCycleWarningsAreWarnings: at registry load a cycle is advisory,
+// because it is real only once a task picks a root and shadowing decides
+// which files those are.
+func TestLaneCycleWarningsAreWarnings(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"b": "name: b\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: a}]}\n",
+	})
+	a := mustParse(t, "name: a\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: l, workflow: b}]}\n")
+	warns := LaneCycleWarnings(a, lookup)
+	if len(warns) != 1 || !strings.Contains(warns[0], "cycle") {
+		t.Errorf("warnings = %v, want one naming a cycle", warns)
+	}
+	// A tree with no cycle warns about nothing, or the log stops meaning
+	// anything.
+	clean := mustParse(t, "name: c\nsteps:\n  - {id: s, type: command, run: make}\n")
+	if w := LaneCycleWarnings(clean, lookup); len(w) != 0 {
+		t.Errorf("warnings = %v for an acyclic workflow, want none", w)
+	}
+}

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -188,6 +188,7 @@ func (r *Registry) ReloadGlobal() {
 	r.mu.Lock()
 	r.global = entries
 	r.mu.Unlock()
+	r.warnFanOutCycles(0)
 	r.notify()
 }
 
@@ -210,7 +211,37 @@ func (r *Registry) ReloadProject(id int64) {
 		ps.entries = entries
 	}
 	r.mu.Unlock()
+	r.warnFanOutCycles(id)
 	r.notify()
+}
+
+// warnFanOutCycles logs the §8.2 fan-out cycle warning for one project's
+// resolved view (task 014 decision 5).
+//
+// It runs after the load rather than inside it, because a cycle is a property
+// of *resolved* names: which files a lane's `workflow:` reaches is decided by
+// builtin < global < project shadowing, which loadDir cannot see while it is
+// still building a scope.
+//
+// A warning, not an error. A cycle between two files is real only once a task
+// picks a root, and a project workflow may shadow the very name that closed
+// the loop. Task creation is where it becomes a 400.
+func (r *Registry) warnFanOutCycles(projectID int64) {
+	lookup := func(name string) (*Workflow, bool) {
+		e, ok := r.Lookup(projectID, name)
+		if !ok || !e.Valid() {
+			return nil, false
+		}
+		return e.Workflow, true
+	}
+	for _, e := range r.List(projectID) {
+		if !e.Valid() || !HasFanOut(e.Workflow) {
+			continue
+		}
+		for _, w := range LaneCycleWarnings(e.Workflow, lookup) {
+			r.log.Warn("workflow fan-out cycle", "file", e.File, "name", e.Name, "warning", w)
+		}
+	}
 }
 
 func (r *Registry) notify() {

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -22,6 +22,10 @@ type RenderContext struct {
 	Steps       map[string]StepResult
 	Worktree    WorktreeContext
 	LastFailure Failure
+	// Conflicts are the files a fan_out join is asking an `on_conflict:
+	// agent` resolver to fix (§7.6, task 014 decision 24). Empty for every
+	// other step, so a prompt that reads it defensively works anywhere.
+	Conflicts []string
 }
 
 // TaskContext is `.Task`.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -148,6 +148,15 @@ type Lane struct {
 	Workflow string `yaml:"workflow,omitempty"`
 	// Steps is an inline workflow body, used when Workflow is empty.
 	Steps []Step `yaml:"steps,omitempty"`
+	// ResolvedFrom records the registry workflow a named lane was resolved
+	// from, and is written by ResolveTree at task creation — never by hand.
+	//
+	// Resolution moves the name here and fills Steps, rather than leaving
+	// Workflow set beside them: `workflow` and `steps` are mutually exclusive
+	// in an authored file, and a resolved snapshot that carried both would no
+	// longer parse. The name is still needed, as the child task's
+	// workflow_name (decision 4).
+	ResolvedFrom string `yaml:"resolved_from,omitempty"`
 	// Fields are merged over the parent task's, this lane winning
 	// (decision 29).
 	Fields map[string]string `yaml:"fields,omitempty"`
@@ -634,6 +643,11 @@ func validateLanes(wf *Workflow, step Step, base string, opts Options, add func(
 			add(lanePath, "a lane needs either a workflow name or inline steps")
 		case lane.Workflow != "" && len(lane.Steps) > 0:
 			add(lanePath, "a lane has either a workflow name or inline steps, not both")
+		}
+		if lane.ResolvedFrom != "" && lane.Workflow != "" {
+			// resolved_from is machine-written; a hand-written file carrying
+			// both is describing two different sources for one lane.
+			add(lanePath+".resolved_from", "resolved_from is set by task creation, not by hand")
 		}
 		if lane.Workflow != "" && strings.ContainsAny(lane.Workflow, " \t/\\") {
 			add(lanePath+".workflow",

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -25,6 +25,24 @@ const (
 	StepCommand  = "command"
 	StepManual   = "manual"
 	StepParallel = "parallel"
+	// StepFanOut spawns each lane as a real child task and merges their
+	// branches back into this task's own (§7.6, task 014). Where `parallel`
+	// runs processes, this creates tasks — they share concepts and nothing
+	// else, which is why they are two types (decision 2).
+	StepFanOut = "fan_out"
+)
+
+// Conflict policies for a fan_out step's join (§7.6, task 014 decision 8).
+const (
+	// ConflictBlock stops the task with `merge_conflict` and leaves the
+	// worktree conflicted for a human. The default, deliberately: an agent
+	// silently resolving a semantic conflict and the merge commit landing
+	// unread is the one outcome that turns a time-saving feature into a
+	// correctness liability.
+	ConflictBlock = "block"
+	// ConflictAgent attempts an agent resolution first, gated by that step's
+	// own `check`, and falls back to the block when it fails.
+	ConflictAgent = "agent"
 )
 
 // Permission modes (spec §9.4).
@@ -110,6 +128,61 @@ type Step struct {
 	// this struct writes its zero values out deliberately (see Marshal).
 	Steps       []Step `yaml:"steps,omitempty"`
 	MaxParallel *int   `yaml:"max_parallel,omitempty"`
+
+	// fan_out steps (task 014)
+	Lanes []Lane `yaml:"lanes,omitempty"`
+	Merge *Merge `yaml:"merge,omitempty"`
+}
+
+// Lane is one branch of a `fan_out` step: a named registry workflow or inline
+// steps, which become a real child task's own flat snapshot (§7.6,
+// decision 4).
+//
+// Exactly one of Workflow and Steps is set. Nesting lives here and only here
+// — a lane's workflow may itself fan out, to any depth, bounded by
+// `fan_out.max_depth` at creation (decision 5).
+type Lane struct {
+	ID string `yaml:"id"`
+	// Workflow names a registry workflow, resolved through the usual
+	// builtin < global < project shadowing at **task-creation** time.
+	Workflow string `yaml:"workflow,omitempty"`
+	// Steps is an inline workflow body, used when Workflow is empty.
+	Steps []Step `yaml:"steps,omitempty"`
+	// Fields are merged over the parent task's, this lane winning
+	// (decision 29).
+	Fields map[string]string `yaml:"fields,omitempty"`
+	// Agent, Model, Effort and Priority override the root's inherited values
+	// for this lane's whole subtree (decision 10). Empty inherits.
+	Agent    string `yaml:"agent,omitempty"`
+	Model    string `yaml:"model,omitempty"`
+	Effort   string `yaml:"effort,omitempty"`
+	Priority *int   `yaml:"priority,omitempty"`
+}
+
+// Merge is how a `fan_out` step joins its lanes back (§7.6, decisions 7, 8).
+// Lanes are merged `--no-ff` one at a time in declared order, stopping at the
+// first conflict.
+//
+// The two fields are one setting split in two because YAML unions are worse
+// than the split: `on_conflict` is the policy, and `agent` carries the step
+// that policy runs. Validation keeps them consistent, so neither can be set
+// without the other making sense.
+type Merge struct {
+	// OnConflict is `block` (the default) or `agent`.
+	OnConflict string `yaml:"on_conflict,omitempty"`
+	// Agent is a full agent Step — same fields, same validation, same
+	// executor — run in the parent's worktree over the conflicted files
+	// (decision 24). Required by, and only by, `on_conflict: agent`.
+	Agent *Step `yaml:"agent,omitempty"`
+}
+
+// ConflictPolicy resolves a fan_out step's conflict policy, defaulting to
+// `block` for a step that declares no `merge:` at all.
+func (s Step) ConflictPolicy() string {
+	if s.Merge == nil || s.Merge.OnConflict == "" {
+		return ConflictBlock
+	}
+	return s.Merge.OnConflict
 }
 
 // placedStep is a step together with the YAML path it was found at, so a
@@ -277,13 +350,15 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 		base := fmt.Sprintf("steps[%d]", i)
 		checkID(step, base)
 		validateStep(step, base, opts, add)
-		if step.Type != StepParallel {
-			continue
-		}
-		for j, sub := range step.Steps {
-			subBase := fmt.Sprintf("%s.steps[%d]", base, j)
-			checkID(sub, subBase)
-			validateSubStep(wf, sub, subBase, opts, add)
+		switch step.Type {
+		case StepParallel:
+			for j, sub := range step.Steps {
+				subBase := fmt.Sprintf("%s.steps[%d]", base, j)
+				checkID(sub, subBase)
+				validateSubStep(wf, sub, subBase, opts, add)
+			}
+		case StepFanOut:
+			validateLanes(wf, step, base, opts, add)
 		}
 	}
 	warns = validateCatalogs(wf, opts, loc, add)
@@ -399,8 +474,8 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 func validateStep(step Step, base string, opts Options, add func(string, string, ...any)) {
 	switch step.Type {
 	case "":
-		add(base+".type", "type is required (one of %s, %s, %s, %s)",
-			StepAgent, StepCommand, StepManual, StepParallel)
+		add(base+".type", "type is required (one of %s, %s, %s, %s, %s)",
+			StepAgent, StepCommand, StepManual, StepParallel, StepFanOut)
 	case StepAgent:
 		if step.Prompt == "" {
 			add(base+".prompt", "agent steps require a prompt")
@@ -417,7 +492,7 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 				InputWait, InputDeny, InputRequire, step.OnInput)
 		}
 		rejectFields(step, base, add, "run", "shell", "env", "instructions",
-			"steps", "max_parallel")
+			"steps", "max_parallel", "lanes", "merge")
 	case StepCommand:
 		if step.Run == "" {
 			add(base+".run", "command steps require a run command")
@@ -428,14 +503,14 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		}
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "instructions",
-			"steps", "max_parallel")
+			"steps", "max_parallel", "lanes", "merge")
 	case StepManual:
 		if step.Instructions == "" {
 			add(base+".instructions", "manual steps require instructions")
 		}
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env", "steps", "max_parallel")
+			"run", "shell", "env", "steps", "max_parallel", "lanes", "merge")
 	case StepParallel:
 		if len(step.Steps) == 0 {
 			add(base+".steps", "parallel steps require at least one sub-step")
@@ -447,10 +522,18 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		// `max_retries`, checked below for every type, bound the group itself.
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env", "instructions")
+			"run", "shell", "env", "instructions", "lanes", "merge")
+	case StepFanOut:
+		if len(step.Lanes) == 0 {
+			add(base+".lanes", "fan_out steps require at least one lane")
+		}
+		validateMerge(step, base, opts, add)
+		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+			"run", "shell", "env", "instructions", "steps", "max_parallel")
 	default:
-		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s)",
-			step.Type, StepAgent, StepCommand, StepManual, StepParallel)
+		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s, %s)",
+			step.Type, StepAgent, StepCommand, StepManual, StepParallel, StepFanOut)
 	}
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
@@ -477,6 +560,129 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 	}
 }
 
+// validateMerge checks a fan_out step's join settings: the policy is known,
+// and the agent step is present exactly when the policy calls for it.
+func validateMerge(step Step, base string, opts Options, add func(string, string, ...any)) {
+	m := step.Merge
+	if m == nil {
+		return // `block`, the default (§7.6)
+	}
+	switch m.OnConflict {
+	case "", ConflictBlock:
+		if m.Agent != nil {
+			add(base+".merge.agent",
+				"merge.agent is only used by on_conflict: %s; this step blocks on a conflict", ConflictAgent)
+		}
+	case ConflictAgent:
+		if m.Agent == nil {
+			add(base+".merge.agent", "on_conflict: %s requires merge.agent", ConflictAgent)
+			return
+		}
+	default:
+		add(base+".merge.on_conflict", "on_conflict must be %q or %q, got %q",
+			ConflictBlock, ConflictAgent, m.OnConflict)
+	}
+	if m.Agent == nil {
+		return
+	}
+	// A full agent step, judged by the ordinary rules (decision 24) — its
+	// prompt, check, timeout and agent selection all mean what they mean
+	// everywhere else. `type:` is implied rather than written out.
+	resolver := *m.Agent
+	if resolver.Type == "" {
+		resolver.Type = StepAgent
+	}
+	if resolver.Type != StepAgent {
+		add(base+".merge.agent.type", "merge.agent must be an %s step, got %q", StepAgent, resolver.Type)
+		return
+	}
+	if resolver.ID == "" {
+		// Ids matter here for the same reason they do anywhere: this step
+		// gets step_runs rows of its own.
+		add(base+".merge.agent.id", "merge.agent requires an id")
+	}
+	if m.Agent.OnInput == InputRequire {
+		// The resolver runs while the task holds its slot mid-join; a
+		// mid-run question is answerable, but the conflict it is resolving
+		// is a worktree state no human can inspect through the request.
+		add(base+".merge.agent.on_input", "on_input: %s is not valid on a merge resolver", InputRequire)
+	}
+	validateStep(resolver, base+".merge.agent", opts, add)
+}
+
+// validateLanes checks a fan_out step's lanes. Lane step ids live in their
+// own namespace — each lane becomes a **separate child task** with its own
+// flat snapshot (decision 4) — so they are checked against a fresh set rather
+// than the parent workflow's.
+func validateLanes(wf *Workflow, step Step, base string, opts Options, add func(string, string, ...any)) {
+	seen := make(map[string]string, len(step.Lanes))
+	for i, lane := range step.Lanes {
+		lanePath := fmt.Sprintf("%s.lanes[%d]", base, i)
+		switch {
+		case lane.ID == "":
+			add(lanePath+".id", "id is required")
+		case !isSlug(lane.ID):
+			add(lanePath+".id", "lane id %q must be a slug (lowercase letters, digits, '-', '_', '.')", lane.ID)
+		default:
+			if prev, dup := seen[lane.ID]; dup {
+				add(lanePath+".id", "duplicate lane id %q (first used by %s)", lane.ID, prev)
+			}
+			seen[lane.ID] = lanePath
+		}
+		switch {
+		case lane.Workflow == "" && len(lane.Steps) == 0:
+			add(lanePath, "a lane needs either a workflow name or inline steps")
+		case lane.Workflow != "" && len(lane.Steps) > 0:
+			add(lanePath, "a lane has either a workflow name or inline steps, not both")
+		}
+		if lane.Workflow != "" && strings.ContainsAny(lane.Workflow, " \t/\\") {
+			add(lanePath+".workflow",
+				"workflow %q must not contain whitespace or path separators", lane.Workflow)
+		}
+		if lane.Agent != "" && !knownAgent(lane.Agent, opts.KnownAgents) {
+			add(lanePath+".agent", "unknown agent %q (known: %s)",
+				lane.Agent, strings.Join(opts.KnownAgents, ", "))
+		}
+		// Inline steps are a workflow body in their own right, so they are
+		// validated like one: their own id namespace, and their own right to
+		// contain a fan_out (decision 5). What they may not contain is a
+		// gate-free assumption anyone else's steps do not also carry.
+		validateLaneSteps(wf, lane, lanePath, opts, add)
+	}
+}
+
+// validateLaneSteps validates one lane's inline steps as the workflow body
+// they will become.
+func validateLaneSteps(wf *Workflow, lane Lane, base string, opts Options, add func(string, string, ...any)) {
+	if len(lane.Steps) == 0 {
+		return
+	}
+	seen := make(map[string]string, len(lane.Steps))
+	for i, step := range lane.Steps {
+		stepPath := fmt.Sprintf("%s.steps[%d]", base, i)
+		switch {
+		case step.ID == "":
+			add(stepPath+".id", "id is required")
+		case !isSlug(step.ID):
+			add(stepPath+".id", "id %q must be a slug (lowercase letters, digits, '-', '_', '.')", step.ID)
+		default:
+			if prev, dup := seen[step.ID]; dup {
+				add(stepPath+".id", "duplicate step id %q (first used by %s)", step.ID, prev)
+			}
+			seen[step.ID] = stepPath
+		}
+		validateStep(step, stepPath, opts, add)
+		switch step.Type {
+		case StepParallel:
+			for j, sub := range step.Steps {
+				validateSubStep(wf, sub, fmt.Sprintf("%s.steps[%d]", stepPath, j), opts, add)
+			}
+		case StepFanOut:
+			validateLanes(wf, step, stepPath, opts, add)
+		}
+	}
+}
+
 // validateSubStep checks one member of a `parallel` group. Beyond everything
 // validateStep already checks, two step types cannot appear inside a group and
 // one field cannot be set on a member of one — all three for the same reason:
@@ -491,6 +697,12 @@ func validateSubStep(wf *Workflow, sub Step, base string, opts Options, add func
 	case StepParallel:
 		add(base+".type", "parallel groups do not nest; a group's sub-steps are %s or %s steps",
 			StepAgent, StepCommand)
+	case StepFanOut:
+		// A fan_out parks its task in awaiting_children and releases the
+		// slot, which is the same thing a gate does and the same reason
+		// `manual` is refused here.
+		add(base+".type", "fan_out steps are not valid inside a parallel group: "+
+			"the task parks while its lanes run, and a group cannot park half a task")
 	}
 	// Resolved, not literal: `defaults.on_input: require` reaches a sub-step
 	// that says nothing, and it is just as unrunnable there (§7.4).
@@ -517,6 +729,7 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"run": step.Run != "", "shell": step.Shell != "", "env": len(step.Env) > 0,
 		"instructions": step.Instructions != "",
 		"steps":        len(step.Steps) > 0, "max_parallel": step.MaxParallel != nil,
+		"lanes": len(step.Lanes) > 0, "merge": step.Merge != nil,
 	}
 	for _, f := range fields {
 		if set[f] {

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -17,11 +17,14 @@ import (
 	"github.com/lezli01/vincent/internal/config"
 )
 
-// Step types (spec §8.2).
+// Step types (spec §8.2). `parallel` is a group of sub-steps run concurrently
+// in the task's one worktree (§7, task 014) — it produces no branch, no child
+// task and no merge, which is what separates it from `fan_out`.
 const (
-	StepAgent   = "agent"
-	StepCommand = "command"
-	StepManual  = "manual"
+	StepAgent    = "agent"
+	StepCommand  = "command"
+	StepManual   = "manual"
+	StepParallel = "parallel"
 )
 
 // Permission modes (spec §9.4).
@@ -99,6 +102,37 @@ type Step struct {
 
 	// manual steps
 	Instructions string `yaml:"instructions"`
+
+	// parallel steps (task 014). Steps carries the sub-steps; MaxParallel
+	// bounds how many run at once, falling back to the daemon's
+	// `parallel.max_parallel`. Both are omitempty so a marshalled snapshot
+	// does not sprout an empty group on every other step type — the rest of
+	// this struct writes its zero values out deliberately (see Marshal).
+	Steps       []Step `yaml:"steps,omitempty"`
+	MaxParallel *int   `yaml:"max_parallel,omitempty"`
+}
+
+// placedStep is a step together with the YAML path it was found at, so a
+// finding about a sub-step reports `steps[2].steps[0].model` rather than the
+// group's own path (task 014).
+type placedStep struct {
+	Path string
+	Step Step
+}
+
+// allSteps flattens a workflow into every step it contains, groups first and
+// then their sub-steps, in declaration order. Nesting is one level deep by
+// construction: validateSubStep rejects a `parallel` inside a `parallel`.
+func allSteps(wf *Workflow) []placedStep {
+	out := make([]placedStep, 0, len(wf.Steps))
+	for i, step := range wf.Steps {
+		base := fmt.Sprintf("steps[%d]", i)
+		out = append(out, placedStep{Path: base, Step: step})
+		for j, sub := range step.Steps {
+			out = append(out, placedStep{Path: fmt.Sprintf("%s.steps[%d]", base, j), Step: sub})
+		}
+	}
+	return out
 }
 
 // DisplayName is the step's display name, falling back to its id (§8.2).
@@ -221,9 +255,12 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 	if len(wf.Steps) == 0 {
 		add("steps", "steps must not be empty")
 	}
-	seen := make(map[string]int, len(wf.Steps))
-	for i, step := range wf.Steps {
-		base := fmt.Sprintf("steps[%d]", i)
+	// Ids are unique across the whole workflow, sub-steps included: a
+	// sub-step shares its group's step_index and is told apart from its
+	// siblings by step_id alone (task 014 decision 16), which is also what
+	// names its transcript file.
+	seen := make(map[string]string, len(wf.Steps))
+	checkID := func(step Step, base string) {
 		switch {
 		case step.ID == "":
 			add(base+".id", "id is required")
@@ -231,11 +268,23 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 			add(base+".id", "id %q must be a slug (lowercase letters, digits, '-', '_', '.')", step.ID)
 		default:
 			if prev, dup := seen[step.ID]; dup {
-				add(base+".id", "duplicate step id %q (first used by steps[%d])", step.ID, prev)
+				add(base+".id", "duplicate step id %q (first used by %s)", step.ID, prev)
 			}
-			seen[step.ID] = i
+			seen[step.ID] = base
 		}
+	}
+	for i, step := range wf.Steps {
+		base := fmt.Sprintf("steps[%d]", i)
+		checkID(step, base)
 		validateStep(step, base, opts, add)
+		if step.Type != StepParallel {
+			continue
+		}
+		for j, sub := range step.Steps {
+			subBase := fmt.Sprintf("%s.steps[%d]", base, j)
+			checkID(sub, subBase)
+			validateSubStep(wf, sub, subBase, opts, add)
+		}
 	}
 	warns = validateCatalogs(wf, opts, loc, add)
 	sort.SliceStable(errs, func(i, j int) bool { return errs[i].Line < errs[j].Line })
@@ -254,7 +303,11 @@ func validateCatalogs(wf *Workflow, opts Options, loc *locator, add func(string,
 	catalogs := opts.Catalogs()
 	var warns Errors
 	seen := map[string]bool{}
-	for i, step := range wf.Steps {
+	// Sub-steps of a `parallel` group are ordinary agent steps and get the
+	// same cross-catalog check; skipping them would let a group hide a model
+	// name that fails everywhere else in the file (task 014).
+	for _, placed := range allSteps(wf) {
+		base, step := placed.Path, placed.Step
 		if step.Type != StepAgent {
 			continue
 		}
@@ -269,21 +322,21 @@ func validateCatalogs(wf *Workflow, opts Options, loc *locator, add func(string,
 		// no probe is involved. claude's version gate is *not* judged: only a
 		// probe can answer it, and this path must not spawn.
 		if wf.StepRequiresInput(step) && !catalogs.InputEverPossible(sel.Agent) {
-			if path, dup := findingPath(step, "agent", i, seen); !dup {
+			if path, dup := findingPath(step, "agent", base, seen); !dup {
 				add(path, "agent %q can never take mid-run input, which step %q requires (on_input: %s)",
 					sel.Agent, step.DisplayName(), InputRequire)
 			}
 		}
 		cerrs, cwarns := catalogs.Check(sel)
 		for _, f := range cerrs {
-			path, dup := findingPath(step, f.Field, i, seen)
+			path, dup := findingPath(step, f.Field, base, seen)
 			if dup {
 				continue
 			}
 			add(path, "%s", f.Message)
 		}
 		for _, f := range cwarns {
-			path, dup := findingPath(step, f.Field, i, seen)
+			path, dup := findingPath(step, f.Field, base, seen)
 			if dup {
 				continue
 			}
@@ -296,7 +349,7 @@ func validateCatalogs(wf *Workflow, opts Options, loc *locator, add func(string,
 // findingPath locates a catalog finding: the step's own field when the step
 // set the value, else the defaults field — reported once however many steps
 // inherit it.
-func findingPath(step Step, field string, index int, seen map[string]bool) (string, bool) {
+func findingPath(step Step, field string, base string, seen map[string]bool) (string, bool) {
 	var stepValue string
 	switch field {
 	case "effort":
@@ -307,7 +360,7 @@ func findingPath(step Step, field string, index int, seen map[string]bool) (stri
 		stepValue = step.Model
 	}
 	if stepValue != "" {
-		return fmt.Sprintf("steps[%d].%s", index, field), false
+		return base + "." + field, false
 	}
 	path := "defaults." + field
 	if seen[path] {
@@ -346,7 +399,8 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 func validateStep(step Step, base string, opts Options, add func(string, string, ...any)) {
 	switch step.Type {
 	case "":
-		add(base+".type", "type is required (one of %s, %s, %s)", StepAgent, StepCommand, StepManual)
+		add(base+".type", "type is required (one of %s, %s, %s, %s)",
+			StepAgent, StepCommand, StepManual, StepParallel)
 	case StepAgent:
 		if step.Prompt == "" {
 			add(base+".prompt", "agent steps require a prompt")
@@ -362,7 +416,8 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 			add(base+".on_input", "on_input must be %q, %q or %q, got %q",
 				InputWait, InputDeny, InputRequire, step.OnInput)
 		}
-		rejectFields(step, base, add, "run", "shell", "env", "instructions")
+		rejectFields(step, base, add, "run", "shell", "env", "instructions",
+			"steps", "max_parallel")
 	case StepCommand:
 		if step.Run == "" {
 			add(base+".run", "command steps require a run command")
@@ -372,17 +427,30 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 				ShellSh, ShellPwsh, ShellCmd, step.Shell)
 		}
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
-			"permission_mode", "on_input", "input_timeout", "instructions")
+			"permission_mode", "on_input", "input_timeout", "instructions",
+			"steps", "max_parallel")
 	case StepManual:
 		if step.Instructions == "" {
 			add(base+".instructions", "manual steps require instructions")
 		}
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env")
+			"run", "shell", "env", "steps", "max_parallel")
+	case StepParallel:
+		if len(step.Steps) == 0 {
+			add(base+".steps", "parallel steps require at least one sub-step")
+		}
+		if step.MaxParallel != nil && *step.MaxParallel < 1 {
+			add(base+".max_parallel", "max_parallel must be at least 1, got %d", *step.MaxParallel)
+		}
+		// A group carries no work of its own: only `timeout` and
+		// `max_retries`, checked below for every type, bound the group itself.
+		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+			"run", "shell", "env", "instructions")
 	default:
-		add(base+".type", "unknown step type %q (one of %s, %s, %s)",
-			step.Type, StepAgent, StepCommand, StepManual)
+		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s)",
+			step.Type, StepAgent, StepCommand, StepManual, StepParallel)
 	}
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
@@ -409,6 +477,34 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 	}
 }
 
+// validateSubStep checks one member of a `parallel` group. Beyond everything
+// validateStep already checks, two step types cannot appear inside a group and
+// one field cannot be set on a member of one — all three for the same reason:
+// a group runs inside a single admission of a single task, and each of them
+// would need a task state that says "one sub-step of one group is waiting",
+// which §6 has no room for (task 014 decisions 18, 19).
+func validateSubStep(wf *Workflow, sub Step, base string, opts Options, add func(string, string, ...any)) {
+	switch sub.Type {
+	case StepManual:
+		add(base+".type", "manual steps are not valid inside a parallel group: "+
+			"a gate ends the actor goroutine and releases the slot")
+	case StepParallel:
+		add(base+".type", "parallel groups do not nest; a group's sub-steps are %s or %s steps",
+			StepAgent, StepCommand)
+	}
+	// Resolved, not literal: `defaults.on_input: require` reaches a sub-step
+	// that says nothing, and it is just as unrunnable there (§7.4).
+	if wf.StepRequiresInput(sub) {
+		field := base + ".on_input"
+		if sub.OnInput == "" {
+			field = "defaults.on_input"
+		}
+		add(field, "on_input: %s is not valid inside a parallel group: "+
+			"%s holds one pending request for the whole task", InputRequire, "awaiting_input")
+	}
+	validateStep(sub, base, opts, add)
+}
+
 // rejectFields reports the named fields as not allowed for this step's type.
 // Strict decoding catches unknown keys; this catches keys that are known but
 // belong to a different step type (§8.2).
@@ -420,6 +516,7 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"check": step.Check != "", "check_timeout": step.CheckTimeout != nil,
 		"run": step.Run != "", "shell": step.Shell != "", "env": len(step.Env) > 0,
 		"instructions": step.Instructions != "",
+		"steps":        len(step.Steps) > 0, "max_parallel": step.MaxParallel != nil,
 	}
 	for _, f := range fields {
 		if set[f] {

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -209,6 +210,82 @@ func TestParseValidation(t *testing.T) {
 			wantSub:  `unknown agent "gemini"`,
 			wantPath: "defaults.agent",
 		},
+		// task 014 — `type: parallel`.
+		{
+			name:     "parallel group with no sub-steps",
+			src:      "name: x\nsteps:\n  - {id: g, type: parallel, steps: []}\n",
+			wantSub:  "parallel steps require at least one sub-step",
+			wantPath: "steps[0].steps",
+		},
+		{
+			name: "parallel group with max_parallel below one",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    max_parallel: 0\n" +
+				"    steps:\n      - {id: t, type: command, run: go test ./...}\n",
+			wantSub:  "max_parallel must be at least 1",
+			wantPath: "steps[0].max_parallel",
+		},
+		{
+			name: "manual sub-step",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n" +
+				"    steps:\n      - {id: m, type: manual, instructions: hi}\n",
+			wantSub:  "manual steps are not valid inside a parallel group",
+			wantPath: "steps[0].steps[0].type",
+		},
+		{
+			name: "nested parallel group",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    steps:\n" +
+				"      - id: h\n        type: parallel\n" +
+				"        steps:\n          - {id: t, type: command, run: ls}\n",
+			wantSub:  "parallel groups do not nest",
+			wantPath: "steps[0].steps[0].type",
+		},
+		{
+			name: "sub-step requiring mid-run input",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    steps:\n" +
+				"      - {id: a, type: agent, prompt: hi, on_input: require}\n",
+			wantSub:  "not valid inside a parallel group",
+			wantPath: "steps[0].steps[0].on_input",
+		},
+		{
+			// Resolved, not literal: the sub-step names no policy at all, and
+			// the requirement reaches it from `defaults:` — which is where the
+			// error must point, since that is the line to change.
+			name: "sub-step inheriting require from defaults",
+			src: "name: x\ndefaults:\n  on_input: require\nsteps:\n  - id: g\n    type: parallel\n" +
+				"    steps:\n      - {id: a, type: agent, prompt: hi}\n",
+			wantSub:  "not valid inside a parallel group",
+			wantPath: "defaults.on_input",
+		},
+		{
+			// Sub-steps are validated like any other step of their type.
+			name: "sub-step failing its own type's rules",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n" +
+				"    steps:\n      - {id: c, type: command}\n",
+			wantSub:  "command steps require a run command",
+			wantPath: "steps[0].steps[0].run",
+		},
+		{
+			// Ids are unique workflow-wide, not merely within a group: a
+			// sub-step shares its group's step_index and is told apart by id.
+			name: "sub-step id colliding with a top-level step",
+			src: "name: x\nsteps:\n  - {id: a, type: command, run: ls}\n  - id: g\n    type: parallel\n" +
+				"    steps:\n      - {id: a, type: command, run: ls}\n",
+			wantSub:  "duplicate step id",
+			wantPath: "steps[1].steps[0].id",
+		},
+		{
+			name: "group carrying a field of another type",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    prompt: hi\n" +
+				"    steps:\n      - {id: t, type: command, run: ls}\n",
+			wantSub:  "prompt is not valid on a parallel step",
+			wantPath: "steps[0].prompt",
+		},
+		{
+			name:     "sub-steps on a step that is not a group",
+			src:      "name: x\nsteps:\n  - {id: a, type: command, run: ls, steps: [{id: b, type: command, run: ls}]}\n",
+			wantSub:  "steps is not valid on a command step",
+			wantPath: "steps[0].steps",
+		},
 	}
 
 	opts := Options{KnownAgents: []string{"claude", "codex"}}
@@ -243,6 +320,98 @@ func hasPath(errs Errors, path string) bool {
 
 // TestParseReportsLines pins the file/line reporting T2.1 promises: both a
 // strict-decoding failure and a semantic failure point at the offending line.
+// TestParseParallelGroup covers the shape task 014 exists to allow, and the
+// two properties the engine leans on: sub-steps decode in declaration order,
+// and a group's own `steps:` survives a Marshal round-trip — `edit + retry`
+// rewrites a snapshot through Marshal, and a group that lost its members
+// there would come back as an empty group.
+func TestParseParallelGroup(t *testing.T) {
+	src := strings.TrimSpace(`
+name: verify
+steps:
+  - id: build
+    type: command
+    run: go build ./...
+  - id: verify
+    type: parallel
+    max_parallel: 2
+    timeout: 30m
+    steps:
+      - {id: test, type: command, run: go test ./...}
+      - {id: lint, type: command, run: golangci-lint run}
+      - {id: review, type: agent, prompt: "Review {{.Task.Title}}.", check: go vet ./...}
+`) + "\n"
+	wf, _, err := Parse([]byte(src), Options{KnownAgents: []string{"claude"}})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	group := wf.Steps[1]
+	if group.Type != StepParallel {
+		t.Fatalf("steps[1].type = %q, want %q", group.Type, StepParallel)
+	}
+	if group.MaxParallel == nil || *group.MaxParallel != 2 {
+		t.Errorf("max_parallel = %v, want 2", group.MaxParallel)
+	}
+	if group.Timeout == nil || group.Timeout.Std() != 30*time.Minute {
+		t.Errorf("group timeout = %v, want 30m", group.Timeout)
+	}
+	gotIDs := make([]string, 0, len(group.Steps))
+	for _, sub := range group.Steps {
+		gotIDs = append(gotIDs, sub.ID)
+	}
+	if want := []string{"test", "lint", "review"}; !reflect.DeepEqual(gotIDs, want) {
+		t.Errorf("sub-step ids = %v, want %v in declaration order", gotIDs, want)
+	}
+	if group.Steps[2].Check != "go vet ./..." {
+		t.Errorf("sub-step check = %q, want it preserved", group.Steps[2].Check)
+	}
+
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	back, _, err := Parse(out, Options{KnownAgents: []string{"claude"}})
+	if err != nil {
+		t.Fatalf("re-parse marshalled workflow: %v", err)
+	}
+	// Not a whole-struct DeepEqual: Marshal is canonical rather than
+	// faithful, so an unset `env:` comes back as an empty map rather than a
+	// nil one. What matters here is that the group kept its members.
+	rt := back.Steps[1]
+	rtIDs := make([]string, 0, len(rt.Steps))
+	for _, sub := range rt.Steps {
+		rtIDs = append(rtIDs, sub.ID)
+	}
+	if want := []string{"test", "lint", "review"}; !reflect.DeepEqual(rtIDs, want) {
+		t.Errorf("round-tripped sub-step ids = %v, want %v", rtIDs, want)
+	}
+	if rt.MaxParallel == nil || *rt.MaxParallel != 2 {
+		t.Errorf("round-tripped max_parallel = %v, want 2", rt.MaxParallel)
+	}
+	if rt.Steps[2].Prompt != group.Steps[2].Prompt {
+		t.Errorf("round-tripped sub-step prompt = %q, want %q", rt.Steps[2].Prompt, group.Steps[2].Prompt)
+	}
+}
+
+// TestMarshalOmitsEmptyGroupFields: `steps:` and `max_parallel:` are omitempty
+// so a marshalled snapshot does not give every agent and command step an empty
+// group — which would then have to be ignored by everything reading it.
+func TestMarshalOmitsEmptyGroupFields(t *testing.T) {
+	wf, _, err := Parse([]byte("name: x\nsteps:\n  - {id: a, type: command, run: ls}\n"), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	for _, key := range []string{"steps:\n    -", "max_parallel"} {
+		if strings.Contains(string(out), key) {
+			t.Errorf("marshalled a command step with %q:\n%s", key, out)
+		}
+	}
+}
+
 func TestParseReportsLines(t *testing.T) {
 	semantic := "name: x\nsteps:\n  - id: a\n    type: agent\n    timeout: 0s\n    prompt: hi\n"
 	_, _, err := Parse([]byte(semantic), Options{})

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -286,6 +286,86 @@ func TestParseValidation(t *testing.T) {
 			wantSub:  "steps is not valid on a command step",
 			wantPath: "steps[0].steps",
 		},
+		// task 014 — `type: fan_out`.
+		{
+			name:     "fan_out with no lanes",
+			src:      "name: x\nsteps:\n  - {id: f, type: fan_out, lanes: []}\n",
+			wantSub:  "fan_out steps require at least one lane",
+			wantPath: "steps[0].lanes",
+		},
+		{
+			name: "lane with neither a workflow nor steps",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n" +
+				"    lanes:\n      - {id: api}\n",
+			wantSub:  "either a workflow name or inline steps",
+			wantPath: "steps[0].lanes[0]",
+		},
+		{
+			name: "lane with both a workflow and steps",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n" +
+				"      - id: api\n        workflow: build\n" +
+				"        steps: [{id: s, type: command, run: ls}]\n",
+			wantSub:  "not both",
+			wantPath: "steps[0].lanes[0]",
+		},
+		{
+			name: "duplicate lane id",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n" +
+				"      - {id: api, workflow: build}\n      - {id: api, workflow: docs}\n",
+			wantSub:  "duplicate lane id",
+			wantPath: "steps[0].lanes[1].id",
+		},
+		{
+			name: "inline lane step failing its own rules",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n" +
+				"      - id: api\n        steps: [{id: s, type: agent}]\n",
+			wantSub:  "agent steps require a prompt",
+			wantPath: "steps[0].lanes[0].steps[0].prompt",
+		},
+		{
+			name: "on_conflict: agent without a resolver",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n" +
+				"    merge: {on_conflict: agent}\n    lanes: [{id: api, workflow: build}]\n",
+			wantSub:  "requires merge.agent",
+			wantPath: "steps[0].merge.agent",
+		},
+		{
+			name: "a resolver the policy never runs",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    merge:\n      agent:\n" +
+				"        id: resolve\n        prompt: fix it\n    lanes: [{id: api, workflow: build}]\n",
+			wantSub:  "only used by on_conflict",
+			wantPath: "steps[0].merge.agent",
+		},
+		{
+			name: "unknown conflict policy",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n" +
+				"    merge: {on_conflict: yolo}\n    lanes: [{id: api, workflow: build}]\n",
+			wantSub:  "on_conflict must be",
+			wantPath: "steps[0].merge.on_conflict",
+		},
+		{
+			// The resolver is a full agent step, so it is judged by the
+			// ordinary agent rules rather than a private subset.
+			name: "resolver failing the ordinary agent rules",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    merge:\n      on_conflict: agent\n" +
+				"      agent: {id: resolve, prompt: fix it, agent: gemini}\n" +
+				"    lanes: [{id: api, workflow: build}]\n",
+			wantSub:  `unknown agent "gemini"`,
+			wantPath: "steps[0].merge.agent.agent",
+		},
+		{
+			name: "fan_out inside a parallel group",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    steps:\n" +
+				"      - id: f\n        type: fan_out\n        lanes: [{id: api, workflow: build}]\n",
+			wantSub:  "not valid inside a parallel group",
+			wantPath: "steps[0].steps[0].type",
+		},
+		{
+			name:     "lanes on a step that is not a fan_out",
+			src:      "name: x\nsteps:\n  - {id: a, type: command, run: ls, lanes: [{id: l, workflow: w}]}\n",
+			wantSub:  "lanes is not valid on a command step",
+			wantPath: "steps[0].lanes",
+		},
 	}
 
 	opts := Options{KnownAgents: []string{"claude", "codex"}}
@@ -390,6 +470,106 @@ steps:
 	}
 	if rt.Steps[2].Prompt != group.Steps[2].Prompt {
 		t.Errorf("round-tripped sub-step prompt = %q, want %q", rt.Steps[2].Prompt, group.Steps[2].Prompt)
+	}
+}
+
+// TestParseFanOutStep covers the shape phase 2 exists to allow, including the
+// two things the engine leans on: lane order is declaration order (it is the
+// merge order, decision 7), and lanes survive Marshal — the snapshot a child
+// is cut from goes through it.
+//
+// It also pins decision 5: a lane's inline steps may themselves fan out, to
+// any depth. The bound on that is a creation-time check against
+// `fan_out.max_depth`, not a parse-time ban.
+func TestParseFanOutStep(t *testing.T) {
+	src := strings.TrimSpace(`
+name: build-all
+steps:
+  - id: build
+    type: fan_out
+    merge:
+      on_conflict: agent
+      agent:
+        id: resolve
+        prompt: "Resolve the conflict in {{.Task.Title}}."
+        check: go build ./...
+    lanes:
+      - id: api
+        workflow: implement-module
+        fields: { module: api }
+        model: opus
+        priority: 5
+      - id: docs
+        steps:
+          - id: write
+            type: agent
+            prompt: Document the API.
+          - id: deep
+            type: fan_out
+            lanes:
+              - { id: inner, workflow: proofread }
+`) + "\n"
+	wf, _, err := Parse([]byte(src), Options{KnownAgents: []string{"claude"}})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	step := wf.Steps[0]
+	if step.Type != StepFanOut {
+		t.Fatalf("type = %q, want %q", step.Type, StepFanOut)
+	}
+	if got := []string{step.Lanes[0].ID, step.Lanes[1].ID}; got[0] != "api" || got[1] != "docs" {
+		t.Errorf("lane order = %v, want [api docs] as declared", got)
+	}
+	if step.Lanes[0].Fields["module"] != "api" {
+		t.Errorf("lane fields = %v, want module=api", step.Lanes[0].Fields)
+	}
+	if step.Lanes[0].Model != "opus" || step.Lanes[0].Priority == nil || *step.Lanes[0].Priority != 5 {
+		t.Errorf("lane overrides not decoded: model=%q priority=%v",
+			step.Lanes[0].Model, step.Lanes[0].Priority)
+	}
+	if step.ConflictPolicy() != ConflictAgent || step.Merge.Agent == nil {
+		t.Fatalf("conflict policy = %q, resolver = %v", step.ConflictPolicy(), step.Merge.Agent)
+	}
+	if step.Merge.Agent.Check != "go build ./..." {
+		t.Errorf("resolver check = %q, want it preserved", step.Merge.Agent.Check)
+	}
+	// Depth 2: a lane's inline steps fan out again.
+	if inner := step.Lanes[1].Steps[1]; inner.Type != StepFanOut || inner.Lanes[0].ID != "inner" {
+		t.Errorf("nested fan_out not parsed: %+v", inner)
+	}
+
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	back, _, err := Parse(out, Options{KnownAgents: []string{"claude"}})
+	if err != nil {
+		t.Fatalf("re-parse marshalled workflow: %v", err)
+	}
+	rt := back.Steps[0]
+	if len(rt.Lanes) != 2 || rt.Lanes[0].ID != "api" || rt.Lanes[1].ID != "docs" {
+		t.Errorf("round-tripped lanes = %+v, want both in order", rt.Lanes)
+	}
+	if rt.Lanes[1].Steps[1].Lanes[0].ID != "inner" {
+		t.Error("the depth-2 lane did not survive the round trip")
+	}
+	if rt.ConflictPolicy() != ConflictAgent || rt.Merge.Agent == nil ||
+		rt.Merge.Agent.Prompt != step.Merge.Agent.Prompt {
+		t.Errorf("round-tripped merge = %+v, want the resolver preserved", rt.Merge)
+	}
+}
+
+// TestDefaultConflictPolicyIsBlock: a fan_out that says nothing about
+// conflicts blocks on one. An agent resolving a semantic conflict silently is
+// the outcome decision 8 refuses to make the default.
+func TestDefaultConflictPolicyIsBlock(t *testing.T) {
+	src := "name: x\nsteps:\n  - id: f\n    type: fan_out\n    lanes: [{id: api, workflow: build}]\n"
+	wf, _, err := Parse([]byte(src), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := wf.Steps[0].ConflictPolicy(); got != ConflictBlock {
+		t.Errorf("default conflict policy = %q, want %q", got, ConflictBlock)
 	}
 }
 

--- a/internal/worktree/merge.go
+++ b/internal/worktree/merge.go
@@ -1,0 +1,149 @@
+package worktree
+
+// Merging a fan-out lane's branch into its parent's (spec §7.6, task 014
+// decisions 7, 9).
+//
+// The git primitives live here rather than in the engine for the reason every
+// other git call does: this package owns the repository vocabulary and the
+// `Reason*` taxonomy a block_reason is drawn from.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ReasonMergeConflict is a lane whose merge into the parent's branch
+// conflicted (§18, task 014 decision 8). The worktree is left conflicted so a
+// human can resolve in place — that is the point of the block, not a
+// side effect of it.
+const ReasonMergeConflict = "merge_conflict"
+
+// MergeResult is the outcome of merging one lane.
+type MergeResult int
+
+const (
+	// MergeOK is a completed merge, including an "Already up to date" no-op —
+	// which is what re-merging an already-merged lane produces, and is what
+	// makes the whole join idempotent (decision 9).
+	MergeOK MergeResult = iota
+	// MergeConflicted is a merge stopped by a conflict, with the worktree and
+	// index left in the conflicted state.
+	MergeConflicted
+)
+
+// MergeLane merges branch into the branch checked out in worktreePath, with
+// `--no-ff` and a message naming the lane and the task it came from.
+//
+// --no-ff keeps each lane visible in history and matches the repo's own
+// no-squash convention. No author or committer is set: vincent runs as the
+// invoking user (§16) and has no business inventing an identity.
+func (m *Manager) MergeLane(
+	ctx context.Context, worktreePath, branch, laneID string, childID int64,
+) (MergeResult, error) {
+	msg := fmt.Sprintf("Merge lane '%s' of task %d", laneID, childID)
+	out, err := m.git.Run(ctx, worktreePath, "merge", "--no-ff", "-m", msg, branch)
+	if err == nil {
+		return MergeOK, nil
+	}
+	// A conflict is an ordinary outcome here, not a git failure: git exits
+	// non-zero either way, and MERGE_HEAD is what tells them apart.
+	if inMerge, mErr := m.InMerge(ctx, worktreePath); mErr == nil && inMerge {
+		return MergeConflicted, nil
+	}
+	return MergeOK, &Error{
+		Reason: ReasonGitError,
+		Err:    fmt.Errorf("merge lane %q: %w: %s", laneID, err, strings.TrimSpace(out)),
+	}
+}
+
+// InMerge reports whether a merge is in progress in the worktree — MERGE_HEAD
+// exists. It is the fact both re-entry paths turn on (decision 9), read from
+// git rather than from a persisted cursor, because git holds it
+// authoritatively and a stored copy can disagree after a human runs
+// `git merge --abort` themselves.
+func (m *Manager) InMerge(ctx context.Context, worktreePath string) (bool, error) {
+	dir, err := m.gitDir(ctx, worktreePath)
+	if err != nil {
+		return false, err
+	}
+	_, statErr := os.Stat(filepath.Join(dir, "MERGE_HEAD"))
+	if statErr == nil {
+		return true, nil
+	}
+	if os.IsNotExist(statErr) {
+		return false, nil
+	}
+	return false, &Error{Reason: ReasonGitError, Err: fmt.Errorf("stat MERGE_HEAD: %w", statErr)}
+}
+
+// IndexConflicted reports whether the worktree's index still holds unmerged
+// paths. A human who has resolved by hand and staged the result leaves
+// MERGE_HEAD in place with a clean index, which is the case the retry path
+// completes rather than restarts (decision 9).
+func (m *Manager) IndexConflicted(ctx context.Context, worktreePath string) (bool, error) {
+	out, err := m.git.Run(ctx, worktreePath, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return false, &Error{Reason: ReasonGitError, Err: fmt.Errorf("list unmerged paths: %w", err)}
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// ConflictedPaths lists the files with unresolved conflicts, for the block's
+// message and for an `on_conflict: agent` resolver's prompt.
+func (m *Manager) ConflictedPaths(ctx context.Context, worktreePath string) ([]string, error) {
+	out, err := m.git.Run(ctx, worktreePath, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil, &Error{Reason: ReasonGitError, Err: fmt.Errorf("list unmerged paths: %w", err)}
+	}
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
+}
+
+// CommitMerge completes a merge whose conflicts have been resolved and
+// staged, keeping the message git already recorded for it.
+func (m *Manager) CommitMerge(ctx context.Context, worktreePath string) error {
+	if _, err := m.git.Run(ctx, worktreePath, "commit", "--no-edit"); err != nil {
+		return &Error{Reason: ReasonGitError, Err: fmt.Errorf("commit resolved merge: %w", err)}
+	}
+	return nil
+}
+
+// AbortMerge undoes an in-progress merge.
+//
+// Recovery calls this and a human retry must not: aborting over a conflict
+// somebody spent an hour resolving is the specific, expensive failure
+// decision 9 exists to prevent.
+func (m *Manager) AbortMerge(ctx context.Context, worktreePath string) error {
+	if _, err := m.git.Run(ctx, worktreePath, "merge", "--abort"); err != nil {
+		return &Error{Reason: ReasonGitError, Err: fmt.Errorf("abort merge: %w", err)}
+	}
+	return nil
+}
+
+// StageAll stages everything in the worktree, for an agent resolver that
+// edited files but did not stage them.
+func (m *Manager) StageAll(ctx context.Context, worktreePath string) error {
+	if _, err := m.git.Run(ctx, worktreePath, "add", "-A"); err != nil {
+		return &Error{Reason: ReasonGitError, Err: fmt.Errorf("stage resolved files: %w", err)}
+	}
+	return nil
+}
+
+// gitDir resolves the worktree's own git directory — for a linked worktree
+// that is `.git/worktrees/{name}`, not the repository's `.git`, and MERGE_HEAD
+// lives in the former.
+func (m *Manager) gitDir(ctx context.Context, worktreePath string) (string, error) {
+	out, err := m.git.Run(ctx, worktreePath, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return "", &Error{Reason: ReasonGitError, Err: fmt.Errorf("resolve git dir: %w", err)}
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+# M6 phase gate (task 014; spec §7.5, §7.6): prove via curl alone that
+# parallel step groups and workflow fan-out behave as specified.
+#
+# Phase 1 — `type: parallel`:
+#   1. a group's sub-steps run concurrently and the task completes
+#   2. a failing sub-step blocks the task without cancelling its siblings
+#   3. a retry re-runs only the sub-step that failed
+#
+# Phase 2 — `type: fan_out`:
+#   4. two lanes become real child tasks and both branches are merged back
+#   5. an induced conflict reaches `merge_conflict`; resolved by hand and
+#      retried, the remaining lanes merge
+#   6. a crash mid-merge recovers by aborting and re-merging idempotently
+#   7. a depth-2 tree runs to completion
+#   8. a cancelled lane blocks the join with `lane_failed`, merging nothing
+#   9. both creation-time 400s: a workflow cycle and fan_out.max_tasks
+#
+# Every scenario uses command steps only, so no agent CLI is involved at all
+# and the gate is as fast on CI as it is locally.
+#
+# Each scenario gets fresh config/data/repo dirs and its own daemon, so one
+# scenario's leftovers cannot reach another's assertions (PR G decision,
+# inherited from m2-gate.sh). VINCENT_GATE_SCENARIO=N runs one scenario.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+ONLY="${VINCENT_GATE_SCENARIO:-}"
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+CONFIG_DIR="" DATA_DIR=""
+scenario_dirs() { # scenario_dirs NAME
+  CONFIG_DIR="$TMP/$1/config"
+  DATA_DIR="$TMP/$1/data"
+  mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+  export VINCENT_CONFIG_DIR
+  VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+  export VINCENT_DATA_DIR
+  VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+}
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+# api_status prints "STATUS<newline>BODY" without failing on a 4xx, for the
+# scenarios whose whole point is the 400.
+api_status() { # api_status METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  printf '%s\n%s' "${out##*$'\n'}" "${out%$'\n'*}"
+}
+
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+}
+
+register_project() { git init >/dev/null 2>&1 || true; api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+wait_for_state() { # wait_for_state TASK_ID STATE TRIES
+  local id="$1" want="$2" tries="$3" state=""
+  for _ in $(seq 1 "$tries"); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" ]] && [[ "$want" != "aborted" ]]; then
+      api GET "/tasks/$id" | jq . >&2
+      fail "task $id reached $state while waiting for $want"
+    fi
+    sleep 1
+  done
+  api GET "/tasks/$id" | jq . >&2
+  fail "task $id never reached $want (last: $state)"
+}
+
+create_task() { # create_task PROJECT_ID WORKFLOW TITLE -> id
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg w "$2" --arg t "$3" \
+    '{project_id: $p, workflow: $w, title: $t}')" | jq -r .id
+}
+
+# branch_has reports whether a path exists on a branch's tip.
+branch_has() { # branch_has REPO BRANCH PATH
+  [[ -n "$(git -C "$1" ls-tree --name-only "$2" "$3")" ]]
+}
+
+run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+# --------------------------------------------------------------------------
+# Scenario 1: a parallel group runs its sub-steps concurrently.
+#
+# Each sub-step waits for a marker file the others write, with a timeout. If
+# they ran in sequence, the first one would time out waiting for markers that
+# do not exist yet — which is a far stronger statement than a wall-clock
+# comparison, and does not go flaky on a loaded CI runner.
+# --------------------------------------------------------------------------
+if run_scenario 1; then
+  echo "=== scenario 1: a parallel group runs concurrently"
+  scenario_dirs s1
+  REPO="$TMP/s1/repo"; make_repo "$REPO"
+  write_workflow parallel-ok "$(cat <<'YAML'
+name: parallel-ok
+steps:
+  - id: verify
+    type: parallel
+    max_parallel: 3
+    steps:
+      - id: one
+        type: command
+        max_retries: 0
+        run: |
+          touch one.marker
+          for i in $(seq 1 100); do [ -f two.marker ] && [ -f three.marker ] && exit 0; sleep 0.1; done
+          echo "siblings never started: ran in sequence" >&2; exit 1
+      - id: two
+        type: command
+        max_retries: 0
+        run: |
+          touch two.marker
+          for i in $(seq 1 100); do [ -f one.marker ] && [ -f three.marker ] && exit 0; sleep 0.1; done
+          echo "siblings never started: ran in sequence" >&2; exit 1
+      - id: three
+        type: command
+        max_retries: 0
+        run: |
+          touch three.marker
+          for i in $(seq 1 100); do [ -f one.marker ] && [ -f two.marker ] && exit 0; sleep 0.1; done
+          echo "siblings never started: ran in sequence" >&2; exit 1
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" parallel-ok "parallel happy path")"
+  wait_for_state "$TID" done 60
+
+  RUNS="$(api GET "/tasks/$TID" | jq '[.steps[] | select(.state == "succeeded")] | length')"
+  [[ "$RUNS" == 3 ]] || fail "expected 3 succeeded sub-step runs, got $RUNS"
+  # One row per sub-step, all sharing the group's index (decision 16).
+  IDX="$(api GET "/tasks/$TID" | jq '[.steps[].step_index] | unique | length')"
+  [[ "$IDX" == 1 ]] || fail "sub-steps span $IDX step indexes, want 1"
+  daemon_down
+  echo "=== scenario 1 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: a failing sub-step blocks the group without cancelling siblings.
+# Scenario 3: the retry re-runs only what failed.
+#
+# The failing sub-step succeeds once a marker exists, so the human retry can
+# clear it — and the sibling's attempt count is what proves the retry did not
+# re-run work that had already succeeded.
+# --------------------------------------------------------------------------
+if run_scenario 2; then
+  echo "=== scenario 2+3: a failing sub-step blocks, and the retry re-runs only it"
+  scenario_dirs s2
+  REPO="$TMP/s2/repo"; make_repo "$REPO"
+  write_workflow parallel-fail "$(cat <<'YAML'
+name: parallel-fail
+steps:
+  - id: verify
+    type: parallel
+    steps:
+      - id: flaky
+        type: command
+        max_retries: 0
+        run: |
+          if [ -f cleared.marker ]; then exit 0; fi
+          touch cleared.marker
+          exit 7
+      - id: steady
+        type: command
+        max_retries: 0
+        run: |
+          sleep 1
+          echo steady > steady.txt
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" parallel-fail "one sub-step fails")"
+  wait_for_state "$TID" blocked 60
+
+  BODY="$(api GET "/tasks/$TID")"
+  REASON="$(jq -r .block_reason <<<"$BODY")"
+  [[ "$REASON" == "nonzero_exit" ]] || fail "block_reason = $REASON, want nonzero_exit"
+  # The sibling ran to completion: a failure does not cancel it (decision 18).
+  STEADY="$(jq -r '[.steps[] | select(.step_id == "steady" and .state == "succeeded")] | length' <<<"$BODY")"
+  [[ "$STEADY" == 1 ]] || fail "the sibling did not finish (succeeded rows: $STEADY)"
+
+  api POST "/tasks/$TID/retry" '{}' >/dev/null
+  wait_for_state "$TID" done 60
+
+  BODY="$(api GET "/tasks/$TID")"
+  STEADY="$(jq -r '[.steps[] | select(.step_id == "steady")] | length' <<<"$BODY")"
+  [[ "$STEADY" == 1 ]] || fail "the retry re-ran an already-succeeded sub-step ($STEADY attempts)"
+  FLAKY="$(jq -r '[.steps[] | select(.step_id == "flaky")] | length' <<<"$BODY")"
+  [[ "$FLAKY" == 2 ]] || fail "the failed sub-step has $FLAKY attempts, want 2"
+  daemon_down
+  echo "=== scenario 2+3 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: two lanes become real child tasks, and both are merged back.
+# --------------------------------------------------------------------------
+if run_scenario 4; then
+  echo "=== scenario 4: fan-out spawns lanes and merges them back"
+  scenario_dirs s4
+  REPO="$TMP/s4/repo"; make_repo "$REPO"
+  write_workflow fan-ok "$(cat <<'YAML'
+name: fan-ok
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: api
+        steps:
+          - {id: write-api, type: command, max_retries: 0, run: 'echo api > api.txt && git add -A && git commit -qm api'}
+      - id: docs
+        steps:
+          - {id: write-docs, type: command, max_retries: 0, run: 'echo docs > docs.txt && git add -A && git commit -qm docs'}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" fan-ok "fan out happy path")"
+
+  # The lanes are real tasks, hidden from the default listing (decision 13).
+  for _ in $(seq 1 30); do
+    LANES="$(api GET "/tasks?parent_id=$TID" | jq 'length')"
+    [[ "$LANES" == 2 ]] && break
+    sleep 1
+  done
+  [[ "$LANES" == 2 ]] || fail "expected 2 lanes, got $LANES"
+  ROOTS="$(api GET "/tasks" | jq 'length')"
+  [[ "$ROOTS" == 1 ]] || fail "the default task list shows $ROOTS tasks, want only the root"
+  ALL="$(api GET "/tasks?include_children=true" | jq 'length')"
+  [[ "$ALL" == 3 ]] || fail "include_children shows $ALL tasks, want 3"
+
+  wait_for_state "$TID" done 120
+  BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name)"
+  branch_has "$REPO" "$BRANCH" api.txt || fail "api.txt is not on the delivered branch"
+  branch_has "$REPO" "$BRANCH" docs.txt || fail "docs.txt is not on the delivered branch"
+  daemon_down
+  echo "=== scenario 4 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 5: a conflict blocks; a hand resolution plus retry completes it.
+# --------------------------------------------------------------------------
+if run_scenario 5; then
+  echo "=== scenario 5: merge_conflict, resolved by hand, retried"
+  scenario_dirs s5
+  REPO="$TMP/s5/repo"; make_repo "$REPO"
+  write_workflow fan-conflict "$(cat <<'YAML'
+name: fan-conflict
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: left
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo left > shared.txt && git add -A && git commit -qm left'}
+      - id: right
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo right > shared.txt && git add -A && git commit -qm right'}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" fan-conflict "conflicting lanes")"
+  wait_for_state "$TID" blocked 120
+
+  BODY="$(api GET "/tasks/$TID")"
+  REASON="$(jq -r .block_reason <<<"$BODY")"
+  [[ "$REASON" == "merge_conflict" ]] || fail "block_reason = $REASON, want merge_conflict"
+  WT="$(jq -r .worktree_path <<<"$BODY")"
+  [[ -f "$WT/.git" || -d "$WT/.git" ]] || fail "no worktree left to resolve in"
+  # The conflict is left in place on purpose: this is a human resolving it.
+  # Both lanes *create* the file, so git reports an add/add conflict (AA)
+  # rather than a content one (UU). Match any unmerged status.
+  git -C "$WT" status --porcelain | grep -qE '^(DD|AU|UD|UA|DU|AA|UU)' \
+    || fail "no conflicted file in the worktree: $(git -C "$WT" status --porcelain)"
+  echo resolved > "$WT/shared.txt"
+  git -C "$WT" add shared.txt
+
+  api POST "/tasks/$TID/retry" '{}' >/dev/null
+  wait_for_state "$TID" done 120
+  BRANCH="$(jq -r .branch_name <<<"$BODY")"
+  [[ "$(git -C "$REPO" show "$BRANCH:shared.txt")" == "resolved" ]] \
+    || fail "the hand resolution is not what landed on the branch"
+  daemon_down
+  echo "=== scenario 5 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 6: a crash mid-merge recovers by aborting and re-merging.
+#
+# The daemon is killed while the join is blocked with a conflict, then
+# restarted. Recovery must abort the half-finished merge and re-merge from the
+# top — every already-merged lane a no-op — rather than leaving the repository
+# stuck in a merge nobody owns.
+# --------------------------------------------------------------------------
+if run_scenario 6; then
+  echo "=== scenario 6: a crash mid-merge recovers idempotently"
+  scenario_dirs s6
+  REPO="$TMP/s6/repo"; make_repo "$REPO"
+  write_workflow fan-conflict "$(cat <<'YAML'
+name: fan-conflict
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: left
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo left > shared.txt && git add -A && git commit -qm left'}
+      - id: right
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo right > shared.txt && git add -A && git commit -qm right'}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" fan-conflict "crash mid-merge")"
+  wait_for_state "$TID" blocked 120
+  WT="$(api GET "/tasks/$TID" | jq -r .worktree_path)"
+  [[ -f "$WT/.git" || -d "$WT/.git" ]] || fail "no worktree"
+
+  # A merge is in progress and the daemon dies.
+  daemon_down
+  daemon_up
+
+  # Resolve as a human would, then retry: the recovered daemon must complete
+  # the join rather than refuse it.
+  git -C "$WT" checkout --theirs shared.txt 2>/dev/null || echo resolved > "$WT/shared.txt"
+  git -C "$WT" add shared.txt
+  api POST "/tasks/$TID/retry" '{}' >/dev/null
+  wait_for_state "$TID" done 120
+  daemon_down
+  echo "=== scenario 6 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 7: a depth-2 tree runs to completion.
+# --------------------------------------------------------------------------
+if run_scenario 7; then
+  echo "=== scenario 7: a depth-2 fan-out tree"
+  scenario_dirs s7
+  REPO="$TMP/s7/repo"; make_repo "$REPO"
+  write_workflow inner "$(cat <<'YAML'
+name: inner
+steps:
+  - id: deep
+    type: fan_out
+    lanes:
+      - id: leaf
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo leaf > leaf.txt && git add -A && git commit -qm leaf'}
+YAML
+)"
+  write_workflow outer "$(cat <<'YAML'
+name: outer
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - {id: mid, workflow: inner}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" outer "depth two")"
+  wait_for_state "$TID" done 180
+
+  # Three tasks in the tree, and the leaf's work reached the root's branch.
+  ALL="$(api GET "/tasks?include_children=true" | jq 'length')"
+  [[ "$ALL" == 3 ]] || fail "depth-2 tree has $ALL tasks, want 3"
+  BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name)"
+  branch_has "$REPO" "$BRANCH" leaf.txt || fail "the depth-2 lane's work never reached the root branch"
+  daemon_down
+  echo "=== scenario 7 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 8: a cancelled lane blocks the join with lane_failed, merging
+# nothing — a partial merge is indistinguishable downstream from a complete
+# one (decision 21).
+# --------------------------------------------------------------------------
+if run_scenario 8; then
+  echo "=== scenario 8: a cancelled lane blocks the join"
+  scenario_dirs s8
+  REPO="$TMP/s8/repo"; make_repo "$REPO"
+  write_workflow fan-slow "$(cat <<'YAML'
+name: fan-slow
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: quick
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'echo quick > quick.txt && git add -A && git commit -qm quick'}
+      - id: slow
+        steps:
+          - {id: w, type: command, max_retries: 0, run: 'sleep 60'}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" fan-slow "a lane is cancelled")"
+  for _ in $(seq 1 30); do
+    SLOW="$(api GET "/tasks?parent_id=$TID" | jq -r '.[] | select(.lane_id == "slow") | .id')"
+    [[ -n "$SLOW" ]] && break
+    sleep 1
+  done
+  [[ -n "$SLOW" ]] || fail "the slow lane never appeared"
+  api POST "/tasks/$SLOW/cancel" '{}' >/dev/null
+  wait_for_state "$TID" blocked 120
+
+  REASON="$(api GET "/tasks/$TID" | jq -r .block_reason)"
+  [[ "$REASON" == "lane_failed" ]] || fail "block_reason = $REASON, want lane_failed"
+  BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name)"
+  branch_has "$REPO" "$BRANCH" quick.txt \
+    && fail "the successful lane was merged anyway; the branch looks complete"
+  daemon_down
+  echo "=== scenario 8 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 9: both creation-time 400s.
+#
+# The whole tree's shape is static at creation, which is what lets a depth
+# explosion be a 400 in front of the person typing rather than two hundred
+# worktrees discovered six hours later.
+# --------------------------------------------------------------------------
+if run_scenario 9; then
+  echo "=== scenario 9: creation-time cycle and max_tasks refusals"
+  scenario_dirs s9
+  REPO="$TMP/s9/repo"; make_repo "$REPO"
+  cat > "$CONFIG_DIR/config.yaml" <<'YAML'
+fan_out:
+  max_tasks: 2
+YAML
+  write_workflow alpha "$(cat <<'YAML'
+name: alpha
+steps:
+  - {id: f, type: fan_out, lanes: [{id: l, workflow: beta}]}
+YAML
+)"
+  write_workflow beta "$(cat <<'YAML'
+name: beta
+steps:
+  - {id: f, type: fan_out, lanes: [{id: l, workflow: alpha}]}
+YAML
+)"
+  write_workflow wide "$(cat <<'YAML'
+name: wide
+steps:
+  - id: f
+    type: fan_out
+    lanes:
+      - {id: a, steps: [{id: sa, type: command, run: 'true'}]}
+      - {id: b, steps: [{id: sb, type: command, run: 'true'}]}
+      - {id: c, steps: [{id: sc, type: command, run: 'true'}]}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+
+  OUT="$(api_status POST /tasks "$(jq -cn --argjson p "$PID" '{project_id: $p, workflow: "alpha", title: "cycle"}')")"
+  STATUS="${OUT%%$'\n'*}"; BODY="${OUT#*$'\n'}"
+  [[ "$STATUS" == 400 ]] || fail "a cyclic workflow created with HTTP $STATUS"
+  grep -q cycle <<<"$BODY" || fail "the 400 does not say cycle: $BODY"
+  grep -q alpha <<<"$BODY" || fail "the 400 does not name the path: $BODY"
+
+  OUT="$(api_status POST /tasks "$(jq -cn --argjson p "$PID" '{project_id: $p, workflow: "wide", title: "wide"}')")"
+  STATUS="${OUT%%$'\n'*}"; BODY="${OUT#*$'\n'}"
+  [[ "$STATUS" == 400 ]] || fail "a tree past max_tasks created with HTTP $STATUS"
+  grep -q max_tasks <<<"$BODY" || fail "the 400 does not name the bound: $BODY"
+  daemon_down
+  echo "=== scenario 9 PASS"
+fi
+
+echo "M6 GATE PASS"


### PR DESCRIPTION
## Summary

Delivers task 014 in full — both phases, 14/14 subtasks.

**Phase 1, `type: parallel`.** A group runs its sub-steps concurrently in the task's one worktree: one step, one index, one slot, no branch and no merge. One `step_runs` row per sub-step sharing the group's `step_index` and keyed by `step_id`; the group writes no row of its own and its outcome is derived. A failure does not cancel its siblings — the group waits for everything it started, then blocks with the first failure in declaration order — and a retry re-runs only what did not succeed, within an admission and across one. `parallel.max_parallel` (default 4) bounds it and is a second concurrency dimension the §11 caps do not govern.

**Phase 2, `type: fan_out`.** Each lane becomes a real child task — its own row, worktree, branch, slot, gates, blocks, transcripts and recovery — and their branches are merged back `--no-ff` in declared order into the branch the task already owns, so one branch is still delivered. The parent parks in the new `awaiting_children` state, which holds **no** slot: it releases its slot before its children need one, which is what makes this deadlock-free at any depth. The scheduler, not the last child's actor, re-queues it once every descendant has settled.

A conflict blocks with `merge_conflict` and leaves the worktree conflicted for a human; `on_conflict: agent` opts into a resolver first. A lane that settles without finishing blocks with `lane_failed` and merges nothing. No merge cursor is persisted — git holds that fact, and the task's previous attempt separates a crash (abort and re-merge) from a hand resolution (commit and continue).

## Related

Closes 014.1 through 014.14 — the whole of [docs/tasks/014-workflow-fan-out.md](docs/tasks/014-workflow-fan-out.md).

The grilling session that preceded this added **decisions 16–31** to that document, dated, each with the alternative it beat. They are new decisions rather than revisitings: decisions 1–15 were taken against the design, these were taken against the code, and several are only visible once the existing store, FSM and validation are read. Two do adjust earlier wording, and say so in place:

- **Decision 6** says the parent resumes when descendants reach "a terminal state". Read against the code that is wrong — `taskstate.Terminal()` is `archived` alone, which no child reaches on its own. Decision 20 adds a `Settled()` predicate instead and leaves `Terminal()` meaning what it says.
- **Decisions 13 and 8** describe the rollup as present in `awaiting_children`, and spell `on_conflict` two different ways between the opening example and decision 8. Decisions 27 and 31 settle both.

One decision was amended mid-implementation, in place: **decision 16**'s transcript rename applies to sub-steps only, not to every step, so §12.2 stays true for every workflow that does not use a group.

## Three bugs the work surfaced

Recorded in the task document's Verification section, because each is the kind of thing that would otherwise be rediscovered:

1. A resolved lane could not carry both `workflow:` and `steps:` — they are mutually exclusive in an authored file, so the resolved snapshot no longer parsed. The name moved to `resolved_from:`. *Caught by an API test.*
2. A child's snapshot could not be named `{parent}/{step}/{lane}`: validation rejects `/` in a workflow name, so every child blocked with `invalid_snapshot` on its first admission. The synthetic name belongs to the `workflow_name` **column**, where its `/` is exactly what makes it collision-proof. *Caught by the end-to-end engine test.*
3. Decision 9's re-entry rule read the task's live state, which cannot answer it — the scheduler moves a retried task out of `blocked` before the engine sees it. It reads the previous attempt's outcome instead, and must read it before the new attempt's row exists. The symptom was the worst case the decision exists to prevent: `git merge --abort` over a resolution somebody had just finished. *Caught by the m6 gate.*

## ⚠️ One thing needs a hand: the CI wiring

`scripts/m6-gate.sh` is committed executable and passes all nine scenarios, but **it is not wired into CI on this branch**. The push token has no `workflow` scope, so any branch touching `.github/workflows` is rejected outright. Please apply this after `M5 gate (fake agent)` in `.github/workflows/ci.yml`:

```yaml
      # M6: parallel step groups and workflow fan-out (task 014). It runs on
      # all three OSes because the merge half is where platform differences
      # actually bite — git's behaviour on Windows is the thing a gate should
      # prove rather than assume.
      - name: M6 gate (parallel and fan-out)
        shell: bash
        run: ./scripts/m6-gate.sh
```

Nothing else in the task depends on it, and the gate runs identically by hand.

## Verification

- `go run mage.go build test testrace lint`, plus `golangci-lint` cross-built for `windows`, `darwin` and `linux` — a host-only lint hides findings in build-tagged files.
- `m1`, `m2` and `m5` re-run to prove no regression; the new `m6` passes all nine scenarios (a group running concurrently, a failing sub-step blocking without cancelling siblings, a retry re-running only what failed, a two-lane fan-out merging back, a conflict resolved by hand and retried, a crash mid-merge recovering, a depth-2 tree, a cancelled lane blocking with `lane_failed`, and both creation-time 400s).
- The fan-out engine tests got a larger budget after one flake under `-race` with the whole package running: a fan-out is a chain of admissions with a worktree per lane and a merge at the end, paced by the scheduler's 5s tick.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

## A note on size

This is a large diff for one PR. That was a deliberate call — the request was to deliver the whole task — but it is worth saying once here rather than discovering it at review time. The commits are subtask-sized and each stands alone, so reviewing commit by commit is likely to be easier than reviewing the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SW2UwsJRHDPdSkaNemUaNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SW2UwsJRHDPdSkaNemUaNz)_