### PR TITLE
fix(gate): make m6's step bodies portable to pwsh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,29 @@ jobs:
       - name: M5 gate (fake agent)
         shell: bash
         run: ./scripts/m5-gate.sh
+
+      # M6: parallel step groups and workflow fan-out (task 014). It runs on
+      # all three OSes because the merge half is where platform differences
+      # actually bite — git's behaviour on Windows is the thing a gate should
+      # prove rather than assume.
+      - name: M6 gate (parallel and fan-out)
+        shell: bash
+        run: ./scripts/m6-gate.sh
+
+      # M7: conditions between steps (task 015). Guards, condition steps and
+      # allow_failure are pure control flow, so the value of the three-OS
+      # matrix here is the shell: every `run:` body is written to be accepted
+      # by /bin/sh and pwsh alike, and Windows is what proves it.
+      - name: M7 gate (conditions)
+        shell: bash
+        run: ./scripts/m7-gate.sh
+
+      # M8: loops (task 016). Every `run:` body is `exit N` or `git …`, the
+      # same restricted vocabulary m7 uses, so the three-OS matrix is proving
+      # the shell as much as the feature. Scenario 8 is the one that most
+      # needs Windows: it hard-kills the daemon and asserts the loop resumes
+      # mid-iteration, and the kill path is `taskkill` there and SIGKILL
+      # everywhere else.
+      - name: M8 gate (loops)
+        shell: bash
+        run: ./scripts/m8-gate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,14 @@ New gate scripts must be committed **executable** (`git update-index
 bit, so a non-executable gate passes on Windows and fails both POSIX legs with
 exit 126 before running an assertion.
 
+A gate's *workflow* `run:` bodies run under the daemon's shell — `/bin/sh` on
+POSIX, `pwsh` on Windows (§8.3) — not under the gate's bash, so they must be
+spelled in the intersection of the two: `exit N`, `sleep N` and `git ...`.
+That excludes `touch`, `seq`, `[ -f ]` and `for`/`if`, and it is why a lane
+that needs a file on disk writes it with `git config -f x k v` and one that
+only needs a commit uses `git commit --allow-empty`. Assert concurrency and
+timing from the API instead of from inside a step body.
+
 Requires bash, go, git, curl, jq.
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ go test -race ./internal/tui -run TestLiveChangeFromRealServer
 ```
 
 Acceptance gates — bash scripts that drive a real daemon end to end over curl
-against the fake agent; CI runs all three on Linux, macOS, and Windows:
+against the fake agent; CI runs every one of them on Linux, macOS and Windows:
 
 ```sh
 ./scripts/m1-gate.sh
@@ -79,11 +79,12 @@ VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CL
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-CI runs `m1`, `m2` and `m5` on all three platforms. `m6`, `m7` and `m8` are not
-wired in: the push token used for this work has no `workflow` scope, so a
-branch touching `.github/workflows` is rejected outright. Adding them is two
-lines each in `ci.yml`'s `gates` job, and all three scripts run identically by
-hand.
+All six run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
+`m8` spent a while unwired because a cloud session's token has no `workflow`
+scope and so cannot write `.github/workflows/` by any route — push or API
+(#120, #122, #125). A gate that has never run on a platform is not known to
+pass there: wiring these in turned up two Windows-only faults in a script that
+had passed on Linux for weeks, both recorded below.
 
 `scripts/m3-gate.sh` seeds a human walkthrough instead of asserting — M3's
 acceptance is a judgement about a TUI. The manual legs of M5 are walked
@@ -105,6 +106,12 @@ as a command named `exit` and fails. A body that must pass or fail on a
 condition is one command whose own exit code says so — `git config --get`
 exits 1 on a missing key. Assert concurrency and timing from the API instead
 of from inside a step body.
+
+In the gate's own bash, a capture spanning **several lines** of `jq` output
+needs `| tr -d '\r'`: jq writes CRLF on Windows, `$(...)` drops only the
+trailing one, and the interior CRs then fail an exact comparison against a
+`$'a\nb'` literal. Single-line captures are unaffected, which is how this hid
+until `m8` compared a list.
 
 Requires bash, go, git, curl, jq.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,12 @@ POSIX, `pwsh` on Windows (§8.3) — not under the gate's bash, so they must be
 spelled in the intersection of the two: `exit N`, `sleep N` and `git ...`.
 That excludes `touch`, `seq`, `[ -f ]` and `for`/`if`, and it is why a lane
 that needs a file on disk writes it with `git config -f x k v` and one that
-only needs a commit uses `git commit --allow-empty`. Assert concurrency and
-timing from the API instead of from inside a step body.
+only needs a commit uses `git commit --allow-empty`. `exit N` has to be the
+*whole* body: pwsh's `&&`/`||` take pipelines, so `... && exit 0` is parsed
+as a command named `exit` and fails. A body that must pass or fail on a
+condition is one command whose own exit code says so — `git config --get`
+exits 1 on a missing key. Assert concurrency and timing from the API instead
+of from inside a step body.
 
 Requires bash, go, git, curl, jq.
 

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -718,6 +718,16 @@ wait on marker files its siblings write, and the lanes that must produce a
 file write it with `git config -f` because `echo >` and `Set-Content` share no
 spelling. Still nine scenarios, still passing on Linux.
 
+*2026-08-18 (later).* #120 applied: the `gates` job runs `m6` on all three
+platforms, and all nine scenarios pass on each (run 32143694231). The Windows
+leg took one more fix first — the rewritten flaky sub-step chained `exit 0`
+after a `&&`, and pwsh's chain operators take pipelines, so `exit` was parsed
+as a command name. It is now a single `git config --get` that exits 1 while
+its marker is absent, with the gate writing the marker before it retries. The
+prediction this note opened with is settled: the merge half of task 014 does
+behave the same on Windows, which is a fact rather than an assumption for the
+first time.
+
 Three bugs the work surfaced, each recorded where it was found:
 
 1. **A resolved lane could not carry both `workflow:` and `steps:`.** They are

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -684,9 +684,12 @@ an `agent:` the policy will never run.
   worktrees until archived.
 - [x] **014.14 — Gate.** ✓ 2026-08-17 Depends: 014.2, 014.9, 014.10. New `scripts/m6-gate.sh`
   covering **both** phases, committed executable via `git update-index --chmod=+x`
-  — a non-executable gate passes on Windows and exits 126 on both POSIX legs —
-  and wired into CI on all three platforms, merge behaviour on Windows being
-  the thing a gate should prove rather than assume. Scenarios: a `parallel`
+  — a non-executable gate passes on Windows and exits 126 on both POSIX legs.
+  The CI wiring did **not** land with it: a cloud session's token has no
+  `workflow` scope, so `.github/workflows/` is unwritable from one, and the
+  step is tracked in #120. Merge behaviour on Windows is the thing the gate
+  exists to prove rather than assume, so hand-running it on Linux is a partial
+  result until that step is added. Scenarios: a `parallel`
   happy path; a failing sub-step; a retry re-running only the failed sub-step;
   happy-path two-lane merge; an induced conflict reaching `merge_conflict`,
   resolved by hand, retried, remaining lanes merged; a crash mid-merge
@@ -702,7 +705,18 @@ an `agent:` the policy will never run.
   for `windows`, `darwin` and `linux` — a host-only lint hides findings in
   build-tagged files.
 - Gates: `m1`, `m2` and `m5` re-run to prove no regression; the new `m6` passes
-  all nine scenarios, and is wired into CI on all three platforms.
+  all nine scenarios on Linux. It is not wired into CI (#120).
+
+*2026-08-18.* `m6`'s `run:` bodies were POSIX-only — `touch`, `seq`, `[ -f ]`
+and a `for` loop, none of which `pwsh` speaks — which only ever stood because
+the gate had never run anywhere but Linux. They now use the same restricted
+vocabulary `m7` and `m8` do (`exit N`, `sleep N`, `git ...`), so the Windows
+leg has a chance of passing the day #120 is applied. Two scenarios changed
+shape rather than spelling: scenario 1 proves the overlap by polling the API
+for three simultaneously-`running` sub-steps instead of having each sub-step
+wait on marker files its siblings write, and the lanes that must produce a
+file write it with `git config -f` because `echo >` and `Set-Content` share no
+spelling. Still nine scenarios, still passing on Linux.
 
 Three bugs the work surfaced, each recorded where it was found:
 

--- a/docs/tasks/015-conditional-steps.md
+++ b/docs/tasks/015-conditional-steps.md
@@ -390,6 +390,11 @@ commit with `--allow-empty` rather than writing a file, because `printf >` and
 `Set-Content` share no spelling. It should pass on all three platforms the day
 someone can wire it in.
 
+*2026-08-18 (later).* It did. #122 applied, and `m7` passed ubuntu, macOS
+**and** Windows on the first CI run that reached it (run 32143694231), with no
+change to the script. `m6` needed two fixes to get there and `m8` one; the
+restricted vocabulary was worth writing to.
+
 ### One decision reversed by implementation
 
 Decision 14 (`condition_error` does not consume the retry budget) reverses the

--- a/docs/tasks/016-workflow-loops.md
+++ b/docs/tasks/016-workflow-loops.md
@@ -517,6 +517,15 @@ push token used for this work has no `workflow` scope, so a branch touching
 Say so in CLAUDE.md's command list beside `m6` and `m7`, so the gap stays
 documented rather than silently carried.
 
+*2026-08-18.* Wired in after all (#125), and green on all three platforms
+(run 32143694231). The `run:` bodies were as portable as claimed — the
+Windows fault was in the gate's **own** bash: `jq` writes CRLF there, and
+while `$(...)` drops the trailing one it keeps the interior ones, so six
+assertions comparing a multi-line capture against a `$'a\nb'` literal failed
+on stray `\r`s. `rows_for` and `items_ran` now end in `tr -d '\r'`. Worth
+knowing that the portability rule has two halves: what the daemon's shell
+accepts, and what the gate's own shell reads back.
+
 **Three things the implementation settled that the plan left open.**
 
 - **`loop_limit` is reachable for `count:` too.** Decision 5 says the cap

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -19,6 +19,15 @@
 # Every scenario uses command steps only, so no agent CLI is involved at all
 # and the gate is as fast on CI as it is locally.
 #
+# The `run:` bodies are restricted to what `/bin/sh` and `pwsh` both accept —
+# `exit N`, `sleep N` and `git ...`, and nothing else, the same rule `m7` and
+# `m8` follow. §8.3 leaves portability to the workflow author, and a gate that
+# runs on all three platforms is that author. This is why a lane that has to
+# produce a file writes it with `git config -f`: `echo > x` and `Set-Content`
+# share no spelling, and `touch` is not a shell builtin anywhere. The original
+# bodies were POSIX-only (`touch`, `seq`, `[ -f ]`), which stood only because
+# the gate was hand-run on Linux until it was wired into CI (#120).
+#
 # Each scenario gets fresh config/data/repo dirs and its own daemon, so one
 # scenario's leftovers cannot reach another's assertions (PR G decision,
 # inherited from m2-gate.sh). VINCENT_GATE_SCENARIO=N runs one scenario.
@@ -142,10 +151,12 @@ run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
 # --------------------------------------------------------------------------
 # Scenario 1: a parallel group runs its sub-steps concurrently.
 #
-# Each sub-step waits for a marker file the others write, with a timeout. If
-# they ran in sequence, the first one would time out waiting for markers that
-# do not exist yet — which is a far stronger statement than a wall-clock
-# comparison, and does not go flaky on a loaded CI runner.
+# The overlap is observed from the API, not from inside the steps: each
+# sub-step only sleeps, and the gate polls until it sees all three `running`
+# at the same instant. Sequential execution tops out at one, so this fails
+# deterministically rather than on a wall-clock comparison — and it keeps the
+# step bodies to a vocabulary `/bin/sh` and `pwsh` both accept, which is what
+# the earlier marker-file version (`touch`, `seq`, `[ -f ]`) did not.
 # --------------------------------------------------------------------------
 if run_scenario 1; then
   echo "=== scenario 1: a parallel group runs concurrently"
@@ -158,32 +169,28 @@ steps:
     type: parallel
     max_parallel: 3
     steps:
-      - id: one
-        type: command
-        max_retries: 0
-        run: |
-          touch one.marker
-          for i in $(seq 1 100); do [ -f two.marker ] && [ -f three.marker ] && exit 0; sleep 0.1; done
-          echo "siblings never started: ran in sequence" >&2; exit 1
-      - id: two
-        type: command
-        max_retries: 0
-        run: |
-          touch two.marker
-          for i in $(seq 1 100); do [ -f one.marker ] && [ -f three.marker ] && exit 0; sleep 0.1; done
-          echo "siblings never started: ran in sequence" >&2; exit 1
-      - id: three
-        type: command
-        max_retries: 0
-        run: |
-          touch three.marker
-          for i in $(seq 1 100); do [ -f one.marker ] && [ -f two.marker ] && exit 0; sleep 0.1; done
-          echo "siblings never started: ran in sequence" >&2; exit 1
+      - {id: one, type: command, max_retries: 0, run: 'sleep 8'}
+      - {id: two, type: command, max_retries: 0, run: 'sleep 8'}
+      - {id: three, type: command, max_retries: 0, run: 'sleep 8'}
 YAML
 )"
   daemon_up
   PID="$(register_project "$REPO")"
   TID="$(create_task "$PID" parallel-ok "parallel happy path")"
+
+  # The eight-second body is the observation window: a one-second poll sees it
+  # several times over, and a sequential run would never show more than one.
+  MAX=0
+  for _ in $(seq 1 90); do
+    BODY="$(api GET "/tasks/$TID")"
+    # `.steps` is null until the group's first attempt rows exist.
+    N="$(jq '[(.steps // [])[] | select(.state == "running")] | length' <<<"$BODY")"
+    if [[ "$N" -gt "$MAX" ]]; then MAX="$N"; fi
+    if [[ "$MAX" == 3 || "$(jq -r .state <<<"$BODY")" == "done" ]]; then break; fi
+    sleep 1
+  done
+  [[ "$MAX" == 3 ]] || fail "sub-steps never overlapped: at most $MAX ran at once, want 3"
+
   wait_for_state "$TID" done 60
 
   RUNS="$(api GET "/tasks/$TID" | jq '[.steps[] | select(.state == "succeeded")] | length')"
@@ -216,16 +223,11 @@ steps:
       - id: flaky
         type: command
         max_retries: 0
-        run: |
-          if [ -f cleared.marker ]; then exit 0; fi
-          touch cleared.marker
-          exit 7
+        run: 'git config -f cleared.marker --get gate.cleared && exit 0 || git config -f cleared.marker gate.cleared 1 && exit 7'
       - id: steady
         type: command
         max_retries: 0
-        run: |
-          sleep 1
-          echo steady > steady.txt
+        run: 'sleep 2'
 YAML
 )"
   daemon_up
@@ -267,10 +269,10 @@ steps:
     lanes:
       - id: api
         steps:
-          - {id: write-api, type: command, max_retries: 0, run: 'echo api > api.txt && git add -A && git commit -qm api'}
+          - {id: write-api, type: command, max_retries: 0, run: 'git config -f api.txt gate.lane api && git add -A && git commit -qm api'}
       - id: docs
         steps:
-          - {id: write-docs, type: command, max_retries: 0, run: 'echo docs > docs.txt && git add -A && git commit -qm docs'}
+          - {id: write-docs, type: command, max_retries: 0, run: 'git config -f docs.txt gate.lane docs && git add -A && git commit -qm docs'}
 YAML
 )"
   daemon_up
@@ -312,10 +314,10 @@ steps:
     lanes:
       - id: left
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo left > shared.txt && git add -A && git commit -qm left'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f shared.txt gate.side left && git add -A && git commit -qm left'}
       - id: right
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo right > shared.txt && git add -A && git commit -qm right'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f shared.txt gate.side right && git add -A && git commit -qm right'}
 YAML
 )"
   daemon_up
@@ -365,10 +367,10 @@ steps:
     lanes:
       - id: left
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo left > shared.txt && git add -A && git commit -qm left'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f shared.txt gate.side left && git add -A && git commit -qm left'}
       - id: right
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo right > shared.txt && git add -A && git commit -qm right'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f shared.txt gate.side right && git add -A && git commit -qm right'}
 YAML
 )"
   daemon_up
@@ -407,7 +409,7 @@ steps:
     lanes:
       - id: leaf
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo leaf > leaf.txt && git add -A && git commit -qm leaf'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f leaf.txt gate.lane leaf && git add -A && git commit -qm leaf'}
 YAML
 )"
   write_workflow outer "$(cat <<'YAML'
@@ -450,7 +452,7 @@ steps:
     lanes:
       - id: quick
         steps:
-          - {id: w, type: command, max_retries: 0, run: 'echo quick > quick.txt && git add -A && git commit -qm quick'}
+          - {id: w, type: command, max_retries: 0, run: 'git config -f quick.txt gate.lane quick && git add -A && git commit -qm quick'}
       - id: slow
         steps:
           - {id: w, type: command, max_retries: 0, run: 'sleep 60'}
@@ -510,9 +512,9 @@ steps:
   - id: f
     type: fan_out
     lanes:
-      - {id: a, steps: [{id: sa, type: command, run: 'true'}]}
-      - {id: b, steps: [{id: sb, type: command, run: 'true'}]}
-      - {id: c, steps: [{id: sc, type: command, run: 'true'}]}
+      - {id: a, steps: [{id: sa, type: command, run: 'exit 0'}]}
+      - {id: b, steps: [{id: sb, type: command, run: 'exit 0'}]}
+      - {id: c, steps: [{id: sc, type: command, run: 'exit 0'}]}
 YAML
 )"
   daemon_up

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -21,7 +21,9 @@
 #
 # The `run:` bodies are restricted to what `/bin/sh` and `pwsh` both accept —
 # `exit N`, `sleep N` and `git ...`, and nothing else, the same rule `m7` and
-# `m8` follow. §8.3 leaves portability to the workflow author, and a gate that
+# `m8` follow. `exit N` may only be the *whole* body: pwsh's `&&` and `||`
+# take pipelines, so an `exit` after one is parsed as a command name and dies
+# with "the term 'exit' is not recognized" (run 32140128084, windows leg). §8.3 leaves portability to the workflow author, and a gate that
 # runs on all three platforms is that author. This is why a lane that has to
 # produce a file writes it with `git config -f`: `echo > x` and `Set-Content`
 # share no spelling, and `touch` is not a shell builtin anywhere. The original
@@ -206,9 +208,12 @@ fi
 # Scenario 2: a failing sub-step blocks the group without cancelling siblings.
 # Scenario 3: the retry re-runs only what failed.
 #
-# The failing sub-step succeeds once a marker exists, so the human retry can
-# clear it — and the sibling's attempt count is what proves the retry did not
-# re-run work that had already succeeded.
+# The failing sub-step is one `git config --get`, which exits 1 while its
+# marker file is absent and 0 once it is there. The gate writes that marker
+# into the worktree before retrying, the way scenario 5 resolves its conflict
+# — a human clearing the fault is what a retry means here. The sibling's
+# attempt count is what proves the retry did not re-run work that had already
+# succeeded.
 # --------------------------------------------------------------------------
 if run_scenario 2; then
   echo "=== scenario 2+3: a failing sub-step blocks, and the retry re-runs only it"
@@ -223,7 +228,7 @@ steps:
       - id: flaky
         type: command
         max_retries: 0
-        run: 'git config -f cleared.marker --get gate.cleared && exit 0 || git config -f cleared.marker gate.cleared 1 && exit 7'
+        run: git config -f cleared.marker --get gate.cleared
       - id: steady
         type: command
         max_retries: 0
@@ -241,6 +246,13 @@ YAML
   # The sibling ran to completion: a failure does not cancel it (decision 18).
   STEADY="$(jq -r '[.steps[] | select(.step_id == "steady" and .state == "succeeded")] | length' <<<"$BODY")"
   [[ "$STEADY" == 1 ]] || fail "the sibling did not finish (succeeded rows: $STEADY)"
+
+  # Clear the fault by hand, then retry: `git config -f` writes the marker
+  # byte-identically on every platform, where `touch` exists on none of the
+  # shells that matter.
+  WT="$(jq -r .worktree_path <<<"$BODY")"
+  [[ -f "$WT/.git" || -d "$WT/.git" ]] || fail "no worktree left to clear the fault in"
+  git config -f "$WT/cleared.marker" gate.cleared 1
 
   api POST "/tasks/$TID/retry" '{}' >/dev/null
   wait_for_state "$TID" done 60

--- a/scripts/m8-gate.sh
+++ b/scripts/m8-gate.sh
@@ -132,10 +132,14 @@ run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
 
 steps_json() { api GET "/tasks/$1/steps"; }
 
-# rows_for prints "ITERATION STATE" for every attempt of one body step,
-# oldest first.
+# `tr -d '\r'` on every helper below that prints more than one line: jq writes
+# CRLF on Windows, and while `$(...)` in MSYS bash drops the trailing one, the
+# interior ones survive and make an exact multi-line comparison fail against a
+# `$'a\nb'` literal. Single-line captures are unaffected, which is why every
+# other gate has always passed there and only these assertions did not.
 rows_for() { # rows_for TASK_ID STEP_ID
-  steps_json "$1" | jq -r --arg s "$2" '.[] | select(.step_id == $s) | "\(.iteration) \(.state)"'
+  steps_json "$1" | jq -r --arg s "$2" '.[] | select(.step_id == $s) | "\(.iteration) \(.state)"' \
+    | tr -d '\r'
 }
 
 # iterations_ran is how many distinct iterations the loop produced rows for.
@@ -146,7 +150,8 @@ iterations_ran() { # iterations_ran TASK_ID
 # items_ran prints the for_each item of each iteration, in iteration order.
 items_ran() { # items_ran TASK_ID
   steps_json "$1" | jq -r '[.[] | select(.loop_item != null)]
-    | group_by(.iteration) | sort_by(.[0].iteration) | .[] | .[0].loop_item'
+    | group_by(.iteration) | sort_by(.[0].iteration) | .[] | .[0].loop_item' \
+    | tr -d '\r'
 }
 
 step_field() { # step_field TASK_ID STEP_ID FIELD


### PR DESCRIPTION
`scripts/m6-gate.sh` wrote its workflow `run:` bodies in POSIX shell —
`touch`, `seq`, `[ -f ]`, `for`/`if` — but a workflow's command steps run
under the daemon's shell, which is `pwsh` on Windows (§8.3). The gate has
only ever been hand-run on Linux, so nothing caught it; wiring it into CI
(#120) would have failed the Windows leg on the merge half of task 014,
which is the half the gate exists to prove.

The bodies now use the intersection m7 and m8 already restrict themselves
to — `exit N`, `sleep N`, `git ...`. Two scenarios changed shape rather
than spelling:

- Scenario 1 proved concurrency by having each sub-step poll for marker
  files its siblings wrote. It now sleeps, and the gate polls the API for
  three simultaneously-`running` sub-steps. Sequential execution tops out
  at one, so the assertion is still deterministic, and the step bodies
  become one word.
- Lanes that must leave a file behind write it with `git config -f`
  rather than `echo >`: same file, same add/add conflict in scenario 5,
  identical bytes on every platform.

All nine scenarios pass on Linux. The Windows and macOS legs remain
unproven until #120 can be applied.