### PR TITLE
feat(workflow): loops — `type: loop`, `type: break`, and `.Loop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,35 @@ Please pull request.
 
 ### Added
 
+- **Loops in workflows — `type: loop` and `type: break`.** A workflow can now
+  repeat a body of steps: `count:` a fixed number of times, or `for_each:` once
+  per item in a list, including a list a step discovered at run time. That
+  makes three shapes writable that were not: **converge** ("run the tests, fix
+  what broke, run them again" — a probe under `allow_failure:`, a `break`
+  reading it, a repair), **repeat** (ten passes of the race detector without
+  ten copy-pasted steps), and **iterate a set** (once per changed file). A loop
+  is one step, one index, one concurrency slot and the task's one worktree — no
+  branch and nothing to merge, which is what separates it from `fan_out`.
+
+  `type: break` ends the loop successfully when its `if:` is true. There is no
+  `continue` type: a `condition` inside a loop body ends *that iteration*,
+  which is what continue means, using the meaning that word already had. There
+  is no `while:` either — a guard can only read what a run has produced, so a
+  `while:` about its own body is either loud on iteration 1 or silently false,
+  and `count:` plus `break` is the same loop written correctly.
+
+  `.Loop` (`Index`, `Item`, `IsFirst`, `IsLast`) joins the template context,
+  with `Index: 0` outside any loop. `loop.max_iterations` (default **10**) is
+  the ceiling: `count:` is checked against it when the file loads, and a
+  `for_each` list longer than it blocks with `loop_limit` before the first
+  iteration rather than quietly doing the first ten — ten iterations of a
+  three-step body is already thirty agent runs. A loop's position is derived
+  from its step rows on every admission and never persisted, so `retry` and a
+  daemon restart both resume **mid-iteration**; `skip` skips the whole loop,
+  and `edit + retry` on a body step applies to every remaining iteration. The
+  board shows `loop 4/10` and the detail view groups rows by iteration, folded
+  with the latest open. See
+  [`type: loop`](docs/reference/workflow-schema.md#type-loop).
 - **Conditions between steps.** A workflow can decide at run time what to do
   next. `if:` on any step is a guard: false skips that step and the workflow
   carries on, recording a `skipped` row whose reason says a condition did it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,15 +73,17 @@ against the fake agent; CI runs all three on Linux, macOS, and Windows:
 ./scripts/m5-gate.sh                            # cursor adapter (§9.7)
 ./scripts/m6-gate.sh                            # parallel steps and fan-out (§7.5, §7.6)
 ./scripts/m7-gate.sh                            # conditions between steps (§7.7)
+./scripts/m8-gate.sh                            # loops (§7.8)
 VINCENT_GATE_SCENARIO=2 ./scripts/m2-gate.sh    # single scenario, for debugging
 VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CLI
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-CI runs `m1`, `m2` and `m5` on all three platforms. `m6` and `m7` are not
+CI runs `m1`, `m2` and `m5` on all three platforms. `m6`, `m7` and `m8` are not
 wired in: the push token used for this work has no `workflow` scope, so a
 branch touching `.github/workflows` is rejected outright. Adding them is two
-lines in `ci.yml`'s `gates` job, and both scripts run identically by hand.
+lines each in `ci.yml`'s `gates` job, and all three scripts run identically by
+hand.
 
 `scripts/m3-gate.sh` seeds a human walkthrough instead of asserting — M3's
 acceptance is a judgement about a TUI. The manual legs of M5 are walked
@@ -137,7 +139,7 @@ is a correctness bug, not a style issue:
 | `internal/api` | Localhost REST + SSE, bearer auth, snake_case error envelope |
 | `internal/apiclient` | Typed HTTP+SSE client — the one client for TUI and CLI; owns its wire types (server DTOs stay unexported) |
 | `internal/workflow` | YAML registry (builtin < global < project shadowing), live reload, `text/template` step engine |
-| `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out` and `condition` are structure, and `check` is a *field* agent and command steps may carry, never a type — plus guards (`if:`, §7.7), retries, timeouts, human actions, recovery, transcripts |
+| `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out`, `condition`, `loop` and `break` are structure, and `check` is a *field* agent and command steps may carry, never a type — plus guards (`if:`, §7.7), loop iteration (§7.8), retries, timeouts, human actions, recovery, transcripts |
 | `internal/agent` | `AgentAdapter` interface + option catalog; `agent/claude`, `agent/codex`, `agent/cursor` implement it |
 | `internal/worktree` | Per-task git worktrees, `vincent/{id}-{slug}` branches, dirty detection |
 | `internal/tui` | Bubble Tea client: six views (board, detail, new-task, projects, workflows, daemon) routed by `viewID` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ that is *not* true are stated rather than smoothed over.
 - [Security model](security-model.md) — what full-auto means, what the worktree
   does and does not isolate, and how to tighten it.
 - [FAQ](faq.md) — the short answers.
-- [Example workflows](../examples) — four ready-to-copy files.
+- [Example workflows](../examples) — five ready-to-copy files.
 - [Commercial licensing](../COMMERCIAL-LICENSE.md) — vincent is source-available
   and dual-licensed: free for personal and non-commercial use under the
   [PolyForm Noncommercial License 1.0.0](../LICENSE), separate license required

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -347,6 +347,45 @@ re-evaluated from scratch, as it is on every pass.
 not one that parses and renders the wrong thing — that needs the task's
 context, which only exists at run time.
 
+### `loop_limit`
+
+A `loop` step has more iterations ahead of it than `max_iterations` allows, so
+the task blocked instead of doing some of them. Two ways to get here:
+
+- a **`for_each:` list longer than the ceiling**. It blocks *before* the first
+  iteration and names the count, so nothing has run yet;
+- a **`count:` the ceiling moved under** — `loop.max_iterations` was lowered
+  while the task was queued or paused. The ceiling is read per loop, so a
+  config reload reaches a task already in flight.
+
+It blocks rather than truncating the list or advancing past the loop, because a
+loop that ran out of iterations did not do what it was looping for, and
+advancing would hand every later guard a `.Steps` saying the work is finished.
+`condition` (the step type) is what a workflow uses to stop *and succeed*;
+running out of tries is not that.
+
+Three fixes, in the order worth trying:
+
+- **filter the list at its source.** `git diff --name-only … | grep -v
+  _test.go` is usually what you wanted anyway, and it keeps the filtering where
+  the output already is;
+- **raise the ceiling for this loop** with `max_iterations:` on the step;
+- **raise it for the machine** with `loop.max_iterations` in `config.yaml`. The
+  default of 10 is low on purpose: ten iterations of a three-step body is
+  thirty agent runs.
+
+### A loop ran fewer iterations than I expected after a retry
+
+Working as intended. A loop's position is derived from its step rows on every
+admission, so a `retry` resumes at the body step that failed, in the iteration
+it failed in — body steps that already succeeded in that iteration are not run
+again, and earlier iterations are not repeated. The detail view groups the rows
+by iteration, folded, with the latest one open, which is where to check what
+actually ran.
+
+If you wanted the whole loop again, the loop is not the unit to retry — retry
+the task from an earlier step, or `skip` the loop and start over.
+
 ### A workflow finished having run only half its steps
 
 Almost certainly working as intended. Two things end a run early:
@@ -354,7 +393,10 @@ Almost certainly working as intended. Two things end a run early:
 - a **`condition` step** whose guard was false. The task is `done`, and the
   detail view shows a `stopped` row where it ended;
 - a chain of **`if:` guards** that all evaluated false, each leaving a
-  `skipped` row with reason `condition`.
+  `skipped` row with reason `condition`;
+- a **`break`** inside a loop, which ends the loop successfully and moves on —
+  a `stopped` row on the break step, and the loop's own iterations stopping
+  short of its `count:`.
 
 Both are visible in the task's step list, which is the place to look: the board
 shows a finished task as finished, and does not try to say how much of the
@@ -398,6 +440,7 @@ The block reason names what happened:
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `template_error` | A template failed to render (see above) |
 | `condition_error` | A step's `if:` guard rendered nothing usable (see below) |
+| `loop_limit` | A `loop` has more iterations to run than it is allowed (see below) |
 | `restricted_unsupported` | The adapter cannot restrict on this platform |
 | `platform_unsupported` | The workflow's `platforms:` list does not admit this host |
 | `input_unsupported` | A step needs an agent that can answer questions mid-run, and this one cannot (see below) |

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -168,6 +168,16 @@ the right shows the live tail of the running step.
 Selecting an attempt in the timeline *is* how you read scrollback — that is why
 the two panels are side by side and both always visible.
 
+A structure step gets a tier of its own. A `parallel` group's sub-steps share
+the group's index, so the group is one header and each sub-step sits beneath
+it. A `loop` (§7.8) goes one further: its body's rows are grouped **by
+iteration**, folded shut with the latest one open, and a `for_each` iteration's
+header names the item it ran on. Ten passes of a four-step body is forty rows,
+and the one you arrived to read is almost always the pass it stopped on.
+
+The board's and the header's step column say the same thing more briefly: a
+task inside a loop reads `3/7 green · loop 4/10`.
+
 | Key | Does |
 |---|---|
 | `]` | Switch the output pane tab: Output ⇄ Diff (`[`, `]` and `d` all work) |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -75,7 +75,7 @@ steps:                           # required; runs in order, top to bottom
 Unknown keys are rejected rather than ignored, so a typo is an error at
 validation time instead of a setting that silently never applied.
 
-## Six step types
+## Eight step types
 
 **`agent`** runs an agent CLI headlessly in the worktree. Needs `prompt`.
 
@@ -143,6 +143,23 @@ takes nothing else.
     if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
 ```
 
+**`loop`** runs its body over and over in the same worktree, a fixed number of
+times or once per item in a list. Needs `steps` and exactly one of `count:` /
+`for_each:`.
+
+```yaml
+  - id: green
+    type: loop
+    count: 5
+    steps:
+      - { id: suite, type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
+      - { id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+      - { id: repair, type: agent, prompt: "The suite is red: {{ (index .Steps \"suite\").Result }}" }
+```
+
+**`break`** ends the enclosing loop, successfully. Needs `if:`, and takes
+nothing else — see the loop above.
+
 `check` is a **field** on agent and command steps, not a step of its own — see
 below.
 
@@ -193,6 +210,101 @@ It only ever swallows failures the step itself produced — a nonzero exit, a
 failed `check`, an agent error, a timeout. A missing CLI or an unrenderable
 template still blocks, because a workflow should not be able to branch on "the
 agent is not installed" as though that were a result.
+
+## Loops are for converging, repeating, and iterating a set
+
+Three shapes could not be written before, and all three are one step type.
+
+**Converge** — run the tests, fix what broke, run them again. This is the most
+common agent loop there is, and `max_retries` was never it: retries re-run
+*the same step* on *its own* failure, with no way to say "run the probe, and
+if it is red run a *different* step, then probe again."
+
+```yaml
+  - id: green
+    type: loop
+    count: 5
+    steps:
+      - { id: suite,  type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
+      - { id: passed, type: break,   if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+      - id: repair
+        type: agent
+        prompt: |
+          The suite is red:
+
+          {{ (index .Steps "suite").Result }}
+
+          Fix the underlying cause. Do not weaken, skip or delete a test.
+```
+
+Read it in three lines: the probe is `allow_failure`, so its red exit is
+*data* rather than a block; the `break` reads that data and ends the loop the
+first time it is green; the repair only runs when the break did not fire. The
+`count:` is the budget — five repairs and no more.
+
+**Repeat** — prove a flake is gone by running the race detector ten times,
+without ten copy-pasted steps and ten step ids.
+
+```yaml
+  - id: soak
+    type: loop
+    count: 10
+    steps:
+      - { id: race, type: command, run: go test -race ./internal/taskrun }
+```
+
+**Iterate a set** — do something once per item, over a list a step found at run
+time. `fan_out` looks like it should fit here and does not: its lane list has
+to be static in the snapshot, which is exactly what lets it check for cycles
+and cap the tree at creation.
+
+```yaml
+  - id: changed
+    type: command
+    run: git diff --name-only {{.Task.BaseBranch}}...HEAD -- '*.go' | grep -v _test.go
+    allow_failure: true
+
+  - id: review-each
+    type: loop
+    for_each: '{{ .Steps.changed.Result }}'
+    max_iterations: 25
+    steps:
+      - { id: read, type: agent, prompt: 'Review {{ .Loop.Item }} against CLAUDE.md.' }
+```
+
+`.Loop` carries `Index` (1-based, and `0` outside any loop), `Item`, `IsFirst`
+and `IsLast`.
+
+### Four things to know before you use one
+
+**There is no `while:`, and that is deliberate.** A guard can read only what a
+run has already produced, so on the first iteration a `while:` about the body
+has no row to read — it either errors out loudly or, worse, quietly renders
+false and the loop never runs. `count:` plus `break` is the same loop written
+correctly, and the ceiling it needs is a ceiling `while:` would have needed
+anyway.
+
+**`continue` is spelled `condition`.** A `condition` step inside a loop body
+ends *that iteration*, not the run — a loop body is a sequence, and "end the
+sequence" ends the pass. The same word means the same thing everywhere; what
+changes is what it is attached to.
+
+**Ten iterations of a three-step body is thirty agent runs.** That is why the
+default ceiling is 10, why `count:` is checked against it when the file loads,
+and why a `for_each` list longer than it **blocks** with `loop_limit` instead
+of quietly doing the first ten. Raise it per step with `max_iterations:`, or
+per machine with `loop.max_iterations`.
+
+**A loop resumes where it stopped.** Block it on iteration 4 and `retry` picks
+up at the body step that failed, in iteration 4 — including after a daemon
+restart. `skip` skips the whole loop, not one pass. And `E` (edit + retry)
+rewrites the body step in this task's snapshot, so your fix applies to every
+remaining iteration rather than to one.
+
+A loop body may hold `agent`, `command`, `condition` and `break` steps. It may
+not hold `manual`, `on_input: require`, `parallel`, `fan_out` or another loop:
+all of those park the task mid-body, and nothing in the schema can say
+"iteration 3 of this loop is waiting on a human".
 
 ## Verification is where parallel pays
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -255,7 +255,7 @@ rather than inventing a model name.
 | `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort? }` — `branch_name` is used verbatim and wins over any template |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
-| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt. `state` may be `stopped` (a `condition` step ended the run), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did |
+| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based; `0` outside one) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart |
 
 Human actions, all `POST /v1/tasks/{id}/…`:
 
@@ -330,6 +330,23 @@ request from one recursive CTE rather than stored — a counter would be a secon
 truth that drifts from the rows it counts. `blocked` and `awaiting_gate` are
 ids: fetch the ones you decide to show. This is what pays for hiding lanes from
 the list, since a blocked lane would otherwise be invisible.
+
+Both the list and the detail endpoint carry `loop` while a task's **current**
+step is a `loop` (§7.8), and omit it otherwise:
+
+```json
+"loop": { "driver": "for_each", "iteration": 4, "max_iterations": 10, "item": "internal/store" }
+```
+
+`iteration` is the pass in progress (0 before the first one starts) and
+`max_iterations` is the largest it could reach — the `count:` itself, or the
+ceiling a `for_each` is bounded by, whose real length is only known at run
+time. It is on the list endpoint too, so a board can render `loop 4/10` without
+a request per row. Like `children`, it is derived per request from the step
+rows rather than stored: a persisted loop cursor would be a second truth that
+recovery would have to reconcile. There is deliberately **no** step-lifecycle
+event for iterations — ten passes of a four-step body would put forty durable
+events on the stream to say what forty rows already say.
 - **`?archived=` defaults to false.** `true` selects only archived tasks, `all`
   returns both.
 - **Every task representation carries `available_actions`** (the actions valid

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -74,6 +74,10 @@ fan_out:
   max_depth: 3
   max_tasks: 64
 
+# Ceiling on a `type: loop` step's iterations.
+loop:
+  max_iterations: 10
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
@@ -359,6 +363,33 @@ worktrees discovered six hours later.
 Depth is unlimited by design and bounded by a default: a deeper tree is a
 config edit, not a code change. See
 [Workflow schema](workflow-schema.md#type-fan_out).
+
+### `loop`
+
+```yaml
+loop:
+  max_iterations: 10
+```
+
+The ceiling on a `type: loop` step's iterations, used when the step declares no
+`max_iterations:` of its own. Must be at least 1.
+
+It is a ceiling in two places. At **load** it is what `count:` is checked
+against, so `count: 5000` is a validation error in front of the person typing
+rather than a discovery on iteration 300. At **run time** it is what a
+`for_each:` list is measured against: a list longer than the ceiling blocks the
+task with `loop_limit` before the first iteration, naming the count. A loop
+that hits the ceiling does not truncate and does not advance — running out of
+tries is not a decision the workflow made.
+
+The default is deliberately low. An agent step is minutes and dollars, and ten
+iterations of a three-step body is already thirty agent runs. Raise it in
+config for a whole machine, or per step with `max_iterations:` for the one loop
+that needs more.
+
+Read when a loop starts, so a reload governs the next loop — including one
+already running, which will block with `loop_limit` if the lowered ceiling is
+already behind it. See [Workflow schema](workflow-schema.md#type-loop).
 
 ### `log_level`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -161,6 +161,7 @@ same thing wherever it originated.
 | `input_protocol_error` | A control message the adapter could not parse — it fails, it never hangs |
 | `template_error` | A template failed to render, before any process started |
 | `condition_error` | A step's `if:` guard failed to render, or rendered something that is neither `true` nor `false`. The one reason that is **not** retried — a guard is evaluated before the step becomes an attempt, and re-rendering it cannot answer differently. Fix the workflow and retry |
+| `loop_limit` | A `loop` step cannot run within `max_iterations`: a `for_each` list longer than the ceiling, or a `count:` the ceiling moved under. It blocks rather than truncating or advancing — running out of tries is not a decision the workflow made, and advancing would tell every later guard the work is finished. Raise `max_iterations:` on the step or `loop.max_iterations` in config, or narrow the list at its source |
 | `restricted_unsupported` | The adapter cannot restrict on this platform (cursor on Windows) |
 | `transcript_limit` | The attempt hit `transcript_max_bytes` |
 | `shell_unavailable` | The requested shell is not installed |

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -118,9 +118,9 @@ Common to every step:
 |---|---|---|---|
 | `id` | slug | ✅ | Unique within the file, sub-steps included. How `.Steps` addresses it |
 | `name` | string | | Display name; defaults to `id` |
-| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` | ✅ | `check` is a *field*, not a type |
+| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` \| `loop` \| `break` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
-| `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group, bounds the whole group |
+| `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group or a `loop`, bounds the whole thing |
 | `if` | template | | Guard: skip this step unless it renders `true`. See [Conditions](#conditions) |
 
 `allow_failure: true` is available on `agent` and `command` steps only; it is
@@ -329,6 +329,129 @@ block.
 > is what `vincent gc` and `vincent doctor` are for, and you will meet it
 > before you meet anything else in this feature.
 
+### `type: loop`
+
+Runs its body — a **sequence** — repeatedly, in the task's one worktree. No
+branch, no child task, nothing to merge: that is `fan_out`. Where a `parallel`
+group is a set run once, a loop is a sequence run more than once.
+
+| Key | Type | Required |
+|---|---|---|
+| `steps` | list of steps | ✅ |
+| `count` | int | exactly one of `count` / `for_each` |
+| `for_each` | string, or list of strings | exactly one of `count` / `for_each` |
+| `max_iterations` | int | — (default `loop.max_iterations`, 10) |
+
+**Fix until green** — the archetype the feature exists for. Bounded by
+construction, and post-test by construction, because the condition lives in the
+body where it can see the body:
+
+```yaml
+  - id: green
+    type: loop
+    count: 5
+    steps:
+      - { id: suite, type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
+      - { id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+      - id: repair
+        type: agent
+        prompt: |
+          The suite is red:
+
+          {{ (index .Steps "suite").Result }}
+
+          Fix the underlying cause. Do not weaken, skip or delete a test.
+```
+
+**Once per item**, over a list a step discovered at run time:
+
+```yaml
+  - id: changed
+    type: command
+    run: git diff --name-only {{.Task.BaseBranch}}...HEAD -- '*.go' | grep -v _test.go
+    allow_failure: true
+
+  - id: review-each
+    type: loop
+    for_each: '{{ .Steps.changed.Result }}'
+    max_iterations: 25
+    steps:
+      - { id: read, type: agent, prompt: 'Review {{ .Loop.Item }} against CLAUDE.md.' }
+```
+
+`for_each:` takes a YAML sequence or a single scalar. Either way each entry is
+rendered, trimmed and split on newlines with empty lines dropped, so
+`[api, web]` and a command's multi-line output are the same mechanism.
+
+**There is no `while:`.** A guard can read only what a run has already
+produced, and on the first iteration the body has not run — so a `while:`
+reading its own body is either an error or, worse, silently false, and one
+reading a step *before* the loop reads a constant and spins to the ceiling.
+`count:` plus `break` writes the same loop correctly.
+
+#### `.Loop`
+
+| Field | |
+|---|---|
+| `.Loop.Index` | the 1-based iteration, and **0** outside any loop, so a shared template can tell |
+| `.Loop.Item` | the `for_each` item this pass runs on; empty for a `count:` loop |
+| `.Loop.IsFirst` / `.Loop.IsLast` | |
+
+#### What a body may contain
+
+`agent`, `command`, `condition` and `break`. Rejected at load: `manual`,
+`on_input: require`, `parallel`, `fan_out` and a nested `loop` — each for the
+reason a `parallel` group rejects it. All of them park or end the task's
+admission mid-body, and a loop's position is *derived* from its rows, which
+have no way to say "iteration 3 of this loop is waiting on a human".
+
+#### Ending a loop
+
+- The driver runs out, or a `break` fires → the loop **succeeds** and the
+  cursor advances.
+- A `condition` inside the body is false → **that iteration** ends and the loop
+  carries on. That is `continue`, and it needs no new step type: a loop body is
+  a sequence, so "end the sequence" ends the pass.
+- The loop cannot run within `max_iterations` → the task **blocks** with
+  `loop_limit`. A `for_each` list longer than the ceiling blocks before the
+  first iteration, naming the count.
+- A body step exhausts its retries → the task blocks with **that step's** own
+  reason. Use `allow_failure:` when a red probe is the point.
+
+Retries and iterations are different things: `max_retries` is for a step that
+*failed*, and an iteration is for a body that *succeeded and must run again*.
+Each body step spends its own budget within each iteration.
+
+#### Human actions
+
+`skip` skips the **whole loop** and advances past it — there is no "skip this
+iteration". `retry` resumes at the failed body step of the iteration it
+stopped in, with a fresh budget; it does not restart at iteration 1. `edit +
+retry` rewrites that body step in the task's snapshot, so it applies to
+**every remaining iteration** — fix the prompt, let it keep going.
+
+The same is true after a crash: position is derived from the rows on every
+admission, so a restarted daemon resumes mid-iteration rather than redoing work
+you may have waited an hour for.
+
+> **A loop is one step: one index, one slot, one worktree, one timeline entry**,
+> and its iterations are strictly sequential. Unlike `max_parallel`, it adds no
+> concurrency your caps cannot see. What it does add is *spend*: ten iterations
+> of a three-step body is thirty agent runs, which is why the default ceiling
+> is 10.
+
+### `type: break`
+
+Ends the enclosing loop, successfully. Takes `id`, `name` and a required `if:`,
+and nothing else — like `condition`, it starts no process, so it cannot time
+out, be retried or write a transcript.
+
+```yaml
+      - { id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+```
+
+Only valid inside a loop body: elsewhere there is no loop for it to end.
+
 ## Conditions
 
 A workflow can decide at run time what to do next. Three fields do it.
@@ -422,6 +545,7 @@ Guards mostly read `.Steps`, which after this change carries a little more:
 | A step that succeeded | `{{ eq (index .Steps "x").Status "succeeded" }}` |
 | A step skipped by its guard | `{{ eq (index .Steps "x").Status "skipped" }}` |
 | A step that failed under `allow_failure` | `{{ ne (index .Steps "x").ExitCode 0 }}` |
+| A body step of the loop pass you are in | `{{ (index .Steps "probe").Result }}` — inside a loop, earlier body steps of the same iteration are visible; a repeated step id resolves to its **latest** iteration |
 | The platform | `{{ ne .Host.OS "windows" }}` |
 | A field typed at creation | `{{ eq (index .Task.Fields "ship") "yes" }}` |
 
@@ -456,14 +580,17 @@ starts.
 | `.Project` | `Name`, `Path` (the original repo root), `DefaultBranch` |
 | `.Workflow` | `Name`, `Description` |
 | `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
+| `.Loop` | `Index` (1-based iteration, **0** outside any loop), `Item`, `IsFirst`, `IsLast`. See [`type: loop`](#type-loop) |
 | `.Steps` | **completed** steps by id → `{Status, Result, ExitCode}`. Includes steps skipped by a guard (`Status: "skipped"`) and steps that failed under `allow_failure`, once the workflow has moved past them |
 | `.Host` | `OS`, `Arch` — the machine the daemon runs on. This is the per-step platform gate: `{{ ne .Host.OS "windows" }}` |
 | `.Worktree` | `Path` |
 | `.LastFailure` | retries only: `{Reason, Output}`; empty otherwise |
 
 `.Steps.<id>.Result` is the agent's final result text for agent steps, or the
-last 100 lines of stdout for command steps. That is how one step's output feeds
-the next:
+last **200** lines of stdout for command steps. That is how one step's output
+feeds the next — and, with `for_each:`, how one step's output becomes a loop's
+item list. A producer meant to feed a loop should filter at the source rather
+than lean on that tail:
 
 ```yaml
   - id: fix
@@ -530,6 +657,14 @@ network, no agent CLI installed.
   and `allow_failure` included. `allow_failure` is valid on `agent` and
   `command` steps only. A `condition` step in **last** position is a *warning*:
   the task is done whether it continues or stops.
+- A `loop` has at least one body step and **exactly one** driver: `count` (at
+  least 1, and at most the effective ceiling — the step's own `max_iterations`,
+  else `loop.max_iterations`) or `for_each`. Its body steps join the file-wide
+  id namespace, and are not `manual`, `parallel`, `fan_out` or another `loop`,
+  and do not resolve to `on_input: require`. A `loop` rejects `max_retries` and
+  `allow_failure`: it has no attempt of its own. A `break` has an `if:` and
+  nothing else, and is valid only inside a loop body. `count`, `for_each` and
+  `max_iterations` are rejected on every other step type.
 - A `fan_out` step has at least one lane; lane ids are unique within the step;
   each lane has exactly one of `workflow` and `steps`. `merge.agent` is
   required by, and only valid with, `on_conflict: agent`. A lane's inline
@@ -563,5 +698,5 @@ the task-creation response, and in the daemon log.
 ## See also
 
 - [Writing workflows](../guides/workflows.md) — the guide.
-- [Example workflows](../../examples) — four working files.
+- [Example workflows](../../examples) — five working files.
 - [Agent CLIs](../guides/agents.md) — what each adapter honors.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -720,6 +720,97 @@ succeed is the human's, after they fix the workflow.
 deferred, with no new schema. The whole-workflow `platforms:` stays as it is —
 it gates *offering* a workflow, which a run-time guard cannot do.
 
+### 7.8 Loops
+
+*Added 2026-08-18 (task 016).* A `loop` step runs its body repeatedly in the
+task's **one** worktree. It creates no branch, no child task and nothing to
+merge — that is `fan_out` (§7.6). Where a `parallel` group (§7.5) is a set run
+once, a loop is a **sequence** run more than once.
+
+```yaml
+- id: green
+  type: loop
+  count: 5
+  steps:
+    - { id: suite,  type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
+    - { id: passed, type: break,   if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+    - { id: repair, type: agent,   prompt: "The suite is red: {{ (index .Steps \"suite\").Result }}" }
+```
+
+- **Exactly one driver.** `count:` (a positive integer, at most
+  `loop.max_iterations`) or `for_each:` (a YAML sequence of templates, or a
+  scalar template). Every `for_each` entry is rendered, trimmed and split on
+  newlines with empty lines dropped, so a hand-written list and a command's
+  multi-line output are one mechanism. There is no `while:`; the converge loop
+  is `count:` plus `break`, which puts the condition in the body where it can
+  see the body.
+
+  A list drawn from `.Steps[…].Result` is bounded by that field's **200-line
+  tail** (§8.4): a producer printing more paths than that loses the earliest
+  ones silently. In practice `max_iterations` bites an order of magnitude
+  sooner and blocks loudly, but a producer meant to feed a loop should filter
+  at the source rather than rely on either.
+- **The body is `agent`, `command`, `condition` and `break`.** `manual`,
+  `on_input: require`, `parallel`, `fan_out` and a nested `loop` are rejected
+  at load, each for the reason §7.5 rejects it: anything that ends the actor
+  goroutine mid-body is state a derived loop position cannot express.
+- **Rows.** One `step_runs` row per body step per iteration, all sharing the
+  loop's `step_index`, told apart by `step_id` and a 1-based `iteration`; a
+  `for_each` row also carries its `loop_item`. The loop has no row of its own;
+  its outcome is derived. A body step's transcript is
+  `{step_index}-i{iteration}-{step_id}-{attempt}.jsonl` (§12.2).
+- **`.Loop`** (§8.4) is `Index`, `Item`, `IsFirst`, `IsLast`, with `Index: 0`
+  outside any loop.
+- **Ending.** The driver being exhausted, or a `break` whose guard is true,
+  ends the loop **successfully** and the cursor advances. A `condition` whose
+  guard is false inside a body ends **that iteration**; the loop continues. A
+  loop that cannot run within `max_iterations` **blocks** with `loop_limit` —
+  running out of tries is not a decision, and `condition` (§7.7) is what a
+  workflow uses to stop and succeed. A `for_each` list longer than
+  `max_iterations` blocks before the first iteration, naming the count. An
+  empty list, or a whole loop guarded off by its `if:`, succeeds having run
+  nothing.
+- **Failure.** A body step that exhausts its retry budget fails the iteration
+  and blocks the task with that step's own reason. `allow_failure:` (§7.2) is
+  how a probe's red result becomes data a `break` can read. Retries are for a
+  step that failed; iterations are for a body that succeeded and must run
+  again — each body step spends its own `max_retries` **within** an iteration.
+- **Resuming.** Position is derived from the rows, never persisted: a
+  re-admitted loop skips body steps whose latest attempt succeeded and
+  continues mid-iteration. Iterations that already have rows take their item
+  from those rows; only new iterations draw from a re-derived `for_each` list.
+- **Human actions** (§6). `skip` skips the **whole loop step** and advances
+  past it; there is no "skip this iteration". `retry` resumes at the failed
+  body step of the current iteration with a fresh budget. `edit + retry`
+  rewrites that body step in the task's snapshot and therefore applies to
+  **every remaining iteration**, which is the useful behaviour: fix the
+  prompt, let it keep going.
+- **Concurrency.** A loop is one step, one slot, one worktree, and its
+  iterations are strictly sequential. §11's caps see one running task, exactly
+  as they always did. `max_parallel` has no meaning on a loop.
+
+**`type: break` ends the loop.** It carries `id`, `name` and a required `if:`,
+and nothing else — the same fields, for the same reason, as `condition`
+(§7.7): it starts no process, so it cannot time out, be interrupted, be
+retried or write a transcript. A true guard ends the loop and the cursor
+advances past it; the loop **succeeds**. It is rejected outside a loop body,
+symmetric with `condition` being rejected inside a `parallel` group.
+
+There is no `continue` type. A `condition` inside a loop body keeps the
+meaning §7.7 gave it — "end the sequence" — and the enclosing structure
+supplies the consequence; a loop body *is* a sequence, so ending it ends that
+iteration. One word, one meaning, whose consequence follows from what it is
+attached to.
+
+**`.Steps` visibility is positional.** A failed row is visible to a template
+only once the run has passed it, and "passed it" is compared on
+`(step_index, iteration, body position)`. Outside a loop that is the step
+index alone, as it always was. Inside one it is what lets a `break` read the
+`allow_failure` probe two lines above it in its own body. A `parallel`
+sub-step has no body position and therefore never precedes a sibling, so
+§7.5's set-invisibility is unchanged. A step's own failed attempt still stays
+out of `.Steps["itself"]` mid-retry, because `.LastFailure` is that channel.
+
 ## 8. Workflow definition (YAML)
 
 ### 8.1 File format
@@ -840,9 +931,15 @@ step is the exception: it takes `id`, `name` and `if` only.
 | `parallel` | `steps` | `max_parallel` |
 | `fan_out` | `lanes` | `merge` |
 | `condition` | `if` | — |
+| `loop` | `steps`, and exactly one of `count` / `for_each` | `max_iterations` |
+| `break` | `if` | — |
 
 *`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.
-`condition`, `if` and `allow_failure` added 2026-08-18 (task 015); see §7.7.*
+`condition`, `if` and `allow_failure` added 2026-08-18 (task 015); see §7.7.
+`loop` and `break` added 2026-08-18 (task 016); see §7.8. A `loop` also takes
+the common `if` and `timeout`, and rejects `max_retries` and `allow_failure`:
+it has no attempt of its own. A `break` is the exception a `condition` is —
+`id`, `name` and `if` only.*
 
 A lane carries `id` plus exactly one of `workflow` (a registry name) or
 `steps` (inline), and optionally `if` (*added 2026-08-18, task 015*), `fields`,
@@ -873,6 +970,16 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   A `condition` step in **last** position is a **warning**, not an error: the
   task is `done` whether it continues or stops, so the step cannot do anything
   a missing step would not.
+- *Added 2026-08-18 (task 016).* A `loop` step needs at least one body step
+  and **exactly one** driver: `count` (at least 1, and at most the effective
+  ceiling — the step's own `max_iterations` when it declares one, else
+  `loop.max_iterations` from config) or `for_each`. `max_iterations` is at
+  least 1. Body step ids join the workflow-wide namespace, for the reason a
+  group's sub-steps do: they share the loop's `step_index`. A body may not
+  contain `manual`, `fan_out`, `parallel` or a nested `loop`, and may not
+  resolve to `on_input: require`. A `break` requires `if`, rejects every other
+  field, and is valid **only** inside a loop body. `count`, `for_each` and
+  `max_iterations` are rejected on every other step type.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
   workflow validates on a Windows CI runner exactly as it does on Linux, or
@@ -924,7 +1031,8 @@ defensively: `{{ with index .Task.Fields "ticket" }}…{{ end }}`.
 | `.Project` | `Name`, `Path` (original repo root), `DefaultBranch` |
 | `.Workflow` | `Name`, `Description` |
 | `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
-| `.Steps` | map of *completed* step id → `{Status, Result, ExitCode}`; `Result` is the agent's final result text (agent steps) or the last 100 lines of stdout (command steps). *Amended 2026-08-18 (task 015):* a step skipped by its guard appears with `Status: "skipped"`, and a **failed** step appears once the engine has advanced past it — which happens only under `allow_failure` (§7.2), and is what a downstream guard reads. A step's own failed attempt stays out of `.Steps` mid-retry, because `.LastFailure` is already that channel; `interrupted` never appears, since §7.2 says it is not an outcome |
+| `.Steps` | map of *completed* step id → `{Status, Result, ExitCode}`; `Result` is the agent's final result text (agent steps) or the last **200** lines of stdout (command steps). *Corrected 2026-08-18 (task 016): this said 100; the daemon has always used 200, and a `for_each:` reading `.Steps[…].Result` (§7.8) makes the exact bound load-bearing rather than incidental.* *Amended 2026-08-18 (task 015):* a step skipped by its guard appears with `Status: "skipped"`, and a **failed** step appears once the engine has advanced past it — which happens only under `allow_failure` (§7.2), and is what a downstream guard reads. A step's own failed attempt stays out of `.Steps` mid-retry, because `.LastFailure` is already that channel; `interrupted` never appears, since §7.2 says it is not an outcome. *Amended 2026-08-18 (task 016):* "advanced past it" is compared on `(step_index, iteration, body position)`, which is what lets a loop body's later steps read its earlier ones while a `parallel` group's members stay blind to each other (§7.8). Under repetition a step id resolves to its **latest** iteration |
+| `.Loop` | *Added 2026-08-18 (task 016).* `Index` (1-based iteration, and **0** outside any loop, so a shared template can tell), `Item` (the `for_each` item this iteration runs on — a string; empty for a `count:` loop), `IsFirst`, `IsLast`. See §7.8 |
 | `.Host` | *Added 2026-08-18 (task 015).* `OS`, `Arch` — the **daemon's** GOOS/GOARCH, since the daemon is what runs the steps (§8.1.1). This is the per-step platform gate: `{{ ne .Host.OS "windows" }}`. There is deliberately no `.Now`: a guard reading wall-clock makes a run non-reproducible |
 | `.Worktree` | `Path` |
 | `.LastFailure` | on retry attempts only: `{Reason, Output}` from the previous attempt; empty otherwise |
@@ -1864,6 +1972,7 @@ platform the standing answer to an agent that will not resolve is the §12.3
   worktrees/{task_id}/
   transcripts/{task_id}/{step_index}-{attempt}.jsonl
   transcripts/{task_id}/{step_index}-{step_id}-{attempt}.jsonl  # sub-step of a parallel group (§7.5)
+  transcripts/{task_id}/{step_index}-i{iteration}-{step_id}-{attempt}.jsonl  # loop body step (§7.8)
   logs/daemon.log            # rotated, size-capped
 ```
 
@@ -2355,8 +2464,16 @@ CREATE TABLE step_runs (
   task_id             INTEGER NOT NULL REFERENCES tasks(id),
   step_index          INTEGER NOT NULL,
   step_id             TEXT NOT NULL,
-  step_type           TEXT NOT NULL,          -- agent | command | manual
-  attempt             INTEGER NOT NULL,       -- 1-based
+  step_type           TEXT NOT NULL,          -- agent | command | manual | condition | break | fan_out
+  attempt             INTEGER NOT NULL,       -- 1-based, within the position below
+  -- Where inside a `loop` step this row sits (§7.8, task 016, migration 0009).
+  -- A loop's body steps share the loop's step_index and repeat, so step_id
+  -- alone stops telling two rows apart; iteration is what does. 0 for every
+  -- row outside a loop, which keeps pre-0009 rows correct without a backfill.
+  -- The loop itself writes no row: its position and its outcome are derived
+  -- from these.
+  iteration           INTEGER NOT NULL DEFAULT 0, -- 1-based inside a loop; 0 outside one
+  loop_item           TEXT,                   -- the `for_each` item this iteration ran on; NULL otherwise
   state               TEXT NOT NULL,          -- running | succeeded | failed | interrupted
                                               -- | approved | rejected | skipped | stopped
   agent               TEXT,                   -- adapter name, agent steps only
@@ -2871,7 +2988,11 @@ currently true to show (§15 view 6).
 | Template references missing field | Step fails at render time (before any process starts) with the template error |
 | A step's `if:` does not render, or renders something that is not `true`/`false` | *Added 2026-08-18 (task 015).* The step blocks with `condition_error` and records one `failed` row naming it. The only reason in this table that does **not** run the §7.2 retry budget: a guard is evaluated before the step becomes an attempt, so there is no attempt to retry, and re-rendering an unchanged template cannot answer differently (§7.7). A human `retry` re-evaluates it |
 | A guard skips a step | *Added 2026-08-18 (task 015).* A `skipped` row with `skip_reason: condition`, visible in `.Steps`; the workflow carries on. The same guard on a fan-out lane or a group sub-step subsets the set instead — the others still run |
-| A `condition` step's guard is false | *Added 2026-08-18 (task 015).* The run ends there: one `stopped` row, the cursor moves to the end of the step list, the task is `done`. The steps after it record nothing, because they were never considered |
+| A `condition` step's guard is false | *Added 2026-08-18 (task 015).* The run ends there: one `stopped` row, the cursor moves to the end of the step list, the task is `done`. The steps after it record nothing, because they were never considered. *Amended 2026-08-18 (task 016):* inside a `loop` body the same step ends **that iteration** and the loop carries on — the sequence it ends is the body's (§7.8) |
+| A `loop` cannot run within `max_iterations` | *Added 2026-08-18 (task 016).* The task blocks with `loop_limit`: a `for_each` list longer than the ceiling blocks before iteration 1 naming the count, and a `count:` the ceiling moved under (config lowered while the task was queued) blocks too. It does not truncate and does not advance — running out of tries is not a decision, and advancing would hand every downstream guard a `.Steps` that says the work is finished (§7.8) |
+| A `break` step's guard is true | *Added 2026-08-18 (task 016).* The loop ends there and **succeeds**: one `stopped` row, the cursor advances past the loop step. A false guard records `succeeded` and the body carries on |
+| A loop body step exhausts its retry budget | *Added 2026-08-18 (task 016).* The iteration fails and the task blocks with **that step's own** reason, not `loop_limit`. `allow_failure:` (§7.2) is how a probe's red result becomes data a `break` can read instead |
+| The daemon dies mid-iteration | *Added 2026-08-18 (task 016).* §12.4 finalizes the running row as `interrupted`, and the re-admitted loop derives its position from the rows: body steps whose latest attempt succeeded are skipped, and it continues **mid-iteration**. Iterations that already have rows keep the `for_each` item those rows recorded; only new iterations draw from a re-derived list (§7.8) |
 | Every lane of a `fan_out` is guarded off | *Added 2026-08-18 (task 015).* A no-op success: the step records a row saying no lane was selected and advances. It must not park — a parent in `awaiting_children` with no children would be re-queued, spawn nothing and park again (§7.6) |
 | `answer` posted when task isn't `awaiting_input` | `409` with the current state (standard invalid-transition handling) |
 | Agent process dies while `awaiting_input` | Attempt fails with its exit code (retry policy applies); `pending_input` cleared |
@@ -2950,11 +3071,35 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
 - ~~workflow branching/conditionals~~ — **promoted out of future work,
   2026-08-18** (§7.7, task 015): `if:` guards on steps, lanes and group
   sub-steps, `type: condition` for early finish, and `allow_failure:` so a
-  guard has a run's own findings to read. What remains here is *nested*
-  control flow — `branch`/`switch` step types with `then:`/`else:` bodies,
-  which would make the step list a tree and the §7 cursor something other than
-  an integer. Guards are flat by construction, and the trigger for
-  reconsidering is a workflow that genuinely cannot be written flat.
+  guard has a run's own findings to read.
+- ~~loops in workflows~~ — **promoted out of future work, 2026-08-18** (§7.8,
+  task 016): `type: loop` with `count:` and `for_each:`, `type: break`, and
+  `.Loop`. This was task 015's named trigger firing — "the first workflow that
+  cannot be written flat" — and a loop body was affordable where `branch` is
+  not, because a loop has one arm: the step list stays a list and
+  `current_step` stays an integer.
+- **`branch`/`switch` step types** with `then:`/`else:` bodies, which would
+  make the step list a tree and the §7 cursor something other than an integer.
+  Deferred by task 015 decision 1 and still deferred: §7.7's guards plus
+  §7.8's loop cover the shapes that have come up. The trigger is a workflow
+  needing two *different* bodies chosen at run time, which no guard-and-skip
+  spelling can express without duplicating every step of both.
+- **Dynamic per-item fan-out** — plausibly `for_each:` on a `fan_out` step, one
+  child task and branch per item. Kept apart from §7.8 deliberately (task 016
+  decision 4): §7.6's creation-time cycle, `max_depth` and `max_tasks` checks
+  are possible **only** because the lane list is static in the snapshot, and
+  015 decision 11 already had to weaken them into a conservative
+  over-approximation to allow *conditional* lanes. A width discovered at run
+  time leaves nothing to check at creation. The trigger is an answer to "what
+  replaces the creation-time bound".
+- **A template FuncMap for §8.4** — `hasSuffix`, `contains`, `split`, `trim`,
+  `default`. `text/template` builtins are all any template gets today, which
+  `for_each:` makes felt: `.Loop.Item` is a string authors immediately want to
+  test by extension or path segment, and the answer is to filter at the source
+  (`git diff --name-only … | grep -v _test.go`). A FuncMap lands in *every*
+  prompt, check, run and guard at once and invites the expression-language
+  argument 015 decision 4 settled, so it earns its own task. The trigger is
+  the first `for_each` that cannot filter at its source.
 - LLM-as-judge verification as an optional third success layer.
 - Multi-user / remote daemons / fleet view across hosts.
 - Task templates & recurring tasks; issue-tracker ingestion (Jira → task).

--- a/docs/tasks/016-workflow-loops.md
+++ b/docs/tasks/016-workflow-loops.md
@@ -1,6 +1,6 @@
 # 016 — Loops in workflows (`type: loop`, `type: break`)
 
-**Status:** 📋 planned (0/10) · **Opened:** 2026-08-18
+**Status:** ✅ done (10/10) · **Opened:** 2026-08-18 · **Closed:** 2026-08-18
 
 A workflow may now repeat a body of steps — a fixed number of times, or once
 per item in a list:
@@ -388,9 +388,8 @@ at its source.
 
 ## Spec §7.8 draft
 
-To land in `docs/spec.md` **with the code**, not before it — the spec describes
-the system as it is now (CLAUDE.md), so it is amended in the PR that makes the
-amendment true.
+*Landed in `docs/spec.md` as §7.8 on 2026-08-18, with the code.* Kept here as
+the record of what was drafted; the spec is the live text.
 
 > ### 7.8 Loops
 >
@@ -448,7 +447,7 @@ amendment true.
 
 ## Tasks
 
-- [ ] **016.1 — Schema, parser, validation.** `StepLoop` and `StepBreak` in the
+- [x] **016.1 — Schema, parser, validation.** `StepLoop` and `StepBreak` in the
   type set; `Count`, `ForEach`, `MaxIterations`, `Steps` on `Step`. Exactly one
   driver; `count` within the ceiling; body-type rejection list (decision 10);
   `break` required-`if:`-and-nothing-else and rejected outside a loop body;
@@ -456,46 +455,46 @@ amendment true.
   ids and body ids unique across the whole workflow; `max_retries` and
   `allow_failure` rejected on a loop. `loop.max_iterations` in
   `internal/config`. Spec §8.2, §8.1.
-- [ ] **016.2 — Store.** Migration `0009_loops.sql`: `step_runs.iteration`,
+- [x] **016.2 — Store.** Migration `0009_loops.sql`: `step_runs.iteration`,
   `step_runs.loop_item`. `ListStepRuns` ordered
   `(step_index, iteration, attempt)`. Spec §14.
-- [ ] **016.3 — Template context.** `.Loop` in `RenderContext`; the positional
+- [x] **016.3 — Template context.** `.Loop` in `RenderContext`; the positional
   `.Steps` visibility rule replacing `run.StepIndex >= env.index`, with the
   `parallel`-sibling case pinned by a test that fails under a naive rewrite.
   Spec §8.4.
   *Depends: 016.2.*
-- [ ] **016.4 — Engine: `count:`.** The loop executor, body sequencing, derived
+- [x] **016.4 — Engine: `count:`.** The loop executor, body sequencing, derived
   position and mid-iteration resumption; `loop_limit`; the loop-level
   `timeout:`. Spec §7.8, §18.
   *Depends: 016.1, 016.2, 016.3.*
-- [ ] **016.5 — Engine: `break` and iteration-scoped `condition`.** `break`
+- [x] **016.5 — Engine: `break` and iteration-scoped `condition`.** `break`
   ending the loop successfully; `condition` inside a body ending the iteration
   and leaving its existing top-level meaning untouched. Spec §7.7, §7.8.
   *Depends: 016.4.*
-- [ ] **016.6 — Engine: `for_each:`.** List resolution (sequence or scalar,
+- [x] **016.6 — Engine: `for_each:`.** List resolution (sequence or scalar,
   split on newlines); `loop_item` on the row and rows-are-authoritative
   resumption; the over-cap block before iteration 1; the empty-list no-op.
   Document the `outputTailLines` (100-line) bound on a list drawn from
   `.Steps[…].Result`. Spec §7.8.
   *Depends: 016.4.*
-- [ ] **016.7 — Recovery and human actions.** §12.4 finalization of an
+- [x] **016.7 — Recovery and human actions.** §12.4 finalization of an
   interrupted body step; `skip` skipping the whole loop; `retry` resuming at the
   failed body step; `edit + retry` applying to remaining iterations. Spec §6,
   §12.4.
   *Depends: 016.4, 016.6.*
-- [ ] **016.8 — API and TUI.** `iteration` and `loop_item` through
+- [x] **016.8 — API and TUI.** `iteration` and `loop_item` through
   `internal/api` and `internal/apiclient`; the `loop` rollup on the task detail
   endpoint; board `loop 4/10`; detail-view rows grouped by iteration, folded,
   latest open. No new event type (decision 14). Spec §13.2.
   *Depends: 016.2, 016.4.*
-- [ ] **016.9 — Gate.** `scripts/m8-gate.sh`, committed executable via
+- [x] **016.9 — Gate.** `scripts/m8-gate.sh`, committed executable via
   `git update-index --chmod=+x`. Command steps only, bodies restricted to
   `exit N` and `git …` so it is portable to pwsh the way `m7` is and `m6` is
   not. Scenarios: count to completion; converge-and-break; `loop_limit`;
   `for_each` static; `for_each` from step output; empty list; iteration-scoped
   `condition`; crash mid-iteration and resume.
   *Depends: 016.4, 016.5, 016.6, 016.7.*
-- [ ] **016.10 — Docs.** Workflow schema, guides and block-reason pages; the
+- [x] **016.10 — Docs.** Workflow schema, guides and block-reason pages; the
   config reference for `loop.max_iterations`; CLAUDE.md's gate list; the §20
   amendment promoting loops out of future work and leaving behind, with named
   triggers, `branch`/`switch` (015 decision 1), dynamic per-item fan-out
@@ -517,6 +516,25 @@ push token used for this work has no `workflow` scope, so a branch touching
 
 Say so in CLAUDE.md's command list beside `m6` and `m7`, so the gap stays
 documented rather than silently carried.
+
+**Three things the implementation settled that the plan left open.**
+
+- **`loop_limit` is reachable for `count:` too.** Decision 5 says the cap
+  blocks; §7.8's "Ending" says the *driver* being exhausted succeeds. Both are
+  true, and they meet at the ceiling: `count:` is validated against it at load,
+  so the only way a count loop reaches it is a config edit landing under a
+  queued task — `loop.max_iterations` is read per loop, so a hot reload does
+  exactly that. The engine enforces it, which is what stops the reason being
+  decorative on one of the two drivers.
+- **`for_each` has one rule, not two.** The draft distinguished "a sequence of
+  templates" from "a scalar template, split on newlines". The implementation
+  applies the split to *every* entry, which agrees with the draft on both
+  stated cases and makes a hand-written list and a command's output one
+  mechanism rather than two.
+- **§8.4's output tail is 200 lines, not 100.** The spec said 100 and the
+  daemon has always used 200; `for_each:` reading `.Steps[…].Result` turns that
+  from incidental into load-bearing, so the spec was corrected in the same PR
+  rather than left to be discovered.
 
 **Two decisions here reverse the design this task was drafted with**, both
 because examples were written before the doc was: `while:` was a driver

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -30,7 +30,7 @@ description of how the system actually behaves.
 | [013](013-interactive-workflow-agent-gating.md) | Gating workflows that require mid-run interaction | ✅ done (8/8) |
 | [014](014-workflow-fan-out.md) | Parallel steps and workflow fan-out | ✅ done (14/14) |
 | [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | ✅ done (10/10) |
-| [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | 📋 planned (0/10) |
+| [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 
 ## How to add and update a task document
 

--- a/examples/converge.yaml
+++ b/examples/converge.yaml
@@ -1,0 +1,79 @@
+# converge — implement, then loop until the suite is green.
+#
+# The archetype `type: loop` exists for. `max_retries` was never this: a retry
+# re-runs *the same step* on *its own* failure, and converging needs three
+# different steps — probe, decide, repair — with the decision in the middle.
+#
+# Read the loop in three lines:
+#
+#   suite   is `allow_failure: true`, so a red run advances instead of blocking
+#           the task. That is what turns its exit code into data.
+#   passed  reads that exit code and ends the loop the first time it is zero.
+#           A `break` is post-test by construction: it can only run after the
+#           body above it has, which is why there is no `while:`.
+#   repair  only runs when the break did not fire, and sees the failure text.
+#
+# `count: 4` is the budget, not a target — four repairs and no more. The final
+# `verify` step is deliberately outside the loop and carries no
+# `allow_failure`: if the loop spent its budget without converging, that is the
+# step that blocks the task, and it is the one whose red output a human reads.
+name: converge
+description: Implement a change, then repair until the test suite passes.
+
+defaults:
+  agent: claude
+  max_retries: 2
+  timeout: 30m
+
+steps:
+  - id: implement
+    type: agent
+    prompt: |
+      Implement this change on {{.Task.BranchName}}.
+
+      {{.Task.Title}}
+      {{with .Task.Description}}
+      Details:
+      {{.}}
+      {{end}}
+      Match the conventions of the code you are editing. Add tests for what you
+      add; do not weaken, skip or delete an existing one.
+
+  - id: green
+    type: loop
+    count: 4
+    steps:
+      # A probe has nothing to gain from retrying: it is deterministic, and a
+      # second identical run costs a minute to reach the same answer.
+      - id: suite
+        type: command
+        run: go test ./...
+        allow_failure: true
+        max_retries: 0
+
+      - id: passed
+        type: break
+        if: '{{ eq (index .Steps "suite").ExitCode 0 }}'
+
+      - id: repair
+        type: agent
+        max_retries: 0
+        prompt: |
+          The test suite is red on iteration {{.Loop.Index}} of {{.Task.Title}}:
+
+          {{ (index .Steps "suite").Result }}
+
+          Fix the underlying cause. Do not weaken, skip, disable or delete a
+          test to get green, and do not change a test's expectations unless the
+          test itself is what is wrong — if it is, say so in the commit.
+
+  # Outside the loop on purpose: the loop succeeding means "it stopped", and
+  # this is what makes it mean "it worked".
+  - id: verify
+    type: command
+    run: go test ./...
+    max_retries: 0
+
+  - id: commit
+    type: command
+    run: 'git add -A && git commit -m "{{.Task.Title}}"'

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -168,7 +168,7 @@ func TestTaskListArchivedParamRejectsGarbage(t *testing.T) {
 // on the board's refresh path, and re-parsing immutable YAML per row per
 // request is the cost it was added to avoid.
 func TestSnapshotCacheParsesOnce(t *testing.T) {
-	c := newSnapshotCache()
+	c := newSnapshotCache(nil)
 	const yaml = "name: x\nsteps:\n  - id: a\n    type: agent\n    prompt: hi\n  - id: b\n    name: second\n    type: agent\n    prompt: yo\n"
 
 	first := c.get(7, yaml)
@@ -201,7 +201,7 @@ func TestSnapshotCacheParsesOnce(t *testing.T) {
 // TestSnapshotCacheToleratesUnparsableSnapshot keeps a corrupt snapshot from
 // failing the whole board: the row renders without step columns.
 func TestSnapshotCacheToleratesUnparsableSnapshot(t *testing.T) {
-	c := newSnapshotCache()
+	c := newSnapshotCache(nil)
 	got := c.get(1, "this: is: not: a: workflow")
 	if got.stepTotal != 0 || got.stepName(0) != "" {
 		t.Errorf("got %+v, want an empty summary", got)

--- a/internal/api/loop_test.go
+++ b/internal/api/loop_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// loopSnapshotYAML is a two-step workflow whose second step is a `for_each`
+// loop, so the rollup has a step to be present on and an index to be absent
+// on.
+const loopSnapshotYAML = `name: each
+steps:
+  - id: discover
+    type: command
+    run: ls
+  - id: visit
+    type: loop
+    for_each: '{{ .Steps.discover.Result }}'
+    max_iterations: 6
+    steps:
+      - id: touch
+        type: command
+        run: echo {{ .Loop.Item }}
+`
+
+// TestLoopRollup covers decision 14: visibility into a running loop comes
+// from a rollup on the task endpoints, not from forty durable events saying
+// what forty rows already say. The rollup is derived per request — the
+// persisted loop cursor decision 7 declined — so the test drives it by
+// writing rows.
+func TestLoopRollup(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+
+	// Cursor on step 0, which is not a loop: no rollup at all.
+	plain := h.seedTask(t, loopSnapshotYAML, 0)
+	if got := h.loopOf(t, plain.ID); got != nil {
+		t.Fatalf("loop rollup = %+v on a non-loop step, want absent", got)
+	}
+
+	task := h.seedTask(t, loopSnapshotYAML, 1)
+	for iteration, item := range []string{"alpha", "beta"} {
+		run := &store.StepRun{
+			TaskID: task.ID, StepIndex: 1, StepID: "touch", StepType: "command",
+			Attempt: 1, Iteration: iteration + 1, LoopItem: item, State: store.StepSucceeded,
+		}
+		if err := h.store.CreateStepRun(t.Context(), run); err != nil {
+			t.Fatalf("create step run: %v", err)
+		}
+	}
+
+	got := h.loopOf(t, task.ID)
+	if got == nil {
+		t.Fatal("loop rollup absent while the current step is a loop")
+	}
+	if got.Driver != "for_each" {
+		t.Errorf("driver = %q, want for_each", got.Driver)
+	}
+	if got.Iteration != 2 {
+		t.Errorf("iteration = %d, want 2 — the highest a row carries", got.Iteration)
+	}
+	if got.MaxIterations != 6 {
+		t.Errorf("max_iterations = %d, want the step's own 6", got.MaxIterations)
+	}
+	if got.Item != "beta" {
+		t.Errorf("item = %q, want beta — the item the current iteration is on", got.Item)
+	}
+
+	// The board reads the same rollup off the list endpoint, or `loop 4/10`
+	// would need a second request per row.
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: %d %s", resp.StatusCode, body)
+	}
+	var list []listTaskResponse
+	if err := json.Unmarshal(body, &list); err != nil || len(list) == 0 {
+		t.Fatalf("list body: %v (%d rows)", err, len(list))
+	}
+	var rolled *loopResponse
+	for i := range list {
+		if list[i].ID == task.ID {
+			rolled = list[i].Loop
+		}
+	}
+	if rolled == nil || rolled.Iteration != 2 {
+		t.Errorf("list loop rollup = %+v, want iteration 2", rolled)
+	}
+}
+
+// TestStepRunCarriesItsPosition pins the two columns migration 0009 added on
+// the wire. Without them a client cannot tell two attempts of one body step
+// apart, because they share the loop's step_index and step_id.
+func TestStepRunCarriesItsPosition(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	created := h.createTask(t, map[string]any{"title": "loops", "workflow": "adhoc"})
+	run := &store.StepRun{
+		TaskID: created.ID, StepIndex: 0, StepID: "touch", StepType: "command",
+		Attempt: 1, Iteration: 3, LoopItem: "gamma", State: store.StepSucceeded,
+	}
+	if err := h.store.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+	resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/tasks/%d/steps", created.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("steps: %d %s", resp.StatusCode, body)
+	}
+	var steps []stepRunResponse
+	if err := json.Unmarshal(body, &steps); err != nil || len(steps) != 1 {
+		t.Fatalf("steps body: %v (%d rows)", err, len(steps))
+	}
+	if steps[0].Iteration != 3 {
+		t.Errorf("iteration = %d, want 3", steps[0].Iteration)
+	}
+	if steps[0].LoopItem == nil || *steps[0].LoopItem != "gamma" {
+		t.Errorf("loop_item = %v, want gamma", steps[0].LoopItem)
+	}
+}
+
+// seedTask inserts a task with a chosen snapshot and step cursor, straight
+// through the store. Creation over HTTP would need the loop workflow to be in
+// a registry scope, and what these tests are about is what the endpoints make
+// of a task once it exists.
+func (h *taskHarness) seedTask(t *testing.T, snapshot string, currentStep int) *store.Task {
+	t.Helper()
+	task := &store.Task{
+		ProjectID:        h.projectID,
+		Title:            "loops",
+		WorkflowName:     "each",
+		WorkflowSnapshot: snapshot,
+		BaseBranch:       "main",
+		State:            store.TaskQueued,
+		CurrentStep:      currentStep,
+	}
+	resolve := func(id int64) (string, error) { return fmt.Sprintf("vincent/%d-loops", id), nil }
+	if err := h.store.CreateTask(t.Context(), task, resolve); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	return task
+}
+
+func (h *taskHarness) loopOf(t *testing.T, id int64) *loopResponse {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/tasks/%d", id), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("detail: %d %s", resp.StatusCode, body)
+	}
+	var detail taskResponse
+	if err := json.Unmarshal(body, &detail); err != nil {
+		t.Fatalf("detail body: %v", err)
+	}
+	return detail.Loop
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -115,7 +115,12 @@ func New(deps Deps) *Server {
 		// built-in ad-hoc workflow is still served.
 		deps.Workflows = workflow.NewRegistry("", workflow.Options{}, deps.Logger)
 	}
-	s := &Server{deps: deps, snaps: newSnapshotCache()}
+	s := &Server{deps: deps, snaps: newSnapshotCache(func() int {
+		if deps.Config == nil {
+			return 0
+		}
+		return deps.Config().Loop.MaxIterations
+	})}
 	s.handler = s.buildHandler()
 	s.httpSrv = &http.Server{
 		Handler:           s.handler,

--- a/internal/api/snapcache.go
+++ b/internal/api/snapcache.go
@@ -23,6 +23,19 @@ type stepDefinition struct {
 	prompt       string
 	run          string
 	instructions string
+	// loop is the §7.8 shape of a `loop` step, nil for every other type. It
+	// is what lets the task endpoints report a loop rollup without re-parsing
+	// the snapshot per request.
+	loop *loopDefinition
+}
+
+// loopDefinition is what a `loop` step's rollup needs from the snapshot: its
+// driver, and the largest iteration it could reach. For `count:` that is the
+// count itself; for `for_each:` the list length is only known at run time, so
+// the ceiling is the honest n in a k/n.
+type loopDefinition struct {
+	driver string
+	total  int
 }
 
 // stepName returns the display name of step index i, or "" when the index is
@@ -33,6 +46,16 @@ func (s snapshotSummary) stepName(i int) string {
 		return ""
 	}
 	return s.stepNames[i]
+}
+
+// loopAt is the loop shape of step index i, or nil when that step is not a
+// loop — which includes the out-of-range index a finished task's cursor sits
+// at.
+func (s snapshotSummary) loopAt(i int) *loopDefinition {
+	if i < 0 || i >= len(s.steps) {
+		return nil
+	}
+	return s.steps[i].loop
 }
 
 // snapshotCache memoizes parsed workflow snapshots by task id.
@@ -46,10 +69,18 @@ func (s snapshotSummary) stepName(i int) string {
 type snapshotCache struct {
 	mu sync.Mutex
 	m  map[int64]snapshotSummary
+	// ceiling supplies `loop.max_iterations` for a loop step that declares no
+	// bound of its own. It is a func for the reason the registry's is: config
+	// hot-reloads (§12.3), and an entry parsed at startup must not pin the
+	// number a rollup reports for the rest of the daemon's life.
+	ceiling func() int
 }
 
-func newSnapshotCache() *snapshotCache {
-	return &snapshotCache{m: make(map[int64]snapshotSummary)}
+func newSnapshotCache(ceiling func() int) *snapshotCache {
+	if ceiling == nil {
+		ceiling = func() int { return 0 }
+	}
+	return &snapshotCache{m: make(map[int64]snapshotSummary), ceiling: ceiling}
 }
 
 // get returns the summary for taskID, parsing snapshot on first use. A
@@ -62,7 +93,7 @@ func (c *snapshotCache) get(taskID int64, snapshot string) snapshotSummary {
 	if s, ok := c.m[taskID]; ok {
 		return s
 	}
-	s := parseSnapshot(snapshot)
+	s := parseSnapshot(snapshot, c.ceiling())
 	c.m[taskID] = s
 	return s
 }
@@ -75,7 +106,26 @@ func (c *snapshotCache) forget(taskID int64) {
 	delete(c.m, taskID)
 }
 
-func parseSnapshot(snapshot string) snapshotSummary {
+// loopDefinitionOf extracts the §7.8 rollup shape of a `loop` step. ceiling
+// is `loop.max_iterations`, used when the step declares no `max_iterations:`
+// of its own.
+func loopDefinitionOf(step workflow.Step, ceiling int) *loopDefinition {
+	if step.Type != workflow.StepLoop {
+		return nil
+	}
+	def := &loopDefinition{driver: step.Driver()}
+	switch {
+	case step.Count != nil:
+		def.total = *step.Count
+	case step.MaxIterations != nil:
+		def.total = *step.MaxIterations
+	default:
+		def.total = ceiling
+	}
+	return def
+}
+
+func parseSnapshot(snapshot string, ceiling int) snapshotSummary {
 	if snapshot == "" {
 		return snapshotSummary{}
 	}
@@ -103,6 +153,7 @@ func parseSnapshot(snapshot string) snapshotSummary {
 			prompt:       wf.Steps[i].Prompt,
 			run:          wf.Steps[i].Run,
 			instructions: wf.Steps[i].Instructions,
+			loop:         loopDefinitionOf(wf.Steps[i], ceiling),
 		})
 	}
 	return s

--- a/internal/api/snapcache_test.go
+++ b/internal/api/snapcache_test.go
@@ -24,7 +24,7 @@ steps:
     type: command
     run: git push
 `
-	got := parseSnapshot(src).steps
+	got := parseSnapshot(src, 10).steps
 	want := []stepDefinition{
 		{index: 0, id: "implement", stepType: "agent", prompt: "write the thing"},
 		{index: 1, id: "review", stepType: "manual", instructions: "look at the diff"},

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -81,6 +81,11 @@ type taskResponse struct {
 	ParentTaskID *int64  `json:"parent_task_id"`
 	LaneID       *string `json:"lane_id"`
 	LaneOrder    *int    `json:"lane_order"`
+	// Loop is the §7.8 rollup, present only while a `loop` step is the
+	// current one. Derived per request from the step's rows, never stored: a
+	// counter would be the persisted loop cursor decision 7 declined, and
+	// §12.4 recovery would have to reconcile it.
+	Loop *loopResponse `json:"loop,omitempty"`
 	// Children is the §13.2 subtree rollup, present on the detail endpoint
 	// whenever the task has lanes. Derived per request from one recursive
 	// CTE, never stored: a counter would be a second truth that drifts.
@@ -198,9 +203,17 @@ type stepRunResponse struct {
 	StepID    string `json:"step_id"`
 	// StepName is the snapshot's display name for this attempt's step, so a
 	// timeline reads in the workflow author's words rather than in step ids.
-	StepName      string  `json:"step_name"`
-	StepType      string  `json:"step_type"`
-	Attempt       int     `json:"attempt"`
+	StepName string `json:"step_name"`
+	StepType string `json:"step_type"`
+	Attempt  int    `json:"attempt"`
+	// Iteration is which pass of an enclosing `loop` produced this attempt —
+	// 1-based, and 0 for every row outside a loop (§7.8). Body steps share
+	// the loop's step_index, so this and step_id together are what tell two
+	// of them apart.
+	Iteration int `json:"iteration"`
+	// LoopItem is the `for_each` item that iteration ran on; null for a
+	// `count:` loop and outside a loop.
+	LoopItem      *string `json:"loop_item"`
 	State         string  `json:"state"`
 	Agent         *string `json:"agent"`
 	Model         *string `json:"model"`
@@ -255,6 +268,8 @@ func toStepRunResponse(r *store.StepRun, summary snapshotSummary) stepRunRespons
 		StepID:         r.StepID,
 		StepName:       summary.stepName(r.StepIndex),
 		StepType:       r.StepType,
+		Iteration:      r.Iteration,
+		LoopItem:       nilIfEmpty(r.LoopItem),
 		PromptOverride: r.PromptOverride != "",
 		RunOverride:    r.RunOverride != "",
 		Attempt:        r.Attempt,
@@ -622,6 +637,50 @@ func toChildrenResponse(r store.ChildrenRollup) *childrenResponse {
 	return out
 }
 
+// loopResponse is the §7.8 loop rollup — the shape of the §13.2 children
+// rollup, one level cheaper. It exists so a board can render `loop 4/10`
+// without a client re-deriving iteration numbers from the step rows, and it
+// is deliberately not a new event type: ten iterations of a four-step body
+// would put forty durable events on the stream to say what forty rows
+// already say (task 016 decision 14).
+type loopResponse struct {
+	// Driver is "count" or "for_each".
+	Driver string `json:"driver"`
+	// Iteration is the pass in progress — the highest a row carries, or 0
+	// before the first one starts.
+	Iteration int `json:"iteration"`
+	// MaxIterations is the largest iteration this loop could reach: the
+	// `count:` itself, or the ceiling a `for_each` is bounded by, whose real
+	// length is only known at run time.
+	MaxIterations int `json:"max_iterations"`
+	// Item is the `for_each` item the current iteration is running on; empty
+	// for a `count:` loop.
+	Item string `json:"item,omitempty"`
+}
+
+// loopRollup builds the §7.8 rollup for a task whose current step is a loop,
+// and returns nil for every other task. The extra query is why it is gated on
+// the snapshot rather than run for every row: the summary is cached, so a
+// task that is not in a loop costs a map lookup.
+func (s *Server) loopRollup(ctx context.Context, t *store.Task, summary snapshotSummary) *loopResponse {
+	def := summary.loopAt(t.CurrentStep)
+	if def == nil {
+		return nil
+	}
+	out := &loopResponse{Driver: def.driver, MaxIterations: def.total}
+	runs, err := s.deps.Store.ListStepRunsAt(ctx, t.ID, t.CurrentStep)
+	if err != nil {
+		s.deps.Logger.Error("loop rollup", "task", t.ID, "error", err)
+		return out
+	}
+	for i := range runs {
+		if run := &runs[i]; run.Iteration >= out.Iteration {
+			out.Iteration, out.Item = run.Iteration, run.LoopItem
+		}
+	}
+	return out
+}
+
 func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	filter := store.TaskFilter{State: store.TaskState(q.Get("state"))}
@@ -695,6 +754,12 @@ func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
 // snapshot's step count and current step name, and the cost/token rollups.
 // Three queries total regardless of task count — the point of the endpoint
 // is that a board never has to fan out per row.
+//
+// The §7.8 loop rollup is the one per-row query, and it is taken only for a
+// task whose *cached* snapshot says its current step is a loop. That is what
+// keeps "a board never fans out" true in practice: a board of fifty tasks
+// none of which is looping still costs three queries, and one that is
+// looping is the row a person is watching iterate.
 func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]listTaskResponse, error) {
 	ids := make([]int64, 0, len(tasks))
 	for i := range tasks {
@@ -723,6 +788,7 @@ func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]list
 			InputTokens:  rollups[t.ID].InputTokens,
 			OutputTokens: rollups[t.ID].OutputTokens,
 		}
+		row.Loop = s.loopRollup(ctx, t, summary)
 		row.ProjectName = names[t.ProjectID]
 		if ru := rollups[t.ID]; ru.HasCost {
 			cost := ru.CostUSD
@@ -759,6 +825,7 @@ func (s *Server) handleTaskGet(w http.ResponseWriter, r *http.Request) {
 	// already done, still wants its lane ids reachable from one GET, and
 	// gating the field on a state would force a client to know the state to
 	// know whether to look.
+	resp.Loop = s.loopRollup(r.Context(), t, summary)
 	if rollup, err := s.deps.Store.ChildrenOf(r.Context(), t.ID); err != nil {
 		s.deps.Logger.Error("children rollup", "task", t.ID, "error", err)
 	} else if rollup.Total > 0 {

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -44,6 +44,9 @@ type Task struct {
 	// the task has lanes. Lanes are hidden from the task list by design, and
 	// this is what pays for that: it is where a blocked lane becomes visible.
 	Children *ChildrenRollup `json:"children,omitempty"`
+	// Loop is the §7.8 rollup, present only while a `loop` step is the
+	// current one. It is what a board renders `loop 4/10` from.
+	Loop *LoopRollup `json:"loop,omitempty"`
 
 	BlockReason      *string  `json:"block_reason"`
 	PauseRequested   bool     `json:"pause_requested"`
@@ -173,7 +176,14 @@ type StepRun struct {
 	StepName  string `json:"step_name"`
 	StepType  string `json:"step_type"`
 	Attempt   int    `json:"attempt"`
-	State     string `json:"state"`
+	// Iteration is which pass of an enclosing `loop` produced this attempt —
+	// 1-based, 0 outside a loop (§7.8). Body steps share the loop's
+	// StepIndex, so this and StepID together identify one of them.
+	Iteration int `json:"iteration"`
+	// LoopItem is the `for_each` item that iteration ran on; nil for a
+	// `count:` loop and outside a loop.
+	LoopItem *string `json:"loop_item"`
+	State    string  `json:"state"`
 
 	Agent  *string `json:"agent"`
 	Model  *string `json:"model"`
@@ -236,6 +246,29 @@ type ChildrenRollup struct {
 	ByState      map[string]int `json:"by_state"`
 	Blocked      []int64        `json:"blocked"`
 	AwaitingGate []int64        `json:"awaiting_gate"`
+}
+
+// LoopRollup is the §7.8 loop rollup: where a task is inside the `loop` step
+// it is currently on.
+type LoopRollup struct {
+	Driver        string `json:"driver"`
+	Iteration     int    `json:"iteration"`
+	MaxIterations int    `json:"max_iterations"`
+	Item          string `json:"item,omitempty"`
+}
+
+// Display is the short form a board row shows beside the k/n step column:
+// "loop 4/10", plus the item when a `for_each` is running one. Empty before
+// the first iteration has a row, when there is nothing yet to report.
+func (r *LoopRollup) Display() string {
+	if r == nil || r.Iteration == 0 {
+		return ""
+	}
+	out := fmt.Sprintf("loop %d/%d", r.Iteration, r.MaxIterations)
+	if r.Item != "" {
+		out += " " + r.Item
+	}
+	return out
 }
 
 // Summary is the short form a board row shows beside `awaiting_children` —

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lezli01/vincent/internal/agent/codex"
 	"github.com/lezli01/vincent/internal/agent/cursor"
 	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/workflow"
 )
 
@@ -205,9 +206,15 @@ func localValidateOptions() workflow.Options {
 	for _, a := range reg.All() {
 		catalogs[a.Name()] = a.Curated()
 	}
+	// The loop ceiling comes from the built-in default rather than the user's
+	// config: `vincent workflow validate` runs wherever the file does — a CI
+	// runner with no config file at all — and a workflow that validates on a
+	// laptop must validate there too.
+	ceiling := config.Default().Loop.MaxIterations
 	return workflow.Options{
-		KnownAgents: reg.Names(),
-		Catalogs:    func() agent.Catalogs { return catalogs },
+		KnownAgents:   reg.Names(),
+		Catalogs:      func() agent.Catalogs { return catalogs },
+		MaxIterations: func() int { return ceiling },
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,6 +211,10 @@ type Config struct {
 	// in the task-creation path, so a reload governs the next task rather
 	// than anything already running (decision 30).
 	FanOut FanOut `yaml:"fan_out"`
+	// Loop bounds a `type: loop` step (§7.8, task 016). It sits beside
+	// Parallel and FanOut for the same reason they do: it is a ceiling on
+	// what one step may do, not a timeout a step inherits.
+	Loop Loop `yaml:"loop"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -304,6 +308,22 @@ type FanOut struct {
 	MaxTasks int `yaml:"max_tasks"`
 }
 
+// Loop configures `type: loop` steps (spec §7.8 — task 016).
+//
+// MaxIterations is both the default for a step that declares no
+// `max_iterations:` and the ceiling `count:` is validated against at load, so
+// `count: 5000` is refused in front of the person typing rather than
+// discovered on iteration 300. It is deliberately low: an agent step is
+// minutes and dollars, and ten iterations of a three-step body is already
+// thirty agent runs (decision 5).
+//
+// It is read per loop rather than cached, so a hot reload (§12.3) governs
+// the next loop — including one already running, which blocks with
+// `loop_limit` if the lowered ceiling is already behind it.
+type Loop struct {
+	MaxIterations int `yaml:"max_iterations"`
+}
+
 // Agents configures how agent CLIs are located.
 type Agents struct {
 	Claude Agent `yaml:"claude"`
@@ -349,6 +369,7 @@ func Default() Config {
 		// caps will run concurrently anyway, so it bounds the explosion
 		// rather than the throughput.
 		FanOut: FanOut{MaxDepth: 3, MaxTasks: 64},
+		Loop:   Loop{MaxIterations: 10},
 		TUI: TUI{Board: BoardView{
 			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
 		}},
@@ -407,6 +428,9 @@ func (c Config) validate() error {
 	}
 	if c.FanOut.MaxTasks < 1 {
 		return fmt.Errorf("fan_out.max_tasks must be at least 1, got %d", c.FanOut.MaxTasks)
+	}
+	if c.Loop.MaxIterations < 1 {
+		return fmt.Errorf("loop.max_iterations must be at least 1, got %d", c.Loop.MaxIterations)
 	}
 	if c.TranscriptRetentionDays < 0 {
 		return fmt.Errorf("transcript_retention_days must not be negative, got %d", c.TranscriptRetentionDays)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,7 @@ agents:
 		// max_parallel of 0 would refuse to run any sub-step at all.
 		Parallel: Parallel{MaxParallel: 4},
 		FanOut:   FanOut{MaxDepth: 3, MaxTasks: 64},
+		Loop:     Loop{MaxIterations: 10},
 		TUI:      TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -199,7 +199,11 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	// and never probe (§8.2).
 	workflows := workflow.NewRegistry(
 		filepath.Join(dirs.Config, workflow.GlobalDirName),
-		workflow.Options{KnownAgents: agents.Names(), Catalogs: catalog.Catalogs},
+		workflow.Options{
+			KnownAgents:   agents.Names(),
+			Catalogs:      catalog.Catalogs,
+			MaxIterations: func() int { return currentConfig().Loop.MaxIterations },
+		},
 		logger,
 	)
 	workflows.ReloadGlobal()

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 8
+const latestSchemaVersion = 9
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0009_loops.sql
+++ b/internal/store/migrations/0009_loops.sql
@@ -1,0 +1,34 @@
+-- 0009_loops: where a step run sits inside a `loop` (task 016, spec §7.8/§14).
+--
+-- A loop step occupies one step_index and its body steps share it, exactly as
+-- a `parallel` group's sub-steps do (task 014 decision 16). What a loop adds
+-- is that the same body step runs more than once, so step_id no longer tells
+-- two rows apart. `iteration` is what does — 1-based, and 0 for every row that
+-- is not inside a loop, which keeps every existing row correct without a
+-- backfill.
+--
+-- It is a column rather than a composite step id (`repair#3`), which would
+-- have needed no migration: manufactured ids are not in the workflow file,
+-- they break the "step ids are unique across the whole workflow" rule, they
+-- poison `.Steps` keys, and every consumer would have to parse a string to
+-- recover a number (decision 7).
+--
+-- Nothing here records a loop *cursor*. The loop step writes no row of its
+-- own, and a re-admitted loop derives its position — (step_index, iteration,
+-- body position) — from these rows. A persisted cursor would be a second
+-- source of truth for a fact the rows already hold, and §12.4 recovery would
+-- have to reconcile the two (decision 7).
+ALTER TABLE step_runs ADD COLUMN iteration INTEGER NOT NULL DEFAULT 0;
+
+-- The item a `for_each` iteration ran on, NULL for a `count:` loop and for
+-- every row outside one.
+--
+-- Iterations that already have rows take their item from *here*, and only new
+-- iterations draw from a re-derived list (decision 8). That is what separates
+-- a loop's extent from a guard: 015 decision 10 makes guards re-evaluate
+-- every time and never stick, which is right for a question, but a for_each
+-- list is not a question — it is the thing iteration numbers are indices into.
+-- Re-deriving it mid-loop (after a crash, after an `edit + retry` on the
+-- producing step) would make "iteration 3" name a different item than the row
+-- recorded, and resumption would silently re-index onto the wrong work.
+ALTER TABLE step_runs ADD COLUMN loop_item TEXT;

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -142,12 +142,23 @@ type Task struct {
 // StepRun is one attempt at executing one step of one task; history is
 // append-only (spec §5.4).
 type StepRun struct {
-	ID            int64
-	TaskID        int64
-	StepIndex     int
-	StepID        string
-	StepType      string // agent | command | manual
-	Attempt       int    // 1-based
+	ID        int64
+	TaskID    int64
+	StepIndex int
+	StepID    string
+	StepType  string // agent | command | manual | condition | break | fan_out
+	Attempt   int    // 1-based
+	// Iteration is which pass of an enclosing `loop` produced this row —
+	// 1-based, and 0 for every row outside a loop (§7.8, task 016
+	// decision 7). Body steps share the loop's StepIndex, so this and StepID
+	// together are what tell two of them apart.
+	Iteration int
+	// LoopItem is the `for_each` item this iteration ran on, empty for a
+	// `count:` loop and outside a loop. It is recorded rather than
+	// re-derived: it is the loop's extent, not a question, and re-asking it
+	// mid-loop would re-index a resumed iteration onto different work
+	// (decision 8).
+	LoopItem      string
 	State         StepRunState
 	Agent         string // adapter name; agent steps only
 	Model         string // resolved model as passed to the adapter (spec §8.6); "" = CLI default
@@ -176,6 +187,23 @@ type StepRun struct {
 	InputWaitMS int64
 	StartedAt   time.Time
 	FinishedAt  *time.Time
+}
+
+// StepRef names one step's run history — the position a `step_runs` row
+// belongs to.
+//
+// It is four values because an index alone stopped identifying a step twice.
+// A `parallel` group's sub-steps share the group's StepIndex and are told
+// apart by StepID (task 014 decision 16); a `loop` body's steps share the
+// loop's StepIndex *and* repeat, and are told apart by Iteration as well
+// (§7.8, task 016 decision 7). Outside both, StepID is the step's own id and
+// Iteration is 0, so the extra fields cost an ordinary step nothing.
+type StepRef struct {
+	TaskID    int64
+	StepIndex int
+	StepID    string
+	// Iteration is the 1-based pass of an enclosing loop; 0 outside one.
+	Iteration int
 }
 
 // Override is the prompt or command a human supplied with `edit + retry`

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -10,7 +10,8 @@ import (
 	"time"
 )
 
-const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, state, agent, model, effort, pid,
+const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
+	state, agent, model, effort, pid,
 	proc_started_at, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
 	prompt_override, run_override, transcript_path,
 	input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at`
@@ -83,12 +84,14 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 		r.StartedAt = time.Now()
 	}
 	res, err := db.ExecContext(ctx, `
-		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, state, agent, model, effort, pid,
+		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
+			state, agent, model, effort, pid,
 			proc_started_at, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
 			prompt_override, run_override, transcript_path,
 			input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, string(r.State),
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, r.Iteration, nullString(r.LoopItem),
+		string(r.State),
 		nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
 		r.PID, formatTimePtr(r.ProcStartedAt), r.ExitCode, r.CheckExitCode,
 		nullString(r.FailureReason), nullString(r.SkipReason), nullString(r.ResultSummary),
@@ -146,14 +149,15 @@ func (s *Store) GetStepRun(ctx context.Context, id int64) (*StepRun, error) {
 // starts on a step whose earlier attempts failed under a previous actor —
 // the human-retry path, where the §8.4 failure block matters most.
 //
-// stepID narrows it to one member of a `parallel` group, for the reason
-// CountStepAttempts gives (task 014 decision 16): the failure block a
-// sub-step retries under must be its own, not a sibling's.
-func (s *Store) LastFailedStepRun(ctx context.Context, taskID int64, stepIndex int, stepID string) (*StepRun, error) {
+// ref narrows it to one position for the reason CountStepAttempts gives: the
+// failure block a step retries under must be its own — not a group sibling's
+// (task 014 decision 16), and not the same body step's failure from a
+// previous loop iteration (task 016 decision 6).
+func (s *Store) LastFailedStepRun(ctx context.Context, ref StepRef) (*StepRun, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT `+stepRunColumns+` FROM step_runs
-		WHERE task_id = ? AND step_index = ? AND step_id = ? AND state = ?
+		WHERE task_id = ? AND step_index = ? AND step_id = ? AND iteration = ? AND state = ?
 		ORDER BY attempt DESC, id DESC LIMIT 1`,
-		taskID, stepIndex, stepID, string(StepFailed))
+		ref.TaskID, ref.StepIndex, ref.StepID, ref.Iteration, string(StepFailed))
 	r, err := scanStepRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -223,11 +227,49 @@ func (s *Store) LatestStepRun(ctx context.Context, taskID int64, stepIndex int, 
 	return r, nil
 }
 
-// ListStepRuns returns every attempt of every step of the task, ordered by
-// step index, then attempt.
+// ListStepRunsAt returns every row at one step index, in position order:
+// iteration, then attempt. It is a `loop` step's whole history in one read.
+//
+// A loop derives everything it needs from these rows rather than from a
+// stored cursor (task 016 decision 7): which iteration it is in, which body
+// steps of that iteration already succeeded, and — for `for_each` — which
+// item each iteration ran on (decision 8). One query rather than three
+// because the reduction is a walk in Go over a bounded set: a loop's rows are
+// at most max_iterations × body size × attempts.
+func (s *Store) ListStepRunsAt(ctx context.Context, taskID int64, stepIndex int) ([]StepRun, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+stepRunColumns+` FROM step_runs
+		WHERE task_id = ? AND step_index = ?
+		ORDER BY iteration ASC, attempt ASC, id ASC`, taskID, stepIndex)
+	if err != nil {
+		return nil, fmt.Errorf("list step runs at index %d: %w", stepIndex, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []StepRun
+	for rows.Next() {
+		r, err := scanStepRun(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan step run: %w", err)
+		}
+		out = append(out, *r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list step runs at index %d: %w", stepIndex, err)
+	}
+	return out, nil
+}
+
+// ListStepRuns returns every attempt of every step of the task in position
+// order: step index, then iteration, then attempt.
+//
+// `iteration` sits between the two on purpose (task 016 decision 9). The §8.4
+// assembly walks these rows in order and does `steps[run.StepID] = res`, so
+// last row wins — which is exactly what makes `.Steps["suite"]` under
+// repetition resolve to the *latest* iteration, for free, provided the
+// ordering is this one. Ordering by attempt first would interleave the
+// iterations and hand a guard an older pass's result.
 func (s *Store) ListStepRuns(ctx context.Context, taskID int64) ([]StepRun, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT `+stepRunColumns+` FROM step_runs
-		WHERE task_id = ? ORDER BY step_index ASC, attempt ASC, id ASC`, taskID)
+		WHERE task_id = ? ORDER BY step_index ASC, iteration ASC, attempt ASC, id ASC`, taskID)
 	if err != nil {
 		return nil, fmt.Errorf("list step runs: %w", err)
 	}
@@ -275,6 +317,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		r                                       StepRun
 		agent, model, effort                    sql.NullString
 		failure, skip, summary, transcript      sql.NullString
+		loopItem                                sql.NullString
 		promptOv, runOv                         sql.NullString
 		pid, exitCode, checkExit, inTok, outTok sql.NullInt64
 		cost                                    sql.NullFloat64
@@ -282,6 +325,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		started                                 string
 	)
 	if err := row.Scan(&r.ID, &r.TaskID, &r.StepIndex, &r.StepID, &r.StepType, &r.Attempt,
+		&r.Iteration, &loopItem,
 		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &exitCode, &checkExit,
 		&failure, &skip, &summary, &promptOv, &runOv, &transcript,
 		&inTok, &outTok, &cost, &r.InputWaitMS, &started, &finished); err != nil {
@@ -290,6 +334,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	r.Agent = agent.String
 	r.Model = model.String
 	r.Effort = effort.String
+	r.LoopItem = loopItem.String
 	r.FailureReason = failure.String
 	r.SkipReason = skip.String
 	r.ResultSummary = summary.String

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -297,15 +297,19 @@ type StepAttempts struct {
 // CountStepAttempts summarizes attempts for one step. `since` bounds Failed
 // to attempts started after a point in time — the hook a human retry uses to
 // reset the retry budget (§6); the zero time counts all failures. Last is
-// never bounded: attempt numbers must stay monotonic over the step's whole
-// history, or `{step_index}-{attempt}.jsonl` transcript names would collide
-// and truncate earlier attempts (phase 2 decision).
+// never bounded within the position ref names: attempt numbers must stay
+// monotonic over that position's whole history, or transcript names would
+// collide and truncate earlier attempts (phase 2 decision).
 //
-// stepID narrows the count to one member of a `parallel` group, whose
-// sub-steps all share the group's stepIndex and are told apart by id alone
-// (task 014 decision 16). For an ordinary step it is that step's own id and
-// the filter changes nothing — one step owns the index.
-func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex int, stepID string, since time.Time) (StepAttempts, error) {
+// The position is the whole of ref — index, id and iteration. The id narrows
+// the count to one member of a `parallel` group, whose sub-steps share the
+// group's index (task 014 decision 16); the iteration narrows it further to
+// one pass of a `loop` body, which is what makes retries and iterations
+// orthogonal: a body step spends a fresh budget in each iteration, because
+// each iteration is a different piece of work (§7.8, task 016 decision 6).
+// For an ordinary step both filters change nothing — one step owns the index
+// and its rows carry iteration 0.
+func (s *Store) CountStepAttempts(ctx context.Context, ref StepRef, since time.Time) (StepAttempts, error) {
 	var (
 		out    StepAttempts
 		last   sql.NullInt64
@@ -319,8 +323,8 @@ func (s *Store) CountStepAttempts(ctx context.Context, taskID int64, stepIndex i
 	}
 	q := `SELECT MAX(attempt),
 			SUM(CASE WHEN state = ? AND started_at > ? THEN 1 ELSE 0 END)
-		FROM step_runs WHERE task_id = ? AND step_index = ? AND step_id = ?`
-	args := []any{string(StepFailed), sinceArg, taskID, stepIndex, stepID}
+		FROM step_runs WHERE task_id = ? AND step_index = ? AND step_id = ? AND iteration = ?`
+	args := []any{string(StepFailed), sinceArg, ref.TaskID, ref.StepIndex, ref.StepID, ref.Iteration}
 	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&last, &failed); err != nil {
 		return out, fmt.Errorf("count step attempts: %w", err)
 	}

--- a/internal/store/transitions_test.go
+++ b/internal/store/transitions_test.go
@@ -211,7 +211,7 @@ func TestCountStepAttemptsCursorBoundsOnlyFailures(t *testing.T) {
 	}
 
 	cursor := base.Add(2*time.Minute + 30*time.Second) // after attempt 2, before 3
-	got, err := s.CountStepAttempts(ctx, task.ID, 0, "step", cursor)
+	got, err := s.CountStepAttempts(ctx, StepRef{TaskID: task.ID, StepID: "step"}, cursor)
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestCountStepAttemptsCursorBoundsOnlyFailures(t *testing.T) {
 		t.Errorf("Failed = %d, want 1 — only failures after the cursor count", got.Failed)
 	}
 
-	all, err := s.CountStepAttempts(ctx, task.ID, 0, "step", time.Time{})
+	all, err := s.CountStepAttempts(ctx, StepRef{TaskID: task.ID, StepID: "step"}, time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts (zero cursor): %v", err)
 	}

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -135,7 +135,11 @@ func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store
 	now := time.Now()
 	ch := store.TaskChange{RetryCursorAt: &now}
 	if !ov.Empty() {
-		snapshot, err := applyOverride(task, ov)
+		target, err := r.overrideTarget(ctx, task)
+		if err != nil {
+			return nil, err
+		}
+		snapshot, err := applyOverride(task, ov, target)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +387,8 @@ func (r *Runner) recordStepDecision(
 		return nil
 	}
 	stepID, stepType := describeStep(task, task.CurrentStep)
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, task.ID, task.CurrentStep, stepID, time.Time{})
+	attempts, err := r.deps.Store.CountStepAttempts(ctx,
+		store.StepRef{TaskID: task.ID, StepIndex: task.CurrentStep, StepID: stepID}, time.Time{})
 	if err != nil {
 		return err
 	}
@@ -406,9 +411,46 @@ func advance(task *store.Task) store.TaskChange {
 	return store.TaskChange{CurrentStep: &next}
 }
 
-// applyOverride rewrites the current step's prompt or run inside the task's
-// own snapshot copy (§5.3) and returns the new YAML.
-func applyOverride(task *store.Task, ov store.Override) (string, error) {
+// overrideTarget names the step an `edit + retry` rewrites: the current step,
+// or — when that is a `loop` — the body step whose failure blocked the task.
+//
+// A loop occupies one step_index and writes no row of its own, so the cursor
+// alone cannot say what the human is editing; the rows can, and they are the
+// only thing that knows (§7.8, decision 7). An empty string means "the
+// current step itself", which is every task that is not blocked inside a
+// loop.
+//
+// The edit lands in the snapshot, so it applies to **every remaining
+// iteration** (decision 12). That is the useful behaviour — fix the prompt,
+// let it keep going — rather than a one-shot patch the loop discards on its
+// next pass.
+func (r *Runner) overrideTarget(ctx context.Context, task *store.Task) (string, error) {
+	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		return "", fmt.Errorf("parse workflow snapshot: %w", err)
+	}
+	if task.CurrentStep < 0 || task.CurrentStep >= len(wf.Steps) ||
+		wf.Steps[task.CurrentStep].Type != workflow.StepLoop {
+		return "", nil
+	}
+	history, err := r.deps.Store.ListStepRunsAt(ctx, task.ID, task.CurrentStep)
+	if err != nil {
+		return "", err
+	}
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].State == store.StepFailed {
+			return history[i].StepID, nil
+		}
+	}
+	return "", fmt.Errorf("task %d is blocked in a loop with no failed body step to edit", task.ID)
+}
+
+// applyOverride rewrites one step's prompt or run inside the task's own
+// snapshot copy (§5.3) and returns the new YAML.
+//
+// bodyID selects a step inside the current `loop`; empty means the current
+// step itself.
+func applyOverride(task *store.Task, ov store.Override, bodyID string) (string, error) {
 	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
 	if err != nil {
 		return "", fmt.Errorf("parse workflow snapshot: %w", err)
@@ -417,6 +459,18 @@ func applyOverride(task *store.Task, ov store.Override) (string, error) {
 		return "", fmt.Errorf("task %d has no step %d to override", task.ID, task.CurrentStep)
 	}
 	step := &wf.Steps[task.CurrentStep]
+	if bodyID != "" {
+		step = nil
+		for i := range wf.Steps[task.CurrentStep].Steps {
+			if body := &wf.Steps[task.CurrentStep].Steps[i]; body.ID == bodyID {
+				step = body
+				break
+			}
+		}
+		if step == nil {
+			return "", fmt.Errorf("task %d has no body step %q to override", task.ID, bodyID)
+		}
+	}
 	if ov.Prompt != "" {
 		if step.Type != workflow.StepAgent {
 			return "", &OverrideMismatchError{StepType: step.Type, Field: "prompt_override"}

--- a/internal/taskrun/condition.go
+++ b/internal/taskrun/condition.go
@@ -34,7 +34,7 @@ func (r *Runner) evaluateGuard(ctx context.Context, env *stepEnv) (bool, error) 
 // back to 1 rather than failing the guard — the count is context for a
 // template, not the decision itself.
 func (r *Runner) nextAttempt(ctx context.Context, env *stepEnv) int {
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, time.Time{})
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.ref(), time.Time{})
 	if err != nil {
 		env.log.Warn("count attempts for guard context", "error", err)
 		return 1
@@ -60,11 +60,18 @@ func (r *Runner) recordDecisionRow(
 ) {
 	finished := time.Now()
 	run := &store.StepRun{
-		TaskID:        env.task.ID,
-		StepIndex:     env.index,
-		StepID:        env.step.ID,
-		StepType:      env.step.Type,
-		Attempt:       r.nextAttempt(ctx, env),
+		TaskID:    env.task.ID,
+		StepIndex: env.index,
+		StepID:    env.step.ID,
+		StepType:  env.step.Type,
+		Attempt:   r.nextAttempt(ctx, env),
+		// A decision row inside a loop body carries its position like any
+		// other (§7.8, task 016 decision 7). Leaving it at 0 would sort every
+		// `break` and `condition` verdict ahead of the iteration it belongs
+		// to, and hide a `stopped` row from the derivation that resumes the
+		// loop.
+		Iteration:     env.iteration(),
+		LoopItem:      env.loopItem(),
 		State:         state,
 		SkipReason:    skipReason,
 		FailureReason: failureReason,

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -89,7 +89,19 @@ const (
 	// the second try here is the human's, after they fix the workflow
 	// (task 015 decision 14).
 	ReasonConditionError = "condition_error"
-	ReasonInternalError  = "internal_error"
+	// ReasonLoopLimit is a `loop` step that cannot run within its
+	// `max_iterations` (§7.8, task 016 decision 5): a `for_each` list longer
+	// than the ceiling, or a `count:` the ceiling moved under.
+	//
+	// It blocks rather than truncating, and rather than advancing. A loop
+	// that ran out of iterations did not achieve what it was looping for, and
+	// advancing would hand every downstream guard a `.Steps` that says the
+	// work is finished. `condition` (§7.7) is how a workflow stops and
+	// succeeds when it genuinely has nothing more to do — that is a decision
+	// the workflow made. Running out of tries is not a decision, it is a
+	// wall.
+	ReasonLoopLimit     = "loop_limit"
+	ReasonInternalError = "internal_error"
 )
 
 // Durable event types the engine emits (spec §13.3). State changes emit
@@ -135,7 +147,58 @@ type stepEnv struct {
 	// evidence is the previous attempt's outcome and creating this attempt's
 	// row hides it.
 	resumedFromConflict bool
-	log                 *slog.Logger
+	// loop is where this step sits inside an enclosing `loop` body (§7.8,
+	// task 016). Nil for every step outside one, which is where both
+	// `iteration = 0` on the row and `.Loop.Index: 0` in the context come
+	// from — a shared template can therefore tell whether it is in a loop
+	// without the engine keeping a second flag (decision 9).
+	loop *loopEnv
+	log  *slog.Logger
+}
+
+// iteration is the 1-based pass of the enclosing loop, 0 outside one.
+func (e *stepEnv) iteration() int {
+	if e.loop == nil {
+		return 0
+	}
+	return e.loop.iteration
+}
+
+// ref is the position this step's rows belong to: index, id and iteration
+// (§7.8, decision 7). Every attempt count, failure lookup and transcript name
+// is scoped by it, which is what keeps a loop body step's retry budget its
+// own in each iteration (decision 6).
+func (e *stepEnv) ref() store.StepRef {
+	return store.StepRef{
+		TaskID: e.task.ID, StepIndex: e.index, StepID: e.step.ID, Iteration: e.iteration(),
+	}
+}
+
+// precedes reports whether run sits before this step in the run order —
+// (step_index, iteration, body position) — which is the §8.4 visibility rule
+// for a *failed* row (decision 9).
+//
+// Before task 016 this was `run.StepIndex < env.index`, and that is still
+// what it says outside a loop. Inside one it cannot be: a loop's body steps
+// share the loop's index, so under the old rule a `break` guard could not
+// read the `allow_failure` probe two lines above it in its own body, and the
+// converge loop would never break.
+//
+// A `parallel` sub-step has no body position — a group is a set — so no
+// sibling ever precedes another, and §7.5's sibling-blindness is preserved
+// by the nil check rather than by the index comparison.
+func (e *stepEnv) precedes(run *store.StepRun) bool {
+	if run.StepIndex != e.index {
+		return run.StepIndex < e.index
+	}
+	if e.loop == nil {
+		return false // a group sibling, or this step's own earlier attempt
+	}
+	if run.Iteration != e.loop.iteration {
+		return run.Iteration < e.loop.iteration
+	}
+	pos, ok := e.loop.order[run.StepID]
+	return ok && pos < e.loop.pos
 }
 
 // stepOutcome is the result of one attempt.
@@ -251,6 +314,11 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		switch env.step.Type {
 		case workflow.StepParallel:
 			outcome = r.runGroup(ctx, env)
+		case workflow.StepLoop:
+			// Like a group: no attempt of its own, so no retry budget of its
+			// own either. The outcome is collected from the body's rows
+			// (§7.8, decision 7).
+			outcome = r.runLoop(ctx, env)
 		case workflow.StepFanOut:
 			// Spawning parks the task and ends this goroutine; joining
 			// returns an ordinary outcome the switch below acts on
@@ -350,7 +418,7 @@ func (r *Runner) runStepWithRetries(ctx context.Context, env *stepEnv) stepOutco
 	if env.task.RetryCursorAt != nil {
 		since = *env.task.RetryCursorAt
 	}
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, since)
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.ref(), since)
 	if err != nil {
 		env.log.Error("count step attempts", "error", err)
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
@@ -391,7 +459,7 @@ func (r *Runner) previousFailure(ctx context.Context, env *stepEnv, lastAttempt 
 	if lastAttempt == 0 {
 		return stepOutcome{}
 	}
-	prev, err := r.deps.Store.LastFailedStepRun(ctx, env.task.ID, env.index, env.step.ID)
+	prev, err := r.deps.Store.LastFailedStepRun(ctx, env.ref())
 	if err != nil {
 		env.log.Warn("previous failure unavailable for retry context", "error", err)
 		return stepOutcome{}
@@ -418,6 +486,8 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		StepID:    env.step.ID,
 		StepType:  env.step.Type,
 		Attempt:   attempt,
+		Iteration: env.iteration(),
+		LoopItem:  env.loopItem(),
 		State:     store.StepRunning,
 	}
 	var sel agent.Selection
@@ -426,7 +496,7 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		run.Agent, run.Model, run.Effort = sel.Agent, sel.Model, sel.Effort
 	}
 
-	tr, err := openTranscript(r.deps.DataDir, env.task.ID, env.index, attempt, subStepIDOf(env))
+	tr, err := openTranscript(r.deps.DataDir, env.task.ID, env.index, env.iteration(), attempt, subStepIDOf(env))
 	if err != nil {
 		env.log.Error("open transcript", "error", err)
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
@@ -531,8 +601,10 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 			// mid-retry, because `.LastFailure` is already that channel and
 			// two spellings of one fact is how a context rots. Sub-steps of a
 			// group share the group's index, so this also keeps concurrent
-			// siblings invisible to each other, which §7.5 requires.
-			if run.StepIndex >= env.index {
+			// siblings invisible to each other, which §7.5 requires — and a
+			// loop body's earlier steps become visible to its later ones,
+			// which §7.8 requires (task 016 decision 9).
+			if !env.precedes(&run) {
 				continue
 			}
 		default:
@@ -557,6 +629,7 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 			ID: env.step.ID, Name: env.step.DisplayName(), Index: env.index, Attempt: attempt,
 		},
 		Steps:       steps,
+		Loop:        env.loopContext(),
 		Host:        workflow.HostContext{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		Worktree:    workflow.WorktreeContext{Path: env.task.WorktreePath},
 		LastFailure: workflow.Failure{Reason: previous.reason, Output: previous.output},
@@ -568,7 +641,7 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 // entry so the gate's wait is visible in the timeline, and the task gives up
 // its concurrency slot until a human approves or rejects (§6, §11).
 func (r *Runner) enterGate(ctx context.Context, env *stepEnv) {
-	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.task.ID, env.index, env.step.ID, time.Time{})
+	attempts, err := r.deps.Store.CountStepAttempts(ctx, env.ref(), time.Time{})
 	if err != nil {
 		env.log.Error("count gate attempts", "error", err)
 		r.fail(env.task, ReasonInternalError, env.log, "count gate attempts", err)

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -66,6 +66,39 @@ func (h *engineHarness) waitForChildren(t *testing.T, parentID int64, want int) 
 	return nil
 }
 
+// cancelRacingAdmission cancels a task, tolerating the one race any test that
+// cancels a freshly spawned lane has.
+//
+// waitForChildren returns as soon as the lane rows exist, and a lane is
+// `queued` for a moment before the scheduler admits it. Cancel reads the task,
+// checks the action against the state it read, and then transitions with a
+// compare-and-swap on that state — so an admission landing in between fails
+// the swap with "task N is running, not queued", even though `cancel` is
+// perfectly legal from `running` too. It failed about one CI run in ten.
+//
+// Retrying is the right fix *for the test*, which asserts nothing about that
+// race: it wants the lane cancelled, from whichever state it has reached by
+// then. Whether a human action that loses a CAS to the scheduler should retry
+// itself is a §6 question about the product, and is deliberately not answered
+// here.
+func (h *engineHarness) cancelRacingAdmission(t *testing.T, id int64) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_, err := h.runner.Cancel(t.Context(), id)
+		if err == nil {
+			return
+		}
+		if _, conflict := store.AsStateConflict(err); !conflict {
+			t.Fatalf("cancel task %d: %v", id, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("cancel task %d: still losing the transition race after 10s: %v", id, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestFanOutSpawnsLanesAndMerges is the whole of phase 2 in one pass: the
 // parent spawns real child tasks, parks without holding a slot, and — once
 // they finish — merges both branches into its own.
@@ -177,9 +210,7 @@ func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
 	lanes := h.waitForChildren(t, task.ID, 2)
 	for _, lane := range lanes {
 		if lane.LaneID == "slow" {
-			if _, err := h.runner.Cancel(t.Context(), lane.ID); err != nil {
-				t.Fatalf("cancel slow lane: %v", err)
-			}
+			h.cancelRacingAdmission(t, lane.ID)
 		}
 	}
 

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -176,10 +176,11 @@ func (r *Runner) applySubStepGuards(
 }
 
 // subStepIDOf names the transcript of an attempt: empty for an ordinary step,
-// whose index already identifies it, and the step id for a member of a group,
-// whose siblings share that index (decision 16).
+// whose index already identifies it, and the step id for a member of a group
+// or a loop body, whose siblings share that index (task 014 decision 16,
+// task 016 decision 13).
 func subStepIDOf(env *stepEnv) string {
-	if env.inGroup {
+	if env.inGroup || env.loop != nil {
 		return env.step.ID
 	}
 	return ""

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -1,0 +1,389 @@
+package taskrun
+
+// Loops (spec §7.8, task 016). A `type: loop` step runs its body — a
+// *sequence* — repeatedly in the task's one worktree: no branch, no child
+// task, no merge, and no concurrency. Where §7.5's group is a set run once,
+// this is a sequence run more than once.
+//
+// Three properties the rest of the file assumes, each of them task 014
+// decision 17 restated:
+//
+//   - The loop owns **no** `step_runs` row. Its outcome is collected from its
+//     body's rows, and the body's rows all carry the loop's `step_index`.
+//   - No loop cursor is persisted anywhere. Position is
+//     `(step_index, iteration, body position)`, derived from those rows on
+//     every admission, so a re-admitted loop resumes **mid-iteration** rather
+//     than restarting work a human may have waited an hour for.
+//   - A `for_each` item is the one thing that *is* recorded, on the row
+//     (decision 8). The list is the loop's extent, not a question, and
+//     re-deriving it mid-loop would make "iteration 3" name different work
+//     than the row already says it ran.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// loopEnv is where one step sits inside a loop body, and everything §8.4's
+// `.Loop` reports about it.
+type loopEnv struct {
+	iteration int // 1-based
+	item      string
+	isFirst   bool
+	isLast    bool
+	// pos is this step's position in the body, and order maps every body
+	// step id to its own. Together they are the third component of the
+	// position comparison stepEnv.precedes makes (decision 9).
+	pos   int
+	order map[string]int
+}
+
+// loopContext is §8.4's `.Loop` for this step. Outside a loop it is the zero
+// value, whose `Index: 0` is how a template shared between a loop body and an
+// ordinary step tells the two apart (decision 9).
+func (e *stepEnv) loopContext() workflow.LoopContext {
+	if e.loop == nil {
+		return workflow.LoopContext{}
+	}
+	return workflow.LoopContext{
+		Index:   e.loop.iteration,
+		Item:    e.loop.item,
+		IsFirst: e.loop.isFirst,
+		IsLast:  e.loop.isLast,
+	}
+}
+
+// loopItem is the `for_each` item recorded on this step's rows.
+func (e *stepEnv) loopItem() string {
+	if e.loop == nil {
+		return ""
+	}
+	return e.loop.item
+}
+
+// loopPlan is a loop's extent for one admission: how many iterations it will
+// run, and — for `for_each` — what each one runs on.
+type loopPlan struct {
+	driver string
+	total  int
+	// items is empty for a `count:` loop. For `for_each` it is one entry per
+	// iteration, drawn from the rows for iterations that already have them
+	// and from the re-derived list for the rest (decision 8).
+	items []string
+}
+
+// runLoop executes one `loop` step and returns the outcome the engine's step
+// loop acts on, exactly as if the loop had been a single step.
+func (r *Runner) runLoop(ctx context.Context, env *stepEnv) stepOutcome {
+	limit := r.loopLimit(env.step)
+	history, err := r.deps.Store.ListStepRunsAt(ctx, env.task.ID, env.index)
+	if err != nil {
+		env.log.Error("read loop history", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
+	}
+	plan, err := r.planLoop(ctx, env, history, limit)
+	switch {
+	case errors.Is(err, errLoopLimit):
+		// Blocking rather than truncating: a loop with more work than it is
+		// allowed to do did not decide to stop, it hit a wall, and advancing
+		// would hand every downstream guard a `.Steps` that says the work is
+		// finished (decision 5).
+		env.log.Warn("loop exceeds its iteration ceiling", "error", err, "max_iterations", limit)
+		return stepOutcome{state: store.StepFailed, reason: ReasonLoopLimit, result: err.Error()}
+	case err != nil:
+		env.log.Error("resolve loop driver", "error", err)
+		return stepOutcome{state: store.StepFailed, reason: ReasonConditionError, result: err.Error()}
+	}
+	if plan.total == 0 {
+		// An empty `for_each` list. The loop had nothing to iterate, which is
+		// a correct answer rather than a failure — the same way a group whose
+		// every sub-step was guarded off succeeds having run nothing (§7.5).
+		env.log.Info("loop ran nothing: the for_each list is empty")
+		return stepOutcome{state: store.StepSucceeded}
+	}
+
+	// A loop-level `timeout:` bounds the **whole** loop, mirroring §7.5's
+	// group timeout; each body step still has its own. Expiry cancels the
+	// body step in flight, which ends as an interruption — turned back into a
+	// failure below, because the work ran out of the time the workflow gave
+	// it rather than stopping for the daemon's sake (§7.2).
+	loopCtx, cancel := context.WithCancel(ctx)
+	if env.step.Timeout != nil {
+		loopCtx, cancel = context.WithTimeout(ctx, env.step.Timeout.Std())
+	}
+	defer cancel()
+
+	order := bodyOrder(env.step.Steps)
+	env.log.Info("loop started",
+		"driver", plan.driver, "iterations", plan.total, "max_iterations", limit,
+		"body", len(env.step.Steps))
+
+	for iteration := 1; iteration <= plan.total; iteration++ {
+		outcome, stop := r.runIteration(loopCtx, env, plan, order, iteration, history)
+		if stop {
+			return r.loopStop(ctx, loopCtx, env, outcome)
+		}
+	}
+	// The driver is exhausted, which ends the loop **successfully** (§7.8):
+	// `count: 10` means "run ten times", and running ten times achieved it.
+	// A converge loop that never broke is the workflow's own statement that
+	// five repairs were the budget — what it did *not* fix is for the step
+	// after the loop to notice.
+	env.log.Info("loop finished", "iterations", plan.total)
+	return stepOutcome{state: store.StepSucceeded}
+}
+
+// runIteration runs one pass of the body. It returns the outcome that ends
+// the loop and whether the loop is over: a `break`, a failure, an
+// interruption, or the body running out.
+func (r *Runner) runIteration(
+	ctx context.Context, env *stepEnv, plan loopPlan, order map[string]int,
+	iteration int, history []store.StepRun,
+) (stepOutcome, bool) {
+	latest := latestStatesIn(history, iteration)
+	for pos, body := range env.step.Steps {
+		if latest[body.ID] == store.StepSucceeded {
+			// This body step already succeeded in this iteration under an
+			// earlier admission. Re-running it would discard finished work,
+			// which is §7.5's rule verbatim (decision 7).
+			continue
+		}
+		bodyEnv := &stepEnv{
+			task: env.task, project: env.project, wf: env.wf,
+			step: body, index: env.index,
+			loop: &loopEnv{
+				iteration: iteration,
+				item:      itemAt(plan.items, iteration),
+				isFirst:   iteration == 1,
+				isLast:    iteration == plan.total,
+				pos:       pos,
+				order:     order,
+			},
+			log: env.log.With("body_step", body.ID, "iteration", iteration),
+		}
+		outcome, stop := r.runBodyStep(ctx, bodyEnv)
+		if stop {
+			return outcome, true
+		}
+		if outcome.state == store.StepStopped {
+			// A `condition` whose guard is false ends *this iteration*; the
+			// loop carries on with the next. That is `continue`, spelled with
+			// the meaning §7.7 already gave the word and no third step type
+			// (decision 3).
+			bodyEnv.log.Info("iteration ended early by a condition step")
+			return stepOutcome{}, false
+		}
+	}
+	return stepOutcome{}, false
+}
+
+// runBodyStep runs one member of a loop body. stop reports that the loop is
+// over — a `break` taken, a failure, or an interruption; a returned
+// `stopped` outcome without stop ends only the iteration.
+func (r *Runner) runBodyStep(ctx context.Context, env *stepEnv) (out stepOutcome, stop bool) {
+	if env.step.Guarded() || env.step.Type == workflow.StepCondition {
+		pass, err := r.evaluateGuard(ctx, env)
+		switch {
+		case err != nil:
+			r.recordGuardOutcome(ctx, env, store.StepFailed, "", ReasonConditionError)
+			return stepOutcome{state: store.StepFailed, reason: ReasonConditionError}, true
+		case env.step.Type == workflow.StepBreak && pass:
+			// The loop ends here and **succeeds**; the cursor advances past
+			// it (§7.8). A break is a decision the workflow made, which is
+			// exactly what separates it from `loop_limit` (decision 5).
+			r.recordGuardOutcome(ctx, env, store.StepStopped, "", "")
+			env.log.Info("loop ended by a break step")
+			return stepOutcome{state: store.StepSucceeded}, true
+		case env.step.Type == workflow.StepBreak:
+			r.recordGuardOutcome(ctx, env, store.StepSucceeded, "", "")
+			return stepOutcome{}, false
+		case env.step.Type == workflow.StepCondition && !pass:
+			r.recordGuardOutcome(ctx, env, store.StepStopped, "", "")
+			return stepOutcome{state: store.StepStopped}, false
+		case env.step.Type == workflow.StepCondition:
+			r.recordGuardOutcome(ctx, env, store.StepSucceeded, "", "")
+			return stepOutcome{}, false
+		case !pass:
+			r.recordGuardOutcome(ctx, env, store.StepSkipped, store.SkipReasonCondition, "")
+			env.log.Info("body step skipped by its guard")
+			return stepOutcome{}, false
+		}
+	}
+	if env.step.Type == workflow.StepBreak {
+		// Unreachable: validation requires `if:` on a break, so the guard
+		// branch above always claims it. Refusing to fall through to
+		// runStepWithRetries keeps a corrupted snapshot from spawning a
+		// process for a step type that has none.
+		return stepOutcome{state: store.StepFailed, reason: ReasonInvalidSnapshot}, true
+	}
+	outcome := r.runStepWithRetries(ctx, env)
+	switch outcome.state {
+	case store.StepSucceeded:
+		return stepOutcome{}, false
+	case store.StepFailed:
+		if allowFailure(env.step, outcome.reason) {
+			// The row keeps its `failed` state and its reason — the failure
+			// happened — and that row is what the `break` guard two lines
+			// below reads (§7.2, task 015 decision 5).
+			env.log.Info("body step failed; continuing on allow_failure", "reason", outcome.reason)
+			return stepOutcome{}, false
+		}
+		return outcome, true
+	default:
+		// Interrupted, and everything a body step cannot produce. Either way
+		// the loop stops and the engine decides what that means for the task.
+		return outcome, true
+	}
+}
+
+// loopStop turns the outcome that ended the loop into the loop's own. Its one
+// job is the group's: a loop-level timeout arrives as an interruption of
+// whatever was running, and must be reported as the loop failing `timeout`
+// rather than as the daemon stopping.
+func (r *Runner) loopStop(ctx context.Context, loopCtx context.Context, env *stepEnv, out stepOutcome) stepOutcome {
+	if errors.Is(loopCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+		env.log.Warn("loop timed out", "timeout", env.step.Timeout)
+		return stepOutcome{state: store.StepFailed, reason: ReasonTimeout}
+	}
+	return out
+}
+
+// planLoop resolves the loop's extent for this admission (§7.8).
+//
+// `count:` is the count. `for_each:` renders its entries against the §8.4
+// context, then takes each iteration that already has rows from *those* rows
+// rather than from the fresh list (decision 8) — which is what keeps a
+// resumed iteration 3 on the work iteration 3 actually did.
+func (r *Runner) planLoop(
+	ctx context.Context, env *stepEnv, history []store.StepRun, limit int,
+) (loopPlan, error) {
+	if env.step.Count != nil {
+		n := *env.step.Count
+		if n > limit {
+			// Validation refuses this at load, so reaching it means the
+			// ceiling moved under a queued task: `loop.max_iterations` was
+			// lowered, and config is read per loop so a hot reload governs
+			// this one (§12.3).
+			return loopPlan{}, fmt.Errorf("%w: count %d exceeds max_iterations %d", errLoopLimit, n, limit)
+		}
+		return loopPlan{driver: workflow.DriverCount, total: n}, nil
+	}
+	rc, err := r.renderContext(ctx, env, 1, stepOutcome{})
+	if err != nil {
+		return loopPlan{}, err
+	}
+	items, err := resolveForEach(env.step.ForEach, rc)
+	if err != nil {
+		return loopPlan{}, err
+	}
+	if len(items) > limit {
+		// Before iteration 1, naming the count: a list that cannot be
+		// finished is worth saying so about before spending the first agent
+		// run on it (§7.8).
+		return loopPlan{}, fmt.Errorf("%w: for_each produced %d items, max_iterations is %d",
+			errLoopLimit, len(items), limit)
+	}
+	for iteration, recorded := range recordedItems(history) {
+		if iteration >= 1 && iteration <= len(items) {
+			items[iteration-1] = recorded
+		}
+	}
+	return loopPlan{driver: workflow.DriverForEach, total: len(items), items: items}, nil
+}
+
+// errLoopLimit marks a plan that cannot run within `max_iterations`. It is a
+// sentinel rather than a reason string so planLoop can report the numbers in
+// its message and the caller still knows which block reason to use.
+var errLoopLimit = errors.New("loop iteration limit")
+
+// resolveForEach renders a `for_each` list into its items.
+//
+// Every entry is rendered, trimmed and split on newlines with empty lines
+// dropped, whichever spelling the author used. That is what makes the scalar
+// form — `for_each: '{{ .Steps.changed.Result }}'`, the case that opened
+// task 016 — and a hand-written sequence one mechanism rather than two.
+//
+// A list drawn from a step's output is bounded by outputTailLines: `.Steps[…]
+// .Result` is the *tail* of what the command printed, so a producer emitting
+// more paths than that silently loses the earliest ones. Producing a list
+// longer than the loop may run blocks with `loop_limit` anyway, and that
+// ceiling is an order of magnitude lower.
+func resolveForEach(list workflow.ForEach, rc workflow.RenderContext) ([]string, error) {
+	var out []string
+	for i, entry := range list {
+		rendered, err := workflow.Render(fmt.Sprintf("for_each[%d]", i), entry, rc)
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range strings.Split(rendered, "\n") {
+			if trimmed := strings.TrimSpace(line); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+	}
+	return out, nil
+}
+
+// recordedItems is the item each already-started iteration ran on, taken from
+// its rows (decision 8).
+func recordedItems(history []store.StepRun) map[int]string {
+	out := map[int]string{}
+	for i := range history {
+		run := &history[i]
+		if run.Iteration > 0 && run.LoopItem != "" {
+			out[run.Iteration] = run.LoopItem
+		}
+	}
+	return out
+}
+
+// latestStatesIn is the state of the newest attempt of each body step within
+// one iteration — the same derivation `parallel` makes across a group, one
+// iteration at a time (decision 7).
+func latestStatesIn(history []store.StepRun, iteration int) map[string]store.StepRunState {
+	out := map[string]store.StepRunState{}
+	// history is ordered by (iteration, attempt, id), so the last row for a
+	// step id within the iteration is its newest attempt.
+	for i := range history {
+		if run := &history[i]; run.Iteration == iteration {
+			out[run.StepID] = run.State
+		}
+	}
+	return out
+}
+
+// bodyOrder maps each body step id to its declaration position, which is the
+// third component of the §8.4 visibility comparison (decision 9).
+func bodyOrder(body []workflow.Step) map[string]int {
+	order := make(map[string]int, len(body))
+	for i, step := range body {
+		order[step.ID] = i
+	}
+	return order
+}
+
+// itemAt is the `for_each` item of one iteration, empty for a `count:` loop.
+func itemAt(items []string, iteration int) string {
+	if iteration < 1 || iteration > len(items) {
+		return ""
+	}
+	return items[iteration-1]
+}
+
+// loopLimit resolves how many iterations a loop may run: the step's own
+// `max_iterations:`, else the daemon default. Read here rather than cached,
+// so a hot reload governs the next loop (§12.3, decision 5).
+func (r *Runner) loopLimit(step workflow.Step) int {
+	if step.MaxIterations != nil && *step.MaxIterations > 0 {
+		return *step.MaxIterations
+	}
+	if n := r.deps.Config().Loop.MaxIterations; n > 0 {
+		return n
+	}
+	return 1
+}

--- a/internal/taskrun/loop_test.go
+++ b/internal/taskrun/loop_test.go
@@ -1,0 +1,473 @@
+package taskrun
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// loopSnapshot builds a workflow whose only step is a loop holding the given
+// body steps, indented one level deeper than commandStep writes them.
+func loopSnapshot(loopFields string, body ...string) string {
+	var sb strings.Builder
+	sb.WriteString("name: repeat\nsteps:\n  - id: loop\n    type: loop\n")
+	for _, line := range strings.Split(strings.TrimRight(loopFields, "\n"), "\n") {
+		fmt.Fprintf(&sb, "    %s\n", line)
+	}
+	sb.WriteString("    steps:\n")
+	for _, step := range body {
+		for _, line := range strings.Split(strings.TrimRight(step, "\n"), "\n") {
+			fmt.Fprintf(&sb, "  %s\n", line)
+		}
+	}
+	return sb.String()
+}
+
+// appendCmd writes one line to a file in the worktree, portably. It is how a
+// loop test counts its own iterations without depending on the row order.
+func appendCmd(file, text string) string {
+	return script(
+		fmt.Sprintf("echo %s >> %s", text, file),
+		fmt.Sprintf("Add-Content -Path %s -Value '%s'", file, text),
+	)
+}
+
+// countLines is how many lines a marker file in the task's worktree has.
+func countLines(t *testing.T, worktree, file string) int {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(worktree, file))
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	return len(strings.Fields(string(raw)))
+}
+
+// iterationsOf indexes a loop's rows by iteration, in row order.
+func iterationsOf(runs []store.StepRun) map[int][]store.StepRun {
+	out := map[int][]store.StepRun{}
+	for _, r := range runs {
+		out[r.Iteration] = append(out[r.Iteration], r)
+	}
+	return out
+}
+
+// TestLoopCountRunsItsBody is the shape §7.8 exists to allow: a body run a
+// fixed number of times in the task's one worktree. It also pins the row
+// shape — one row per body step per iteration, all sharing the loop's
+// step_index, told apart by step_id and a 1-based iteration — and that the
+// loop itself writes no row of its own (decision 7).
+func TestLoopCountRunsItsBody(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 3",
+		commandStep("tick", appendCmd("ticks.txt", "x")),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	if got := countLines(t, done.WorktreePath, "ticks.txt"); got != 3 {
+		t.Errorf("the body ran %d times, want 3", got)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 3 {
+		t.Fatalf("step runs = %d, want 3 — one per iteration and none for the loop", len(runs))
+	}
+	for i, r := range runs {
+		if r.StepID == "loop" {
+			t.Error("the loop wrote a step_runs row of its own; its outcome is derived")
+		}
+		if r.StepIndex != 0 {
+			t.Errorf("row %d step_index = %d, want the loop's 0", i, r.StepIndex)
+		}
+		if want := i + 1; r.Iteration != want {
+			t.Errorf("row %d iteration = %d, want %d (1-based, in position order)", i, r.Iteration, want)
+		}
+		if r.State != store.StepSucceeded {
+			t.Errorf("row %d state = %s, want succeeded", i, r.State)
+		}
+	}
+}
+
+// TestLoopBreakEndsTheLoop is the converge archetype end to end: a probe that
+// is allowed to fail, a break reading it, and a repair. The break must be
+// able to see a *failed* row two lines above it in its own body, which is the
+// whole of decision 9's positional visibility rule — under the old
+// `StepIndex >= index` filter the loop would never break.
+func TestLoopBreakEndsTheLoop(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// The probe fails while `repairs.txt` has fewer than two lines, so the
+	// third pass is the one that breaks.
+	probe := script(
+		"test -f repairs.txt && test $(wc -l < repairs.txt) -ge 2",
+		"if (-not (Test-Path repairs.txt)) { exit 1 }; if ((Get-Content repairs.txt).Count -lt 2) { exit 1 }",
+	)
+	snapshot := loopSnapshot("count: 8",
+		commandStep("suite", probe, "allow_failure: true", "max_retries: 0"),
+		"  - {id: passed, type: break, if: '{{ eq (index .Steps \"suite\").ExitCode 0 }}'}\n",
+		commandStep("repair", appendCmd("repairs.txt", "fix")),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done — a break ends the loop successfully",
+			done.State, done.BlockReason)
+	}
+	if got := countLines(t, done.WorktreePath, "repairs.txt"); got != 2 {
+		t.Errorf("repairs = %d, want 2 — the loop must break on the pass that finds the probe green", got)
+	}
+
+	byIteration := iterationsOf(h.stepRuns(t, task.ID))
+	if len(byIteration) != 3 {
+		t.Fatalf("iterations = %d, want 3 (two repairs, then a break)", len(byIteration))
+	}
+	// The break took on iteration 3, and a taken break is `stopped`: the loop
+	// ended there, and the row is what says so.
+	third := byIteration[3]
+	if len(third) != 2 {
+		t.Fatalf("iteration 3 rows = %d, want 2 — the probe and the break that ended the loop", len(third))
+	}
+	if third[1].StepID != "passed" || third[1].State != store.StepStopped {
+		t.Errorf("iteration 3 last row = %s/%s, want passed/stopped", third[1].StepID, third[1].State)
+	}
+	// A break that did not take is an ordinary `succeeded` decision row.
+	if first := byIteration[1]; first[1].State != store.StepSucceeded {
+		t.Errorf("iteration 1 break state = %s, want succeeded — it evaluated and let the body carry on",
+			first[1].State)
+	}
+}
+
+// TestLoopConditionEndsTheIteration covers decision 3's other half: a
+// `condition` inside a body is `continue`. Its false verdict must end that
+// iteration and leave the loop running, not stop the task at `done` the way
+// the same step type does at the top level (§7.7).
+func TestLoopConditionEndsTheIteration(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 3",
+		commandStep("head", appendCmd("head.txt", "h")),
+		"  - {id: onward, type: condition, if: '{{ .Loop.IsLast }}'}\n",
+		commandStep("tail", appendCmd("tail.txt", "t")),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	if got := countLines(t, done.WorktreePath, "head.txt"); got != 3 {
+		t.Errorf("head ran %d times, want 3 — a false condition ends the iteration, not the loop", got)
+	}
+	if got := countLines(t, done.WorktreePath, "tail.txt"); got != 1 {
+		t.Errorf("tail ran %d times, want 1 — only the last iteration got past the condition", got)
+	}
+}
+
+// TestLoopForEachFromStepOutput is the second driver, fed by a list a step
+// discovered at run time — the case `fan_out` cannot serve, because its lane
+// list has to be static in the snapshot (decision 4).
+func TestLoopForEachFromStepOutput(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	list := script(
+		"printf 'alpha\\nbeta\\ngamma\\n'",
+		"'alpha'; 'beta'; 'gamma'",
+	)
+	snapshot := "name: each\nsteps:\n" +
+		commandStep("discover", list) +
+		"  - id: visit\n    type: loop\n    for_each: '{{ .Steps.discover.Result }}'\n    steps:\n" +
+		bodyIndent(commandStep("touch", appendCmd("items.txt", "{{ .Loop.Item }}")))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	raw, err := os.ReadFile(filepath.Join(done.WorktreePath, "items.txt"))
+	if err != nil {
+		t.Fatalf("read items.txt: %v", err)
+	}
+	if got := strings.Fields(string(raw)); !equalStrings(got, []string{"alpha", "beta", "gamma"}) {
+		t.Errorf("items = %v, want [alpha beta gamma] in list order", got)
+	}
+
+	// The item is recorded on the row, not re-derived (decision 8).
+	var items []string
+	for _, r := range h.stepRuns(t, task.ID) {
+		if r.StepIndex == 1 {
+			items = append(items, r.LoopItem)
+		}
+	}
+	if !equalStrings(items, []string{"alpha", "beta", "gamma"}) {
+		t.Errorf("loop_item column = %v, want [alpha beta gamma]", items)
+	}
+}
+
+// TestLoopForEachEmptyListSucceeds: a loop with nothing to iterate decided
+// correctly, so it succeeds having run nothing — the same posture §7.5 takes
+// for a group whose every sub-step was guarded off.
+func TestLoopForEachEmptyListSucceeds(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := "name: each\nsteps:\n" +
+		commandStep("discover", script("true", "exit 0")) +
+		"  - id: visit\n    type: loop\n    for_each: '{{ .Steps.discover.Result }}'\n    steps:\n" +
+		bodyIndent(commandStep("touch", appendCmd("items.txt", "x")))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	for _, r := range h.stepRuns(t, task.ID) {
+		if r.StepIndex == 1 {
+			t.Errorf("the loop wrote a row (%s) for an empty list; it must run nothing", r.StepID)
+		}
+	}
+}
+
+// TestLoopForEachOverCeilingBlocks pins decision 5: reaching the cap is not a
+// decision the workflow made, so the task blocks with `loop_limit` before the
+// first iteration rather than truncating the list or advancing.
+func TestLoopForEachOverCeilingBlocks(t *testing.T) {
+	h := newEngineHarnessWith(t, func(c *config.Config) { c.Loop.MaxIterations = 2 })
+	h.start(t)
+	list := script("printf 'a\\nb\\nc\\n'", "'a'; 'b'; 'c'")
+	snapshot := "name: each\nsteps:\n" +
+		commandStep("discover", list) +
+		"  - id: visit\n    type: loop\n    for_each: '{{ .Steps.discover.Result }}'\n    steps:\n" +
+		bodyIndent(commandStep("touch", appendCmd("items.txt", "{{ .Loop.Item }}")))
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked", blocked.State)
+	}
+	if blocked.BlockReason != ReasonLoopLimit {
+		t.Errorf("block_reason = %q, want %q", blocked.BlockReason, ReasonLoopLimit)
+	}
+	for _, r := range h.stepRuns(t, task.ID) {
+		if r.StepIndex == 1 {
+			t.Errorf("the loop ran %q before blocking; the cap is checked before iteration 1", r.StepID)
+		}
+	}
+}
+
+// TestLoopBodyFailureBlocksTheTask: retries are for a step that failed,
+// iterations are for a body that succeeded and must run again (decision 6).
+// A body step that exhausts its budget fails the iteration and blocks the
+// task with that step's own reason, not with `loop_limit`.
+func TestLoopBodyFailureBlocksTheTask(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 3",
+		commandStep("tick", appendCmd("ticks.txt", "x")),
+		commandStep("boom", script("exit 3", "exit 3"), "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked", blocked.State)
+	}
+	if blocked.BlockReason != ReasonNonzeroExit {
+		t.Errorf("block_reason = %q, want the body step's own %q", blocked.BlockReason, ReasonNonzeroExit)
+	}
+	byIteration := iterationsOf(h.stepRuns(t, task.ID))
+	if len(byIteration) != 1 {
+		t.Errorf("iterations = %d, want 1 — a failed body step ends the loop, it does not roll on", len(byIteration))
+	}
+}
+
+// TestLoopRetryResumesMidIteration is decision 7's payoff and decision 12's
+// `retry`: a re-admitted loop skips the body steps whose latest attempt
+// succeeded and carries on from the failed one, in the iteration it was in.
+// Restarting at iteration 1 would discard work a human may have waited an
+// hour for.
+func TestLoopRetryResumesMidIteration(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	// `boom` fails while the flag file is absent; the test creates it and
+	// retries, standing in for the human who fixed whatever was wrong.
+	boom := script(
+		"test -f fixed.txt",
+		"if (-not (Test-Path fixed.txt)) { exit 1 }",
+	)
+	snapshot := loopSnapshot("count: 2",
+		commandStep("tick", appendCmd("ticks.txt", "x")),
+		commandStep("boom", boom, "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked", blocked.State)
+	}
+	if got := countLines(t, blocked.WorktreePath, "ticks.txt"); got != 1 {
+		t.Fatalf("ticks before the retry = %d, want 1", got)
+	}
+	if err := os.WriteFile(filepath.Join(blocked.WorktreePath, "fixed.txt"), []byte("ok\n"), 0o600); err != nil {
+		t.Fatalf("write flag file: %v", err)
+	}
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state after retry = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	// Two ticks, not three: iteration 1's `tick` had already succeeded, so
+	// the resumed loop went straight to `boom`.
+	if got := countLines(t, done.WorktreePath, "ticks.txt"); got != 2 {
+		t.Errorf("ticks = %d, want 2 — a resumed loop must not re-run a body step that succeeded", got)
+	}
+}
+
+// TestLoopSkipSkipsTheWholeLoop pins decision 12: `skip` keeps its §6 meaning
+// and skips the whole loop step. There is no "skip this iteration" action —
+// a second meaning for one word would need a state nobody can see.
+func TestLoopSkipSkipsTheWholeLoop(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 5",
+		commandStep("tick", appendCmd("ticks.txt", "x")),
+		commandStep("boom", script("exit 1", "exit 1"), "max_retries: 0"),
+	) + commandStep("after", appendCmd("after.txt", "done"))
+	task := h.createTask(t, snapshot)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked", blocked.State)
+	}
+	if _, err := h.runner.Skip(t.Context(), task.ID); err != nil {
+		t.Fatalf("Skip: %v", err)
+	}
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state after skip = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	if got := countLines(t, done.WorktreePath, "ticks.txt"); got != 1 {
+		t.Errorf("ticks = %d, want 1 — skip must advance past the loop, not into its next iteration", got)
+	}
+	if got := countLines(t, done.WorktreePath, "after.txt"); got != 1 {
+		t.Errorf("the step after the loop ran %d times, want 1", got)
+	}
+}
+
+// TestLoopTranscriptsCarryTheirIteration pins decision 13's naming. Nothing
+// parses these — `transcript_path` is on the row — so what the test defends is
+// the human reading a directory, and the collision that made the segment
+// necessary: without it every iteration of `tick` would open, and truncate,
+// one file.
+func TestLoopTranscriptsCarryTheirIteration(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 3", commandStep("tick", appendCmd("ticks.txt", "x")))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	seen := map[string]bool{}
+	for _, r := range h.stepRuns(t, task.ID) {
+		name := filepath.Base(r.TranscriptPath)
+		want := fmt.Sprintf("0-i%d-tick-1.jsonl", r.Iteration)
+		if name != want {
+			t.Errorf("iteration %d transcript = %q, want %q", r.Iteration, name, want)
+		}
+		if seen[name] {
+			t.Errorf("two iterations share the transcript %q; each would truncate the other", name)
+		}
+		seen[name] = true
+	}
+}
+
+// bodyIndent shifts an already-rendered step one YAML level deeper, for a
+// loop body written inline rather than through loopSnapshot.
+func bodyIndent(block string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(block, "\n"), "\n") {
+		fmt.Fprintf(&sb, "  %s\n", line)
+	}
+	return sb.String()
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGroupSiblingsStayInvisible is the case decision 9 says a naive rewrite
+// of the visibility filter would break. `run.StepIndex >= env.index` hid a
+// group sibling's failed row because siblings share the group's index; the
+// positional rule has to keep hiding it, and does so because a `parallel`
+// sub-step has no body position and therefore never precedes another.
+//
+// `max_parallel: 1` makes the probe finish before the reader starts, so the
+// row is there to be seen and only the filter stops it. What the reader
+// renders is the zero StepResult — `index` on a missing map key — so a 4 in
+// the file would mean §7.5's sibling-blindness had been lost.
+func TestGroupSiblingsStayInvisible(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := groupSnapshot("max_parallel: 1",
+		commandStep("probe", script("exit 4", "exit 4"), "allow_failure: true", "max_retries: 0"),
+		commandStep("peek", appendCmd("seen.txt", `{{ (index .Steps "probe").ExitCode }}`)),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	raw, err := os.ReadFile(filepath.Join(done.WorktreePath, "seen.txt"))
+	if err != nil {
+		t.Fatalf("read seen.txt: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw)); got != "0" {
+		t.Errorf("sibling read exit code %q, want %q — a group is a set and its members must not see each other",
+			got, "0")
+	}
+}
+
+// TestLoopBodyStepSeesEarlierBodySteps is the other side of the same rule and
+// the reason it had to widen: a body step's guard reads what a body step
+// above it in the *same* iteration produced, which sharing the loop's
+// step_index used to make impossible.
+func TestLoopBodyStepSeesEarlierBodySteps(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	snapshot := loopSnapshot("count: 2",
+		commandStep("probe", script("exit 4", "exit 4"), "allow_failure: true", "max_retries: 0"),
+		commandStep("peek", appendCmd("peeked.txt", "x"),
+			`if: '{{ eq (index .Steps "probe").ExitCode 4 }}'`),
+	)
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	if got := countLines(t, done.WorktreePath, "peeked.txt"); got != 2 {
+		t.Errorf("guarded body step ran %d times, want 2 — it must read the probe above it", got)
+	}
+}

--- a/internal/taskrun/recover_test.go
+++ b/internal/taskrun/recover_test.go
@@ -121,7 +121,7 @@ func TestRecoverRequeuesThroughTheFSM(t *testing.T) {
 	}
 
 	// An interruption consumes no retry (§7.2).
-	attempts, err := st.CountStepAttempts(ctx, running.ID, 0, "s", time.Time{})
+	attempts, err := st.CountStepAttempts(ctx, store.StepRef{TaskID: running.ID, StepID: "s"}, time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -38,14 +38,25 @@ type transcript struct {
 // member of a `parallel` group shares its group's index with its siblings, so
 // its id joins the name — `{step_index}-{step_id}-{attempt}.jsonl` — or three
 // concurrent sub-steps would open, and truncate, one file (task 014 decision
-// 16). Ids are slugs, so nothing here can escape the directory.
-func openTranscript(dataDir string, taskID int64, stepIndex, attempt int, subStepID string) (*transcript, error) {
+// 16). A `loop` body step shares its loop's index *and* repeats, so it takes
+// an iteration segment as well:
+// `{step_index}-i{iteration}-{step_id}-{attempt}.jsonl` (task 016
+// decision 13). Ids are slugs, so nothing here can escape the directory.
+//
+// Only loop bodies gain the segment. Adding it everywhere for uniformity
+// would rename every transcript vincent has ever written to make a directory
+// listing consistent with itself; nothing parses these names, because
+// `transcript_path` is stored on the row.
+func openTranscript(dataDir string, taskID int64, stepIndex, iteration, attempt int, subStepID string) (*transcript, error) {
 	dir := filepath.Join(dataDir, "transcripts", strconv.FormatInt(taskID, 10))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create transcript dir: %w", err)
 	}
 	name := fmt.Sprintf("%d-%d.jsonl", stepIndex, attempt)
-	if subStepID != "" {
+	switch {
+	case iteration > 0:
+		name = fmt.Sprintf("%d-i%d-%s-%d.jsonl", stepIndex, iteration, subStepID, attempt)
+	case subStepID != "":
 		name = fmt.Sprintf("%d-%s-%d.jsonl", stepIndex, subStepID, attempt)
 	}
 	path := filepath.Join(dir, name)

--- a/internal/taskrun/transcript_test.go
+++ b/internal/taskrun/transcript_test.go
@@ -10,7 +10,7 @@ import (
 
 func openTestTranscript(t *testing.T, limit int64) *transcript {
 	t.Helper()
-	tr, err := openTranscript(t.TempDir(), 1, 0, 1, "")
+	tr, err := openTranscript(t.TempDir(), 1, 0, 0, 1, "")
 	if err != nil {
 		t.Fatalf("openTranscript: %v", err)
 	}

--- a/internal/taskrun/usagelimit_test.go
+++ b/internal/taskrun/usagelimit_test.go
@@ -84,7 +84,7 @@ func TestUsageLimitReQueuesAndConsumesNoRetry(t *testing.T) {
 
 	// The budget itself, as the engine counts it: interrupted attempts are
 	// excluded, so the step still has its full max_retries for a real failure.
-	attempts, err := h.store.CountStepAttempts(t.Context(), task.ID, 0, "implement", time.Time{})
+	attempts, err := h.store.CountStepAttempts(t.Context(), store.StepRef{TaskID: task.ID, StepID: "implement"}, time.Time{})
 	if err != nil {
 		t.Fatalf("CountStepAttempts: %v", err)
 	}

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -267,6 +267,11 @@ func formatCost(c *float64) string {
 // formatStep renders k/n plus the step name when there is room. A snapshot
 // that would not parse has no step count, so it renders a dash rather than
 // a confident "1/0".
+//
+// A task inside a `loop` gets its iteration appended — `3/7 green · loop 4/10`
+// — because k/n alone says nothing about the one number that is moving
+// (§7.8, task 016 decision 14). Every other task carries no rollup and reads
+// exactly as it did.
 func formatStep(t apiclient.Task, withName bool) string {
 	k, n, ok := t.StepDisplay()
 	if !ok {
@@ -275,6 +280,9 @@ func formatStep(t apiclient.Task, withName bool) string {
 	s := fmt.Sprintf("%d/%d", k, n)
 	if withName && t.StepName != "" {
 		s += " " + t.StepName
+	}
+	if loop := t.Loop.Display(); withName && loop != "" {
+		s += " · " + loop
 	}
 	return s
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -723,15 +723,21 @@ func (d *detail) moveSelection(delta int) tea.Cmd {
 	return d.syncOutput()
 }
 
-// attempts returns every attempt in timeline order: by step, then — inside a
-// `parallel` group, whose sub-steps share one step index (task 014) — by
-// sub-step, then by attempt. Without the middle tier a group's attempts
-// interleave by number and no sub-step reads as a unit.
+// attempts returns every attempt in timeline order: by step, then by
+// iteration, then — inside a `parallel` group, whose sub-steps share one step
+// index (task 014) — by sub-step, then by attempt. Without the middle tiers a
+// structure step's attempts interleave by number and neither a sub-step nor
+// an iteration reads as a unit.
+//
+// Iteration sits above the sub-step tier because a `loop` body is a
+// *sequence* run more than once (§7.8): iteration 2's first step belongs
+// under iteration 2, not beside iteration 1's copy of itself. Every row
+// outside a loop carries iteration 0, so this tier is invisible there.
 //
 // The order within a group is the server's: ListStepRuns returns rows by
-// index, attempt and id, so the first row of each sub-step appears in the
-// order the sub-steps started. A stable sort keeps that, which is as close to
-// declaration order as the rows can honestly report.
+// index, iteration, attempt and id, so the first row of each sub-step appears
+// in the order the sub-steps started. A stable sort keeps that, which is as
+// close to declaration order as the rows can honestly report.
 func (d *detail) attempts() []apiclient.StepRun {
 	runs := make([]apiclient.StepRun, len(d.task.Steps))
 	copy(runs, d.task.Steps)
@@ -746,6 +752,9 @@ func (d *detail) attempts() []apiclient.StepRun {
 		if runs[i].StepIndex != runs[j].StepIndex {
 			return runs[i].StepIndex < runs[j].StepIndex
 		}
+		if runs[i].Iteration != runs[j].Iteration {
+			return runs[i].Iteration < runs[j].Iteration
+		}
 		if runs[i].StepID != runs[j].StepID {
 			return order[stepRunKey(runs[i])] < order[stepRunKey(runs[j])]
 		}
@@ -755,9 +764,10 @@ func (d *detail) attempts() []apiclient.StepRun {
 }
 
 // stepRunKey identifies one step's run history within a task: the index alone
-// is not enough once a group's sub-steps share it.
+// is not enough once a group's sub-steps, or a loop body's iterations, share
+// it.
 func stepRunKey(r apiclient.StepRun) string {
-	return strconv.Itoa(r.StepIndex) + "/" + r.StepID
+	return strconv.Itoa(r.StepIndex) + "/" + strconv.Itoa(r.Iteration) + "/" + r.StepID
 }
 
 func (d *detail) runIndex(id int64) int {

--- a/internal/tui/detailloop_test.go
+++ b/internal/tui/detailloop_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// iteration is `attempt` with a loop position on it (§7.8).
+func iteration(id int64, stepIndex, iter int, name, state, item string) apiclient.StepRun {
+	r := attempt(id, stepIndex, 1, name, state, false)
+	r.Iteration = iter
+	if item != "" {
+		r.LoopItem = &item
+	}
+	return r
+}
+
+// TestDetailTimelineGroupsLoopIterations: a loop body's rows all share the
+// loop's step index *and* repeat, so the timeline needs a tier above the
+// sub-step one. Ten passes of a four-step body is forty rows, and a reader
+// arriving at a blocked task wants the pass it stopped on — so the iterations
+// are folded shut with the latest open (task 016 decision 14).
+func TestDetailTimelineGroupsLoopIterations(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 11
+
+	build := attempt(1, 0, 1, "build", "succeeded", false)
+	rows := []apiclient.StepRun{
+		build,
+		iteration(2, 1, 1, "suite", "failed", "alpha"),
+		iteration(3, 1, 1, "repair", "succeeded", "alpha"),
+		iteration(4, 1, 2, "suite", "succeeded", "beta"),
+		iteration(5, 1, 2, "repair", "succeeded", "beta"),
+	}
+	d.applyLoaded(detailLoadedMsg{
+		id: d.taskID,
+		task: apiclient.TaskDetail{
+			Task:  apiclient.Task{ID: d.taskID, Title: "looped", State: stateRunning, StepTotal: 2},
+			Steps: rows,
+			WorkflowSteps: []apiclient.WorkflowStep{
+				{Index: 0, ID: "build", Type: "command"},
+				{Index: 1, ID: "green", Type: "loop"},
+			},
+		},
+	})
+
+	got := d.timelinePanel(30)
+	for _, want := range []string{
+		"1 build",        // the ordinary step is unchanged
+		"2 green (loop)", // the loop is named from the snapshot; it writes no row
+		"iteration 1",    // every iteration gets a header…
+		"iteration 2",    //
+		"alpha",          // …carrying the for_each item it ran on
+		"beta",
+		diffFoldClosed, // iteration 1 is folded shut
+		diffFoldOpen,   // iteration 2, the latest, is open
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timeline missing %q:\n%s", want, got)
+		}
+	}
+
+	// Folded means folded: iteration 1's attempts are not rendered, so the
+	// only body-step tiers on screen belong to iteration 2.
+	if n := strings.Count(got, "· suite"); n != 1 {
+		t.Errorf("`suite` tiers on screen = %d, want 1 — only the open iteration renders its attempts", n)
+	}
+
+	// The iterations must not interleave: iteration 1's header comes before
+	// iteration 2's, and a body step belongs under its own pass.
+	first := strings.Index(got, "iteration 1")
+	second := strings.Index(got, "iteration 2")
+	if first < 0 || second < 0 || first > second {
+		t.Errorf("iteration headers out of order (%d, %d):\n%s", first, second, got)
+	}
+}
+
+// TestLoopRollupDisplay pins what the board renders beside k/n. A task with no
+// rollup — every task not currently in a loop — must render nothing at all,
+// or the column would grow a permanent empty suffix.
+func TestLoopRollupDisplay(t *testing.T) {
+	tests := []struct {
+		name   string
+		rollup *apiclient.LoopRollup
+		want   string
+	}{
+		{name: "absent", rollup: nil},
+		{
+			name:   "before the first iteration has a row",
+			rollup: &apiclient.LoopRollup{Driver: "count", MaxIterations: 10},
+		},
+		{
+			name:   "count",
+			rollup: &apiclient.LoopRollup{Driver: "count", Iteration: 4, MaxIterations: 10},
+			want:   "loop 4/10",
+		},
+		{
+			name: "for_each names its item",
+			rollup: &apiclient.LoopRollup{
+				Driver: "for_each", Iteration: 2, MaxIterations: 25, Item: "internal/store",
+			},
+			want: "loop 2/25 internal/store",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rollup.Display(); got != tt.want {
+				t.Errorf("Display() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatStepAppendsTheLoop: the board's step column carries the iteration
+// only for a task that is in one, so nothing changes for every other row.
+func TestFormatStepAppendsTheLoop(t *testing.T) {
+	task := apiclient.Task{CurrentStep: 2, StepTotal: 7, StepName: "green"}
+	if got, want := formatStep(task, true), "3/7 green"; got != want {
+		t.Errorf("formatStep without a loop = %q, want %q", got, want)
+	}
+	task.Loop = &apiclient.LoopRollup{Driver: "count", Iteration: 4, MaxIterations: 10}
+	if got, want := formatStep(task, true), "3/7 green · loop 4/10"; got != want {
+		t.Errorf("formatStep in a loop = %q, want %q", got, want)
+	}
+	// The narrow column drops the name, and the loop with it: what survives
+	// the width budget is k/n (boardcols.go).
+	if got, want := formatStep(task, false), "3/7"; got != want {
+		t.Errorf("formatStep without names = %q, want %q", got, want)
+	}
+}

--- a/internal/tui/detailloop_test.go
+++ b/internal/tui/detailloop_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// iteration is `attempt` with a loop position on it (§7.8).
-func iteration(id int64, stepIndex, iter int, name, state, item string) apiclient.StepRun {
-	r := attempt(id, stepIndex, 1, name, state, false)
+// iteration is `attempt` with a loop position on it (§7.8). The step index is
+// the loop's own — a body step shares it, which is the whole reason the
+// iteration column exists — so it is fixed at 1 here, matching the workflow
+// these tests describe.
+func iteration(id int64, iter int, name, state, item string) apiclient.StepRun {
+	r := attempt(id, 1, 1, name, state, false)
 	r.Iteration = iter
 	if item != "" {
 		r.LoopItem = &item
@@ -29,10 +32,10 @@ func TestDetailTimelineGroupsLoopIterations(t *testing.T) {
 	build := attempt(1, 0, 1, "build", "succeeded", false)
 	rows := []apiclient.StepRun{
 		build,
-		iteration(2, 1, 1, "suite", "failed", "alpha"),
-		iteration(3, 1, 1, "repair", "succeeded", "alpha"),
-		iteration(4, 1, 2, "suite", "succeeded", "beta"),
-		iteration(5, 1, 2, "repair", "succeeded", "beta"),
+		iteration(2, 1, "suite", "failed", "alpha"),
+		iteration(3, 1, "repair", "succeeded", "alpha"),
+		iteration(4, 2, "suite", "succeeded", "beta"),
+		iteration(5, 2, "repair", "succeeded", "beta"),
 	}
 	d.applyLoaded(detailLoadedMsg{
 		id: d.taskID,

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -205,6 +205,9 @@ func (d *detail) headerLine() string {
 	if k, n, ok := t.StepDisplay(); ok {
 		parts = append(parts, fmt.Sprintf("%d/%d", k, n))
 	}
+	if loop := t.Loop.Display(); loop != "" {
+		parts = append(parts, loop)
+	}
 	if t.ProjectName != "" {
 		parts = append(parts, styleDim.Render(t.ProjectName))
 	}
@@ -241,34 +244,63 @@ func (d *detail) renderTimeline(height int) string {
 	}
 
 	// A `parallel` group's sub-steps all carry the group's step index (task
-	// 014), so the header for that index names the group and each sub-step
-	// gets a tier of its own beneath it. Outside a group the shape is
+	// 014), and so do a `loop` body's steps across every iteration (task
+	// 016), so the header for such an index names the structure step and its
+	// members get a tier of their own beneath it. Outside both the shape is
 	// unchanged: one header, then its attempts.
+	//
+	// A loop's iterations are folded shut with the latest open. Ten passes of
+	// a four-step body is forty rows, and a reader arriving at a blocked task
+	// wants the pass it stopped on, not the nine that worked — the same
+	// judgement task 012 made about a twenty-file diff.
 	groups := groupedIndexes(runs)
+	loops := loopIndexes(runs)
+	openIteration := latestIterations(runs)
 	lines := make([]string, 0, len(runs)*2)
 	ids := make([]int64, 0, len(runs)*2)
 	cursorLine := 0
 	lastStep := -1
+	lastIteration := 0
 	lastSub := ""
 	for _, r := range runs {
-		grouped := groups[r.StepIndex]
+		looped := loops[r.StepIndex]
+		grouped := groups[r.StepIndex] && !looped
 		if r.StepIndex != lastStep {
 			lastStep = r.StepIndex
-			lastSub = ""
+			lastSub, lastIteration = "", 0
 			label := stepLabel(r)
-			if grouped {
-				label = d.groupLabel(r.StepIndex)
+			switch {
+			case looped:
+				label = d.structureLabel(r.StepIndex, "loop")
+			case grouped:
+				label = d.structureLabel(r.StepIndex, "parallel")
 			}
 			lines = append(lines, styleStepHeader.Render(
 				fmt.Sprintf("  %d %s", r.StepIndex+1, label)))
 			ids = append(ids, 0)
 		}
-		if grouped && r.StepID != lastSub {
-			lastSub = r.StepID
-			lines = append(lines, styleDim.Render("    · "+stepLabel(r)))
+		if looped && r.Iteration != lastIteration {
+			lastIteration = r.Iteration
+			lastSub = ""
+			lines = append(lines, styleDim.Render("    "+iterationHeader(r, openIteration[r.StepIndex])))
 			ids = append(ids, 0)
 		}
-		line := d.attemptLine(r, grouped)
+		if looped && r.Iteration != openIteration[r.StepIndex] {
+			// Folded: the header above stands for the whole iteration, and
+			// its attempts are not rendered. Selecting a run inside a folded
+			// iteration cannot happen, because it never entered ids.
+			continue
+		}
+		if (grouped || looped) && r.StepID != lastSub {
+			lastSub = r.StepID
+			indent := "    · "
+			if looped {
+				indent = "      · "
+			}
+			lines = append(lines, styleDim.Render(indent+stepLabel(r)))
+			ids = append(ids, 0)
+		}
+		line := d.attemptLine(r, grouped || looped)
 		if r.ID == d.selectedRun {
 			cursorLine = len(lines)
 			line = styleSelected.Render(line)
@@ -308,16 +340,61 @@ func groupedIndexes(runs []apiclient.StepRun) map[int]bool {
 	return out
 }
 
-// groupLabel names a group from the task's snapshot, since the group writes
-// no step_runs row to take a name from (task 014 decision 17). A snapshot
-// that has not loaded yet falls back to the type name, which is still true.
-func (d *detail) groupLabel(index int) string {
-	for _, s := range d.task.WorkflowSteps {
-		if s.Index == index {
-			return fmt.Sprintf("%s (parallel)", s.ID)
+// loopIndexes reports which step indexes hold rows from more than one
+// iteration, or any row carrying an iteration at all — which is exactly the
+// `loop` steps, since every other step type writes iteration 0.
+//
+// Derived from the rows rather than the snapshot for the reason groupedIndexes
+// is: the timeline has to render before workflow_steps arrives, and for a task
+// whose snapshot no longer parses.
+func loopIndexes(runs []apiclient.StepRun) map[int]bool {
+	out := map[int]bool{}
+	for _, r := range runs {
+		if r.Iteration > 0 {
+			out[r.StepIndex] = true
 		}
 	}
-	return "(parallel)"
+	return out
+}
+
+// latestIterations is the highest iteration each loop index has a row for —
+// the one iteration that renders open.
+func latestIterations(runs []apiclient.StepRun) map[int]int {
+	out := map[int]int{}
+	for _, r := range runs {
+		if r.Iteration > out[r.StepIndex] {
+			out[r.StepIndex] = r.Iteration
+		}
+	}
+	return out
+}
+
+// iterationHeader is one iteration's tier line, carrying the fold glyph and —
+// for a `for_each` loop — the item that pass ran on, which is the whole reason
+// a reader wants iteration headers rather than a flat list.
+func iterationHeader(r apiclient.StepRun, open int) string {
+	glyph := diffFoldClosed
+	if r.Iteration == open {
+		glyph = diffFoldOpen
+	}
+	out := fmt.Sprintf("%s iteration %d", glyph, r.Iteration)
+	if r.LoopItem != nil && *r.LoopItem != "" {
+		out += " · " + *r.LoopItem
+	}
+	return out
+}
+
+// structureLabel names a `parallel` group or a `loop` from the task's
+// snapshot, since neither writes a step_runs row to take a name from (task
+// 014 decision 17, task 016 decision 7). A snapshot that has not loaded yet
+// falls back to the type name, which is still true.
+func (d *detail) structureLabel(index int, kind string) string {
+	for _, s := range d.task.WorkflowSteps {
+		if s.Index == index {
+			return fmt.Sprintf("%s (%s)", s.ID, kind)
+		}
+	}
+	return "(" + kind + ")"
 }
 
 // stepStateStopped is the §7.7 state a `condition` step records when its

--- a/internal/workflow/examples_test.go
+++ b/internal/workflow/examples_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lezli01/vincent/internal/agent/claude"
 	"github.com/lezli01/vincent/internal/agent/codex"
 	"github.com/lezli01/vincent/internal/agent/cursor"
+	"github.com/lezli01/vincent/internal/config"
 )
 
 // TestShippedExamplesValidate parses every workflow in examples/ against the
@@ -37,9 +38,13 @@ func TestShippedExamplesValidate(t *testing.T) {
 	for _, a := range reg.All() {
 		catalogs[a.Name()] = a.Curated()
 	}
+	// The loop ceiling is the built-in default, matching what `vincent
+	// workflow validate` uses: an example must validate on a machine with no
+	// config file, so it cannot lean on a raised `loop.max_iterations`.
 	opts := Options{
-		KnownAgents: reg.Names(),
-		Catalogs:    func() agent.Catalogs { return catalogs },
+		KnownAgents:   reg.Names(),
+		Catalogs:      func() agent.Catalogs { return catalogs },
+		MaxIterations: func() int { return config.Default().Loop.MaxIterations },
 	}
 
 	found := 0

--- a/internal/workflow/loop_test.go
+++ b/internal/workflow/loop_test.go
@@ -1,0 +1,454 @@
+package workflow
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// loopOpts is the validation surface a loop is judged against: a known agent
+// and the `loop.max_iterations` ceiling decision 5 validates `count:` on.
+func loopOpts(ceiling int) Options {
+	return Options{
+		KnownAgents:   []string{"claude"},
+		MaxIterations: func() int { return ceiling },
+	}
+}
+
+// TestParseLoopStep covers the shape §7.8 exists to allow, and the two things
+// the engine leans on: the body keeps declaration order (it is a sequence),
+// and a loop survives Marshal — `edit + retry` rewrites the snapshot through
+// it, and decision 12 says such an edit applies to every remaining iteration.
+func TestParseLoopStep(t *testing.T) {
+	src := strings.TrimSpace(`
+name: converge
+steps:
+  - id: green
+    name: Fix until green
+    type: loop
+    count: 5
+    timeout: 90m
+    steps:
+      - {id: suite, type: command, run: go test ./..., allow_failure: true, max_retries: 0}
+      - {id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}'}
+      - {id: repair, type: agent, prompt: "The suite is red: {{ (index .Steps \"suite\").Result }}"}
+`) + "\n"
+	wf, _, err := Parse([]byte(src), loopOpts(10))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	loop := wf.Steps[0]
+	if loop.Type != StepLoop {
+		t.Fatalf("steps[0].type = %q, want %q", loop.Type, StepLoop)
+	}
+	if loop.Count == nil || *loop.Count != 5 {
+		t.Errorf("count = %v, want 5", loop.Count)
+	}
+	if loop.Timeout == nil || loop.Timeout.Std() != 90*time.Minute {
+		t.Errorf("loop timeout = %v, want 90m", loop.Timeout)
+	}
+	gotIDs := make([]string, 0, len(loop.Steps))
+	for _, body := range loop.Steps {
+		gotIDs = append(gotIDs, body.ID)
+	}
+	if want := []string{"suite", "passed", "repair"}; !reflect.DeepEqual(gotIDs, want) {
+		t.Errorf("body ids = %v, want %v in declaration order", gotIDs, want)
+	}
+	if !loop.Steps[0].AllowFailure {
+		t.Error("allow_failure on a body step was dropped; it is how a red probe becomes data a break can read")
+	}
+
+	out, err := Marshal(wf)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	back, _, err := Parse(out, loopOpts(10))
+	if err != nil {
+		t.Fatalf("re-parse marshalled workflow: %v", err)
+	}
+	rt := back.Steps[0]
+	if rt.Count == nil || *rt.Count != 5 {
+		t.Errorf("round-tripped count = %v, want 5", rt.Count)
+	}
+	rtIDs := make([]string, 0, len(rt.Steps))
+	for _, body := range rt.Steps {
+		rtIDs = append(rtIDs, body.ID)
+	}
+	if !reflect.DeepEqual(rtIDs, gotIDs) {
+		t.Errorf("round-tripped body ids = %v, want %v", rtIDs, gotIDs)
+	}
+	if rt.Steps[1].If != loop.Steps[1].If {
+		t.Errorf("round-tripped break guard = %q, want %q", rt.Steps[1].If, loop.Steps[1].If)
+	}
+}
+
+// TestParseForEachSpellings pins that a scalar and a sequence decode to the
+// same slice: they are one mechanism, and the engine renders both the same
+// way (§7.8).
+func TestParseForEachSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want ForEach
+	}{
+		{
+			name: "scalar template",
+			yaml: `for_each: '{{ .Steps.changed.Result }}'`,
+			want: ForEach{"{{ .Steps.changed.Result }}"},
+		},
+		{
+			name: "inline sequence",
+			yaml: `for_each: [api, web, cli]`,
+			want: ForEach{"api", "web", "cli"},
+		},
+		{
+			name: "block sequence",
+			yaml: "for_each:\n      - api\n      - web",
+			want: ForEach{"api", "web"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := strings.TrimSpace(`
+name: each
+steps:
+  - id: review-each
+    type: loop
+    `+tt.yaml+`
+    steps:
+      - {id: read, type: command, run: 'echo {{ .Loop.Item }}'}
+`) + "\n"
+			wf, _, err := Parse([]byte(src), loopOpts(10))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got := wf.Steps[0].ForEach; !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("for_each = %#v, want %#v", got, tt.want)
+			}
+			// The snapshot goes through Marshal, so the canonical sequence
+			// spelling has to come back as the same list.
+			out, err := Marshal(wf)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			back, _, err := Parse(out, loopOpts(10))
+			if err != nil {
+				t.Fatalf("re-parse: %v", err)
+			}
+			if got := back.Steps[0].ForEach; !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("round-tripped for_each = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateLoop(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "no driver",
+			src: `
+  - id: spin
+    type: loop
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "exactly one driver",
+		},
+		{
+			name: "both drivers",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    for_each: [a, b]
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "either count or for_each, not both",
+		},
+		{
+			name: "empty body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps: []`,
+			want: "at least one body step",
+		},
+		{
+			name: "count over the ceiling",
+			src: `
+  - id: spin
+    type: loop
+    count: 5000
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "count 5000 exceeds the 10-iteration ceiling",
+		},
+		{
+			name: "count over its own raised ceiling",
+			src: `
+  - id: spin
+    type: loop
+    count: 30
+    max_iterations: 25
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "count 30 exceeds the 25-iteration ceiling",
+		},
+		{
+			name: "count under a raised ceiling is fine",
+			src: `
+  - id: spin
+    type: loop
+    count: 20
+    max_iterations: 25
+    steps:
+      - {id: work, type: command, run: "true"}`,
+		},
+		{
+			name: "zero count",
+			src: `
+  - id: spin
+    type: loop
+    count: 0
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "count must be at least 1",
+		},
+		{
+			name: "zero max_iterations",
+			src: `
+  - id: spin
+    type: loop
+    for_each: [a]
+    max_iterations: 0
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "max_iterations must be at least 1",
+		},
+		{
+			name: "a loop has no retry budget of its own",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    max_retries: 3
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "max_retries is not valid on a loop step",
+		},
+		{
+			name: "allow_failure on a loop would be a silent loop_limit",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    allow_failure: true
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "allow_failure is not valid on a loop step",
+		},
+		{
+			name: "manual in a body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: gate, type: manual, instructions: look}`,
+			want: "manual steps are not valid inside a loop body",
+		},
+		{
+			name: "fan_out in a body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - id: spread
+        type: fan_out
+        lanes:
+          - {id: one, steps: [{id: inner, type: command, run: "true"}]}`,
+			want: "fan_out steps are not valid inside a loop body",
+		},
+		{
+			name: "parallel in a body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - id: both
+        type: parallel
+        steps:
+          - {id: a, type: command, run: "true"}`,
+			want: "parallel groups are not valid inside a loop body",
+		},
+		{
+			name: "loops do not nest",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - id: inner
+        type: loop
+        count: 2
+        steps:
+          - {id: work, type: command, run: "true"}`,
+			want: "loops do not nest",
+		},
+		{
+			name: "on_input require in a body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: ask, type: agent, prompt: hi, on_input: require}`,
+			want: "is not valid inside a loop body",
+		},
+		{
+			name: "condition is permitted in a body",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: enough, type: condition, if: '{{ true }}'}
+      - {id: work, type: command, run: "true"}`,
+		},
+		{
+			name: "body ids collide with the rest of the workflow",
+			src: `
+  - id: build
+    type: command
+    run: "true"
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: build, type: command, run: "true"}`,
+			want: `duplicate step id "build"`,
+		},
+		{
+			name: "count is not a field of an ordinary step",
+			src: `
+  - id: build
+    type: command
+    run: "true"
+    count: 3`,
+			want: "count is not valid on a command step",
+		},
+		{
+			name: "for_each is not a field of a group",
+			src: `
+  - id: both
+    type: parallel
+    for_each: [a]
+    steps:
+      - {id: a, type: command, run: "true"}`,
+			want: "for_each is not valid on a parallel step",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "name: t\nsteps:" + tt.src + "\n"
+			_, _, err := Parse([]byte(src), loopOpts(10))
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("Parse: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Parse accepted %s, want an error mentioning %q", tt.name, tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateBreak(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "break needs a guard",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: stop, type: break}`,
+			want: "break steps require an if expression",
+		},
+		{
+			name: "break carries nothing else",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: stop, type: break, if: '{{ true }}', timeout: 5m, run: "true"}`,
+			want: "is not valid on a break step",
+		},
+		{
+			name: "break at the top level",
+			src: `
+  - id: stop
+    type: break
+    if: '{{ true }}'`,
+			want: "break steps are only valid inside a loop body",
+		},
+		{
+			name: "break inside a parallel group",
+			src: `
+  - id: both
+    type: parallel
+    steps:
+      - {id: stop, type: break, if: '{{ true }}'}`,
+			want: "break steps are only valid inside a loop body",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "name: t\nsteps:" + tt.src + "\n"
+			_, _, err := Parse([]byte(src), loopOpts(10))
+			if err == nil {
+				t.Fatalf("Parse accepted %s, want an error mentioning %q", tt.name, tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoopCeilingUnsetSkipsTheCheck pins that a nil MaxIterations disables the
+// count check rather than treating the ceiling as zero — every snapshot
+// re-parse in the daemon goes through Options{}, and a snapshot that blew a
+// ceiling apart would otherwise become unrunnable rather than merely bounded.
+func TestLoopCeilingUnsetSkipsTheCheck(t *testing.T) {
+	src := strings.TrimSpace(`
+name: t
+steps:
+  - id: spin
+    type: loop
+    count: 500
+    max_iterations: 500
+    steps:
+      - {id: work, type: command, run: "true"}
+`) + "\n"
+	if _, _, err := Parse([]byte(src), Options{}); err != nil {
+		t.Fatalf("Parse with no ceiling: %v", err)
+	}
+}

--- a/internal/workflow/loop_test.go
+++ b/internal/workflow/loop_test.go
@@ -7,12 +7,17 @@ import (
 	"time"
 )
 
+// testLoopCeiling is the `loop.max_iterations` these tests validate `count:`
+// against — the shipped default, so the messages they assert on are the ones a
+// user reads.
+const testLoopCeiling = 10
+
 // loopOpts is the validation surface a loop is judged against: a known agent
-// and the `loop.max_iterations` ceiling decision 5 validates `count:` on.
-func loopOpts(ceiling int) Options {
+// and the ceiling decision 5 validates `count:` on.
+func loopOpts() Options {
 	return Options{
 		KnownAgents:   []string{"claude"},
-		MaxIterations: func() int { return ceiling },
+		MaxIterations: func() int { return testLoopCeiling },
 	}
 }
 
@@ -34,7 +39,7 @@ steps:
       - {id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}'}
       - {id: repair, type: agent, prompt: "The suite is red: {{ (index .Steps \"suite\").Result }}"}
 `) + "\n"
-	wf, _, err := Parse([]byte(src), loopOpts(10))
+	wf, _, err := Parse([]byte(src), loopOpts())
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
@@ -63,7 +68,7 @@ steps:
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	back, _, err := Parse(out, loopOpts(10))
+	back, _, err := Parse(out, loopOpts())
 	if err != nil {
 		t.Fatalf("re-parse marshalled workflow: %v", err)
 	}
@@ -119,7 +124,7 @@ steps:
     steps:
       - {id: read, type: command, run: 'echo {{ .Loop.Item }}'}
 `) + "\n"
-			wf, _, err := Parse([]byte(src), loopOpts(10))
+			wf, _, err := Parse([]byte(src), loopOpts())
 			if err != nil {
 				t.Fatalf("Parse: %v", err)
 			}
@@ -132,7 +137,7 @@ steps:
 			if err != nil {
 				t.Fatalf("Marshal: %v", err)
 			}
-			back, _, err := Parse(out, loopOpts(10))
+			back, _, err := Parse(out, loopOpts())
 			if err != nil {
 				t.Fatalf("re-parse: %v", err)
 			}
@@ -358,7 +363,7 @@ func TestValidateLoop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			src := "name: t\nsteps:" + tt.src + "\n"
-			_, _, err := Parse([]byte(src), loopOpts(10))
+			_, _, err := Parse([]byte(src), loopOpts())
 			if tt.want == "" {
 				if err != nil {
 					t.Fatalf("Parse: %v", err)
@@ -422,7 +427,7 @@ func TestValidateBreak(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			src := "name: t\nsteps:" + tt.src + "\n"
-			_, _, err := Parse([]byte(src), loopOpts(10))
+			_, _, err := Parse([]byte(src), loopOpts())
 			if err == nil {
 				t.Fatalf("Parse accepted %s, want an error mentioning %q", tt.name, tt.want)
 			}

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -15,11 +15,15 @@ const failureOutputLines = 200
 // populated before a step runs; rendering happens before any process is
 // started, so a bad reference fails the step without side effects.
 type RenderContext struct {
-	Task        TaskContext
-	Project     ProjectContext
-	Workflow    Info
-	Step        StepContext
-	Steps       map[string]StepResult
+	Task     TaskContext
+	Project  ProjectContext
+	Workflow Info
+	Step     StepContext
+	Steps    map[string]StepResult
+	// Loop is where this step sits inside an enclosing `loop` (§7.8, task 016
+	// decision 9). Its zero value — `Index: 0` — is what every step outside a
+	// loop renders with, so a template shared between the two can tell.
+	Loop        LoopContext
 	Worktree    WorktreeContext
 	LastFailure Failure
 	// Host is the daemon's own platform (§8.4, task 015 decision 12). The
@@ -79,6 +83,43 @@ type StepResult struct {
 	Status   string
 	Result   string
 	ExitCode int
+}
+
+// LoopContext is `.Loop` — the current iteration of the enclosing `loop`
+// step (§7.8).
+//
+// Item is a **string** rather than anything structured: `Task.Fields` is
+// map[string]string and every other value in §8.4 is a string, so a
+// structured item would push a new type through the render context, the API
+// DTOs and the TUI for a case nobody has yet (decision 9).
+type LoopContext struct {
+	// Index is the 1-based iteration, and 0 outside any loop.
+	Index int
+	// Item is the `for_each` item this iteration runs on, empty for a
+	// `count:` loop.
+	Item    string
+	IsFirst bool
+	IsLast  bool
+}
+
+// Driver names for a `loop` step's single item source (§7.8, decision 2).
+// There is deliberately no `while`: a guard can read only `.Steps`, which on
+// the first iteration has no row for the body that would fill it, so every
+// spelling of a useful `while` is either loud-and-unwritable or silently
+// false. `count:` plus `break` writes the same loop correctly, post-test by
+// construction, with the condition in the body where it can see the body.
+const (
+	DriverCount   = "count"
+	DriverForEach = "for_each"
+)
+
+// Driver reports which item source a loop step carries. Validation
+// guarantees exactly one, so this is total for a step that parsed.
+func (s Step) Driver() string {
+	if len(s.ForEach) > 0 {
+		return DriverForEach
+	}
+	return DriverCount
 }
 
 // HostContext is `.Host` — the daemon's GOOS and GOARCH.

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -39,7 +39,29 @@ const (
 	// would be a false friend whose failure mode is a task reaching `done`
 	// having silently done half its work (task 015 decision 2).
 	StepCondition = "condition"
+	// StepLoop runs its body — a sequence — repeatedly in the task's one
+	// worktree (§7.8, task 016). It is `parallel`'s structural twin: one
+	// step_index, one scheduler slot, no branch, no child task and nothing to
+	// merge. Where a group is a set run once, a loop is a sequence run more
+	// than once.
+	StepLoop = "loop"
+	// StepBreak ends the enclosing loop successfully when its `if:` is true
+	// (§7.8, decision 3). It is a type rather than a field for the reason
+	// `condition` is: it starts no process, so it cannot time out, be
+	// retried, be interrupted or write a transcript.
+	//
+	// `continue` has no type of its own. A `condition` inside a loop body
+	// ends *that iteration*, which is what continue means, using the meaning
+	// §7.7 already gave the word.
+	StepBreak = "break"
 )
+
+// stepTypeList is the step-type vocabulary as one string, so the two "one of
+// …" messages cannot drift apart as the set grows.
+var stepTypeList = strings.Join([]string{
+	StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition,
+	StepLoop, StepBreak,
+}, ", ")
 
 // Conflict policies for a fan_out step's join (§7.6, task 014 decision 8).
 const (
@@ -159,6 +181,44 @@ type Step struct {
 	// fan_out steps (task 014)
 	Lanes []Lane `yaml:"lanes,omitempty"`
 	Merge *Merge `yaml:"merge,omitempty"`
+
+	// loop steps (task 016). Steps above carries the body — a loop and a
+	// group are the two structure steps, and one field for "the steps inside
+	// me" is what keeps allSteps, the catalog check and the snapshot
+	// marshaller from growing a second case each.
+	//
+	// Exactly one of Count and ForEach is set: the driver (decision 2).
+	// MaxIterations bounds the loop, defaulting to `loop.max_iterations`.
+	Count         *int    `yaml:"count,omitempty"`
+	ForEach       ForEach `yaml:"for_each,omitempty"`
+	MaxIterations *int    `yaml:"max_iterations,omitempty"`
+}
+
+// ForEach is a `loop` step's item list: a YAML sequence of templates, or a
+// single scalar template. Both spellings decode to the same slice, and both
+// are rendered the same way at run time — each entry is rendered, trimmed and
+// split on newlines with empty lines dropped (§7.8) — so a command's
+// multi-line output and a hand-written list are one mechanism, not two.
+//
+// The scalar spelling exists because the motivating case is
+// `for_each: '{{ .Steps.changed.Result }}'`, a list a step discovered at run
+// time, and wrapping that in a one-element sequence would be ceremony.
+type ForEach []string
+
+// UnmarshalYAML accepts either spelling. goccy hands the raw node bytes, so
+// the sequence attempt is tried first and a scalar falls out of its failure.
+func (f *ForEach) UnmarshalYAML(b []byte) error {
+	var list []string
+	if err := yaml.Unmarshal(b, &list); err == nil {
+		*f = list
+		return nil
+	}
+	var scalar string
+	if err := yaml.Unmarshal(b, &scalar); err != nil {
+		return fmt.Errorf("for_each must be a string or a list of strings: %w", err)
+	}
+	*f = ForEach{scalar}
+	return nil
 }
 
 // Lane is one branch of a `fan_out` step: a named registry workflow or inline
@@ -268,6 +328,18 @@ type Options struct {
 	// Nil disables catalog validation. The daemon wires the catalog cache's
 	// never-probing view here (T2.11).
 	Catalogs func() agent.Catalogs
+	// MaxIterations supplies `loop.max_iterations` — the ceiling a `count:`
+	// is checked against at load, so `count: 5000` is refused in front of the
+	// person typing (§7.8, task 016 decision 5).
+	//
+	// A func rather than an int, for the reason Catalogs is one: the registry
+	// captures these Options once and re-parses files for the rest of the
+	// daemon's life, so a plain value would pin the ceiling to whatever
+	// config said at startup and a hot reload (§12.3) would reach the engine
+	// without reaching validation. Nil disables the check, which is what a
+	// caller wanting only structural validation — a snapshot re-parse, a test
+	// — gets by leaving it unset.
+	MaxIterations func() int
 }
 
 // Error is a single validation failure, located in the source file when the
@@ -374,40 +446,11 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 	if len(wf.Steps) == 0 {
 		add("steps", "steps must not be empty")
 	}
-	// Ids are unique across the whole workflow, sub-steps included: a
-	// sub-step shares its group's step_index and is told apart from its
-	// siblings by step_id alone (task 014 decision 16), which is also what
-	// names its transcript file.
-	seen := make(map[string]string, len(wf.Steps))
-	checkID := func(step Step, base string) {
-		switch {
-		case step.ID == "":
-			add(base+".id", "id is required")
-		case !isSlug(step.ID):
-			add(base+".id", "id %q must be a slug (lowercase letters, digits, '-', '_', '.')", step.ID)
-		default:
-			if prev, dup := seen[step.ID]; dup {
-				add(base+".id", "duplicate step id %q (first used by %s)", step.ID, prev)
-			}
-			seen[step.ID] = base
-		}
-	}
-	for i, step := range wf.Steps {
-		base := fmt.Sprintf("steps[%d]", i)
-		checkID(step, base)
-		validateStep(step, base, opts, add)
-		switch step.Type {
-		case StepParallel:
-			for j, sub := range step.Steps {
-				subBase := fmt.Sprintf("%s.steps[%d]", base, j)
-				checkID(sub, subBase)
-				validateSubStep(wf, sub, subBase, opts, add)
-			}
-		case StepFanOut:
-			validateLanes(wf, step, base, opts, add, addWarn)
-		}
-	}
-	warnTrailingCondition(wf.Steps, "steps", addWarn)
+	// Ids are unique across the whole workflow, sub-steps and loop bodies
+	// included: a member of either shares its structure step's step_index and
+	// is told apart from its siblings by step_id alone (task 014 decision 16,
+	// task 016 decision 7), which is also what names its transcript file.
+	validateBody(wf, wf.Steps, "steps", make(map[string]string, len(wf.Steps)), opts, add, addWarn)
 	warns = append(warns, validateCatalogs(wf, opts, loc, add)...)
 	sort.SliceStable(errs, func(i, j int) bool { return errs[i].Line < errs[j].Line })
 	sort.SliceStable(warns, func(i, j int) bool { return warns[i].Line < warns[j].Line })
@@ -521,8 +564,7 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 func validateStep(step Step, base string, opts Options, add func(string, string, ...any)) {
 	switch step.Type {
 	case "":
-		add(base+".type", "type is required (one of %s, %s, %s, %s, %s, %s)",
-			StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition)
+		add(base+".type", "type is required (one of %s)", stepTypeList)
 	case StepAgent:
 		if step.Prompt == "" {
 			add(base+".prompt", "agent steps require a prompt")
@@ -580,6 +622,20 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
 			"allow_failure")
+	case StepLoop:
+		validateLoop(step, base, add, opts)
+	case StepBreak:
+		// `break` is `condition` with the enclosing loop supplying the
+		// consequence, so it carries the same fields and rejects the same
+		// ones: it starts no process, so there is nothing to time out, retry
+		// or allow to fail (decision 3).
+		if step.If == "" {
+			add(base+".if", "break steps require an if expression")
+		}
+		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+			"run", "shell", "env", "instructions", "steps", "max_parallel",
+			"lanes", "merge", "allow_failure", "max_retries", "timeout")
 	case StepCondition:
 		// The guard *is* the body. `if:` may not also act as a skip-guard
 		// here: "skip the check that decides whether to continue" has two
@@ -595,8 +651,13 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
 			"lanes", "merge", "allow_failure", "max_retries", "timeout")
 	default:
-		add(base+".type", "unknown step type %q (one of %s, %s, %s, %s, %s, %s)",
-			step.Type, StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition)
+		add(base+".type", "unknown step type %q (one of %s)", step.Type, stepTypeList)
+	}
+	// `count`, `for_each` and `max_iterations` belong to a loop and to
+	// nothing else. Rejecting them here rather than in each arm keeps the
+	// seven arms above from each growing the same three strings.
+	if step.Type != StepLoop {
+		rejectFields(step, base, add, "count", "for_each", "max_iterations")
 	}
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
@@ -674,6 +735,95 @@ func validateMerge(step Step, base string, opts Options, add func(string, string
 	validateStep(resolver, base+".merge.agent", opts, add)
 }
 
+// validateLoop checks a `loop` step: its body, its single driver, and the
+// ceiling the driver is bounded by (§7.8, task 016 decisions 2, 5, 11).
+//
+// The ceiling is the step's own `max_iterations:` when it declares one, else
+// `loop.max_iterations` from config. Checking `count:` against it at load is
+// the whole of decision 5's "bounded by construction": a loop that could
+// never have finished is a workflow bug, and this is the last moment it can
+// be reported to the person who wrote it.
+func validateLoop(step Step, base string, add func(string, string, ...any), opts Options) {
+	if len(step.Steps) == 0 {
+		add(base+".steps", "loop steps require at least one body step")
+	}
+	switch {
+	case step.Count == nil && len(step.ForEach) == 0:
+		add(base, "a loop needs exactly one driver: %s or %s", "count", "for_each")
+	case step.Count != nil && len(step.ForEach) > 0:
+		add(base, "a loop has either count or for_each, not both")
+	}
+	var ceiling int
+	if opts.MaxIterations != nil {
+		ceiling = opts.MaxIterations()
+	}
+	if step.MaxIterations != nil {
+		if *step.MaxIterations < 1 {
+			add(base+".max_iterations", "max_iterations must be at least 1, got %d", *step.MaxIterations)
+		} else {
+			ceiling = *step.MaxIterations
+		}
+	}
+	if step.Count != nil {
+		switch {
+		case *step.Count < 1:
+			add(base+".count", "count must be at least 1, got %d", *step.Count)
+		case ceiling > 0 && *step.Count > ceiling:
+			add(base+".count",
+				"count %d exceeds the %d-iteration ceiling; raise max_iterations on this step "+
+					"or loop.max_iterations in config", *step.Count, ceiling)
+		}
+	}
+	for i, item := range step.ForEach {
+		if _, err := template.New("for_each").Parse(item); err != nil {
+			add(fmt.Sprintf("%s.for_each[%d]", base, i), "template does not parse: %v", err)
+		}
+	}
+	// No `max_retries` and no `allow_failure` (decision 11): a loop has no
+	// attempt of its own to retry, and "allow" on a loop could only mean "a
+	// loop_limit block advances anyway", which is the silent success
+	// decision 5 refused. Both live on the body steps, where they already do
+	// the useful thing.
+	rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+		"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+		"run", "shell", "env", "instructions", "lanes", "merge", "max_parallel",
+		"allow_failure", "max_retries")
+}
+
+// validateBodyStep checks one member of a `loop` body. Four step types cannot
+// appear there and one field cannot be set on one, all for the reason §7.5
+// gives about a group: a loop's position is *derived from its rows*
+// (decision 7), and each of these needs a state no row can express — "this
+// task is parked in iteration 3" (decisions 10).
+func validateBodyStep(wf *Workflow, body Step, base string, opts Options, add func(string, string, ...any)) {
+	switch body.Type {
+	case StepManual:
+		add(base+".type", "manual steps are not valid inside a loop body: "+
+			"a gate ends the actor goroutine and releases the slot, and no state says which iteration is gated")
+	case StepFanOut:
+		add(base+".type", "fan_out steps are not valid inside a loop body: "+
+			"the task parks in awaiting_children, and a parked parent has no row to say which iteration it parked in")
+	case StepParallel:
+		add(base+".type", "parallel groups are not valid inside a loop body: "+
+			"a loop's position is derived from its rows, and that derivation stays affordable one level deep")
+	case StepLoop:
+		add(base+".type", "loops do not nest: a loop's position is derived from its rows, "+
+			"and that derivation stays affordable one level deep")
+	}
+	// Resolved, not literal, exactly as a group sub-step is: `defaults.on_input:
+	// require` reaches a body step that says nothing, and is just as unrunnable
+	// there (§7.4).
+	if wf.StepRequiresInput(body) {
+		field := base + ".on_input"
+		if body.OnInput == "" {
+			field = "defaults.on_input"
+		}
+		add(field, "on_input: %s is not valid inside a loop body: "+
+			"%s holds one pending request for the whole task", InputRequire, "awaiting_input")
+	}
+	validateStep(body, base, opts, add)
+}
+
 // validateLanes checks a fan_out step's lanes. Lane step ids live in their
 // own namespace — each lane becomes a **separate child task** with its own
 // flat snapshot (decision 4) — so they are checked against a fresh set rather
@@ -735,33 +885,65 @@ func validateLaneSteps(wf *Workflow, lane Lane, base string, opts Options,
 	if len(lane.Steps) == 0 {
 		return
 	}
-	seen := make(map[string]string, len(lane.Steps))
-	for i, step := range lane.Steps {
-		stepPath := fmt.Sprintf("%s.steps[%d]", base, i)
-		switch {
-		case step.ID == "":
-			add(stepPath+".id", "id is required")
-		case !isSlug(step.ID):
-			add(stepPath+".id", "id %q must be a slug (lowercase letters, digits, '-', '_', '.')", step.ID)
-		default:
-			if prev, dup := seen[step.ID]; dup {
-				add(stepPath+".id", "duplicate step id %q (first used by %s)", step.ID, prev)
-			}
-			seen[step.ID] = stepPath
+	// A lane's inline steps *are* a workflow body — they become a child
+	// task's own flat snapshot — so they go through the same walk the
+	// top-level steps do, down to the trailing-`condition` warning. Their id
+	// namespace is their own, which is the one thing that differs and is why
+	// the map is made here (decision 4).
+	validateBody(wf, lane.Steps, base+".steps", make(map[string]string, len(lane.Steps)), opts, add, addWarn)
+}
+
+// validateBody validates one workflow body: the top-level steps, or a
+// fan-out lane's inline steps. ids is the namespace step ids are unique
+// within, shared with every structure step's members.
+func validateBody(wf *Workflow, steps []Step, base string, ids map[string]string, opts Options,
+	add func(string, string, ...any), addWarn func(string, string, ...any),
+) {
+	for i, step := range steps {
+		stepPath := fmt.Sprintf("%s[%d]", base, i)
+		checkStepID(step, stepPath, ids, add)
+		if step.Type == StepBreak {
+			// `break` names the loop it ends, and there is none here.
+			// Symmetric with `condition` being rejected inside a group: one
+			// word, one meaning, supplied by what it is attached to
+			// (decision 3).
+			add(stepPath+".type", "break steps are only valid inside a loop body: "+
+				"there is no loop here for one to end")
 		}
 		validateStep(step, stepPath, opts, add)
 		switch step.Type {
 		case StepParallel:
 			for j, sub := range step.Steps {
-				validateSubStep(wf, sub, fmt.Sprintf("%s.steps[%d]", stepPath, j), opts, add)
+				subPath := fmt.Sprintf("%s.steps[%d]", stepPath, j)
+				checkStepID(sub, subPath, ids, add)
+				validateSubStep(wf, sub, subPath, opts, add)
 			}
 		case StepFanOut:
 			validateLanes(wf, step, stepPath, opts, add, addWarn)
+		case StepLoop:
+			for j, body := range step.Steps {
+				bodyPath := fmt.Sprintf("%s.steps[%d]", stepPath, j)
+				checkStepID(body, bodyPath, ids, add)
+				validateBodyStep(wf, body, bodyPath, opts, add)
+			}
 		}
 	}
-	// A lane's inline steps are a workflow body, so its last step carries the
-	// same warning a top-level one does.
-	warnTrailingCondition(lane.Steps, base+".steps", addWarn)
+	warnTrailingCondition(steps, base, addWarn)
+}
+
+// checkStepID validates one step id and records it in the body's namespace.
+func checkStepID(step Step, base string, ids map[string]string, add func(string, string, ...any)) {
+	switch {
+	case step.ID == "":
+		add(base+".id", "id is required")
+	case !isSlug(step.ID):
+		add(base+".id", "id %q must be a slug (lowercase letters, digits, '-', '_', '.')", step.ID)
+	default:
+		if prev, dup := ids[step.ID]; dup {
+			add(base+".id", "duplicate step id %q (first used by %s)", step.ID, prev)
+		}
+		ids[step.ID] = base
+	}
 }
 
 // warnTrailingCondition reports a `condition` step in last position. It is a
@@ -803,6 +985,15 @@ func validateSubStep(wf *Workflow, sub Step, base string, opts Options, add func
 		// what `if:` on a sub-step already does.
 		add(base+".type", "condition steps are not valid inside a parallel group: "+
 			"a group has no later steps to stop; guard the sub-step with `if:` instead")
+	case StepLoop:
+		// A loop's position is derived from its rows, which are keyed by the
+		// structure step's index; nesting one inside a group would put two
+		// derivations on one index (task 016 decision 10).
+		add(base+".type", "loop steps are not valid inside a parallel group: "+
+			"both derive their position from rows sharing one step_index")
+	case StepBreak:
+		add(base+".type", "break steps are only valid inside a loop body: "+
+			"there is no loop here for one to end")
 	}
 	// Resolved, not literal: `defaults.on_input: require` reaches a sub-step
 	// that says nothing, and it is just as unrunnable there (§7.4).
@@ -832,6 +1023,8 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"lanes": len(step.Lanes) > 0, "merge": step.Merge != nil,
 		"if": step.If != "", "allow_failure": step.AllowFailure,
 		"max_retries": step.MaxRetries != nil, "timeout": step.Timeout != nil,
+		"count": step.Count != nil, "for_each": len(step.ForEach) > 0,
+		"max_iterations": step.MaxIterations != nil,
 	}
 	for _, f := range fields {
 		if set[f] {

--- a/scripts/m8-gate.sh
+++ b/scripts/m8-gate.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+# M8 phase gate (task 016; spec §7.8): prove via curl alone that loops behave
+# as specified.
+#
+#   1. `count:` runs its body that many times and the workflow carries on
+#   2. converge — an `allow_failure` probe, a `break` reading it, a repair
+#   3. a `for_each` list longer than max_iterations blocks with `loop_limit`
+#   4. `for_each` over a static list, one iteration per item, in order
+#   5. `for_each` over a list a step discovered at run time
+#   6. an empty `for_each` list succeeds having run nothing
+#   7. a `condition` inside a body ends that iteration, not the loop
+#   8. a hard-killed daemon resumes the loop mid-iteration, not at iteration 1
+#
+# Every scenario uses command steps only, so no agent CLI is involved and the
+# gate is as fast on CI as it is locally.
+#
+# The `run:` bodies are restricted to `exit N` and `git ...`, which is what
+# makes this portable to pwsh the way m7 is and m6 is not (§8.3 leaves
+# portability to the workflow author, and a gate running on three platforms is
+# that author). It is also why the loops count themselves in empty commits:
+# `printf > x` and `Set-Content` share no spelling, and `git log` can be asked
+# afterwards what happened.
+#
+# Each scenario gets fresh config/data/repo dirs and its own daemon, so one
+# scenario's leftovers cannot reach another's assertions (PR G decision,
+# inherited from m2-gate.sh). VINCENT_GATE_SCENARIO=N runs one scenario.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+ONLY="${VINCENT_GATE_SCENARIO:-}"
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+CONFIG_DIR="" DATA_DIR=""
+scenario_dirs() { # scenario_dirs NAME
+  CONFIG_DIR="$TMP/$1/config"
+  DATA_DIR="$TMP/$1/data"
+  mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+  export VINCENT_CONFIG_DIR
+  VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+  export VINCENT_DATA_DIR
+  VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+}
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+}
+
+register_project() { git init >/dev/null 2>&1 || true; api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+wait_for_state() { # wait_for_state TASK_ID STATE TRIES
+  local id="$1" want="$2" tries="$3" state=""
+  for _ in $(seq 1 "$tries"); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" ]] && [[ "$want" != "aborted" ]]; then
+      api GET "/tasks/$id" | jq . >&2
+      fail "task $id reached $state while waiting for $want"
+    fi
+    sleep 1
+  done
+  api GET "/tasks/$id" | jq . >&2
+  fail "task $id never reached $want (last: $state)"
+}
+
+create_task() { # create_task PROJECT_ID WORKFLOW TITLE -> id
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg w "$2" --arg t "$3" \
+    '{project_id: $p, workflow: $w, title: $t}')" | jq -r .id
+}
+
+run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+# --- loop-shaped assertions -----------------------------------------------
+# A loop writes no row of its own; everything below reads the body's rows,
+# which is the same derivation the engine makes (§7.8 decision 7).
+
+steps_json() { api GET "/tasks/$1/steps"; }
+
+# rows_for prints "ITERATION STATE" for every attempt of one body step,
+# oldest first.
+rows_for() { # rows_for TASK_ID STEP_ID
+  steps_json "$1" | jq -r --arg s "$2" '.[] | select(.step_id == $s) | "\(.iteration) \(.state)"'
+}
+
+# iterations_ran is how many distinct iterations the loop produced rows for.
+iterations_ran() { # iterations_ran TASK_ID
+  steps_json "$1" | jq '[.[] | select(.iteration > 0) | .iteration] | unique | length'
+}
+
+# items_ran prints the for_each item of each iteration, in iteration order.
+items_ran() { # items_ran TASK_ID
+  steps_json "$1" | jq -r '[.[] | select(.loop_item != null)]
+    | group_by(.iteration) | sort_by(.[0].iteration) | .[] | .[0].loop_item'
+}
+
+step_field() { # step_field TASK_ID STEP_ID FIELD
+  steps_json "$1" | jq -r --arg s "$2" --arg f "$3" \
+    '[.[] | select(.step_id == $s)] | last | .[$f] // "null"'
+}
+
+# subject_count is how many commits on the task's branch carry a subject.
+subject_count() { # subject_count REPO TASK_ID SUBJECT
+  local branch
+  branch="$(api GET "/tasks/$2" | jq -r .branch_name)"
+  git -C "$1" log --format=%s "$branch" | grep -cx -- "$3" || true
+}
+
+# --------------------------------------------------------------------------
+# Scenario 1: `count:` runs its body that many times, then the workflow
+# carries on. The loop writes no row of its own, and each body row carries a
+# 1-based iteration.
+# --------------------------------------------------------------------------
+if run_scenario 1; then
+  echo "=== scenario 1: count runs its body three times"
+  scenario_dirs s1
+  REPO="$TMP/s1/repo"; make_repo "$REPO"
+  write_workflow count-to-three "$(cat <<'YAML'
+name: count-to-three
+steps:
+  - id: spin
+    type: loop
+    count: 3
+    steps:
+      - id: tick
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m tick
+  - id: after
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m after
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" count-to-three "count to three")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(iterations_ran "$TID")" == 3 ]] \
+    || fail "the body ran $(iterations_ran "$TID") iterations, want 3"
+  [[ "$(subject_count "$REPO" "$TID" tick)" == 3 ]] \
+    || fail "the body did its work $(subject_count "$REPO" "$TID" tick) times, want 3"
+  [[ "$(subject_count "$REPO" "$TID" after)" == 1 ]] \
+    || fail "the step after the loop did not run exactly once"
+  [[ "$(rows_for "$TID" spin)" == "" ]] \
+    || fail "the loop wrote a step_runs row of its own; its outcome is derived"
+  [[ "$(rows_for "$TID" tick)" == $'1 succeeded\n2 succeeded\n3 succeeded' ]] \
+    || fail "body rows are not one per iteration, 1-based: $(rows_for "$TID" tick)"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: converge. The probe is `allow_failure`, so its red row is data
+# rather than a block (§7.2); the `break` two lines below reads that row,
+# which is the whole of decision 9's positional visibility rule — under an
+# index comparison a body step cannot see its own body and this never breaks.
+#
+# `git rev-parse HEAD~2` succeeds once the branch has three commits, so the
+# probe goes green on the third pass.
+# --------------------------------------------------------------------------
+if run_scenario 2; then
+  echo "=== scenario 2: converge and break"
+  scenario_dirs s2
+  REPO="$TMP/s2/repo"; make_repo "$REPO"
+  write_workflow converge "$(cat <<'YAML'
+name: converge
+steps:
+  - id: green
+    type: loop
+    count: 8
+    steps:
+      - id: suite
+        type: command
+        max_retries: 0
+        allow_failure: true
+        run: git rev-parse --verify HEAD~2
+      - id: passed
+        type: break
+        if: '{{ eq (index .Steps "suite").ExitCode 0 }}'
+      - id: repair
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m repair
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" converge "fix until green")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(iterations_ran "$TID")" == 3 ]] \
+    || fail "converged in $(iterations_ran "$TID") iterations, want 3"
+  [[ "$(subject_count "$REPO" "$TID" repair)" == 2 ]] \
+    || fail "repaired $(subject_count "$REPO" "$TID" repair) times, want 2 — the third pass must break"
+  # A taken break is `stopped`: the loop ended there, on purpose.
+  [[ "$(step_field "$TID" passed state)" == "stopped" ]] \
+    || fail "the break's last row is $(step_field "$TID" passed state), want stopped"
+  [[ "$(rows_for "$TID" passed)" == $'1 succeeded\n2 succeeded\n3 stopped' ]] \
+    || fail "the break did not evaluate once per iteration: $(rows_for "$TID" passed)"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3: a `for_each` list longer than max_iterations blocks with
+# `loop_limit`, before iteration 1. Running out of tries is not a decision the
+# workflow made, so it must not succeed and must not silently advance
+# (decision 5).
+# --------------------------------------------------------------------------
+if run_scenario 3; then
+  echo "=== scenario 3: over the ceiling blocks with loop_limit"
+  scenario_dirs s3
+  REPO="$TMP/s3/repo"; make_repo "$REPO"
+  cat > "$CONFIG_DIR/config.yaml" <<'YAML'
+loop:
+  max_iterations: 2
+YAML
+  write_workflow too-many "$(cat <<'YAML'
+name: too-many
+steps:
+  - id: visit
+    type: loop
+    for_each: [alpha, beta, gamma]
+    steps:
+      - id: touch
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m touch
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" too-many "three items, room for two")"
+  wait_for_state "$TID" blocked 60
+
+  [[ "$(api GET "/tasks/$TID" | jq -r .block_reason)" == "loop_limit" ]] \
+    || fail "block_reason is not loop_limit"
+  [[ "$(iterations_ran "$TID")" == 0 ]] \
+    || fail "the loop ran before blocking; the ceiling is checked before iteration 1"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: `for_each` over a static list — one iteration per item, in list
+# order, with the item recorded on the row rather than re-derived (decision 8).
+# --------------------------------------------------------------------------
+if run_scenario 4; then
+  echo "=== scenario 4: for_each over a static list"
+  scenario_dirs s4
+  REPO="$TMP/s4/repo"; make_repo "$REPO"
+  write_workflow each-static "$(cat <<'YAML'
+name: each-static
+steps:
+  - id: visit
+    type: loop
+    for_each: [alpha, beta, gamma]
+    steps:
+      - id: touch
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m {{ .Loop.Item }}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" each-static "once per item")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(items_ran "$TID")" == $'alpha\nbeta\ngamma' ]] \
+    || fail "loop_item column = $(items_ran "$TID"), want alpha/beta/gamma in list order"
+  for item in alpha beta gamma; do
+    [[ "$(subject_count "$REPO" "$TID" "$item")" == 1 ]] \
+      || fail "item $item did not get exactly one iteration's work"
+  done
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 5: `for_each` over a list a step discovered at run time. This is
+# the case `fan_out` cannot serve — its lane list has to be static in the
+# snapshot, which is exactly what makes its creation-time checks possible
+# (decision 4).
+#
+# `git tag -l` prints one tag per line, which is a list produced by a command
+# without leaving the `exit N` / `git ...` vocabulary.
+# --------------------------------------------------------------------------
+if run_scenario 5; then
+  echo "=== scenario 5: for_each over a list a step found"
+  scenario_dirs s5
+  REPO="$TMP/s5/repo"; make_repo "$REPO"
+  for tag in one two; do git -C "$REPO" tag "mod-$tag"; done
+  write_workflow each-found "$(cat <<'YAML'
+name: each-found
+steps:
+  - id: discover
+    type: command
+    max_retries: 0
+    run: git tag -l mod-*
+  - id: visit
+    type: loop
+    for_each: '{{ .Steps.discover.Result }}'
+    steps:
+      - id: touch
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m {{ .Loop.Item }}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" each-found "once per module")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(items_ran "$TID")" == $'mod-one\nmod-two' ]] \
+    || fail "loop_item column = $(items_ran "$TID"), want the two tags the step printed"
+  [[ "$(subject_count "$REPO" "$TID" mod-one)" == 1 ]] \
+    || fail "the discovered item mod-one did not get an iteration"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 6: an empty `for_each` list succeeds having run nothing. The loop
+# had nothing to iterate, which is a correct answer rather than a failure —
+# the same posture §7.5 takes for a group whose every sub-step was guarded off.
+# --------------------------------------------------------------------------
+if run_scenario 6; then
+  echo "=== scenario 6: an empty list is a no-op success"
+  scenario_dirs s6
+  REPO="$TMP/s6/repo"; make_repo "$REPO"
+  write_workflow each-none "$(cat <<'YAML'
+name: each-none
+steps:
+  - id: discover
+    type: command
+    max_retries: 0
+    run: git tag -l absent-*
+  - id: visit
+    type: loop
+    for_each: '{{ .Steps.discover.Result }}'
+    steps:
+      - id: touch
+        type: command
+        max_retries: 0
+        run: exit 9
+  - id: after
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m after
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" each-none "nothing to do")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(iterations_ran "$TID")" == 0 ]] \
+    || fail "an empty list still ran $(iterations_ran "$TID") iterations"
+  [[ "$(subject_count "$REPO" "$TID" after)" == 1 ]] \
+    || fail "the workflow did not carry on past an empty loop"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 7: a `condition` inside a body ends *that iteration* and the loop
+# carries on — which is `continue`, spelled with the meaning §7.7 already gave
+# the word and no third step type (decision 3).
+# --------------------------------------------------------------------------
+if run_scenario 7; then
+  echo "=== scenario 7: a condition ends the iteration, not the loop"
+  scenario_dirs s7
+  REPO="$TMP/s7/repo"; make_repo "$REPO"
+  write_workflow skip-tails "$(cat <<'YAML'
+name: skip-tails
+steps:
+  - id: spin
+    type: loop
+    count: 3
+    steps:
+      - id: head
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m head
+      - id: onward
+        type: condition
+        if: '{{ .Loop.IsLast }}'
+      - id: tail
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m tail
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" skip-tails "continue, spelled condition")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(subject_count "$REPO" "$TID" head)" == 3 ]] \
+    || fail "head ran $(subject_count "$REPO" "$TID" head) times, want 3 — the loop must carry on"
+  [[ "$(subject_count "$REPO" "$TID" tail)" == 1 ]] \
+    || fail "tail ran $(subject_count "$REPO" "$TID" tail) times, want 1 — only the last iteration continues"
+  [[ "$(rows_for "$TID" onward)" == $'1 stopped\n2 stopped\n3 succeeded' ]] \
+    || fail "the condition's rows are $(rows_for "$TID" onward), want two stops then a pass"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 8: a hard-killed daemon resumes the loop mid-iteration. Position is
+# derived from the rows, never persisted (decision 7), so the restarted daemon
+# must skip the body steps whose latest attempt succeeded and carry on from
+# the failed one — in the iteration it was in, not at iteration 1.
+#
+# The failure that holds the task still is portable (`exit 7`); the kill is
+# real (SIGKILL, then §12.4 recovery on restart). What the two together prove
+# is that nothing outside the rows was carrying the loop's position across the
+# process boundary.
+# --------------------------------------------------------------------------
+if run_scenario 8; then
+  echo "=== scenario 8: crash and resume mid-iteration"
+  scenario_dirs s8
+  REPO="$TMP/s8/repo"; make_repo "$REPO"
+  # `boom` fails until the marker tag exists, which the gate creates while the
+  # daemon is dead — standing in for the human who fixed whatever was wrong.
+  write_workflow resume "$(cat <<'YAML'
+name: resume
+steps:
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - id: tick
+        type: command
+        max_retries: 0
+        run: git commit --allow-empty -m tick
+      - id: boom
+        type: command
+        max_retries: 0
+        run: git rev-parse --verify refs/tags/fixed
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" resume "resume where it stopped")"
+  wait_for_state "$TID" blocked 60
+
+  [[ "$(subject_count "$REPO" "$TID" tick)" == 1 ]] \
+    || fail "the loop ran past its failed body step"
+
+  echo "== hard-kill the daemon (pid from daemon.json)"
+  DAEMON_PID="$(jq -r .pid "$DATA_DIR/daemon.json")"
+  if [[ "${OS:-}" == "Windows_NT" ]]; then
+    # Git Bash kill -9 can't reliably kill a native process; // stops MSYS
+    # from mangling the flags into paths (phase 2 decision).
+    taskkill //F //PID "$DAEMON_PID" >/dev/null
+  else
+    kill -9 "$DAEMON_PID"
+  fi
+  for _ in $(seq 1 20); do
+    kill -0 "$DAEMON_PID" 2>/dev/null || break
+    sleep 0.5
+  done
+
+  git -C "$REPO" tag fixed
+  daemon_up
+  api POST "/tasks/$TID/retry" '{}' >/dev/null
+  wait_for_state "$TID" done 60
+
+  # Two ticks, not three: iteration 1's `tick` had already succeeded, so the
+  # resumed loop went straight to `boom`.
+  [[ "$(subject_count "$REPO" "$TID" tick)" == 2 ]] \
+    || fail "tick ran $(subject_count "$REPO" "$TID" tick) times, want 2 — a resumed loop must not re-run a succeeded body step"
+  [[ "$(iterations_ran "$TID")" == 2 ]] \
+    || fail "the resumed loop ran $(iterations_ran "$TID") iterations, want 2"
+  [[ "$(rows_for "$TID" boom)" == $'1 failed\n1 succeeded\n2 succeeded' ]] \
+    || fail "boom's rows are $(rows_for "$TID" boom), want a failed then a fresh attempt in iteration 1"
+  daemon_down
+fi
+
+echo
+echo "M8 GATE PASSED"


### PR DESCRIPTION
A workflow may now repeat a body of steps: a fixed number of times
(`count:`) or once per item in a list (`for_each:`). Closes 016.1–016.8.

A loop is `parallel`'s structural twin (§7.5): one step_index, one
scheduler slot, the task's one worktree, no branch and nothing to merge.
What it adds is that its body is a *sequence*, run more than once.

- Schema and validation. `StepLoop`/`StepBreak`; `count`, `for_each` and
  `max_iterations` on Step; exactly one driver; `count` checked against
  `loop.max_iterations` at load; the body-type rejection list; `break`
  required-`if:`-and-nothing-else and rejected outside a body. The
  top-level and lane-inline step walks collapse into one `validateBody`,
  which is what gives loop bodies id-uniqueness and lane parity for free.
- Store. Migration 0009 adds `step_runs.iteration` and `loop_item`; a new
  `StepRef` names a run history by index, id *and* iteration, so a body
  step's retry budget is its own in each pass. `ListStepRunsAt` is a
  loop's whole history in one read.
- Engine. `internal/taskrun/loop.go`: derived position, mid-iteration
  resumption, `break`, iteration-scoped `condition`, the loop-level
  timeout, and `loop_limit` for a list the ceiling cannot hold. No loop
  cursor is persisted anywhere — the rows are the truth.
- Context. `.Loop{Index, Item, IsFirst, IsLast}`, and the `.Steps`
  visibility rule widens from an index comparison to a positional one, so
  a `break` can read the probe two lines above it while a `parallel`
  group's members stay blind to each other.
- API and TUI. `iteration`/`loop_item` on the wire, a `loop` rollup on
  both task endpoints, `loop 4/10` on the board, and detail-view rows
  grouped by iteration and folded shut with the latest open.

Two decisions are worth restating because they read as omissions: there
is no `while:` (a guard can only read `.Steps`, which the first iteration
has not filled), and there is no `continue` type (a `condition` inside a
body ends that iteration, which is what continue means).