### PR TITLE
fix(taskrun): three control-flow correctness fixes (closes 018.1-018.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,15 @@ Please pull request.
   offers is stable between admissions, so this bounds the derivation rather than
   a reachable failure.
 
+- **A `loop` with an empty `for_each` list left its step index with no row.**
+  The two structure steps each have a case where they are reached and run
+  nothing — every `fan_out` lane guarded off, an empty `for_each` list — and only
+  the fan-out recorded a row saying so, leaving a detail view unable to tell
+  "ran nothing" from "never reached" for the loop. The empty case now records
+  one row under the loop's own id. That row is deliberately not a `.Steps`
+  entry: a loop's id is never one, or it would be a key present exactly when the
+  loop did nothing and absent when it did something.
+
 - **A leaked context in `parallel` and `loop` steps.** Both created a
   cancellable context and then overwrote it — `cancel` included — when the step
   carried a `timeout:`, leaving the first context attached to the parent for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,44 @@ Please pull request.
   --include-children/--parent`, and `L` in the TUI to drill into a fan-out's
   lanes.
 
+### Fixed
+
+- **A fan-out whose spawn failed part-way could never be retried.** Lanes were
+  created one at a time, each committing before the next, so a failure on lane
+  two left lane one committed; the cleanup cancelled it, and a cancelled lane
+  stays attached to its step. The parent's `retry` therefore found a lane, took
+  the *join* path instead of re-spawning, read the lane as aborted and blocked
+  `lane_failed` — again on every retry, with nothing in the API or the TUI able
+  to clear it. Lanes are now inserted in one transaction, so a failure leaves no
+  lane behind and `retry` re-spawns from a clean slate.
+
+- **A fan-out could join lanes that had not started.** The parent decided
+  *spawn or join* on whether the step had lanes, which only answers "have the
+  lanes finished" if the park after spawning always commits — and it is a
+  compare-and-swap. A parent left `running` with `queued` lanes joined on its
+  next admission and blocked `lane_failed` against work about to run perfectly
+  well. It now parks again instead.
+
+- **A `parallel` sub-step's guard could read a sibling after a retry.** §7.5
+  says a group is a set whose members cannot see each other, and that held on a
+  group's first admission only: a re-admitted group skips the sub-steps that
+  already succeeded, and their rows were still visible in `.Steps`. The same
+  guard against the same context answered one way on the first run and another
+  after a human pressed `retry`. Set-invisibility now holds in every admission.
+
+- **A `loop` whose `for_each` list re-derived shorter than its own rows.** The
+  extent came from the fresh list alone, so a shorter one would have left the
+  loop reporting success over iterations it started and never revisited. The
+  extent is now the longer of the list and the recorded iterations, with the
+  `max_iterations` ceiling re-checked against it. Every `for_each` source §8.4
+  offers is stable between admissions, so this bounds the derivation rather than
+  a reachable failure.
+
+- **A leaked context in `parallel` and `loop` steps.** Both created a
+  cancellable context and then overwrote it — `cancel` included — when the step
+  carried a `timeout:`, leaving the first context attached to the parent for the
+  rest of the task's run.
+
 ### Changed
 
 - **vincent is now source-available and dual-licensed, not MIT.** Personal and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -517,7 +517,14 @@ that happens to share the word.
   sub-step may carry an `if:`, which subsets the group. Sub-step guards are
   evaluated **once, before anything in the group starts**, so no sibling has
   run and none can be read by another's guard; a group whose sub-steps are all
-  guarded off succeeds having run nothing.
+  guarded off succeeds having run nothing. *Amended 2026-08-19 (task 018):*
+  the blindness is a property of the *set*, not of that ordering, and holds in
+  every admission. A group re-admitted after one sub-step failed skips the
+  ones that already succeeded, and their rows are still on disk — so a
+  sub-step's context omits **every** row sharing the group's `step_index` that
+  is not its own, whatever state that row ended in. Without it the same guard
+  against the same context would answer one way on the first run and another
+  after a human pressed `retry`.
 - **Rows.** One `step_runs` row per sub-step, all sharing the group's
   `step_index` and told apart by `step_id`. The group has no row of its own;
   its outcome is derived. Attempt numbers and retry budgets are per sub-step,
@@ -588,13 +595,31 @@ does not finish until every lane is merged.
   of them for its own subtree. Priority inheritance is load-bearing: admission
   is `priority DESC, created_at ASC` and descendants are created late, so
   priority-0 children of a priority-5 root would queue behind unrelated work.
+- **The spawn is one transaction.** *Added 2026-08-19 (task 018).* Every lane
+  of a step is inserted together, so a failure part-way leaves **no** lane
+  behind and the step blocks having spawned nothing; `retry` re-spawns from a
+  clean slate. Creating them one at a time made a partial spawn reachable, and
+  it had no honest recovery: whatever is cleaned up afterwards, a lane that
+  committed stays attached to the step, so the parent's next admission reads
+  it as its lanes and takes the join path below — blocking `lane_failed`
+  forever on work that never ran. Deleting the committed rows was the
+  alternative, and it would have made a hard task delete the first thing in
+  vincent that destroys work.
 - **Parking.** After spawning, the parent moves to `awaiting_children`, which
   holds **no** slot (§6, §11). That is what makes fan-out deadlock-free at any
   depth: a parent releases its slot *before* its children need one, so there
   is no hold-and-wait anywhere in the chain under any cap. A fan-out is not a
   way to exceed the caps — it is a way to fill them.
 - **Resuming.** The scheduler returns the parent to the queue once every
-  descendant has *settled* (`done` or `aborted`). A `blocked`, `awaiting_gate`
+  descendant has *settled* (`done` or `aborted`). *Amended 2026-08-19
+  (task 018):* the step decides "spawn or join" on whether its lanes have
+  settled, not merely on whether they exist. A parent admitted at the step
+  with unsettled lanes **parks again** rather than joining. That state is not
+  produced on purpose — it is a park transition that lost its compare-and-swap
+  or failed to commit, after which §12.4 re-queues a `running` parent whose
+  lanes are still `queued` — and joining there would read every lane as "not
+  done" and block `lane_failed` on work about to run perfectly well, which
+  `retry` cannot clear because the lanes are still not done. A `blocked`, `awaiting_gate`
   or `paused` lane holds the join open until a human resolves it; the §13.2
   `children` rollup is what makes that visible.
 - **The join** merges each lane branch with `git merge --no-ff` in **declared**
@@ -779,6 +804,15 @@ once, a loop is a **sequence** run more than once.
   re-admitted loop skips body steps whose latest attempt succeeded and
   continues mid-iteration. Iterations that already have rows take their item
   from those rows; only new iterations draw from a re-derived `for_each` list.
+  *Amended 2026-08-19 (task 018):* the loop's **extent** likewise never falls
+  below the iterations it has rows for. A re-derived list shorter than those
+  rows would otherwise leave the loop reporting success over iterations it
+  started and never revisited, so the extent is the longer of the two and the
+  `max_iterations` ceiling is re-checked against it. Every `for_each` source
+  §8.4 offers is stable between admissions, so this bounds the derivation
+  rather than a reachable failure; a `for_each` whose source is *not* stable
+  across admissions is a workflow bug, and the one silent way it could fail is
+  the one closed here.
 - **Human actions** (§6). `skip` skips the **whole loop step** and advances
   past it; there is no "skip this iteration". `retry` resumes at the failed
   body step of the current iteration with a fresh budget. `edit + retry`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -794,7 +794,17 @@ once, a loop is a **sequence** run more than once.
   workflow uses to stop and succeed. A `for_each` list longer than
   `max_iterations` blocks before the first iteration, naming the count. An
   empty list, or a whole loop guarded off by its `if:`, succeeds having run
-  nothing.
+  nothing. *Amended 2026-08-19 (task 018):* an empty list records **one** row
+  under the loop's own id — `succeeded`, `iteration: 0`, with a summary saying
+  the list was empty. "The loop has no row of its own" is about its
+  *iterations*: those are the body's rows, and with none of those the step index
+  a task passed through would carry no row at all, breaking the phase 2
+  invariant that every one has at least one and leaving a detail view unable to
+  tell "ran nothing" from "never reached". A `fan_out` that selects no lane has
+  recorded exactly this row since task 015. The row is invisible to the loop's
+  own derivation, which filters on `iteration > 0`, and it is **not** a
+  `.Steps` entry (§8.4): a loop's id is never one, or it would be a key present
+  exactly when the loop did nothing and absent when it did something.
 - **Failure.** A body step that exhausts its retry budget fails the iteration
   and blocks the task with that step's own reason. `allow_failure:` (§7.2) is
   how a probe's red result becomes data a `break` can read. Retries are for a

--- a/docs/tasks/018-control-flow-review.md
+++ b/docs/tasks/018-control-flow-review.md
@@ -1,11 +1,11 @@
-# 018 — Control-flow review: three correctness fixes
+# 018 — Control-flow review: four correctness fixes
 
-**Status:** ✅ done (7/7) · **Opened:** 2026-08-19 · **Closed:** 2026-08-19
+**Status:** ✅ done (9/9) · **Opened:** 2026-08-19 · **Closed:** 2026-08-19
 
 A review of the control-flow engine — `parallel` (§7.5), `fan_out` (§7.6),
 `condition`/`if:` (§7.7) and `loop`/`break` (§7.8) — against the spec sections
-that define them. Three of the four findings are behaviour changes with a
-recorded alternative; the fourth is a leak. Nothing here adds a step type, a
+that define them. Four of the five findings are behaviour changes with a
+recorded alternative; the fifth is a leak. Nothing here adds a step type, a
 field or a driver: the feature surface is unchanged, and the last section
 records what a review of that surface concluded should *not* change.
 
@@ -77,6 +77,22 @@ run. `govet`'s `lostcancel` does not see it, because `cancel` *is* used.
 
 **Fixed:** one context, not two.
 
+### 5. A loop with an empty `for_each` left its step index with no row at all
+
+`fan_out` and `loop` are the two structure steps, and each has a degenerate
+case where it is reached and runs nothing: every lane guarded off, and an empty
+`for_each` list. The fan-out recorded a row saying so; the loop recorded
+nothing, and `TestLoopForEachEmptyListSucceeds` asserted that it must not.
+
+That leaves the one step index a task can pass through carrying no row —
+against the phase 2 invariant that every one has at least one — and a detail
+view with no way to tell "ran nothing" from "never reached".
+
+**Fixed:** the empty case records one row under the loop's own id, `succeeded`
+with `iteration: 0` and a summary. It is invisible to the loop's own
+derivation, which filters on `iteration > 0`, and it is filtered out of
+`.Steps`.
+
 ## Decisions
 
 **D1 (2026-08-19) — a partial spawn is made unreachable, not recoverable.**
@@ -114,6 +130,27 @@ through any documented input today. It is eight lines, and the failure it
 forecloses is the silent kind: a loop reporting success over iterations it
 started and never revisited.
 
+**D6 (2026-08-19) — the empty loop records a row, and that row is not a
+`.Steps` entry.** §7.8's "the loop has no row of its own" is about its
+*iterations*, which are the body's rows; with no iterations there are none, and
+the invariant that loses is the phase 2 one. Beat: *leave it and reverse
+nothing*, which was this review's own first answer — filed as a separate task on
+the grounds that it changes what a detail view shows rather than fixing a
+correctness bug. That reasoning does not survive the invariant being named: a
+step index with no row is not a display preference.
+
+The second half of the decision is the one that took the work. A `succeeded`
+row is visible in `.Steps` under the loop's id, which would make that id a key
+present exactly when the loop did **nothing** and absent when it did something
+— an inverted signal, worse than no signal, and worse than the gap it was
+closing. Beat: *record it as `skipped` with a new skip reason*, which is
+arguably the more accurate state but reads as visible-and-meaningful under §7.7
+and so has the same problem. So the row is `succeeded`, matching the fan-out's
+no-lane row exactly, and `stepEnv.blindTo` filters every `loop`-typed row out
+of `.Steps`. A `fan_out`'s row is a real result — "merged 3 lanes" — and stays
+visible; the asymmetry between the two structure steps is now in one place and
+stated, rather than spread across a missing row and a surprising key.
+
 **D5 (2026-08-19) — no new step type, field or driver.** The last section says
 why, item by item. The review's conclusion is that the control-flow surface is
 the right size for the project's scope and that its stated omissions —
@@ -132,6 +169,9 @@ the right size for the project's scope and that its stated omissions —
 - [x] 018.6 one context per structure step, not two ✓ 2026-08-19
 - [x] 018.7 §7.5, §7.6 and §7.8 amended in place; tests for each fix, each
   verified red without it ✓ 2026-08-19
+- [x] 018.8 an empty `for_each` records one row under the loop's own id;
+  `TestLoopForEachEmptyListSucceeds` reversed ✓ 2026-08-19
+- [x] 018.9 `blindTo` keeps a `loop`-typed row out of `.Steps` ✓ 2026-08-19
 
 ## Verification
 
@@ -147,6 +187,8 @@ Each behaviour fix has a test that was verified to fail without it:
 | 2 | `TestFanOutParksWhenItsLanesHaveNotSettled` | `stop = false` — falls through to the join |
 | 3 | `TestGroupSiblingsStayInvisibleAcrossAdmissions` | attempt 2 reads `[succeeded]`, want `[]` |
 | 4 | `TestLoopForEachExtentNeverShrinksBelowItsRows` | `plan.total = 1`, want 3 |
+| 5 | `TestLoopForEachEmptyListSucceeds` | 0 rows at the loop, want 1 |
+| 5 | `TestLoopForEachEmptyListSucceeds` | a later step reads the loop id as `[succeeded]`, want `[]` |
 
 Fix 2 and 018.5 are driven directly rather than through the scheduler, because
 each needs a state no admission produces on purpose. That is stated rather than
@@ -207,12 +249,8 @@ truthiness in a guard (§7.7). These are binding decisions from tasks 015 and
   plus an `if:` on the next step is the same thing composed from parts that
   already exist, and it keeps one failure vocabulary (§7.2) instead of two.
 
-**One observability asymmetry, left alone.** A `fan_out` that selects no lanes
-records a decision row saying so; a `loop` whose `for_each` list is empty
-records nothing, and `TestLoopForEachEmptyListSucceeds` asserts that it must
-not. The two are inconsistent, and the loop's side is the odd one — "every step
-index a task passes through has at least one row" is a phase 2 decision the
-empty loop breaks. It is left as it is because the assertion is deliberate and
-reversing it is a change to what the TUI shows for a step that did nothing, not
-a correctness fix. Worth a task of its own if the empty-loop case ever confuses
-someone reading a detail view.
+**One observability asymmetry, fixed rather than deferred.** The empty-loop row
+was first written up here, as a display question worth a task of its own. It is
+finding 5 above instead: naming the phase 2 invariant it broke settled that it
+was not a display question. D6 records both halves, including the `.Steps`
+visibility problem that only appeared once the row existed.

--- a/docs/tasks/018-control-flow-review.md
+++ b/docs/tasks/018-control-flow-review.md
@@ -1,0 +1,218 @@
+# 018 — Control-flow review: three correctness fixes
+
+**Status:** ✅ done (7/7) · **Opened:** 2026-08-19 · **Closed:** 2026-08-19
+
+A review of the control-flow engine — `parallel` (§7.5), `fan_out` (§7.6),
+`condition`/`if:` (§7.7) and `loop`/`break` (§7.8) — against the spec sections
+that define them. Three of the four findings are behaviour changes with a
+recorded alternative; the fourth is a leak. Nothing here adds a step type, a
+field or a driver: the feature surface is unchanged, and the last section
+records what a review of that surface concluded should *not* change.
+
+## The findings
+
+### 1. A partial fan-out spawn was a permanent dead end (bug)
+
+`spawnLanes` created one child per lane with its own `CreateTask`, each
+committing before the next. A failure on lane 2 therefore left lane 1
+committed, and the recovery was `abandonPartialSpawn` — cancel the lanes that
+made it, so "a retry starts from a clean slate rather than half a tree".
+
+It did not. A cancelled lane keeps `parent_task_id` and `parent_step_index`,
+and `runFanOut` decides *spawn or join* by whether the step has lanes at all.
+So the human's `retry` found one lane, took the join path, read it as
+`aborted`, and blocked `lane_failed` — forever, because retrying again found
+the same lane. Nothing in the API or the TUI clears it. No test covered the
+path.
+
+**Fixed** by making the state unreachable rather than recoverable:
+`store.CreateTasks` inserts every lane in one transaction, so a failure leaves
+no lane behind, and `abandonPartialSpawn` is deleted.
+
+### 2. The join ran against lanes that had not started (bug)
+
+The same *spawn or join* test has a second hole, independent of the first.
+"This step has lanes" only means "the lanes have finished" if the parent
+reliably parked after spawning them — and the park is a transition that can
+lose its compare-and-swap or fail to commit. When it does, the parent stays
+`running` with `queued` lanes, §12.4 re-queues it, and the join blocks
+`lane_failed` against work that is about to run perfectly well. `retry` walks
+straight back into it.
+
+**Fixed:** a parent admitted at a `fan_out` step whose lanes have not all
+settled parks again instead of joining.
+
+### 3. Group sibling-blindness only held on the first admission (spec deviation)
+
+§7.5 promises that no `parallel` sibling can be read by another sub-step's
+guard, and grounds it in *when* guards run — before anything in the group
+starts. That reasoning covers one admission. `renderContext` sent `succeeded`
+and `skipped` rows into `.Steps` unconditionally (only `failed` rows went
+through the positional `precedes` filter), so a group re-admitted after one
+sub-step failed exposed the siblings that had already succeeded.
+
+The observable effect, now pinned by a test that fails without the fix: the
+same guard against the same context rendered `[]` on the first run and
+`[succeeded]` after a human pressed `retry`. A verdict that depends on retry
+history is the decision cache §7.7 refused, reached from the other direction.
+
+**Fixed:** `stepEnv.blindTo` omits every row sharing the group's `step_index`
+that is not the sub-step's own, whatever state it ended in.
+
+### 4. A leaked cancel in both structure steps (leak)
+
+`runGroup` and `runLoop` each did:
+
+```go
+groupCtx, cancel := context.WithCancel(ctx)
+if env.step.Timeout != nil {
+    groupCtx, cancel = context.WithTimeout(ctx, env.step.Timeout.Std())
+}
+defer cancel()
+```
+
+With a `timeout:` set, the first context's `cancel` is overwritten and never
+called, so that context stays attached to the parent for the rest of the task's
+run. `govet`'s `lostcancel` does not see it, because `cancel` *is* used.
+
+**Fixed:** one context, not two.
+
+## Decisions
+
+**D1 (2026-08-19) — a partial spawn is made unreachable, not recoverable.**
+Beat: *delete the abandoned lanes*, which was the first choice and was
+abandoned on contact. There is no task delete anywhere in vincent and no
+`task.deleted` event, so it meant introducing the first destructive task
+primitive plus an event type for clients to drop the phantom lane — in a system
+whose stated posture is that nothing destroys work. Also beat: *filter aborted
+lanes out of the spawn-or-join test*, which cannot work, because it would turn
+a human's deliberate `cancel` of one lane into a silent re-spawn and §7.6 says
+that must block `lane_failed`. One transaction removes the state instead, and
+takes 25 lines of cleanup code with it.
+
+**D2 (2026-08-19) — the join's precondition is settled lanes, not existing
+lanes.** These are the same question only when the park always commits, and it
+is a compare-and-swap. Parking again is idempotent and costs one admission;
+the alternative is a block a human cannot clear.
+
+**D3 (2026-08-19) — sibling-blindness is a property of the set, in every
+admission.** Beat: *amend §7.5 to say siblings that succeeded under an earlier
+admission are visible*. That is cheaper to write and worse to use: it makes a
+guard's answer depend on whether a human has pressed `retry`, which is exactly
+the non-reproducibility §7.6 chose declared lane order to avoid and §7.7 chose
+never to cache a verdict to avoid. The set/sequence distinction is the axis
+§7.5–§7.8 are built on; it should not hold only on Tuesdays.
+
+**D4 (2026-08-19) — a loop's extent never falls below the iterations it has
+rows for.** Beat: *pin the whole `for_each` list on the first admission* by
+persisting it, which would break §7.8's "no loop cursor is persisted anywhere"
+for a case that only bites when the author fed the loop something unstable.
+Also beat: *leave it and document it*. This is defence-in-depth, and it is
+recorded as such: every `for_each` source §8.4 offers — a step result, a task
+field, `.Host` — is stable between admissions, so the shrink is not reachable
+through any documented input today. It is eight lines, and the failure it
+forecloses is the silent kind: a loop reporting success over iterations it
+started and never revisited.
+
+**D5 (2026-08-19) — no new step type, field or driver.** The last section says
+why, item by item. The review's conclusion is that the control-flow surface is
+the right size for the project's scope and that its stated omissions —
+`while:`, `continue`, `on_false:`, nesting — are still right.
+
+## Tasks
+
+- [x] 018.1 `store.CreateTasks`: insert several tasks in one transaction,
+  sharing the branch resolution and event append with `CreateTask` ✓ 2026-08-19
+- [x] 018.2 `spawnLanes` uses it; `abandonPartialSpawn` deleted ✓ 2026-08-19
+- [x] 018.3 `runFanOut` parks when its lanes have not all settled ✓ 2026-08-19
+- [x] 018.4 `stepEnv.blindTo`: group set-invisibility in every admission
+  ✓ 2026-08-19
+- [x] 018.5 `planLoop` clamps the extent to the highest recorded iteration and
+  re-checks the ceiling ✓ 2026-08-19
+- [x] 018.6 one context per structure step, not two ✓ 2026-08-19
+- [x] 018.7 §7.5, §7.6 and §7.8 amended in place; tests for each fix, each
+  verified red without it ✓ 2026-08-19
+
+## Verification
+
+`go test ./...` and `go run mage.go lint` for `GOOS=linux`, `darwin` and
+`windows` are clean. The four gates that touch control flow pass: `m1`, `m2`,
+`m6` (parallel and fan-out), `m7` (conditions), `m8` (loops).
+
+Each behaviour fix has a test that was verified to fail without it:
+
+| Fix | Test | Failure without the fix |
+|---|---|---|
+| 1 | `TestCreateTasksIsAllOrNothing` | 1 task and 1 `task.created` committed, want 0 |
+| 2 | `TestFanOutParksWhenItsLanesHaveNotSettled` | `stop = false` — falls through to the join |
+| 3 | `TestGroupSiblingsStayInvisibleAcrossAdmissions` | attempt 2 reads `[succeeded]`, want `[]` |
+| 4 | `TestLoopForEachExtentNeverShrinksBelowItsRows` | `plan.total = 1`, want 3 |
+
+Fix 2 and 018.5 are driven directly rather than through the scheduler, because
+each needs a state no admission produces on purpose. That is stated rather than
+papered over: an end-to-end test would have to fake the same state anyway, and
+would spend a worktree and a minute doing it.
+
+## What a review of the feature set concluded not to change
+
+The brief asked what should be added or modified. The answer is nothing, and
+the reasons are worth recording because each of these will be proposed again.
+
+**Already-settled omissions, not relitigated.** `while:` (§7.8 — the converge
+loop is `count:` plus `break`, which puts the condition in the body where it
+can see the body), `continue` (§7.8 — a `condition` in a loop body already
+means it), `on_false:` on a `condition` (§7.7 — "stop and block" is a `command`
+that exits nonzero; the gap the type fills is *stop and succeed*), and loose
+truthiness in a guard (§7.7). These are binding decisions from tasks 015 and
+016.
+
+**Considered and declined:**
+
+- **`.Loop.Total`** (so a prompt can say "attempt 3 of 5"). The cheapest thing
+  on the list — the API's loop rollup already carries `max_iterations`, so this
+  is one field through `LoopContext`. Declined because `.Loop.Index` plus
+  `.Loop.IsLast` covers what a prompt actually needs to say, and §8.4 pays for
+  every field in the API DTOs and the TUI. It is the first thing to add if a
+  real workflow wants it.
+- **`cancel_siblings:` on a `parallel` group** (fail-fast). Today a sub-step's
+  failure never cancels its siblings, and §7.5 gives the reason: a
+  nearly-finished test run should not be thrown away by a linter that failed
+  first. Fail-fast is the right default for CI, where the run is free to
+  restart; it is the wrong one here, where a sibling may be twenty minutes of
+  agent time. An opt-in field would be honest, but it is a second policy on a
+  step type whose whole value is that its members are independent, and the
+  workflow that wants it can put the two steps in sequence.
+- **Relaxing the nesting rules** (a `loop` in a `parallel`, a `parallel` in a
+  loop body, nested loops). Every one of these is refused at load with the same
+  reason: position is *derived from the rows* keyed by one `step_index`, and two
+  derivations on one index have no answer. Lifting the restriction means
+  persisting a structure cursor, which is the crash-recovery property tasks 014
+  and 016 spent their design budget avoiding. Not worth it for shapes a lane's
+  own workflow can already express.
+- **`for_each` over `fan_out` lanes** (a dynamic lane list). This is the most
+  tempting item and the most expensive. §7.6's creation-time cycle, `max_depth`
+  and `max_tasks` refusals are all "possible because the whole tree's shape is
+  static once lane lists are in the snapshot". A run-time lane list gives that
+  up, and what replaces it is discovering a depth explosion as two hundred
+  worktrees six hours later — the exact failure §7.6 exists to refuse in front
+  of the person typing.
+- **Structured `for_each` items** (maps rather than strings). §8.4 is
+  string-valued throughout and `LoopContext.Item` says so deliberately. A
+  workflow that needs fields per item can put them in a line and split them in
+  the body.
+- **A `switch`/multi-way branch.** A chain of `if:` guards is longer to write
+  and needs no new concept; the shorter spelling buys nothing a reader of the
+  YAML did not already have.
+- **A step-level failure handler (`on_failure:` / try-catch).** `allow_failure:`
+  plus an `if:` on the next step is the same thing composed from parts that
+  already exist, and it keeps one failure vocabulary (§7.2) instead of two.
+
+**One observability asymmetry, left alone.** A `fan_out` that selects no lanes
+records a decision row saying so; a `loop` whose `for_each` list is empty
+records nothing, and `TestLoopForEachEmptyListSucceeds` asserts that it must
+not. The two are inconsistent, and the loop's side is the odd one — "every step
+index a task passes through has at least one row" is a phase 2 decision the
+empty loop breaks. It is left as it is because the assertion is deliberate and
+reversing it is a change to what the TUI shows for a step that did nothing, not
+a correctness fix. Worth a task of its own if the empty-loop case ever confuses
+someone reading a detail view.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -32,7 +32,7 @@ description of how the system actually behaves.
 | [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | ✅ done (10/10) |
 | [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 | [017](017-workflow-visualization.md) | Workflow visualization in the TUI | ✅ done (9/9) |
-| [018](018-control-flow-review.md) | Control-flow review: three correctness fixes | ✅ done (7/7) |
+| [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -32,6 +32,7 @@ description of how the system actually behaves.
 | [015](015-conditional-steps.md) | Conditions between steps (`if:`, `type: condition`) | ✅ done (10/10) |
 | [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 | [017](017-workflow-visualization.md) | Workflow visualization in the TUI | ✅ done (9/9) |
+| [018](018-control-flow-review.md) | Control-flow review: three correctness fixes | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -66,76 +66,131 @@ func (e *BranchClaimedError) Error() string {
 // rolls back. Archived tasks are excluded on purpose: they keep their
 // branch_name, so counting them would forbid reusing a name even after the user
 // deleted the branch by hand, which is the one case where reuse is legitimate.
+//
+// It is the one-task spelling of CreateTasks, which is where the transaction
+// lives.
 func (s *Store) CreateTask(ctx context.Context, t *Task, resolveBranch func(id int64) (string, error)) error {
+	return s.CreateTasks(ctx, []*Task{t}, resolveBranch)
+}
+
+// CreateTasks inserts several tasks in **one** transaction, resolving each
+// one's branch name the way CreateTask does. Either every row is committed or
+// none is.
+//
+// It exists for a fan_out step's lanes (spec §7.6). Spawning them one
+// CreateTask at a time made a *partial* spawn reachable — some lanes
+// committed, the rest not — and there is no honest way to clean that up
+// afterwards: cancelling the lanes that made it leaves them settled-aborted
+// and still attached to the step, so the parent's next admission takes the
+// join path and blocks `lane_failed` forever, while deleting them would need
+// the first destructive task primitive in a system whose posture is that
+// nothing destroys work. One transaction removes the state instead of
+// cleaning up after it.
+//
+// The branch claim (claimBranchTx) runs per task inside the shared
+// transaction, so two lanes resolving to the same name collide here exactly
+// as a lane colliding with an existing task does.
+func (s *Store) CreateTasks(ctx context.Context, tasks []*Task, resolveBranch func(id int64) (string, error)) error {
+	if len(tasks) == 0 {
+		return nil
+	}
 	now := time.Now()
+	events := make([]*Event, 0, len(tasks))
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		events = events[:0]
+		for _, t := range tasks {
+			ev, err := insertTaskTx(ctx, tx, t, now, resolveBranch)
+			if err != nil {
+				return err
+			}
+			events = append(events, ev)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// After the commit, in insertion order: a subscriber must never see a
+	// task.created for a row a rollback took away.
+	for _, ev := range events {
+		s.notify(ev)
+	}
+	return nil
+}
+
+// insertTaskTx is one task's insert, branch-name resolution, branch claim and
+// task.created event, inside the caller's transaction. The event is returned
+// rather than published: publishing belongs after the commit.
+func insertTaskTx(
+	ctx context.Context, tx *sql.Tx, t *Task, now time.Time,
+	resolveBranch func(id int64) (string, error),
+) (*Event, error) {
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = now
 	}
 	t.UpdatedAt = now
 	fields, err := marshalFields(t.Fields)
 	if err != nil {
-		return fmt.Errorf("insert task: %w", err)
+		return nil, fmt.Errorf("insert task: %w", err)
 	}
-	var ev *Event
-	err = s.withTx(ctx, func(tx *sql.Tx) error {
-		res, err := tx.ExecContext(ctx, `
-			INSERT INTO tasks (project_id, title, description, fields_json, workflow_name, workflow_snapshot,
-				base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
-				state, current_step, block_reason,
-				parent_task_id, parent_step_index, lane_id, lane_order,
-				created_at, updated_at, started_at, finished_at, archived_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			t.ProjectID, t.Title, t.Description, fields, t.WorkflowName, t.WorkflowSnapshot,
-			t.BaseBranch, t.BranchName, nullString(t.WorktreePath), t.Priority,
-			nullString(t.AgentOverride), nullString(t.ModelOverride), nullString(t.EffortOverride),
-			string(t.State), t.CurrentStep, nullString(t.BlockReason),
-			t.ParentTaskID, t.ParentStepIndex, nullString(t.LaneID), t.LaneOrder,
-			formatTime(t.CreatedAt), formatTime(t.UpdatedAt),
-			formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt))
+	res, err := tx.ExecContext(ctx, `
+		INSERT INTO tasks (project_id, title, description, fields_json, workflow_name, workflow_snapshot,
+			base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
+			state, current_step, block_reason,
+			parent_task_id, parent_step_index, lane_id, lane_order,
+			created_at, updated_at, started_at, finished_at, archived_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ProjectID, t.Title, t.Description, fields, t.WorkflowName, t.WorkflowSnapshot,
+		t.BaseBranch, t.BranchName, nullString(t.WorktreePath), t.Priority,
+		nullString(t.AgentOverride), nullString(t.ModelOverride), nullString(t.EffortOverride),
+		string(t.State), t.CurrentStep, nullString(t.BlockReason),
+		t.ParentTaskID, t.ParentStepIndex, nullString(t.LaneID), t.LaneOrder,
+		formatTime(t.CreatedAt), formatTime(t.UpdatedAt),
+		formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt))
+	if err != nil {
+		return nil, fmt.Errorf("insert task: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("insert task: %w", err)
+	}
+	t.ID = id
+	// The id exists now, so a name that needed it can be produced and written
+	// before this transaction commits.
+	if resolveBranch != nil {
+		branch, err := resolveBranch(id)
 		if err != nil {
-			return fmt.Errorf("insert task: %w", err)
+			return nil, err
 		}
-		id, err := res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("insert task: %w", err)
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE tasks SET branch_name = ? WHERE id = ?`, branch, id); err != nil {
+			return nil, fmt.Errorf("assign branch name: %w", err)
 		}
-		t.ID = id
-		// The id exists now, so a name that needed it can be produced and written
-		// before this transaction commits.
-		if resolveBranch != nil {
-			branch, err := resolveBranch(id)
-			if err != nil {
-				return err
-			}
-			if _, err := tx.ExecContext(ctx,
-				`UPDATE tasks SET branch_name = ? WHERE id = ?`, branch, id); err != nil {
-				return fmt.Errorf("assign branch name: %w", err)
-			}
-			t.BranchName = branch
-		}
-		if err := claimBranchTx(ctx, tx, t.ProjectID, t.BranchName, id); err != nil {
-			return err
-		}
-		payload, err := json.Marshal(map[string]any{
-			"state": string(t.State), "title": t.Title, "workflow": t.WorkflowName,
-		})
-		if err != nil {
-			return fmt.Errorf("marshal task.created event: %w", err)
-		}
-		// Copied, not aliased: the event goes to the broker, and t belongs to the
-		// caller.
-		taskID, projectID := t.ID, t.ProjectID
-		ev = &Event{
-			TS: now, Type: EventTaskCreated,
-			TaskID: &taskID, ProjectID: &projectID, Payload: payload,
-		}
-		return appendEventTx(ctx, tx, ev)
+		t.BranchName = branch
+	}
+	if err := claimBranchTx(ctx, tx, t.ProjectID, t.BranchName, id); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(map[string]any{
+		"state": string(t.State), "title": t.Title, "workflow": t.WorkflowName,
 	})
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("marshal task.created event: %w", err)
 	}
-	s.notify(ev)
-	return nil
+	// Copied, not aliased: the event goes to the broker, and t belongs to the
+	// caller.
+	taskID, projectID := t.ID, t.ProjectID
+	ev := &Event{
+		TS: now, Type: EventTaskCreated,
+		TaskID: &taskID, ProjectID: &projectID, Payload: payload,
+	}
+	// Appended inside the caller's transaction, so a rolled-back insert takes
+	// its event with it; the caller publishes it to the broker after the
+	// commit.
+	if err := appendEventTx(ctx, tx, ev); err != nil {
+		return nil, err
+	}
+	return ev, nil
 }
 
 // claimBranchTx fails when another unarchived task in the project already holds

--- a/internal/store/tasks_test.go
+++ b/internal/store/tasks_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -262,5 +263,82 @@ func TestTaskGetMissing(t *testing.T) {
 	s := openTest(t)
 	if _, err := s.GetTask(t.Context(), 42); !errors.Is(err, ErrNotFound) {
 		t.Errorf("GetTask(missing) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestCreateTasksIsAllOrNothing is the property a fan_out step's spawn rests
+// on (spec §7.6): lanes are inserted in one transaction, so a failure part-way
+// leaves no lane behind at all.
+//
+// Spawning one CreateTask at a time made a *partial* spawn reachable, and
+// there is no honest recovery from it — the lanes that committed stay attached
+// to the step, so the parent's next admission reads them as its lanes, takes
+// the join path and blocks lane_failed on work that never ran.
+func TestCreateTasksIsAllOrNothing(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	first := newTask(p.ID, "lane-a", TaskQueued)
+	first.BranchName = "vincent/lanes"
+	second := newTask(p.ID, "lane-b", TaskQueued)
+	second.BranchName = "vincent/lanes" // the same name: the claim refuses it
+
+	err := s.CreateTasks(ctx, []*Task{first, second}, nil)
+	var claimed *BranchClaimedError
+	if !errors.As(err, &claimed) {
+		t.Fatalf("CreateTasks error = %v, want *BranchClaimedError", err)
+	}
+
+	tasks, err := s.ListTasks(ctx, TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("committed %d tasks, want 0 — the batch must roll back whole", len(tasks))
+	}
+	// The event goes in the same transaction, so a rolled-back insert must not
+	// leave a task.created behind for a row that does not exist.
+	events, err := s.ListEvents(ctx, EventFilter{Types: []string{EventTaskCreated}})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("task.created events = %d, want 0", len(events))
+	}
+}
+
+// TestCreateTasksAssignsEachItsOwnBranch: the resolver is called once per row
+// with that row's own id, and every row is committed with the name it
+// produced.
+func TestCreateTasksAssignsEachItsOwnBranch(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	in := []*Task{newTask(p.ID, "a", TaskQueued), newTask(p.ID, "b", TaskQueued)}
+	for _, task := range in {
+		task.BranchName = ""
+	}
+	if err := s.CreateTasks(ctx, in, func(id int64) (string, error) {
+		return fmt.Sprintf("vincent/%d", id), nil
+	}); err != nil {
+		t.Fatalf("CreateTasks: %v", err)
+	}
+	for _, task := range in {
+		want := fmt.Sprintf("vincent/%d", task.ID)
+		if task.BranchName != want {
+			t.Errorf("task %d branch = %q, want %q", task.ID, task.BranchName, want)
+		}
+		got, err := s.GetTask(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("GetTask %d: %v", task.ID, err)
+		}
+		if got.BranchName != want {
+			t.Errorf("committed branch = %q, want %q", got.BranchName, want)
+		}
+	}
+	if in[0].ID == in[1].ID {
+		t.Errorf("both tasks got id %d", in[0].ID)
 	}
 }

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -201,8 +201,22 @@ func (e *stepEnv) precedes(run *store.StepRun) bool {
 	return ok && pos < e.loop.pos
 }
 
-// blindTo reports whether run is a `parallel` sibling this step may not see
-// at all, whatever state it ended in (§7.5).
+// blindTo reports whether run is a row this step's context may not see. Two
+// unrelated rules share the gate because both are "this row is not a result of
+// a step that precedes me".
+//
+// The second is the simpler one: a `loop` step's own row is never a `.Steps`
+// entry. A loop contributes results under its *body* steps' ids, and the one
+// row it writes under its own — the task 018 D6 row saying an empty `for_each`
+// ran nothing — is a record for a detail view, not a result. Letting it
+// through would make the loop's id a `.Steps` key that is present exactly when
+// the loop did nothing and absent when it did something, which is a worse
+// signal than no signal. A `fan_out`'s row is a real result ("merged 3 lanes")
+// and stays visible; only `loop` is filtered, and every row a loop step writes
+// under its own id carries that type.
+//
+// The first rule: run is a `parallel` sibling this step may not see at all,
+// whatever state it ended in (§7.5).
 //
 // A group is a *set*: §7.5 promises that no sibling can be read by another's
 // guard, and gives as its reason that guards are evaluated before anything in
@@ -220,6 +234,9 @@ func (e *stepEnv) precedes(run *store.StepRun) bool {
 // covers every state, and it says nothing about a step's own rows — a
 // sub-step being retried still reads its own history through `.LastFailure`.
 func (e *stepEnv) blindTo(run *store.StepRun) bool {
+	if run.StepType == workflow.StepLoop {
+		return true
+	}
 	if !e.inGroup || e.loop != nil {
 		return false
 	}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -201,6 +201,31 @@ func (e *stepEnv) precedes(run *store.StepRun) bool {
 	return ok && pos < e.loop.pos
 }
 
+// blindTo reports whether run is a `parallel` sibling this step may not see
+// at all, whatever state it ended in (§7.5).
+//
+// A group is a *set*: §7.5 promises that no sibling can be read by another's
+// guard, and gives as its reason that guards are evaluated before anything in
+// the group starts. That reason only covers the first admission. A group
+// re-admitted after one sub-step failed skips the ones that already succeeded
+// (pendingSubSteps) and their `succeeded` rows are still on disk, so without
+// this the surviving sub-step's guard would read a sibling on the retry and
+// not on the first run — the same guard, the same context, two verdicts,
+// decided by whether a human had pressed retry. Making the blindness
+// unconditional is what keeps §7.5's set semantics a fact rather than a
+// property of timing.
+//
+// It is deliberately narrower than precedes, which answers a different
+// question for *failed* rows only: this one is about the whole set, so it
+// covers every state, and it says nothing about a step's own rows — a
+// sub-step being retried still reads its own history through `.LastFailure`.
+func (e *stepEnv) blindTo(run *store.StepRun) bool {
+	if !e.inGroup || e.loop != nil {
+		return false
+	}
+	return run.StepIndex == e.index && run.StepID != e.step.ID
+}
+
 // stepOutcome is the result of one attempt.
 type stepOutcome struct {
 	state         store.StepRunState
@@ -589,6 +614,9 @@ func (r *Runner) renderContext(ctx context.Context, env *stepEnv, attempt int, p
 	steps := map[string]workflow.StepResult{}
 	for i := range runs {
 		run := runs[i]
+		if env.blindTo(&run) {
+			continue
+		}
 		switch run.State {
 		case store.StepSucceeded, store.StepApproved, store.StepSkipped:
 		case store.StepFailed:

--- a/internal/taskrun/fanout.go
+++ b/internal/taskrun/fanout.go
@@ -44,8 +44,25 @@ func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutco
 		}
 	}
 	if len(mine) > 0 {
-		// The children exist, so this admission is the join (decision 3). It
-		// runs through the ordinary attempt path, which gives it a
+		if unsettled := unsettledLanes(mine); unsettled > 0 {
+			// The lanes exist but have not all settled, so this admission is
+			// not the join: the parent was admitted without having parked.
+			// The route is a park transition that did not commit — a lost CAS
+			// or a DB error after a successful spawn — after which recovery
+			// re-queues a `running` parent whose lanes are still `queued`.
+			// Joining here would read them as "not done" and block
+			// `lane_failed` on lanes that are about to run perfectly well, so
+			// the parent parks now and the scheduler brings it back when they
+			// have settled (§7.6).
+			env.log.Info("fan-out lanes are still running; parking",
+				"lanes", len(mine), "unsettled", unsettled)
+			if r.transition(env.task, taskstate.FanOut, store.TaskChange{}, env.log) {
+				env.log.Info("awaiting children", "step", env.step.ID)
+			}
+			return stepOutcome{}, true
+		}
+		// Every lane has settled, so this admission is the join (decision 3).
+		// It runs through the ordinary attempt path, which gives it a
 		// step_runs row like any other step.
 		//
 		// The budget is one attempt unless the author asked for more: the two
@@ -84,10 +101,12 @@ func (r *Runner) runFanOut(ctx context.Context, env *stepEnv) (outcome stepOutco
 	}
 
 	if err := r.spawnLanes(ctx, env, selected); err != nil {
-		// A partial spawn is not left behind: the lanes that were created are
-		// cancelled, so a retry starts from a clean slate rather than
-		// half a tree.
-		r.abandonPartialSpawn(ctx, env)
+		// Nothing to clean up: the lanes are created in one transaction
+		// (store.CreateTasks), so a failure leaves *no* lane behind and a
+		// retry re-spawns from a clean slate. Cancelling half a tree used to
+		// stand here, and it was the bug: a cancelled lane stays attached to
+		// this step, so the retry took the join path and blocked
+		// `lane_failed` on lanes that had never run.
 		env.log.Error("spawn lanes", "error", err)
 		r.fail(env.task, ReasonInternalError, env.log, "spawn lanes", err)
 		return stepOutcome{}, true
@@ -111,6 +130,11 @@ func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv, selected []int) e
 	if err != nil {
 		return fmt.Errorf("load project: %w", err)
 	}
+	spec := worktree.BranchSpec{
+		ProjectTemplate: project.BranchTemplate,
+		ConfigTemplate:  r.deps.Config().BranchTemplate,
+	}
+	children := make([]*store.Task, 0, len(selected))
 	for _, order := range selected {
 		lane := env.step.Lanes[order]
 		// order is the lane's **declared** index, not its position among the
@@ -121,27 +145,62 @@ func (r *Runner) spawnLanes(ctx context.Context, env *stepEnv, selected []int) e
 		if err != nil {
 			return err
 		}
-		// The child's branch is resolved inside the insert's own transaction,
-		// exactly as any other task's is (task 001) — a lane is not a special
-		// case in the one place branch names are decided.
-		spec := worktree.BranchSpec{
-			ProjectTemplate: project.BranchTemplate,
-			ConfigTemplate:  r.deps.Config().BranchTemplate,
+		children = append(children, child)
+	}
+	// The children's branch names are resolved inside the insert's own
+	// transaction, exactly as any other task's are (task 001) — a lane is not
+	// a special case in the one place branch names are decided. resolveBranch
+	// is called once per row, and the row it is called for is the one whose ID
+	// the insert has just assigned: matching on that rather than counting
+	// calls keeps this correct however CreateTasks orders its inserts.
+	resolve := func(id int64) (string, error) {
+		child := laneByID(children, id)
+		if child == nil {
+			return "", fmt.Errorf("resolve lane branch: no lane holds task id %d", id)
 		}
 		bctx := worktree.NewBranchContext(child.Title, child.BaseBranch, child.Fields,
 			worktree.BranchProject{
 				Name: project.Name, Path: project.Path, DefaultBranch: project.DefaultBranch,
 			})
-		resolve := func(id int64) (string, error) {
-			name, _, err := worktree.ResolveBranchName(spec, bctx.WithID(id))
-			return name, err
-		}
-		if err := r.deps.Store.CreateTask(r.persistCtx(), child, resolve); err != nil {
-			return fmt.Errorf("create lane %q: %w", lane.ID, err)
-		}
-		env.log.Info("lane spawned", "lane", lane.ID, "child", child.ID, "branch", child.BranchName)
+		name, _, err := worktree.ResolveBranchName(spec, bctx.WithID(id))
+		return name, err
+	}
+	// One transaction for every lane (§7.6): a partial spawn is the one
+	// fan-out state with no honest recovery, so it is made unreachable rather
+	// than cleaned up. A lane that fails to insert takes its siblings with it
+	// and the step blocks with nothing spawned.
+	if err := r.deps.Store.CreateTasks(r.persistCtx(), children, resolve); err != nil {
+		return fmt.Errorf("create %d lanes of step %q: %w", len(children), env.step.ID, err)
+	}
+	for _, child := range children {
+		env.log.Info("lane spawned", "lane", child.LaneID, "child", child.ID, "branch", child.BranchName)
 	}
 	return nil
+}
+
+// laneByID is the child CreateTasks has just assigned id to. insertTaskTx
+// writes the id onto the row before it asks for a branch name, which is what
+// makes this lookup possible at all.
+func laneByID(children []*store.Task, id int64) *store.Task {
+	for _, child := range children {
+		if child.ID == id {
+			return child
+		}
+	}
+	return nil
+}
+
+// unsettledLanes counts the lanes of one fan_out step that have not reached a
+// terminal state. A non-zero count means the parent is mid-fan-out and must
+// park, not join.
+func unsettledLanes(lanes []store.Task) int {
+	n := 0
+	for i := range lanes {
+		if !taskstate.Settled(lanes[i].State) {
+			n++
+		}
+	}
+	return n
 }
 
 // selectLanes evaluates every lane's `if:` and returns the declared indices of
@@ -262,29 +321,4 @@ func mergeFields(parent, lane map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
-}
-
-// abandonPartialSpawn cancels lanes created before a spawn failed part-way.
-//
-// Without it a retry would create a second set of lanes beside the first, and
-// the join would merge a mixture of the two. Cancelling rather than deleting
-// keeps the rule that nothing destroys work: the branches and worktrees of
-// anything that started survive (decision 11).
-func (r *Runner) abandonPartialSpawn(ctx context.Context, env *stepEnv) {
-	children, err := r.deps.Store.ListChildren(ctx, env.task.ID)
-	if err != nil {
-		env.log.Error("list lanes to abandon", "error", err)
-		return
-	}
-	for _, c := range children {
-		if c.ParentStepIndex == nil || *c.ParentStepIndex != env.index {
-			continue
-		}
-		if taskstate.Settled(c.State) {
-			continue
-		}
-		if _, err := r.Cancel(r.persistCtx(), c.ID); err != nil {
-			env.log.Error("abandon partial lane", "child", c.ID, "error", err)
-		}
-	}
 }

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -2,6 +2,7 @@ package taskrun
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/gitx"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
 )
 
 // fanOutBudget is how long a fan-out test waits. It is larger than the
@@ -34,12 +36,13 @@ func writeFileStep(id, file, content string) string {
 // lanes, each writing a file. The content is the lane id, so two lanes given
 // the same filename produce a real conflict rather than an identical blob git
 // merges without noticing.
-func fanOutSnapshot(merge string, lanes ...[2]string) string {
+//
+// Every lane takes the default `on_conflict: block`; a test that wants
+// `agent` writes its own `merge:` block, which is what the removed parameter
+// never once carried.
+func fanOutSnapshot(lanes ...[2]string) string {
 	var sb strings.Builder
 	sb.WriteString("name: root\nsteps:\n  - id: build\n    type: fan_out\n")
-	if merge != "" {
-		sb.WriteString(merge)
-	}
 	sb.WriteString("    lanes:\n")
 	for _, lane := range lanes {
 		fmt.Fprintf(&sb, "      - id: %s\n        steps:\n", lane[0])
@@ -105,7 +108,7 @@ func (h *engineHarness) cancelRacingAdmission(t *testing.T, id int64) {
 func TestFanOutSpawnsLanesAndMerges(t *testing.T) {
 	h := newEngineHarness(t)
 	h.start(t)
-	task := h.createTask(t, fanOutSnapshot("", [2]string{"api", "api.txt"}, [2]string{"docs", "docs.txt"}))
+	task := h.createTask(t, fanOutSnapshot([2]string{"api", "api.txt"}, [2]string{"docs", "docs.txt"}))
 
 	lanes := h.waitForChildren(t, task.ID, 2)
 	// A lane is an ordinary task carrying four extra columns (decision 1).
@@ -155,7 +158,7 @@ func TestFanOutSpawnsLanesAndMerges(t *testing.T) {
 func TestFanOutParentHoldsNoSlotWhileWaiting(t *testing.T) {
 	h := newEngineHarnessWith(t, func(c *config.Config) { c.MaxParallelTasks = 1 })
 	h.start(t)
-	task := h.createTask(t, fanOutSnapshot("", [2]string{"api", "api.txt"}))
+	task := h.createTask(t, fanOutSnapshot([2]string{"api", "api.txt"}))
 
 	// Under a cap of 1 this can only finish if the parked parent stopped
 	// counting against it.
@@ -172,7 +175,7 @@ func TestFanOutParentHoldsNoSlotWhileWaiting(t *testing.T) {
 func TestFanOutBlocksOnMergeConflict(t *testing.T) {
 	h := newEngineHarness(t)
 	h.start(t)
-	task := h.createTask(t, fanOutSnapshot("",
+	task := h.createTask(t, fanOutSnapshot(
 		[2]string{"api", "shared.txt"}, [2]string{"docs", "shared.txt"}))
 
 	blocked := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskBlocked, store.TaskDone)
@@ -250,3 +253,93 @@ func (h *engineHarness) fileOnBranch(t *testing.T, branch, file string) bool {
 
 // git is a handle for reading the repository the test asserts against.
 func (h *engineHarness) git() *gitx.Git { return gitx.New() }
+
+// TestFanOutParksWhenItsLanesHaveNotSettled: a parent admitted at a fan_out
+// step whose lanes exist but are still running parks again instead of joining.
+//
+// The route is narrow and expensive. runFanOut decides "spawn or join" by
+// whether this step has lanes, which is only the same question as "have the
+// lanes finished" when the parent reliably parked after spawning them. It does
+// not: the park is a transition that can lose its compare-and-swap or fail to
+// commit, leaving a `running` parent with `queued` lanes for recovery to
+// re-queue. Joining there reads every lane as "not done" and blocks
+// lane_failed on work that is about to run perfectly well — and `retry` walks
+// straight back into it, because the lanes are still not done.
+//
+// It is driven directly rather than through the scheduler because the state it
+// needs is one no admission produces on purpose.
+func TestFanOutParksWhenItsLanesHaveNotSettled(t *testing.T) {
+	h := newEngineHarness(t)
+	ctx := t.Context()
+
+	snapshot := fanOutSnapshot([2]string{"api", "api.txt"}, [2]string{"docs", "docs.txt"})
+	parent := h.createTask(t, snapshot)
+	if _, _, err := h.store.TransitionTask(ctx, parent.ID,
+		store.TaskQueued, store.TaskRunning, store.TaskChange{}); err != nil {
+		t.Fatalf("put the parent in running: %v", err)
+	}
+	parent, err := h.store.GetTask(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	// Two lanes that exist and have not settled — exactly what a spawn
+	// followed by a lost park leaves behind.
+	index := 0
+	for order, lane := range []string{"api", "docs"} {
+		child := &store.Task{
+			ProjectID: h.projectID, Title: "lane " + lane,
+			WorkflowName: lane, WorkflowSnapshot: "name: " + lane + "\nsteps: []",
+			BaseBranch: parent.BranchName, BranchName: "vincent/lane-" + lane,
+			State:        store.TaskQueued,
+			ParentTaskID: &parent.ID, ParentStepIndex: &index,
+			LaneID: lane, LaneOrder: order,
+		}
+		if err := h.store.CreateTask(ctx, child, nil); err != nil {
+			t.Fatalf("create lane %s: %v", lane, err)
+		}
+	}
+
+	env := h.firstStepEnv(t, parent, snapshot)
+	outcome, stop := h.runner.runFanOut(ctx, env)
+	if !stop {
+		t.Fatalf("runFanOut stop = false, want true — the parent must park, not fall through")
+	}
+	if outcome.state != "" {
+		t.Errorf("outcome state = %q, want empty — parking is not a step outcome", outcome.state)
+	}
+
+	got, err := h.store.GetTask(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.State != store.TaskAwaitingChildren {
+		t.Errorf("parent state = %s, want %s", got.State, store.TaskAwaitingChildren)
+	}
+	if got.BlockReason != "" {
+		t.Errorf("block_reason = %q, want empty — nothing failed here", got.BlockReason)
+	}
+	for _, run := range h.stepRuns(t, parent.ID) {
+		if run.FailureReason == ReasonLaneFailed {
+			t.Errorf("the join ran and blocked %q against lanes that had not started", ReasonLaneFailed)
+		}
+	}
+}
+
+// firstStepEnv is the stepEnv the engine would build for the first step of
+// snapshot, for a test that drives one step directly.
+func (h *engineHarness) firstStepEnv(t *testing.T, task *store.Task, snapshot string) *stepEnv {
+	t.Helper()
+	wf, _, err := workflow.Parse([]byte(snapshot), workflow.Options{})
+	if err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	project, err := h.store.GetProject(t.Context(), task.ProjectID)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	return &stepEnv{
+		task: task, project: project, wf: wf,
+		step: wf.Steps[0], index: 0,
+		log: slog.New(slog.DiscardHandler),
+	}
+}

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -64,7 +64,11 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 	// the group turns that back into a failure below, because the work ran
 	// out of the time the workflow gave it rather than stopping for the
 	// daemon's sake (§7.2).
-	groupCtx, cancel := context.WithCancel(ctx)
+	// One context, not two: the unconditional WithCancel that used to stand
+	// here was overwritten — cancel and all — when the step carried a
+	// `timeout:`, leaking its child context onto the parent for the rest of
+	// the task's run.
+	groupCtx, cancel := ctx, func() {}
 	if env.step.Timeout != nil {
 		groupCtx, cancel = context.WithTimeout(ctx, env.step.Timeout.Std())
 	}
@@ -141,11 +145,14 @@ func (r *Runner) pendingSubSteps(ctx context.Context, env *stepEnv) (subs []work
 // `skipped` row for each, and returns the rest in declaration order.
 //
 // Guards are evaluated **before anything in the group starts**, one after
-// another, which is what makes §7.5's sibling-blindness a fact rather than a
-// warning: no sibling has run, so none can be in `.Steps` for another's guard
-// to read. A group is a set, so a false guard subsets it rather than stopping
-// anything — the same meaning `if:` has on a fan-out lane (task 015
-// decision 3), and the reason a `condition` step is refused in here at all.
+// another, so within an admission no sibling has run and none can be in
+// `.Steps` for another's guard to read. Across admissions that ordering is not
+// enough — a re-admitted group's already-succeeded siblings still have their
+// rows — so §7.5's sibling-blindness is enforced by stepEnv.blindTo rather
+// than by this timing alone. A group is a set, so a false guard subsets it
+// rather than stopping anything — the same meaning `if:` has on a fan-out lane
+// (task 015 decision 3), and the reason a `condition` step is refused in here
+// at all.
 func (r *Runner) applySubStepGuards(
 	ctx context.Context, env *stepEnv, subs []workflow.Step,
 ) (kept []workflow.Step, guardedOff int, err error) {

--- a/internal/taskrun/group_test.go
+++ b/internal/taskrun/group_test.go
@@ -2,6 +2,8 @@ package taskrun
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -264,5 +266,64 @@ func TestParallelSubStepTranscriptsDoNotCollide(t *testing.T) {
 			t.Errorf("sub-steps %q and %q share transcript %s", other, r.StepID, r.TranscriptPath)
 		}
 		seen[r.TranscriptPath] = r.StepID
+	}
+}
+
+// TestGroupSiblingsStayInvisibleAcrossAdmissions is TestGroupSiblingsStay-
+// Invisible's re-admission half, and it is the case §7.5's own reasoning did
+// not cover.
+//
+// §7.5 says no sibling can be read by another sub-step's guard, and grounds
+// that in *when* guards run: before anything in the group starts. That holds
+// within one admission. It does not hold across two — a group re-admitted
+// after one sub-step failed skips the ones that already succeeded, whose
+// `succeeded` rows are still on disk — so the same guard, against the same
+// context, would answer one way on the first run and another after a human
+// pressed retry.
+//
+// `peek` writes what it can see of its sibling on every attempt: the first
+// (which fails) and the retry. Both lines must be empty. `[succeeded]` on the
+// second would mean set membership had become a function of retry history.
+func TestGroupSiblingsStayInvisibleAcrossAdmissions(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	peek := script(
+		`echo "[{{ (index .Steps "first" ).Status }}]" >> seen.txt; `+
+			`if [ -f marker ]; then exit 0; fi; touch marker; exit 1`,
+		`Add-Content -Path seen.txt -Value '[{{ (index .Steps "first" ).Status }}]'; `+
+			`if (Test-Path marker) { exit 0 }; New-Item -ItemType File marker | Out-Null; exit 1`,
+	)
+	// max_parallel: 1 in declaration order, so `first` has finished and its row
+	// is on disk by the time `peek` renders — only the filter can hide it.
+	snapshot := groupSnapshot("max_parallel: 1",
+		commandStep("first", script("true", "Write-Output ok"), "max_retries: 0"),
+		commandStep("peek", peek, "max_retries: 0"),
+	)
+	task := h.createTask(t, snapshot)
+
+	if blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone); blocked.State != store.TaskBlocked {
+		t.Fatalf("task state = %s, want blocked before the retry", blocked.State)
+	}
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(done.WorktreePath, "seen.txt"))
+	if err != nil {
+		t.Fatalf("read seen.txt: %v", err)
+	}
+	lines := strings.Fields(string(raw))
+	if len(lines) != 2 {
+		t.Fatalf("seen.txt = %q, want one line per attempt", lines)
+	}
+	for i, line := range lines {
+		if line != "[]" {
+			t.Errorf("attempt %d saw sibling status %q, want %q — a group is a set in every admission",
+				i+1, line, "[]")
+		}
 	}
 }

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -112,7 +112,7 @@ func (r *Runner) runLoop(ctx context.Context, env *stepEnv) stepOutcome {
 	// body step in flight, which ends as an interruption — turned back into a
 	// failure below, because the work ran out of the time the workflow gave
 	// it rather than stopping for the daemon's sake (§7.2).
-	loopCtx, cancel := context.WithCancel(ctx)
+	loopCtx, cancel := ctx, func() {}
 	if env.step.Timeout != nil {
 		loopCtx, cancel = context.WithTimeout(ctx, env.step.Timeout.Std())
 	}
@@ -288,10 +288,31 @@ func (r *Runner) planLoop(
 		return loopPlan{}, fmt.Errorf("%w: for_each produced %d items, max_iterations is %d",
 			errLoopLimit, len(items), limit)
 	}
-	for iteration, recorded := range recordedItems(history) {
-		if iteration >= 1 && iteration <= len(items) {
-			items[iteration-1] = recorded
+	// Recorded iterations win over the fresh list, and they also *extend* it:
+	// the list is re-derived on every admission (decision 8), so a source
+	// whose output shrank between admissions would otherwise leave the loop
+	// with fewer iterations than it already has rows for — it would report
+	// success having silently skipped work iterations 1..n are on record as
+	// having started. Clamping to the highest recorded iteration keeps the
+	// loop's extent monotonic without persisting a plan.
+	recorded := recordedItems(history)
+	highest := 0
+	for iteration := range recorded {
+		if iteration > highest {
+			highest = iteration
 		}
+	}
+	for len(items) < highest {
+		items = append(items, "")
+	}
+	for iteration, item := range recorded {
+		items[iteration-1] = item
+	}
+	if len(items) > limit {
+		// Re-checked after the clamp: rows past a ceiling that has since been
+		// lowered are still work this loop is not allowed to finish.
+		return loopPlan{}, fmt.Errorf("%w: for_each has %d iterations on record, max_iterations is %d",
+			errLoopLimit, len(items), limit)
 	}
 	return loopPlan{driver: workflow.DriverForEach, total: len(items), items: items}, nil
 }

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -103,7 +103,18 @@ func (r *Runner) runLoop(ctx context.Context, env *stepEnv) stepOutcome {
 		// An empty `for_each` list. The loop had nothing to iterate, which is
 		// a correct answer rather than a failure — the same way a group whose
 		// every sub-step was guarded off succeeds having run nothing (§7.5).
+		//
+		// It records a row saying so (task 018 D6). "The loop has no row of
+		// its own" is about its *iterations*: those are the body's rows, and
+		// here there are none, so without this the step index a task passed
+		// through would have no row at all — breaking the phase 2 invariant
+		// that every one has at least one, and leaving a detail view unable to
+		// tell "ran nothing" from "never reached". A `fan_out` that selects no
+		// lane has recorded exactly this row since task 015; this is the same
+		// degenerate case in the other structure step.
 		env.log.Info("loop ran nothing: the for_each list is empty")
+		r.recordDecisionRow(ctx, env, store.StepSucceeded, "", "",
+			"the for_each list is empty: the loop ran nothing")
 		return stepOutcome{state: store.StepSucceeded}
 	}
 

--- a/internal/taskrun/loop_test.go
+++ b/internal/taskrun/loop_test.go
@@ -219,24 +219,79 @@ func TestLoopForEachFromStepOutput(t *testing.T) {
 // TestLoopForEachEmptyListSucceeds: a loop with nothing to iterate decided
 // correctly, so it succeeds having run nothing — the same posture §7.5 takes
 // for a group whose every sub-step was guarded off.
+//
+// It records one row saying so, and no body rows. This test used to assert the
+// opposite — that the step index stayed empty — which left the one step index a
+// task can pass through carrying no row at all: the phase 2 invariant says
+// every one has at least one, and a detail view has no way to tell "ran
+// nothing" from "never reached". A `fan_out` selecting no lane had recorded
+// exactly this row since task 015 (task 018 D6).
 func TestLoopForEachEmptyListSucceeds(t *testing.T) {
 	h := newEngineHarness(t)
 	h.start(t)
 	snapshot := "name: each\nsteps:\n" +
 		commandStep("discover", script("true", "exit 0")) +
 		"  - id: visit\n    type: loop\n    for_each: '{{ .Steps.discover.Result }}'\n    steps:\n" +
-		bodyIndent(commandStep("touch", appendCmd("items.txt", "x")))
+		bodyIndent(commandStep("touch", appendCmd("items.txt", "x"))) +
+		// The loop's own row must not become a `.Steps` entry: its id would
+		// then be a key that is present exactly when the loop did nothing.
+		commandStep("peek", appendCmd("seen.txt", `[{{ (index .Steps "visit").Status }}]`))
 	task := h.createTask(t, snapshot)
 
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
 	if done.State != store.TaskDone {
 		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
 	}
+	var atLoop []store.StepRun
 	for _, r := range h.stepRuns(t, task.ID) {
 		if r.StepIndex == 1 {
-			t.Errorf("the loop wrote a row (%s) for an empty list; it must run nothing", r.StepID)
+			atLoop = append(atLoop, r)
 		}
 	}
+	if len(atLoop) != 1 {
+		t.Fatalf("rows at the loop = %d, want exactly 1 saying it ran nothing", len(atLoop))
+	}
+	row := atLoop[0]
+	if row.StepID != "visit" {
+		t.Errorf("row step_id = %q, want the loop's own %q — a body step must not have run",
+			row.StepID, "visit")
+	}
+	if row.State != store.StepSucceeded {
+		t.Errorf("row state = %s, want %s", row.State, store.StepSucceeded)
+	}
+	if row.Iteration != 0 {
+		t.Errorf("row iteration = %d, want 0 — there was no iteration to belong to", row.Iteration)
+	}
+	if row.ResultSummary == "" {
+		t.Error("row carries no summary; the detail view has nothing to show for a step that did nothing")
+	}
+	// No body rows, so nothing feeds the loop's own derivation on a
+	// re-admission: the iteration-0 row is invisible to both latestStatesIn
+	// (which filters on the iteration it is asking about) and recordedItems
+	// (which requires iteration > 0).
+	if got := countLoopBodyRows(atLoop); got != 0 {
+		t.Errorf("body rows = %d, want 0", got)
+	}
+	raw, err := os.ReadFile(filepath.Join(done.WorktreePath, "seen.txt"))
+	if err != nil {
+		t.Fatalf("read seen.txt: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw)); got != "[]" {
+		t.Errorf("a later step read the loop id as %q, want %q — a loop's own row is not a result",
+			got, "[]")
+	}
+}
+
+// countLoopBodyRows is how many of a loop step index's rows belong to an
+// iteration rather than to the loop step itself.
+func countLoopBodyRows(runs []store.StepRun) int {
+	n := 0
+	for _, r := range runs {
+		if r.Iteration > 0 {
+			n++
+		}
+	}
+	return n
 }
 
 // TestLoopForEachOverCeilingBlocks pins decision 5: reaching the cap is not a

--- a/internal/taskrun/loop_test.go
+++ b/internal/taskrun/loop_test.go
@@ -1,11 +1,14 @@
 package taskrun
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/store"
@@ -469,5 +472,86 @@ func TestLoopBodyStepSeesEarlierBodySteps(t *testing.T) {
 	}
 	if got := countLines(t, done.WorktreePath, "peeked.txt"); got != 2 {
 		t.Errorf("guarded body step ran %d times, want 2 — it must read the probe above it", got)
+	}
+}
+
+// TestLoopForEachExtentNeverShrinksBelowItsRows: a `for_each` list re-derived
+// smaller than the iterations already on record does not shorten the loop.
+//
+// §7.8 re-derives the list on every admission and takes each already-started
+// iteration's item from its rows rather than from the fresh list, which keeps
+// "iteration 3" naming the work iteration 3 actually did. The extent was still
+// taken from the fresh list alone, so a shorter one would have left the loop
+// reporting success over iterations it has rows for and never revisited.
+//
+// Every `for_each` source §8.4 offers is stable between admissions — a step
+// result, a task field, the host — so this is a guard on the derivation rather
+// than a reachable failure today. It is cheap, and the failure it forecloses
+// is silent: a loop that says it finished having skipped work.
+func TestLoopForEachExtentNeverShrinksBelowItsRows(t *testing.T) {
+	h := newEngineHarness(t)
+	ctx := t.Context()
+
+	// One item in the list; three iterations on record.
+	snapshot := loopSnapshot("for_each: [alpha]", commandStep("body", appendCmd("ran.txt", "x")))
+	task := h.createTask(t, snapshot)
+	recorded := []string{"alpha", "beta", "gamma"}
+	for i, item := range recorded {
+		finished := time.Now()
+		if err := h.store.CreateStepRun(ctx, &store.StepRun{
+			TaskID: task.ID, StepIndex: 0, StepID: "body", StepType: "command",
+			Attempt: 1, Iteration: i + 1, LoopItem: item,
+			State: store.StepSucceeded, FinishedAt: &finished,
+		}); err != nil {
+			t.Fatalf("seed iteration %d: %v", i+1, err)
+		}
+	}
+
+	env := h.firstStepEnv(t, task, snapshot)
+	history, err := h.store.ListStepRunsAt(ctx, task.ID, 0)
+	if err != nil {
+		t.Fatalf("ListStepRunsAt: %v", err)
+	}
+	plan, err := h.runner.planLoop(ctx, env, history, 10)
+	if err != nil {
+		t.Fatalf("planLoop: %v", err)
+	}
+	if plan.total != len(recorded) {
+		t.Errorf("plan.total = %d, want %d — the extent must cover every recorded iteration",
+			plan.total, len(recorded))
+	}
+	if !reflect.DeepEqual(plan.items, recorded) {
+		t.Errorf("plan.items = %q, want %q — a recorded iteration keeps the item its rows carry",
+			plan.items, recorded)
+	}
+}
+
+// TestLoopForEachRecordedIterationsPastTheCeilingBlock: the ceiling is
+// re-checked after the clamp, so rows past a `max_iterations` that has since
+// been lowered block rather than silently running to the smaller list.
+func TestLoopForEachRecordedIterationsPastTheCeilingBlock(t *testing.T) {
+	h := newEngineHarness(t)
+	ctx := t.Context()
+
+	snapshot := loopSnapshot("for_each: [alpha]", commandStep("body", appendCmd("ran.txt", "x")))
+	task := h.createTask(t, snapshot)
+	for i, item := range []string{"alpha", "beta", "gamma"} {
+		finished := time.Now()
+		if err := h.store.CreateStepRun(ctx, &store.StepRun{
+			TaskID: task.ID, StepIndex: 0, StepID: "body", StepType: "command",
+			Attempt: 1, Iteration: i + 1, LoopItem: item,
+			State: store.StepSucceeded, FinishedAt: &finished,
+		}); err != nil {
+			t.Fatalf("seed iteration %d: %v", i+1, err)
+		}
+	}
+
+	env := h.firstStepEnv(t, task, snapshot)
+	history, err := h.store.ListStepRunsAt(ctx, task.ID, 0)
+	if err != nil {
+		t.Fatalf("ListStepRunsAt: %v", err)
+	}
+	if _, err := h.runner.planLoop(ctx, env, history, 2); !errors.Is(err, errLoopLimit) {
+		t.Errorf("planLoop error = %v, want errLoopLimit", err)
 	}
 }


### PR DESCRIPTION
A review of `parallel` (§7.5), `fan_out` (§7.6), `condition`/`if:` (§7.7) and
`loop`/`break` (§7.8) against the spec sections that define them. No step
type, field or driver is added; docs/tasks/018 records what the review
concluded should not change and why.

Two dead ends in the fan-out spawn/join decision. `runFanOut` chose between
spawning and joining on whether the step had lanes, which is only the same
question as "have the lanes finished" when the parent always parks after
spawning. It does not, on two routes:

  - Lanes were created one CreateTask at a time, each committing before the
    next, so a failure part-way left some committed. The cleanup cancelled
    them, and a cancelled lane keeps its parent link — so the human's retry
    found a lane, joined, read it as aborted and blocked lane_failed forever.
    store.CreateTasks now inserts every lane in one transaction, making the
    partial spawn unreachable; abandonPartialSpawn is deleted. Deleting the
    committed rows was the alternative and would have made a hard task delete
    the first thing in vincent that destroys work (D1).

  - The park after a successful spawn is a compare-and-swap that can lose or
    fail to commit, leaving a running parent with queued lanes for §12.4 to
    re-queue. The join then blocked lane_failed against work about to run
    perfectly well. A parent whose lanes have not all settled now parks again
    (D2).

Group sibling-blindness held on the first admission only. §7.5 promises that
no parallel sibling can be read by another sub-step's guard and grounds it in
when guards run, which covers one admission; renderContext sent succeeded and
skipped rows into .Steps unconditionally, so a re-admitted group exposed the
siblings that had already succeeded. The same guard rendered [] on the first
run and [succeeded] after a retry. stepEnv.blindTo makes the blindness a
property of the set rather than of timing (D3).

A loop's extent came from the re-derived for_each list alone, so a list that
came back shorter than the iterations already on record would have left the
loop reporting success over iterations it started and never revisited.
planLoop clamps to the highest recorded iteration and re-checks the ceiling.
Defence-in-depth, recorded as such: every for_each source §8.4 offers is
stable between admissions (D4).

Both structure steps leaked a context: each built a cancellable one and then
overwrote it, cancel included, when the step carried a timeout. govet's
lostcancel cannot see it because cancel is used.

§7.5, §7.6 and §7.8 amended in place. Each behaviour fix has a test verified
to fail without it; the two that need a state no admission produces on purpose
drive the step directly and say so. go test ./..., -race on the changed
packages, lint for linux/darwin/windows, and the m1, m2, m6, m7 and m8 gates
all pass.