### PR TITLE
feat(workflow): conditions between steps — `if:`, `type: condition`, `allow_failure:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Please pull request.
 
 ### Added
 
+- **Conditions between steps.** A workflow can decide at run time what to do
+  next. `if:` on any step is a guard: false skips that step and the workflow
+  carries on, recording a `skipped` row whose reason says a condition did it
+  rather than you. On a fan-out lane or a `parallel` sub-step the same `if:`
+  subsets the set instead — the others still run and the join still happens.
+  `type: condition` is a step whose whole body is the guard: false ends the run
+  and the task is `done`, which is how a workflow finishes early. And
+  `allow_failure:` on agent and command steps turns the failures a step itself
+  produced into an advance, so a guard has something a run *discovered* to
+  read — without it, a guard could only see what you typed when you created the
+  task. Guards are ordinary templates that must render exactly `true` or
+  `false`, are re-evaluated every time rather than cached, and can now read
+  `.Host.OS`. See [Conditions](docs/reference/workflow-schema.md#conditions).
 - **`type: parallel` — sub-steps that run at once.** A group runs its
   sub-steps concurrently in the task's one worktree: one step, one index, one
   concurrency slot, no branch and no merge. It succeeds when every sub-step

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,17 @@ against the fake agent; CI runs all three on Linux, macOS, and Windows:
 ./scripts/m1-gate.sh
 ./scripts/m2-gate.sh
 ./scripts/m5-gate.sh                            # cursor adapter (§9.7)
+./scripts/m6-gate.sh                            # parallel steps and fan-out (§7.5, §7.6)
+./scripts/m7-gate.sh                            # conditions between steps (§7.7)
 VINCENT_GATE_SCENARIO=2 ./scripts/m2-gate.sh    # single scenario, for debugging
 VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CLI
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
+
+CI runs `m1`, `m2` and `m5` on all three platforms. `m6` and `m7` are not
+wired in: the push token used for this work has no `workflow` scope, so a
+branch touching `.github/workflows` is rejected outright. Adding them is two
+lines in `ci.yml`'s `gates` job, and both scripts run identically by hand.
 
 `scripts/m3-gate.sh` seeds a human walkthrough instead of asserting — M3's
 acceptance is a judgement about a TUI. The manual legs of M5 are walked
@@ -130,7 +137,7 @@ is a correctness bug, not a style issue:
 | `internal/api` | Localhost REST + SSE, bearer auth, snake_case error envelope |
 | `internal/apiclient` | Typed HTTP+SSE client — the one client for TUI and CLI; owns its wire types (server DTOs stay unexported) |
 | `internal/workflow` | YAML registry (builtin < global < project shadowing), live reload, `text/template` step engine |
-| `internal/taskrun` | Step executors — there are **three** step types (agent, command, manual); `check` is a *field* agent and command steps may carry, not a fourth type — plus retries, timeouts, human actions, recovery, transcripts |
+| `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out` and `condition` are structure, and `check` is a *field* agent and command steps may carry, never a type — plus guards (`if:`, §7.7), retries, timeouts, human actions, recovery, transcripts |
 | `internal/agent` | `AgentAdapter` interface + option catalog; `agent/claude`, `agent/codex`, `agent/cursor` implement it |
 | `internal/worktree` | Per-task git worktrees, `vincent/{id}-{slug}` branches, dirty detection |
 | `internal/tui` | Bubble Tea client: six views (board, detail, new-task, projects, workflows, daemon) routed by `viewID` |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -317,6 +317,53 @@ The usual cause is an optional task field read directly. Read it defensively:
 The other cause is `.Steps.<id>` for a step that has not completed — `.Steps`
 holds *completed* steps only.
 
+### `condition_error`
+
+A step's `if:` guard did not produce a verdict. Guards must render to exactly
+`true` or `false`; anything else is this error, including the two spellings a
+broken guard usually produces:
+
+- **an empty string or `<no value>`** — the guard is reading something that is
+  not there. `{{ .Steps.probe.ExitCode }}` for a step that has not run yet does
+  this;
+- **a value that is merely truthy** — `yes`, `1`, `0`, a number. Loose
+  truthiness is deliberately not accepted, because it would treat the two cases
+  above as decisions.
+
+Write comparisons, not values:
+
+```yaml
+if: '{{ ne (index .Steps "probe").ExitCode 0 }}'    # ✅ renders true or false
+if: '{{ index .Steps "probe" }}'                    # ❌ renders a struct
+```
+
+This is the one block reason vincent does **not** retry. A guard is evaluated
+before the step becomes an attempt, so there is no attempt to retry, and
+re-rendering the same template against the same context cannot answer
+differently. Fix the workflow file and retry the task — the guard is
+re-evaluated from scratch, as it is on every pass.
+
+`vincent workflow validate <file>` catches a guard that does not *parse*, but
+not one that parses and renders the wrong thing — that needs the task's
+context, which only exists at run time.
+
+### A workflow finished having run only half its steps
+
+Almost certainly working as intended. Two things end a run early:
+
+- a **`condition` step** whose guard was false. The task is `done`, and the
+  detail view shows a `stopped` row where it ended;
+- a chain of **`if:` guards** that all evaluated false, each leaving a
+  `skipped` row with reason `condition`.
+
+Both are visible in the task's step list, which is the place to look: the board
+shows a finished task as finished, and does not try to say how much of the
+workflow it walked.
+
+If it was *not* intended, the guard is the thing to read. `.Steps` holds only
+steps the workflow has moved past, so a guard naming a later step, or naming a
+step that was itself skipped, evaluates against something you did not mean.
+
 ### `shell_unavailable`
 
 The shell a command step asked for is not installed. On Windows vincent uses
@@ -350,6 +397,7 @@ The block reason names what happened:
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `template_error` | A template failed to render (see above) |
+| `condition_error` | A step's `if:` guard rendered nothing usable (see below) |
 | `restricted_unsupported` | The adapter cannot restrict on this platform |
 | `platform_unsupported` | The workflow's `platforms:` list does not admit this host |
 | `input_unsupported` | A step needs an agent that can answer questions mid-run, and this one cannot (see below) |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -75,7 +75,7 @@ steps:                           # required; runs in order, top to bottom
 Unknown keys are rejected rather than ignored, so a typo is an error at
 validation time instead of a setting that silently never applied.
 
-## Five step types
+## Six step types
 
 **`agent`** runs an agent CLI headlessly in the worktree. Needs `prompt`.
 
@@ -134,8 +134,65 @@ back into this task's own. Needs `lanes`.
       - { id: docs, steps: [ { id: write, type: agent, prompt: "Document the API." } ] }
 ```
 
+**`condition`** ends the workflow when its guard is false. Needs `if:`, and
+takes nothing else.
+
+```yaml
+  - id: nothing-to-do
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+```
+
 `check` is a **field** on agent and command steps, not a step of its own — see
 below.
+
+## Conditions let a workflow do less when there is less to do
+
+Every step can carry an `if:`, and a false one **skips that step and carries
+on**:
+
+```yaml
+  - id: changelog
+    type: agent
+    if: '{{ eq (index .Task.Fields "changelog") "yes" }}'
+    prompt: Update CHANGELOG.md.
+```
+
+A guard must render exactly `true` or `false`. That strictness is on purpose:
+the two things a broken guard usually renders — an empty string, or a truthy
+`yes` — are exactly the cases where guessing an answer is worse than refusing
+to have one. You will get `condition_error` instead of a silent decision.
+
+Three things follow from "skip, then carry on":
+
+- On a **fan-out lane** or a **`parallel` sub-step**, `if:` means *do not start
+  this one*. The others still run and the join still happens — a set has no
+  "later" to skip to.
+- To finish *early* rather than skip one step, use a **`condition` step**. False
+  ends the run and the task is `done`.
+- Guards are re-evaluated every time — on each attempt, on a retry, after a
+  restart. Nothing is cached, so fixing a workflow and retrying really does ask
+  the question again.
+
+**The field that makes guards worth having is `allow_failure`.** Without it,
+nothing a run *discovers* is readable: a nonzero command exit blocks the task,
+so any step that succeeded has exit code 0 and there is nothing to branch on.
+
+```yaml
+  - id: probe
+    type: command
+    run: git diff --quiet HEAD~1
+    allow_failure: true          # the failure advances instead of blocking
+    max_retries: 0               # a probe has nothing to gain from retrying
+  - id: stop-if-clean
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+```
+
+It only ever swallows failures the step itself produced — a nonzero exit, a
+failed `check`, an agent error, a timeout. A missing CLI or an unrenderable
+template still blocks, because a workflow should not be able to branch on "the
+agent is not installed" as though that were a result.
 
 ## Verification is where parallel pays
 
@@ -469,6 +526,16 @@ its own fix.
 step that pushes, publishes, deploys or deletes. The gate costs you one
 keystroke and is the difference between "an agent wrote to a branch" and "an
 agent wrote to production".
+
+**Guard the expensive step, not the whole workflow.** Splitting one workflow
+into `with-changelog` and `without-changelog` moves the decision to task
+creation, which is the one moment the facts that decide it do not exist yet. An
+`if:` on the step keeps one workflow and lets the run decide.
+
+**Probe, then decide, in two steps.** `allow_failure` on a cheap command that
+answers a question, then a `condition` or an `if:` that reads its exit code.
+Trying to do both in one step means a step whose failure is sometimes a failure
+and sometimes an answer, which nothing downstream can tell apart.
 
 **Use `restricted` for steps that only read and write text.** A docs pass has no
 business running commands; the mode says so, and the adapter enforces it.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -255,7 +255,7 @@ rather than inventing a model name.
 | `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort? }` — `branch_name` is used verbatim and wins over any template |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
-| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt |
+| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt. `state` may be `stopped` (a `condition` step ended the run), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did |
 
 Human actions, all `POST /v1/tasks/{id}/…`:
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -101,7 +101,7 @@ its worktree, its branch and its transcripts while it does.
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step as a fresh attempt with the retry counter reset → `queued` |
 | `edit + retry` | blocked | Overrides the step's prompt or command **in this task's snapshot only**, then retries. The override is recorded on the step run |
-| `skip` | blocked, awaiting_gate | Marks the step `skipped` and advances → `queued` |
+| `skip` | blocked, awaiting_gate | Marks the step `skipped` and advances → `queued`. A step skipped this way carries no `skip_reason`, which is how it stays distinguishable from one an `if:` guard skipped |
 | `answer` | awaiting_input | Delivers the answer into the live agent session → `running`, and the step clock resumes |
 | `approve` | awaiting_gate | Gate `approved`, advance → `queued` |
 | `reject` | awaiting_gate | Gate `rejected` → `blocked`, from which you can edit-and-retry an earlier step, skip, or abort |
@@ -126,7 +126,8 @@ that is what the TUI's timeline lists.
 | `succeeded` | Exit 0, a terminal result, and any `check` passed |
 | `failed` | A retryable failure; see the reasons below |
 | `interrupted` | The daemon stopped mid-step. **Does not consume a retry** |
-| `skipped` | You skipped it |
+| `skipped` | You skipped it, **or** its `if:` guard was false. `skip_reason` is `condition` in the second case and empty in the first |
+| `stopped` | A `condition` step whose guard was false: the run ended here, deliberately, and the task is `done` |
 | `approved` / `rejected` | A manual gate's two outcomes |
 
 A step succeeds only when *all* of its criteria hold:
@@ -159,6 +160,7 @@ same thing wherever it originated.
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `input_protocol_error` | A control message the adapter could not parse — it fails, it never hangs |
 | `template_error` | A template failed to render, before any process started |
+| `condition_error` | A step's `if:` guard failed to render, or rendered something that is neither `true` nor `false`. The one reason that is **not** retried — a guard is evaluated before the step becomes an attempt, and re-rendering it cannot answer differently. Fix the workflow and retry |
 | `restricted_unsupported` | The adapter cannot restrict on this platform (cursor on Windows) |
 | `transcript_limit` | The attempt hit `transcript_max_bytes` |
 | `shell_unavailable` | The requested shell is not installed |

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -118,9 +118,14 @@ Common to every step:
 |---|---|---|---|
 | `id` | slug | ✅ | Unique within the file, sub-steps included. How `.Steps` addresses it |
 | `name` | string | | Display name; defaults to `id` |
-| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` | ✅ | `check` is a *field*, not a type |
+| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
 | `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group, bounds the whole group |
+| `if` | template | | Guard: skip this step unless it renders `true`. See [Conditions](#conditions) |
+
+`allow_failure: true` is available on `agent` and `command` steps only; it is
+covered under [Conditions](#conditions), because it exists to give a guard
+something to read.
 
 ### `type: agent`
 
@@ -324,6 +329,105 @@ block.
 > is what `vincent gc` and `vincent doctor` are for, and you will meet it
 > before you meet anything else in this feature.
 
+## Conditions
+
+A workflow can decide at run time what to do next. Three fields do it.
+
+### `if:` — skip a step, carry on
+
+Any step may carry a guard. It renders like every other template here and must
+produce, after trimming, exactly `true` or `false` — nothing else counts, and
+`yes`, `1` and an empty string are all errors rather than a guess.
+
+```yaml
+  - id: changelog
+    type: agent
+    if: '{{ eq (index .Task.Fields "changelog") "yes" }}'
+    prompt: Update CHANGELOG.md.
+```
+
+A false guard **skips that step and the workflow continues**. The step still
+appears in the task's step list, in state `skipped` with reason `condition` —
+so you can tell it apart from a step you skipped by hand — and downstream
+templates can see it in `.Steps`.
+
+On a **fan-out lane** and on a **`parallel` sub-step**, the same `if:` means
+"do not start this one": the other lanes and sub-steps still run, and the join
+still happens. A set has no "later" to skip to, so a false guard subsets it.
+
+Guards are re-evaluated every single time — on each attempt, on a retry, and
+after a daemon restart. Nothing is cached. If you fix a workflow and retry a
+blocked step whose guard is now false, the step is skipped, which is the point.
+
+### `type: condition` — finish early
+
+A step whose entire body is the guard. True continues; **false ends the run and
+the task is `done`**. It takes `id`, `name` and `if:` and nothing else — no
+`run`, no `timeout`, no `max_retries` — because it starts no process.
+
+```yaml
+  - id: nothing-to-do
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+```
+
+The steps after it are never considered and record nothing; the one row it
+leaves is in state `stopped`, which is where the detail view shows the run
+ended.
+
+There is no "stop and block for a human" option, because you already have one:
+a `command` step that exits nonzero. What this adds is *stop and succeed*.
+
+A `condition` step is valid at the top level and inside a lane's workflow. It
+is rejected inside a `parallel` group — a group is a set, so there is no
+sequence there to end.
+
+### `allow_failure:` — a failure that is data
+
+Without this, a guard can only read what a human typed when creating the task.
+A command step that exits nonzero **blocks the task**, so no step that
+succeeded ever has a nonzero exit code to branch on.
+
+`allow_failure: true` changes that for one step: once its retry budget is
+spent, the workflow advances instead of blocking. The row keeps its `failed`
+state and its reason — the failure happened — and that row is what the next
+guard reads.
+
+```yaml
+  - id: probe
+    type: command
+    run: git diff --quiet HEAD~1
+    allow_failure: true
+    max_retries: 0                # a probe should not retry
+  - id: stop-if-clean
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+```
+
+It only swallows failures **the step itself produced** — a nonzero exit, a
+failed `check`, an agent error, a timeout, a transcript-cap kill. It never
+swallows vincent failing to *run* the step: a missing CLI, an expired login, a
+template error. Branching on "the agent is not installed" as though it were a
+test result is not a thing a workflow should be able to do.
+
+It is deliberately not available in `defaults:`. A file-wide "failures do not
+block" is a footgun, and it should cost you one line per step that wants it.
+
+### Reading the outcome of an earlier step
+
+Guards mostly read `.Steps`, which after this change carries a little more:
+
+| What | Reads as |
+|---|---|
+| A step that succeeded | `{{ eq (index .Steps "x").Status "succeeded" }}` |
+| A step skipped by its guard | `{{ eq (index .Steps "x").Status "skipped" }}` |
+| A step that failed under `allow_failure` | `{{ ne (index .Steps "x").ExitCode 0 }}` |
+| The platform | `{{ ne .Host.OS "windows" }}` |
+| A field typed at creation | `{{ eq (index .Task.Fields "ship") "yes" }}` |
+
+A step's *own* failed attempt is not in `.Steps` while it is retrying — use
+`.LastFailure` for that.
+
 ### `check` is a field, not a step type
 
 It runs after the step body, in the worktree, with the same environment as a
@@ -342,7 +446,7 @@ Invert it when failure is the deliverable: `check: '! go test ./...'`.
 
 ## Template context
 
-`prompt`, `run`, `check` and `instructions` are Go `text/template`, rendered
+`prompt`, `run`, `check`, `instructions` and `if` are Go `text/template`, rendered
 with `missingkey=error` — a bad reference fails the step *before* any process
 starts.
 
@@ -352,7 +456,8 @@ starts.
 | `.Project` | `Name`, `Path` (the original repo root), `DefaultBranch` |
 | `.Workflow` | `Name`, `Description` |
 | `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
-| `.Steps` | **completed** steps by id → `{Status, Result, ExitCode}` |
+| `.Steps` | **completed** steps by id → `{Status, Result, ExitCode}`. Includes steps skipped by a guard (`Status: "skipped"`) and steps that failed under `allow_failure`, once the workflow has moved past them |
+| `.Host` | `OS`, `Arch` — the machine the daemon runs on. This is the per-step platform gate: `{{ ne .Host.OS "windows" }}` |
 | `.Worktree` | `Path` |
 | `.LastFailure` | retries only: `{Reason, Output}`; empty otherwise |
 
@@ -419,8 +524,12 @@ network, no agent CLI installed.
 - `steps` non-empty; step `id`s unique **across the whole file**, sub-steps
   of a `parallel` group included; `type` known.
 - A `parallel` group has at least one sub-step and a `max_parallel` of at
-  least 1; its sub-steps are not `manual`, not `parallel`, and do not
-  resolve to `on_input: require`.
+  least 1; its sub-steps are not `manual`, not `parallel`, not `condition`,
+  and do not resolve to `on_input: require`.
+- A `condition` step has an `if:` and nothing else — `timeout`, `max_retries`
+  and `allow_failure` included. `allow_failure` is valid on `agent` and
+  `command` steps only. A `condition` step in **last** position is a *warning*:
+  the task is done whether it continues or stops.
 - A `fan_out` step has at least one lane; lane ids are unique within the step;
   each lane has exactly one of `workflow` and `steps`. `merge.agent` is
   required by, and only valid with, `on_conflict: agent`. A lane's inline

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -76,7 +76,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 9 | Workflow storage | YAML files: global (config dir) + per-project (`.vincent/workflows/`); runs snapshot content |
 | 10 | Step context | Fresh agent session per step; Go `text/template` context; state persists via worktree |
 | 11 | Delivery | Owned entirely by workflow steps; no hardcoded push/PR/merge behavior |
-| 12 | Step types | `agent`, `command`, `manual` (gate) |
+| 12 | Step types | `agent`, `command`, `manual` (gate); `parallel` and `fan_out` added by row 23/24, `condition` by row 25 |
 | 13 | Permissions | Agents run full-auto by default; workflow/step can restrict |
 | 14 | Concurrency | Configurable global cap **and** per-project cap on parallel running tasks |
 | 15 | Task shape | Title, markdown description, project, workflow, base branch, free-form key/value fields |
@@ -90,6 +90,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 
 | 23 | Parallel steps | `type: parallel` runs sub-steps concurrently in the task's one worktree: one step, one index, one slot, no branch and no merge. `manual`, nested groups and `on_input: require` are refused inside one; `max_parallel` (default 4) is a second concurrency dimension the §11 caps do not govern (§7.5, task 014) |
 | 24 | Workflow fan-out | `type: fan_out` makes each lane a real child task with its own worktree and branch, merged back `--no-ff` in declared order at the end of the same step. The parent parks in `awaiting_children` holding no slot, so no depth deadlocks; a conflict blocks by default, a lane that did not finish blocks the join, and the tree's bounds are checked at creation (§7.6, task 014) |
+| 25 | Conditions between steps | `if:` guards any step (skip and carry on) and any fan-out lane or group sub-step (subset the set); `type: condition` ends the sequence with the task `done`; `allow_failure:` turns the failures a step itself produced into an advance, so a guard has a run's own findings to read. Guards are §8.4 templates that must render exactly `true` or `false`, re-evaluated every time and never cached (§7.7, task 015) |
 
 ## 4. Architecture
 
@@ -205,10 +206,17 @@ One attempt at executing one step of one task. Every attempt (including retries 
 re-runs after interruption) is a distinct StepRun row — history is append-only.
 
 Records: step id/index/type, attempt number, state (`running`, `succeeded`, `failed`,
-`interrupted`, `approved`, `rejected`, `skipped`), timestamps, agent/model/effort used (as resolved per §8.6), exit code,
-check exit code, failure reason, transcript file path, input/output tokens, cost (USD,
+`interrupted`, `approved`, `rejected`, `skipped`, `stopped`), timestamps, agent/model/effort used (as resolved per §8.6), exit code,
+check exit code, failure reason, skip reason, transcript file path, input/output tokens, cost (USD,
 nullable — not all agents report cost), input wait time (ms spent in `awaiting_input`,
 §7.4 — excluded from duration metrics).
+
+*Amended 2026-08-18 (task 015).* `stopped` is a `condition` step whose guard
+was false: the run ended there, deliberately and successfully (§7.7). It is
+neither a success nor a failure of the step — the step evaluated perfectly, and
+its answer was "stop". `skip_reason` says why a `skipped` row is skipped:
+`condition` for a false guard, empty for the human `skip` action (§6), which
+share one state.
 
 ## 6. Task lifecycle
 
@@ -298,6 +306,12 @@ Steps execute strictly in order. Executing step *i* means: render templates → 
 step body → evaluate success → on success advance to step *i+1* (or `done` if last) →
 persist → repeat.
 
+*Amended 2026-08-18 (task 015).* A step may carry an `if:` guard and a
+workflow may carry `condition` steps (§7.7). Neither changes the order: a
+guarded step is skipped in place and the cursor advances past it, and a
+`condition` step advances the cursor to the end. The walk is still forward,
+one index at a time, over a flat list.
+
 *Amended 2026-08-17 (task 014).* Order is still strict **between** steps; a
 `parallel` step is one step whose body runs several sub-steps at once. It
 occupies one index, holds one scheduler slot, and the cursor advances past it
@@ -340,6 +354,30 @@ stdout/stderr are captured to the step transcript.
   between attempts a walled step would otherwise spend its whole budget in
   seconds. `usage_limit` is therefore a `queued_reason`, never a `block_reason`.
   Recovery needs no human: the scheduler re-admits the task when the hold expires.
+- **`allow_failure: true` advances instead of blocking.** *Added 2026-08-18
+  (task 015).* On an `agent` or `command` step, the failures **the step itself
+  produced** — `nonzero_exit`, `check_failed`, `agent_error`, `timeout`,
+  `transcript_limit` — advance the cursor once the retry budget is spent,
+  rather than blocking the task. The row keeps its `failed` state and its
+  reason: the failure happened, it just did not stop the workflow, and that row
+  is what a later guard reads through `.Steps` (§8.4). It is what gives a
+  condition something a run *discovered* to branch on.
+
+  Everything else is vincent failing to **run** the step —
+  `agent_unavailable`, `agent_unauthenticated`, `restricted_unsupported`,
+  `input_unsupported`, `platform_unsupported`, `invalid_snapshot`,
+  `template_error`, `condition_error` — and is never swallowed: a workflow must
+  not be able to branch on "the CLI is not installed" as though that were a
+  test result. `usage_limit` and `interrupted` are untouched for a different
+  reason: this section already says they are not failures.
+
+  It is orthogonal to the retry budget, which runs first and in full. A probe
+  that should not retry says `max_retries: 0`. There is no
+  `defaults: allow_failure:` — a workflow-wide "failures do not block" turns
+  this section off in one line at the top of a file.
+- **`condition_error` is the one reason that does not run this budget.**
+  *Added 2026-08-18 (task 015).* A guard is evaluated before the step becomes
+  an attempt, so there is no attempt to retry (§7.7).
 - **`agent_unauthenticated` stays under the normal budget.** *Added 2026-08-14
   (task 003).* A CLI that refuses because it is not logged in fails the attempt
   like any other, retries as usual, and blocks when the budget is spent. Waiting
@@ -474,7 +512,12 @@ that happens to share the word.
   actor goroutine and releases the slot (§6), and no state means "one sub-step
   is gated". `on_input: require` is rejected for the same reason —
   `awaiting_input` holds one pending request for the whole task (§7.4).
-  Groups do not nest.
+  Groups do not nest. *Amended 2026-08-18 (task 015):* `condition` steps are
+  rejected here too — a group is a set, with no sequence to end — and a
+  sub-step may carry an `if:`, which subsets the group. Sub-step guards are
+  evaluated **once, before anything in the group starts**, so no sibling has
+  run and none can be read by another's guard; a group whose sub-steps are all
+  guarded off succeeds having run nothing.
 - **Rows.** One `step_runs` row per sub-step, all sharing the group's
   `step_index` and told apart by `step_id`. The group has no row of its own;
   its outcome is derived. Attempt numbers and retry budgets are per sub-step,
@@ -520,6 +563,20 @@ does not finish until every lane is merged.
   resolved through the usual builtin < global < project shadowing at **task
   creation** and written into the task's snapshot — never read from the
   registry again (§5.3). A lane's workflow may itself fan out, to any depth.
+- **A lane may carry an `if:`.** *Added 2026-08-18 (task 015).* It is
+  evaluated when the `fan_out` step runs, in the parent's context, so a lane
+  can depend on what an earlier step found. A guarded-off lane is not spawned;
+  its siblings still run and the join still merges them, in **declared** lane
+  order — the absent lane's index is not reused, so a re-run merges identically.
+  A step whose lanes are *all* guarded off is a no-op success: it records a row
+  saying so and advances, and specifically does **not** park, because a parent
+  in `awaiting_children` with no children would be re-queued, spawn nothing and
+  park again.
+
+  A conditional lane makes the tree's shape non-static, so the creation-time
+  checks below count **every** lane, guarded ones included. A tree that could
+  never spawn `max_tasks` descendants may still be refused. That
+  over-approximation is stated here rather than left to be discovered.
 - **Creation-time checks**, possible because the whole tree's shape is static
   once lane lists are in the snapshot: a cycle is a `400` naming the path, and
   so is a tree past `fan_out.max_depth` (3) or `fan_out.max_tasks` (64,
@@ -551,7 +608,11 @@ does not finish until every lane is merged.
   to the block. Blocking by default is §7.2's posture: a human decides what a
   machine could not.
 - **A lane that settles without finishing** blocks the join with
-  `lane_failed`, and **nothing** is merged. A partial merge is
+  `lane_failed`, and **nothing** is merged. *Clarified 2026-08-18 (task 015):*
+  "without finishing" means `blocked` or `aborted`. A lane whose own workflow
+  stopped early at a `condition` step (§7.7) settles `done`, and `done` is
+  `done` — it merges normally. Lanes doing different amounts of work is the
+  point of guarding them. A partial merge is
   indistinguishable downstream from a complete one. `retry` re-checks the
   lanes; the remedy is to fix the child, which is an ordinary task. `skip`
   keeps its meaning — it skips the whole join — and is deliberately not a
@@ -568,6 +629,96 @@ does not finish until every lane is merged.
   dirty-worktree rules.
 - **Cost.** N lanes leave N worktrees on disk until someone archives them.
   That is what `vincent gc` and `vincent doctor` are for, and it will be felt.
+
+### 7.7 Conditions between steps
+
+*Added 2026-08-18 (task 015).* A workflow decides at run time what to do next.
+Three fields do it, and they are deliberately not one:
+
+```yaml
+steps:
+  - id: probe
+    type: command
+    run: git diff --quiet HEAD~1
+    allow_failure: true              # a nonzero exit is data, not a block
+
+  - id: nothing-to-do
+    type: condition                  # false ends the run; the task is `done`
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+
+  - id: changelog
+    type: agent
+    if: '{{ eq (index .Task.Fields "changelog") "yes" }}'   # skip, then carry on
+    prompt: Update CHANGELOG.md.
+```
+
+**`if:` on a step is a guard.** It renders against the §8.4 context — the same
+context, the same `missingkey=error`, the same parse-at-load check as `prompt`,
+`run` and `check` — and must produce, after trimming, exactly `true` or
+`false`. Loose truthiness was rejected: a guard reading a field that is not
+there renders the empty string or `<no value>`, and a permissive rule would
+accept either as a decision. A guard that renders anything else fails the step
+with `condition_error`.
+
+**A false guard skips the step and the workflow carries on.** The step records
+a `step_runs` row in state `skipped` with `skip_reason: condition` — the same
+state the human `skip` action writes (§6), told apart by that column — and the
+row stays visible in `.Steps` (§8.4) so a later guard can see that the step did
+not run. This is the answer §8.1.1 deferred for per-step `platforms:`.
+
+**A false guard on a *set* subsets it instead.** On a `fan_out` lane (§7.6) and
+on a `parallel` sub-step (§7.5), "skip and carry on" is subsetting: the other
+members still run, the group still succeeds, the join still happens. One word,
+one meaning — "this member does not run" — whose consequence follows from
+whether it is attached to a sequence or a set.
+
+**`type: condition` ends the sequence.** It carries `id`, `name` and a required
+`if:`, and nothing else — no `run`, no `timeout`, no `max_retries`, no
+`allow_failure` — because it starts no process: it cannot time out, cannot be
+interrupted, has nothing to retry and writes no transcript. Its `if:` is its
+condition rather than a skip-guard on itself.
+
+- **True** continues: the step records `succeeded` and the cursor advances.
+- **False** stops: the step records **`stopped`**, the cursor advances to the
+  end of the step list, and the task is `done`. The steps after it record
+  nothing, because they were never considered.
+
+There is no `on_false:` policy. "Stop and block for a human" already exists —
+it is a `command` step that exits nonzero (§7.1, §7.2) — and the gap this type
+fills is *stop and succeed*.
+
+The shell phrasing of an early finish composes rather than being built in:
+
+```yaml
+- { id: probe, type: command, run: git diff --quiet, allow_failure: true }
+- { id: gate,  type: condition, if: '{{ ne (index .Steps "probe").ExitCode 0 }}' }
+```
+
+A `condition` step is valid at the top level and in a lane's own workflow. It
+is **rejected inside a `parallel` group**, joining `manual` and
+`on_input: require` on §7.5's list: a group is a set, so "end the sequence" has
+nothing there to name.
+
+**Guards are re-evaluated every time, never sticky.** Every attempt, every
+human `retry`, every re-run after §12.4 recovery asks the question again; no
+verdict is persisted. A human who retries a blocked step whose guard is now
+false will see it skipped, and that is correct — if the guard is false now,
+running the step now would be wrong. The alternative is a decision cache
+recovery would have to reason about, holding a verdict computed against facts
+that have since changed.
+
+**A guard error blocks without consuming the retry budget** — the one failure
+in §18's vocabulary that does not run §7.2's budget. A guard is evaluated
+*before* the step becomes an attempt, so there is no attempt to retry, and
+re-rendering an unchanged template against an unchanged context cannot answer
+differently. One `failed` row is recorded for the step carrying
+`condition_error`, so the block names where and why. The second try that can
+succeed is the human's, after they fix the workflow.
+
+**`.Host`** (§8.4) is what a guard reads to gate on the platform:
+`if: '{{ ne .Host.OS "windows" }}'` is the per-step `platforms:` §8.1.1
+deferred, with no new schema. The whole-workflow `platforms:` stays as it is —
+it gates *offering* a workflow, which a run-time guard cannot do.
 
 ## 8. Workflow definition (YAML)
 
@@ -667,24 +818,36 @@ The restriction is **whole-workflow**. A per-step `platforms:` was considered
 and deferred: it needs an answer to "what does a skipped step do to `.Steps`
 and to the task's success", which is a lifecycle question, not a schema one.
 
+*Resolved 2026-08-18 (task 015).* §7.7 answers that question, and the answer
+made the schema unnecessary: a per-step platform gate is
+`if: '{{ ne .Host.OS "windows" }}'`, using `.Host` (§8.4) and the ordinary skip
+semantics. The whole-workflow `platforms:` stays exactly as described above,
+because it does something a run-time guard cannot — it stops the workflow being
+*offered*, in the picker and at task creation, rather than skipping steps once
+a task exists.
+
 ### 8.2 Step types and fields
 
 Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
-`timeout`.
+`timeout`, and — *added 2026-08-18 (task 015)* — `if` (§7.7). A `condition`
+step is the exception: it takes `id`, `name` and `if` only.
 
 | Type | Required | Optional |
 |---|---|---|
-| `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `on_input`, `input_timeout`, `check`, `check_timeout` |
-| `command` | `run` | `shell`, `env` (map), `check`, `check_timeout` |
+| `agent` | `prompt` | `agent`, `model`, `effort`, `permission_mode`, `on_input`, `input_timeout`, `check`, `check_timeout`, `allow_failure` |
+| `command` | `run` | `shell`, `env` (map), `check`, `check_timeout`, `allow_failure` |
 | `manual` | `instructions` | — |
 | `parallel` | `steps` | `max_parallel` |
 | `fan_out` | `lanes` | `merge` |
+| `condition` | `if` | — |
 
-*`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.*
+*`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.
+`condition`, `if` and `allow_failure` added 2026-08-18 (task 015); see §7.7.*
 
 A lane carries `id` plus exactly one of `workflow` (a registry name) or
-`steps` (inline), and optionally `fields`, `agent`, `model`, `effort` and
-`priority`, which override the inherited values for that lane's subtree.
+`steps` (inline), and optionally `if` (*added 2026-08-18, task 015*), `fields`,
+`agent`, `model`, `effort` and `priority`, which override the inherited values
+for that lane's subtree.
 `merge` carries `on_conflict` (`block` | `agent`) and, for the latter, an
 `agent` step.
 
@@ -702,6 +865,14 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   lane ids are unique within the step, and a lane's inline steps have their
   own id namespace because each lane becomes a separate task. `merge.agent`
   is required by, and only valid with, `on_conflict: agent`.
+- *Added 2026-08-18 (task 015).* A `condition` step requires `if` and rejects
+  every other field, `timeout`, `max_retries` and `allow_failure` included: it
+  starts no process. `allow_failure` is valid only on `agent` and `command`
+  steps, sub-steps of a group included. Every `if` — a step's, a sub-step's and
+  a lane's — must parse as a template at load, like every other template field.
+  A `condition` step in **last** position is a **warning**, not an error: the
+  task is `done` whether it continues or stops, so the step cannot do anything
+  a missing step would not.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
   workflow validates on a Windows CI runner exactly as it does on Linux, or
@@ -753,7 +924,8 @@ defensively: `{{ with index .Task.Fields "ticket" }}…{{ end }}`.
 | `.Project` | `Name`, `Path` (original repo root), `DefaultBranch` |
 | `.Workflow` | `Name`, `Description` |
 | `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
-| `.Steps` | map of *completed* step id → `{Status, Result, ExitCode}`; `Result` is the agent's final result text (agent steps) or the last 100 lines of stdout (command steps) |
+| `.Steps` | map of *completed* step id → `{Status, Result, ExitCode}`; `Result` is the agent's final result text (agent steps) or the last 100 lines of stdout (command steps). *Amended 2026-08-18 (task 015):* a step skipped by its guard appears with `Status: "skipped"`, and a **failed** step appears once the engine has advanced past it — which happens only under `allow_failure` (§7.2), and is what a downstream guard reads. A step's own failed attempt stays out of `.Steps` mid-retry, because `.LastFailure` is already that channel; `interrupted` never appears, since §7.2 says it is not an outcome |
+| `.Host` | *Added 2026-08-18 (task 015).* `OS`, `Arch` — the **daemon's** GOOS/GOARCH, since the daemon is what runs the steps (§8.1.1). This is the per-step platform gate: `{{ ne .Host.OS "windows" }}`. There is deliberately no `.Now`: a guard reading wall-clock makes a run non-reproducible |
 | `.Worktree` | `Path` |
 | `.LastFailure` | on retry attempts only: `{Reason, Output}` from the previous attempt; empty otherwise |
 
@@ -2031,6 +2203,9 @@ POST   /v1/tasks/{id}/archive          { force? } or ?force        (done/aborted
                                         never failed by a branch problem (§10, task 008)
 
 GET    /v1/tasks/{id}/steps             all StepRuns (every attempt)
+                                        (task 015, 2026-08-18: each carries `skip_reason`
+                                        — "condition" for a false `if:`, null for the human
+                                        skip — and `state` may now be "stopped", §5.4/§7.7)
 GET    /v1/tasks/{id}/steps/{run_id}/transcript?offset=&tail=&format=
                                         the attempt's JSONL transcript, ranged.
                                         `offset=` (bytes) and `tail=` (last N bytes) are
@@ -2183,7 +2358,7 @@ CREATE TABLE step_runs (
   step_type           TEXT NOT NULL,          -- agent | command | manual
   attempt             INTEGER NOT NULL,       -- 1-based
   state               TEXT NOT NULL,          -- running | succeeded | failed | interrupted
-                                              -- | approved | rejected | skipped
+                                              -- | approved | rejected | skipped | stopped
   agent               TEXT,                   -- adapter name, agent steps only
   model               TEXT,                   -- resolved model as passed to the adapter (§8.6)
   effort              TEXT,                   -- resolved effort as passed to the adapter (§8.6)
@@ -2192,6 +2367,7 @@ CREATE TABLE step_runs (
   exit_code           INTEGER,
   check_exit_code     INTEGER,
   failure_reason      TEXT,
+  skip_reason         TEXT,                   -- 'condition' for a false `if:` (§7.7); NULL for the human skip (§6)
   result_summary      TEXT,                   -- agent result text / command stdout tail
   prompt_override     TEXT,                   -- edit+retry: the prompt a human supplied for this attempt (§6)
   run_override        TEXT,                   -- edit+retry: the command a human supplied for this attempt (§6)
@@ -2693,6 +2869,10 @@ currently true to show (§15 view 6).
 | DB corruption | Startup fails loudly, points at the file, never auto-deletes |
 | Agent emits gigabytes of output | Transcript writes are streamed to disk; SSE output chunks are rate-limited/coalesced (~10 Hz); per-run transcript size cap (`transcript_max_bytes`, default 512 MB) fails the step past the cap with `transcript_limit` |
 | Template references missing field | Step fails at render time (before any process starts) with the template error |
+| A step's `if:` does not render, or renders something that is not `true`/`false` | *Added 2026-08-18 (task 015).* The step blocks with `condition_error` and records one `failed` row naming it. The only reason in this table that does **not** run the §7.2 retry budget: a guard is evaluated before the step becomes an attempt, so there is no attempt to retry, and re-rendering an unchanged template cannot answer differently (§7.7). A human `retry` re-evaluates it |
+| A guard skips a step | *Added 2026-08-18 (task 015).* A `skipped` row with `skip_reason: condition`, visible in `.Steps`; the workflow carries on. The same guard on a fan-out lane or a group sub-step subsets the set instead — the others still run |
+| A `condition` step's guard is false | *Added 2026-08-18 (task 015).* The run ends there: one `stopped` row, the cursor moves to the end of the step list, the task is `done`. The steps after it record nothing, because they were never considered |
+| Every lane of a `fan_out` is guarded off | *Added 2026-08-18 (task 015).* A no-op success: the step records a row saying no lane was selected and advances. It must not park — a parent in `awaiting_children` with no children would be re-queued, spawn nothing and park again (§7.6) |
 | `answer` posted when task isn't `awaiting_input` | `409` with the current state (standard invalid-transition handling) |
 | Agent process dies while `awaiting_input` | Attempt fails with its exit code (retry policy applies); `pending_input` cleared |
 | `input_timeout` expires | Process killed; attempt fails with reason `input_timeout`; normal retry/blocked policy (§7.2) |
@@ -2766,8 +2946,15 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
 - ~~More adapters~~ — **Cursor promoted out of future work to M5, 2026-08-11**
   (§9.7). Gemini CLI, opencode, and adapter capability flags remain here.
 - ~~parallel steps and step fan-out~~ — **promoted out of future work,
-  2026-08-17** (§7.5, §7.6, task 014). Workflow branching/conditionals remains
-  here.
+  2026-08-17** (§7.5, §7.6, task 014).
+- ~~workflow branching/conditionals~~ — **promoted out of future work,
+  2026-08-18** (§7.7, task 015): `if:` guards on steps, lanes and group
+  sub-steps, `type: condition` for early finish, and `allow_failure:` so a
+  guard has a run's own findings to read. What remains here is *nested*
+  control flow — `branch`/`switch` step types with `then:`/`else:` bodies,
+  which would make the step list a tree and the §7 cursor something other than
+  an integer. Guards are flat by construction, and the trigger for
+  reconsidering is a workflow that genuinely cannot be written flat.
 - LLM-as-judge verification as an optional third success layer.
 - Multi-user / remote daemons / fleet view across hosts.
 - Task templates & recurring tasks; issue-tracker ingestion (Jira → task).

--- a/docs/tasks/015-conditional-steps.md
+++ b/docs/tasks/015-conditional-steps.md
@@ -1,0 +1,357 @@
+# 015 — Conditions between steps (`if:`, `type: condition`, `allow_failure:`)
+
+**Status:** 🚧 in progress (0/10) · **Opened:** 2026-08-18
+
+A workflow may now decide, at run time, what to do next:
+
+```yaml
+steps:
+  - id: probe
+    type: command
+    run: git diff --quiet HEAD~1
+    allow_failure: true              # a nonzero exit is data, not a block
+
+  - id: nothing-to-do
+    type: condition                  # false ends the run; the task is `done`
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+
+  - id: changelog
+    type: agent
+    if: '{{ eq (index .Task.Fields "changelog") "yes" }}'   # skip, then carry on
+    prompt: Update CHANGELOG.md.
+
+  - id: build
+    type: fan_out
+    lanes:
+      - { id: api,     workflow: implement-module, fields: { module: api } }
+      - { id: windows, workflow: implement-module, if: '{{ eq .Host.OS "windows" }}' }
+```
+
+Three fields, three jobs, deliberately not one:
+
+- **`if:` on a step** — skip this step and carry on. Records a `skipped` row
+  with `skip_reason: condition`, which stays visible in `.Steps`.
+- **`if:` on a fan-out lane or a `parallel` sub-step** — do not start this
+  member. The other members still run and the join still happens.
+- **`type: condition`** — a step whose entire body is the guard. False ends
+  the sequence: no later step runs and the task is `done`.
+- **`allow_failure:`** on `agent` and `command` steps — the failures the step
+  itself produced advance instead of blocking, which is what gives a guard
+  something to read.
+
+## The problem
+
+Every workflow in vincent is a straight line. §7 opens with "steps execute
+strictly in order", and the engine is literally
+`for index := task.CurrentStep; index < len(wf.Steps); index++`. A workflow
+therefore does the same amount of work whatever it finds: the review step runs
+on a one-line change, the fan-out spawns all six lanes when two of them have
+nothing to build, and a run that discovers at step 2 that there is nothing to
+do still walks through steps 3 to 6 to reach `done`.
+
+The workaround is to split one workflow into several and make the *human*
+choose at creation, which moves the decision to the one point in the lifecycle
+where the facts that decide it do not exist yet.
+
+§8.1.1 already recorded this gap from the other side. A per-step `platforms:`
+was deferred because "it needs an answer to *what does a skipped step do to
+`.Steps` and to the task's success*, which is a lifecycle question, not a
+schema one." That is this task's central question, and answering it settles
+both (decision 8).
+
+§20 keeps "branching and conditionals" in future work, promoted out of it by
+this task the way cursor and fan-out were.
+
+## Decisions
+
+### 1. A guard is a field, not a control-flow step type
+
+*2026-08-18.* `if:` is a field alongside `max_retries` and `timeout`, on every
+step and on every lane. There is no `branch`/`switch` type with nested
+`then:`/`else:` bodies.
+
+**Beat:** control-flow step types. They are more expressive — mutually
+exclusive arms, grouped bodies — and they cost the two invariants the engine is
+built on: "steps execute strictly in order" (§7) and a single integer
+`current_step` cursor. `parallel` already bends the first and paid for it with
+a rule (sub-steps share the group's `step_index`, §7.5); a nested tree would
+bend both. Every use case that opened this task — early finish, lane
+subsetting — is expressible as guards. A `branch` type is a later question with
+a known trigger: the first workflow that cannot be written flat.
+
+### 2. Stopping is a step type, not a second guard field
+
+*2026-08-18.* Skip-and-continue and stop-the-run are different behaviours, and
+they are spelled differently: `if:` is the guard, `type: condition` is the
+terminator.
+
+**Beat:** one field with prefix semantics — `continue_if:`, where a false guard
+on any step ends the run. It is fewer concepts, and it makes "finish early"
+fall out with no new type. It was rejected on how it reads: every CI system in
+use — GitHub Actions, GitLab, Woodpecker — spells skip-and-continue `if:`, so a
+guard field with stop semantics is a false friend whose failure mode is a task
+reaching **`done`** having silently done half its work. Naming it `continue_if:`
+to dodge that was the tell: the design was being bent around a name.
+
+Putting the consequence in the *type* fixes it. `if:` keeps the meaning it has
+everywhere else, and "the workflow ends here" is a line a reader can point at
+rather than a modifier they have to notice.
+
+**Beat also:** both guard fields at once (`if:` and `skip_if:`). Two fields
+with near-identical syntax and opposite control flow read fine in a spec and
+confuse every author afterward. If a workflow turns up that genuinely needs
+skip-and-continue *and* stop in one guard position, it earns the second field
+then.
+
+### 3. `if:` means skip on a sequence and subset on a set
+
+*2026-08-18.* One word, one meaning — "this member does not run" — whose
+consequence follows from what it is attached to. On a step list (a sequence)
+that is skip-and-continue. On a lane list or a `parallel` group's sub-step list
+(both sets, with no ordering and no "later") it is subsetting: the other
+members run, and the group or join proceeds without the absent one.
+
+This is why `condition` steps are rejected inside a `parallel` group
+(decision 7): a group has no sequence to end.
+
+### 4. Guards are Go templates, strictly boolean
+
+*2026-08-18.* An `if:` is rendered with the §8.4 `RenderContext` — the same
+context, the same `missingkey=error`, the same parse-at-load validation as
+`prompt`, `run` and `check`. The rendered string, trimmed, must be exactly
+`true` or `false`; anything else fails the step with `condition_error`.
+
+**Beat:** an expression language (`expr-lang/expr`, CEL). `steps.probe.exit_code
+== 0` reads far better than `{{ ne (index .Steps "probe").ExitCode 0 }}`, and it
+is typed and statically analysable. It is also a second language inside one YAML
+file, a new dependency, and a second context shape to keep in sync with §8.4
+forever. One language in the file wins; the verbosity is the price.
+
+**Beat:** loose truthiness (`"yes"`, `"1"`, non-empty). Strictness is this
+schema's posture everywhere else — strict YAML decoding, `missingkey=error`,
+`macos` rejected as a typo of `darwin` (§8.1.1). And loose truthiness has a
+specific trap here: `{{ .Missing }}` renders `false` under some spellings and
+the string `<no value>` under others, both of which a permissive rule would
+happily accept as a decision.
+
+### 5. `allow_failure:` ships with the guards, not after them
+
+*2026-08-18.* Without it, a guard can read almost nothing. §7.1 blocks the task
+on a nonzero command exit, so a step that *succeeded* always has
+`ExitCode: 0`, and `.Steps` never contained a failed step at all
+(`engine.go:451`). Guards would have been able to branch on task fields typed by
+a human at creation, and on nothing a run discovered — which is the half of the
+feature worth having.
+
+`allow_failure: true` converts only **the outcomes the step itself produced**:
+`nonzero_exit`, `check_failed`, `agent_error`, `timeout`, `transcript_limit`.
+Everything else is vincent failing to *run* the step —
+`agent_unavailable`, `agent_unauthenticated`, `restricted_unsupported`,
+`input_unsupported`, `platform_unsupported`, `invalid_snapshot`,
+`template_error`, `condition_error` — and swallowing those would let a workflow
+branch on "the CLI is not installed" as though it were a test result.
+`usage_limit` and `interrupted` are untouched because §7.2 already says they are
+not failures.
+
+It is **orthogonal to the retry budget**: the step retries as it always did, and
+`allow_failure` decides only what happens when the budget is spent. An author
+writing a probe sets `max_retries: 0`; folding that in would make one field mean
+two things.
+
+There is no `defaults: allow_failure:`. A workflow-wide "failures do not block"
+turns §7.2 off by accident, which is not a thing an author should be able to do
+in one line at the top of a file.
+
+### 6. `.Steps` gains failed steps the engine advanced past
+
+*2026-08-18.* The §8.4 filter widens from
+`succeeded | approved | skipped` to also admit `failed` — but only for a step
+whose index is **behind** the current one.
+
+A step's own failed attempt stays out of `.Steps["itself"]` mid-retry, because
+`.LastFailure` is already the documented channel for that and two spellings of
+one fact is how a template context rots. `interrupted` stays out: §7.2 says it
+is not an outcome, and a guard branching on "the daemon restarted" is a bug
+waiting to be written. `rejected` stays out by construction — a rejected gate
+does not advance.
+
+### 7. A `condition` step evaluates a template and nothing else
+
+*2026-08-18.* It carries `id`, `name` and a required `if:`. It rejects every
+other field, including `timeout`, `max_retries` and `allow_failure`, because it
+starts no process: it cannot time out, cannot be interrupted, has nothing to
+retry, and produces no transcript.
+
+**Beat:** letting it carry `run:`, exit 0 meaning continue. The natural phrasing
+of early finish really is a shell test — `git diff --quiet`. But that composes
+exactly, in two lines, out of pieces that already exist (a `command` step with
+`allow_failure`, then a guard reading its `ExitCode`), and the composition keeps
+the command's output in a transcript where a human can read it. A
+condition step that spawned processes would need `timeout`, `shell`, `env`, a
+retry budget and a transcript — a `command` step wearing a hat.
+
+`if:` on a `condition` step is its condition, and may not also act as a
+skip-guard: "skip the check that decides whether to continue" has two readings
+and neither is worth having.
+
+**Where it is legal:** top-level steps, and the steps of a lane's own workflow.
+Rejected inside a `parallel` group, joining `manual` and `on_input: require` on
+§7.5's rejection list and for the same reason — a group is a set, so there is no
+"stop the rest" to mean.
+
+### 8. A false condition stops as `done`, with no policy field
+
+*2026-08-18.* There is no `on_false: finish | block | fail`. Stopping always
+finishes the task successfully.
+
+**Beat:** the policy field. "Stop and block for a human" is worth having and
+already exists — it is a `command` step that exits nonzero (§7.1, §7.2). The
+gap in the vocabulary is *stop and succeed*, and that is the whole of what this
+type fills. A policy field would give vincent two spellings of one behaviour,
+which is what §7.6's `merge` shape was careful to avoid.
+
+The cursor advances to `len(steps)` so `r.complete()` fires on the existing
+path and a finished task does not read as mid-run to every client. The deciding
+step gets one row; the steps after it get none, because they were never
+considered and inventing rows for them would make
+`GET /v1/tasks/{id}/steps` claim a decision the engine never made.
+
+### 9. `stopped` is a new step-run state; `skip_reason` is a new column
+
+*2026-08-18.* Two different events, recorded two different ways.
+
+A `condition` step that passes records `succeeded`. One that fails records
+**`stopped`** — a new `StepRunState`. No existing value fits: `failed`
+contradicts a `done` task, `skipped` is false because the step did evaluate, and
+`succeeded` hides the single most important fact about the run. The churn is
+real (`store/models.go`, the steps DTO, the TUI detail renderer) and is the
+price of the detail view being able to say where a run ended and why.
+
+An ordinary step skipped by its guard records `skipped` — the existing state,
+already shared with the human `skip` action — plus a new
+`step_runs.skip_reason` column carrying `condition`. Overloading
+`failure_reason` on a row that did not fail was rejected: this schema has been
+careful that one column means one thing (`usage_limit` is a `queued_reason` and
+never a `block_reason`, on exactly this principle).
+
+### 10. Guards are re-evaluated every time, never sticky
+
+*2026-08-18.* A guard is part of rendering: it is evaluated fresh on every
+attempt, on a human `retry`, and after crash recovery re-runs an `interrupted`
+step. No verdict is persisted and consulted later.
+
+The surprising case is real — a human retries a blocked step and the guard,
+now false, skips it — and it is also *correct*: if the guard is false now,
+running the step now would be wrong. The alternative is a persisted decision
+cache that §12.4 recovery would then have to reason about, to preserve a verdict
+computed against facts that have since changed. The mitigation is visibility
+(the skipped row records why), not stickiness.
+
+### 11. Lane guards are evaluated at run time, and the creation-time limits count conservatively
+
+*2026-08-18.* A lane's `if:` is evaluated when the `fan_out` step runs, in the
+parent's context, so a lane can depend on what an earlier step found — which is
+the use case ("fan out fixups only for the modules that failed").
+
+That breaks the premise §7.6 leans on: the tree's shape is no longer static once
+lanes are conditional. So `fan_out.max_depth` and `fan_out.max_tasks` keep
+counting **every** lane, guarded ones included. A tree that could never spawn 64
+tasks may still be refused at creation. That is an over-approximation and it is
+stated in §7.6 rather than left to be discovered, because the alternative —
+evaluating lane guards at creation against `.Task.Fields` only — forecloses the
+interesting half of the feature to make a limit exact that nobody is near.
+
+**All lanes guarded off** is a no-op success, not an error. The step is reached,
+chooses nothing, and advances; a workflow whose conditions all said "not this
+time" decided correctly.
+
+**A lane that stops early merges normally.** §7.6's `lane_failed` is about a lane
+that settles `blocked` or `aborted`; a child that hit a false `condition` at
+step 2 of 5 settles `done`, and `done` is `done`. §7.6's phrase "settles without
+finishing" needed one clarifying sentence, since an early stop *is* finishing.
+
+### 12. `.Host` joins the template context; `.Now` does not
+
+*2026-08-18.* `.Host{OS, Arch}` — the daemon's own GOOS/GOARCH, since the daemon
+is what runs the steps (§8.1.1).
+
+It costs one struct and it closes §8.1.1's deferral without new schema: the
+per-step `platforms:` deferred there is now `if: '{{ ne .Host.OS "windows" }}'`,
+using a guard whose skip semantics this task defines. The whole-workflow
+`platforms:` stays as it is — it gates *offering* a workflow, which a run-time
+guard cannot do.
+
+`.Now` was rejected. A guard reading wall-clock makes a run non-reproducible,
+which is the property §7.6 worked to preserve when it chose declared lane order
+over completion order, and nothing this task exists for needs it.
+
+### 13. No new event type
+
+*2026-08-18.* §13.3 records that `step.started`, `step.finished` and
+`step.retrying` "were listed here through M2 but were never emitted" — a step's
+lifecycle is reconstructed from `GET /v1/tasks/{id}/steps`, and `task.step_advanced`
+already fires when the cursor moves. A skip moves the cursor and an early stop
+moves it to the end, so both are already visible on the stream. Adding
+`step.skipped` would be the first step-lifecycle event vincent ever emitted, to
+carry something a client can already see.
+
+### 14. A guard error blocks without consuming the retry budget
+
+*2026-08-18.* `condition_error` is the one failure in the §18 vocabulary that
+does not run §7.2's retry budget. It blocks on the first evaluation.
+
+This **reverses the answer this task was designed with**, which was to run the
+ordinary budget for uniformity, on the `agent_unauthenticated` precedent
+(§7.2: short-circuiting "would make it the only reason in vincent that bypasses
+this section — to save one process spawn"). Implementation showed the two cases
+are not the same shape. `agent_unauthenticated` is an *attempt* that failed:
+there is a row, a transcript and an attempt number, and the budget is machinery
+that already exists around it. A guard is evaluated **before** the step becomes
+an attempt — it decides whether there is one — so retrying it would mean
+inventing attempt rows for a step that never ran, purely to have something to
+count. Decision 8 refuses exactly that ("inventing rows for them would make
+`GET /v1/tasks/{id}/steps` claim a decision the engine never made").
+
+And the retries could not work. Re-rendering an unchanged template against an
+unchanged context cannot answer differently, and unlike a spawn it cannot fail
+for an environmental reason that clears. The second try that can actually
+succeed is the human's, after they fix the workflow — which decision 10 already
+guarantees re-asks the question.
+
+One `failed` row is written for the guard, carrying `condition_error`, so the
+block is diagnosable in the detail view rather than being a state change with
+no step behind it.
+
+## Tasks
+
+- [ ] **015.1 — Schema and validation.** `If` and `AllowFailure` on `Step`, `If`
+  on `Lane`, `StepCondition` in the type set. Guard templates parse-checked at
+  load like every other template field. `rejectFields` extended so a `condition`
+  step refuses everything but `id`/`name`/`if`, and so `allow_failure` is
+  rejected on `manual`, `parallel`, `fan_out` and `condition`. A trailing
+  `condition` step is a **warning**, not an error (it can only mean "or don't"),
+  riding the existing `warnings[]`. Spec §8.2.
+- [ ] **015.2 — Evaluation.** `.Host` in `RenderContext`; an `Evaluate` that
+  renders a guard and demands exactly `true`/`false`; `ReasonConditionError`
+  under §7.2's ordinary retry budget (uniformity, per the `agent_unauthenticated`
+  precedent); `.Steps` widened per decision 6. Spec §8.4, §18.
+- [ ] **015.3 — Store.** Migration `0008`: `step_runs.skip_reason`. `StepStopped`
+  in `StepRunState`. Spec §14.
+- [ ] **015.4 — Engine.** Depends: 015.1, 015.2, 015.3. Guard evaluation before a
+  step runs; the skipped row; the `condition` executor and its `stopped` row;
+  `current_step` → `len(steps)` on a stop; `allow_failure` converting the
+  decision-5 reasons into an advance. New spec §7.7, amended §7.2.
+- [ ] **015.5 — Parallel groups.** Depends: 015.4. `if:` on sub-steps (subset
+  semantics, evaluated once at group start, so siblings are invisible to each
+  other); `condition` rejected as a sub-step. Spec §7.5.
+- [ ] **015.6 — Fan-out lanes.** Depends: 015.4. Lane `if:` at run time; the
+  zero-lane no-op; conservative creation-time counting; the early-stopped-lane
+  clarification. Spec §7.6.
+- [ ] **015.7 — API.** Depends: 015.3. `skip_reason` and the `stopped` state
+  through `internal/api` and `internal/apiclient`. Spec §13.2.
+- [ ] **015.8 — TUI.** Depends: 015.7. Skipped and stopped rows in the detail
+  view, both on the existing no-transcript path.
+- [ ] **015.9 — Gate.** Depends: 015.4, 015.5, 015.6. New `scripts/m7-gate.sh`,
+  command steps only, committed executable via `git update-index --chmod=+x`.
+- [ ] **015.10 — Docs.** Depends: all. User-facing schema, guides and
+  block-reason pages; §20 promotion; CLAUDE.md's gate list.

--- a/docs/tasks/015-conditional-steps.md
+++ b/docs/tasks/015-conditional-steps.md
@@ -1,6 +1,6 @@
 # 015 — Conditions between steps (`if:`, `type: condition`, `allow_failure:`)
 
-**Status:** 🚧 in progress (0/10) · **Opened:** 2026-08-18
+**Status:** ✅ done (10/10) · **Opened:** 2026-08-18
 
 A workflow may now decide, at run time, what to do next:
 
@@ -324,34 +324,86 @@ no step behind it.
 
 ## Tasks
 
-- [ ] **015.1 — Schema and validation.** `If` and `AllowFailure` on `Step`, `If`
+- [x] **015.1 — Schema and validation.** ✓ 2026-08-18 `If` and `AllowFailure` on `Step`, `If`
   on `Lane`, `StepCondition` in the type set. Guard templates parse-checked at
   load like every other template field. `rejectFields` extended so a `condition`
   step refuses everything but `id`/`name`/`if`, and so `allow_failure` is
   rejected on `manual`, `parallel`, `fan_out` and `condition`. A trailing
   `condition` step is a **warning**, not an error (it can only mean "or don't"),
   riding the existing `warnings[]`. Spec §8.2.
-- [ ] **015.2 — Evaluation.** `.Host` in `RenderContext`; an `Evaluate` that
+- [x] **015.2 — Evaluation.** ✓ 2026-08-18 `.Host` in `RenderContext`; an `Evaluate` that
   renders a guard and demands exactly `true`/`false`; `ReasonConditionError`
   under §7.2's ordinary retry budget (uniformity, per the `agent_unauthenticated`
   precedent); `.Steps` widened per decision 6. Spec §8.4, §18.
-- [ ] **015.3 — Store.** Migration `0008`: `step_runs.skip_reason`. `StepStopped`
+- [x] **015.3 — Store.** ✓ 2026-08-18 Migration `0008`: `step_runs.skip_reason`. `StepStopped`
   in `StepRunState`. Spec §14.
-- [ ] **015.4 — Engine.** Depends: 015.1, 015.2, 015.3. Guard evaluation before a
+- [x] **015.4 — Engine.** ✓ 2026-08-18 Depends: 015.1, 015.2, 015.3. Guard evaluation before a
   step runs; the skipped row; the `condition` executor and its `stopped` row;
   `current_step` → `len(steps)` on a stop; `allow_failure` converting the
   decision-5 reasons into an advance. New spec §7.7, amended §7.2.
-- [ ] **015.5 — Parallel groups.** Depends: 015.4. `if:` on sub-steps (subset
+- [x] **015.5 — Parallel groups.** ✓ 2026-08-18 Depends: 015.4. `if:` on sub-steps (subset
   semantics, evaluated once at group start, so siblings are invisible to each
   other); `condition` rejected as a sub-step. Spec §7.5.
-- [ ] **015.6 — Fan-out lanes.** Depends: 015.4. Lane `if:` at run time; the
+- [x] **015.6 — Fan-out lanes.** ✓ 2026-08-18 Depends: 015.4. Lane `if:` at run time; the
   zero-lane no-op; conservative creation-time counting; the early-stopped-lane
   clarification. Spec §7.6.
-- [ ] **015.7 — API.** Depends: 015.3. `skip_reason` and the `stopped` state
+- [x] **015.7 — API.** ✓ 2026-08-18 Depends: 015.3. `skip_reason` and the `stopped` state
   through `internal/api` and `internal/apiclient`. Spec §13.2.
-- [ ] **015.8 — TUI.** Depends: 015.7. Skipped and stopped rows in the detail
+- [x] **015.8 — TUI.** ✓ 2026-08-18 Depends: 015.7. Skipped and stopped rows in the detail
   view, both on the existing no-transcript path.
-- [ ] **015.9 — Gate.** Depends: 015.4, 015.5, 015.6. New `scripts/m7-gate.sh`,
+- [x] **015.9 — Gate.** ✓ 2026-08-18 Depends: 015.4, 015.5, 015.6. New `scripts/m7-gate.sh`,
   command steps only, committed executable via `git update-index --chmod=+x`.
-- [ ] **015.10 — Docs.** Depends: all. User-facing schema, guides and
+- [x] **015.10 — Docs.** ✓ 2026-08-18 Depends: all. User-facing schema, guides and
   block-reason pages; §20 promotion; CLAUDE.md's gate list.
+
+## Verification
+
+*2026-08-18.* All 10 subtasks delivered.
+
+- `go run mage.go build test testrace lint`, plus `golangci-lint` cross-built
+  for `windows`, `darwin` and `linux` — a host-only lint hides findings in
+  build-tagged files, and this change touches none of them, which is worth
+  having proved rather than assumed.
+- Gates: `m1`, `m2`, `m5` and `m6` re-run to prove no regression; the new `m7`
+  passes all seven scenarios.
+- `m7` is **not wired into CI**, for the reason `m6` is not: the push token
+  used for this work has no `workflow` scope, so a branch touching
+  `.github/workflows` is rejected outright. The addition is two lines in
+  `ci.yml`'s `gates` job, beside the existing M1/M2/M5 steps:
+
+  ```yaml
+      - name: M7 gate (conditions)
+        shell: bash
+        run: ./scripts/m7-gate.sh
+  ```
+
+  `CLAUDE.md`'s command list now names both `m6` and `m7` and says they are
+  hand-run, so the gap is documented rather than silently carried.
+
+### `m7` is portable where `m6` is not
+
+`m6`'s `run:` bodies use `touch`, `seq` and `sleep 0.1`, which pwsh does not
+speak — it is a POSIX-only gate whose header claims three platforms, and never
+having been wired into CI is what let that stand. `m7`'s bodies are restricted
+to `exit N` and `git …`, which `/bin/sh` and `pwsh` both accept, and its lanes
+commit with `--allow-empty` rather than writing a file, because `printf >` and
+`Set-Content` share no spelling. It should pass on all three platforms the day
+someone can wire it in.
+
+### One decision reversed by implementation
+
+Decision 14 (`condition_error` does not consume the retry budget) reverses the
+answer this task was designed with. The reasoning is in that decision; the
+short version is that a guard is evaluated before the step becomes an attempt,
+so honouring the budget would have meant inventing attempt rows for a step that
+never ran — which decision 8 refuses on its own grounds.
+
+### A pre-existing flake, observed and left alone
+
+`TestFanOutBlocksWhenALaneDidNotFinish` (task 014) fails roughly 1 run in 30:
+it cancels a lane it expects to still be `queued`, and the scheduler sometimes
+admits that lane first. Measured at 1/30 on `origin/master` and at the same
+order on this branch, so it is not this task's doing. Left unfixed
+deliberately — a timing fix to somebody else's test does not belong in a diff
+about conditions — and recorded here so the next person to see it red does not
+re-diagnose it.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -29,7 +29,7 @@ description of how the system actually behaves.
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
 | [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | ✅ done (14/14) |
-| [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | 🚧 in progress (0/10) |
+| [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | ✅ done (10/10) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -29,6 +29,7 @@ description of how the system actually behaves.
 | [012](012-diff-view-file-grouping.md) | A diff tab grouped by file, folded shut | ✅ done (5/5) |
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
 | [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | ✅ done (14/14) |
+| [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | 🚧 in progress (0/10) |
 
 ## How to add and update a task document
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -198,17 +198,21 @@ type stepRunResponse struct {
 	StepID    string `json:"step_id"`
 	// StepName is the snapshot's display name for this attempt's step, so a
 	// timeline reads in the workflow author's words rather than in step ids.
-	StepName       string   `json:"step_name"`
-	StepType       string   `json:"step_type"`
-	Attempt        int      `json:"attempt"`
-	State          string   `json:"state"`
-	Agent          *string  `json:"agent"`
-	Model          *string  `json:"model"`
-	Effort         *string  `json:"effort"`
-	PID            *int     `json:"pid"`
-	ExitCode       *int     `json:"exit_code"`
-	CheckExitCode  *int     `json:"check_exit_code"`
-	FailureReason  *string  `json:"failure_reason"`
+	StepName      string  `json:"step_name"`
+	StepType      string  `json:"step_type"`
+	Attempt       int     `json:"attempt"`
+	State         string  `json:"state"`
+	Agent         *string `json:"agent"`
+	Model         *string `json:"model"`
+	Effort        *string `json:"effort"`
+	PID           *int    `json:"pid"`
+	ExitCode      *int    `json:"exit_code"`
+	CheckExitCode *int    `json:"check_exit_code"`
+	FailureReason *string `json:"failure_reason"`
+	// SkipReason says why a `skipped` attempt was skipped: "condition" for a
+	// false `if:` guard (§7.7), null for the human `skip` action (§6). The
+	// two share one state, so this is what tells a timeline which it is.
+	SkipReason     *string  `json:"skip_reason"`
 	ResultSummary  string   `json:"result_summary"`
 	TranscriptPath *string  `json:"transcript_path"`
 	InputTokens    *int64   `json:"input_tokens"`
@@ -262,6 +266,7 @@ func toStepRunResponse(r *store.StepRun, summary snapshotSummary) stepRunRespons
 		ExitCode:       r.ExitCode,
 		CheckExitCode:  r.CheckExitCode,
 		FailureReason:  nilIfEmpty(r.FailureReason),
+		SkipReason:     nilIfEmpty(r.SkipReason),
 		ResultSummary:  r.ResultSummary,
 		TranscriptPath: nilIfEmpty(r.TranscriptPath),
 		InputTokens:    r.InputTokens,

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -182,6 +182,10 @@ type StepRun struct {
 	ExitCode      *int    `json:"exit_code"`
 	CheckExitCode *int    `json:"check_exit_code"`
 	FailureReason *string `json:"failure_reason"`
+	// SkipReason is "condition" for an attempt skipped by a false `if:`
+	// guard (§7.7) and nil for the human `skip` action (§6) — both of which
+	// carry State "skipped".
+	SkipReason    *string `json:"skip_reason"`
 	ResultSummary string  `json:"result_summary"`
 
 	// TranscriptPath is nil for a step that produced no transcript — a manual

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 7
+const latestSchemaVersion = 8
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0008_conditions.sql
+++ b/internal/store/migrations/0008_conditions.sql
@@ -1,0 +1,32 @@
+-- 0008_conditions: why a step run was skipped (task 015, spec §7.7/§14).
+--
+-- `skipped` has meant one thing since 0001 — a human pressed skip (§6) — and
+-- now means two, because a false `if:` guard skips a step and carries on.
+-- The two are recorded in the same state and told apart by this column:
+-- 'condition' for the guard, NULL for the human action, which keeps every
+-- existing row correct without a backfill.
+--
+-- It is a column of its own rather than a value written into failure_reason.
+-- A row in state 'skipped' did not fail, and this schema has been careful that
+-- one column means one thing: `usage_limit` is a queued_reason and never a
+-- block_reason on exactly that principle (task 003). A reader filtering
+-- failure_reason IS NOT NULL to count failures would otherwise have counted
+-- skips.
+--
+-- No CHECK constraint, matching every other reason column in this schema
+-- (failure_reason, block_reason, queued_reason): the vocabulary lives in Go
+-- constants, where adding one is an append rather than a migration.
+ALTER TABLE step_runs ADD COLUMN skip_reason TEXT;
+
+-- The 'stopped' state joins the step_runs.state vocabulary in the same change
+-- (task 015 decision 9): it is what a `condition` step records when its guard
+-- is false, ending the sequence with the task `done`. It needs no DDL — state
+-- is TEXT with no CHECK — but it is written here because 0001's column comment
+-- is where a reader looks for the list, and that comment is now incomplete:
+--
+--   state: running | succeeded | failed | interrupted
+--        | approved | rejected | skipped | stopped
+--
+-- No existing value fitted. 'failed' contradicts a task that is `done`,
+-- 'skipped' is untrue because the step did evaluate, and 'succeeded' hides the
+-- single most important fact about the run — where it ended, and why.

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -43,7 +43,17 @@ const (
 	StepApproved    StepRunState = "approved"
 	StepRejected    StepRunState = "rejected"
 	StepSkipped     StepRunState = "skipped"
+	// StepStopped is a `condition` step whose guard was false (§7.7, task
+	// 015): the sequence ends here and the task is `done`. It is the one
+	// state that is neither a success nor a failure of the step — the step
+	// evaluated perfectly, and its answer was "stop".
+	StepStopped StepRunState = "stopped"
 )
+
+// SkipReasonCondition is written to StepRun.SkipReason when a false `if:`
+// guard skipped the step (§7.7, task 015). A human `skip` (§6) leaves it
+// empty, which is what tells the two apart.
+const SkipReasonCondition = "condition"
 
 // Project is a registered local git repository (spec §5.1).
 type Project struct {
@@ -147,6 +157,9 @@ type StepRun struct {
 	ExitCode      *int
 	CheckExitCode *int
 	FailureReason string
+	// SkipReason says why a `skipped` row is skipped: SkipReasonCondition
+	// for a false guard, empty for the human `skip` action (§6, §7.7).
+	SkipReason    string
 	ResultSummary string
 	// PromptOverride and RunOverride record the text a human supplied for
 	// this attempt via edit+retry (spec §6). Empty on every other attempt,

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -11,7 +11,7 @@ import (
 )
 
 const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, state, agent, model, effort, pid,
-	proc_started_at, exit_code, check_exit_code, failure_reason, result_summary,
+	proc_started_at, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
 	prompt_override, run_override, transcript_path,
 	input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at`
 
@@ -84,14 +84,14 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 	}
 	res, err := db.ExecContext(ctx, `
 		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, state, agent, model, effort, pid,
-			proc_started_at, exit_code, check_exit_code, failure_reason, result_summary,
+			proc_started_at, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
 			prompt_override, run_override, transcript_path,
 			input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, string(r.State),
 		nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
 		r.PID, formatTimePtr(r.ProcStartedAt), r.ExitCode, r.CheckExitCode,
-		nullString(r.FailureReason), nullString(r.ResultSummary),
+		nullString(r.FailureReason), nullString(r.SkipReason), nullString(r.ResultSummary),
 		nullString(r.PromptOverride), nullString(r.RunOverride), nullString(r.TranscriptPath),
 		r.InputTokens, r.OutputTokens, r.CostUSD, r.InputWaitMS,
 		formatTime(r.StartedAt), formatTimePtr(r.FinishedAt))
@@ -111,13 +111,14 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 func (s *Store) UpdateStepRun(ctx context.Context, r *StepRun) error {
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE step_runs SET state = ?, agent = ?, model = ?, effort = ?, pid = ?, proc_started_at = ?,
-			exit_code = ?, check_exit_code = ?, failure_reason = ?, result_summary = ?,
+			exit_code = ?, check_exit_code = ?, failure_reason = ?, skip_reason = ?, result_summary = ?,
 			prompt_override = ?, run_override = ?, transcript_path = ?,
 			input_tokens = ?, output_tokens = ?, cost_usd = ?, input_wait_ms = ?, finished_at = ?
 		WHERE id = ?`,
 		string(r.State), nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
 		r.PID, formatTimePtr(r.ProcStartedAt),
-		r.ExitCode, r.CheckExitCode, nullString(r.FailureReason), nullString(r.ResultSummary),
+		r.ExitCode, r.CheckExitCode, nullString(r.FailureReason), nullString(r.SkipReason),
+		nullString(r.ResultSummary),
 		nullString(r.PromptOverride), nullString(r.RunOverride), nullString(r.TranscriptPath),
 		r.InputTokens, r.OutputTokens, r.CostUSD, r.InputWaitMS, formatTimePtr(r.FinishedAt),
 		r.ID)
@@ -273,7 +274,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	var (
 		r                                       StepRun
 		agent, model, effort                    sql.NullString
-		failure, summary, transcript            sql.NullString
+		failure, skip, summary, transcript      sql.NullString
 		promptOv, runOv                         sql.NullString
 		pid, exitCode, checkExit, inTok, outTok sql.NullInt64
 		cost                                    sql.NullFloat64
@@ -282,7 +283,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	)
 	if err := row.Scan(&r.ID, &r.TaskID, &r.StepIndex, &r.StepID, &r.StepType, &r.Attempt,
 		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &exitCode, &checkExit,
-		&failure, &summary, &promptOv, &runOv, &transcript,
+		&failure, &skip, &summary, &promptOv, &runOv, &transcript,
 		&inTok, &outTok, &cost, &r.InputWaitMS, &started, &finished); err != nil {
 		return nil, err
 	}
@@ -290,6 +291,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	r.Model = model.String
 	r.Effort = effort.String
 	r.FailureReason = failure.String
+	r.SkipReason = skip.String
 	r.ResultSummary = summary.String
 	r.PromptOverride = promptOv.String
 	r.RunOverride = runOv.String

--- a/internal/taskrun/condition.go
+++ b/internal/taskrun/condition.go
@@ -1,0 +1,106 @@
+package taskrun
+
+import (
+	"context"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// Step guards (spec §7.7, task 015).
+//
+// A guard is evaluated *before* the step becomes an attempt: it decides
+// whether there is an attempt at all. That is why everything here writes its
+// own row rather than going through runAttempt — a skipped step has no
+// process, no transcript and no retry budget, and a `condition` step has none
+// of those by construction (decision 7).
+
+// evaluateGuard renders a step's `if:` against the §8.4 context and returns
+// its verdict. The context is assembled fresh on every call: a verdict is
+// never cached and never persisted (decision 10), so a human `retry` after
+// fixing a workflow re-asks the question rather than replaying an answer
+// computed against facts that have since changed.
+func (r *Runner) evaluateGuard(ctx context.Context, env *stepEnv) (bool, error) {
+	rc, err := r.renderContext(ctx, env, r.nextAttempt(ctx, env), stepOutcome{})
+	if err != nil {
+		return false, err
+	}
+	return workflow.Evaluate("if", env.step.If, rc)
+}
+
+// nextAttempt is the attempt number a guard renders `.Step.Attempt` as: the
+// one the step would run as if the guard let it. A counting failure falls
+// back to 1 rather than failing the guard — the count is context for a
+// template, not the decision itself.
+func (r *Runner) nextAttempt(ctx context.Context, env *stepEnv) int {
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, time.Time{})
+	if err != nil {
+		env.log.Warn("count attempts for guard context", "error", err)
+		return 1
+	}
+	return attempts.Last + 1
+}
+
+// recordGuardOutcome writes the one row a guard decision produces. Every
+// caller is terminal for the step: it skipped, it stopped, or it passed.
+func (r *Runner) recordGuardOutcome(
+	ctx context.Context, env *stepEnv, state store.StepRunState, skipReason, failureReason string,
+) {
+	r.recordDecisionRow(ctx, env, state, skipReason, failureReason, env.step.If)
+}
+
+// recordDecisionRow writes a row for a step that reached a verdict without
+// running a process. summary is what the detail view shows in place of output:
+// the guard itself for a guarded step, a sentence for a fan-out that selected
+// no lanes.
+func (r *Runner) recordDecisionRow(
+	ctx context.Context, env *stepEnv, state store.StepRunState,
+	skipReason, failureReason, summary string,
+) {
+	finished := time.Now()
+	run := &store.StepRun{
+		TaskID:        env.task.ID,
+		StepIndex:     env.index,
+		StepID:        env.step.ID,
+		StepType:      env.step.Type,
+		Attempt:       r.nextAttempt(ctx, env),
+		State:         state,
+		SkipReason:    skipReason,
+		FailureReason: failureReason,
+		ResultSummary: truncate(summary, resultSummaryLimit),
+		FinishedAt:    &finished,
+	}
+	if err := r.deps.Store.CreateStepRun(r.persistCtx(), run); err != nil {
+		env.log.Error("record guard outcome", "state", state, "error", err)
+		return
+	}
+	r.emit(env.task, eventStepFinished, map[string]any{
+		"step_id": env.step.ID, "step_index": env.index, "attempt": run.Attempt,
+		"run_id": run.ID, "state": string(state), "skip_reason": skipReason,
+		"failure_reason": failureReason,
+	})
+}
+
+// allowFailure reports whether `allow_failure: true` on this step turns the
+// given failure reason into an advance (§7.2, decision 5).
+//
+// The rule is "outcomes the step itself produced". Everything absent from
+// this set is vincent failing to *run* the step — an absent CLI, an expired
+// login, a snapshot this host cannot honour — and swallowing those would let
+// a workflow branch on "the agent is not installed" as though that were a
+// test result. `usage_limit` and `interrupted` are absent for a different
+// reason: §7.2 says they are not failures at all, so there is nothing to
+// allow.
+func allowFailure(step workflow.Step, reason string) bool {
+	if !step.AllowFailure {
+		return false
+	}
+	switch reason {
+	case ReasonNonzeroExit, ReasonCheckFailed, ReasonAgentError,
+		ReasonTimeout, ReasonTranscriptLimit:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/taskrun/condition_test.go
+++ b/internal/taskrun/condition_test.go
@@ -1,0 +1,306 @@
+package taskrun
+
+import (
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// Guards, condition steps and allow_failure end to end (§7.7, task 015).
+// Command steps only: nothing here needs an agent, and a gate-speed test is
+// one more test that actually gets run.
+
+func TestEngineGuardSkipsStepAndCarriesOn(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := "name: guarded\nsteps:\n" +
+		commandStep("first", script("echo one", "Write-Output one")) +
+		commandStep("skipped", script("echo two", "Write-Output two"), `if: "{{ false }}"`) +
+		commandStep("last", script("echo three", "Write-Output three"))
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 3 {
+		t.Fatalf("rows = %d, want 3 (a skipped step still records one)", len(runs))
+	}
+	skipped := runs[1]
+	if skipped.State != store.StepSkipped {
+		t.Errorf("guarded step state = %s, want skipped", skipped.State)
+	}
+	if skipped.SkipReason != store.SkipReasonCondition {
+		t.Errorf("skip_reason = %q, want %q — a human skip leaves it empty",
+			skipped.SkipReason, store.SkipReasonCondition)
+	}
+	if skipped.TranscriptPath != "" {
+		t.Error("a skipped step opened a transcript")
+	}
+	if runs[2].State != store.StepSucceeded {
+		t.Errorf("step after the skip = %s, want succeeded: a skip carries on", runs[2].State)
+	}
+}
+
+func TestEngineConditionStepStopsTheWorkflow(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: early-finish
+steps:
+` + commandStep("first", script("echo one", "Write-Output one")) + `  - id: gate
+    type: condition
+    if: "{{ false }}"
+` + commandStep("never", script("echo two", "Write-Output two"))
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done — a false condition finishes successfully",
+			done.State, done.BlockReason)
+	}
+	if done.CurrentStep != 3 {
+		t.Errorf("current_step = %d, want 3 (len(steps)): completion runs the ordinary path",
+			done.CurrentStep)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("rows = %d, want 2: the steps after the stop are never considered", len(runs))
+	}
+	if runs[1].State != store.StepStopped {
+		t.Errorf("condition row state = %s, want stopped", runs[1].State)
+	}
+}
+
+func TestEngineConditionStepTrueContinues(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: carry-on
+steps:
+  - id: gate
+    type: condition
+    if: "{{ true }}"
+` + commandStep("after", script("echo done", "Write-Output done"))
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 || runs[0].State != store.StepSucceeded {
+		t.Fatalf("rows = %+v, want a succeeded condition then the next step", runs)
+	}
+}
+
+func TestEngineAllowFailureAdvancesAndFeedsTheNextGuard(t *testing.T) {
+	h := newEngineHarness(t)
+	// The probe fails; allow_failure advances past it; the guard on the next
+	// step reads the exit code the probe left behind, which is the whole
+	// point of pairing the two fields.
+	snapshot := "name: probe\nsteps:\n" +
+		commandStep("probe", script("exit 3", "exit 3"), "allow_failure: true", "max_retries: 0") +
+		commandStep("fixup", script("echo fixing", "Write-Output fixing"),
+			`if: '{{ ne (index .Steps "probe").ExitCode 0 }}'`)
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("rows = %d, want 2", len(runs))
+	}
+	if runs[0].State != store.StepFailed || runs[0].FailureReason != ReasonNonzeroExit {
+		t.Errorf("probe row = %s/%q, want failed/nonzero_exit — allow_failure advances, it does not relabel",
+			runs[0].State, runs[0].FailureReason)
+	}
+	if runs[1].State != store.StepSucceeded {
+		t.Errorf("fixup = %s, want succeeded: its guard should have read exit code 3", runs[1].State)
+	}
+}
+
+func TestEngineAllowFailureIgnoresFailuresTheStepDidNotProduce(t *testing.T) {
+	h := newEngineHarness(t)
+	// A render failure is vincent failing to run the step, not the step
+	// failing — allow_failure must not swallow it (decision 5).
+	snapshot := `name: not-mine
+steps:
+  - id: broken
+    type: command
+    allow_failure: true
+    max_retries: 0
+    run: "echo {{.Task.Titel}}"
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonTemplateError {
+		t.Fatalf("task = %s/%q, want blocked/template_error", blocked.State, blocked.BlockReason)
+	}
+}
+
+func TestEngineGuardErrorBlocksWithoutRetrying(t *testing.T) {
+	h := newEngineHarness(t)
+	// Renders to "7", which is neither true nor false. The budget is
+	// deliberately not spent on re-rendering it (decision 14).
+	snapshot := "name: bad-guard\nsteps:\n" +
+		commandStep("step", script("echo hi", "Write-Output hi"),
+			`if: "{{ 7 }}"`, "max_retries: 3")
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonConditionError {
+		t.Fatalf("task = %s/%q, want blocked/condition_error", blocked.State, blocked.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("rows = %d, want 1: a guard error is not retried", len(runs))
+	}
+	if runs[0].FailureReason != ReasonConditionError {
+		t.Errorf("row reason = %q, want condition_error", runs[0].FailureReason)
+	}
+}
+
+func TestEngineGuardReadsHost(t *testing.T) {
+	h := newEngineHarness(t)
+	// `.Host` is what closes §8.1.1's deferred per-step `platforms:`.
+	snapshot := "name: host\nsteps:\n" +
+		commandStep("elsewhere", script("echo no", "Write-Output no"),
+			`if: '{{ eq .Host.OS "plan9" }}'`)
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 || runs[0].State != store.StepSkipped {
+		t.Fatalf("rows = %+v, want one skipped step", runs)
+	}
+}
+
+func TestEngineGuardedSubStepsSubsetTheGroup(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := `name: group
+steps:
+  - id: verify
+    type: parallel
+    steps:
+      - id: ran
+        type: command
+        run: ` + script("echo ran", "Write-Output ran") + `
+      - id: guarded-off
+        type: command
+        if: "{{ false }}"
+        run: ` + script("exit 9", "exit 9") + `
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done — the failing sub-step was guarded off",
+			done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	byID := map[string]store.StepRun{}
+	for _, r := range runs {
+		byID[r.StepID] = r
+	}
+	if got := byID["guarded-off"]; got.State != store.StepSkipped ||
+		got.SkipReason != store.SkipReasonCondition {
+		t.Errorf("guarded sub-step = %s/%q, want skipped/condition", got.State, got.SkipReason)
+	}
+	if byID["ran"].State != store.StepSucceeded {
+		t.Errorf("unguarded sub-step = %s, want succeeded", byID["ran"].State)
+	}
+}
+
+// Lane guards subset a fan-out (§7.6, task 015 decision 11). These live here
+// rather than in fanout_test.go because what they prove is the guard, not the
+// join.
+
+func TestFanOutGuardedLaneIsNotSpawned(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := `name: root
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: api
+        steps:
+` + indent(writeFileStep("write-api", "api.txt", "api")) +
+		`      - id: skipped
+        if: "{{ false }}"
+        steps:
+` + indent(writeFileStep("write-skipped", "skipped.txt", "skipped"))
+	task := h.createTask(t, snapshot)
+
+	lanes := h.waitForChildren(t, task.ID, 1)
+	if lanes[0].LaneID != "api" {
+		t.Fatalf("spawned lane = %q, want api", lanes[0].LaneID)
+	}
+	done := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("parent = %s/%q, want done", done.State, done.BlockReason)
+	}
+	if !h.fileOnBranch(t, task.BranchName, "api.txt") {
+		t.Error("the selected lane's file is missing from the parent's branch")
+	}
+	if h.fileOnBranch(t, task.BranchName, "skipped.txt") {
+		t.Error("the guarded-off lane ran anyway")
+	}
+}
+
+func TestFanOutWithEveryLaneGuardedOffIsANoOp(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// The parent must not park here: `awaiting_children` with no children
+	// would be re-queued the moment the scheduler looked, spawn nothing and
+	// park again.
+	snapshot := `name: root
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: none
+        if: "{{ false }}"
+        steps:
+` + indent(writeFileStep("write-none", "none.txt", "none")) +
+		commandStep("after", script("echo after", "Write-Output after"))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("parent = %s/%q, want done", done.State, done.BlockReason)
+	}
+	children, err := h.store.ListChildren(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("list children: %v", err)
+	}
+	if len(children) != 0 {
+		t.Fatalf("children = %d, want 0", len(children))
+	}
+	var sawFanOut, sawAfter bool
+	for _, run := range h.stepRuns(t, task.ID) {
+		if run.StepID == "build" && run.State == store.StepSucceeded {
+			sawFanOut = true
+		}
+		if run.StepID == "after" && run.State == store.StepSucceeded {
+			sawAfter = true
+		}
+	}
+	if !sawFanOut {
+		t.Error("the no-op fan_out recorded no row; the step was reached and chose nothing")
+	}
+	if !sawAfter {
+		t.Error("the workflow did not carry on past the no-op fan_out")
+	}
+}

--- a/internal/taskrun/condition_test.go
+++ b/internal/taskrun/condition_test.go
@@ -304,3 +304,38 @@ steps:
 		t.Error("the workflow did not carry on past the no-op fan_out")
 	}
 }
+
+// TestEngineGuardIsReEvaluatedOnRetry proves decision 10 with a guard whose
+// verdict actually changes: `.Step.Attempt` is 1 on the first pass and 2 on
+// the retry, so a cached verdict would run the step twice and a re-evaluated
+// one skips it the second time.
+func TestEngineGuardIsReEvaluatedOnRetry(t *testing.T) {
+	h := newEngineHarness(t)
+	snapshot := "name: reeval\nsteps:\n" +
+		commandStep("once", script("exit 4", "exit 4"),
+			`if: "{{ eq .Step.Attempt 1 }}"`, "max_retries: 0")
+	task := h.createTask(t, snapshot)
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked on the first pass", blocked.State)
+	}
+
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task after retry = %s/%q, want done: the guard is false on attempt 2",
+			done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 2 {
+		t.Fatalf("rows = %d, want 2 (the failed attempt, then the skip)", len(runs))
+	}
+	if runs[1].State != store.StepSkipped || runs[1].SkipReason != store.SkipReasonCondition {
+		t.Errorf("second row = %s/%q, want skipped/condition — the guard was re-evaluated",
+			runs[1].State, runs[1].SkipReason)
+	}
+}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
@@ -76,7 +77,19 @@ const (
 	// agent_unavailable on the same grounds restricted_unsupported is — the
 	// CLI is installed and healthy, just not able to hold a conversation.
 	ReasonInputUnsupported = "input_unsupported"
-	ReasonInternalError    = "internal_error"
+	// ReasonConditionError is a step guard that did not produce a verdict
+	// (§7.7, task 015): the `if:` template failed to render, or it rendered
+	// to something that is neither `true` nor `false`.
+	//
+	// It blocks without consuming the retry budget, unlike every other
+	// failure in this vocabulary, because a guard is evaluated *before* the
+	// step becomes an attempt — there is no attempt to retry, and re-rendering
+	// an unchanged template against an unchanged context cannot answer
+	// differently. §7.2's budget bounds work that a second try could complete;
+	// the second try here is the human's, after they fix the workflow
+	// (task 015 decision 14).
+	ReasonConditionError = "condition_error"
+	ReasonInternalError  = "internal_error"
 )
 
 // Durable event types the engine emits (spec §13.3). State changes emit
@@ -188,6 +201,45 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			step: wf.Steps[index], index: index,
 			log: log.With("step", wf.Steps[index].ID, "step_index", index),
 		}
+		// Guards run before the dispatch below, so every step type is
+		// guarded by the same code — including the three that never reach
+		// runAttempt (§7.7). A verdict is computed fresh here and nowhere
+		// else (decision 10).
+		if env.step.Guarded() || env.step.Type == workflow.StepCondition {
+			pass, err := r.evaluateGuard(ctx, env)
+			switch {
+			case err != nil:
+				r.recordGuardOutcome(ctx, env, store.StepFailed, "", ReasonConditionError)
+				r.fail(task, ReasonConditionError, env.log, "evaluate step guard", err)
+				return
+			case env.step.Type == workflow.StepCondition && !pass:
+				// The sequence ends here and the task is `done` (§7.7,
+				// decision 8). The cursor goes to the end rather than
+				// staying put, so completion runs the same path every other
+				// finished task runs and no client reads a done task as
+				// mid-run.
+				r.recordGuardOutcome(ctx, env, store.StepStopped, "", "")
+				task.CurrentStep = len(wf.Steps)
+				r.persistStepCursor(ctx, task, env.log)
+				env.log.Info("workflow stopped early by a condition step")
+				r.complete(task, log)
+				return
+			case env.step.Type == workflow.StepCondition:
+				r.recordGuardOutcome(ctx, env, store.StepSucceeded, "", "")
+				task.CurrentStep = index + 1
+				r.persistStepCursor(ctx, task, env.log)
+				continue
+			case !pass:
+				// Skip and carry on: the step did not run, the workflow did
+				// not stop, and the row says which of the two kinds of skip
+				// this was (decision 9).
+				r.recordGuardOutcome(ctx, env, store.StepSkipped, store.SkipReasonCondition, "")
+				task.CurrentStep = index + 1
+				r.persistStepCursor(ctx, task, env.log)
+				env.log.Info("step skipped by its guard")
+				continue
+			}
+		}
 		if env.step.Type == workflow.StepManual {
 			r.enterGate(ctx, env)
 			return
@@ -214,10 +266,7 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		switch outcome.state {
 		case store.StepSucceeded:
 			task.CurrentStep = index + 1
-			next := task.CurrentStep
-			if err := r.deps.Store.SetTaskProgress(ctx, task.ID, &next, nil); err != nil {
-				env.log.Error("persist step advance", "error", err)
-			}
+			r.persistStepCursor(ctx, task, env.log)
 		case store.StepInterrupted:
 			// A quota stop is interruption-shaped — no retry consumed, the
 			// slot released — but it must not be re-admitted immediately, or
@@ -228,7 +277,19 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			}
 			r.interrupt(task, log)
 			return
-		case store.StepFailed, store.StepRunning, store.StepApproved, store.StepRejected, store.StepSkipped:
+		case store.StepFailed, store.StepRunning, store.StepApproved,
+			store.StepRejected, store.StepSkipped, store.StepStopped:
+			// `allow_failure` advances past the failures the step itself
+			// produced (§7.2, task 015 decision 5). The row keeps its
+			// `failed` state and its reason — the failure happened, it just
+			// did not stop the workflow — and that row is what a later
+			// guard reads through `.Steps`.
+			if outcome.state == store.StepFailed && allowFailure(env.step, outcome.reason) {
+				env.log.Info("step failed; advancing on allow_failure", "reason", outcome.reason)
+				task.CurrentStep = index + 1
+				r.persistStepCursor(ctx, task, env.log)
+				continue
+			}
 			r.fail(task, outcome.reason, env.log, "step failed", nil)
 			return
 		}
@@ -437,6 +498,17 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 	return outcome
 }
 
+// persistStepCursor writes the task's advanced step cursor. A failed write is
+// logged rather than fatal, as it always has been: the in-memory cursor is
+// what this admission walks, and recovery re-runs the step the row still
+// names (§12.4).
+func (r *Runner) persistStepCursor(ctx context.Context, task *store.Task, log *slog.Logger) {
+	next := task.CurrentStep
+	if err := r.deps.Store.SetTaskProgress(ctx, task.ID, &next, nil); err != nil {
+		log.Error("persist step advance", "error", err)
+	}
+}
+
 // renderContext assembles the §8.4 template context, including the results
 // of steps completed so far.
 func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, previous stepOutcome) (workflow.RenderContext, error) {
@@ -449,6 +521,20 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 		run := runs[i]
 		switch run.State {
 		case store.StepSucceeded, store.StepApproved, store.StepSkipped:
+		case store.StepFailed:
+			// A failed step is visible only once the engine has advanced past
+			// it — which happens only under `allow_failure` (§7.2), and is
+			// the whole point of that field: a guard downstream reads what
+			// the probe found (task 015 decision 6).
+			//
+			// A step's own failed attempt stays out of `.Steps["itself"]`
+			// mid-retry, because `.LastFailure` is already that channel and
+			// two spellings of one fact is how a context rots. Sub-steps of a
+			// group share the group's index, so this also keeps concurrent
+			// siblings invisible to each other, which §7.5 requires.
+			if run.StepIndex >= env.index {
+				continue
+			}
 		default:
 			continue
 		}
@@ -471,6 +557,7 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 			ID: env.step.ID, Name: env.step.DisplayName(), Index: env.index, Attempt: attempt,
 		},
 		Steps:       steps,
+		Host:        workflow.HostContext{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		Worktree:    workflow.WorktreeContext{Path: env.task.WorktreePath},
 		LastFailure: workflow.Failure{Reason: previous.reason, Output: previous.output},
 		Conflicts:   env.conflicts,

--- a/internal/taskrun/fanout.go
+++ b/internal/taskrun/fanout.go
@@ -63,7 +63,27 @@ func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutco
 		return r.runStepWithRetries(ctx, &joinEnv), false
 	}
 
-	if err := r.spawnLanes(ctx, env); err != nil {
+	selected, err := r.selectLanes(ctx, env)
+	if err != nil {
+		r.recordDecisionRow(ctx, env, store.StepFailed, "", ReasonConditionError, "")
+		r.fail(env.task, ReasonConditionError, env.log, "evaluate lane guard", err)
+		return stepOutcome{}, true
+	}
+	if len(selected) == 0 {
+		// Every lane was guarded off. The step is reached, chooses nothing and
+		// advances: a fan-out whose conditions all said "not this time"
+		// decided correctly (§7.6, task 015 decision 11).
+		//
+		// It must not park. A parent in `awaiting_children` with no children
+		// would be re-queued by the scheduler the moment it looked, find no
+		// lanes, spawn none and park again — a loop with no exit.
+		env.log.Info("fan-out selected no lanes; nothing to spawn")
+		r.recordDecisionRow(ctx, env, store.StepSucceeded, "", "",
+			"no lane was selected: every lane's `if:` was false")
+		return stepOutcome{state: store.StepSucceeded}, false
+	}
+
+	if err := r.spawnLanes(ctx, env, selected); err != nil {
 		// A partial spawn is not left behind: the lanes that were created are
 		// cancelled, so a retry starts from a clean slate rather than
 		// half a tree.
@@ -86,12 +106,17 @@ func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutco
 // child's base branch, its overrides and priority propagate, and a lane spec
 // may override any of them for its own subtree. Fields merge with the
 // parent's, the lane winning (decision 29).
-func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv) error {
+func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv, selected []int) error {
 	project, err := r.deps.Store.GetProject(ctx, env.task.ProjectID)
 	if err != nil {
 		return fmt.Errorf("load project: %w", err)
 	}
-	for order, lane := range env.step.Lanes {
+	for _, order := range selected {
+		lane := env.step.Lanes[order]
+		// order is the lane's **declared** index, not its position among the
+		// selected: `lane_order` is what the join merges by (§7.6,
+		// decision 7), so renumbering around a guarded-off lane would make a
+		// re-run merge in a different order than the first run.
 		child, err := r.laneTask(env, lane, order)
 		if err != nil {
 			return err
@@ -117,6 +142,43 @@ func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv) error {
 		env.log.Info("lane spawned", "lane", lane.ID, "child", child.ID, "branch", child.BranchName)
 	}
 	return nil
+}
+
+// selectLanes evaluates every lane's `if:` and returns the declared indices of
+// the lanes to spawn (§7.6, task 015 decision 11).
+//
+// Evaluated here, at run time and in the parent's context, rather than at task
+// creation: that is what lets a lane depend on what an earlier step found,
+// which is the use case the feature exists for. The price is paid at creation,
+// where `fan_out.max_depth` and `fan_out.max_tasks` go on counting guarded
+// lanes — an over-approximation §7.6 states rather than leaves to be
+// discovered.
+func (r *Runner) selectLanes(ctx context.Context, env *stepEnv) ([]int, error) {
+	selected := make([]int, 0, len(env.step.Lanes))
+	for i, lane := range env.step.Lanes {
+		if !lane.Guarded() {
+			selected = append(selected, i)
+			continue
+		}
+		rc, err := r.renderContext(ctx, env, r.nextAttempt(ctx, env), stepOutcome{})
+		if err != nil {
+			return nil, err
+		}
+		pass, err := workflow.Evaluate(fmt.Sprintf("lanes[%d].if", i), lane.If, rc)
+		if err != nil {
+			return nil, err
+		}
+		if !pass {
+			// No child, so no row of its own to record it in: a lane that was
+			// never spawned has no task to carry the fact. The parent's log
+			// and the absent child are the record, which is the same way a
+			// lane list that never mentioned it would read.
+			env.log.Info("lane skipped by its guard", "lane", lane.ID)
+			continue
+		}
+		selected = append(selected, i)
+	}
+	return selected, nil
 }
 
 // laneTask builds the child task row for one lane, without inserting it.

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -43,7 +43,7 @@ func fanOutSnapshot(merge string, lanes ...[2]string) string {
 	sb.WriteString("    lanes:\n")
 	for _, lane := range lanes {
 		fmt.Fprintf(&sb, "      - id: %s\n        steps:\n", lane[0])
-		sb.WriteString(indent(writeFileStep("write-"+lane[0], lane[1], lane[0]), laneStepIndent))
+		sb.WriteString(indent(writeFileStep("write-"+lane[0], lane[1], lane[0])))
 	}
 	return sb.String()
 }
@@ -169,9 +169,9 @@ func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
 	// The slow lane is cancelled while it runs; the quick one finishes.
 	snapshot := "name: root\nsteps:\n  - id: build\n    type: fan_out\n    lanes:\n" +
 		"      - id: quick\n        steps:\n" +
-		indent(writeFileStep("write-quick", "quick.txt", "quick"), laneStepIndent) +
+		indent(writeFileStep("write-quick", "quick.txt", "quick")) +
 		"      - id: slow\n        steps:\n" +
-		indent(commandStep("wait", sleepCmd(30), "max_retries: 0"), laneStepIndent)
+		indent(commandStep("wait", sleepCmd(30), "max_retries: 0"))
 	task := h.createTask(t, snapshot)
 
 	lanes := h.waitForChildren(t, task.ID, 2)
@@ -197,11 +197,12 @@ func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
 	}
 }
 
-// indent shifts a block of YAML right by prefix.
-func indent(block, prefix string) string {
+// indent shifts a block of YAML right to sit under a lane's `steps:`, which
+// is the only place these tests ever need it.
+func indent(block string) string {
 	var sb strings.Builder
 	for _, line := range strings.Split(strings.TrimRight(block, "\n"), "\n") {
-		sb.WriteString(prefix + line + "\n")
+		sb.WriteString(laneStepIndent + line + "\n")
 	}
 	return sb.String()
 }

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -45,6 +45,20 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 		return stepOutcome{state: store.StepSucceeded}
 	}
 
+	subs, guarded, err := r.applySubStepGuards(ctx, env, subs)
+	if err != nil {
+		env.log.Error("evaluate sub-step guard", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonConditionError}
+	}
+	if len(subs) == 0 {
+		// Every sub-step was guarded off. A group whose conditions all said
+		// "not this time" decided correctly, so it succeeds having run
+		// nothing (§7.5, task 015).
+		env.log.Info("parallel group ran nothing: every sub-step was guarded off",
+			"guarded_off", guarded)
+		return stepOutcome{state: store.StepSucceeded}
+	}
+
 	// A group-level `timeout:` bounds the whole group; each sub-step still
 	// has its own. Expiry cancels the sub-steps, which end as interruptions —
 	// the group turns that back into a failure below, because the work ran
@@ -58,7 +72,8 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 
 	limit := r.groupLimit(env.step)
 	env.log.Info("parallel group started",
-		"sub_steps", len(subs), "already_succeeded", skipped, "max_parallel", limit)
+		"sub_steps", len(subs), "already_succeeded", skipped,
+		"guarded_off", guarded, "max_parallel", limit)
 
 	outcomes := make([]stepOutcome, len(subs))
 	sem := make(chan struct{}, limit)
@@ -77,7 +92,15 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 				step: sub, index: env.index, inGroup: true,
 				log: env.log.With("sub_step", sub.ID),
 			}
-			outcomes[i] = r.runStepWithRetries(groupCtx, subEnv)
+			out := r.runStepWithRetries(groupCtx, subEnv)
+			// `allow_failure` on a sub-step keeps its `failed` row and its
+			// reason — the failure happened — while taking it out of the
+			// group's own verdict (§7.2, task 015 decision 5).
+			if out.state == store.StepFailed && allowFailure(sub, out.reason) {
+				subEnv.log.Info("sub-step failed; allowed by allow_failure", "reason", out.reason)
+				out = stepOutcome{state: store.StepSucceeded}
+			}
+			outcomes[i] = out
 		}()
 	}
 	wg.Wait()
@@ -112,6 +135,44 @@ func (r *Runner) pendingSubSteps(ctx context.Context, env *stepEnv) (subs []work
 		subs = append(subs, sub)
 	}
 	return subs, skipped, nil
+}
+
+// applySubStepGuards drops the sub-steps whose `if:` is false, recording a
+// `skipped` row for each, and returns the rest in declaration order.
+//
+// Guards are evaluated **before anything in the group starts**, one after
+// another, which is what makes §7.5's sibling-blindness a fact rather than a
+// warning: no sibling has run, so none can be in `.Steps` for another's guard
+// to read. A group is a set, so a false guard subsets it rather than stopping
+// anything — the same meaning `if:` has on a fan-out lane (task 015
+// decision 3), and the reason a `condition` step is refused in here at all.
+func (r *Runner) applySubStepGuards(
+	ctx context.Context, env *stepEnv, subs []workflow.Step,
+) (kept []workflow.Step, guardedOff int, err error) {
+	for _, sub := range subs {
+		if !sub.Guarded() {
+			kept = append(kept, sub)
+			continue
+		}
+		subEnv := &stepEnv{
+			task: env.task, project: env.project, wf: env.wf,
+			step: sub, index: env.index, inGroup: true,
+			log: env.log.With("sub_step", sub.ID),
+		}
+		pass, evalErr := r.evaluateGuard(ctx, subEnv)
+		if evalErr != nil {
+			r.recordGuardOutcome(ctx, subEnv, store.StepFailed, "", ReasonConditionError)
+			return nil, 0, evalErr
+		}
+		if !pass {
+			r.recordGuardOutcome(ctx, subEnv, store.StepSkipped, store.SkipReasonCondition, "")
+			subEnv.log.Info("sub-step skipped by its guard")
+			guardedOff++
+			continue
+		}
+		kept = append(kept, sub)
+	}
+	return kept, guardedOff, nil
 }
 
 // subStepIDOf names the transcript of an attempt: empty for an ordinary step,
@@ -156,7 +217,7 @@ func collectGroup(outcomes []stepOutcome) stepOutcome {
 				failure = &outcomes[i]
 			}
 		case store.StepSucceeded, store.StepRunning, store.StepApproved,
-			store.StepRejected, store.StepSkipped:
+			store.StepRejected, store.StepSkipped, store.StepStopped:
 		}
 	}
 	if failure != nil {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -320,6 +320,10 @@ func (d *detail) groupLabel(index int) string {
 	return "(parallel)"
 }
 
+// stepStateStopped is the §7.7 state a `condition` step records when its
+// guard is false: the run ended here, on purpose and successfully.
+const stepStateStopped = "stopped"
+
 func stepLabel(r apiclient.StepRun) string {
 	name := r.StepName
 	if name == "" {
@@ -363,6 +367,15 @@ func (d *detail) attemptLine(r apiclient.StepRun, indented bool) string {
 	}
 	if r.FailureReason != nil && *r.FailureReason != "" {
 		fields = append(fields, styleBad.Render(*r.FailureReason))
+	}
+	// A `skipped` row is either a human pressing skip (§6) or a false `if:`
+	// guard (§7.7). The state cannot tell them apart, so the reason is shown
+	// whenever there is one — a bare "skipped" means the human.
+	if r.SkipReason != nil && *r.SkipReason != "" {
+		fields = append(fields, styleDim.Render("by "+*r.SkipReason))
+	}
+	if r.State == stepStateStopped {
+		fields = append(fields, styleDim.Render("workflow ended here"))
 	}
 	if r.Agent != nil && *r.Agent != "" {
 		fields = append(fields, styleDim.Render(agentTriple(r)))
@@ -485,7 +498,7 @@ func (d *detail) outputEmptyState() (string, bool) {
 	case d.selectedRun == 0:
 		return "no attempt selected", true
 	case d.noTranscript:
-		return "this step wrote no transcript (a gate or a skipped step)", true
+		return "this step wrote no transcript (a gate, a skipped step, or a condition)", true
 	case d.fetching && len(d.records) == 0:
 		return "loading transcript…", true
 	case d.fetchErr != nil && len(d.records) == 0:

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -1,0 +1,69 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Guard evaluation (spec §7.7, task 015).
+//
+// A guard is an ordinary §8.4 template — same context, same
+// `missingkey=error`, same parse-at-load validation as `prompt`, `run` and
+// `check`. One language in the file was worth more than the readability an
+// expression language would have bought, because a second language means a
+// second context shape to keep in sync with §8.4 forever (decision 4).
+
+// TrueLiteral and FalseLiteral are the only two things a guard may render to.
+const (
+	TrueLiteral  = "true"
+	FalseLiteral = "false"
+)
+
+// ConditionError is a guard that rendered to something other than `true` or
+// `false`. It is separate from a render failure so the message can show what
+// the guard actually produced, which is the whole diagnosis: a guard that
+// renders `<no value>` is reading a field that is not there, and one that
+// renders `0` is written in a language vincent does not speak.
+type ConditionError struct {
+	Field  string
+	Output string
+}
+
+func (e *ConditionError) Error() string {
+	shown := e.Output
+	if shown == "" {
+		shown = "an empty string"
+	} else {
+		shown = fmt.Sprintf("%q", shown)
+	}
+	return fmt.Sprintf("%s must render to %q or %q, got %s",
+		e.Field, TrueLiteral, FalseLiteral, shown)
+}
+
+// Evaluate renders a guard and demands exactly `true` or `false`.
+//
+// Strictness rather than a truthiness table (decision 4): a permissive rule
+// would accept `<no value>` and the empty string, both of which mean the
+// guard is reading something that is not there — the one case where guessing
+// a verdict is worse than refusing to have one.
+func Evaluate(name, expr string, rc RenderContext) (bool, error) {
+	out, err := Render(name, expr, rc)
+	if err != nil {
+		return false, err
+	}
+	switch strings.TrimSpace(out) {
+	case TrueLiteral:
+		return true, nil
+	case FalseLiteral:
+		return false, nil
+	default:
+		return false, &ConditionError{Field: name, Output: strings.TrimSpace(out)}
+	}
+}
+
+// Guarded reports whether the step carries a guard at all. An unguarded step
+// runs, which is what every step did before task 015.
+func (s Step) Guarded() bool { return s.If != "" }
+
+// Guarded reports whether the lane carries a guard (§7.6).
+func (l Lane) Guarded() bool { return l.If != "" }

--- a/internal/workflow/condition_test.go
+++ b/internal/workflow/condition_test.go
@@ -1,0 +1,201 @@
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEvaluate(t *testing.T) {
+	rc := RenderContext{
+		Task:  TaskContext{Title: "t", Fields: map[string]string{"ship": "yes"}},
+		Steps: map[string]StepResult{"probe": {Status: "failed", ExitCode: 3}},
+		Host:  HostContext{OS: "linux", Arch: "amd64"},
+	}
+	tests := []struct {
+		name    string
+		expr    string
+		want    bool
+		wantErr string
+	}{
+		{name: "literal true", expr: "{{ true }}", want: true},
+		{name: "literal false", expr: "{{ false }}", want: false},
+		{name: "surrounding whitespace is trimmed", expr: "  {{ true }}\n", want: true},
+		{name: "field comparison", expr: `{{ eq (index .Task.Fields "ship") "yes" }}`, want: true},
+		{name: "exit code of an allowed failure", expr: `{{ ne (index .Steps "probe").ExitCode 0 }}`, want: true},
+		{name: "host", expr: `{{ eq .Host.OS "linux" }}`, want: true},
+		{
+			name: "a number is not a verdict", expr: "{{ 7 }}",
+			wantErr: `must render to "true" or "false"`,
+		},
+		{
+			// The trap a truthiness table would fall into: this is what a
+			// guard reading a field that is not there renders to.
+			name: "empty is not false", expr: "",
+			wantErr: "an empty string",
+		},
+		{
+			name: "yes is not true", expr: "yes",
+			wantErr: `got "yes"`,
+		},
+		{
+			name: "missing key is a render error", expr: `{{ index .Task.Fields "absent" }}`,
+			wantErr: "render",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Evaluate("if", tt.expr, rc)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Evaluate(%q) = %v, want an error", tt.expr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want it to mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Evaluate(%q): %v", tt.expr, err)
+			}
+			if got != tt.want {
+				t.Errorf("Evaluate(%q) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConditionValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantSub  string
+		wantPath string
+	}{
+		{
+			name:     "condition without an if",
+			src:      "name: x\nsteps:\n  - {id: a, type: condition}\n",
+			wantSub:  "condition steps require an if expression",
+			wantPath: "steps[0].if",
+		},
+		{
+			name: "condition carrying a body",
+			src: "name: x\nsteps:\n  - {id: a, type: condition, if: \"{{ true }}\", run: echo hi}\n" +
+				"  - {id: b, type: manual, instructions: hi}\n",
+			wantSub:  "run is not valid on a condition step",
+			wantPath: "steps[0].run",
+		},
+		{
+			name: "condition carrying a retry budget",
+			src: "name: x\nsteps:\n  - {id: a, type: condition, if: \"{{ true }}\", max_retries: 2}\n" +
+				"  - {id: b, type: manual, instructions: hi}\n",
+			wantSub:  "max_retries is not valid on a condition step",
+			wantPath: "steps[0].max_retries",
+		},
+		{
+			name:     "allow_failure on a manual gate",
+			src:      "name: x\nsteps:\n  - {id: a, type: manual, instructions: hi, allow_failure: true}\n",
+			wantSub:  "allow_failure is not valid on a manual step",
+			wantPath: "steps[0].allow_failure",
+		},
+		{
+			name: "condition inside a parallel group",
+			src: "name: x\nsteps:\n  - id: g\n    type: parallel\n    steps:\n" +
+				"      - {id: c, type: condition, if: \"{{ true }}\"}\n",
+			wantSub:  "condition steps are not valid inside a parallel group",
+			wantPath: "steps[0].steps[0].type",
+		},
+		{
+			name:     "guard that does not parse",
+			src:      "name: x\nsteps:\n  - {id: a, type: manual, instructions: hi, if: \"{{ oops\"}\n",
+			wantSub:  "template does not parse",
+			wantPath: "steps[0].if",
+		},
+		{
+			name: "lane guard that does not parse",
+			src: "name: x\nsteps:\n  - id: f\n    type: fan_out\n    lanes:\n" +
+				"      - {id: l, workflow: other, if: \"{{ oops\"}\n",
+			wantSub:  "template does not parse",
+			wantPath: "steps[0].lanes[0].if",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := Parse([]byte(tt.src), Options{})
+			if err == nil {
+				t.Fatal("Parse succeeded, want a validation error")
+			}
+			var errs Errors
+			if !errors.As(err, &errs) {
+				t.Fatalf("error is %T, want Errors", err)
+			}
+			for _, e := range errs {
+				if strings.Contains(e.Message, tt.wantSub) &&
+					(tt.wantPath == "" || e.Path == tt.wantPath) {
+					return
+				}
+			}
+			t.Fatalf("no finding matched %q at %q; got %v", tt.wantSub, tt.wantPath, errs)
+		})
+	}
+}
+
+func TestParseConditionAccepted(t *testing.T) {
+	src := `name: conditional
+steps:
+  - id: probe
+    type: command
+    run: git diff --quiet
+    allow_failure: true
+  - id: gate
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+  - id: fix
+    type: agent
+    if: '{{ eq .Host.OS "linux" }}'
+    prompt: Fix it.
+`
+	wf, warns, err := Parse([]byte(src), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %v, want none", warns)
+	}
+	if !wf.Steps[0].AllowFailure {
+		t.Error("allow_failure did not survive the round trip")
+	}
+	if wf.Steps[1].Type != StepCondition || !wf.Steps[1].Guarded() {
+		t.Errorf("step 1 = %+v, want a guarded condition step", wf.Steps[1])
+	}
+	if !wf.Steps[2].Guarded() {
+		t.Error("the agent step's guard was dropped")
+	}
+	// A snapshot round-trips: the engine re-parses it on every admission.
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	again, _, err := Parse(out, Options{})
+	if err != nil {
+		t.Fatalf("re-parse of the marshalled snapshot: %v", err)
+	}
+	if again.Steps[1].If != wf.Steps[1].If {
+		t.Errorf("guard after round trip = %q, want %q", again.Steps[1].If, wf.Steps[1].If)
+	}
+}
+
+func TestParseWarnsOnTrailingCondition(t *testing.T) {
+	src := "name: x\nsteps:\n  - {id: a, type: manual, instructions: hi}\n" +
+		"  - {id: last, type: condition, if: \"{{ true }}\"}\n"
+	_, warns, err := Parse([]byte(src), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v — a trailing condition is a warning, not an error", err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0].Message, "has no effect") {
+		t.Fatalf("warnings = %v, want one about a trailing condition having no effect", warns)
+	}
+	if warns[0].Path != "steps[1].type" {
+		t.Errorf("warning path = %q, want steps[1].type", warns[0].Path)
+	}
+}

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -22,6 +22,17 @@ type RenderContext struct {
 	Steps       map[string]StepResult
 	Worktree    WorktreeContext
 	LastFailure Failure
+	// Host is the daemon's own platform (§8.4, task 015 decision 12). The
+	// daemon is what runs the steps, so it is the daemon's GOOS a guard must
+	// judge — the same reasoning §8.1.1 gives for `platforms:`.
+	//
+	// It is what closes §8.1.1's deferred per-step `platforms:` with no new
+	// schema: `if: '{{ ne .Host.OS "windows" }}'` says the same thing using
+	// a guard whose skip semantics §7.7 defines. `.Now` was deliberately not
+	// added beside it — a guard reading wall-clock makes a run
+	// non-reproducible, which is the property §7.6 chose declared lane order
+	// to preserve.
+	Host HostContext
 	// Conflicts are the files a fan_out join is asking an `on_conflict:
 	// agent` resolver to fix (§7.6, task 014 decision 24). Empty for every
 	// other step, so a prompt that reads it defensively works anywhere.
@@ -68,6 +79,12 @@ type StepResult struct {
 	Status   string
 	Result   string
 	ExitCode int
+}
+
+// HostContext is `.Host` — the daemon's GOOS and GOARCH.
+type HostContext struct {
+	OS   string
+	Arch string
 }
 
 // WorktreeContext is `.Worktree`.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -30,6 +30,15 @@ const (
 	// runs processes, this creates tasks — they share concepts and nothing
 	// else, which is why they are two types (decision 2).
 	StepFanOut = "fan_out"
+	// StepCondition evaluates its `if:` and nothing else (§7.7, task 015).
+	// True continues; false ends the sequence and the task is `done`.
+	//
+	// It is a *type* rather than a second guard field because the
+	// consequence belongs on its own line: every CI system spells
+	// skip-and-continue `if:`, so a guard field that stopped the run instead
+	// would be a false friend whose failure mode is a task reaching `done`
+	// having silently done half its work (task 015 decision 2).
+	StepCondition = "condition"
 )
 
 // Conflict policies for a fan_out step's join (§7.6, task 014 decision 8).
@@ -100,6 +109,24 @@ type Step struct {
 	MaxRetries *int             `yaml:"max_retries"`
 	Timeout    *config.Duration `yaml:"timeout"`
 
+	// If guards the step (§7.7, task 015). It renders against the §8.4
+	// context and must produce exactly `true` or `false`. On an ordinary
+	// step false means *skip this step and carry on*; on a `condition` step
+	// it is the condition itself, and false ends the sequence. On a
+	// `parallel` sub-step it means *do not start this member*, because a
+	// group is a set with no "later" to skip to (decision 3).
+	//
+	// Empty means unguarded, which is why it is a plain string rather than a
+	// pointer: an empty template renders to an empty string, which is not
+	// `true`, so "unset" and "set to nothing" must be the same thing and are.
+	If string `yaml:"if,omitempty"`
+	// AllowFailure turns the failures the step itself produced into an
+	// advance instead of a block (§7.2, task 015 decision 5) — the field
+	// that gives a guard something a run discovered to read. It is
+	// orthogonal to the retry budget: the step retries as it always did, and
+	// this decides only what happens when the budget is spent.
+	AllowFailure bool `yaml:"allow_failure,omitempty"`
+
 	// agent steps
 	Prompt         string           `yaml:"prompt"`
 	Agent          string           `yaml:"agent"`
@@ -143,6 +170,13 @@ type Step struct {
 // `fan_out.max_depth` at creation (decision 5).
 type Lane struct {
 	ID string `yaml:"id"`
+	// If guards the lane (§7.6, task 015 decision 11): false means this lane
+	// is not spawned, while its siblings still run and the join still
+	// happens. Evaluated when the `fan_out` step runs, in the parent's
+	// context, so a lane can depend on what an earlier step found — which is
+	// why the creation-time `max_depth`/`max_tasks` limits count guarded
+	// lanes too.
+	If string `yaml:"if,omitempty"`
 	// Workflow names a registry workflow, resolved through the usual
 	// builtin < global < project shadowing at **task-creation** time.
 	Workflow string `yaml:"workflow,omitempty"`
@@ -325,6 +359,9 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 	add := func(path, format string, args ...any) {
 		errs = append(errs, Error{Path: path, Line: loc.line(path), Message: fmt.Sprintf(format, args...)})
 	}
+	addWarn := func(path, format string, args ...any) {
+		warns = append(warns, Error{Path: path, Line: loc.line(path), Message: fmt.Sprintf(format, args...)})
+	}
 
 	if wf.Name == "" {
 		add("name", "name is required")
@@ -367,10 +404,11 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 				validateSubStep(wf, sub, subBase, opts, add)
 			}
 		case StepFanOut:
-			validateLanes(wf, step, base, opts, add)
+			validateLanes(wf, step, base, opts, add, addWarn)
 		}
 	}
-	warns = validateCatalogs(wf, opts, loc, add)
+	warnTrailingCondition(wf.Steps, "steps", addWarn)
+	warns = append(warns, validateCatalogs(wf, opts, loc, add)...)
 	sort.SliceStable(errs, func(i, j int) bool { return errs[i].Line < errs[j].Line })
 	sort.SliceStable(warns, func(i, j int) bool { return warns[i].Line < warns[j].Line })
 	return errs, warns
@@ -483,8 +521,8 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 func validateStep(step Step, base string, opts Options, add func(string, string, ...any)) {
 	switch step.Type {
 	case "":
-		add(base+".type", "type is required (one of %s, %s, %s, %s, %s)",
-			StepAgent, StepCommand, StepManual, StepParallel, StepFanOut)
+		add(base+".type", "type is required (one of %s, %s, %s, %s, %s, %s)",
+			StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition)
 	case StepAgent:
 		if step.Prompt == "" {
 			add(base+".prompt", "agent steps require a prompt")
@@ -519,7 +557,8 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		}
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env", "steps", "max_parallel", "lanes", "merge")
+			"run", "shell", "env", "steps", "max_parallel", "lanes", "merge",
+			"allow_failure")
 	case StepParallel:
 		if len(step.Steps) == 0 {
 			add(base+".steps", "parallel steps require at least one sub-step")
@@ -531,7 +570,7 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		// `max_retries`, checked below for every type, bound the group itself.
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env", "instructions", "lanes", "merge")
+			"run", "shell", "env", "instructions", "lanes", "merge", "allow_failure")
 	case StepFanOut:
 		if len(step.Lanes) == 0 {
 			add(base+".lanes", "fan_out steps require at least one lane")
@@ -539,10 +578,25 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		validateMerge(step, base, opts, add)
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
-			"run", "shell", "env", "instructions", "steps", "max_parallel")
+			"run", "shell", "env", "instructions", "steps", "max_parallel",
+			"allow_failure")
+	case StepCondition:
+		// The guard *is* the body. `if:` may not also act as a skip-guard
+		// here: "skip the check that decides whether to continue" has two
+		// readings and neither is worth having (task 015 decision 7).
+		if step.If == "" {
+			add(base+".if", "condition steps require an if expression")
+		}
+		// Everything else goes, `timeout`, `max_retries` and `allow_failure`
+		// included: a condition step starts no process, so it cannot time
+		// out, has nothing to retry and has no failure of its own to allow.
+		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+			"run", "shell", "env", "instructions", "steps", "max_parallel",
+			"lanes", "merge", "allow_failure", "max_retries", "timeout")
 	default:
-		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s, %s)",
-			step.Type, StepAgent, StepCommand, StepManual, StepParallel, StepFanOut)
+		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s, %s, %s)",
+			step.Type, StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition)
 	}
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
@@ -558,7 +612,8 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		add(base+".input_timeout", "input_timeout must be positive, got %s", step.InputTimeout)
 	}
 	for field, text := range map[string]string{
-		"prompt": step.Prompt, "run": step.Run, "check": step.Check, "instructions": step.Instructions,
+		"prompt": step.Prompt, "run": step.Run, "check": step.Check,
+		"instructions": step.Instructions, "if": step.If,
 	} {
 		if text == "" {
 			continue
@@ -623,7 +678,9 @@ func validateMerge(step Step, base string, opts Options, add func(string, string
 // own namespace — each lane becomes a **separate child task** with its own
 // flat snapshot (decision 4) — so they are checked against a fresh set rather
 // than the parent workflow's.
-func validateLanes(wf *Workflow, step Step, base string, opts Options, add func(string, string, ...any)) {
+func validateLanes(wf *Workflow, step Step, base string, opts Options,
+	add func(string, string, ...any), addWarn func(string, string, ...any),
+) {
 	seen := make(map[string]string, len(step.Lanes))
 	for i, lane := range step.Lanes {
 		lanePath := fmt.Sprintf("%s.lanes[%d]", base, i)
@@ -657,17 +714,24 @@ func validateLanes(wf *Workflow, step Step, base string, opts Options, add func(
 			add(lanePath+".agent", "unknown agent %q (known: %s)",
 				lane.Agent, strings.Join(opts.KnownAgents, ", "))
 		}
+		if lane.If != "" {
+			if _, err := template.New("if").Parse(lane.If); err != nil {
+				add(lanePath+".if", "template does not parse: %v", err)
+			}
+		}
 		// Inline steps are a workflow body in their own right, so they are
 		// validated like one: their own id namespace, and their own right to
 		// contain a fan_out (decision 5). What they may not contain is a
 		// gate-free assumption anyone else's steps do not also carry.
-		validateLaneSteps(wf, lane, lanePath, opts, add)
+		validateLaneSteps(wf, lane, lanePath, opts, add, addWarn)
 	}
 }
 
 // validateLaneSteps validates one lane's inline steps as the workflow body
 // they will become.
-func validateLaneSteps(wf *Workflow, lane Lane, base string, opts Options, add func(string, string, ...any)) {
+func validateLaneSteps(wf *Workflow, lane Lane, base string, opts Options,
+	add func(string, string, ...any), addWarn func(string, string, ...any),
+) {
 	if len(lane.Steps) == 0 {
 		return
 	}
@@ -692,8 +756,24 @@ func validateLaneSteps(wf *Workflow, lane Lane, base string, opts Options, add f
 				validateSubStep(wf, sub, fmt.Sprintf("%s.steps[%d]", stepPath, j), opts, add)
 			}
 		case StepFanOut:
-			validateLanes(wf, step, stepPath, opts, add)
+			validateLanes(wf, step, stepPath, opts, add, addWarn)
 		}
+	}
+	// A lane's inline steps are a workflow body, so its last step carries the
+	// same warning a top-level one does.
+	warnTrailingCondition(lane.Steps, base+".steps", addWarn)
+}
+
+// warnTrailingCondition reports a `condition` step in last position. It is a
+// warning rather than an error because a file being edited toward its final
+// shape should still load: what it says is that the step cannot do anything a
+// missing step would not, since continuing past the last step and stopping at
+// it are the same outcome — the task is `done` either way (task 015).
+func warnTrailingCondition(steps []Step, base string, addWarn func(string, string, ...any)) {
+	if n := len(steps); n > 0 && steps[n-1].Type == StepCondition {
+		addWarn(fmt.Sprintf("%s[%d].type", base, n-1),
+			"a %s step in last position has no effect: the task is done whether it continues or stops",
+			StepCondition)
 	}
 }
 
@@ -717,6 +797,12 @@ func validateSubStep(wf *Workflow, sub Step, base string, opts Options, add func
 		// `manual` is refused here.
 		add(base+".type", "fan_out steps are not valid inside a parallel group: "+
 			"the task parks while its lanes run, and a group cannot park half a task")
+	case StepCondition:
+		// A group is a set, not a sequence, so "end the sequence" has
+		// nothing to name here (task 015 decision 7). Subsetting a group is
+		// what `if:` on a sub-step already does.
+		add(base+".type", "condition steps are not valid inside a parallel group: "+
+			"a group has no later steps to stop; guard the sub-step with `if:` instead")
 	}
 	// Resolved, not literal: `defaults.on_input: require` reaches a sub-step
 	// that says nothing, and it is just as unrunnable there (§7.4).
@@ -744,6 +830,8 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"instructions": step.Instructions != "",
 		"steps":        len(step.Steps) > 0, "max_parallel": step.MaxParallel != nil,
 		"lanes": len(step.Lanes) > 0, "merge": step.Merge != nil,
+		"if": step.If != "", "allow_failure": step.AllowFailure,
+		"max_retries": step.MaxRetries != nil, "timeout": step.Timeout != nil,
 	}
 	for _, f := range fields {
 		if set[f] {

--- a/scripts/m7-gate.sh
+++ b/scripts/m7-gate.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# M7 phase gate (task 015; spec §7.7): prove via curl alone that conditions
+# between steps behave as specified.
+#
+#   1. `if: false` skips a step and the workflow carries on
+#   2. a `condition` step ends the run, and the task is `done`
+#   3. `allow_failure` advances, and the next step's guard reads the exit code
+#      the failure left behind
+#   4. a guarded-off fan-out lane is not spawned; the rest still merge
+#   5. every lane guarded off is a no-op success that does not park
+#   6. a guard that renders no verdict blocks with `condition_error`, once,
+#      whatever the retry budget says
+#   7. a retry re-evaluates the guard rather than replaying its verdict
+#
+# Every scenario uses command steps only, so no agent CLI is involved and the
+# gate is as fast on CI as it is locally.
+#
+# The `run:` bodies are restricted to what `/bin/sh` and `pwsh` both accept —
+# `exit N`, `git ...`, and nothing else. §8.3 leaves portability to the
+# workflow author, and a gate that has to run on all three platforms is that
+# author. This is why the lanes commit with `--allow-empty` instead of writing
+# a file: `printf > x` and `Set-Content` share no spelling, and the join has
+# something to merge either way.
+#
+# Each scenario gets fresh config/data/repo dirs and its own daemon, so one
+# scenario's leftovers cannot reach another's assertions (PR G decision,
+# inherited from m2-gate.sh). VINCENT_GATE_SCENARIO=N runs one scenario.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+ONLY="${VINCENT_GATE_SCENARIO:-}"
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+CONFIG_DIR="" DATA_DIR=""
+scenario_dirs() { # scenario_dirs NAME
+  CONFIG_DIR="$TMP/$1/config"
+  DATA_DIR="$TMP/$1/data"
+  mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+  export VINCENT_CONFIG_DIR
+  VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+  export VINCENT_DATA_DIR
+  VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+}
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+# api_status prints "STATUS<newline>BODY" without failing on a 4xx, for the
+# scenarios whose whole point is the 400.
+api_status() { # api_status METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  printf '%s\n%s' "${out##*$'\n'}" "${out%$'\n'*}"
+}
+
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+}
+
+register_project() { git init >/dev/null 2>&1 || true; api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+wait_for_state() { # wait_for_state TASK_ID STATE TRIES
+  local id="$1" want="$2" tries="$3" state=""
+  for _ in $(seq 1 "$tries"); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" ]] && [[ "$want" != "aborted" ]]; then
+      api GET "/tasks/$id" | jq . >&2
+      fail "task $id reached $state while waiting for $want"
+    fi
+    sleep 1
+  done
+  api GET "/tasks/$id" | jq . >&2
+  fail "task $id never reached $want (last: $state)"
+}
+
+create_task() { # create_task PROJECT_ID WORKFLOW TITLE -> id
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg w "$2" --arg t "$3" \
+    '{project_id: $p, workflow: $w, title: $t}')" | jq -r .id
+}
+
+# branch_has reports whether a path exists on a branch's tip.
+branch_has() { # branch_has REPO BRANCH PATH
+  [[ -n "$(git -C "$1" ls-tree --name-only "$2" "$3")" ]]
+}
+
+run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+
+# step_state prints one step run's state, selected by step id. A step with
+# several attempts prints them all, newest last.
+step_state() { # step_state TASK_ID STEP_ID
+  api GET "/tasks/$1/steps" | jq -r --arg s "$2" '.[] | select(.step_id == $s) | .state'
+}
+
+step_field() { # step_field TASK_ID STEP_ID FIELD
+  api GET "/tasks/$1/steps" | jq -r --arg s "$2" --arg f "$3" \
+    '[.[] | select(.step_id == $s)] | last | .[$f] // "null"'
+}
+
+step_count() { # step_count TASK_ID
+  api GET "/tasks/$1/steps" | jq 'length'
+}
+
+# --------------------------------------------------------------------------
+# Scenario 1: a false `if:` skips its step and the workflow carries on.
+# --------------------------------------------------------------------------
+if run_scenario 1; then
+  echo "=== scenario 1: a guard skips a step"
+  scenario_dirs s1
+  REPO="$TMP/s1/repo"; make_repo "$REPO"
+  write_workflow guard-skip "$(cat <<'YAML'
+name: guard-skip
+steps:
+  - id: first
+    type: command
+    max_retries: 0
+    run: exit 0
+  - id: skipped
+    type: command
+    max_retries: 0
+    if: "{{ false }}"
+    run: exit 1
+  - id: last
+    type: command
+    max_retries: 0
+    run: exit 0
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" guard-skip "guard skips a step")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(step_state "$TID" skipped)" == "skipped" ]] \
+    || fail "the guarded step is not recorded as skipped"
+  [[ "$(step_field "$TID" skipped skip_reason)" == "condition" ]] \
+    || fail "skip_reason is not 'condition'; a human skip must stay distinguishable"
+  [[ "$(step_field "$TID" skipped transcript_path)" == "null" ]] \
+    || fail "a skipped step opened a transcript"
+  [[ "$(step_state "$TID" last)" == "succeeded" ]] \
+    || fail "the workflow did not carry on past the skip"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: a `condition` step ends the run, successfully.
+# --------------------------------------------------------------------------
+if run_scenario 2; then
+  echo "=== scenario 2: a condition step stops the workflow"
+  scenario_dirs s2
+  REPO="$TMP/s2/repo"; make_repo "$REPO"
+  write_workflow early-finish "$(cat <<'YAML'
+name: early-finish
+steps:
+  - id: first
+    type: command
+    max_retries: 0
+    run: exit 0
+  - id: gate
+    type: condition
+    if: "{{ false }}"
+  - id: never
+    type: command
+    max_retries: 0
+    run: exit 1
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" early-finish "condition ends the run")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(step_state "$TID" gate)" == "stopped" ]] \
+    || fail "the condition step is not recorded as stopped"
+  [[ "$(step_count "$TID")" == 2 ]] \
+    || fail "expected 2 step rows: the steps after a stop are never considered"
+  CURRENT="$(api GET "/tasks/$TID" | jq -r .current_step)"
+  [[ "$CURRENT" == 3 ]] \
+    || fail "current_step = $CURRENT, want 3 (len(steps)) so completion runs the ordinary path"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3: allow_failure advances and feeds the next step's guard.
+#
+# This is the pairing the feature stands on: without allow_failure a guard can
+# only read what a human typed at creation, never what the run discovered.
+# --------------------------------------------------------------------------
+if run_scenario 3; then
+  echo "=== scenario 3: allow_failure advances and the next guard reads it"
+  scenario_dirs s3
+  REPO="$TMP/s3/repo"; make_repo "$REPO"
+  write_workflow probe "$(cat <<'YAML'
+name: probe
+steps:
+  - id: probe
+    type: command
+    max_retries: 0
+    allow_failure: true
+    run: exit 3
+  - id: fixup
+    type: command
+    max_retries: 0
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+    run: exit 0
+  - id: unreached
+    type: command
+    max_retries: 0
+    if: '{{ eq (index .Steps "probe").ExitCode 0 }}'
+    run: exit 1
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" probe "allow_failure feeds a guard")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(step_state "$TID" probe)" == "failed" ]] \
+    || fail "allow_failure relabelled the row; the failure still happened"
+  [[ "$(step_field "$TID" probe failure_reason)" == "nonzero_exit" ]] \
+    || fail "the probe's failure reason was not preserved"
+  [[ "$(step_state "$TID" fixup)" == "succeeded" ]] \
+    || fail "the guard did not see the probe's exit code"
+  [[ "$(step_state "$TID" unreached)" == "skipped" ]] \
+    || fail "the complementary guard should have skipped its step"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: a guarded-off lane is not spawned; the rest still merge.
+# --------------------------------------------------------------------------
+if run_scenario 4; then
+  echo "=== scenario 4: a fan-out lane is guarded off"
+  scenario_dirs s4
+  REPO="$TMP/s4/repo"; make_repo "$REPO"
+  write_workflow lane-guard "$(cat <<'YAML'
+name: lane-guard
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: api
+        steps:
+          - id: work
+            type: command
+            max_retries: 0
+            run: git commit --allow-empty -m lane-api
+      - id: skipped
+        if: "{{ false }}"
+        steps:
+          - id: work
+            type: command
+            max_retries: 0
+            run: git commit --allow-empty -m lane-skipped
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" lane-guard "one lane guarded off")"
+  wait_for_state "$TID" done 240
+
+  KIDS="$(api GET "/tasks?parent_id=$TID" | jq 'length')"
+  [[ "$KIDS" == 1 ]] || fail "expected 1 lane to be spawned, got $KIDS"
+  BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name)"
+  git -C "$REPO" log --format=%s "$BRANCH" | grep -qx lane-api \
+    || fail "the selected lane's commit is not on the parent's branch"
+  if git -C "$REPO" log --format=%s "$BRANCH" | grep -qx lane-skipped; then
+    fail "the guarded-off lane ran anyway"
+  fi
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 5: every lane guarded off is a no-op that does not park.
+#
+# The regression this guards against is specific: a parent parked in
+# `awaiting_children` with no children is re-queued the moment the scheduler
+# looks, spawns nothing, and parks again — a loop with no exit. Reaching
+# `done` at all is the assertion.
+# --------------------------------------------------------------------------
+if run_scenario 5; then
+  echo "=== scenario 5: every lane guarded off"
+  scenario_dirs s5
+  REPO="$TMP/s5/repo"; make_repo "$REPO"
+  write_workflow no-lanes "$(cat <<'YAML'
+name: no-lanes
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: none
+        if: "{{ false }}"
+        steps:
+          - id: work
+            type: command
+            max_retries: 0
+            run: git commit --allow-empty -m lane-none
+  - id: after
+    type: command
+    max_retries: 0
+    run: exit 0
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" no-lanes "no lane selected")"
+  wait_for_state "$TID" done 120
+
+  KIDS="$(api GET "/tasks?parent_id=$TID" | jq 'length')"
+  [[ "$KIDS" == 0 ]] || fail "expected no lanes to be spawned, got $KIDS"
+  [[ "$(step_state "$TID" build)" == "succeeded" ]] \
+    || fail "the no-op fan_out recorded no successful row"
+  [[ "$(step_state "$TID" after)" == "succeeded" ]] \
+    || fail "the workflow did not carry on past the no-op fan_out"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 6: a guard with no verdict blocks once, whatever the budget says.
+# --------------------------------------------------------------------------
+if run_scenario 6; then
+  echo "=== scenario 6: a guard that renders no verdict"
+  scenario_dirs s6
+  REPO="$TMP/s6/repo"; make_repo "$REPO"
+  write_workflow bad-guard "$(cat <<'YAML'
+name: bad-guard
+steps:
+  - id: step
+    type: command
+    max_retries: 3
+    if: "{{ 7 }}"
+    run: exit 0
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" bad-guard "a guard with no verdict")"
+  wait_for_state "$TID" blocked 60
+
+  REASON="$(api GET "/tasks/$TID" | jq -r .block_reason)"
+  [[ "$REASON" == "condition_error" ]] || fail "block_reason = $REASON, want condition_error"
+  [[ "$(step_count "$TID")" == 1 ]] \
+    || fail "a guard error was retried; it is the one reason that does not run the §7.2 budget"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 7: a retry re-evaluates the guard rather than replaying its verdict.
+#
+# `.Step.Attempt` is 1 on the first pass and 2 on the retry, so a cached
+# verdict would run the step twice and a re-evaluated one skips it.
+# --------------------------------------------------------------------------
+if run_scenario 7; then
+  echo "=== scenario 7: a retry re-evaluates the guard"
+  scenario_dirs s7
+  REPO="$TMP/s7/repo"; make_repo "$REPO"
+  write_workflow reeval "$(cat <<'YAML'
+name: reeval
+steps:
+  - id: once
+    type: command
+    max_retries: 0
+    if: "{{ eq .Step.Attempt 1 }}"
+    run: exit 4
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" reeval "guards are never sticky")"
+  wait_for_state "$TID" blocked 60
+
+  api POST "/tasks/$TID/retry" '{}' >/dev/null
+  wait_for_state "$TID" done 60
+
+  LAST="$(step_field "$TID" once state)"
+  [[ "$LAST" == "skipped" ]] \
+    || fail "the retry's row is $LAST, want skipped — the guard was not re-evaluated"
+  [[ "$(step_field "$TID" once skip_reason)" == "condition" ]] \
+    || fail "the retry's skip is not attributed to the guard"
+  daemon_down
+fi
+
+echo
+echo "M7 GATE PASSED"


### PR DESCRIPTION
A workflow may now decide at run time what to do next (task 015, 015.1–015.8).

Three fields, three jobs:

- `if:` on a step skips it and carries on, recording a `skipped` row with
  `skip_reason: condition` that stays visible in `.Steps`.
- `if:` on a fan-out lane or a `parallel` sub-step subsets the set: the other
  members still run, and the join still happens.
- `type: condition` is a step whose whole body is the guard. False ends the
  sequence and the task is `done`, recorded as a single `stopped` row.
- `allow_failure:` on agent and command steps turns the failures the step
  itself produced into an advance, which is what gives a guard something a run
  discovered to read.

Guards are ordinary §8.4 templates rendered with `missingkey=error` and must
produce exactly `true` or `false`; `.Host{OS,Arch}` joins the context. They are
evaluated fresh every time, never cached — a human retry re-asks the question.

Migration 0008 adds `step_runs.skip_reason`; `stopped` joins the step-run state
vocabulary and reaches the API, the client and the TUI detail view.