### PR TITLE
docs: restructure the workflow guide and correct schema errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Three things to know about the Cursor adapter specifically:
   deliberate: a restricted mode that quietly isn't restricted is worse than
   none.
 
-Four ready-to-copy workflows ship in [`examples/`](examples);
+Five ready-to-copy workflows ship in [`examples/`](examples);
 [Writing workflows](docs/guides/workflows.md) is the authoring guide and
 [Agent CLIs](docs/guides/agents.md) covers the adapters in full.
 
@@ -318,7 +318,8 @@ vincent workflow ls --project 1  # add this project's own .vincent/workflows
 `feature-pr` runs an agent, checks that the result still builds and passes
 tests, stops at a human gate, and pushes only after you approve. The others
 are [`fix-and-test`](examples/fix-and-test.yaml) (write a failing test, then
-fix it), [`docs-update`](examples/docs-update.yaml), and
+fix it), [`converge`](examples/converge.yaml) (loop until the suite is green),
+[`docs-update`](examples/docs-update.yaml), and
 [`cursor-review`](examples/cursor-review.yaml).
 
 Its check is `go build ./... && go test ./...`, so open the file and change

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ whole system is built from, then walk the
 
 | Page | What it covers |
 |---|---|
-| [Writing workflows](guides/workflows.md) | The authoring guide: step types, checks, templates, retries, permission modes |
+| [Writing workflows](guides/workflows.md) | The authoring guide, in 14 sections: the eight step types, control flow, templates, checks, retries, agents, portability |
 | [Agent CLIs](guides/agents.md) | Claude Code, Codex and Cursor: installing, authenticating, and what each one can and cannot do |
 | [Using the TUI](guides/tui.md) | The board, task detail, the four takeover screens, every key |
 | [Scripting vincent](guides/scripting.md) | `--json`, exit codes, and driving the API directly from a script or CI |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -91,7 +91,7 @@ Add `--project <id>` — without it you see built-in and global scopes only.
 Because a `check` disagreed. An agent reporting success is a claim; a build is a
 fact. `check_failed` is the healthy, common failure: read the transcript, then
 press `E` to edit the prompt and retry. See
-[Checks](guides/workflows.md#checks-are-how-you-stop-an-agent-grading-its-own-homework).
+[Checks](guides/workflows.md#7-verification-with-check).
 
 ### A task is stuck in `queued`
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -77,7 +77,7 @@ The task moves to `awaiting_input`, keeps its concurrency slot, and pauses the
 step's timeout clock. Answer from the TUI popup or
 `POST /v1/tasks/{id}/answer`; the run resumes where it stopped. Set
 `on_input: deny` on a workflow that must stay unattended — see
-[Writing workflows → mid-run questions](workflows.md#mid-run-questions).
+[Writing workflows → mid-run questions](workflows.md#94-mid-run-questions-on_input).
 
 Input support is **version-gated** to the CLI family vincent has verified
 against real captured runs. Outside that range the adapter reports

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,141 +1,587 @@
 # Writing workflows
 
-A workflow is a YAML file describing an ordered list of steps. Every task runs
-one, in its own git worktree on its own branch. This guide is the practical
-companion to [spec §8](../spec.md), which is the normative reference
-when the two disagree; the field-by-field version is the
-[workflow schema](../reference/workflow-schema.md).
+A **workflow** is a YAML file describing an ordered list of steps. Every task
+runs exactly one, in its own git worktree on its own branch, and the daemon is
+what runs it.
 
-Four ready-to-copy workflows live in [`examples/`](../../examples). Start there.
+This page is the practical guide: what to write, in what order, and why the
+schema is shaped the way it is. Two companions sit beside it:
 
-- [Where files live](#where-files-live)
-- [The shape of a file](#the-shape-of-a-file)
-- [Five step types](#five-step-types)
-- [Parallel verification](#verification-is-where-parallel-pays)
-- [Fan-out](#fan-out-is-for-deliverables-that-are-several-disjoint-pieces)
-- [Checks](#checks-are-how-you-stop-an-agent-grading-its-own-homework)
-- [Templates](#templates)
-- [Retries and timeouts](#retries-and-timeouts)
-- [Choosing an agent](#choosing-an-agent)
-- [Permission modes](#permission-modes)
-- [Mid-run questions](#mid-run-questions)
-- [Writing portable command steps](#writing-portable-command-steps)
-- [Patterns that work](#patterns-that-work)
-- [A checklist before you commit one](#a-checklist-before-you-commit-one)
+| Document | Use it for |
+|---|---|
+| [Workflow schema](../reference/workflow-schema.md) | Every field, every default, in tables |
+| [spec §7–§8](../spec.md) | The normative definition — authoritative when this page and it disagree |
+
+Five ready-to-copy files live in [`examples/`](../../examples). If you would
+rather read one working workflow than a guide, start with
+[`feature-pr.yaml`](../../examples/feature-pr.yaml) and come back here for the
+parts you want to change.
 
 ---
 
-## Where files live
+## Contents
 
-| Scope | Location | Wins |
+**Getting started**
+
+- [1. Before you start](#1-before-you-start) — [1.1 What a workflow is](#11-what-a-workflow-is) · [1.2 Where files live](#12-where-workflow-files-live) · [1.3 Validating](#13-validating-a-file) · [1.4 Live reload](#14-live-reload)
+- [2. Your first workflow](#2-your-first-workflow) — [2.1 Minimum file](#21-the-minimum-viable-file) · [2.2 Add a check](#22-add-a-check) · [2.3 Add a gate](#23-add-a-gate) · [2.4 Run it](#24-run-it)
+
+**The file**
+
+- [3. File anatomy](#3-file-anatomy) — [3.1 Top-level keys](#31-top-level-keys) · [3.2 `defaults`](#32-defaults) · [3.3 Steps and ids](#33-steps-and-ids) · [3.4 What a step inherits](#34-what-a-step-inherits)
+- [4. The eight step types](#4-the-eight-step-types) — [4.1 Choosing](#41-choosing-a-step-type) · [4.2 `agent`](#42-agent) · [4.3 `command`](#43-command) · [4.4 `manual`](#44-manual) · [4.5 `parallel`](#45-parallel) · [4.6 `fan_out`](#46-fan_out) · [4.7 `condition`](#47-condition) · [4.8 `loop`](#48-loop) · [4.9 `break`](#49-break) · [4.10 Nesting rules](#410-where-each-type-may-appear)
+
+**Making steps talk to each other**
+
+- [5. Templates and data flow](#5-templates-and-data-flow) — [5.1 Template fields](#51-which-fields-are-templates) · [5.2 The context](#52-the-template-context) · [5.3 Step to step](#53-passing-one-steps-output-to-the-next) · [5.4 Task fields](#54-task-fields) · [5.5 Environment](#55-environment-variables)
+- [6. Control flow](#6-control-flow) — [6.1 `if:`](#61-if--skip-a-step-and-carry-on) · [6.2 `allow_failure:`](#62-allow_failure--a-failure-that-is-data) · [6.3 `condition`](#63-condition--finish-early-and-succeed) · [6.4 Loops in depth](#64-loops-in-depth) · [6.5 Guard recipes](#65-guard-recipes)
+
+**Making it reliable**
+
+- [7. Verification with `check`](#7-verification-with-check) — [7.1 Why](#71-why-every-writing-step-wants-one) · [7.2 How it runs](#72-how-a-check-runs) · [7.3 Inverted](#73-inverting-a-check) · [7.4 Limits](#74-what-a-check-is-not)
+- [8. Failure, retries and timeouts](#8-failure-retries-and-timeouts) — [8.1 Success](#81-what-counts-as-success) · [8.2 Retries](#82-retries) · [8.3 Timeouts](#83-timeouts) · [8.4 Running out](#84-when-a-step-runs-out-of-attempts) · [8.5 Interruption](#85-interruption-is-not-failure)
+- [9. Agents, models and permissions](#9-agents-models-and-permissions) — [9.1 Resolution](#91-resolution-order) · [9.2 Adapters](#92-what-each-adapter-can-do) · [9.3 Permission modes](#93-permission-modes) · [9.4 Mid-run questions](#94-mid-run-questions-on_input)
+- [10. Portability](#10-portability) — [10.1 Shells](#101-which-shell-runs-a-command-step) · [10.2 Portable commands](#102-writing-portable-command-steps) · [10.3 `platforms:`](#103-platforms--declare-what-you-did-not-port) · [10.4 Per-step gates](#104-gating-one-step-by-platform)
+- [11. Concurrency, cost and limits](#11-concurrency-cost-and-limits)
+
+**Shipping**
+
+- [12. Patterns that work](#12-patterns-that-work)
+- [13. Reviewing a workflow before you commit it](#13-reviewing-a-workflow-before-you-commit-it)
+- [14. Troubleshooting](#14-troubleshooting)
+
+---
+
+# Getting started
+
+## 1. Before you start
+
+### 1.1 What a workflow is
+
+A workflow is a **recipe**, not a script. It describes steps; the daemon
+decides when they run, retries them, times them out, records every attempt, and
+survives its own restart mid-step. You write what should happen; vincent owns
+how.
+
+Three properties are worth internalising before you write one, because the
+schema follows from them:
+
+1. **One task, one worktree, one branch.** Every step of a run sees the same
+   working tree, and what a step leaves on disk is what the next step finds.
+   State flows through the filesystem and through `{{.Steps}}`, never through a
+   shared agent conversation.
+2. **Every agent step is a fresh session.** Nothing is resumed between steps or
+   between attempts. If step 3 needs to know what step 1 found, step 1's result
+   has to be in the prompt — see [§5.3](#53-passing-one-steps-output-to-the-next).
+3. **A step that runs out of attempts blocks the task.** Nothing is silently
+   abandoned; a human is asked. That is why `check:`
+   ([§7](#7-verification-with-check)) is worth writing: it decides what "the
+   step worked" means.
+
+### 1.2 Where workflow files live
+
+| Scope | Location | Precedence |
 |---|---|---|
-| Project | `.vincent/workflows/*.yaml` inside the repo | ✅ shadows global |
-| Global | `{config_dir}/workflows/*.yaml` | |
-| Built-in | `adhoc` — one agent step, always available | |
+| **Project** | `.vincent/workflows/*.yaml` inside the repo | Highest — shadows global |
+| **Global** | `{config_dir}/workflows/*.yaml` | Shadows built-in |
+| **Built-in** | `adhoc` — one agent step, always present | Lowest |
 
 `{config_dir}` is `%APPDATA%\vincent` on Windows, `~/Library/Application
-Support/vincent` on macOS, `~/.config/vincent` on Linux (the full table is in
-[Files and directories](../reference/files.md)). `vincent workflow ls` shows the
-merged registry with its scope badges; add `--project <id>` to include that
-repository's own files.
+Support/vincent` on macOS and `~/.config/vincent` on Linux; the full table is in
+[Files and directories](../reference/files.md).
 
-The daemon watches both directories and reloads on save — there is no restart
-and no "apply" step. A file that fails to parse is reported as invalid and the
-previously loaded version keeps running.
+Details that matter in practice:
 
-Check a file before the daemon does:
+- Both `.yaml` and `.yml` are read, from the directory itself — **not**
+  recursively, so a `subdir/` inside `workflows/` is ignored.
+- Workflows are addressed by their `name:` field, not by filename. A file named
+  `ci.yaml` declaring `name: feature-pr` is the workflow `feature-pr`.
+  Keeping the two the same is a convention worth following, not a rule.
+- **Shadowing is per name.** A project file named `adhoc` replaces the built-in
+  for that project only.
+- Two files in **one scope** declaring the same `name:` is an error, resolved
+  deterministically: the first in filename order keeps the name, and the loser
+  is listed as invalid rather than silently dropped.
+
+`vincent workflow ls` prints the merged registry with a scope badge per entry;
+`--project <id>` includes that repository's own files.
+
+### 1.3 Validating a file
 
 ```sh
 vincent workflow validate .vincent/workflows/feature-pr.yaml
 ```
 
-That runs locally: no daemon, no network, no agent CLI installed. It is meant
-for pre-commit hooks and CI.
+This runs **entirely locally**: no daemon, no network, no agent CLI installed.
+That is deliberate, so it works in a pre-commit hook and in CI. It exits 1 on an
+invalid file and prints `line N: path: message` for each finding.
+
+Two things it uses local stand-ins for, because it cannot ask a daemon:
+
+- **Agent catalogs** are the curated, compiled-in ones rather than whatever a
+  live `claude --help` reports. Probing only ever *adds* values, so a verdict
+  can soften on a real daemon but never harden.
+- **The loop ceiling** is the built-in default (10), not your `config.yaml`. A
+  workflow that validates on your laptop has to validate on a CI runner with no
+  config file at all.
+
+Add `--json` for machine-readable findings.
+
+### 1.4 Live reload
+
+The daemon watches both workflow directories and reloads on save. There is no
+restart and no "apply" step.
+
+- A file that fails to parse is **reported as invalid and kept visible**; the
+  previously loaded version keeps running.
+- Editing a workflow never affects a task already created from it. A task
+  captures the file's source as its **snapshot** at creation, so an in-flight
+  or historical run is immutable. Fixing a file fixes the *next* task — to fix
+  a blocked one, use `edit + retry`, which rewrites the step inside that task's
+  own snapshot.
 
 ---
 
-## The shape of a file
+## 2. Your first workflow
+
+### 2.1 The minimum viable file
 
 ```yaml
-name: feature-pr                 # required; how tasks refer to it
-description: One line, shown in the picker.
+name: tidy
+description: Run the formatter and commit the result.
 
-defaults:                        # optional; every step inherits these
+steps:
+  - id: format
+    type: command
+    run: gofmt -w .
+
+  - id: commit
+    type: command
+    run: 'git add -A && git commit -m "chore: gofmt" --allow-empty'
+```
+
+That is a valid workflow: a `name`, and a non-empty `steps` list where every
+step has a unique `id` and a `type`. Save it as
+`.vincent/workflows/tidy.yaml` and it is available to that repo's tasks within
+a second.
+
+### 2.2 Add a check
+
+An agent step succeeds when its process exits 0 and its event stream reports no
+error. That is the *agent's* claim about its own work. A `check:` turns it into
+something a machine verifies:
+
+```yaml
+name: tidy
+description: Fix the lint findings, and prove it.
+
+steps:
+  - id: fix
+    type: agent
+    prompt: |
+      Fix every finding reported by `golangci-lint run` in this repository.
+      Do not disable a linter or add a nolint directive to silence one.
+    check: go build ./... && golangci-lint run
+
+  - id: commit
+    type: command
+    run: 'git add -A && git commit -m "fix: lint findings" --allow-empty'
+```
+
+If the check fails, the attempt fails, and the retry gets the failure appended
+to its prompt automatically. That loop — write, verify, be told exactly what
+broke, try again — is most of the value of running an agent under a workflow
+rather than by hand.
+
+### 2.3 Add a gate
+
+Anything that leaves the machine belongs behind a human:
+
+```yaml
+  - id: review
+    type: manual
+    instructions: |
+      Read the diff for task #{{.Task.ID}} on branch {{.Task.BranchName}}.
+      Approve to push.
+
+  - id: publish
+    type: command
+    run: git push -u origin {{.Task.BranchName}}
+    max_retries: 0
+```
+
+The task parks in `awaiting_gate` and **releases its concurrency slot** while it
+waits, so a workflow waiting on you is not occupying a runner.
+
+### 2.4 Run it
+
+```sh
+vincent workflow validate .vincent/workflows/tidy.yaml
+vincent task add --project 1 --workflow tidy --title "Clear the lint backlog"
+```
+
+or press `n` in the TUI and pick it from the workflow list. Follow it with
+`vincent task show <id>`, or open the TUI's detail view for live output.
+
+---
+
+# The file
+
+## 3. File anatomy
+
+### 3.1 Top-level keys
+
+```yaml
+name: feature-pr                 # required — how tasks refer to it
+description: One line, shown in the picker.
+platforms: [posix]               # optional — where this file may run (§10.3)
+
+defaults:                        # optional — inherited by every step
   agent: claude
   max_retries: 2
   timeout: 45m
 
-steps:                           # required; runs in order, top to bottom
-  - id: implement                # required, unique within the file
-    type: agent                  # agent | command | manual
+steps:                           # required, non-empty — runs top to bottom
+  - id: implement
+    type: agent
     prompt: |
-      Do the thing.
+      Implement {{.Task.Title}}.
 ```
 
-Unknown keys are rejected rather than ignored, so a typo is an error at
-validation time instead of a setting that silently never applied.
+| Key | Required | Notes |
+|---|---|---|
+| `name` | ✅ | Unique per scope. No whitespace and no `/` or `\` |
+| `description` | | One line; shown in the TUI picker and `vincent workflow ls` |
+| `platforms` | | Empty means anywhere — [§10.3](#103-platforms--declare-what-you-did-not-port) |
+| `defaults` | | Workflow-wide fallbacks — [§3.2](#32-defaults) |
+| `steps` | ✅ | Runs strictly in order |
 
-## Eight step types
+**Unknown keys are errors, not ignored.** A misspelled `max_reties:` fails
+validation instead of becoming a setting that silently never applied. The same
+is true of a field on the wrong step type: `run:` on an agent step is an error,
+not a hint.
 
-**`agent`** runs an agent CLI headlessly in the worktree. Needs `prompt`.
+### 3.2 `defaults`
+
+`defaults:` holds workflow-wide fallbacks. Every key in it is also settable per
+step, where the step wins.
+
+| Key | Applies to | Falls back to |
+|---|---|---|
+| `agent` | agent steps | the daemon's configured default |
+| `model` | agent steps | the adapter's own default |
+| `effort` | agent steps | the adapter's own default (cursor has none) |
+| `permission_mode` | agent steps | `full-auto` |
+| `on_input` | agent steps | `wait` |
+| `input_timeout` | agent steps | `defaults.input_timeout` in config — 24h |
+| `max_retries` | all steps | `1` |
+| `timeout` | all steps | `defaults.agent_timeout` (60m) or `defaults.command_timeout` (15m) in config |
+
+Durations are Go duration strings: `90s`, `45m`, `1h30m`. A bare number is a
+validation error.
+
+Three deliberate absences:
+
+- **`check` is not in `defaults`.** A check is specific to what a step produced;
+  a workflow-wide one would run after steps it makes no sense for.
+- **`shell` and `env` are not in `defaults`.** They belong to command steps, and
+  a file-wide shell pin hides which steps actually need it.
+- **`allow_failure` is not in `defaults`** ([§6.2](#62-allow_failure--a-failure-that-is-data)).
+  A file-wide "failures do not block" is a footgun; it should cost one line per
+  step that wants it.
+
+### 3.3 Steps and ids
+
+Every step needs an `id` and a `type`. Ids are slugs: lowercase letters,
+digits, `-`, `_` and `.`, starting with a letter or digit.
+
+Ids are the file's public surface — they are how `{{.Steps}}` addresses a
+result, how a transcript file is named, and how the TUI labels a row. Two rules
+follow:
+
+- **Ids are unique across the whole file**, including sub-steps of a `parallel`
+  group and body steps of a `loop`. Those share their structure step's index
+  and are told apart by id alone.
+- **A lane's inline steps have their own namespace**, because each lane becomes
+  a separate task with its own flat snapshot ([§4.6](#46-fan_out)).
+
+`name:` is an optional display name and defaults to the id.
+
+### 3.4 What a step inherits
+
+Reading top to bottom, a value on an agent step resolves like this:
+
+```
+step field  →  task-level override (chosen at creation)  →  defaults:  →  adapter default
+```
+
+with one refinement: **`model` and `effort` only inherit from a level whose
+resolved agent matches the step's.** Switching agent without setting them resets
+them to the new adapter's default rather than leaking a claude alias onto a
+codex step. The full rules are in [§9.1](#91-resolution-order).
+
+---
+
+## 4. The eight step types
+
+### 4.1 Choosing a step type
+
+| You want to… | Type |
+|---|---|
+| Have an agent write, edit or review code | [`agent`](#42-agent) |
+| Run a build, test, lint or git command | [`command`](#43-command) |
+| Stop and wait for a person | [`manual`](#44-manual) |
+| Run several independent verifications at once, in one worktree | [`parallel`](#45-parallel) |
+| Split one deliverable into disjoint pieces, each on its own branch | [`fan_out`](#46-fan_out) |
+| Finish the run early, successfully | [`condition`](#47-condition) |
+| Repeat a sequence until it converges, or once per item | [`loop`](#48-loop) |
+| End the enclosing loop | [`break`](#49-break) |
+
+`check` is a **field** on agent and command steps, not a type of its own
+([§7](#7-verification-with-check)). Four types — `parallel`, `fan_out`, `loop`
+and `condition`/`break` — are *structure*: they organise other steps rather than
+running anything themselves.
+
+### 4.2 `agent`
+
+Runs an agent CLI headlessly in the worktree. Requires `prompt`.
 
 ```yaml
   - id: implement
     type: agent
     agent: claude                # else defaults.agent, else the daemon default
-    model: sonnet                # optional; adapter-native
-    effort: high                 # optional; not all adapters have one
+    model: sonnet                # optional; adapter-native id or alias
+    effort: high                 # optional; cursor has no effort concept
     permission_mode: full-auto   # full-auto (default) | restricted
+    on_input: wait               # wait (default) | deny | require
     prompt: |
       Implement {{.Task.Title}}.
+
+      {{.Task.Description}}
+    check: go build ./... && go test ./...
+    check_timeout: 15m
 ```
 
-**`command`** runs a shell command in the worktree. Needs `run`.
+**Succeeds when** the process exits 0, **and** the event stream produced a
+terminal result rather than an error, **and** any declared `check` exits 0.
+
+Agent steps do **not** take `run`, `shell`, `env` or `instructions` — those
+belong to other types, and setting one is a validation error rather than a
+silently ignored key.
+
+### 4.3 `command`
+
+Runs a shell command in the worktree. Requires `run`.
 
 ```yaml
   - id: commit
     type: command
     run: 'git add -A && git commit -m "{{.Task.Title}}"'
-    shell: bash                  # optional pin; default is the platform's
+    shell: sh                    # optional pin: sh | pwsh | cmd
     env:
       CI: "true"
+    check: git log -1 --format=%s
 ```
 
-**`manual`** stops and waits for a person. Needs `instructions`.
+**Succeeds when** the command exits 0 **and** any declared `check` exits 0.
+
+The rendered `run` string is handed to one shell as a single script, so shell
+syntax — `&&`, pipes, redirection — works, subject to which shell you get
+([§10.1](#101-which-shell-runs-a-command-step)). `shell:` accepts exactly `sh`,
+`pwsh` or `cmd`; `bash` is not a value.
+
+Command steps do not take `prompt`, `agent`, `model`, `effort`,
+`permission_mode`, `on_input` or `instructions`.
+
+> **Quote a `run:` that contains a colon.** `run: git commit -m "fix: thing"` is
+> a YAML parse error, not a command — the parser sees `fix:` as a second mapping
+> key. Wrap the whole value in single quotes, or use a block scalar:
+>
+> ```yaml
+>     run: 'git commit -m "fix: thing"'
+>     run: >-
+>       git commit -m "fix: thing"
+> ```
+
+### 4.4 `manual`
+
+Stops and waits for a person. Requires `instructions`.
 
 ```yaml
   - id: review
     type: manual
     instructions: |
       Read the diff for #{{.Task.ID}} before it ships.
+      Reject if any test was weakened rather than fixed.
 ```
 
-**`parallel`** runs several sub-steps at once, in the same worktree. Needs
+The task enters `awaiting_gate` and **releases its concurrency slot** — the
+actor goroutine ends, and the task is re-admitted when a human acts. Approving
+advances to the next step; rejecting blocks the task with reason `rejected`.
+
+`instructions` is a template, so a gate can tell the reviewer what they are
+looking at. A manual step takes no `check`, no agent fields, and no
+`allow_failure` — there is no failure of its own to allow. It *may* carry an
+`if:` guard, which is how a gate becomes conditional.
+
+### 4.5 `parallel`
+
+Runs its sub-steps at the same time, in the task's **one** worktree. Requires
 `steps`.
 
 ```yaml
   - id: verify
     type: parallel
-    max_parallel: 4
+    max_parallel: 4              # default: parallel.max_parallel (4)
+    timeout: 30m                 # bounds the whole group
     steps:
       - { id: test,      type: command, run: go test ./... }
       - { id: lint,      type: command, run: golangci-lint run }
       - { id: typecheck, type: command, run: go vet ./... }
 ```
 
-**`fan_out`** turns each lane into a real child task and merges their branches
-back into this task's own. Needs `lanes`.
+Verification is what this is for. Tests, a linter and a type check do not
+interact — they read the tree and report an exit code. In sequence they cost the
+sum of three waits; in a group they cost the longest.
+
+**The group is one step**: one index, one concurrency slot, one entry in the
+timeline, one thing to retry.
+
+- It succeeds when **every** sub-step succeeds.
+- A failure does **not** cancel the others. The group waits for everything it
+  started, then blocks with the first failure in declaration order — so you get
+  all three verdicts, not just the first bad one.
+- A retry re-runs **only what failed**, including after a human retry. A passing
+  test suite is not re-run because the linter was unhappy.
+
+Sub-steps are ordinary `agent` and `command` steps with their own `check`,
+`timeout`, `max_retries`, `if:` and agent selection, resolved exactly as at the
+top level. They may not be any other type — see
+[§4.10](#410-where-each-type-may-appear).
+
+> **Sub-steps share one working tree.** Two of them writing the same file is a
+> bug in your workflow. vincent isolates worktrees between *tasks*, not
+> processes inside one task.
+
+> **`max_parallel` is not covered by your concurrency caps.** Those count tasks
+> ([§11](#11-concurrency-cost-and-limits)); the whole group lives inside one.
+> A board showing "1 running" can be a machine running four compilers. Size it
+> for the hardware.
+
+### 4.6 `fan_out`
+
+Turns each lane into a **real child task** — its own worktree, branch, slot,
+gates, retries and transcripts — then merges those branches back into this
+task's own. Requires `lanes`.
 
 ```yaml
   - id: build
     type: fan_out
+    merge:
+      on_conflict: block         # block (default) | agent
     lanes:
-      - { id: api,  workflow: implement-module, fields: { module: api } }
-      - { id: docs, steps: [ { id: write, type: agent, prompt: "Document the API." } ] }
+      - id: api
+        workflow: implement-module      # a registry workflow…
+        fields: { module: api }
+      - id: docs
+        steps:                          # …or inline steps
+          - { id: write, type: agent, prompt: "Document the API." }
 ```
 
-**`condition`** ends the workflow when its guard is false. Needs `if:`, and
-takes nothing else.
+Use it when one deliverable has parts with no reason to wait for each other —
+two modules that do not touch, or code in one place and docs in another. A
+single task cannot do that: it has one worktree, one branch and one cursor.
+
+**A lane** carries `id` plus exactly one of `workflow` or `steps`, and
+optionally:
+
+| Key | Meaning |
+|---|---|
+| `if` | Guard. False means this lane is not spawned; siblings still run and the join still happens |
+| `fields` | Merged over the parent task's fields, the lane winning |
+| `agent` / `model` / `effort` | Override the inherited selection for this lane's whole subtree |
+| `priority` | Same, for scheduler priority |
+
+**What a lane inherits.** Its **base branch is the parent's branch**, which is
+how the work lands where it belongs. Priority and the agent overrides propagate
+too: a fan-out inside an urgent task would otherwise queue behind unrelated work
+and make the urgent task *slower* than not fanning out.
+
+**Nesting.** A lane's workflow may itself contain a `fan_out`, to any depth. The
+bounds are `fan_out.max_depth` (3) and `fan_out.max_tasks` (64), both checked
+when the task is created — a cycle or an oversized tree is a `400` naming what
+is wrong, not something you discover as two hundred worktrees. Guarded lanes
+count toward those limits, because a guard is evaluated at run time and the
+limits are enforced before that.
+
+**How the step runs.** Spawning parks the parent in `awaiting_children` and
+releases its slot; the scheduler brings it back once every descendant has
+settled, and that second admission runs the join. Lanes are merged `--no-ff`,
+one at a time, in **declared** order, stopping at the first conflict. You still
+get one branch to review.
+
+Watch the children with `vincent task ls --include-children`, or press `L` on
+the parent in the TUI. They are hidden from the board by default; the parent's
+`awaiting_children (2 blocked)` summary is how you learn one of them needs you.
+
+**When every lane is guarded off**, the step chooses nothing and simply
+advances. A fan-out whose conditions all said "not this time" decided
+correctly.
+
+#### `merge` and conflicts
+
+| Key | Values | Notes |
+|---|---|---|
+| `on_conflict` | `block` (default) \| `agent` | |
+| `agent` | an agent step | Required by, and only valid with, `on_conflict: agent` |
+
+**`block`** stops the task with `merge_conflict` and leaves the worktree
+conflicted, so you resolve it in place, stage the files, and retry — the join
+commits your resolution and merges what is left. That is the default
+deliberately: an agent silently resolving a semantic conflict, with the merge
+commit landing unread, is the one outcome that turns a time-saving feature into
+a correctness liability.
+
+**`agent`** tries an agent resolution first. It is an ordinary agent step —
+same fields, same validation, same executor — run in the parent's worktree, and
+the conflicted files are in its context as `{{.Conflicts}}`. If it fails, or its
+check fails, or conflict markers survive it, you get the same block.
+
+```yaml
+    merge:
+      on_conflict: agent
+      agent:
+        id: resolve
+        prompt: |
+          Resolve the merge conflict in:
+          {{ range .Conflicts }}- {{ . }}
+          {{ end }}
+          Keep both sides' intent. Do not delete a test to make it merge.
+        check: go build ./... && go test ./...
+```
+
+A merge resolver may not declare `on_input: require`: it runs mid-join, and the
+worktree state it is resolving is not something a human can inspect through a
+question.
+
+**If a lane is cancelled or ends without finishing**, the join blocks with
+`lane_failed` and merges **nothing**. Fix the lane — it is an ordinary task, so
+retry it — then retry the parent. There is deliberately no "merge the rest
+anyway": a partial merge looks exactly like a complete one to everything
+downstream.
+
+> **A fan-out fills your caps, it does not exceed them.** Every lane is a task
+> competing for `max_parallel_tasks`. What it buys is parallelism you would
+> otherwise start by hand.
+
+> **N lanes leave N worktrees** on disk until someone archives the tree.
+> `vincent gc` and `vincent doctor` exist for this, and you will meet it early
+> if you fan out routinely.
+
+### 4.7 `condition`
+
+A step whose entire body is a guard. True continues; **false ends the run and
+the task is `done`**. Requires `if:`, and takes nothing else.
 
 ```yaml
   - id: nothing-to-do
@@ -143,30 +589,269 @@ takes nothing else.
     if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
 ```
 
-**`loop`** runs its body over and over in the same worktree, a fixed number of
-times or once per item in a list. Needs `steps` and exactly one of `count:` /
-`for_each:`.
+It takes no `run`, no `timeout`, no `max_retries` and no `allow_failure`,
+because it starts no process: there is nothing to time out, retry, or allow to
+fail.
+
+The steps after it are never considered and record nothing. The one row it
+leaves is in state `stopped`, which is where the detail view shows the run
+ended.
+
+There is deliberately no "stop and block for a human" variant, because you
+already have one: a `command` step that exits nonzero. What `condition` adds is
+*stop and succeed*.
+
+A `condition` in **last** position is a warning, not an error — the task is
+`done` whether it continues or stops, so the step cannot do anything a missing
+step would not.
+
+### 4.8 `loop`
+
+Runs its body — a **sequence** — repeatedly, in the task's one worktree.
+Requires `steps` and exactly one of `count:` / `for_each:`.
+
+Where a `parallel` group is a set run once, a loop is a sequence run more than
+once. It produces no branch, no child task and nothing to merge; that is
+`fan_out`.
 
 ```yaml
   - id: green
     type: loop
-    count: 5
+    count: 5                     # or: for_each: […]
+    max_iterations: 10           # optional ceiling; default loop.max_iterations
     steps:
-      - { id: suite, type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
-      - { id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
-      - { id: repair, type: agent, prompt: "The suite is red: {{ (index .Steps \"suite\").Result }}" }
+      - { id: suite,  type: command, run: go test ./..., allow_failure: true, max_retries: 0 }
+      - { id: passed, type: break,   if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+      - id: repair
+        type: agent
+        prompt: |
+          The suite is red:
+
+          {{ (index .Steps "suite").Result }}
+
+          Fix the underlying cause. Do not weaken, skip or delete a test.
 ```
 
-**`break`** ends the enclosing loop, successfully. Needs `if:`, and takes
-nothing else — see the loop above.
+Loops have enough surface to deserve their own section:
+[§6.4](#64-loops-in-depth).
 
-`check` is a **field** on agent and command steps, not a step of its own — see
-below.
+### 4.9 `break`
 
-## Conditions let a workflow do less when there is less to do
+Ends the enclosing loop, **successfully**. Requires `if:`, takes `id` and
+`name`, and nothing else.
 
-Every step can carry an `if:`, and a false one **skips that step and carries
-on**:
+```yaml
+      - { id: passed, type: break, if: '{{ eq (index .Steps "suite").ExitCode 0 }}' }
+```
+
+Like `condition`, it starts no process, so it cannot time out, be retried, or
+write a transcript. It is valid **only** inside a loop body — elsewhere there is
+no loop for it to end, and that is a validation error rather than a no-op.
+
+### 4.10 Where each type may appear
+
+| Type | Top level | In a `parallel` group | In a `loop` body | In a lane's inline steps |
+|---|:--:|:--:|:--:|:--:|
+| `agent` | ✅ | ✅ | ✅ | ✅ |
+| `command` | ✅ | ✅ | ✅ | ✅ |
+| `manual` | ✅ | ❌ | ❌ | ✅ |
+| `parallel` | ✅ | ❌ | ❌ | ✅ |
+| `fan_out` | ✅ | ❌ | ❌ | ✅ |
+| `condition` | ✅ | ❌ | ✅ | ✅ |
+| `loop` | ✅ | ❌ | ❌ | ✅ |
+| `break` | ❌ | ❌ | ✅ | ❌ |
+
+A lane's inline steps are a workflow body in their own right — they become a
+child task's flat snapshot — so the "top level" column is the one that applies
+to them.
+
+The ❌s all come from one fact: a `parallel` group and a `loop` iteration run
+**inside a single admission of a single task**, and each rejected type needs a
+task state that says "one member of this structure is parked". There is no such
+state, and inventing one would mean a task that is half-waiting.
+
+- `manual` — a gate ends the actor goroutine and releases the slot.
+- `fan_out` — the task parks in `awaiting_children`; a parked parent has no row
+  saying which iteration or which member it parked in.
+- `parallel` and `loop` inside each other — both derive their position from rows
+  sharing one `step_index`, and that derivation stays affordable exactly one
+  level deep.
+- `condition` inside a `parallel` group — a group is a *set*, so "end the
+  sequence" has nothing to name. Subsetting a group is what `if:` on a sub-step
+  already does.
+- `on_input: require` inside either — `awaiting_input` holds one pending request
+  for the whole task, so a structure whose members each want to ask has nowhere
+  to put the answers. This is judged on the **resolved** value, so a
+  `defaults.on_input: require` reaching a silent sub-step is caught too.
+
+---
+
+# Making steps talk to each other
+
+## 5. Templates and data flow
+
+### 5.1 Which fields are templates
+
+Five fields are Go [`text/template`](https://pkg.go.dev/text/template):
+
+| Field | On |
+|---|---|
+| `prompt` | agent steps |
+| `run` | command steps |
+| `check` | agent and command steps |
+| `instructions` | manual steps |
+| `if` | any step, plus fan-out lanes |
+
+`for_each:` entries on a `loop` are templates too.
+
+**Rendering uses `missingkey=error`**, and rendering happens *before* any
+process starts. A typo fails the step with `template_error` rather than
+rendering a silent hole into a prompt, and nothing has run when it does.
+
+Templates are parsed at **load** time as well, so a syntax error is a validation
+finding on the file rather than a surprise at run time. What load cannot check
+is whether `.Steps.foo` exists — that is a run-time fact.
+
+### 5.2 The template context
+
+| Variable | Fields |
+|---|---|
+| `.Task` | `ID`, `Title`, `Description`, `Fields` (map), `BaseBranch`, `BranchName` |
+| `.Project` | `Name`, `Path` (the original repo root, not the worktree), `DefaultBranch` |
+| `.Workflow` | `Name`, `Description` |
+| `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
+| `.Steps` | completed steps by id → `{Status, Result, ExitCode}` — [§5.3](#53-passing-one-steps-output-to-the-next) |
+| `.Loop` | `Index` (1-based, **0** outside any loop), `Item`, `IsFirst`, `IsLast` — [§6.4](#64-loops-in-depth) |
+| `.Host` | `OS`, `Arch` — the **daemon's** GOOS/GOARCH — [§10.4](#104-gating-one-step-by-platform) |
+| `.Worktree` | `Path` |
+| `.LastFailure` | retry attempts only: `{Reason, Output}`; empty otherwise |
+| `.Conflicts` | the conflicted files, on a `merge.agent` resolver only; empty everywhere else |
+
+Two are worth calling out because they are easy to reach for wrongly:
+
+- **`.Project.Path` is the original repository**, not where the step is running.
+  The step's working directory is `.Worktree.Path`.
+- **There is no `.Now`.** A guard reading wall-clock time makes a run
+  non-reproducible, which is the property declared lane order exists to
+  preserve.
+
+### 5.3 Passing one step's output to the next
+
+`.Steps` is what makes a multi-step workflow more than a list. Each entry is:
+
+| Field | Value |
+|---|---|
+| `Status` | `succeeded`, `approved`, `skipped`, or `failed` |
+| `Result` | the agent's final result text (agent steps), or the last **200** lines of stdout (command steps) |
+| `ExitCode` | the process exit code, where there was one |
+
+```yaml
+  - id: survey
+    type: agent
+    prompt: List every place this API is called. One per line, no commentary.
+
+  - id: fix
+    type: agent
+    prompt: |
+      A previous step reported:
+
+      {{.Steps.survey.Result}}
+
+      Update exactly those call sites.
+```
+
+Splitting work this way beats one prompt asking for both halves: each half is
+individually retryable, and the first half's output is a thing the second half
+has to satisfy.
+
+**What appears in `.Steps`, and when:**
+
+- A step that **succeeded**, was **approved** at a gate, or was **skipped** by
+  its guard appears as soon as the run moves past it.
+- A step that **failed** appears only once the engine has advanced past it —
+  which happens only under `allow_failure`
+  ([§6.2](#62-allow_failure--a-failure-that-is-data)). That is the whole point
+  of that field.
+- A step's **own** failed attempt is never in `.Steps["itself"]` mid-retry.
+  `.LastFailure` is already that channel, and two spellings of one fact is how
+  a context rots.
+- **Members of a `parallel` group are invisible to each other**, by the same
+  rule: nothing is visible until the engine has advanced past it, and
+  concurrent siblings never have.
+- **Inside a loop body, earlier steps of the current iteration are visible to
+  later ones.** Under repetition an id resolves to its **latest** iteration.
+- `interrupted` never appears — it is not an outcome.
+
+**`Result` is a tail, not a stream.** 200 lines of stdout is generous for a
+summary and useless as a data channel. A step meant to feed
+[`for_each:`](#64-loops-in-depth) should filter at the source rather than lean
+on the tail.
+
+### 5.4 Task fields
+
+`.Task.Fields` is a free-form `map[string]string` supplied when the task is
+created. It is how one workflow serves many jobs — a ticket id, a module name, a
+"ship it: yes/no" flag.
+
+Because rendering is strict, an **optional** field must be read defensively or
+the step fails:
+
+```yaml
+    prompt: |
+      Implement {{.Task.Title}}.
+      {{ with index .Task.Fields "ticket" }}Related ticket: {{ . }}{{ end }}
+```
+
+`{{ index .Task.Fields "ticket" }}` on its own is correct only for a field the
+workflow *requires*, where failing loudly is what you want.
+
+### 5.5 Environment variables
+
+Command steps and checks run with the working directory set to the worktree and
+receive these on top of the daemon's own environment:
+
+| Variable | |
+|---|---|
+| `VINCENT_TASK_ID` | |
+| `VINCENT_TASK_TITLE` | |
+| `VINCENT_PROJECT_NAME` | |
+| `VINCENT_PROJECT_PATH` | the original repo root |
+| `VINCENT_WORKTREE` | the working directory |
+| `VINCENT_BRANCH` | |
+| `VINCENT_BASE_BRANCH` | |
+| `VINCENT_STEP_ID` | |
+| `VINCENT_STEP_ATTEMPT` | 1-based |
+| `VINCENT_WORKFLOW` | |
+
+These are the portable way to reach task context from a script you would rather
+keep out of the YAML:
+
+```yaml
+  - id: notify
+    type: command
+    run: ./scripts/notify.sh
+    env:
+      SLACK_CHANNEL: "#builds"
+```
+
+A step's `env:` is layered on top and wins. What the daemon passes down in the
+first place is itself configurable — see
+[`environment`](../reference/configuration.md#environment) — but neither that
+policy nor a step's `env:` can remove a `VINCENT_*` variable: those are facts
+about the run, not inherited state.
+
+---
+
+## 6. Control flow
+
+A workflow can decide at run time what to do next. Three fields and two step
+types do it, and they compose.
+
+### 6.1 `if:` — skip a step and carry on
+
+Any step may carry a guard, and so may a fan-out lane. It renders like every
+other template here and must produce, after trimming, exactly `true` or
+`false`.
 
 ```yaml
   - id: changelog
@@ -175,50 +860,93 @@ on**:
     prompt: Update CHANGELOG.md.
 ```
 
-A guard must render exactly `true` or `false`. That strictness is on purpose:
-the two things a broken guard usually renders — an empty string, or a truthy
-`yes` — are exactly the cases where guessing an answer is worse than refusing
-to have one. You will get `condition_error` instead of a silent decision.
+**A false guard skips that step and the workflow continues.** The step still
+appears in the task's step list, in state `skipped` with skip reason
+`condition` — so you can tell it apart from a step you skipped by hand — and
+downstream templates can see it in `.Steps`.
 
-Three things follow from "skip, then carry on":
+**On a set rather than a sequence**, `if:` means *do not start this one*: on a
+fan-out lane and on a `parallel` sub-step, the others still run and the join
+still happens. A set has no "later" to skip to, so a false guard subsets it.
 
-- On a **fan-out lane** or a **`parallel` sub-step**, `if:` means *do not start
-  this one*. The others still run and the join still happens — a set has no
-  "later" to skip to.
-- To finish *early* rather than skip one step, use a **`condition` step**. False
-  ends the run and the task is `done`.
-- Guards are re-evaluated every time — on each attempt, on a retry, after a
-  restart. Nothing is cached, so fixing a workflow and retrying really does ask
-  the question again.
+**Nothing renders but `true` or `false`.** `yes`, `1`, an empty string and
+`<no value>` are all `condition_error`, not a guess. That strictness is the
+point: the two things a broken guard usually produces are an empty string and a
+truthy word, and both mean the guard is reading something that is not there —
+the one case where guessing a verdict is worse than refusing to have one.
+`condition_error` is also the one failure that is **not** retried: re-rendering
+a guard cannot answer differently. Fix the workflow and retry.
 
-**The field that makes guards worth having is `allow_failure`.** Without it,
-nothing a run *discovers* is readable: a nonzero command exit blocks the task,
-so any step that succeeded has exit code 0 and there is nothing to branch on.
+**Guards are re-evaluated every single time** — on each attempt, on a retry, and
+after a daemon restart. Nothing is cached. Fix a workflow and retry a blocked
+step whose guard is now false, and the step is skipped. That is the point.
+
+### 6.2 `allow_failure:` — a failure that is data
+
+Without this, a guard can only read what a human typed when the task was
+created. A command step that exits nonzero **blocks the task**, so no step that
+survived long enough to be read ever has a nonzero exit code to branch on.
+
+`allow_failure: true` changes that for one step: once its retry budget is spent,
+the workflow **advances instead of blocking**. The row keeps its `failed` state
+and its reason — the failure happened, it just did not stop the run — and that
+row is what the next guard reads.
 
 ```yaml
   - id: probe
     type: command
     run: git diff --quiet HEAD~1
-    allow_failure: true          # the failure advances instead of blocking
+    allow_failure: true
     max_retries: 0               # a probe has nothing to gain from retrying
   - id: stop-if-clean
     type: condition
     if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
 ```
 
-It only ever swallows failures the step itself produced — a nonzero exit, a
-failed `check`, an agent error, a timeout. A missing CLI or an unrenderable
-template still blocks, because a workflow should not be able to branch on "the
-agent is not installed" as though that were a result.
+**It only swallows failures the step itself produced:** a nonzero exit, a failed
+`check`, an agent error, a timeout, a transcript-cap kill. It never swallows
+vincent failing to *run* the step — a missing CLI, an expired login, a template
+error, an unavailable shell. Branching on "the agent is not installed" as though
+it were a test result is not something a workflow should be able to do.
 
-## Loops are for converging, repeating, and iterating a set
+It is valid on `agent` and `command` steps only, sub-steps of a group included,
+and it is not available in `defaults:`.
 
-Three shapes could not be written before, and all three are one step type.
+### 6.3 `condition` — finish early and succeed
 
-**Converge** — run the tests, fix what broke, run them again. This is the most
-common agent loop there is, and `max_retries` was never it: retries re-run
-*the same step* on *its own* failure, with no way to say "run the probe, and
-if it is red run a *different* step, then probe again."
+Where `if:` skips one step, a [`condition` step](#47-condition) ends the run:
+false means the sequence stops here and the task is `done`.
+
+The pairing that makes both useful is **probe, then decide, in two steps**:
+
+```yaml
+  - id: probe
+    type: command
+    run: git diff --quiet {{.Task.BaseBranch}}...HEAD
+    allow_failure: true
+    max_retries: 0
+
+  - id: only-if-changed
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+
+  - id: publish
+    type: command
+    run: git push -u origin {{.Task.BranchName}}
+```
+
+Trying to do both in one step means a step whose failure is sometimes a failure
+and sometimes an answer, which nothing downstream can tell apart.
+
+### 6.4 Loops in depth
+
+Three shapes need a loop, and `max_retries` was never any of them: a retry
+re-runs *the same step* on *its own* failure, with no way to say "run the probe,
+and if it is red run a **different** step, then probe again".
+
+#### 6.4.1 Converge — fix until green
+
+The archetype the feature exists for:
 
 ```yaml
   - id: green
@@ -237,13 +965,14 @@ if it is red run a *different* step, then probe again."
           Fix the underlying cause. Do not weaken, skip or delete a test.
 ```
 
-Read it in three lines: the probe is `allow_failure`, so its red exit is
-*data* rather than a block; the `break` reads that data and ends the loop the
-first time it is green; the repair only runs when the break did not fire. The
-`count:` is the budget — five repairs and no more.
+Read it in three lines: the probe is `allow_failure`, so its red exit is *data*
+rather than a block; the `break` reads that data and ends the loop the first
+time it is green; the repair only runs when the break did not fire. The `count:`
+is the budget — five repairs and no more.
 
-**Repeat** — prove a flake is gone by running the race detector ten times,
-without ten copy-pasted steps and ten step ids.
+#### 6.4.2 Repeat — the same thing, N times
+
+Prove a flake is gone without ten copy-pasted steps and ten step ids:
 
 ```yaml
   - id: soak
@@ -253,10 +982,9 @@ without ten copy-pasted steps and ten step ids.
       - { id: race, type: command, run: go test -race ./internal/taskrun }
 ```
 
-**Iterate a set** — do something once per item, over a list a step found at run
-time. `fan_out` looks like it should fit here and does not: its lane list has
-to be static in the snapshot, which is exactly what lets it check for cycles
-and cap the tree at creation.
+#### 6.4.3 Iterate — once per item
+
+Over a list a step discovered at run time:
 
 ```yaml
   - id: changed
@@ -272,122 +1000,123 @@ and cap the tree at creation.
       - { id: read, type: agent, prompt: 'Review {{ .Loop.Item }} against CLAUDE.md.' }
 ```
 
-`.Loop` carries `Index` (1-based, and `0` outside any loop), `Item`, `IsFirst`
-and `IsLast`.
+`fan_out` looks like it should fit here and does not: its lane list has to be
+static in the snapshot, which is exactly what lets it check for cycles and cap
+the tree at creation.
 
-### Four things to know before you use one
+#### 6.4.4 The two drivers
 
-**There is no `while:`, and that is deliberate.** A guard can read only what a
-run has already produced, so on the first iteration a `while:` about the body
-has no row to read — it either errors out loudly or, worse, quietly renders
-false and the loop never runs. `count:` plus `break` is the same loop written
-correctly, and the ceiling it needs is a ceiling `while:` would have needed
-anyway.
+| Driver | Shape | Iterations |
+|---|---|---|
+| `count:` | an integer | exactly that many, unless a `break` fires |
+| `for_each:` | a template string, or a list of them | one per item |
 
-**`continue` is spelled `condition`.** A `condition` step inside a loop body
-ends *that iteration*, not the run — a loop body is a sequence, and "end the
-sequence" ends the pass. The same word means the same thing everywhere; what
-changes is what it is attached to.
+`for_each:` accepts both spellings and treats them identically: **each entry is
+rendered, trimmed, and split on newlines with empty lines dropped**. So
+`[api, web]` and a command's multi-line output are one mechanism, not two. The
+scalar spelling exists because the motivating case is
+`for_each: '{{ .Steps.changed.Result }}'`, and wrapping that in a one-element
+sequence would be ceremony.
 
-**Ten iterations of a three-step body is thirty agent runs.** That is why the
-default ceiling is 10, why `count:` is checked against it when the file loads,
-and why a `for_each` list longer than it **blocks** with `loop_limit` instead
-of quietly doing the first ten. Raise it per step with `max_iterations:`, or
-per machine with `loop.max_iterations`.
+Exactly one driver per loop. Both, or neither, is a validation error.
 
-**A loop resumes where it stopped.** Block it on iteration 4 and `retry` picks
-up at the body step that failed, in iteration 4 — including after a daemon
-restart. `skip` skips the whole loop, not one pass. And `E` (edit + retry)
-rewrites the body step in this task's snapshot, so your fix applies to every
-remaining iteration rather than to one.
+#### 6.4.5 `.Loop`
 
-A loop body may hold `agent`, `command`, `condition` and `break` steps. It may
-not hold `manual`, `on_input: require`, `parallel`, `fan_out` or another loop:
-all of those park the task mid-body, and nothing in the schema can say
-"iteration 3 of this loop is waiting on a human".
+| Field | |
+|---|---|
+| `.Loop.Index` | the 1-based iteration, and **0** outside any loop, so a shared template can tell |
+| `.Loop.Item` | the `for_each` item this pass runs on; empty for a `count:` loop |
+| `.Loop.IsFirst` / `.Loop.IsLast` | booleans |
 
-## Verification is where parallel pays
+`Item` is a **string**, deliberately. Every other value in the context is a
+string, and a structured item would push a new type through the render context,
+the API and the TUI for a case nobody has yet.
 
-Tests, a linter and a type check do not interact: they read the worktree and
-report an exit code. Run in sequence they cost the sum of three waits; in a
-`parallel` group they cost the longest one.
+#### 6.4.6 There is no `while:`
 
-The group is still **one step**. One index in the timeline, one concurrency
-slot, one thing to retry. It succeeds when every sub-step succeeds, and when
-one fails the others still run to completion — you get all three verdicts, not
-just the first bad one. Retrying re-runs only what failed, so a passing test
-suite is not re-run because the linter was unhappy.
+A guard can read only what a run has already produced. On the first iteration
+the body has not run, so a `while:` reading its own body either errors out
+loudly or — worse — quietly renders false and the loop never runs; and one
+reading a step *before* the loop reads a constant and spins to the ceiling.
 
-Three things a sub-step cannot be, all for the same underlying reason — the
-group lives inside a single task, which has a single state:
+`count:` plus `break` is the same loop written correctly: post-test by
+construction, with the condition in the body where it can see the body, and
+bounded by a ceiling `while:` would have needed anyway.
 
-- `manual`, because a gate releases the task's slot and waits for a human;
-- another `parallel`, because groups do not nest;
-- `on_input: require`, because the task holds one pending question at a time.
+#### 6.4.7 `continue` is spelled `condition`
 
-> **Sizing it.** `max_parallel` (default 4) is *not* covered by your
-> `max_parallel_tasks` caps — those count tasks, and the whole group is inside
-> one. A board showing "1 running" can be a machine running four compilers.
-> Set it for the hardware.
+A `condition` step inside a loop body ends **that iteration**, not the run — a
+loop body is a sequence, and "end the sequence" ends the pass. The same word
+means the same thing everywhere; what changes is what it is attached to.
 
-Sub-steps share one working tree, so two of them writing the same file is a
-bug in the workflow. Worktrees isolate tasks from each other, not the
-processes inside one task.
+#### 6.4.8 How a loop ends
 
-## Fan-out is for deliverables that are several disjoint pieces
+| Cause | Result |
+|---|---|
+| The driver runs out, or a `break` fires | The loop **succeeds** and the run advances |
+| A `condition` in the body is false | **That iteration** ends; the loop carries on |
+| The loop cannot run within the ceiling | The task **blocks** with `loop_limit` |
+| A body step exhausts its retries | The task blocks with **that step's** own reason |
 
-Some work is one deliverable whose parts have no reason to wait for each
-other — two modules that do not touch, or code in one place and docs in
-another. A single task cannot do that: it has one worktree, one branch and one
-cursor. `fan_out` gives each lane its own task, and merges the branches back
-at the end of the same step, so you still get **one branch** to review.
+The ceiling is the step's own `max_iterations:` when it declares one, else
+`loop.max_iterations` from config (default 10). A `count:` above it is a
+**validation error at load** — the last moment it can be reported to the person
+typing it. A `for_each:` list longer than it blocks with `loop_limit` before the
+first iteration, naming the count, rather than quietly doing the first ten:
+running out of tries is not a decision the workflow made, and advancing would
+tell every later guard the work is finished.
 
-A lane is either a named workflow or inline steps. Naming one is the point —
-it is how a workflow becomes reusable as a piece of a bigger one:
+Retries and iterations are different things. `max_retries` is for a step that
+*failed*; an iteration is for a body that *succeeded and must run again*. Each
+body step spends its own budget within each iteration. A `loop` itself takes no
+`max_retries` and no `allow_failure` — it has no attempt of its own, and "allow"
+on a loop could only mean "a `loop_limit` block advances anyway", which is the
+silent success the design refused.
 
-```yaml
-  - id: build
-    type: fan_out
-    lanes:
-      - { id: api,  workflow: implement-module, fields: { module: api } }
-      - { id: web,  workflow: implement-module, fields: { module: web } }
-```
+#### 6.4.9 Human actions on a loop
 
-Each lane becomes an ordinary task: its own worktree, branch, retries, gates
-and blocks, visible with `vincent task ls --include-children` or by pressing
-`L` on the parent in the TUI. The parent shows `awaiting_children (2 blocked)`
-while they run — lanes are hidden from the board by default, and that summary
-is how you find out one of them needs you.
+| Action | Effect |
+|---|---|
+| `skip` | Skips the **whole loop** and advances past it. There is no "skip this iteration" |
+| `retry` | Resumes at the failed body step **of the iteration it stopped in**, with a fresh budget. It does not restart at iteration 1 |
+| `edit + retry` | Rewrites that body step in the task's snapshot, so the fix applies to **every remaining iteration** |
 
-### Three things to know before you use it
+The same is true after a crash: a loop's position is derived from its rows on
+every admission, so a restarted daemon resumes mid-iteration rather than redoing
+an hour of work.
 
-**It fills your caps, it does not exceed them.** Every lane is a task
-competing for `max_parallel_tasks`. Fan-out buys you parallelism you would
-otherwise start by hand; it does not buy you more of the machine.
+> **A loop is one step**: one index, one slot, one worktree, one timeline entry,
+> and its iterations are strictly sequential. It adds no concurrency your caps
+> cannot see. What it adds is *spend* — ten iterations of a three-step body is
+> thirty agent runs, which is why the default ceiling is 10.
 
-**N lanes leave N worktrees** until someone archives the tree. `vincent gc`
-and `vincent doctor` exist for this, and if you fan out routinely you will
-meet it early.
+### 6.5 Guard recipes
 
-**Conflicts stop, they do not get guessed.** Two lanes touching the same file
-end with the task blocked on `merge_conflict` and the worktree left conflicted
-for you to fix, stage, and retry. You can opt into an agent attempt first with
-`merge: {on_conflict: agent, agent: {...}}` — gated by that step's own
-`check` — but the default is deliberately to stop, because a semantic conflict
-resolved silently and merged unread is the one outcome that turns this feature
-into a liability.
+| What you want to ask | Write |
+|---|---|
+| Did step `x` succeed? | `{{ eq (index .Steps "x").Status "succeeded" }}` |
+| Was step `x` skipped by its guard? | `{{ eq (index .Steps "x").Status "skipped" }}` |
+| Did probe `x` fail (under `allow_failure`)? | `{{ ne (index .Steps "x").ExitCode 0 }}` |
+| Is this not Windows? | `{{ ne .Host.OS "windows" }}` |
+| Did the creator ask for it? | `{{ eq (index .Task.Fields "ship") "yes" }}` |
+| Is this the first pass of a loop? | `{{ .Loop.IsFirst }}` |
+| Is this step inside a loop at all? | `{{ gt .Loop.Index 0 }}` |
+| Is a field present at all? | `{{ if index .Task.Fields "ticket" }}true{{ else }}false{{ end }}` |
 
-If a lane is cancelled or ends without finishing, the join blocks with
-`lane_failed` and merges **nothing**. Fix the lane — it is an ordinary task,
-so retry it — then retry the parent. There is deliberately no "merge the rest
-anyway" button: a partial merge looks exactly like a complete one to
-everything downstream.
+`.Steps.x.Status` is valid shorthand for `(index .Steps "x").Status` when the id
+is a bare identifier; the `index` form is required for ids containing `-` or
+`.`.
 
-## Checks are how you stop an agent grading its own homework
+---
 
-An agent step succeeds when the process exits 0 and its stream reports no
-error. That is a claim by the agent about its own work. A `check` turns it
-into something the machine verifies:
+# Making it reliable
+
+## 7. Verification with `check`
+
+### 7.1 Why every writing step wants one
+
+`check` is a **field** on `agent` and `command` steps, not a step type. It is
+the difference between "the agent said it was done" and "the compiler agrees".
 
 ```yaml
   - id: implement
@@ -397,8 +1126,17 @@ into something the machine verifies:
     check_timeout: 15m
 ```
 
-The check runs after the step, in the worktree. Non-zero fails the attempt,
-and the retry gets the failure appended to its prompt automatically:
+**If a step produces something checkable, check it.** If a step genuinely
+produces nothing checkable, that is usually a sign it is doing two things.
+
+### 7.2 How a check runs
+
+- After the step body, in the worktree, with the same environment as a command
+  step ([§5.5](#55-environment-variables)) and under the same shell rules
+  ([§10.1](#101-which-shell-runs-a-command-step)).
+- Its output is captured to the step's transcript.
+- **Non-zero fails the attempt** with reason `check_failed`, and the retry gets
+  the failure appended to its prompt automatically:
 
 ```
 <previous-attempt-failure attempt="1">
@@ -408,267 +1146,497 @@ reason: check command failed (exit 1)
 </previous-attempt-failure>
 ```
 
-That loop — write, verify, be told exactly what failed, try again — is most of
-the value of running an agent under a workflow rather than by hand. **If a
-step produces something checkable, check it.**
+- `check_timeout:` bounds it, defaulting to the daemon's
+  `defaults.command_timeout` (15m) — **not** to the step's own `timeout` and not
+  to workflow `defaults.timeout`. A long agent step with a short check is the
+  usual shape, so set `check_timeout:` explicitly when the check is the slow
+  half.
 
-A check can be inverted when the deliverable is a failure. `examples/fix-and-test.yaml`
-uses `! go test ./...` for a step whose job is to produce a red test.
+### 7.3 Inverting a check
 
-## Templates
-
-Prompts, `run`, `check` and `instructions` are Go `text/template`.
-
-| Variable | Contents |
-|---|---|
-| `.Task` | `ID`, `Title`, `Description`, `Fields`, `BaseBranch`, `BranchName` |
-| `.Project` | `Name`, `Path`, `DefaultBranch` |
-| `.Workflow` | `Name`, `Description` |
-| `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
-| `.Steps` | completed steps by id → `{Status, Result, ExitCode}` |
-| `.Worktree` | `Path` |
-| `.LastFailure` | retries only: `{Reason, Output}` |
-
-`.Steps` is what makes a multi-step workflow more than a list. Feeding one
-step's output into the next is how you split work an agent does badly in one
-go:
+When the deliverable *is* a failure, invert it:
 
 ```yaml
-  - id: fix
+  - id: reproduce
     type: agent
-    prompt: |
-      A previous step reported:
-
-      {{.Steps.survey.Result}}
-
-      Fix exactly those items.
+    prompt: Write a test that fails, reproducing the bug described above.
+    check: '! go test ./...'
 ```
 
-**Rendering uses `missingkey=error`**, so a typo fails the step *before* any
-process starts rather than rendering a silent hole into a prompt. Task fields
-are free-form, so read optional ones defensively:
+Without this, an agent asked to "add a failing test and fix it" reliably writes
+a test that passes against its own fix. See
+[`fix-and-test.yaml`](../../examples/fix-and-test.yaml). Note that `!` is POSIX
+shell syntax — a file relying on it should declare `platforms: [posix]` or pin
+`shell: sh`.
 
-```yaml
-{{with index .Task.Fields "ticket"}}Ticket: {{.}}{{end}}
-```
+### 7.4 What a check is not
 
-## Retries and timeouts
+- It is not a second step: it has no id, no row of its own, and no retry budget
+  separate from its step's.
+- It cannot be set in `defaults:`.
+- It is not available on `manual`, `parallel`, `fan_out`, `condition`, `loop` or
+  `break` steps. To verify after a group, put a `command` step behind it.
+
+---
+
+## 8. Failure, retries and timeouts
+
+### 8.1 What counts as success
+
+| Type | Succeeds when |
+|---|---|
+| `agent` | the process exits 0, **and** the stream produced a terminal result rather than an error, **and** any `check` exits 0 |
+| `command` | the command exits 0, **and** any `check` exits 0 |
+| `manual` | a person approves |
+| `parallel` | every sub-step succeeds |
+| `fan_out` | every lane finishes and every branch merges |
+| `loop` | the driver runs out or a `break` fires |
+| `condition` | its guard is true (false ends the run, also successfully) |
+
+### 8.2 Retries
 
 ```yaml
 defaults:
-  max_retries: 2      # attempts after the first
-  timeout: 45m        # per attempt
+  max_retries: 2      # attempts AFTER the first — so up to three
 ```
 
-Both can be set per step. A step that exhausts its retries blocks the task,
-which then waits for a human — nothing is silently abandoned.
+The default is `1`, i.e. up to two attempts. `0` means one attempt and no
+retry, which is right for probes and for anything with a side effect you would
+not want repeated — a push, a release, a comment on an issue.
 
-## Choosing an agent
+Set it per step where the step's cost says so:
 
-Set `agent:` on a step, in `defaults:`, or per task at creation. The
-resolution order is step → task override → workflow defaults → adapter default
-(§8.6), and **`model` and `effort` only inherit from a level whose agent
-matches** — so a claude alias never leaks onto a codex step.
+```yaml
+  - id: publish
+    type: command
+    run: git push -u origin {{.Task.BranchName}}
+    max_retries: 0
+```
 
-Adapters differ, and the differences are documented rather than smoothed over:
+Retries are for failures a retry can plausibly fix. `condition_error` is
+excluded by construction, and an `interrupted` attempt does **not** consume
+budget. `parallel` groups and `loop` steps carry no retry budget of their own —
+their members do.
+
+### 8.3 Timeouts
+
+`timeout:` bounds **one attempt**, and can be set in `defaults:` or per step.
+Without either it is the daemon's `defaults.agent_timeout` (60m) for agent steps
+and `defaults.command_timeout` (15m) for everything else.
+
+On a `parallel` group or a `loop`, `timeout:` bounds the whole structure rather
+than one member.
+
+Two related bounds that are *not* the step timeout:
+
+- **`check_timeout:`** — [§7.2](#72-how-a-check-runs).
+- **`input_timeout:`** — bounds each wait in `awaiting_input`, per request. The
+  step's own timeout clock **pauses** while a question is pending: it measures
+  agent work, not human latency.
+
+### 8.4 When a step runs out of attempts
+
+The task **blocks**, carrying that step's failure reason, and waits for a human.
+Nothing is silently abandoned and nothing downstream runs. From there you can
+retry, skip, edit + retry, or cancel.
+
+The one exception is [`allow_failure:`](#62-allow_failure--a-failure-that-is-data),
+which turns the step's own failures into an advance.
+
+The full reason vocabulary — `check_failed`, `nonzero_exit`, `agent_error`,
+`timeout`, `loop_limit`, `merge_conflict`, `lane_failed`, and the rest — is in
+[Task lifecycle → failure reasons](../reference/task-lifecycle.md#failure-reasons).
+A reason means the same thing wherever it originated.
+
+### 8.5 Interruption is not failure
+
+vincent is crash-first: every transition is persisted before it is acted on. A
+daemon that stops mid-step marks the run `interrupted`, kills verified orphan
+processes, and re-runs the step as a **fresh attempt that does not consume a
+retry**.
+
+This is safe because every agent step is a fresh session over a worktree whose
+committed state survives. **You help by having agents commit incrementally** —
+say so in the prompt. A step that does an hour of work and commits at the end
+loses the hour; one that commits as it goes loses minutes.
+
+---
+
+## 9. Agents, models and permissions
+
+### 9.1 Resolution order
+
+For each agent step, `agent`, `model` and `effort` resolve first-hit-wins:
+
+1. the explicit **step** field;
+2. the **task-level override** chosen at creation (`--agent`, `--model`,
+   `--effort`) — this replaces workflow `defaults`, never an explicit step
+   field;
+3. workflow **`defaults`**;
+4. the **adapter** default — usually empty, meaning the CLI decides.
+
+**Agent-scoped inheritance.** `model` and `effort` only inherit from a level
+whose resolved agent matches the step's. A step that switches agent without
+setting them gets the new adapter's defaults rather than a claude alias leaking
+onto a codex step.
+
+```yaml
+defaults:
+  agent: claude
+  model: sonnet
+
+steps:
+  - id: implement
+    type: agent          # → claude / sonnet
+    prompt: …
+  - id: review
+    type: agent
+    agent: codex         # → codex / codex's default model, NOT sonnet
+    effort: high
+    prompt: …
+```
+
+`POST /v1/resolve` answers "what does this resolve to, and which level won" for
+every step in a workflow. That is what the TUI's new-task form renders; no
+client re-derives it.
+
+### 9.2 What each adapter can do
+
+Adapters differ, and the differences are documented rather than smoothed over. A
+capability an adapter lacks is ignored at run time; it is never emulated.
 
 | | claude | codex | cursor |
-|---|---|---|---|
-| Mid-run questions | ✅ | — | — |
+|---|:--:|:--:|:--:|
+| Mid-run questions (`on_input`) | ✅ | — | — |
 | Reports cost | ✅ | — | — |
 | `effort:` | ✅ | ✅ | **—** (it lives in the model id) |
-| `restricted` on Windows | ✅ | ✅ | **—** (step fails, never downgrades) |
+| Model catalog | ✅ | — (account-dependent; free text) | ✅ (probed over the network) |
+| `restricted` on Windows | ✅ | ✅ | **—** (the step fails; it never downgrades) |
 
-`vincent workflow validate` catches an effort value belonging to another
-adapter's catalog. It cannot catch a model your account lacks — the CLI is the
-final authority there, and you will find out at run time.
+`vincent workflow validate` catches a model or effort value belonging to
+*another* adapter's catalog — claude's `sonnet` or `max` reaching a codex step
+is an error. A value in **no** catalog is a warning and passes: the CLI is the
+final authority at run time, so free-text models and future CLI values are not
+blocked. What validation cannot catch is a model your account lacks.
 
-## Permission modes
+Full details per adapter: [Agent CLIs](agents.md).
 
-`full-auto` is the default and **the agent can run arbitrary commands as you**
-(§16). The worktree isolates collisions between tasks, not privileges.
+### 9.3 Permission modes
 
-`restricted` maps to each adapter's own confinement. Use it for steps that
-have no business running commands — a docs pass, a review. Note that an
-adapter which cannot restrict on your platform **fails the step** rather than
-running it unrestricted, because a restricted mode that quietly isn't
-restricted is worse than none.
+```yaml
+permission_mode: full-auto     # default
+```
 
-The full picture, including what "restricted" means for each CLI, is in
-[Agent CLIs](agents.md) and the [Security model](../security-model.md).
+`full-auto` is the default and **the agent can run arbitrary commands as you**.
+The worktree isolates collisions between tasks, not privileges. This is a
+documented design decision, not an oversight — see the
+[Security model](../security-model.md).
 
-## Mid-run questions
+`restricted` maps to each adapter's own confinement. Use it for steps that have
+no business running commands — a docs pass, a review. Two things to know:
 
-An input-capable adapter (claude today) can surface a structured question from
-the agent mid-step. Only machine-readable requests from the agent's event stream
+- An adapter that **cannot** restrict on your platform **fails the step** with
+  `restricted_unsupported` rather than running it unrestricted. A restricted
+  mode that quietly is not restricted is worse than none.
+- It changes agent behaviour in ways that read as bugs if you did not ask for
+  them: claude turns every non-allowlisted tool into a permission prompt. That
+  is why the shipped examples are all `full-auto`.
+
+### 9.4 Mid-run questions (`on_input`)
+
+An input-capable adapter (claude today) can surface a **structured** question
+from the agent mid-step. Only machine-readable requests from the event stream
 qualify — vincent never guesses that some output text "looks like a question".
 
 ```yaml
 defaults:
-  on_input: wait        # wait (default) | deny
+  on_input: wait        # wait (default) | deny | require
   input_timeout: 24h    # bounds each wait; also settable per step
 ```
 
-- **`wait`** — the task moves to `awaiting_input`, **keeping its concurrency
-  slot** (the agent process is alive, idle on its stdin). The step's own timeout
-  clock pauses: it measures agent work, not human latency. The board pins the
-  task, rings the terminal bell, and the answer form opens on `enter`. Answering
-  resumes the same session where it stopped.
-- **`deny`** — for runs that must stay strictly unattended. vincent answers
-  immediately through the adapter: questions get a canned "no user is available;
-  decide with your best judgment", permission requests are denied. The task never
-  leaves `running`.
+**`wait`** — the task moves to `awaiting_input` and **keeps its concurrency
+slot**: the agent process is alive, idle on its stdin. The step's timeout clock
+pauses. The board pins the task, rings the terminal bell, and the answer form
+opens on `enter`. Answering resumes the same session where it stopped.
 
-`input_timeout` is measured **per request** — a new question starts a fresh
-window. On expiry the process is killed and the attempt fails under the normal
-retry policy.
+**`deny`** — for runs that must stay strictly unattended. vincent answers
+immediately through the adapter: questions get a canned "no user is available;
+decide with your best judgment", and permission requests are denied. The task
+never leaves `running`.
 
-- **`require`** — `wait`, plus a promise that a human is part of the run. The
-  step will only run on an agent that can stop and ask; one that cannot is
-  refused rather than left to guess.
-
-Adapters that report `supports_input: false` (codex, cursor) never produce input
-requests, and `wait` and `deny` have no effect on their steps.
-
-### When the conversation *is* the workflow
-
-`wait` and `deny` both degrade quietly on an agent with no control channel: the
-step runs, nothing is ever asked, and the agent decides alone. That is usually
-what you want — but not for a workflow built around asking you which of three
-designs to take. There, an agent that cannot ask does not degrade, it guesses,
-and nothing in the run says so.
-
-`on_input: require` makes that explicit:
+**`require`** — `wait`, plus a promise that a human is part of the run. Use it
+when the conversation *is* the workflow:
 
 ```yaml
-steps:
   - id: clarify
     type: agent
     on_input: require
     prompt: Ask me whatever you need before you start, then implement it.
 ```
 
-What it changes, and where you notice:
+`wait` and `deny` both degrade quietly on an agent with no control channel: the
+step runs, nothing is asked, and the agent decides alone. That is usually what
+you want — but not for a step built around asking you which of three designs to
+take. There, an agent that cannot ask does not degrade, it guesses, and nothing
+in the run says so. `require` makes that explicit, and you notice it in four
+places:
 
-- **In the file.** Pinning `agent: codex` (or `cursor`) on a requiring step is
-  a validation error — those CLIs have no control channel in any version, so
-  the file could never work. `vincent workflow validate` catches it.
-- **When creating a task.** The new-task agent picker greys out an agent that
-  cannot answer questions, and `POST /v1/tasks` refuses one with a 400 naming
-  the step. A workflow whose requiring steps leave their agent to the task is
-  marked `needs an interactive agent` in the picker.
+- **In the file.** Pinning `agent: codex` or `agent: cursor` on a requiring step
+  is a validation error — those CLIs have no control channel in any version.
+- **At task creation.** The agent picker greys out an agent that cannot answer
+  questions, and `POST /v1/tasks` refuses one with a 400 naming the step. A
+  workflow whose requiring steps leave their agent to the task is marked *needs
+  an interactive agent* in the picker.
 - **Never on a guess.** An agent that is not installed, or whose probe did not
-  answer, is *unknown* — and unknown never refuses anything. You are only ever
-  blocked by a definite "this one cannot".
-- **At run time.** If the answer changes under you — claude upgraded past the
-  version family vincent has verified the protocol against — the step fails
+  answer, is *unknown* — and unknown never refuses anything. Only a definite
+  "this one cannot" blocks you.
+- **At run time.** If the answer changes underneath you — claude upgraded past
+  the version family vincent has verified the protocol against — the step fails
   with `input_unsupported` instead of running an unattended conversation.
 
-A step's own `on_input` still wins over `defaults:`, so a mostly-interactive
-workflow can mark one long cleanup step `on_input: deny` and leave it to run
-unattended.
+`require` is not valid inside a `parallel` group, inside a `loop` body, or on a
+`merge.agent` resolver: `awaiting_input` holds one pending request for the whole
+task. A step's own `on_input` still wins over `defaults:`, so a
+mostly-interactive workflow can mark one long cleanup step `on_input: deny` and
+leave it unattended.
 
-## Writing portable command steps
+---
 
-`run` and `check` are rendered, then handed to a shell:
+## 10. Portability
+
+Windows, macOS and Linux all run vincent, and **vincent never translates a
+command step between shells**. Portability of command steps is the author's job
+— or an explicit declaration that you did not do it.
+
+### 10.1 Which shell runs a command step
+
+`run` and `check` are rendered, then handed to one shell as a single script:
 
 | Platform | Shell |
 |---|---|
 | POSIX | `/bin/sh -c "<rendered>"` |
-| Windows | `pwsh -NoProfile -Command "<rendered>"`, falling back to `powershell` |
+| Windows | `pwsh -NoProfile -Command "<rendered>"`, falling back to Windows PowerShell (`powershell`) |
 
-Pin one explicitly with `shell: sh | pwsh | cmd` when a step is only ever meant
-to run one way. vincent makes no attempt to translate between them: cross-OS
-portability of command steps is the author's job.
+Pin one with `shell:` when a step is only ever meant to run one way:
 
-**Or say you did not do that job.** A workflow written against `cat`, `grep`
-and pipes is a POSIX workflow, and pretending otherwise only moves the failure
-to run time. Declare it once at the top of the file:
+| Value | Runs as |
+|---|---|
+| `sh` | `/bin/sh -c` (on Windows: whatever `sh` is on `PATH` — Git Bash's, if you put it there) |
+| `pwsh` | `pwsh -NoProfile -Command` |
+| `cmd` | `cmd /C` |
+
+Those three are the whole vocabulary. **`bash` is not a value** — use `sh` for
+portable POSIX syntax, or invoke bash explicitly with
+`run: bash -c '…'` when you genuinely need bash-only features. A pinned shell is
+never silently replaced: if it is not installed, the step fails with
+`shell_unavailable`.
+
+### 10.2 Writing portable command steps
+
+If a file must run everywhere, spell its command steps in the intersection of
+`sh` and `pwsh`:
+
+| Works in both | Does not |
+|---|---|
+| `git …`, and any binary on `PATH` | `test -f x`, `[ -f x ]` |
+| `&&` and `\|\|` between simple commands | `for` / `if` / `case` |
+| `exit N` as the whole command | `touch`, `seq`, `cat`, `grep` |
+
+Two tricks worth knowing, both borrowed from vincent's own acceptance gates:
+
+- A step that must **write a file** portably: `git config -f <file> <key> <value>`.
+- A step that must **pass or fail on a condition**: use one command whose own
+  exit code says so. `git config --get <key>` exits 1 on a missing key.
+
+`exit N` must be the *whole* command body. In pwsh, `&&` takes pipelines, so
+`… && exit 0` parses as a command named `exit` and fails.
+
+If that list feels like a straitjacket, it is — which is what
+[§10.3](#103-platforms--declare-what-you-did-not-port) is for.
+
+### 10.3 `platforms:` — declare what you did not port
+
+A workflow that pipes `cat` into `wc` is a POSIX workflow. Say so once, at the
+top of the file:
 
 ```yaml
 name: posix-tools
-platforms: [posix]        # every non-Windows host; or [linux, darwin], [windows]
+platforms: [posix]
 ```
 
-On a host the list does not admit, the workflow is still listed with the
-platforms it needs, but nothing will offer it: the new-task picker refuses it
-and the API rejects a task naming it. Omitting the key means "runs anywhere",
-which is the right answer for most files — see the
-[schema reference](../reference/workflow-schema.md#platforms).
+| Token | Matches |
+|---|---|
+| `linux` | Linux |
+| `darwin` | macOS |
+| `windows` | Windows |
+| `posix` | Every non-Windows host — the shorthand for "needs a POSIX shell" |
 
-Every command and check step runs with cwd set to the worktree, inherits the
-daemon's environment, and additionally gets:
+Any combination is allowed: `[linux, darwin]` is `[posix]` spelled out, and
+`[posix, windows]` is the same as omitting the key. Tokens are matched exactly —
+`macos` and `Linux` are validation errors, not silent non-matches. Duplicates
+are errors too.
 
-```
-VINCENT_TASK_ID       VINCENT_TASK_TITLE     VINCENT_PROJECT_NAME
-VINCENT_PROJECT_PATH  VINCENT_WORKTREE       VINCENT_BRANCH
-VINCENT_BASE_BRANCH   VINCENT_STEP_ID        VINCENT_STEP_ATTEMPT
-VINCENT_WORKFLOW
-```
+On a host the list does not admit:
 
-Those are the portable way to reach task context from a script you would rather
-keep out of the YAML:
+- the workflow is still **listed** — by `vincent workflow ls` with status
+  `unsupported`, and in the TUI's workflow view, with the platforms it needs;
+- it cannot be **selected**: the new-task picker refuses it and `POST /v1/tasks`
+  rejects it with a 400 naming the restriction and the host;
+- a task that somehow already carries it — a data directory moved between
+  machines — blocks at admission with `platform_unsupported`, before any step
+  runs.
+
+`vincent workflow validate` checks the tokens but **never** the host, so a
+POSIX-only workflow validates the same on a Windows CI runner as on Linux. That
+is what makes it usable as a portable pre-commit check.
+
+The restriction is **whole-workflow**. Omitting the key means "runs anywhere",
+which is the right answer for most files.
+
+### 10.4 Gating one step by platform
+
+There is no per-step `platforms:`, and none is needed: `.Host` plus an ordinary
+guard says the same thing with skip semantics that are already defined.
 
 ```yaml
-  - id: notify
+  - id: unix-only-cleanup
     type: command
-    run: ./scripts/notify.sh
-    env:
-      SLACK_CHANNEL: "#builds"
+    if: '{{ ne .Host.OS "windows" }}'
+    run: rm -rf ./tmp
 ```
 
-## Patterns that work
+`.Host` is the **daemon's** GOOS and GOARCH, because the daemon is what runs the
+steps. Use `platforms:` when the whole file should not be *offered*; use `if:`
+when one step should be *skipped*.
+
+---
+
+## 11. Concurrency, cost and limits
+
+Four different limits bound a run. They are easy to confuse, and only the first
+counts tasks.
+
+| Limit | Counts | Default | Set in |
+|---|---|---|---|
+| `max_parallel_tasks` | concurrently running **tasks** | 3 | `config.yaml`, plus a per-project cap |
+| `parallel.max_parallel` | sub-steps of **one group** at once | 4 | `config.yaml`, or `max_parallel:` on the step |
+| `fan_out.max_depth` / `max_tasks` | depth and size of a **fan-out tree** | 3 / 64 | `config.yaml`, checked at task creation |
+| `loop.max_iterations` | iterations of **one loop** | 10 | `config.yaml`, or `max_iterations:` on the step |
+
+What follows from that:
+
+- **A `parallel` group hides work from the board.** One task at
+  `max_parallel: 8` starts eight processes while the board shows a single
+  running task. Size it for the machine.
+- **A `fan_out` fills your caps rather than exceeding them.** Every lane is a
+  task competing for `max_parallel_tasks` like any other.
+- **A `loop` adds no concurrency at all** — its iterations are strictly
+  sequential. What it adds is spend: ten iterations of a three-step body is
+  thirty agent runs.
+- **Steps that release their slot**: `manual` (`awaiting_gate`) and `fan_out`
+  while its children run (`awaiting_children`). A step waiting on a mid-run
+  question (`awaiting_input`) **keeps** its slot, because the process is alive.
+
+Two more bounds worth knowing when a run behaves oddly:
+`transcript_max_bytes` (512MB per attempt, then `transcript_limit`) and
+`usage_limit`, which is not a failure — the task waits `queued` until the
+agent's quota window reopens, consuming no retry.
+
+---
+
+# Shipping
+
+## 12. Patterns that work
 
 **Split what an agent does badly in one go.** A survey step whose output feeds a
-fix step beats one prompt asking for both, because `.Steps` carries the first
-result into the second and each half is individually retryable.
+fix step beats one prompt asking for both: `.Steps` carries the first result
+into the second, and each half is individually retryable.
 
 **Make the deliverable checkable.** `check: go build ./... && go test ./...` on
-the step that writes code turns "the agent said it was done" into "the compiler
-agrees". If a step genuinely produces nothing checkable, that is usually a sign
-it is doing two things.
+the step that writes code turns a claim into a verdict. A step with nothing
+checkable is usually doing two things.
 
 **Invert the check when failure is the point.** `check: '! go test ./...'` on a
 step whose job is to produce a red test — see
-[`fix-and-test`](../../examples/fix-and-test.yaml). Without it, an agent asked
-to "add a failing test and fix it" reliably writes a test that passes against
-its own fix.
+[`fix-and-test`](../../examples/fix-and-test.yaml).
 
 **Gate before anything leaves the machine.** Put a `manual` step in front of any
-step that pushes, publishes, deploys or deletes. The gate costs you one
-keystroke and is the difference between "an agent wrote to a branch" and "an
-agent wrote to production".
+step that pushes, publishes, deploys or deletes. The gate costs one keystroke
+and is the difference between "an agent wrote to a branch" and "an agent wrote
+to production".
 
-**Guard the expensive step, not the whole workflow.** Splitting one workflow
-into `with-changelog` and `without-changelog` moves the decision to task
-creation, which is the one moment the facts that decide it do not exist yet. An
-`if:` on the step keeps one workflow and lets the run decide.
+**Guard the expensive step, not the whole workflow.** Splitting one file into
+`with-changelog` and `without-changelog` moves the decision to task creation —
+the one moment the facts that decide it do not exist yet. An `if:` on the step
+keeps one workflow and lets the run decide.
 
 **Probe, then decide, in two steps.** `allow_failure` on a cheap command that
 answers a question, then a `condition` or an `if:` that reads its exit code.
-Trying to do both in one step means a step whose failure is sometimes a failure
-and sometimes an answer, which nothing downstream can tell apart.
+
+**Converge with a loop, not with retries.** `max_retries` re-runs the same step;
+converging needs probe → decide → repair, which is a loop body.
+
+**Ask agents to commit incrementally.** It is what makes crash recovery cheap,
+and it costs one sentence in the prompt.
+
+**Set `max_retries: 0` on anything with a side effect.** A push, a release, a
+comment on an issue: retrying it does something twice.
 
 **Use `restricted` for steps that only read and write text.** A docs pass has no
-business running commands; the mode says so, and the adapter enforces it.
+business running commands; the mode says so and the adapter enforces it.
 
-## A checklist before you commit one
+## 13. Reviewing a workflow before you commit it
 
-- `vincent workflow validate` passes with no warnings.
-- Every step that produces something checkable has a `check`.
-- Prompts say what "done" means, not just what to attempt.
-- Any step that pushes, publishes or deletes sits **after** a `manual` gate.
-- Optional `.Task.Fields` reads are wrapped in `{{with}}`.
-- Commands work in the shell your teammates have — `&&` is fine everywhere;
-  `test -f` is not.
+- [ ] `vincent workflow validate <file>` passes with **no warnings**.
+- [ ] Every step that produces something checkable has a `check:`.
+- [ ] Prompts say what "done" means, not just what to attempt.
+- [ ] Any step that pushes, publishes or deletes sits **after** a `manual` gate
+      and carries `max_retries: 0`.
+- [ ] Optional `.Task.Fields` reads are wrapped in `{{ with }}`.
+- [ ] Command steps work in the shell your teammates have — or the file declares
+      `platforms:`.
+- [ ] Loops have a `break` or a `count:` you would be happy to pay for.
+- [ ] Step ids read like nouns you would want to see in a timeline.
+- [ ] The file name matches the `name:` field.
+
+Wiring it into CI is one line, and it needs no daemon:
+
+```sh
+for f in .vincent/workflows/*.yaml; do vincent workflow validate "$f" || exit 1; done
+```
+
+## 14. Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `unknown field "…"` at load | A typo, or a field on the wrong step type. Unknown keys are never ignored |
+| `template does not parse` | A syntax error in `prompt`/`run`/`check`/`instructions`/`if`. Caught at load |
+| `template_error` at run time | A reference to something that is not there — usually an optional `.Task.Fields` key read without `{{ with }}`, or a `.Steps` id that has not completed |
+| `condition_error` | A guard rendered something other than `true`/`false`. Not retried — fix the file and retry |
+| `shell must be one of sh, pwsh, cmd` | `shell: bash` — see [§10.1](#101-which-shell-runs-a-command-step) |
+| `count N exceeds the M-iteration ceiling` | Raise `max_iterations:` on the step, or `loop.max_iterations` in config |
+| `break steps are only valid inside a loop body` | A `break` at the top level or in a group |
+| `agent "codex" can never take mid-run input` | `on_input: require` resolved to an adapter with no control channel |
+| A model name is an error, not a warning | It belongs to *another* adapter's catalog. A model in no catalog only warns |
+| Workflow listed but not offered | `platforms:` does not admit this host — [§10.3](#103-platforms--declare-what-you-did-not-port) |
+| The workflow ran an old version | A task uses the snapshot captured at creation. Use `edit + retry`, or create a new task |
+| A group hangs long after one sub-step failed | By design: the group waits for everything it started, then reports the first failure in declaration order |
+
+Anything not on this list is probably a task-level rather than a
+workflow-level problem: see
+[Troubleshooting](troubleshooting.md) and
+[Task lifecycle](../reference/task-lifecycle.md).
 
 ---
 
 ## See also
 
-- [Workflow schema](../reference/workflow-schema.md) — every field, every
-  default, in one table.
+- [Workflow schema](../reference/workflow-schema.md) — every field and default,
+  in tables.
+- [Example workflows](../../examples) — five working files.
 - [Agent CLIs](agents.md) — what each adapter can and cannot do.
 - [Task lifecycle](../reference/task-lifecycle.md) — what `blocked` means and
   what you can do from there.
-- [Example workflows](../../examples) — the four shipped files.
+- [Configuration](../reference/configuration.md) — the daemon-side defaults
+  every workflow inherits.
+- [Security model](../security-model.md) — what `full-auto` really allows.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -446,7 +446,7 @@ ask it to.
 expanded, so `PATH: "${PATH}:/opt/bin"` sets that string verbatim rather than
 appending.
 
-Command and check steps layer the [`VINCENT_*` variables](../guides/workflows.md#writing-portable-command-steps)
+Command and check steps layer the [`VINCENT_*` variables](../guides/workflows.md#55-environment-variables)
 and then their own `env:` on top. Neither `unset` nor `set` can touch those —
 they are facts about the run, not inherited state — and a step's `env:` still
 wins over everything.
@@ -596,7 +596,7 @@ Command and check steps additionally receive `VINCENT_TASK_ID`,
 `VINCENT_TASK_TITLE`, `VINCENT_PROJECT_NAME`, `VINCENT_PROJECT_PATH`,
 `VINCENT_WORKTREE`, `VINCENT_BRANCH`, `VINCENT_BASE_BRANCH`, `VINCENT_STEP_ID`,
 `VINCENT_STEP_ATTEMPT` and `VINCENT_WORKFLOW` — see
-[Writing workflows](../guides/workflows.md#writing-portable-command-steps).
+[Writing workflows](../guides/workflows.md#55-environment-variables).
 
 ## Reading the config in effect
 

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -7,11 +7,33 @@ The complete YAML field reference. The practical, prose version is
 **Unknown keys are errors, not ignored.** A typo fails validation instead of
 becoming a setting that silently never applied.
 
+**The file**
+
 - [File structure](#file-structure)
 - [Top level](#top-level)
-- [`platforms`](#platforms)
-- [`defaults`](#defaults)
-- [Step fields](#step-fields)
+  - [`platforms`](#platforms)
+  - [`defaults`](#defaults)
+
+**Steps**
+
+- [Step fields](#step-fields) — common to every type
+  - [`type: agent`](#type-agent)
+  - [`type: command`](#type-command)
+  - [`type: manual`](#type-manual)
+  - [`type: parallel`](#type-parallel)
+  - [`type: fan_out`](#type-fan_out) · [`merge` and conflicts](#merge-and-conflicts)
+  - [`type: loop`](#type-loop) · [`.Loop`](#loop) · [body contents](#what-a-body-may-contain) · [ending](#ending-a-loop) · [human actions](#human-actions)
+  - [`type: break`](#type-break)
+  - [Nesting rules](#nesting-rules) — which type may appear where
+
+**Behaviour**
+
+- [Conditions](#conditions)
+  - [`if:` — skip a step](#if--skip-a-step-carry-on)
+  - [`type: condition` — finish early](#type-condition--finish-early)
+  - [`allow_failure:` — a failure that is data](#allow_failure--a-failure-that-is-data)
+  - [Reading an earlier step](#reading-the-outcome-of-an-earlier-step)
+  - [`check` is a field](#check-is-a-field-not-a-step-type)
 - [Template context](#template-context)
 - [Environment](#environment)
 - [Resolution order](#resolution-order)
@@ -141,7 +163,7 @@ Runs an agent CLI headlessly in the worktree.
 | `on_input` | string | | `wait` (default), `deny`, or `require`. `wait`/`deny` have no effect on codex or cursor; `require` refuses them |
 | `input_timeout` | duration | | Bounds each wait in `awaiting_input`, per request |
 | `check` | string | | Shell command that must exit 0 for the attempt to succeed |
-| `check_timeout` | duration | | Defaults to the command timeout |
+| `check_timeout` | duration | | Defaults to the daemon's `defaults.command_timeout` (15m) — **not** the step's own `timeout`, and not workflow `defaults.timeout` |
 
 ```yaml
   - id: implement
@@ -172,13 +194,13 @@ Runs a shell command in the worktree.
 | `shell` | `sh` \| `pwsh` \| `cmd` | | Pin the shell; default is the platform's |
 | `env` | map | | Extra environment for this step |
 | `check` | string | | Must exit 0 for the attempt to succeed |
-| `check_timeout` | duration | | Defaults to the command timeout |
+| `check_timeout` | duration | | Defaults to the daemon's `defaults.command_timeout` (15m) |
 
 ```yaml
   - id: commit
     type: command
     run: 'git add -A && git commit -m "{{.Task.Title}}"'
-    shell: bash
+    shell: sh
     env:
       CI: "true"
 ```
@@ -186,6 +208,21 @@ Runs a shell command in the worktree.
 Default shells: `/bin/sh -c` on POSIX, `pwsh -NoProfile -Command` on Windows
 (falling back to `powershell`). vincent does not translate between them —
 portability is the author's job.
+
+`shell:` accepts exactly three values — **`bash` is not one of them**. Use `sh`
+for portable POSIX syntax, or invoke bash explicitly with `run: bash -c '…'`.
+
+| Value | Runs as |
+|---|---|
+| `sh` | `/bin/sh -c`; on Windows, whatever `sh` resolves to on `PATH` (Git Bash's, if it is there) |
+| `pwsh` | `pwsh -NoProfile -Command` |
+| `cmd` | `cmd /C` |
+
+A pinned shell is never silently replaced: if it is not installed the step
+fails with `shell_unavailable`.
+
+Quote a `run:` containing a colon — `run: git commit -m "fix: thing"` is a YAML
+parse error, since the parser reads `fix:` as a second mapping key.
 
 ### `type: manual`
 
@@ -226,14 +263,23 @@ Runs its sub-steps at the same time, in the task's one worktree.
 ```
 
 Sub-steps are ordinary `agent` and `command` steps: each has its own `check`,
-`timeout`, `max_retries` and agent selection, resolved exactly as at the top
-level. What they may **not** be:
+`timeout`, `max_retries`, `if:` and agent selection, resolved exactly as at the
+top level. Those two types are the whole list — see
+[Nesting rules](#nesting-rules) for what is refused and why:
 
 - `manual` — a gate releases the task's slot, and there is no such thing as
   half a task waiting at a gate;
-- another `parallel` — groups do not nest;
+- another `parallel`, and `loop` — both derive their position from rows sharing
+  one `step_index`, and that derivation stays affordable one level deep;
+- `fan_out` — the task parks in `awaiting_children`, and a group cannot park
+  half a task;
+- `condition` — a group is a set with no later steps to stop; guard the
+  sub-step with `if:` instead;
+- `break` — there is no loop here for one to end;
 - `on_input: require` — the task has one pending question at a time, so a
-  group of agents that each want to ask has nowhere to put the answers.
+  group of agents that each want to ask has nowhere to put the answers. This is
+  judged on the **resolved** value, so a `defaults.on_input: require` reaching a
+  silent sub-step is caught too.
 
 The group is one step: one index, one slot, one entry in the timeline. It
 succeeds when every sub-step succeeds. A failure does **not** cancel the
@@ -278,6 +324,7 @@ A **lane** carries `id` and exactly one of `workflow` or `steps`, plus:
 
 | Key | Type | Notes |
 |---|---|---|
+| `if` | template | Guard. False means this lane is not spawned; siblings still run and the join still happens |
 | `fields` | map | Merged over the parent task's fields; the lane wins |
 | `agent` / `model` / `effort` | string | Override the inherited selection for this lane's whole subtree |
 | `priority` | int | Same, for scheduler priority |
@@ -293,7 +340,23 @@ too — a fan-out inside an urgent task would otherwise queue behind unrelated
 work and make the urgent task *slower* than not fanning out.
 
 **One branch is still delivered.** The step does not finish until every lane is
-merged, `--no-ff`, in the order the lanes are declared.
+merged, `--no-ff`, in the order the lanes are declared. Order is the lane's
+**declared** index, not its position among the lanes actually spawned, so a
+guarded-off lane does not renumber the merge.
+
+**Spawning parks the parent** in `awaiting_children` and releases its slot; the
+scheduler re-admits it once every descendant has settled, and that second
+admission runs the join. If the spawn is only partial, the lanes already created
+are cancelled, so a retry starts from a clean slate rather than half a tree.
+
+**When every lane is guarded off**, the step chooses nothing and advances. It
+must not park: a parent in `awaiting_children` with no children would be
+re-queued forever.
+
+**The join gets one attempt** unless the step declares `max_retries` itself. The
+two ways a join fails — a conflict, and a lane that did not finish — are both
+"a human decides", and an automatic second merge would abort the first, hit the
+same conflict and block anyway.
 
 #### `merge` and conflicts
 
@@ -310,6 +373,11 @@ commits your resolution and merges what is left.
 and the conflicted files are in its template context as `{{.Conflicts}}`. If
 it fails, or its check fails, or conflict markers survive it, you get the same
 block.
+
+A merge resolver is a full agent step and needs an `id`, since it gets step-run
+rows of its own. It may **not** declare `on_input: require`: it runs mid-join,
+and the worktree state it is resolving is not something a human can inspect
+through a question.
 
 ```yaml
     merge:
@@ -452,6 +520,31 @@ out, be retried or write a transcript.
 
 Only valid inside a loop body: elsewhere there is no loop for it to end.
 
+### Nesting rules
+
+| Type | Top level | In a `parallel` group | In a `loop` body | In a lane's inline steps |
+|---|:--:|:--:|:--:|:--:|
+| `agent` | ✅ | ✅ | ✅ | ✅ |
+| `command` | ✅ | ✅ | ✅ | ✅ |
+| `manual` | ✅ | ❌ | ❌ | ✅ |
+| `parallel` | ✅ | ❌ | ❌ | ✅ |
+| `fan_out` | ✅ | ❌ | ❌ | ✅ |
+| `condition` | ✅ | ❌ | ✅ | ✅ |
+| `loop` | ✅ | ❌ | ❌ | ✅ |
+| `break` | ❌ | ❌ | ✅ | ❌ |
+
+A lane's inline steps become a child task's own flat snapshot, so they are a
+workflow body in their own right: the "top level" column is the one that applies
+to them, and their step ids live in their own namespace.
+
+Every ❌ has one cause. A `parallel` group and a `loop` iteration run inside a
+**single admission of a single task**, and each rejected type needs a task state
+saying "one member of this structure is parked" — which §6 has no room for.
+`on_input: require` is refused inside both for the same reason: `awaiting_input`
+holds one pending request for the whole task. Refusal is judged on the
+**resolved** value, so `defaults.on_input: require` reaching a silent member is
+caught at load.
+
 ## Conditions
 
 A workflow can decide at run time what to do next. Three fields do it.
@@ -581,10 +674,22 @@ starts.
 | `.Workflow` | `Name`, `Description` |
 | `.Step` | `ID`, `Name`, `Index`, `Attempt` (1-based) |
 | `.Loop` | `Index` (1-based iteration, **0** outside any loop), `Item`, `IsFirst`, `IsLast`. See [`type: loop`](#type-loop) |
-| `.Steps` | **completed** steps by id → `{Status, Result, ExitCode}`. Includes steps skipped by a guard (`Status: "skipped"`) and steps that failed under `allow_failure`, once the workflow has moved past them |
+| `.Steps` | **completed** steps by id → `{Status, Result, ExitCode}`. `Status` is `succeeded`, `approved` (a passed gate), `skipped` (a false guard) or `failed` — the last only once the workflow has moved past it, which happens only under `allow_failure`. `interrupted` never appears |
 | `.Host` | `OS`, `Arch` — the machine the daemon runs on. This is the per-step platform gate: `{{ ne .Host.OS "windows" }}` |
 | `.Worktree` | `Path` |
 | `.LastFailure` | retries only: `{Reason, Output}`; empty otherwise |
+| `.Conflicts` | the conflicted file paths, on an `on_conflict: agent` [merge resolver](#merge-and-conflicts) only. Empty everywhere else, so a prompt may read it defensively anywhere |
+
+Visibility follows one rule — a step appears once the engine has advanced past
+it — and three consequences follow from it:
+
+- a step's **own** failed attempt is never in `.Steps["itself"]` mid-retry;
+  `.LastFailure` is that channel;
+- members of a `parallel` group are **invisible to each other**, since
+  concurrent siblings have never been advanced past;
+- inside a `loop` body, earlier steps of the current iteration **are** visible
+  to later ones, and under repetition an id resolves to its **latest**
+  iteration.
 
 `.Steps.<id>.Result` is the agent's final result text for agent steps, or the
 last **200** lines of stdout for command steps. That is how one step's output
@@ -646,7 +751,16 @@ re-derives it.
 ## Validation rules
 
 `vincent workflow validate <file>` checks all of this locally — no daemon, no
-network, no agent CLI installed.
+network, no agent CLI installed. Two values it cannot ask a daemon for, and
+substitutes deterministically so a file that validates on a laptop validates on
+a bare CI runner:
+
+- **agent catalogs** are the curated, compiled-in ones rather than a live
+  `claude --help`. Probing only ever *adds* values, so a verdict can soften on a
+  real daemon but never harden;
+- **the loop ceiling** is the built-in default (10), not your `config.yaml`.
+
+Exit status is 1 for an invalid file; `--json` emits the findings structurally.
 
 - `steps` non-empty; step `id`s unique **across the whole file**, sub-steps
   of a `parallel` group included; `type` known.
@@ -665,10 +779,12 @@ network, no agent CLI installed.
   `allow_failure`: it has no attempt of its own. A `break` has an `if:` and
   nothing else, and is valid only inside a loop body. `count`, `for_each` and
   `max_iterations` are rejected on every other step type.
-- A `fan_out` step has at least one lane; lane ids are unique within the step;
-  each lane has exactly one of `workflow` and `steps`. `merge.agent` is
-  required by, and only valid with, `on_conflict: agent`. A lane's inline
-  steps have their own id namespace, because each lane becomes its own task.
+- A `fan_out` step has at least one lane; lane ids are unique within the step
+  and are slugs; each lane has exactly one of `workflow` and `steps`.
+  `merge.agent` is required by, and only valid with, `on_conflict: agent`; it is
+  a full agent step, needs an `id`, and may not declare `on_input: require`. A
+  lane's inline steps have their own id namespace, because each lane becomes its
+  own task. `resolved_from` is written by task creation and is an error by hand.
 - Every template parses.
 - `platforms` entries are known tokens, with no duplicates. The list is checked
   for shape, never against the validating host.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -106,7 +106,7 @@ automatically, keeping the run strictly unattended.
 
 Use `restricted` for steps that have no business running commands: a docs pass, a
 review, a summarization step. See
-[Writing workflows](guides/workflows.md#permission-modes).
+[Writing workflows](guides/workflows.md#93-permission-modes).
 
 ## The API surface
 
@@ -195,5 +195,5 @@ Stated so you do not assume otherwise:
 
 - [SECURITY.md](../SECURITY.md) — reporting a vulnerability.
 - [Agent CLIs](guides/agents.md) — per-adapter behavior.
-- [Writing workflows](guides/workflows.md#permission-modes).
+- [Writing workflows](guides/workflows.md#93-permission-modes).
 - Spec [§16](spec.md) — the normative version.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -824,7 +824,7 @@ description: Implement, test, review, then push and open a PR.
 platforms: [posix]                    # optional; where this workflow may run (§8.1.1)
 
 defaults:                             # optional; per-step values override
-  agent: claude                       # claude | codex
+  agent: claude                       # claude | codex | cursor (§9.7)
   model: ""                           # adapter-native id/alias (e.g. sonnet); options via GET /v1/agents (§9.6)
   effort: ""                          # adapter-native effort (claude: low…max; codex: minimal…high) (§8.6)
   permission_mode: full-auto          # full-auto | restricted   (§9.4)
@@ -1036,6 +1036,7 @@ defensively: `{{ with index .Task.Fields "ticket" }}…{{ end }}`.
 | `.Host` | *Added 2026-08-18 (task 015).* `OS`, `Arch` — the **daemon's** GOOS/GOARCH, since the daemon is what runs the steps (§8.1.1). This is the per-step platform gate: `{{ ne .Host.OS "windows" }}`. There is deliberately no `.Now`: a guard reading wall-clock makes a run non-reproducible |
 | `.Worktree` | `Path` |
 | `.LastFailure` | on retry attempts only: `{Reason, Output}` from the previous attempt; empty otherwise |
+| `.Conflicts` | *Documented 2026-08-18: the field has shipped since task 014 but was never listed here.* The conflicted file paths a `fan_out` join hands an `on_conflict: agent` resolver (§7.6). Empty for every other step, so a prompt may read it defensively anywhere |
 
 For `agent` steps on attempt > 1, in addition to `.LastFailure` being available, the
 daemon appends a structured block to the rendered prompt automatically:


### PR DESCRIPTION
The workflow guide had grown organically into a flat sequence of essays
with no navigable structure: its own table of contents pointed at a
heading that no longer existed ("five step types" — there are eight),
and finding "how do I bound a loop" meant reading past four unrelated
sections. Rebuild it as 14 numbered sections with subsections, ordered
as a reading path — getting started, the file, control flow,
reliability, shipping — with a nested contents block, a step-type
decision table, a nesting matrix, and a troubleshooting table keyed by
the error strings the validator actually emits.

Correctness fixes found by checking every claim against the source:

- `shell: bash` appeared as a valid pin in both the guide and the
  schema reference. `isShell` accepts only sh, pwsh and cmd, so both
  snippets were files that fail validation. Replaced, and the closed
  three-value vocabulary is now stated with what each one execs.
- `check_timeout` was documented as defaulting to "the command
  timeout", which reads as the step's own. It resolves to the daemon's
  defaults.command_timeout and consults neither the step's `timeout`
  nor workflow `defaults.timeout`.
- The `parallel` sub-step rejection list named three of the six refused
  cases; fan_out, condition, loop and break were missing, as was the
  fact that `on_input: require` is judged on the resolved value.
- `.Conflicts` was reachable from a merge resolver but absent from
  every context table, spec §8.4 included.
- `.Steps` omitted `approved`, and did not state the visibility rule
  that makes group siblings blind to each other and loop body steps
  visible within an iteration.
- Lane `if:`, the parked-parent spawn path, the all-lanes-guarded-off
  advance, the join's single-attempt budget and the merge resolver's
  `on_input: require` refusal were undocumented.
- `vincent workflow validate` substitutes curated catalogs and the
  built-in loop ceiling; a reader would otherwise expect it to honour
  their config.yaml.
- spec §8.1 still offered `claude | codex`, predating the cursor
  adapter.
- README undercounted examples/ as four files; it has held five since
  converge.yaml landed.

Verified with two throwaway harnesses: one resolving every relative
link and anchor across the 100 markdown files in the repo (19 broken,
now 0), and one extracting every ```yaml block from the docs and
running it through `vincent workflow validate`. The second is what
caught the `shell: bash` pins and two `run:` values whose unquoted
colon made them YAML parse errors rather than commands.

Sibling visibility was checked against the engine rather than assumed:
renderContext filters only `failed` rows through `precedes`, so a
succeeded sibling looked reachable on a retry render. A scratch test
proved it is not, so the existing claim stands and no wording was
weakened to accommodate a bug that does not exist.