### PR TITLE
feat(workflow): splice an included workflow's steps at task creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,13 @@ jobs:
       - name: M8 gate (loops)
         shell: bash
         run: ./scripts/m8-gate.sh
+
+      # M9: workflow includes (task 019). Command steps only, with `run:`
+      # bodies in the same restricted `exit N` / `git …` vocabulary m7 and m8
+      # use, so the three-OS matrix proves the shell as much as the feature.
+      # Scenario 1 is the one that most needs Windows: it asserts the exact
+      # multi-line step order and provenance chain, which is where jq's CRLF
+      # bites (the m8 finding).
+      - name: M9 gate (includes)
+        shell: bash
+        run: ./scripts/m9-gate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,10 +80,7 @@ VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CL
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-All six of those run in `ci.yml`'s `gates` job on all three platforms. **`m9`
-does not yet**: a cloud session cannot write `.github/workflows/`, so task
-019.10 carries the one-step edit that wires it in. Until that lands, m9 is
-known to pass on Linux only. `m6`, `m7` and
+All seven run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
 `m8` spent a while unwired because a cloud session's token has no `workflow`
 scope and so cannot write `.github/workflows/` by any route — push or API
 (#120, #122, #125). A gate that has never run on a platform is not known to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,12 +74,16 @@ against the fake agent; CI runs every one of them on Linux, macOS and Windows:
 ./scripts/m6-gate.sh                            # parallel steps and fan-out (§7.5, §7.6)
 ./scripts/m7-gate.sh                            # conditions between steps (§7.7)
 ./scripts/m8-gate.sh                            # loops (§7.8)
+./scripts/m9-gate.sh                            # workflow includes (§7.9)
 VINCENT_GATE_SCENARIO=2 ./scripts/m2-gate.sh    # single scenario, for debugging
 VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CLI
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-All six run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
+All six of those run in `ci.yml`'s `gates` job on all three platforms. **`m9`
+does not yet**: a cloud session cannot write `.github/workflows/`, so task
+019.10 carries the one-step edit that wires it in. Until that lands, m9 is
+known to pass on Linux only. `m6`, `m7` and
 `m8` spent a while unwired because a cloud session's token has no `workflow`
 scope and so cannot write `.github/workflows/` by any route — push or API
 (#120, #122, #125). A gate that has never run on a platform is not known to
@@ -161,8 +165,8 @@ is a correctness bug, not a style issue:
 | `internal/daemon` | Lifecycle: foreground/detached start, lock file, token, `daemon.json`, log rotation |
 | `internal/api` | Localhost REST + SSE, bearer auth, snake_case error envelope |
 | `internal/apiclient` | Typed HTTP+SSE client — the one client for TUI and CLI; owns its wire types (server DTOs stay unexported) |
-| `internal/workflow` | YAML registry (builtin < global < project shadowing), live reload, `text/template` step engine |
-| `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out`, `condition`, `loop` and `break` are structure, and `check` is a *field* agent and command steps may carry, never a type — plus guards (`if:`, §7.7), loop iteration (§7.8), retries, timeouts, human actions, recovery, transcripts |
+| `internal/workflow` | YAML registry (builtin < global < project shadowing), live reload, `text/template` step engine, creation-time expansion of `include` steps (§7.9) |
+| `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out`, `condition`, `loop` and `break` are structure, `check` is a *field* agent and command steps may carry, never a type, and `include` never arrives at all — it is spliced away at task creation (§7.9) — plus guards (`if:`, §7.7), loop iteration (§7.8), retries, timeouts, human actions, recovery, transcripts |
 | `internal/agent` | `AgentAdapter` interface + option catalog; `agent/claude`, `agent/codex`, `agent/cursor` implement it |
 | `internal/worktree` | Per-task git worktrees, `vincent/{id}-{slug}` branches, dirty detection |
 | `internal/tui` | Bubble Tea client: six views (board, detail, new-task, projects, workflows, daemon) routed by `viewID` |

--- a/docs/gates/corpus/include.yaml
+++ b/docs/gates/corpus/include.yaml
@@ -1,0 +1,32 @@
+# 10 — includes (§7.9). The graph draws the file as authored, so each include
+# is one collapsed node labelled with the workflow it splices in: what it
+# expands to is decided at task creation, against a registry this view is not
+# resolving (task 019 decision 12).
+#
+# Two of them, one at the top level and one inside a loop body, because an
+# include may appear anywhere a step may (decision 9) and the node has to read
+# correctly inside a frame as well as outside one.
+name: include
+steps:
+  - id: plan
+    type: agent
+    prompt: plan the work
+
+  - id: verify
+    type: include
+    workflow: go-checks
+
+  - id: repeat
+    type: loop
+    count: 2
+    steps:
+      - id: attempt
+        type: agent
+        prompt: fix what the checks found
+      - id: recheck
+        type: include
+        workflow: go-checks
+
+  - id: ship
+    type: command
+    run: git push

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -29,7 +29,7 @@ parts you want to change.
 **The file**
 
 - [3. File anatomy](#3-file-anatomy) — [3.1 Top-level keys](#31-top-level-keys) · [3.2 `defaults`](#32-defaults) · [3.3 Steps and ids](#33-steps-and-ids) · [3.4 What a step inherits](#34-what-a-step-inherits)
-- [4. The eight step types](#4-the-eight-step-types) — [4.1 Choosing](#41-choosing-a-step-type) · [4.2 `agent`](#42-agent) · [4.3 `command`](#43-command) · [4.4 `manual`](#44-manual) · [4.5 `parallel`](#45-parallel) · [4.6 `fan_out`](#46-fan_out) · [4.7 `condition`](#47-condition) · [4.8 `loop`](#48-loop) · [4.9 `break`](#49-break) · [4.10 Nesting rules](#410-where-each-type-may-appear)
+- [4. The nine step types](#4-the-nine-step-types) — [4.1 Choosing](#41-choosing-a-step-type) · [4.2 `agent`](#42-agent) · [4.3 `command`](#43-command) · [4.4 `manual`](#44-manual) · [4.5 `parallel`](#45-parallel) · [4.6 `fan_out`](#46-fan_out) · [4.7 `condition`](#47-condition) · [4.8 `loop`](#48-loop) · [4.9 `break`](#49-break) · [4.10 `include`](#410-include) · [4.11 Nesting rules](#411-where-each-type-may-appear)
 
 **Making steps talk to each other**
 
@@ -322,7 +322,7 @@ codex step. The full rules are in [§9.1](#91-resolution-order).
 
 ---
 
-## 4. The eight step types
+## 4. The nine step types
 
 ### 4.1 Choosing a step type
 
@@ -336,11 +336,13 @@ codex step. The full rules are in [§9.1](#91-resolution-order).
 | Finish the run early, successfully | [`condition`](#47-condition) |
 | Repeat a sequence until it converges, or once per item | [`loop`](#48-loop) |
 | End the enclosing loop | [`break`](#49-break) |
+| Reuse another workflow's steps here | [`include`](#410-include) |
 
 `check` is a **field** on agent and command steps, not a type of its own
 ([§7](#7-verification-with-check)). Four types — `parallel`, `fan_out`, `loop`
 and `condition`/`break` — are *structure*: they organise other steps rather than
-running anything themselves.
+running anything themselves. `include` is a fifth kind of thing again: it is
+resolved away before the task runs.
 
 ### 4.2 `agent`
 
@@ -457,7 +459,7 @@ timeline, one thing to retry.
 Sub-steps are ordinary `agent` and `command` steps with their own `check`,
 `timeout`, `max_retries`, `if:` and agent selection, resolved exactly as at the
 top level. They may not be any other type — see
-[§4.10](#410-where-each-type-may-appear).
+[§4.11](#411-where-each-type-may-appear).
 
 > **Sub-steps share one working tree.** Two of them writing the same file is a
 > bug in your workflow. vincent isolates worktrees between *tasks*, not
@@ -648,7 +650,68 @@ Like `condition`, it starts no process, so it cannot time out, be retried, or
 write a transcript. It is valid **only** inside a loop body — elsewhere there is
 no loop for it to end, and that is a validation error rather than a no-op.
 
-### 4.10 Where each type may appear
+### 4.10 `include`
+
+Runs another workflow's steps here, in **this** task and **this** worktree.
+This is how you stop copy-pasting the same three verification steps into every
+workflow you own.
+
+```yaml
+# .vincent/workflows/go-checks.yaml — the fragment
+name: go-checks
+defaults: { max_retries: 0 }
+steps:
+  - { id: lint, type: command, run: go run mage.go lint }
+  - { id: test, type: command, run: go run mage.go test }
+```
+
+```yaml
+# .vincent/workflows/feature.yaml — a workflow that uses it
+name: feature
+steps:
+  - { id: implement, type: agent, prompt: "{{ .Task.Description }}" }
+  - { id: checks, type: include, workflow: go-checks }
+  - { id: review, type: agent, prompt: "lint said: {{ .Steps.lint.Result }}" }
+```
+
+Create a task on `feature` and it runs **four** steps: `implement`, `lint`,
+`test`, `review`. The include is not one of them. It is replaced by the steps it
+names when the task is created, and after that nothing can tell the difference —
+which is why `review` reads `.Steps.lint` as if you had typed it there yourself.
+
+Three things follow from that, and they are the whole of what you need to know:
+
+**The include takes no other fields.** No `if:`, no `timeout`, no
+`max_retries` — there is no step at run time for them to apply to. To make one
+conditional, guard the fragment's own steps, or put a `condition` in front of
+it.
+
+**Step ids must not collide.** The expansion is one namespace, so `go-checks`
+cannot bring a `lint` if `feature` already has one, and you cannot include the
+same fragment twice. Name a fragment's steps as if they were going to sit
+beside someone else's, because they are.
+
+**The fragment keeps its own `defaults:`.** `go-checks` says `max_retries: 0`,
+and its steps still get 0 after being spliced into a workflow that says 3. A
+fragment behaves the way it was written to behave. Your task-level `--agent`
+still wins over both.
+
+Everything else is an error when you create the task, with a message naming
+what is wrong: a workflow that isn't there, a cycle (`a` includes `b` includes
+`a`), more than `include.max_depth` levels (5 by default), a colliding step id,
+or a fragment whose `platforms:` rules out this machine. Nothing fails halfway
+through a run because of an include.
+
+> **Careful with `condition` in a fragment.** There is no include boundary at
+> run time, so a `condition` that stops the fragment stops the *whole task* —
+> the steps after the include never run. And a fragment that needs a `break`
+> cannot be factored out at all, since `break` only validates inside a loop
+> body.
+
+Editing `go-checks.yaml` never affects a task that is already running: the task
+took its copy when it was created. New tasks pick up the new version.
+
+### 4.11 Where each type may appear
 
 | Type | Top level | In a `parallel` group | In a `loop` body | In a lane's inline steps |
 |---|:--:|:--:|:--:|:--:|
@@ -660,6 +723,12 @@ no loop for it to end, and that is a validation error rather than a no-op.
 | `condition` | ✅ | ❌ | ✅ | ✅ |
 | `loop` | ✅ | ❌ | ❌ | ✅ |
 | `break` | ❌ | ❌ | ✅ | ❌ |
+| `include` | ✅ | ✅ | ✅ | ✅ |
+
+`include` is allowed everywhere because it is gone by the time anything runs.
+What gets checked against this table is what it *expands to* — so a fragment
+containing a `loop`, included into a loop body, is refused when you create the
+task, with the message a hand-written nested loop would get.
 
 A lane's inline steps are a workflow body in their own right — they become a
 child task's flat snapshot — so the "top level" column is the one that applies

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -205,7 +205,7 @@ to disable the sweep.
 | `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort?, title?, fields?, base_branch?, branch_name? }` → resolution per step, plus the previewed branch name |
 
 Registry entries carry
-`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, requires_input, errors[]?, warnings[]?, error? }`.
+`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, requires_input, includes[]?, errors[]?, warnings[]?, error? }`.
 
 `platforms[]` is the entry's [platform restriction](workflow-schema.md#platforms)
 as the file declares it, and `platform_supported` is **the daemon's own verdict**
@@ -221,6 +221,12 @@ mid-run, or `POST /v1/tasks` rejects it with a `400` naming the step. Each
 adapter's `input_verdict` in `GET /v1/agents` (`supported`, `unsupported`,
 `unknown`) is the verdict that gate uses; only `unsupported` refuses anything,
 so an agent that is not installed never blocks a task.
+
+`includes[]` names the workflows this one splices in with
+[`type: include`](workflow-schema.md#type-include). Whether those names resolve
+is **not** answered here: which file a name reaches depends on the project's
+registry, so an unresolvable or cyclic include is a `400` from `POST /v1/tasks`
+rather than an error on the entry.
 
 ### One workflow's full definition
 
@@ -409,10 +415,16 @@ events on the stream to say what forty rows already say.
 - **Every task representation carries `available_actions`** (the actions valid
   right now) and `pause_requested`, so clients never restate the state machine.
   The detail response adds `workflow_steps[]` — this task's snapshot, which is
-  what edit-and-retry prefills an editor with, reflecting any earlier edit.
+  what edit-and-retry prefills an editor with, reflecting any earlier edit. A
+  step spliced in by [`type: include`](workflow-schema.md#type-include) carries
+  `resolved_from[]`, the chain of workflows it came through, outermost first.
 
 Task creation validates the agent/model/effort override: a known-invalid value is
-`400`, a catalog-unknown one is reported in `warnings[]` on the `201` body.
+`400`, a catalog-unknown one is reported in `warnings[]` on the `201` body. It is
+also where a workflow's [includes](workflow-schema.md#type-include) are
+resolved into the snapshot, so an include that cycles, names a workflow this
+project cannot see, nests past `include.max_depth`, brings a step id already in
+use, or is restricted to another platform is a `400` here.
 
 ## Transcripts and diffs
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -391,6 +391,28 @@ Read when a loop starts, so a reload governs the next loop — including one
 already running, which will block with `loop_limit` if the lowered ceiling is
 already behind it. See [Workflow schema](workflow-schema.md#type-loop).
 
+### `include`
+
+```yaml
+include:
+  max_depth: 5
+```
+
+How many levels of `type: include` one workflow may expand to. A workflow
+including another is depth 1; that one's own include is depth 2. Must be at
+least 1.
+
+Checked when a task is created, which is where an include is resolved: the
+callee's steps are spliced into the task's snapshot there and the registry is
+never read again. Exceeding it is a `400` naming the depth and the bound.
+
+There is no bound on the expanded *step count*, because step ids must be unique
+across an expansion — a workflow reached twice is an error rather than a
+doubling, so an expansion cannot multiply silently. Depth is the only dimension
+left to bound, and a deeper chain is a config edit rather than a code change.
+
+See [Workflow schema](workflow-schema.md#type-include).
+
 ### `log_level`
 
 ```yaml

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -24,6 +24,7 @@ becoming a setting that silently never applied.
   - [`type: fan_out`](#type-fan_out) · [`merge` and conflicts](#merge-and-conflicts)
   - [`type: loop`](#type-loop) · [`.Loop`](#loop) · [body contents](#what-a-body-may-contain) · [ending](#ending-a-loop) · [human actions](#human-actions)
   - [`type: break`](#type-break)
+  - [`type: include`](#type-include) — reuse another workflow
   - [Nesting rules](#nesting-rules) — which type may appear where
 
 **Behaviour**
@@ -140,7 +141,7 @@ Common to every step:
 |---|---|---|---|
 | `id` | slug | ✅ | Unique within the file, sub-steps included. How `.Steps` addresses it |
 | `name` | string | | Display name; defaults to `id` |
-| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` \| `loop` \| `break` | ✅ | `check` is a *field*, not a type |
+| `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` \| `loop` \| `break` \| `include` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
 | `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group or a `loop`, bounds the whole thing |
 | `if` | template | | Guard: skip this step unless it renders `true`. See [Conditions](#conditions) |
@@ -520,6 +521,80 @@ out, be retried or write a transcript.
 
 Only valid inside a loop body: elsewhere there is no loop for it to end.
 
+### `type: include`
+
+Runs another registry workflow's steps here, in this task and this worktree.
+It is how a workflow becomes reusable.
+
+| Field | | Required |
+|---|---|:--:|
+| `workflow` | the name of the workflow to include, resolved with the usual project > global > built-in shadowing | ✅ |
+
+```yaml
+# .vincent/workflows/go-checks.yaml
+name: go-checks
+defaults: { max_retries: 0 }
+steps:
+  - { id: lint, type: command, run: go run mage.go lint }
+  - { id: test, type: command, run: go run mage.go test }
+```
+
+```yaml
+# .vincent/workflows/feature.yaml
+name: feature
+steps:
+  - { id: implement, type: agent, prompt: "{{ .Task.Description }}" }
+  - { id: checks, type: include, workflow: go-checks }
+  - { id: review, type: agent, prompt: "lint said: {{ .Steps.lint.Result }}" }
+```
+
+**The include disappears.** When the task is created, `checks` is replaced by
+`lint` and `test`, and the task runs four steps. There is no include at run
+time: no step of its own, no grouping, no boundary. That is why `review` can
+read `.Steps.lint` — after the splice, those steps *are* `feature`'s steps.
+
+It also means an include takes no other fields. `if`, `timeout`, `max_retries`,
+`allow_failure` and `check` are all rejected, because there is no step for them
+to bind to. To make an include conditional, guard the callee's own steps, or
+put a [`type: condition`](#type-condition--finish-early) in front of it.
+
+**Resolved once, when the task is created.** Editing `go-checks.yaml`
+afterwards does not touch a task already running — the task's snapshot is its
+execution truth. It also means everything that can go wrong is reported when
+you create the task, not six hours in:
+
+| | |
+|---|---|
+| The workflow is not found | `400` naming it |
+| A cycle — `a` includes `b` includes `a` | `400` naming the path |
+| More than `include.max_depth` levels (default 5) | `400` naming the bound |
+| The callee brings a step id already in use | `400` naming both workflows |
+| The callee's `platforms:` excludes this machine | `400` naming both |
+
+**Step ids are shared.** The whole expansion is one namespace, so a callee
+cannot bring an id the caller already uses — and a given workflow can be
+included at most once per caller. Ids are never rewritten or prefixed: the
+callee's own templates say `.Steps.<id>`, and renaming its steps would break
+them.
+
+**The callee's `defaults:` come with it.** `go-checks` above was written with
+`max_retries: 0`, and its steps keep that after being spliced into a workflow
+whose defaults say otherwise. The order is
+[the usual one](#resolution-order) with the included workflow inserted below
+the task: the step's own field, then the task's `--agent`/`--model`/`--effort`,
+then the *included* workflow's defaults, then the including workflow's, then
+the daemon's.
+
+**A `condition` inside a callee ends the whole run.** There is no include
+boundary for it to end instead, so a fragment that finishes early finishes the
+caller too. And a fragment containing a `break` cannot be factored out at all,
+because `break` is only valid inside a loop body and so a workflow whose top
+level has one does not load.
+
+In the TUI a workflow's graph shows an include as a single collapsed node
+labelled with the workflow it pulls in; a task's detail view badges each
+spliced step with `from <workflow>`.
+
 ### Nesting rules
 
 | Type | Top level | In a `parallel` group | In a `loop` body | In a lane's inline steps |
@@ -532,6 +607,13 @@ Only valid inside a loop body: elsewhere there is no loop for it to end.
 | `condition` | ✅ | ❌ | ✅ | ✅ |
 | `loop` | ✅ | ❌ | ❌ | ✅ |
 | `break` | ❌ | ❌ | ✅ | ❌ |
+| `include` | ✅ | ✅ | ✅ | ✅ |
+
+`include` is ✅ everywhere because it is not there when the workflow runs — what
+matters is what it *expands to*, and that is checked against this same table
+once the steps are in place. A fragment containing a `loop`, included into a
+loop body, is refused when the task is created with the message a hand-written
+nested loop would get.
 
 A lane's inline steps become a child task's own flat snapshot, so they are a
 workflow body in their own right: the "top level" column is the one that applies
@@ -736,8 +818,10 @@ For each agent step, `agent`, `model` and `effort` resolve first-hit-wins:
 1. the explicit **step** field
 2. the **task**-level override chosen at creation (`--agent`, `--model`,
    `--effort`) — replaces workflow `defaults`, never an explicit step field
-3. workflow **`defaults`**
-4. the **adapter** default (usually empty: the CLI decides)
+3. the **included** workflow's `defaults`, for a step that came from a
+   [`type: include`](#type-include) — innermost first when includes nest
+4. the including workflow's **`defaults`**
+5. the **adapter** default (usually empty: the CLI decides)
 
 **Agent-scoped inheritance:** `model` and `effort` only inherit from a level
 whose resolved agent matches the step's. Switching agent without setting them
@@ -759,6 +843,12 @@ a bare CI runner:
   `claude --help`. Probing only ever *adds* values, so a verdict can soften on a
   real daemon but never harden;
 - **the loop ceiling** is the built-in default (10), not your `config.yaml`.
+
+One thing it cannot check at all: whether a [`type: include`](#type-include)
+resolves. Which file a name reaches depends on the project's registry, and a
+project workflow may shadow the very name that was missing or that closed a
+cycle — so includes are resolved and checked when a task is created, and a
+`400` there is the report.
 
 Exit status is 1 for an invalid file; `--json` emits the findings structurally.
 
@@ -785,6 +875,10 @@ Exit status is 1 for an invalid file; `--json` emits the findings structurally.
   a full agent step, needs an `id`, and may not declare `on_input: require`. A
   lane's inline steps have their own id namespace, because each lane becomes its
   own task. `resolved_from` is written by task creation and is an error by hand.
+- An `include` step has a `workflow` and nothing else. `workflow` is rejected on
+  every other type, and `resolved_from` — written by task creation — is an error
+  beside it. Whether the name resolves is *not* checked here: see the note
+  above.
 - Every template parses.
 - `platforms` entries are known tokens, with no duplicates. The list is checked
   for shape, never against the validating host.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -855,6 +855,106 @@ sub-step has no body position and therefore never precedes a sibling, so
 §7.5's set-invisibility is unchanged. A step's own failed attempt still stays
 out of `.Steps["itself"]` mid-retry, because `.LastFailure` is that channel.
 
+### 7.9 Included workflows
+
+*Added 2026-08-19 (task 019).*
+
+A `type: include` step names another registry workflow, and is replaced by
+that workflow's steps when the task is **created**:
+
+```yaml
+# .vincent/workflows/go-checks.yaml
+name: go-checks
+defaults: { max_retries: 0 }
+steps:
+  - { id: lint, type: command, run: go run mage.go lint }
+  - { id: test, type: command, run: go run mage.go test }
+
+# .vincent/workflows/feature.yaml
+name: feature
+steps:
+  - { id: implement, type: agent, prompt: "{{ .Task.Description }}" }
+  - { id: checks, type: include, workflow: go-checks }
+  - { id: review, type: agent, prompt: "lint said: {{ .Steps.lint.Result }}" }
+```
+
+The created task's snapshot holds four steps — `implement`, `lint`, `test`,
+`review` — each with its own `step_index`. **No include survives into the
+run.** There is no `step_runs` row for one, no cursor, no boundary, and
+nothing in §7's engine, §11's scheduler or §12.4's recovery knows the word:
+they see the flat step list they already saw.
+
+That is what separates an include from `parallel` (§7.5) and `loop` (§7.8),
+which own a `step_index` and run a body under it, and from `fan_out` (§7.6),
+which creates tasks. An include creates nothing. It is an authoring-time
+construct that has been resolved away before anything runs.
+
+**Resolved once, at creation.** §5.3 says execution uses the snapshot
+precisely so that later edits to a workflow file cannot mutate an in-flight
+task, and a callee read from the registry six hours into a run would be
+exactly that mutation. It is also what makes the whole expanded shape
+checkable in the insert path, so every failure below is a 400 in front of the
+person creating the task.
+
+**An include may appear anywhere a step may**: at the top level, inside a
+`parallel` group, inside a `loop` body, and inside a `fan_out` lane's inline
+`steps:`. This is the point of splicing rather than nesting — a callee may
+itself contain a `loop`, a `parallel` or a `fan_out`, because those land at
+the caller's own level rather than one level inside something. The nesting
+rules of §8.2 are therefore checked **after** expansion: a fragment containing
+a `loop`, included into a loop body, is refused at creation with the same
+message a hand-written nested loop gets.
+
+**Step ids are shared, and a collision is refused.** Ids are unique across the
+whole expansion, so a callee bringing an id the caller already uses is a 400
+naming both workflows. A given callee can therefore appear at most once in one
+expansion. Ids are *not* rewritten or prefixed: a callee's own templates read
+`.Steps.<id>`, and renaming its steps would mean rewriting them.
+
+**A callee's `defaults:` travel with its steps.** At creation each spliced step
+is given the callee's defaults for any field it does not set itself, so a
+fragment keeps the behaviour it was written with rather than adopting its
+caller's. The resolution order is §8.6's, with the callee inserted below the
+task: **step field → task override → callee `defaults:` → caller `defaults:` →
+daemon default**, innermost callee first when includes nest. Because task-level
+overrides are immutable (§13.2 — `priority` is the only mutable task field),
+this is decided at creation and written into the snapshot; a value no level
+supplies is left unset, so the caller's defaults still apply at run time.
+
+**A `condition` inside a callee ends the whole task's sequence.** There is no
+include boundary at run time for it to end instead. A fragment ending in a
+`condition` therefore stops the caller too, and the task is `done` — which is
+§7.7's meaning applied to a step list that no longer records where it came
+from.
+
+**`break` cannot be factored out.** It is valid only inside a loop body
+(§7.8), so a workflow whose top-level steps contain one does not load and can
+never be a callee.
+
+**Provenance.** Every spliced step records `resolved_from:` — the chain of
+workflow names it came through, outermost first — written by the resolver and
+never by hand. It is what the TUI attributes a step to; it has no effect on
+execution.
+
+**Refused at creation** (each a 400, and each a warning at registry load,
+because which files a name reaches is decided by builtin < global < project
+shadowing and only a task picks a root):
+
+| Refusal | Message names |
+|---|---|
+| A cycle: A includes B includes A | the path, `a → b → a` |
+| A name this project cannot resolve | the missing workflow |
+| More than `include.max_depth` levels (§12.3) | the depth and the bound |
+| A step id the expansion already used | both workflows |
+| A callee whose `platforms:` (§8.1.1) excludes this host | the callee and the host |
+
+The caller's own `platforms:` is **not** rewritten from its callees': it stays
+a property of the file as written, so a workflow's declared restriction means
+one thing. The consequence is that `vincent workflow validate` cannot tell you
+a caller includes a fragment this host cannot run — the same trade §8.1.1
+already makes by checking the list for shape rather than against the
+validating host.
+
 ## 8. Workflow definition (YAML)
 
 ### 8.1 File format
@@ -977,6 +1077,13 @@ step is the exception: it takes `id`, `name` and `if` only.
 | `condition` | `if` | — |
 | `loop` | `steps`, and exactly one of `count` / `for_each` | `max_iterations` |
 | `break` | `if` | — |
+| `include` | `workflow` | — |
+
+*`include` added 2026-08-19 (task 019); see §7.9. It takes `id`, `name`,
+`type` and `workflow` and nothing else — not `if`, `timeout`, `max_retries`,
+`allow_failure` or `check` — because it is resolved away at task creation and
+owns no attempt for any of them to bind to. It is the third exception to this
+table's common fields, after `condition` and `break`.*
 
 *`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.
 `condition`, `if` and `allow_failure` added 2026-08-18 (task 015); see §7.7.
@@ -1024,6 +1131,12 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   resolve to `on_input: require`. A `break` requires `if`, rejects every other
   field, and is valid **only** inside a loop body. `count`, `for_each` and
   `max_iterations` are rejected on every other step type.
+- *Added 2026-08-19 (task 019).* An `include` step requires `workflow` and
+  rejects every other field. `workflow` is rejected on every other step type,
+  and `resolved_from` — which the resolver writes into a task's snapshot — may
+  not be set by hand beside it. Everything an include implies about the
+  *expansion* is checked at task creation rather than at load, because it
+  depends on which files the name resolves to: see §7.9's table.
 - `platforms` entries are known tokens and carry no duplicate (§8.1.1). The
   list is checked for *shape*, never against the validating host: a POSIX-only
   workflow validates on a Windows CI runner exactly as it does on Linux, or
@@ -2257,12 +2370,16 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         (shadowing applied); each entry:
                                         { name, scope, project_id, file, description, steps[],
                                           platforms[]?, platform_supported, requires_input,
-                                          errors[]?, warnings[]?, error? }
+                                          includes[]?, errors[]?, warnings[]?, error? }
                                         platform_supported is this daemon's own verdict on the
                                         entry's §8.1.1 restriction (task 010, added 2026-08-16);
                                         requires_input marks an entry whose §7.4 `require` steps
                                         leave their agent to the task, so the agent picked for a
-                                        task must be one that can ask (task 013, added 2026-08-17)
+                                        task must be one that can ask (task 013, added 2026-08-17);
+                                        includes names the workflows this one splices in (§7.9,
+                                        task 019, added 2026-08-19). Whether those names resolve
+                                        is not answered here: it depends on the project's
+                                        resolved view and becomes a 400 at task creation
 GET    /v1/workflows/definition         one workflow's whole recursive structure, selected with
        ?name=&project_id=               the same §5.2 shadowing the list applies (task 017,
                                         added 2026-08-18):
@@ -2349,10 +2466,14 @@ GET    /v1/tasks/{id}                   full task incl. step runs summary and pe
                                         (the §6 human actions valid right now) and
                                         `pause_requested`, so clients never restate the FSM.
                                         Detail-only: `workflow_steps[]` — the task's snapshot
-                                        as { index, id, type, prompt?, run?, instructions? },
-                                        which is what edit+retry prefills an editor with. It
-                                        reflects edits made by a previous edit+retry, since
-                                        the snapshot is this task's execution truth (§5.3)
+                                        as { index, id, type, prompt?, run?, instructions?,
+                                        resolved_from[]? }, which is what edit+retry prefills
+                                        an editor with. It reflects edits made by a previous
+                                        edit+retry, since the snapshot is this task's execution
+                                        truth (§5.3). resolved_from is the chain of workflows a
+                                        step was spliced through (§7.9, task 019, added
+                                        2026-08-19), absent for a step the task's own workflow
+                                        wrote
 PATCH  /v1/tasks/{id}                   { priority }               (queued/paused only);
                                         emits task.priority_changed and re-runs admission
 POST   /v1/tasks/{id}/cancel
@@ -3081,6 +3202,7 @@ currently true to show (§15 view 6).
 | Agent CLI missing at step start | Step fails (retry policy applies) with a `agent_unavailable` reason; typically → blocked |
 | A fan-out lane's merge conflicts | The join stops at that lane and the task blocks `merge_conflict`, with the worktree left conflicted so a human resolves in place (*added 2026-08-17, task 014*). `on_conflict: agent` tries a resolver first, gated by its `check`, and falls back to the same block. Archive gets no special case: a conflicted worktree is dirty by construction and §10 already refuses a dirty worktree without confirmation |
 | A fan-out lane ends without finishing | The join blocks `lane_failed` and merges **nothing** — a partial merge is indistinguishable downstream from a complete one. `retry` re-checks the lanes; the remedy is to fix the child, which is an ordinary task (*added 2026-08-17, task 014*) |
+| A workflow's includes are cyclic, unresolvable or too deep | Refused at task creation with a `400` naming the cycle path, the missing workflow, or `include.max_depth`. A callee bringing a step id the expansion already uses, and one whose `platforms:` excludes this host, are refused there too. Possible because expansion happens in the insert path (*added 2026-08-19, task 019*) |
 | A fan-out tree is cyclic or too large | Refused at task creation with a `400` naming the cycle path or the bound crossed (`fan_out.max_depth`, `fan_out.max_tasks`). Possible because the whole tree's shape is static once lane lists are in the snapshot (*added 2026-08-17, task 014*) |
 | Two sub-steps of a `parallel` group write the same file | Undefined: the group shares one worktree, and §10 isolates working trees between *tasks*, not processes within one. A workflow bug, documented as such rather than arbitrated (*added 2026-08-17, task 014*) |
 | Option probe fails (help unparseable) | `GET /v1/agents` serves the curated catalog with `probe_error` set; selection and free text keep working (§9.6) |
@@ -3199,6 +3321,15 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
   cannot be written flat" — and a loop body was affordable where `branch` is
   not, because a loop has one arm: the step list stays a list and
   `current_step` stays an integer.
+- ~~reusable workflows / including one workflow in another~~ — **promoted out
+  of future work, 2026-08-19** (§7.9, task 019): `type: include`, spliced into
+  the caller's snapshot at task creation. Splicing rather than nesting is what
+  kept it affordable: the step list stays a list, `current_step` stays an
+  integer, and a callee may contain a `loop`, a `parallel` or a `fan_out`
+  because those land at the caller's own level. Deliberately *not* included:
+  per-call parameters. Two calls with no arguments are the same call, which is
+  why a duplicate id is refused outright; the trigger for both is the first
+  workflow that must include one callee twice with different values.
 - **`branch`/`switch` step types** with `then:`/`else:` bodies, which would
   make the step list a tree and the §7 cursor something other than an integer.
   Deferred by task 015 decision 1 and still deferred: §7.7's guards plus

--- a/docs/tasks/019-workflow-includes.md
+++ b/docs/tasks/019-workflow-includes.md
@@ -1,0 +1,316 @@
+# 019 — Including one workflow in another (`type: include`)
+
+**Status:** [~] in progress (0/10) · **Opened:** 2026-08-19
+
+Make a workflow reusable inside another workflow: a step that runs another
+registry workflow's steps in the caller's own task and worktree.
+
+## Why this is not already `fan_out`
+
+A `fan_out` lane may already name a registry workflow (§7.6), so "run workflow
+B from workflow A" exists. It runs B as a **child task**: its own worktree, its
+own `vincent/{id}-{slug}` branch, a merge back into the parent, a slot against
+`fan_out.max_tasks`, and a row on the board. Three consequences make it the
+wrong tool for a shared three-step fragment:
+
+- B's step results are invisible to A. `.Steps.<id>` reads the *task's* rows,
+  and B's rows belong to another task.
+- B cannot appear inside a `loop` body or a `parallel` group: §8.2 rejects
+  `fan_out` in both.
+- The ceremony — a branch, a merge that can block on a conflict, a second row
+  on the board — is out of proportion to "run the lint-and-test steps here".
+
+What is missing is a **sequential, same-worktree include** whose steps are
+indistinguishable from steps the caller typed inline.
+
+## The mechanism: splice at creation
+
+An `include` step is resolved **when the task is created**: the callee's steps
+replace it in the caller's `workflow_snapshot`, each becoming an ordinary
+top-level step with its own `step_index`. There is no include at run time — no
+`step_runs` row, no cursor, no boundary.
+
+That is the whole design, and everything below follows from it. The engine,
+`internal/scheduler`, `internal/taskrun`, recovery (§12.4), `current_step`,
+`.Steps` rendering and the guard-blindness rules are **unchanged**: they see a
+flat step list, which is what they already saw.
+
+```yaml
+# .vincent/workflows/go-checks.yaml
+name: go-checks
+defaults: { max_retries: 0 }
+steps:
+  - { id: lint, type: command, run: go run mage.go lint }
+  - { id: test, type: command, run: go run mage.go test }
+
+# .vincent/workflows/feature.yaml
+name: feature
+steps:
+  - { id: implement, type: agent, prompt: "{{ .Task.Description }}" }
+  - { id: checks, type: include, workflow: go-checks }
+  - { id: review, type: agent, prompt: "lint said: {{ .Steps.lint.Result }}" }
+```
+
+The created task's snapshot has four steps — `implement`, `lint`, `test`,
+`review` — where `lint` and `test` carry `resolved_from: [go-checks]` and a
+materialised `max_retries: 0`. `review` reads `.Steps.lint` because there is no
+boundary at run time to hide it.
+
+## Decisions
+
+Recorded 2026-08-19, each with the alternative it beat.
+
+### 1. Splice at creation, not a structure step at run time
+
+The alternative was a `loop`-twin: `type: include` as a structure step owning
+one `step_index`, its body's rows sharing that index, exactly as §7.5's group
+and §7.8's loop do.
+
+**Splice wins on the thing that matters most for reuse: what a callee may
+contain.** A structure step forces a choice between forbidding a callee that
+itself contains `loop`, `parallel` or `fan_out` — which excludes precisely the
+fragments worth factoring out — and opening structure-inside-structure, which
+§7.8 (task 016 decision 10) and §20 have both refused, because a loop's and a
+group's position are derived from rows keyed by one `step_index` and two
+derivations cannot share one.
+
+Under splice the question does not arise: a callee's `loop` lands at top level
+and is an ordinary top-level loop.
+
+The cost is real and accepted: the include has no run-time identity, so it can
+carry no `timeout`, no `max_retries` and no `if` (decision 11), and its
+provenance has to be recorded per step (decision 6) rather than held by a
+frame.
+
+### 2. Resolution at creation only
+
+The callee is read from the registry once, in the insert path, and written
+into the snapshot. Never read again.
+
+This is §5.3 restated, and the same reasoning `internal/workflow/fanout.go`
+already carries for lanes: execution uses the snapshot precisely so that later
+edits to workflow files cannot mutate an in-flight task, and a callee read from
+the registry six hours into a run would be exactly that mutation, in the one
+place nobody would look for it.
+
+It is also what makes decisions 4, 5 and 7 possible: the expanded shape is
+computable in the insert path, so every failure is a 400 in front of the person
+typing.
+
+### 3. No parameters
+
+The callee reads `.Task.Fields` and `.Steps` exactly as if its steps had been
+typed inline. There is no `with:` map and no declared `inputs:` block.
+
+Beaten: a `with:` map merged over task fields (the sequential analogue of a
+lane's `fields:`), and full declared inputs with names, defaults and
+required-ness.
+
+Nothing yet needs it: with no parameters, two calls to the same callee are the
+same call, which is also why decision 5 can reject duplicates outright. The
+trigger for revisiting is the first workflow that must include one callee twice
+with different values — and it is the same trigger, so `with:` and repeat
+inclusion should land together or not at all.
+
+### 4. A step type, spelled `include`
+
+`- { id: checks, type: include, workflow: go-checks }`.
+
+Beaten: a bare `uses:` field with no `type` (every validation path branches on
+`type` first, and a typeless step is a new shape in `Step`), and a file-level
+`include:` list (which cannot say *where* in the sequence the fragment goes).
+
+The word is `include` rather than `workflow` because `type: workflow, workflow:
+go-checks` stutters, and because the config knob, the error strings, the docs
+page and the provenance field all need one verb — and `workflow` is the
+domain's most overloaded noun. Hence `include.max_depth`, "included workflow",
+`docs/guides/workflows.md`.
+
+### 5. A duplicate step id after splice is a 400
+
+Step ids are unique across the whole workflow (§8.2) and name the transcript
+file. A callee whose step id collides with one already in the expansion is a
+creation-time error naming both paths.
+
+Beaten: prefixing spliced ids with the call step's id (`checks.lint`). It would
+allow repeat inclusion, but every `.Steps.<id>` reference **inside the callee's
+own templates** would then have to be rewritten — mechanically editing Go
+template text, which is fragile and, under `missingkey=error`, fails at run
+time rather than at creation. Also beaten: prefixing only on collision, which
+makes a callee's step ids depend on what its caller happens to contain.
+
+The accepted consequence is that a given callee may appear at most once in one
+expansion. See decision 3 for the trigger.
+
+### 6. Provenance is a chain of workflow names
+
+Each spliced step carries `resolved_from: [outer, …, inner]`, outermost first,
+written by the resolver and never by hand — the rule `Lane.ResolvedFrom`
+already states.
+
+Beaten: a single innermost name (mirroring `Lane.ResolvedFrom` exactly), which
+cannot say how a step from a nested include got where it is; and a chain of
+call-site step ids, which is unambiguous but shows the caller's local labels
+rather than the names a human recognises.
+
+Grouping in any view is "contiguous steps sharing a prefix". The chain is
+unique because decision 5 means a given callee appears at most once.
+
+### 7. The callee's `defaults:` are materialised at creation
+
+A fragment written with `defaults: {agent: codex, max_retries: 0}` keeps that
+behaviour after splice. At creation the splice runs a **four-level** resolve —
+step field, then task override, then *callee* defaults, then caller defaults —
+and writes the winners onto each spliced step's own fields.
+
+Beaten: dropping the callee's defaults and letting the caller's govern, which
+silently changes what the fragment does — the failure mode this codebase
+consistently refuses; and rejecting any callee that declares `defaults:`, which
+makes reusability a property you must have designed for in advance.
+
+Two facts make materialising exact rather than approximate:
+
+- Task-level overrides are **immutable** (`priority` is the only mutable task
+  field in v1, `internal/api/actions.go`), so the full §8.6 chain is knowable
+  at creation.
+- `agent.ResolveWithSources` is *agent-scoped* — a level whose agent differs
+  from the resolved one contributes nothing but its agent field — so the
+  (agent, model, effort) triple cannot be merged field by field and is resolved
+  as a unit.
+
+The four-level logic lives in the splice path alone. `agent.Resolve` keeps its
+three levels and §8.6 keeps its four, so nothing that resolves a step at run
+time learns a new rule. The cost is provenance: `GET /v1/tasks/{id}/resolution`
+reports `SourceStep` for a value the callee's defaults supplied, and `edit +
+retry` shows fields the author did not type. `resolved_from` is the
+explanation.
+
+### 8. The creation-time gate: cycles, depth, platforms
+
+Three checks that cannot be decided at load — shadowing decides which files
+even participate — and are exact at creation. The same split
+`LaneCycleWarnings` already makes: a warning at registry load, a 400 at
+creation.
+
+- **Cycles** (A includes B includes A): 400 naming the path,
+  `workflow cycle: a → b → a`, plus a load-time warning.
+- **Depth**: `include.max_depth`, default 5, beside `fan_out.max_depth: 3` and
+  `loop.max_iterations: 10`. No expanded-step bound: decision 5 already makes a
+  diamond a 400, so an expansion cannot silently multiply.
+- **Platforms**: if any transitively included callee's `platforms:` (§8.1.1)
+  excludes this host, 400 at creation plus a load-time warning.
+
+Beaten for platforms: recomputing the caller's declared `platforms:` from its
+callees'. The caller's `platforms:` stays a property of the file as written, so
+`Entry.RunsHere()` keeps one meaning. The consequence — `vincent workflow
+validate` on a Windows box passes a caller that includes a POSIX-only fragment
+— is the trade §8.1.1 already made ("checked for *shape*, never against the
+validating host").
+
+### 9. An include may appear anywhere a step may
+
+Top level, inside a `parallel` group, inside a `loop` body, and inside a
+`fan_out` lane's inline `steps:`.
+
+This is the payoff of decision 1, and it means the existing nesting bans can
+only be enforced **after** expansion. So the full §8.2 validation re-runs on
+the expanded workflow at creation, with error paths naming both the call site
+and the offending callee step. That re-validation is required anyway — id
+uniqueness (decision 5), the cross-catalog check, the `on_input: require`
+gate — so allowing includes inside bodies costs only the error-path plumbing.
+
+Beaten: top-level-only, which would forfeit the main advantage of splice.
+
+Note the resulting overlap: a `fan_out` lane can name a workflow two ways — the
+lane's own `workflow:` and an `include` in its inline `steps:`. They mean
+different things (a child task vs. steps in that child's own sequence), and
+that is a sentence in §8.2, not a restriction.
+
+### 10. A spliced `condition` ends the whole task's sequence
+
+There is no include boundary at run time, so a `condition` inside a callee
+whose `if:` renders false ends the caller's sequence too: the task is `done`
+having skipped the caller's remaining steps.
+
+Beaten: rejecting `condition` inside a callee. That would make some workflows
+un-reusable for a reason invisible from the file being written, and it would
+give `condition` a second meaning ("ends the include") that §7.7 does not have.
+
+The related limitation is accepted rather than solved: `break` is valid only
+inside a loop body, so a workflow whose top-level steps contain one fails to
+load and can never be a callee — **loop-body fragments needing `break` cannot
+be factored out**. The alternative was demoting that to a load-time warning
+promoted to an error at creation unless the call site is inside a loop, which
+weakens a clean load-time error for a case nobody has yet. The trigger is the
+first fragment worth factoring out of a loop body.
+
+### 11. An include carries `id`, `name`, `type` and `workflow` only
+
+`timeout`, `max_retries`, `allow_failure` and `check` are rejected because
+there is no run-time step for them to bind to — the include owns no
+`step_runs` row, no attempt and no process.
+
+`if:` is rejected too, which is the one that had a real alternative. Honouring
+a guard on an include would mean distributing it onto every spliced step at
+creation. That reads correctly for ordinary steps, but a spliced `condition` or
+`break` already carries its own `if:` and rejects every other field, so
+combining the two would mean rewriting Go template text — the string surgery
+decision 5 refused — or a creation-time error about an interaction two files
+apart.
+
+So `include` joins `condition` and `break` as an exception to the §8.2 common
+field table. A conditional include is spelled by guarding the callee's own
+steps, or by a preceding `condition` step. The trigger for revisiting is the
+first workflow that needs a whole fragment skipped on one condition and cannot
+express it either way.
+
+The include's `id` is still required and still joins the workflow-wide id
+namespace at authoring time, even though it vanishes from the snapshot: it is
+what the creation-time errors name.
+
+### 12. The graph keeps includes collapsed
+
+In the workflows view the graph renders the **authored** definition, so an
+include is a node. It reuses `KindWorkflowRef` — the kind that already exists
+for a `fan_out` lane naming a registry workflow, and which task 017 documented
+as staying collapsed because "expanding it is navigation, not rendering".
+
+In the task detail the snapshot is already expanded, so spliced steps are
+ordinary steps and carry a `from <name>` badge, with the full chain in the step
+detail. No grouping frame.
+
+Beaten: expanding includes inline in the graph. Making includes the exception
+would give one question two answers. The trigger is the first time someone
+cannot tell what a workflow does without opening three files.
+
+## Tasks
+
+- [ ] **019.1** `include.max_depth` in `internal/config` (default 5, validated
+      ≥ 1), documented in `docs/reference/configuration.md`.
+- [ ] **019.2** `StepInclude`, the `workflow:` and `resolved_from:` fields on
+      `Step`, and §8.2 validation: `include` requires `workflow` and rejects
+      every other field (decision 11); `workflow`/`resolved_from` are rejected
+      on every other step type; `resolved_from` is machine-written.
+- [ ] **019.3** `internal/workflow/include.go`: `Expand` — splice, cycle
+      detection, depth bound, platform check, defaults materialisation
+      (decision 7), duplicate-id detection (decision 5), provenance chains
+      (decision 6). Plus `HasInclude` and load-time cycle warnings.
+      *Depends: 019.2*
+- [ ] **019.4** Wire expansion into task creation in `internal/api/tasks.go`,
+      before fan-out tree resolution, with post-splice re-validation
+      (decision 9). *Depends: 019.3*
+- [ ] **019.5** `Entry.Includes` on the registry and `GET /v1/workflows`;
+      `workflow`/`resolved_from` on the workflow-definition DTOs.
+- [ ] **019.6** TUI: `KindWorkflowRef` for an include in the graph; the
+      `from <name>` badge in the task detail. *Depends: 019.5*
+- [ ] **019.7** Spec: new §7.9, the §8.2 table row and constraint bullets, and
+      the §20 promotion note.
+- [ ] **019.8** User docs: `reference/workflow-schema.md`,
+      `reference/configuration.md`, `reference/api.md`, `guides/workflows.md`.
+- [ ] **019.9** `scripts/m9-gate.sh`, committed executable, written to the
+      POSIX ∩ pwsh intersection the CLAUDE.md gate notes describe.
+- [ ] **019.10** Wire `m9` into `ci.yml`'s `gates` job on all three platforms.
+      **Not doable from a cloud session:** its token has no `workflow` scope and
+      so cannot write `.github/workflows/` by any route (#120, #122, #125).
+      Until this lands, `m9` is not known to pass on any platform CI has not run
+      it on.

--- a/docs/tasks/019-workflow-includes.md
+++ b/docs/tasks/019-workflow-includes.md
@@ -1,6 +1,6 @@
 # 019 — Including one workflow in another (`type: include`)
 
-**Status:** [~] in progress (0/10) · **Opened:** 2026-08-19
+**Status:** [~] in progress (9/10) · **Opened:** 2026-08-19
 
 Make a workflow reusable inside another workflow: a step that runs another
 registry workflow's steps in the caller's own task and worktree.
@@ -285,32 +285,53 @@ cannot tell what a workflow does without opening three files.
 
 ## Tasks
 
-- [ ] **019.1** `include.max_depth` in `internal/config` (default 5, validated
-      ≥ 1), documented in `docs/reference/configuration.md`.
-- [ ] **019.2** `StepInclude`, the `workflow:` and `resolved_from:` fields on
+- [x] **019.1** `include.max_depth` in `internal/config` (default 5, validated
+      ≥ 1), documented in `docs/reference/configuration.md`. ✓ 2026-08-19
+
+- [x] **019.2** `StepInclude`, the `workflow:` and `resolved_from:` fields on
       `Step`, and §8.2 validation: `include` requires `workflow` and rejects
       every other field (decision 11); `workflow`/`resolved_from` are rejected
-      on every other step type; `resolved_from` is machine-written.
-- [ ] **019.3** `internal/workflow/include.go`: `Expand` — splice, cycle
+      on every other step type; `resolved_from` is machine-written. ✓ 2026-08-19
+
+- [x] **019.3** `internal/workflow/include.go`: `Expand` — splice, cycle
       detection, depth bound, platform check, defaults materialisation
       (decision 7), duplicate-id detection (decision 5), provenance chains
       (decision 6). Plus `HasInclude` and load-time cycle warnings.
-      *Depends: 019.2*
-- [ ] **019.4** Wire expansion into task creation in `internal/api/tasks.go`,
+      *Depends: 019.2* ✓ 2026-08-19
+
+- [x] **019.4** Wire expansion into task creation in `internal/api/tasks.go`,
       before fan-out tree resolution, with post-splice re-validation
-      (decision 9). *Depends: 019.3*
-- [ ] **019.5** `Entry.Includes` on the registry and `GET /v1/workflows`;
-      `workflow`/`resolved_from` on the workflow-definition DTOs.
-- [ ] **019.6** TUI: `KindWorkflowRef` for an include in the graph; the
-      `from <name>` badge in the task detail. *Depends: 019.5*
-- [ ] **019.7** Spec: new §7.9, the §8.2 table row and constraint bullets, and
-      the §20 promotion note.
-- [ ] **019.8** User docs: `reference/workflow-schema.md`,
-      `reference/configuration.md`, `reference/api.md`, `guides/workflows.md`.
-- [ ] **019.9** `scripts/m9-gate.sh`, committed executable, written to the
-      POSIX ∩ pwsh intersection the CLAUDE.md gate notes describe.
-- [ ] **019.10** Wire `m9` into `ci.yml`'s `gates` job on all three platforms.
+      (decision 9). *Depends: 019.3* ✓ 2026-08-19
+
+- [x] **019.5** `Entry.Includes` on the registry and `GET /v1/workflows`;
+      `workflow`/`resolved_from` on the workflow-definition DTOs. ✓ 2026-08-19
+
+- [x] **019.6** TUI: `KindWorkflowRef` for an include in the graph; the
+      `from <name>` badge in the task detail. *Depends: 019.5* ✓ 2026-08-19
+
+- [x] **019.7** Spec: new §7.9, the §8.2 table row and constraint bullets, and
+      the §20 promotion note. ✓ 2026-08-19
+
+- [x] **019.8** User docs: `reference/workflow-schema.md`,
+      `reference/configuration.md`, `reference/api.md`, `guides/workflows.md`. ✓ 2026-08-19
+
+- [x] **019.9** `scripts/m9-gate.sh`, committed executable, written to the
+      POSIX ∩ pwsh intersection the CLAUDE.md gate notes describe. ✓ 2026-08-19
+
+- [!] **019.10** Wire `m9` into `ci.yml`'s `gates` job on all three platforms.
       **Not doable from a cloud session:** its token has no `workflow` scope and
       so cannot write `.github/workflows/` by any route (#120, #122, #125).
       Until this lands, `m9` is not known to pass on any platform CI has not run
-      it on.
+      it on. Walked green on Linux at 019.9, together with m1, m2, m5, m6, m7
+      and m8 as a regression check.
+
+      The edit is one step appended to the `gates` job, beside M8's:
+
+      ```yaml
+            # M9: includes (task 019). Command steps only, with `run:` bodies
+            # in the same `exit N` / `git …` vocabulary m7 and m8 use, so the
+            # matrix proves the shell as much as the feature.
+            - name: M9 gate (includes)
+              shell: bash
+              run: ./scripts/m9-gate.sh
+      ```

--- a/docs/tasks/019-workflow-includes.md
+++ b/docs/tasks/019-workflow-includes.md
@@ -1,6 +1,6 @@
 # 019 — Including one workflow in another (`type: include`)
 
-**Status:** [~] in progress (9/10) · **Opened:** 2026-08-19
+**Status:** ✅ done (10/10) · **Opened:** 2026-08-19 · **Closed:** 2026-08-19
 
 Make a workflow reusable inside another workflow: a step that runs another
 registry workflow's steps in the caller's own task and worktree.
@@ -318,20 +318,16 @@ cannot tell what a workflow does without opening three files.
 - [x] **019.9** `scripts/m9-gate.sh`, committed executable, written to the
       POSIX ∩ pwsh intersection the CLAUDE.md gate notes describe. ✓ 2026-08-19
 
-- [!] **019.10** Wire `m9` into `ci.yml`'s `gates` job on all three platforms.
-      **Not doable from a cloud session:** its token has no `workflow` scope and
-      so cannot write `.github/workflows/` by any route (#120, #122, #125).
-      Until this lands, `m9` is not known to pass on any platform CI has not run
-      it on. Walked green on Linux at 019.9, together with m1, m2, m5, m6, m7
-      and m8 as a regression check.
+- [x] **019.10** Wire `m9` into `ci.yml`'s `gates` job on all three platforms.
+      ✓ 2026-08-19
 
-      The edit is one step appended to the `gates` job, beside M8's:
+      Not doable from the cloud session that wrote the rest: its token has no
+      `workflow` scope and so cannot write `.github/workflows/` by any route
+      (#120, #122, #125) — confirmed by attempting the push and being refused.
+      Applied by hand on the branch instead.
 
-      ```yaml
-            # M9: includes (task 019). Command steps only, with `run:` bodies
-            # in the same `exit N` / `git …` vocabulary m7 and m8 use, so the
-            # matrix proves the shell as much as the feature.
-            - name: M9 gate (includes)
-              shell: bash
-              run: ./scripts/m9-gate.sh
-      ```
+      **First three-platform run, 2026-08-19** (run 322, head `0e971e7`): m9
+      green on ubuntu-latest, macos-latest and windows-latest, alongside m1,
+      m2, m5, m6, m7 and m8. Windows was the leg worth watching — scenario 1
+      compares an exact multi-line step order and provenance chain, which is
+      where jq's CRLF bit m8 — and the `tr -d '\r'` the helpers carry held.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -33,7 +33,7 @@ description of how the system actually behaves.
 | [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 | [017](017-workflow-visualization.md) | Workflow visualization in the TUI | ✅ done (9/9) |
 | [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
-| [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | 🚧 in progress (9/10) |
+| [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | ✅ done (10/10) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -33,6 +33,7 @@ description of how the system actually behaves.
 | [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 | [017](017-workflow-visualization.md) | Workflow visualization in the TUI | ✅ done (9/9) |
 | [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
+| [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | 🚧 in progress (0/10) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -33,7 +33,7 @@ description of how the system actually behaves.
 | [016](016-workflow-loops.md) | Loops in workflows (`type: loop`, `type: break`) | ✅ done (10/10) |
 | [017](017-workflow-visualization.md) | Workflow visualization in the TUI | ✅ done (9/9) |
 | [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
-| [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | 🚧 in progress (0/10) |
+| [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | 🚧 in progress (9/10) |
 
 ## How to add and update a task document
 

--- a/internal/api/include_test.go
+++ b/internal/api/include_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// createTaskFrom posts a task on the named workflow and returns the response.
+func createTaskFrom(t *testing.T, h *workflowHarness, projectID int64, name string) (*http.Response, []byte) {
+	t.Helper()
+	return h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": projectID, "title": "include", "workflow": name,
+	})
+}
+
+// snapshotOf creates a task and returns its parsed snapshot.
+func snapshotOf(t *testing.T, h *workflowHarness, projectID int64, name string) *workflow.Workflow {
+	t.Helper()
+	resp, body := createTaskFrom(t, h, projectID, name)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d %s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	task, err := h.store.GetTask(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	return wf
+}
+
+// TestTaskCreateExpandsIncludes is §7.9 at the seam that matters: the registry
+// is read once, at creation, and what it said is frozen into the snapshot.
+// Editing the included file afterwards must not reach the task.
+func TestTaskCreateExpandsIncludes(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "checks",
+		"name: checks\nsteps:\n  - {id: lint, type: command, run: make original}\n")
+	writeWorkflowFile(t, h.globalDir, "root",
+		"name: root\nsteps:\n"+
+			"  - {id: work, type: command, run: make work}\n"+
+			"  - {id: verify, type: include, workflow: checks}\n")
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	wf := snapshotOf(t, h, projectID, "root")
+	if len(wf.Steps) != 2 {
+		t.Fatalf("snapshot steps = %d, want the include replaced by its callee's one step", len(wf.Steps))
+	}
+	spliced := wf.Steps[1]
+	if spliced.ID != "lint" || spliced.Type != workflow.StepCommand {
+		t.Fatalf("spliced step = %+v, want the callee's lint command", spliced)
+	}
+	if !strings.Contains(spliced.Run, "original") {
+		t.Errorf("run = %q, want what the registry said at creation", spliced.Run)
+	}
+	if strings.Join(spliced.ResolvedFrom, ",") != "checks" {
+		t.Errorf("resolved_from = %v, want [checks]", spliced.ResolvedFrom)
+	}
+
+	// The snapshot is the durable copy (§5.3): a later edit must not move it.
+	writeWorkflowFile(t, h.globalDir, "checks",
+		"name: checks\nsteps:\n  - {id: lint, type: command, run: make edited}\n")
+	h.reg.ReloadGlobal()
+	again := snapshotOf(t, h, projectID, "root")
+	if !strings.Contains(again.Steps[1].Run, "edited") {
+		t.Error("a task created after the edit did not pick the new file up")
+	}
+}
+
+// TestTaskCreateRejectsBadIncludes: every one of these is something the person
+// creating the task can act on, so each is a 400 in front of them rather than
+// a step that fails six hours in.
+func TestTaskCreateRejectsBadIncludes(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "missing",
+		"name: missing\nsteps:\n  - {id: c, type: include, workflow: nowhere}\n")
+	writeWorkflowFile(t, h.globalDir, "alpha",
+		"name: alpha\nsteps:\n  - {id: c, type: include, workflow: beta}\n")
+	writeWorkflowFile(t, h.globalDir, "beta",
+		"name: beta\nsteps:\n  - {id: c, type: include, workflow: alpha}\n")
+	writeWorkflowFile(t, h.globalDir, "shared",
+		"name: shared\nsteps:\n  - {id: clash, type: command, run: make}\n")
+	writeWorkflowFile(t, h.globalDir, "collides",
+		"name: collides\nsteps:\n"+
+			"  - {id: clash, type: command, run: make mine}\n"+
+			"  - {id: c, type: include, workflow: shared}\n")
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	// The wants are matched against the JSON body, so quoted names appear
+	// escaped: `\"nowhere\"` is what a reader of the response sees.
+	for _, tc := range []struct{ workflow, want string }{
+		{"missing", `\"nowhere\" not found`},
+		{"alpha", "workflow cycle"},
+		{"collides", `step id \"clash\" twice`},
+	} {
+		t.Run(tc.workflow, func(t *testing.T) {
+			resp, body := createTaskFrom(t, h, projectID, tc.workflow)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("create: %d %s, want 400", resp.StatusCode, body)
+			}
+			if !strings.Contains(string(body), tc.want) {
+				t.Errorf("body = %s, want it to mention %q", body, tc.want)
+			}
+		})
+	}
+}
+
+// TestTaskCreateRevalidatesExpansion is decision 9: an include may appear
+// anywhere a step may, so the nesting rules it can break are only decidable
+// once the steps are in place. A loop fragment included *into* a loop body is
+// the case that has no other way of being caught.
+func TestTaskCreateRevalidatesExpansion(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "innerloop",
+		"name: innerloop\nsteps:\n"+
+			"  - {id: l, type: loop, count: 2, steps: [{id: work, type: command, run: make}]}\n")
+	writeWorkflowFile(t, h.globalDir, "nests",
+		"name: nests\nsteps:\n"+
+			"  - {id: outer, type: loop, count: 2, steps: [{id: c, type: include, workflow: innerloop}]}\n")
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	resp, body := createTaskFrom(t, h, projectID, "nests")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("create: %d %s, want 400 — loops do not nest", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "once its includes are expanded") {
+		t.Errorf("body = %s, want it to say the expansion is what failed", body)
+	}
+}
+
+// TestWorkflowListReportsIncludes: a client shows what a workflow depends on
+// without resolving anything itself.
+func TestWorkflowListReportsIncludes(t *testing.T) {
+	h := newInputHarness(t, agenttest.BuildFakeAgent(t))
+	writeWorkflowFile(t, h.globalDir, "checks",
+		"name: checks\nsteps:\n  - {id: lint, type: command, run: make}\n")
+	writeWorkflowFile(t, h.globalDir, "root",
+		"name: root\nsteps:\n  - {id: c, type: include, workflow: checks}\n")
+	h.reg.ReloadGlobal()
+
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/workflows", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: %d %s", resp.StatusCode, body)
+	}
+	var list struct {
+		Workflows []struct {
+			Name     string   `json:"name"`
+			Includes []string `json:"includes"`
+		} `json:"workflows"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, w := range list.Workflows {
+		switch w.Name {
+		case "root":
+			if strings.Join(w.Includes, ",") != "checks" {
+				t.Errorf("root includes = %v, want [checks]", w.Includes)
+			}
+		case "checks":
+			if len(w.Includes) != 0 {
+				t.Errorf("checks includes = %v, want none", w.Includes)
+			}
+		}
+	}
+}

--- a/internal/api/snapcache.go
+++ b/internal/api/snapcache.go
@@ -23,6 +23,11 @@ type stepDefinition struct {
 	prompt       string
 	run          string
 	instructions string
+	// resolvedFrom is the chain of workflows this step was spliced through
+	// (§7.9), outermost first, and empty for a step the task's own workflow
+	// wrote. It is what the detail view attributes a step to — after a splice
+	// there is no include left to point at, so the step has to carry it.
+	resolvedFrom []string
 	// loop is the §7.8 shape of a `loop` step, nil for every other type. It
 	// is what lets the task endpoints report a loop rollup without re-parsing
 	// the snapshot per request.
@@ -153,6 +158,7 @@ func parseSnapshot(snapshot string, ceiling int) snapshotSummary {
 			prompt:       wf.Steps[i].Prompt,
 			run:          wf.Steps[i].Run,
 			instructions: wf.Steps[i].Instructions,
+			resolvedFrom: wf.Steps[i].ResolvedFrom,
 			loop:         loopDefinitionOf(wf.Steps[i], ceiling),
 		})
 	}

--- a/internal/api/snapcache_test.go
+++ b/internal/api/snapcache_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/lezli01/vincent/internal/store"
@@ -33,8 +34,10 @@ steps:
 	if len(got) != len(want) {
 		t.Fatalf("steps = %d, want %d", len(got), len(want))
 	}
+	// reflect.DeepEqual rather than ==: stepDefinition carries the §7.9
+	// provenance chain, and a struct holding a slice is not comparable.
 	for i := range want {
-		if got[i] != want[i] {
+		if !reflect.DeepEqual(got[i], want[i]) {
 			t.Errorf("step %d = %+v, want %+v", i, got[i], want[i])
 		}
 	}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -395,16 +395,62 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Include expansion (§7.9, task 019). Every `type: include` is spliced
+	// into the snapshot **now**, for the reason the fan-out tree below is
+	// resolved now: §5.3 says execution uses the snapshot precisely so later
+	// edits to a workflow file cannot mutate an in-flight task.
+	//
+	// It runs before fan-out resolution because an include can *bring* a
+	// fan_out step, and that step's lanes need resolving like any other.
+	//
+	// The task's own override goes in because it outranks a callee's
+	// `defaults:` in §8.6's order (decision 7); it is read here rather than
+	// from the task row below because expansion has to happen before the row
+	// is built.
+	wf, snapshot := entry.Workflow, entry.Source
+	if workflow.HasInclude(wf) {
+		expanded, xerr := workflow.Expand(wf, workflow.ExpandOptions{
+			Lookup: s.laneLookup(project.ID),
+			Limits: workflow.IncludeLimits{MaxDepth: s.deps.Config().Include.MaxDepth},
+			Override: agent.Level{
+				Agent:  agentOverride,
+				Model:  strings.TrimSpace(ptrValue(req.Model)),
+				Effort: strings.TrimSpace(ptrValue(req.Effort)),
+			},
+		})
+		if xerr != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, xerr.Error())
+			return
+		}
+		// Re-validate the expansion, not just its shape. The nesting rules an
+		// include can break — no `loop` inside a `loop`, no `fan_out` inside a
+		// `parallel` — are decidable only once the steps are in place
+		// (decision 9), and so is the §8.2 catalog check over a callee's
+		// materialised agent fields.
+		out, merr := workflow.Marshal(expanded)
+		if merr != nil {
+			s.internalError(w, "re-encode expanded snapshot", merr)
+			return
+		}
+		revalidated, _, verr := workflow.Parse(out, s.deps.Workflows.Options())
+		if verr != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("workflow %q does not validate once its includes are expanded: %s",
+					workflowName, verr.Error()))
+			return
+		}
+		wf, snapshot = revalidated, string(out)
+	}
+
 	// Fan-out tree resolution (§7.6, task 014 decisions 4, 5). Every lane
 	// naming a registry workflow is resolved into the snapshot **now**, so
 	// the tree's shape is fixed at creation and later edits to those files
 	// cannot mutate this task. The bounds are checked here for the same
 	// reason: a depth-3 explosion should be a 400 in front of the person
 	// typing, not two hundred worktrees discovered six hours later.
-	snapshot := entry.Source
-	if workflow.HasFanOut(entry.Workflow) {
+	if workflow.HasFanOut(wf) {
 		cfg := s.deps.Config()
-		resolved, _, terr := workflow.ResolveTree(entry.Workflow, s.laneLookup(project.ID),
+		resolved, _, terr := workflow.ResolveTree(wf, s.laneLookup(project.ID),
 			workflow.Limits{MaxDepth: cfg.FanOut.MaxDepth, MaxTasks: cfg.FanOut.MaxTasks})
 		if terr != nil {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed, terr.Error())
@@ -415,7 +461,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			s.internalError(w, "re-encode resolved fan-out snapshot", merr)
 			return
 		}
-		snapshot = string(out)
+		wf, snapshot = resolved, string(out)
 	}
 
 	t := store.Task{
@@ -440,7 +486,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	if req.Effort != nil {
 		t.EffortOverride = strings.TrimSpace(*req.Effort)
 	}
-	warnings, cerr := s.checkTaskCatalog(entry.Workflow, &t)
+	warnings, cerr := s.checkTaskCatalog(wf, &t)
 	if cerr != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, cerr)
 		return
@@ -448,7 +494,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	// The `on_input: require` gate (§7.4, task 013), after the catalog check
 	// so a task with two problems reports the model one first — that is the
 	// field the human just typed.
-	if mismatch := s.inputMismatch(ctx, entry.Workflow, &t); mismatch != "" {
+	if mismatch := s.inputMismatch(ctx, wf, &t); mismatch != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
 		return
 	}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -120,6 +120,10 @@ type snapshotStepResponse struct {
 	Prompt       string `json:"prompt,omitempty"`
 	Run          string `json:"run,omitempty"`
 	Instructions string `json:"instructions,omitempty"`
+	// ResolvedFrom is the chain of workflows this step was spliced through
+	// (§7.9), outermost first. Absent for a step the task's own workflow
+	// wrote.
+	ResolvedFrom []string `json:"resolved_from,omitempty"`
 }
 
 // workflowSteps renders the parsed snapshot for the detail response. Nil for
@@ -138,6 +142,7 @@ func workflowSteps(summary snapshotSummary) []snapshotStepResponse {
 			Prompt:       s.prompt,
 			Run:          s.run,
 			Instructions: s.instructions,
+			ResolvedFrom: s.resolvedFrom,
 		})
 	}
 	return out

--- a/internal/api/workflowdef.go
+++ b/internal/api/workflowdef.go
@@ -131,6 +131,18 @@ type workflowStepDef struct {
 	Count         *int     `json:"count,omitempty"`
 	ForEach       []string `json:"for_each,omitempty"`
 	MaxIterations *int     `json:"max_iterations,omitempty"`
+
+	// include steps (§7.9). Workflow is the registry name an authored
+	// include carries; ResolvedFrom is the chain of workflows a step was
+	// spliced through, outermost first, and appears only in a task's
+	// snapshot. Both are carried here so one DTO describes a registry entry
+	// and a snapshot alike, which is what a lane's ResolvedFrom already does.
+	//
+	// They never appear together: expansion replaces the include with the
+	// steps it resolved to, so the step carrying the name is gone by the time
+	// anything carries a chain.
+	Workflow     string   `json:"workflow,omitempty"`
+	ResolvedFrom []string `json:"resolved_from,omitempty"`
 }
 
 // workflowLaneDef is one fan_out lane. Exactly one of Workflow and Steps is
@@ -256,6 +268,8 @@ func toWorkflowStepDef(st workflow.Step) workflowStepDef {
 		MaxParallel:    st.MaxParallel,
 		Count:          st.Count,
 		MaxIterations:  st.MaxIterations,
+		Workflow:       st.Workflow,
+		ResolvedFrom:   st.ResolvedFrom,
 	}
 	if len(st.Steps) > 0 {
 		out.Steps = toWorkflowStepDefs(st.Steps)

--- a/internal/api/workflowdef_test.go
+++ b/internal/api/workflowdef_test.go
@@ -378,8 +378,8 @@ func TestGateCorpusIsServable(t *testing.T) {
 		writeWorkflowFile(t, h.globalDir, name, string(src))
 		names = append(names, name)
 	}
-	if len(names) < 9 {
-		t.Fatalf("the corpus has %d workflows; the gate documents nine", len(names))
+	if len(names) < 10 {
+		t.Fatalf("the corpus has %d workflows; the gate documents ten", len(names))
 	}
 	h.reg.ReloadGlobal()
 

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -30,8 +30,13 @@ type workflowResponse struct {
 	// that can stop and ask (§7.4, task 013). Derived by the daemon for the
 	// same reason platform_supported is: the process that would run the steps
 	// is the one that says what they need.
-	RequiresInput bool             `json:"requires_input"`
-	Errors        []workflow.Error `json:"errors,omitempty"`
+	RequiresInput bool `json:"requires_input"`
+	// Includes names the workflows this one splices in (§7.9). It is what a
+	// client shows as "depends on"; whether those names resolve is not
+	// answered here, because it is a property of the project's resolved view
+	// and becomes a 400 at task creation (task 019 decision 8).
+	Includes []string         `json:"includes,omitempty"`
+	Errors   []workflow.Error `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []workflow.Error `json:"warnings,omitempty"`
 	Error    *string          `json:"error"`
@@ -52,6 +57,7 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 		Steps:             []workflowStepResponse{},
 		PlatformSupported: e.RunsHere(),
 		RequiresInput:     e.NeedsInputAgent(),
+		Includes:          e.Includes(),
 	}
 	if e.ProjectID != 0 {
 		id := e.ProjectID

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -313,6 +313,11 @@ type WorkflowStep struct {
 	Prompt       string `json:"prompt,omitempty"`
 	Run          string `json:"run,omitempty"`
 	Instructions string `json:"instructions,omitempty"`
+	// ResolvedFrom is the chain of workflows this step was spliced through
+	// (§7.9, task 019), outermost first. Empty for a step the task's own
+	// workflow wrote, and for a daemon that predates the field — which are
+	// indistinguishable and treated the same.
+	ResolvedFrom []string `json:"resolved_from,omitempty"`
 }
 
 // EditableText reports the text edit+retry opens for this step and the

--- a/internal/apiclient/workflowdef.go
+++ b/internal/apiclient/workflowdef.go
@@ -99,6 +99,14 @@ type WorkflowStepDef struct {
 	Count         *int     `json:"count,omitempty"`
 	ForEach       []string `json:"for_each,omitempty"`
 	MaxIterations *int     `json:"max_iterations,omitempty"`
+
+	// Workflow is the registry workflow an `include` step splices in (§7.9);
+	// ResolvedFrom is the chain of workflows a step was spliced *through*,
+	// outermost first. An authored definition has the first and never the
+	// second; a task's snapshot has the second and never the first, because
+	// expansion replaces the include with the steps it resolved to.
+	Workflow     string   `json:"workflow,omitempty"`
+	ResolvedFrom []string `json:"resolved_from,omitempty"`
 }
 
 // WorkflowLaneDef is one fan_out lane: a named registry workflow or inline

--- a/internal/apiclient/workflows.go
+++ b/internal/apiclient/workflows.go
@@ -32,6 +32,11 @@ type WorkflowEntry struct {
 	// indistinguishable from "no such step" and treated as such.
 	RequiresInput bool `json:"requires_input,omitempty"`
 
+	// Includes names the workflows this one splices in (§7.9, task 019).
+	// Absent means the daemon predates the field, which is indistinguishable
+	// from "includes nothing" and treated as such.
+	Includes []string `json:"includes,omitempty"`
+
 	Errors []WorkflowFinding `json:"errors,omitempty"`
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []WorkflowFinding `json:"warnings,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,10 @@ type Config struct {
 	// Parallel and FanOut for the same reason they do: it is a ceiling on
 	// what one step may do, not a timeout a step inherits.
 	Loop Loop `yaml:"loop"`
+	// Include bounds a `type: include` expansion (§7.9, task 019). It is read
+	// in the task-creation path, like FanOut, so a reload governs the next
+	// task rather than anything already running.
+	Include Include `yaml:"include"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -324,6 +328,22 @@ type Loop struct {
 	MaxIterations int `yaml:"max_iterations"`
 }
 
+// Include configures `type: include` expansion (spec §7.9 — task 019).
+//
+// MaxDepth is enforced at task creation, which is possible for the reason
+// FanOut's bounds are: the callee is resolved into the snapshot there, so the
+// whole expanded shape is static in the insert path (task 019 decision 2).
+//
+// There is deliberately no bound on the expanded *step count*. Step ids are
+// unique across an expansion (decision 5), so a callee reached twice is a 400
+// rather than a doubling, and an expansion cannot multiply silently — depth is
+// the only dimension left to bound.
+type Include struct {
+	// MaxDepth is how many include levels one expansion may have. A root
+	// including a workflow is depth 1; that workflow's own include is depth 2.
+	MaxDepth int `yaml:"max_depth"`
+}
+
 // Agents configures how agent CLIs are located.
 type Agents struct {
 	Claude Agent `yaml:"claude"`
@@ -370,6 +390,10 @@ func Default() Config {
 		// rather than the throughput.
 		FanOut: FanOut{MaxDepth: 3, MaxTasks: 64},
 		Loop:   Loop{MaxIterations: 10},
+		// Five levels, where fan-out gets three: an include costs a splice
+		// rather than a worktree, so the bound is about keeping a mistake
+		// legible rather than about what the machine can afford.
+		Include: Include{MaxDepth: 5},
 		TUI: TUI{Board: BoardView{
 			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
 		}},
@@ -428,6 +452,9 @@ func (c Config) validate() error {
 	}
 	if c.FanOut.MaxTasks < 1 {
 		return fmt.Errorf("fan_out.max_tasks must be at least 1, got %d", c.FanOut.MaxTasks)
+	}
+	if c.Include.MaxDepth < 1 {
+		return fmt.Errorf("include.max_depth must be at least 1, got %d", c.Include.MaxDepth)
 	}
 	if c.Loop.MaxIterations < 1 {
 		return fmt.Errorf("loop.max_iterations must be at least 1, got %d", c.Loop.MaxIterations)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,7 @@ agents:
 		Parallel: Parallel{MaxParallel: 4},
 		FanOut:   FanOut{MaxDepth: 3, MaxTasks: 64},
 		Loop:     Loop{MaxIterations: 10},
+		Include:  Include{MaxDepth: 5},
 		TUI:      TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -275,8 +275,14 @@ func (d *detail) renderTimeline(height int) string {
 			case grouped:
 				label = d.structureLabel(r.StepIndex, "parallel")
 			}
-			lines = append(lines, styleStepHeader.Render(
-				fmt.Sprintf("  %d %s", r.StepIndex+1, label)))
+			header := fmt.Sprintf("  %d %s", r.StepIndex+1, label)
+			if from := d.includedFrom(r.StepIndex); from != "" {
+				// A spliced step is an ordinary step in every other respect,
+				// so the only thing worth saying is where it was written
+				// (§7.9). The full chain is in the workflow graph's inspector.
+				header += styleDim.Render("  from " + from)
+			}
+			lines = append(lines, styleStepHeader.Render(header))
 			ids = append(ids, 0)
 		}
 		if looped && r.Iteration != lastIteration {
@@ -395,6 +401,26 @@ func (d *detail) structureLabel(index int, kind string) string {
 		}
 	}
 	return "(" + kind + ")"
+}
+
+// includedFrom names the workflow step `index` was spliced in from (§7.9,
+// task 019), or "" for a step the task's own workflow wrote.
+//
+// The *innermost* name, where the snapshot carries the whole chain: at the
+// width of a step header, "from go-checks" is the answer to the question the
+// reader is asking, and the chain that reached it is the graph inspector's
+// job.
+func (d *detail) includedFrom(index int) string {
+	for _, s := range d.task.WorkflowSteps {
+		if s.Index != index {
+			continue
+		}
+		if n := len(s.ResolvedFrom); n > 0 {
+			return s.ResolvedFrom[n-1]
+		}
+		return ""
+	}
+	return ""
 }
 
 // stepStateStopped is the §7.7 state a `condition` step records when its

--- a/internal/tui/workflowgraph/corpus_test.go
+++ b/internal/tui/workflowgraph/corpus_test.go
@@ -109,3 +109,18 @@ func fixtureWideLabels() *apiclient.WorkflowBody {
 	b.Name = "🚀🚀🚀 deploy 🚀🚀🚀 everything everywhere"
 	return body(a, b)
 }
+
+// 10 — includes, at the top level and inside a loop body. Each draws as one
+// collapsed node labelled with the workflow it splices in: the graph shows the
+// file as authored, and as authored an include *is* one step (task 019
+// decision 12).
+func fixtureInclude() *apiclient.WorkflowBody {
+	inc := step("verify", "include")
+	inc.Workflow = "go-checks"
+	nested := step("recheck", "include")
+	nested.Workflow = "go-checks"
+	loop := step("repeat", "loop")
+	loop.Count = intp(2)
+	loop.Steps = []apiclient.WorkflowStepDef{step("attempt", "agent"), nested}
+	return body(step("plan", "agent"), inc, loop, step("ship", "command"))
+}

--- a/internal/tui/workflowgraph/diagram.go
+++ b/internal/tui/workflowgraph/diagram.go
@@ -23,14 +23,22 @@ const (
 	KindCondition NodeKind = "condition"
 	KindLoop      NodeKind = "loop"
 	KindBreak     NodeKind = "break"
+	KindInclude   NodeKind = "include"
 
 	// KindMerge is a fan_out's join (§7.6). It is a node because it is work
 	// that runs and can block on a conflict, unlike a parallel group's join,
 	// which is nothing but the members finishing.
 	KindMerge NodeKind = "merge"
-	// KindWorkflowRef is a fan_out lane naming another registry workflow. It
-	// stays collapsed: expanding it is navigation, not rendering (task 017
-	// non-goals).
+	// KindWorkflowRef is a reference to another registry workflow: a fan_out
+	// lane naming one, or — since task 019 — an `include` step splicing one
+	// in. It stays collapsed: expanding it is navigation, not rendering (task
+	// 017 non-goals), and making includes the exception would give one
+	// question two answers (task 019 decision 12).
+	//
+	// The two references differ in what they produce — a lane becomes a child
+	// task, an include becomes steps in this one — which the inspector says
+	// and the node does not: at node size, "this is another workflow" is the
+	// whole of what fits.
 	KindWorkflowRef NodeKind = "workflow_ref"
 	// KindEnd terminates the top-level sequence. Exactly one exists, and only
 	// at the top level: a `condition` inside a loop body ends its iteration
@@ -262,6 +270,15 @@ func (b *builder) step(st apiclient.WorkflowStepDef, f flow) []string {
 		b.add(b.plainNode(st, f))
 		b.link(st.ID, f.brk, EdgeBranch, "true")
 		return []string{st.ID}
+	case KindInclude:
+		// One collapsed node labelled with the workflow it splices in. The
+		// graph draws the file as authored, and as authored this *is* one
+		// step; what it expands to is decided at task creation, against a
+		// registry this view is not resolving (task 019 decision 12).
+		n := b.plainNode(st, f)
+		n.Kind, n.Label = KindWorkflowRef, st.Workflow
+		b.add(n)
+		return []string{st.ID}
 	default:
 		b.add(b.plainNode(st, f))
 		return []string{st.ID}
@@ -432,6 +449,13 @@ func stepDetail(st apiclient.WorkflowStepDef) []DetailField {
 		}
 	}
 	add("name", st.Name)
+	// An authored include says what it will splice in; a step in a task's
+	// snapshot says what it was spliced *through*. They never appear
+	// together, because expansion replaces the one with the other (§7.9).
+	add("workflow", st.Workflow)
+	if len(st.ResolvedFrom) > 0 {
+		add("from", strings.Join(st.ResolvedFrom, " → "))
+	}
 	add("if", st.If)
 	add("check", st.Check)
 	add("agent", st.Agent)

--- a/internal/tui/workflowgraph/diagram_test.go
+++ b/internal/tui/workflowgraph/diagram_test.go
@@ -298,3 +298,31 @@ func TestBuildIdsAreStableAndNamespaced(t *testing.T) {
 		}
 	}
 }
+
+// TestIncludeDrawsAsACollapsedRef is task 019 decision 12: an include reuses
+// the node kind a fan_out lane's `workflow:` already has, because both are the
+// same statement — "this is another workflow" — and expanding either is
+// navigation rather than rendering (task 017 non-goals).
+//
+// It is labelled with the workflow it splices in rather than with its own id:
+// at node size the callee's name is the useful half, and the id is in the
+// inspector.
+func TestIncludeDrawsAsACollapsedRef(t *testing.T) {
+	d := Build(fixtureInclude())
+	for _, id := range []string{"verify", "recheck"} {
+		n := node(t, d, id)
+		if n.Kind != KindWorkflowRef {
+			t.Errorf("%s kind = %q, want %q", id, n.Kind, KindWorkflowRef)
+		}
+		if n.Label != "go-checks" {
+			t.Errorf("%s label = %q, want the included workflow's name", id, n.Label)
+		}
+		if len(n.Detail) == 0 {
+			t.Errorf("%s has no inspector detail", id)
+		}
+	}
+	// The include is an ordinary member of its sequence: it does not branch,
+	// so `plan → verify → repeat` still reads straight through.
+	hasEdge(t, d, "plan->verify[flow]")
+	hasEdge(t, d, "verify->repeat[flow]")
+}

--- a/internal/workflow/include.go
+++ b/internal/workflow/include.go
@@ -308,22 +308,26 @@ func (x *expander) nested(step Step, path string, depth int, stack, chain []stri
 
 // splice resolves one include and returns the steps that replace it.
 func (x *expander) splice(step Step, path string, depth int, stack, chain []string) ([]Step, error) {
-	if depth+1 > x.opts.Limits.MaxDepth {
-		return nil, &IncludeError{
-			Path: path,
-			Message: fmt.Sprintf("includes nest %d levels deep, past include.max_depth (%d)",
-				depth+1, x.opts.Limits.MaxDepth),
-		}
-	}
 	// A cycle is workflow A including B while B includes A: an expansion that
-	// never terminates, and the one failure here no bound would catch in a
-	// useful way. The path is named because "there is a cycle" sends the
+	// never terminates. The path is named because "there is a cycle" sends the
 	// reader to grep every workflow file they own.
+	//
+	// Checked *before* the depth bound, because a cycle crosses any bound
+	// eventually and the bound's message is actively misleading about it:
+	// "past include.max_depth" invites raising a limit that will never help,
+	// while the cycle is a structural error no configuration fixes.
 	if idx := indexOf(stack, step.Workflow); idx >= 0 {
 		return nil, &IncludeError{
 			Path: path,
 			Message: fmt.Sprintf("workflow cycle: %s",
 				strings.Join(append(append([]string{}, stack[idx:]...), step.Workflow), " → ")),
+		}
+	}
+	if depth+1 > x.opts.Limits.MaxDepth {
+		return nil, &IncludeError{
+			Path: path,
+			Message: fmt.Sprintf("includes nest %d levels deep, past include.max_depth (%d)",
+				depth+1, x.opts.Limits.MaxDepth),
 		}
 	}
 	if x.opts.Lookup == nil {

--- a/internal/workflow/include.go
+++ b/internal/workflow/include.go
@@ -1,0 +1,527 @@
+package workflow
+
+// Creation-time expansion of `type: include` steps (spec §7.9, task 019).
+//
+// An include names a registry workflow whose steps are **spliced** into the
+// caller: the include step is replaced by those steps, each becoming an
+// ordinary top-level step with its own step_index. Nothing survives into the
+// run — no step_runs row, no cursor, no boundary — which is why §7's engine,
+// §11's scheduler and §12.4's recovery need no knowledge of includes at all.
+//
+// Resolving here rather than at run time is §5.3 restated, and the reason
+// fanout.go gives for lanes: execution uses the snapshot precisely so that
+// later edits to workflow files cannot mutate an in-flight task, and a callee
+// read from the registry six hours into a run would be exactly that mutation,
+// in the one place nobody would look for it.
+//
+// It is also what makes every check below a 400 in front of the person typing:
+// the expanded shape is static in the insert path, so a cycle, a depth
+// explosion, a duplicate id and an unsupported platform are all decidable
+// there.
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// IncludeLimits bound one expansion (config `include.*`, decision 8).
+type IncludeLimits struct {
+	// MaxDepth is how many include levels one expansion may have. A root
+	// including a workflow is depth 1; that workflow's own include is depth 2.
+	MaxDepth int
+}
+
+// IncludeError is an expansion that cannot be created: an include naming an
+// unknown workflow, a cycle, an expansion past its depth bound, a step id the
+// expansion already used, or a callee this host cannot run. Every case is a
+// 400 — something the person creating the task can act on.
+type IncludeError struct {
+	// Path is the YAML path of the offending include. A path inside a callee
+	// carries the include it came through, so one message locates both the
+	// call site and the step at fault: `steps[1].include(checks).steps[0]`.
+	Path string
+	// Message says what is wrong, naming the workflows involved.
+	Message string
+}
+
+func (e *IncludeError) Error() string {
+	if e.Path == "" {
+		return e.Message
+	}
+	return e.Path + ": " + e.Message
+}
+
+// ExpandOptions is everything Expand needs beyond the workflow itself.
+type ExpandOptions struct {
+	// Lookup resolves an include's workflow name through the registry's
+	// builtin < global < project shadowing.
+	Lookup LookupFunc
+	Limits IncludeLimits
+	// Override is the task's own (agent, model, effort) selection. It sits
+	// *above* a callee's defaults in §8.6's order, so materialisation has to
+	// know it to avoid promoting a callee default over the value a human just
+	// typed (decision 7). Task-level overrides are immutable — priority is
+	// the only mutable task field in v1 — so reading them here is exact
+	// rather than a snapshot of something that may move.
+	Override agent.Level
+	// Platform is the GOOS an included workflow's `platforms:` is judged
+	// against. Empty means the running host, which is what task creation
+	// wants; tests pin it.
+	Platform string
+}
+
+// Expand replaces every `include` step in wf, recursively, returning a copy
+// with a flat step list and no include left in it.
+//
+// The returned workflow is a *candidate*: it is structurally expanded but not
+// re-validated. Callers re-run Parse over the marshalled result, because the
+// nesting rules an expansion can break — no `loop` inside a `loop`, no
+// `fan_out` inside a `parallel` — are only decidable once the steps are in
+// place (decision 9).
+func Expand(wf *Workflow, opts ExpandOptions) (*Workflow, error) {
+	if wf == nil {
+		return nil, &IncludeError{Message: "no workflow to expand"}
+	}
+	x := &expander{opts: opts}
+	if x.opts.Platform == "" {
+		x.opts.Platform = HostPlatform()
+	}
+	steps, err := x.body(wf.Steps, "steps", 0, []string{wf.Name}, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := *wf
+	out.Steps = steps
+	// Ids are checked over the *result* rather than as the splice goes.
+	// Claiming during expansion means claiming each step at whichever level
+	// happens to produce it, and a step reached through two includes is
+	// produced twice — which reported a workflow as colliding with itself.
+	// One pass over the finished list is exactly-once by construction.
+	if err := checkDuplicateIDs(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// checkDuplicateIDs reports the first step id used twice in one namespace
+// (decision 5). There is one namespace per task the expansion can produce: the
+// root's, plus a fresh one per fan_out lane, because each lane becomes a
+// separate child task with its own flat snapshot (§8.2).
+//
+// The message names the *workflows* rather than the expanded paths: after a
+// splice, `steps[4]` does not point at anything the author wrote, while "from
+// checks" does.
+func checkDuplicateIDs(wf *Workflow) error {
+	if err := checkScopeIDs(wf.Steps, wf.Name); err != nil {
+		return err
+	}
+	for _, step := range wf.Steps {
+		for _, lane := range step.Lanes {
+			if err := checkScopeIDs(lane.Steps, wf.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkScopeIDs(steps []Step, root string) error {
+	seen := map[string]string{}
+	for _, step := range steps {
+		for _, owner := range stepIDs(step) {
+			origin := originOf(step, root)
+			if prev, dup := seen[owner]; dup {
+				return &IncludeError{Message: fmt.Sprintf(
+					"expanding this workflow uses step id %q twice: once %s, once %s",
+					owner, prev, origin)}
+			}
+			seen[owner] = origin
+		}
+	}
+	return nil
+}
+
+// originOf says where a step came from, in the words the author would use.
+func originOf(step Step, root string) string {
+	if n := len(step.ResolvedFrom); n > 0 {
+		return fmt.Sprintf("from the included workflow %q", step.ResolvedFrom[n-1])
+	}
+	return fmt.Sprintf("in %q itself", root)
+}
+
+// HasInclude reports whether a workflow contains an include anywhere a splice
+// would reach: at the top level, inside a group or loop body, or inside a
+// fan_out lane's inline steps. Callers use it to skip expansion entirely for
+// the workflows that are the overwhelming majority.
+func HasInclude(wf *Workflow) bool {
+	return wf != nil && bodyHasInclude(wf.Steps)
+}
+
+func bodyHasInclude(steps []Step) bool {
+	for _, s := range steps {
+		if s.Type == StepInclude || bodyHasInclude(s.Steps) {
+			return true
+		}
+		for _, lane := range s.Lanes {
+			if bodyHasInclude(lane.Steps) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IncludeNames lists the workflows a workflow includes directly, in
+// declaration order and without duplicates. It is what `GET /v1/workflows`
+// reports, so a client can show what a workflow depends on without resolving
+// anything.
+func IncludeNames(wf *Workflow) []string {
+	if wf == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	var walk func([]Step)
+	walk = func(steps []Step) {
+		for _, s := range steps {
+			if s.Type == StepInclude && s.Workflow != "" && !seen[s.Workflow] {
+				seen[s.Workflow] = true
+				out = append(out, s.Workflow)
+			}
+			walk(s.Steps)
+			for _, lane := range s.Lanes {
+				walk(lane.Steps)
+			}
+		}
+	}
+	walk(wf.Steps)
+	return out
+}
+
+// IncludeCycleWarnings reports include cycles reachable from a workflow, for
+// the §8.2 registry-load warning (decision 8).
+//
+// A warning rather than an error, and only at load, for the reason
+// LaneCycleWarnings is one: a cycle between two files is real only once a task
+// picks a root, and shadowing decides which files those even are — a project
+// workflow may shadow the very name that closed the loop. Task creation is
+// where it becomes a 400.
+func IncludeCycleWarnings(wf *Workflow, lookup LookupFunc) []string {
+	if wf == nil || lookup == nil || !HasInclude(wf) {
+		return nil
+	}
+	// A generous depth and no platform: this is a cycle probe, not a bound
+	// check, and both bounds are enforced at creation where the config and
+	// the host are in hand. Ids are not checked either — a duplicate is a
+	// creation-time error about a specific pair of files, and reporting it as
+	// a load warning would blame whichever file happened to be loading. Going
+	// through the expander rather than Expand is what leaves it out.
+	x := &expander{opts: ExpandOptions{
+		Lookup:   lookup,
+		Limits:   IncludeLimits{MaxDepth: cycleProbeDepth},
+		Platform: anyPlatform,
+	}}
+	if _, err := x.body(wf.Steps, "steps", 0, []string{wf.Name}, nil); err != nil {
+		var ie *IncludeError
+		if errors.As(err, &ie) && strings.Contains(ie.Message, "cycle") {
+			return []string{ie.Error()}
+		}
+	}
+	return nil
+}
+
+// cycleProbeDepth bounds the load-time probe. It is not a policy — the policy
+// is include.max_depth at creation — only a guard against walking a legal but
+// enormous graph while holding the registry's lock.
+const cycleProbeDepth = 64
+
+// anyPlatform disables the platform check. It is not a GOOS, so
+// SupportsPlatform's token match could never accept it anyway — which is why
+// the check tests for it explicitly rather than relying on the comparison.
+const anyPlatform = "*"
+
+type expander struct {
+	opts ExpandOptions
+}
+
+// body expands one step list. `path` is its YAML path, `depth` how many
+// include levels are already above it, `stack` the workflow names on the
+// current path for cycle detection, `chain` the provenance every step produced
+// here inherits, and `ids` the namespace this body's steps share.
+func (x *expander) body(in []Step, path string, depth int, stack, chain []string) ([]Step, error) {
+	out := make([]Step, 0, len(in))
+	for i, step := range in {
+		stepPath := fmt.Sprintf("%s[%d]", path, i)
+		if step.Type != StepInclude {
+			expanded, err := x.nested(step, stepPath, depth, stack, chain)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, expanded)
+			continue
+		}
+		spliced, err := x.splice(step, stepPath, depth, stack, chain)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, spliced...)
+	}
+	return out, nil
+}
+
+// nested expands the includes inside a step that is not itself an include: a
+// group's or a loop's body, and a fan_out lane's inline steps. A lane's steps
+// become a child task's snapshot, so an include there is resolved here for the
+// same reason one at the top level is — by the time that child runs, the
+// registry is no longer consulted.
+func (x *expander) nested(step Step, path string, depth int, stack, chain []string) (Step, error) {
+	if len(step.Steps) > 0 {
+		sub, err := x.body(step.Steps, path+".steps", depth, stack, chain)
+		if err != nil {
+			return step, err
+		}
+		step.Steps = sub
+	}
+	if len(step.Lanes) == 0 {
+		return step, nil
+	}
+	lanes := make([]Lane, len(step.Lanes))
+	copy(lanes, step.Lanes)
+	for j := range lanes {
+		if len(lanes[j].Steps) == 0 {
+			continue
+		}
+		lanePath := fmt.Sprintf("%s.lanes[%d].steps", path, j)
+		sub, err := x.body(lanes[j].Steps, lanePath, depth, stack, chain)
+		if err != nil {
+			return step, err
+		}
+		lanes[j].Steps = sub
+	}
+	step.Lanes = lanes
+	return step, nil
+}
+
+// splice resolves one include and returns the steps that replace it.
+func (x *expander) splice(step Step, path string, depth int, stack, chain []string) ([]Step, error) {
+	if depth+1 > x.opts.Limits.MaxDepth {
+		return nil, &IncludeError{
+			Path: path,
+			Message: fmt.Sprintf("includes nest %d levels deep, past include.max_depth (%d)",
+				depth+1, x.opts.Limits.MaxDepth),
+		}
+	}
+	// A cycle is workflow A including B while B includes A: an expansion that
+	// never terminates, and the one failure here no bound would catch in a
+	// useful way. The path is named because "there is a cycle" sends the
+	// reader to grep every workflow file they own.
+	if idx := indexOf(stack, step.Workflow); idx >= 0 {
+		return nil, &IncludeError{
+			Path: path,
+			Message: fmt.Sprintf("workflow cycle: %s",
+				strings.Join(append(append([]string{}, stack[idx:]...), step.Workflow), " → ")),
+		}
+	}
+	if x.opts.Lookup == nil {
+		return nil, &IncludeError{Path: path, Message: "included workflows cannot be resolved here"}
+	}
+	callee, ok := x.opts.Lookup(step.Workflow)
+	if !ok {
+		return nil, &IncludeError{
+			Path:    path,
+			Message: fmt.Sprintf("included workflow %q not found", step.Workflow),
+		}
+	}
+	// §8.1.1 travels with the steps: a caller that splices in a POSIX-only
+	// fragment cannot run here either. The caller's own `platforms:` is not
+	// rewritten — it stays a property of the file as written, so
+	// Entry.RunsHere keeps one meaning (decision 8).
+	if x.opts.Platform != anyPlatform && !callee.SupportsPlatform(x.opts.Platform) {
+		return nil, &IncludeError{
+			Path: path,
+			Message: fmt.Sprintf("included workflow %q does not run on %s (platforms: %s)",
+				step.Workflow, x.opts.Platform, strings.Join(callee.Platforms, ", ")),
+		}
+	}
+
+	next := append(append([]string{}, stack...), step.Workflow)
+	nextChain := append(append([]string{}, chain...), step.Workflow)
+
+	// Innermost first: the callee's own includes are spliced before its
+	// defaults are materialised over the result, so a step that came through
+	// two includes keeps the *nearest* enclosing workflow's defaults and the
+	// outer one only fills what is still unset (decision 7).
+	body, err := x.body(callee.Steps, fmt.Sprintf("%s.include(%s).steps", path, step.Workflow),
+		depth+1, next, nextChain)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Step, len(body))
+	for i, spliced := range body {
+		// Materialise first, then attribute. A step that came through a
+		// deeper include already carries the nearer workflow's defaults and
+		// its own chain; this pass fills what that one left unset and leaves
+		// the chain alone, which is what makes "nearest wins" fall out of the
+		// recursion rather than needing a rule (decision 7).
+		out[i] = attribute(materialise(spliced, callee.Defaults, x.opts.Override), nextChain)
+	}
+	return out, nil
+}
+
+// attribute records where a spliced step came from, recursing into a group's
+// sub-steps, a loop's body and a lane's inline steps so a step nested inside a
+// spliced structure step says so too.
+//
+// A chain already present is kept: it was written by a deeper splice and names
+// the workflow the step actually came from, which is the nearer and more
+// useful answer (decision 6).
+func attribute(step Step, chain []string) Step {
+	if len(step.ResolvedFrom) > 0 {
+		return step
+	}
+	step.ResolvedFrom = chain
+	if len(step.Steps) > 0 {
+		subs := make([]Step, len(step.Steps))
+		for i, sub := range step.Steps {
+			subs[i] = attribute(sub, chain)
+		}
+		step.Steps = subs
+	}
+	if len(step.Lanes) > 0 {
+		lanes := make([]Lane, len(step.Lanes))
+		copy(lanes, step.Lanes)
+		for j := range lanes {
+			if len(lanes[j].Steps) == 0 {
+				continue
+			}
+			subs := make([]Step, len(lanes[j].Steps))
+			for i, sub := range lanes[j].Steps {
+				subs[i] = attribute(sub, chain)
+			}
+			lanes[j].Steps = subs
+		}
+		step.Lanes = lanes
+	}
+	return step
+}
+
+// stepIDs is a step's id together with its sub-steps' or loop body's, which
+// share its step_index and live in the same namespace (§8.2).
+func stepIDs(step Step) []string {
+	out := make([]string, 0, 1+len(step.Steps))
+	if step.ID != "" {
+		out = append(out, step.ID)
+	}
+	for _, sub := range step.Steps {
+		if sub.ID != "" {
+			out = append(out, sub.ID)
+		}
+	}
+	return out
+}
+
+// materialise writes a callee's `defaults:` onto one spliced step, so a
+// fragment keeps the behaviour it was written with instead of silently
+// adopting its caller's (decision 7).
+//
+// The rule per field is §8.6's order made explicit: a value the step itself
+// sets is left alone; a value the *task* overrides is left unset, because the
+// run-time resolver applies the override before the snapshot's own defaults
+// and reaches the same answer; only then does the callee's default get
+// written. A field no level supplies stays empty, so the caller's defaults and
+// the daemon default still apply at run time exactly as they would have.
+//
+// It recurses into a group's sub-steps, a loop's body, a fan_out lane's inline
+// steps and a merge's agent step, because all four run steps that would
+// otherwise inherit the caller's defaults — a lane's child task is built with
+// the *root* snapshot's defaults (`internal/taskrun/fanout.go`), which after a
+// splice is the caller's.
+func materialise(step Step, callee Defaults, override agent.Level) Step {
+	if len(step.Steps) > 0 {
+		subs := make([]Step, len(step.Steps))
+		for i, sub := range step.Steps {
+			subs[i] = materialise(sub, callee, override)
+		}
+		step.Steps = subs
+	}
+	if len(step.Lanes) > 0 {
+		lanes := make([]Lane, len(step.Lanes))
+		copy(lanes, step.Lanes)
+		for j := range lanes {
+			if len(lanes[j].Steps) == 0 {
+				continue
+			}
+			subs := make([]Step, len(lanes[j].Steps))
+			for i, sub := range lanes[j].Steps {
+				subs[i] = materialise(sub, callee, override)
+			}
+			lanes[j].Steps = subs
+		}
+		step.Lanes = lanes
+	}
+	if step.Merge != nil && step.Merge.Agent != nil {
+		merge := *step.Merge
+		resolved := materialise(*merge.Agent, callee, override)
+		merge.Agent = &resolved
+		step.Merge = &merge
+	}
+
+	// `timeout` and `max_retries` bind to an attempt, which a `condition` and
+	// a `break` do not have — writing either onto one would produce a
+	// snapshot §8.2 rejects. A `loop` has a timeout but no attempt of its own.
+	switch step.Type {
+	case StepCondition, StepBreak:
+	case StepLoop:
+		step.Timeout = firstDuration(step.Timeout, callee.Timeout)
+	default:
+		step.Timeout = firstDuration(step.Timeout, callee.Timeout)
+		if step.MaxRetries == nil {
+			step.MaxRetries = callee.MaxRetries
+		}
+	}
+
+	// The rest of `defaults:` is agent vocabulary, which §8.2 allows only on
+	// an agent step.
+	if step.Type != StepAgent {
+		return step
+	}
+	if step.PermissionMode == "" {
+		step.PermissionMode = callee.PermissionMode
+	}
+	if step.OnInput == "" {
+		step.OnInput = callee.OnInput
+	}
+	step.InputTimeout = firstDuration(step.InputTimeout, callee.InputTimeout)
+
+	// The (agent, model, effort) triple is resolved as a unit rather than
+	// merged field by field: agent.ResolveWithSources is agent-scoped — a
+	// level whose agent differs from the resolved one contributes nothing but
+	// its agent field — so a per-field merge would carry a model across
+	// adapters that the resolver would have dropped.
+	//
+	// A callee naming none of the three is left completely alone, which keeps
+	// the common case free of baked-in values: with nothing to contribute,
+	// the run-time resolve reaches the same answer from the caller's defaults.
+	if callee.Agent == "" && callee.Model == "" && callee.Effort == "" {
+		return step
+	}
+	sel := agent.Resolve(
+		agent.Level{Agent: step.Agent, Model: step.Model, Effort: step.Effort},
+		override,
+		agent.Level{Agent: callee.Agent, Model: callee.Model, Effort: callee.Effort},
+	)
+	step.Agent, step.Model, step.Effort = sel.Agent, sel.Model, sel.Effort
+	return step
+}
+
+func firstDuration(step, callee *config.Duration) *config.Duration {
+	if step != nil {
+		return step
+	}
+	return callee
+}

--- a/internal/workflow/include.go
+++ b/internal/workflow/include.go
@@ -202,32 +202,37 @@ func IncludeNames(wf *Workflow) []string {
 	return out
 }
 
-// IncludeCycleWarnings reports include cycles reachable from a workflow, for
-// the §8.2 registry-load warning (decision 8).
+// IncludeWarnings reports what is wrong with a workflow's includes as seen
+// from one project's resolved view, for the §8.2 registry-load warning
+// (decision 8): a cycle, a name this project cannot resolve, or a callee that
+// does not run on this host.
 //
-// A warning rather than an error, and only at load, for the reason
-// LaneCycleWarnings is one: a cycle between two files is real only once a task
-// picks a root, and shadowing decides which files those even are — a project
-// workflow may shadow the very name that closed the loop. Task creation is
-// where it becomes a 400.
-func IncludeCycleWarnings(wf *Workflow, lookup LookupFunc) []string {
+// Warnings rather than errors, and only at load, for the reason
+// LaneCycleWarnings gives: every one of these is a property of *resolved*
+// names, and shadowing decides which files even participate — a project
+// workflow may shadow the very name that closed the loop or restricted the
+// platform. Task creation, where the root is known, is where each becomes a
+// 400.
+//
+// At most one is reported: expansion stops at the first problem, and a second
+// pass would only describe the same file differently.
+func IncludeWarnings(wf *Workflow, lookup LookupFunc) []string {
 	if wf == nil || lookup == nil || !HasInclude(wf) {
 		return nil
 	}
-	// A generous depth and no platform: this is a cycle probe, not a bound
-	// check, and both bounds are enforced at creation where the config and
-	// the host are in hand. Ids are not checked either — a duplicate is a
-	// creation-time error about a specific pair of files, and reporting it as
-	// a load warning would blame whichever file happened to be loading. Going
-	// through the expander rather than Expand is what leaves it out.
+	// A generous depth: this is a probe, not a bound check, and the bound is
+	// enforced at creation where the config is in hand. Step ids are not
+	// checked either — a duplicate is a creation-time error about a specific
+	// pair of files, and reporting it as a load warning would blame whichever
+	// file happened to be loading. Going through the expander rather than
+	// Expand is what leaves that check out.
 	x := &expander{opts: ExpandOptions{
-		Lookup:   lookup,
-		Limits:   IncludeLimits{MaxDepth: cycleProbeDepth},
-		Platform: anyPlatform,
+		Lookup: lookup,
+		Limits: IncludeLimits{MaxDepth: cycleProbeDepth},
 	}}
 	if _, err := x.body(wf.Steps, "steps", 0, []string{wf.Name}, nil); err != nil {
 		var ie *IncludeError
-		if errors.As(err, &ie) && strings.Contains(ie.Message, "cycle") {
+		if errors.As(err, &ie) {
 			return []string{ie.Error()}
 		}
 	}
@@ -238,11 +243,6 @@ func IncludeCycleWarnings(wf *Workflow, lookup LookupFunc) []string {
 // is include.max_depth at creation — only a guard against walking a legal but
 // enormous graph while holding the registry's lock.
 const cycleProbeDepth = 64
-
-// anyPlatform disables the platform check. It is not a GOOS, so
-// SupportsPlatform's token match could never accept it anyway — which is why
-// the check tests for it explicitly rather than relying on the comparison.
-const anyPlatform = "*"
 
 type expander struct {
 	opts ExpandOptions
@@ -340,7 +340,7 @@ func (x *expander) splice(step Step, path string, depth int, stack, chain []stri
 	// fragment cannot run here either. The caller's own `platforms:` is not
 	// rewritten — it stays a property of the file as written, so
 	// Entry.RunsHere keeps one meaning (decision 8).
-	if x.opts.Platform != anyPlatform && !callee.SupportsPlatform(x.opts.Platform) {
+	if !callee.SupportsPlatform(x.opts.Platform) {
 		return nil, &IncludeError{
 			Path: path,
 			Message: fmt.Sprintf("included workflow %q does not run on %s (platforms: %s)",

--- a/internal/workflow/include_test.go
+++ b/internal/workflow/include_test.go
@@ -370,20 +370,24 @@ func TestExpandNestedDefaultsNearestWins(t *testing.T) {
 	}
 }
 
-// TestIncludeCycleWarnings is decision 8's load-time half: a warning, because
+// TestIncludeWarnings is decision 8's load-time half: a warning, because
 // shadowing decides which files even participate and a project workflow may
-// shadow the very name that closed the loop.
-func TestIncludeCycleWarnings(t *testing.T) {
+// shadow the very name that closed the loop — or the one that was missing.
+func TestIncludeWarnings(t *testing.T) {
 	lookup := registry(t, map[string]string{
 		"b": "name: b\nsteps:\n  - {id: toa, type: include, workflow: a}\n",
 	})
 	root := mustParse(t, "name: a\nsteps:\n  - {id: tob, type: include, workflow: b}\n")
-	warns := IncludeCycleWarnings(root, lookup)
+	warns := IncludeWarnings(root, lookup)
 	if len(warns) != 1 || !strings.Contains(warns[0], "cycle") {
 		t.Fatalf("warnings = %v, want one cycle warning", warns)
 	}
+	missing := mustParse(t, "name: c\nsteps:\n  - {id: x, type: include, workflow: gone}\n")
+	if w := IncludeWarnings(missing, lookup); len(w) != 1 || !strings.Contains(w[0], "not found") {
+		t.Errorf("warnings for an unresolvable include = %v, want one not-found", w)
+	}
 	clean := mustParse(t, "name: c\nsteps:\n  - {id: x, type: command, run: make}\n")
-	if w := IncludeCycleWarnings(clean, lookup); len(w) != 0 {
+	if w := IncludeWarnings(clean, lookup); len(w) != 0 {
 		t.Errorf("warnings on an include-free workflow = %v", w)
 	}
 }

--- a/internal/workflow/include_test.go
+++ b/internal/workflow/include_test.go
@@ -482,3 +482,18 @@ func TestIncludeStepAccepted(t *testing.T) {
 		t.Fatalf("a well-formed include did not validate: %v", err)
 	}
 }
+
+// TestExpandReportsACycleAheadOfTheDepthBound: a cycle crosses any bound
+// eventually, so whichever check runs first decides what the person sees.
+// "past include.max_depth" invites raising a limit that will never help.
+func TestExpandReportsACycleAheadOfTheDepthBound(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"b": "name: b\nsteps:\n  - {id: back, type: include, workflow: a}\n",
+	})
+	opts := expandOpts(lookup)
+	opts.Limits.MaxDepth = 1
+	_, err := Expand(mustParse(t, "name: a\nsteps:\n  - {id: to, type: include, workflow: b}\n"), opts)
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("error = %v, want the cycle rather than the bound it also crosses", err)
+	}
+}

--- a/internal/workflow/include_test.go
+++ b/internal/workflow/include_test.go
@@ -1,0 +1,480 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// expandOpts is Expand's options with the parts every test wants the same:
+// a generous depth and a pinned platform, so a test asserting about ids or
+// defaults never fails because of the host it ran on.
+func expandOpts(lookup LookupFunc) ExpandOptions {
+	return ExpandOptions{Lookup: lookup, Limits: IncludeLimits{MaxDepth: 5}, Platform: "linux"}
+}
+
+func stepIDsOf(steps []Step) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.ID
+	}
+	return out
+}
+
+// TestExpandSplicesCalleeSteps is the whole feature: the include is gone and
+// the callee's steps stand in its place, at the caller's own level.
+func TestExpandSplicesCalleeSteps(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"checks": "name: checks\nsteps:\n" +
+			"  - {id: lint, type: command, run: make lint}\n" +
+			"  - {id: test, type: command, run: make test}\n",
+	})
+	root := mustParse(t, `
+name: root
+steps:
+  - {id: implement, type: agent, prompt: go}
+  - {id: verify, type: include, workflow: checks}
+  - {id: review, type: agent, prompt: done}
+`)
+	got, err := Expand(root, expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	want := []string{"implement", "lint", "test", "review"}
+	if ids := stepIDsOf(got.Steps); strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Fatalf("steps = %v, want %v", ids, want)
+	}
+	for _, s := range got.Steps {
+		if s.Type == StepInclude {
+			t.Fatal("an include survived expansion")
+		}
+	}
+	if len(root.Steps) != 3 {
+		t.Error("Expand mutated its input")
+	}
+}
+
+// TestExpandRecordsProvenanceChain is decision 6: a step spliced through two
+// includes says so, outermost first, and a step the caller wrote itself
+// carries nothing.
+func TestExpandRecordsProvenanceChain(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"outer": "name: outer\nsteps:\n" +
+			"  - {id: before, type: command, run: make a}\n" +
+			"  - {id: deep, type: include, workflow: inner}\n",
+		"inner": "name: inner\nsteps:\n  - {id: leaf, type: command, run: make b}\n",
+	})
+	got, err := Expand(mustParse(t, `
+name: root
+steps:
+  - {id: own, type: command, run: make own}
+  - {id: call, type: include, workflow: outer}
+`), expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	want := map[string]string{"own": "", "before": "outer", "leaf": "outer,inner"}
+	for _, s := range got.Steps {
+		if chain := strings.Join(s.ResolvedFrom, ","); chain != want[s.ID] {
+			t.Errorf("%s resolved_from = %q, want %q", s.ID, chain, want[s.ID])
+		}
+	}
+}
+
+// TestExpandRejectsDuplicateStepID is decision 5. The collision is reported
+// against the include that introduced the second use, naming where the id was
+// already taken — the alternative was prefixing ids, which would mean
+// rewriting the callee's own templates.
+func TestExpandRejectsDuplicateStepID(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"checks": "name: checks\nsteps:\n  - {id: build, type: command, run: make}\n",
+	})
+	_, err := Expand(mustParse(t, `
+name: root
+steps:
+  - {id: build, type: command, run: make first}
+  - {id: verify, type: include, workflow: checks}
+`), expandOpts(lookup))
+	if err == nil {
+		t.Fatal("Expand accepted a duplicate step id")
+	}
+	// Both sides are named in the words the author would use: after a splice,
+	// `steps[4]` points at nothing anyone wrote, while "from checks" does.
+	if !strings.Contains(err.Error(), `"build"`) ||
+		!strings.Contains(err.Error(), `in "root" itself`) ||
+		!strings.Contains(err.Error(), `included workflow "checks"`) {
+		t.Errorf("error does not name both sides: %v", err)
+	}
+}
+
+// TestExpandLaneIDsAreTheirOwnNamespace: a lane becomes a separate child task
+// with its own flat snapshot (§8.2), so an id it shares with the root is two
+// tasks and no collision.
+func TestExpandLaneIDsAreTheirOwnNamespace(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"checks": "name: checks\nsteps:\n  - {id: build, type: command, run: make}\n",
+	})
+	if _, err := Expand(mustParse(t, `
+name: root
+steps:
+  - {id: build, type: command, run: make first}
+  - id: spread
+    type: fan_out
+    lanes:
+      - {id: one, steps: [{id: verify, type: include, workflow: checks}]}
+`), expandOpts(lookup)); err != nil {
+		t.Fatalf("Expand rejected a lane reusing a root id: %v", err)
+	}
+}
+
+// TestExpandDetectsCycles: A including B while B includes A never terminates,
+// and no bound would report it usefully. The message names the path.
+func TestExpandDetectsCycles(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"a": "name: a\nsteps:\n  - {id: tob, type: include, workflow: b}\n",
+		"b": "name: b\nsteps:\n  - {id: toa, type: include, workflow: a}\n",
+	})
+	_, err := Expand(mustParse(t, "name: a\nsteps:\n  - {id: tob, type: include, workflow: b}\n"),
+		expandOpts(lookup))
+	if err == nil {
+		t.Fatal("Expand accepted a cycle")
+	}
+	if !strings.Contains(err.Error(), "cycle") || !strings.Contains(err.Error(), "a → b → a") {
+		t.Errorf("cycle error does not name the path: %v", err)
+	}
+}
+
+// TestExpandEnforcesMaxDepth: depth is unlimited by design and bounded by
+// config, so a deeper chain is a config edit and not a code change.
+func TestExpandEnforcesMaxDepth(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"one":   "name: one\nsteps:\n  - {id: c2, type: include, workflow: two}\n",
+		"two":   "name: two\nsteps:\n  - {id: c3, type: include, workflow: three}\n",
+		"three": "name: three\nsteps:\n  - {id: leaf, type: command, run: make}\n",
+	})
+	root := mustParse(t, "name: root\nsteps:\n  - {id: c1, type: include, workflow: one}\n")
+	opts := expandOpts(lookup)
+	if _, err := Expand(root, opts); err != nil {
+		t.Fatalf("depth 3 rejected under max_depth 5: %v", err)
+	}
+	opts.Limits.MaxDepth = 2
+	_, err := Expand(root, opts)
+	if err == nil {
+		t.Fatal("Expand accepted an expansion past max_depth")
+	}
+	if !strings.Contains(err.Error(), "include.max_depth") {
+		t.Errorf("error does not name the bound: %v", err)
+	}
+}
+
+// TestExpandUnknownWorkflow: a name this project cannot see is a 400 in front
+// of the person typing, not a step that fails six hours in.
+func TestExpandUnknownWorkflow(t *testing.T) {
+	_, err := Expand(mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: nope}\n"),
+		expandOpts(registry(t, nil)))
+	if err == nil || !strings.Contains(err.Error(), `"nope" not found`) {
+		t.Fatalf("error = %v, want a not-found naming the workflow", err)
+	}
+}
+
+// TestExpandRejectsUnsupportedPlatform is decision 8: §8.1.1 travels with the
+// steps, so a caller splicing in a POSIX-only fragment cannot run here either.
+func TestExpandRejectsUnsupportedPlatform(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"posix": "name: posix\nplatforms: [posix]\nsteps:\n  - {id: sh, type: command, run: make}\n",
+	})
+	root := mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: posix}\n")
+	opts := expandOpts(lookup)
+	opts.Platform = "windows"
+	if _, err := Expand(root, opts); err == nil ||
+		!strings.Contains(err.Error(), "does not run on windows") {
+		t.Fatalf("error = %v, want a platform refusal", err)
+	}
+	opts.Platform = "linux"
+	if _, err := Expand(root, opts); err != nil {
+		t.Errorf("Expand rejected a fragment this platform supports: %v", err)
+	}
+}
+
+// TestExpandMaterialisesCalleeDefaults is decision 7's core: a fragment keeps
+// the behaviour it was written with rather than silently adopting its
+// caller's.
+func TestExpandMaterialisesCalleeDefaults(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"strict": "name: strict\ndefaults: {max_retries: 0, timeout: 30m}\n" +
+			"steps:\n  - {id: once, type: command, run: make}\n" +
+			"  - {id: pinned, type: command, run: make two, timeout: 5m}\n",
+	})
+	got, err := Expand(mustParse(t, `
+name: root
+defaults: {max_retries: 3}
+steps:
+  - {id: c, type: include, workflow: strict}
+`), expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	once := got.Steps[0]
+	if once.MaxRetries == nil || *once.MaxRetries != 0 {
+		t.Errorf("max_retries = %v, want the callee's 0 rather than the caller's 3", once.MaxRetries)
+	}
+	if once.Timeout == nil || once.Timeout.Std() != 30*60*1e9 {
+		t.Errorf("timeout = %v, want the callee's 30m", once.Timeout)
+	}
+	// A step that set the field itself outranks the defaults that would have
+	// filled it, which is §8.6's order and not a special case.
+	if pinned := got.Steps[1]; pinned.Timeout == nil || pinned.Timeout.Std() != 5*60*1e9 {
+		t.Errorf("pinned timeout = %v, want its own 5m", pinned.Timeout)
+	}
+}
+
+// TestExpandTaskOverrideOutranksCalleeDefaults is the other half of decision
+// 7: the value a human just typed beats a fragment's default, which is what
+// materialising has to avoid inverting by writing a default into a step field.
+func TestExpandTaskOverrideOutranksCalleeDefaults(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"fixed": "name: fixed\ndefaults: {agent: codex}\n" +
+			"steps:\n  - {id: think, type: agent, prompt: go}\n",
+	})
+	opts := expandOpts(lookup)
+	opts.Override = agent.Level{Agent: "claude"}
+	got, err := Expand(mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: fixed}\n"), opts)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if a := got.Steps[0].Agent; a != "claude" {
+		t.Errorf("agent = %q, want the task override %q", a, "claude")
+	}
+}
+
+// TestExpandLeavesAnUndeclaredTripleAlone keeps the common case free of baked
+// values: with nothing to contribute, the run-time resolve reaches the same
+// answer from the caller's defaults, so the snapshot should not pin one.
+func TestExpandLeavesAnUndeclaredTripleAlone(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"plain": "name: plain\nsteps:\n  - {id: think, type: agent, prompt: go}\n",
+	})
+	got, err := Expand(mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: plain}\n"),
+		expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if s := got.Steps[0]; s.Agent != "" || s.Model != "" || s.Effort != "" {
+		t.Errorf("triple = (%q, %q, %q), want all empty", s.Agent, s.Model, s.Effort)
+	}
+}
+
+// TestExpandNeverWritesRetriesOntoACondition: `timeout` and `max_retries`
+// bind to an attempt, which a condition does not have — writing the callee's
+// defaults onto one would produce a snapshot §8.2 rejects.
+func TestExpandNeverWritesRetriesOntoACondition(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"guarded": "name: guarded\ndefaults: {max_retries: 2, timeout: 9m}\n" +
+			"steps:\n  - {id: gate, type: condition, if: 'true'}\n" +
+			"  - {id: work, type: command, run: make}\n",
+	})
+	got, err := Expand(mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: guarded}\n"),
+		expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if gate := got.Steps[0]; gate.MaxRetries != nil || gate.Timeout != nil {
+		t.Fatalf("condition carries retries/timeout: %v %v", gate.MaxRetries, gate.Timeout)
+	}
+	// And the expansion still validates, which is the assertion that matters:
+	// a snapshot §8.2 rejects would block the task on its first admission.
+	out, err := Marshal(got)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if _, _, err := Parse(out, Options{}); err != nil {
+		t.Fatalf("expanded snapshot does not re-validate: %v", err)
+	}
+}
+
+// TestExpandInsideLoopAndGroupBodies is decision 9: an include may appear
+// anywhere a step may, which is the payoff of splicing rather than nesting.
+func TestExpandInsideLoopAndGroupBodies(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"one": "name: one\nsteps:\n  - {id: inner, type: command, run: make}\n",
+		"two": "name: two\nsteps:\n  - {id: side, type: command, run: make two}\n",
+	})
+	got, err := Expand(mustParse(t, `
+name: root
+steps:
+  - id: repeat
+    type: loop
+    count: 2
+    steps: [{id: c1, type: include, workflow: one}]
+  - id: both
+    type: parallel
+    steps: [{id: keep, type: command, run: make keep}, {id: c2, type: include, workflow: two}]
+`), expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	if ids := stepIDsOf(got.Steps[0].Steps); strings.Join(ids, ",") != "inner" {
+		t.Errorf("loop body = %v, want [inner]", ids)
+	}
+	if ids := stepIDsOf(got.Steps[1].Steps); strings.Join(ids, ",") != "keep,side" {
+		t.Errorf("group members = %v, want [keep side]", ids)
+	}
+}
+
+// TestExpandInsideLaneSteps: a lane's steps become a child task's snapshot,
+// and that child never consults the registry — so an include there has to be
+// resolved at creation like every other one.
+func TestExpandInsideLaneSteps(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"one": "name: one\nsteps:\n  - {id: inner, type: command, run: make}\n",
+	})
+	got, err := Expand(mustParse(t, `
+name: root
+steps:
+  - id: spread
+    type: fan_out
+    lanes:
+      - {id: only, steps: [{id: c, type: include, workflow: one}]}
+`), expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	lane := got.Steps[0].Lanes[0]
+	if ids := stepIDsOf(lane.Steps); strings.Join(ids, ",") != "inner" {
+		t.Errorf("lane steps = %v, want [inner]", ids)
+	}
+}
+
+// TestExpandNestedDefaultsNearestWins: a step that came through two includes
+// keeps the *nearest* enclosing workflow's defaults, and the outer one fills
+// only what is still unset.
+func TestExpandNestedDefaultsNearestWins(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"outer": "name: outer\ndefaults: {max_retries: 5, timeout: 1h}\n" +
+			"steps:\n  - {id: deep, type: include, workflow: inner}\n",
+		"inner": "name: inner\ndefaults: {max_retries: 0}\n" +
+			"steps:\n  - {id: leaf, type: command, run: make}\n",
+	})
+	got, err := Expand(mustParse(t, "name: root\nsteps:\n  - {id: c, type: include, workflow: outer}\n"),
+		expandOpts(lookup))
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	leaf := got.Steps[0]
+	if leaf.MaxRetries == nil || *leaf.MaxRetries != 0 {
+		t.Errorf("max_retries = %v, want the nearest callee's 0", leaf.MaxRetries)
+	}
+	if leaf.Timeout == nil || leaf.Timeout.Std() != 60*60*1e9 {
+		t.Errorf("timeout = %v, want the outer callee's 1h filling what inner left unset", leaf.Timeout)
+	}
+}
+
+// TestIncludeCycleWarnings is decision 8's load-time half: a warning, because
+// shadowing decides which files even participate and a project workflow may
+// shadow the very name that closed the loop.
+func TestIncludeCycleWarnings(t *testing.T) {
+	lookup := registry(t, map[string]string{
+		"b": "name: b\nsteps:\n  - {id: toa, type: include, workflow: a}\n",
+	})
+	root := mustParse(t, "name: a\nsteps:\n  - {id: tob, type: include, workflow: b}\n")
+	warns := IncludeCycleWarnings(root, lookup)
+	if len(warns) != 1 || !strings.Contains(warns[0], "cycle") {
+		t.Fatalf("warnings = %v, want one cycle warning", warns)
+	}
+	clean := mustParse(t, "name: c\nsteps:\n  - {id: x, type: command, run: make}\n")
+	if w := IncludeCycleWarnings(clean, lookup); len(w) != 0 {
+		t.Errorf("warnings on an include-free workflow = %v", w)
+	}
+}
+
+// TestIncludeNames is what GET /v1/workflows reports: the direct dependencies,
+// without resolving anything.
+func TestIncludeNames(t *testing.T) {
+	wf := mustParse(t, `
+name: root
+steps:
+  - {id: a, type: include, workflow: checks}
+  - id: loop
+    type: loop
+    count: 2
+    steps: [{id: b, type: include, workflow: deploy}, {id: c, type: include, workflow: checks}]
+`)
+	if got := strings.Join(IncludeNames(wf), ","); got != "checks,deploy" {
+		t.Errorf("IncludeNames = %q, want %q", got, "checks,deploy")
+	}
+	if got := IncludeNames(mustParse(t, "name: n\nsteps:\n  - {id: x, type: command, run: make}\n")); got != nil {
+		t.Errorf("IncludeNames on an include-free workflow = %v", got)
+	}
+}
+
+// TestHasInclude guards the fast path task creation takes for the workflows
+// that are the overwhelming majority.
+func TestHasInclude(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"none", "name: n\nsteps:\n  - {id: x, type: command, run: make}\n", false},
+		{"top level", "name: n\nsteps:\n  - {id: x, type: include, workflow: c}\n", true},
+		{"loop body", "name: n\nsteps:\n  - {id: l, type: loop, count: 1, steps: [{id: x, type: include, workflow: c}]}\n", true},
+		{"lane", "name: n\nsteps:\n  - {id: f, type: fan_out, lanes: [{id: o, steps: [{id: x, type: include, workflow: c}]}]}\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasInclude(mustParse(t, tc.src)); got != tc.want {
+				t.Errorf("HasInclude = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIncludeStepFieldValidation is decision 11: an include is resolved away
+// at creation, so it owns no attempt and nothing that binds to one — `if:`
+// included, which is the rejection with a real alternative behind it.
+func TestIncludeStepFieldValidation(t *testing.T) {
+	for _, tc := range []struct{ name, src, want string }{
+		{
+			"workflow required",
+			"name: n\nsteps:\n  - {id: c, type: include}\n",
+			"include steps require the name",
+		},
+		{
+			"if rejected",
+			"name: n\nsteps:\n  - {id: c, type: include, workflow: x, if: 'true'}\n",
+			"if is not valid on a include step",
+		},
+		{
+			"timeout rejected",
+			"name: n\nsteps:\n  - {id: c, type: include, workflow: x, timeout: 5m}\n",
+			"timeout is not valid on a include step",
+		},
+		{
+			"workflow rejected elsewhere",
+			"name: n\nsteps:\n  - {id: c, type: command, run: make, workflow: x}\n",
+			"workflow is not valid on a command step",
+		},
+		{
+			"resolved_from is machine-written",
+			"name: n\nsteps:\n  - {id: c, type: include, workflow: x, resolved_from: [y]}\n",
+			"resolved_from is set by task creation",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Parse([]byte(tc.src), Options{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want one containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestIncludeStepAccepted keeps the positive case honest: the four fields an
+// include may carry, and nothing else, parse and validate.
+func TestIncludeStepAccepted(t *testing.T) {
+	if _, _, err := Parse([]byte(
+		"name: n\nsteps:\n  - {id: c, name: Shared checks, type: include, workflow: checks}\n"),
+		Options{}); err != nil {
+		t.Fatalf("a well-formed include did not validate: %v", err)
+	}
+}

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -63,6 +63,12 @@ func (e Entry) RunsHere() bool { return e.Workflow == nil || e.Workflow.Supports
 // already why it cannot back a task.
 func (e Entry) NeedsInputAgent() bool { return e.Workflow != nil && e.Workflow.RequiresInput() }
 
+// Includes lists the workflows this entry includes directly (§7.9, task 019),
+// so a client can show what a workflow depends on. Derived rather than stored,
+// for the reason RunsHere and NeedsInputAgent are: one source of truth, and
+// nothing to keep in sync when a file reloads.
+func (e Entry) Includes() []string { return IncludeNames(e.Workflow) }
+
 // Registry holds the parsed workflows of every scope and reloads them when
 // their files change (§5.2).
 type Registry struct {
@@ -188,7 +194,7 @@ func (r *Registry) ReloadGlobal() {
 	r.mu.Lock()
 	r.global = entries
 	r.mu.Unlock()
-	r.warnFanOutCycles(0)
+	r.warnCrossFileRefs(0)
 	r.notify()
 }
 
@@ -211,22 +217,23 @@ func (r *Registry) ReloadProject(id int64) {
 		ps.entries = entries
 	}
 	r.mu.Unlock()
-	r.warnFanOutCycles(id)
+	r.warnCrossFileRefs(id)
 	r.notify()
 }
 
-// warnFanOutCycles logs the §8.2 fan-out cycle warning for one project's
-// resolved view (task 014 decision 5).
+// warnCrossFileRefs logs the §8.2 warnings that are properties of *resolved*
+// names for one project's view: fan-out cycles (task 014 decision 5) and
+// whatever is wrong with a workflow's includes (task 019 decision 8).
 //
-// It runs after the load rather than inside it, because a cycle is a property
-// of *resolved* names: which files a lane's `workflow:` reaches is decided by
-// builtin < global < project shadowing, which loadDir cannot see while it is
-// still building a scope.
+// It runs after the load rather than inside it, because which files a lane's
+// `workflow:` or an `include:` reaches is decided by builtin < global <
+// project shadowing, which loadDir cannot see while it is still building a
+// scope.
 //
-// A warning, not an error. A cycle between two files is real only once a task
-// picks a root, and a project workflow may shadow the very name that closed
-// the loop. Task creation is where it becomes a 400.
-func (r *Registry) warnFanOutCycles(projectID int64) {
+// Warnings, not errors. Each is real only once a task picks a root, and a
+// project workflow may shadow the very name that closed the loop, went missing
+// or restricted the platform. Task creation is where each becomes a 400.
+func (r *Registry) warnCrossFileRefs(projectID int64) {
 	lookup := func(name string) (*Workflow, bool) {
 		e, ok := r.Lookup(projectID, name)
 		if !ok || !e.Valid() {
@@ -235,11 +242,16 @@ func (r *Registry) warnFanOutCycles(projectID int64) {
 		return e.Workflow, true
 	}
 	for _, e := range r.List(projectID) {
-		if !e.Valid() || !HasFanOut(e.Workflow) {
+		if !e.Valid() {
 			continue
 		}
-		for _, w := range LaneCycleWarnings(e.Workflow, lookup) {
-			r.log.Warn("workflow fan-out cycle", "file", e.File, "name", e.Name, "warning", w)
+		if HasFanOut(e.Workflow) {
+			for _, w := range LaneCycleWarnings(e.Workflow, lookup) {
+				r.log.Warn("workflow fan-out cycle", "file", e.File, "name", e.Name, "warning", w)
+			}
+		}
+		for _, w := range IncludeWarnings(e.Workflow, lookup) {
+			r.log.Warn("workflow include unresolvable", "file", e.File, "name", e.Name, "warning", w)
 		}
 	}
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -54,13 +54,26 @@ const (
 	// ends *that iteration*, which is what continue means, using the meaning
 	// §7.7 already gave the word.
 	StepBreak = "break"
+	// StepInclude splices another registry workflow's steps into this one
+	// (§7.9, task 019). It is resolved at **task creation**: the callee's
+	// steps replace it in the snapshot, each becoming an ordinary top-level
+	// step with its own step_index, and no include survives into the run.
+	//
+	// That is what separates it from every other structure type here. A
+	// `parallel` or a `loop` owns a step_index and runs its body under it; an
+	// include owns nothing, because by the time anything runs there is no
+	// include left. Splicing rather than nesting is decision 1: a callee may
+	// then itself contain a `loop`, a `parallel` or a `fan_out`, which a
+	// nested body could not, since two position derivations cannot share one
+	// step_index (task 016 decision 10).
+	StepInclude = "include"
 )
 
 // stepTypeList is the step-type vocabulary as one string, so the two "one of
 // …" messages cannot drift apart as the set grows.
 var stepTypeList = strings.Join([]string{
 	StepAgent, StepCommand, StepManual, StepParallel, StepFanOut, StepCondition,
-	StepLoop, StepBreak,
+	StepLoop, StepBreak, StepInclude,
 }, ", ")
 
 // Conflict policies for a fan_out step's join (§7.6, task 014 decision 8).
@@ -192,6 +205,27 @@ type Step struct {
 	Count         *int    `yaml:"count,omitempty"`
 	ForEach       ForEach `yaml:"for_each,omitempty"`
 	MaxIterations *int    `yaml:"max_iterations,omitempty"`
+
+	// include steps (task 019). Workflow names the registry workflow to
+	// splice in, resolved through the usual builtin < global < project
+	// shadowing at **task creation**.
+	//
+	// Unlike a lane's `workflow:`, which is moved to `resolved_from:` beside
+	// the steps it resolved to, this field does not survive resolution at
+	// all: the step it sits on is *replaced* by those steps.
+	Workflow string `yaml:"workflow,omitempty"`
+	// ResolvedFrom is the chain of workflow names a spliced step came
+	// through, outermost first — `[outer, inner]` for a step that workflow
+	// `outer` included from `inner`. Empty for a step the caller wrote
+	// itself. Written by Expand at task creation, never by hand
+	// (decision 6).
+	//
+	// A chain rather than the single name `Lane.ResolvedFrom` carries,
+	// because a nested include otherwise cannot say how its steps got where
+	// they are. It is unambiguous because a given callee appears at most once
+	// in one expansion: a second appearance is a duplicate step id, which is
+	// a 400 (decision 5).
+	ResolvedFrom []string `yaml:"resolved_from,omitempty"`
 }
 
 // ForEach is a `loop` step's item list: a YAML sequence of templates, or a
@@ -650,14 +684,46 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
 			"lanes", "merge", "allow_failure", "max_retries", "timeout")
+	case StepInclude:
+		if step.Workflow == "" {
+			add(base+".workflow", "include steps require the name of the workflow to include")
+		}
+		// An include is resolved away at task creation, so it owns no
+		// step_runs row, no attempt and no process — which is what rejects
+		// `timeout`, `max_retries`, `allow_failure` and `check`: there is
+		// nothing for them to bind to (decision 11).
+		//
+		// `if` goes with them, and that one had a real alternative. Honouring
+		// a guard here would mean distributing it onto every spliced step,
+		// which reads correctly until one of them is a `condition` or a
+		// `break` — both of which carry their own `if:` and reject every
+		// other field, so the two would have to be combined by rewriting Go
+		// template text. Guard the callee's own steps instead, or put a
+		// `condition` in front of the include.
+		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
+			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
+			"run", "shell", "env", "instructions", "steps", "max_parallel",
+			"lanes", "merge", "if", "allow_failure", "max_retries", "timeout")
 	default:
 		add(base+".type", "unknown step type %q (one of %s)", step.Type, stepTypeList)
 	}
 	// `count`, `for_each` and `max_iterations` belong to a loop and to
 	// nothing else. Rejecting them here rather than in each arm keeps the
-	// seven arms above from each growing the same three strings.
+	// eight arms above from each growing the same three strings. `workflow`
+	// is the same shape for `include`.
 	if step.Type != StepLoop {
 		rejectFields(step, base, add, "count", "for_each", "max_iterations")
+	}
+	if step.Type != StepInclude {
+		rejectFields(step, base, add, "workflow")
+	}
+	// resolved_from is written by Expand at task creation. A hand-written
+	// file carrying one is claiming a provenance nothing produced, and a
+	// snapshot re-parse is the only caller that should ever see it — which is
+	// why this is checked against the field being *set*, not against the step
+	// type (decision 6).
+	if len(step.ResolvedFrom) > 0 && step.Workflow != "" {
+		add(base+".resolved_from", "resolved_from is set by task creation, not by hand")
 	}
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
@@ -1025,6 +1091,7 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"max_retries": step.MaxRetries != nil, "timeout": step.Timeout != nil,
 		"count": step.Count != nil, "for_each": len(step.ForEach) > 0,
 		"max_iterations": step.MaxIterations != nil,
+		"workflow":       step.Workflow != "",
 	}
 	for _, f := range fields {
 		if set[f] {

--- a/scripts/m9-gate.sh
+++ b/scripts/m9-gate.sh
@@ -1,0 +1,545 @@
+#!/usr/bin/env bash
+# M9 phase gate (task 019; spec §7.9): prove via curl alone that a workflow
+# can include another workflow.
+#
+#   1. an included fragment's steps run in the caller's own task and worktree,
+#      in place, and a later caller step reads their `.Steps` entries
+#   2. the expansion is frozen at creation: editing the fragment afterwards
+#      reaches the next task and not the one already created
+#   3. what the *caller's* defaults do, so scenario 4 has a baseline
+#   4. the fragment's own `defaults:` travel with its steps
+#   5. an include inside a loop body runs once per iteration
+#   6. the refusals, each a 400 in front of the person creating the task:
+#      unknown workflow, cycle, colliding step id, past include.max_depth,
+#      and an expansion that breaks a nesting rule
+#
+# Every scenario uses command steps only, so no agent CLI is involved and the
+# gate is as fast on CI as it is locally.
+#
+# The `run:` bodies are restricted to `exit N` and `git ...`, which is what
+# makes this portable to pwsh the way m7 and m8 are (§8.3 leaves portability
+# to the workflow author, and a gate running on three platforms is that
+# author). It is also why the fragments record themselves as empty commits and
+# git config keys: `printf > x` and `Set-Content` share no spelling, and both
+# `git log` and `git config --get` can be asked afterwards what happened.
+#
+# Each scenario gets fresh config/data/repo dirs and its own daemon, so one
+# scenario's leftovers cannot reach another's assertions (PR G decision,
+# inherited from m2-gate.sh). VINCENT_GATE_SCENARIO=N runs one scenario.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+ONLY="${VINCENT_GATE_SCENARIO:-}"
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+CONFIG_DIR="" DATA_DIR=""
+scenario_dirs() { # scenario_dirs NAME
+  CONFIG_DIR="$TMP/$1/config"
+  DATA_DIR="$TMP/$1/data"
+  mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+  export VINCENT_CONFIG_DIR
+  VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+  export VINCENT_DATA_DIR
+  VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+}
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+# api_status is api's counterpart for the refusals: it wants the failure, so it
+# returns the status and body instead of treating a non-2xx as a gate failure.
+api_status() { # api_status METHOD PATH [JSON_BODY] -> "STATUS<TAB>BODY"
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  printf '%s\t%s' "$status" "$(printf '%s' "$out" | tr -d '\r\n')"
+}
+
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+}
+
+register_project() { git init >/dev/null 2>&1 || true; api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+wait_for_state() { # wait_for_state TASK_ID STATE TRIES
+  local id="$1" want="$2" tries="$3" state=""
+  for _ in $(seq 1 "$tries"); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" ]] && [[ "$want" != "aborted" ]]; then
+      api GET "/tasks/$id" | jq . >&2
+      fail "task $id reached $state while waiting for $want"
+    fi
+    sleep 1
+  done
+  api GET "/tasks/$id" | jq . >&2
+  fail "task $id never reached $want (last: $state)"
+}
+
+create_task() { # create_task PROJECT_ID WORKFLOW TITLE -> id
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg w "$2" --arg t "$3" \
+    '{project_id: $p, workflow: $w, title: $t}')" | jq -r .id
+}
+
+# refuse asserts that creating a task on WORKFLOW is a 400 whose message
+# contains WANT. Every include failure is decided in the insert path, which is
+# the property this proves: nothing gets a worktree and nothing fails halfway.
+refuse() { # refuse PROJECT_ID WORKFLOW WANT
+  local got status body
+  got="$(api_status POST /tasks \
+    "$(jq -cn --argjson p "$1" --arg w "$2" '{project_id: $p, workflow: $w, title: "refused"}')")"
+  status="${got%%$'\t'*}"
+  body="${got#*$'\t'}"
+  [[ "$status" == 400 ]] || fail "creating a task on $2 returned $status, want 400: $body"
+  [[ "$body" == *"$3"* ]] || fail "the refusal of $2 does not mention '$3': $body"
+}
+
+run_scenario() { # run_scenario N — honours VINCENT_GATE_SCENARIO
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+# --- include-shaped assertions --------------------------------------------
+# An include writes no row of its own — it is gone before anything runs — so
+# every assertion below reads the steps the expansion produced.
+
+steps_json() { api GET "/tasks/$1/steps"; }
+
+# `tr -d '\r'` on every helper that prints more than one line: jq writes CRLF
+# on Windows, and while `$(...)` in MSYS bash drops the trailing one, the
+# interior ones survive and make an exact multi-line comparison fail against a
+# `$'a\nb'` literal (the m8 finding).
+ran_steps() { # ran_steps TASK_ID -> the step ids that produced rows, in order
+  steps_json "$1" | jq -r '[.[] | .step_id]
+    | reduce .[] as $s ([]; if index($s) then . else . + [$s] end) | .[]' \
+    | tr -d '\r'
+}
+
+# snapshot_steps prints each step of the task's own snapshot with the workflow
+# it was spliced through, which is the §7.9 provenance the TUI badges.
+snapshot_steps() { # snapshot_steps TASK_ID
+  api GET "/tasks/$1" \
+    | jq -r '.workflow_steps[] | "\(.id) \((.resolved_from // []) | join(">"))"' \
+    | tr -d '\r'
+}
+
+attempts_for() { # attempts_for TASK_ID STEP_ID
+  steps_json "$1" | jq --arg s "$2" '[.[] | select(.step_id == $s)] | length'
+}
+
+# subject_count is how many commits on the task's branch carry a subject.
+subject_count() { # subject_count REPO TASK_ID SUBJECT
+  local branch
+  branch="$(api GET "/tasks/$2" | jq -r .branch_name)"
+  git -C "$1" log --format=%s "$branch" | grep -cx -- "$3" || true
+}
+
+# --------------------------------------------------------------------------
+# Scenario 1: the whole feature. `checks` is included into `feature`, and the
+# task runs four steps in one worktree on one branch — the include is not one
+# of them. `review` guards on `.Steps.build`, a step the *fragment* owns:
+# templates render with missingkey=error, so a guard naming a step that never
+# reached `.Steps` would be a condition error rather than a pass.
+# --------------------------------------------------------------------------
+if run_scenario 1; then
+  echo "=== scenario 1: an included fragment's steps run in place"
+  scenario_dirs s1
+  REPO="$TMP/s1/repo"; make_repo "$REPO"
+  write_workflow checks "$(cat <<'YAML'
+name: checks
+steps:
+  - id: build
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m build
+  - id: verify
+    type: command
+    max_retries: 0
+    run: git config -f gate.ini checks.ran yes
+YAML
+)"
+  write_workflow feature "$(cat <<'YAML'
+name: feature
+steps:
+  - id: implement
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m implement
+  - id: shared
+    type: include
+    workflow: checks
+  - id: review
+    type: command
+    max_retries: 0
+    if: '{{ eq .Steps.build.Status "succeeded" }}'
+    run: git config --get -f gate.ini checks.ran
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" feature "include a fragment")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(ran_steps "$TID")" == $'implement\nbuild\nverify\nreview' ]] \
+    || fail "the run was $(ran_steps "$TID"), want the fragment's steps spliced in place"
+  [[ "$(snapshot_steps "$TID")" == $'implement \nbuild checks\nverify checks\nreview ' ]] \
+    || fail "the snapshot is $(snapshot_steps "$TID"), want the fragment's two steps attributed to it"
+  # One branch, one worktree: `review` read a file `verify` wrote, and both
+  # commits are on the caller's own branch.
+  [[ "$(subject_count "$REPO" "$TID" build)" == 1 ]] \
+    || fail "the fragment's commit is not on the caller's branch — it did not run in the caller's worktree"
+  [[ "$(subject_count "$REPO" "$TID" implement)" == 1 ]] \
+    || fail "the caller's own commit is missing"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 2: the expansion is frozen at creation (§5.3). The fragment is
+# rewritten *after* the first task exists; the running task keeps what the
+# registry said when it was created, and the next task picks the edit up.
+# --------------------------------------------------------------------------
+if run_scenario 2; then
+  echo "=== scenario 2: an edit to the fragment does not reach an existing task"
+  scenario_dirs s2
+  REPO="$TMP/s2/repo"; make_repo "$REPO"
+  write_workflow frag "$(cat <<'YAML'
+name: frag
+steps:
+  - id: mark
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m original
+YAML
+)"
+  write_workflow caller "$(cat <<'YAML'
+name: caller
+steps:
+  - id: pull
+    type: include
+    workflow: frag
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  FIRST="$(create_task "$PID" caller "before the edit")"
+  wait_for_state "$FIRST" done 60
+
+  write_workflow frag "$(cat <<'YAML'
+name: frag
+steps:
+  - id: mark
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m edited
+YAML
+)"
+  # The registry watches the directory (§12.3); give the reload a moment to
+  # land before the second task reads it.
+  sleep 2
+  SECOND="$(create_task "$PID" caller "after the edit")"
+  wait_for_state "$SECOND" done 60
+
+  [[ "$(subject_count "$REPO" "$FIRST" original)" == 1 ]] \
+    || fail "the first task did not run the fragment as it stood at creation"
+  [[ "$(subject_count "$REPO" "$FIRST" edited)" == 0 ]] \
+    || fail "an edit to the fragment reached a task that already existed"
+  [[ "$(subject_count "$REPO" "$SECOND" edited)" == 1 ]] \
+    || fail "the second task did not pick up the edited fragment"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 3: the baseline for scenario 4. `caller` says `max_retries: 2`, so
+# a failing step of its own gets three attempts. Pinning that here is what
+# makes scenario 4's single attempt mean something: without it, "one attempt"
+# could just as well be a retry budget that never worked.
+# --------------------------------------------------------------------------
+if run_scenario 3; then
+  echo "=== scenario 3: what the caller's own defaults do"
+  scenario_dirs s3
+  REPO="$TMP/s3/repo"; make_repo "$REPO"
+  write_workflow frag "$(cat <<'YAML'
+name: frag
+defaults:
+  max_retries: 0
+steps:
+  - id: boom
+    type: command
+    run: exit 1
+YAML
+)"
+  write_workflow caller "$(cat <<'YAML'
+name: caller
+defaults:
+  max_retries: 2
+steps:
+  - id: own
+    type: command
+    run: exit 1
+  - id: pull
+    type: include
+    workflow: frag
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+
+  OWN="$(create_task "$PID" caller "the caller's own step")"
+  wait_for_state "$OWN" blocked 60
+  [[ "$(attempts_for "$OWN" own)" == 3 ]] \
+    || fail "the caller's own step got $(attempts_for "$OWN" own) attempts, want its defaults' 3"
+
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 4: the fragment's own `defaults:` travel with its steps. The same
+# `max_retries: 2` caller as scenario 3, but the failing step comes from a
+# fragment that says 0 — so it must get one attempt, not three. Otherwise a
+# fragment behaves differently depending on who included it, which is the
+# whole failure decision 7 exists to prevent.
+# --------------------------------------------------------------------------
+if run_scenario 4; then
+  echo "=== scenario 4: the included step spends the fragment's retry budget"
+  scenario_dirs s4
+  REPO="$TMP/s4/repo"; make_repo "$REPO"
+  write_workflow frag "$(cat <<'YAML'
+name: frag
+defaults:
+  max_retries: 0
+steps:
+  - id: boom
+    type: command
+    run: exit 1
+YAML
+)"
+  write_workflow caller "$(cat <<'YAML'
+name: caller
+defaults:
+  max_retries: 2
+steps:
+  - id: pull
+    type: include
+    workflow: frag
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" caller "the fragment's budget")"
+  wait_for_state "$TID" blocked 60
+  [[ "$(attempts_for "$TID" boom)" == 1 ]] \
+    || fail "the fragment's step got $(attempts_for "$TID" boom) attempts, want the fragment's own budget of 1"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 5: an include inside a loop body. This is the payoff of splicing
+# rather than nesting — a fragment is reusable in the one place a `fan_out`
+# lane could never be — and the spliced step has to run once per iteration.
+# --------------------------------------------------------------------------
+if run_scenario 5; then
+  echo "=== scenario 5: an include inside a loop body"
+  scenario_dirs s5
+  REPO="$TMP/s5/repo"; make_repo "$REPO"
+  write_workflow frag "$(cat <<'YAML'
+name: frag
+steps:
+  - id: tick
+    type: command
+    max_retries: 0
+    run: git commit --allow-empty -m tick
+YAML
+)"
+  write_workflow spin "$(cat <<'YAML'
+name: spin
+steps:
+  - id: repeat
+    type: loop
+    count: 3
+    steps:
+      - id: pull
+        type: include
+        workflow: frag
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" spin "include in a loop")"
+  wait_for_state "$TID" done 60
+
+  [[ "$(subject_count "$REPO" "$TID" tick)" == 3 ]] \
+    || fail "the included step ran $(subject_count "$REPO" "$TID" tick) times, want once per iteration"
+  [[ "$(attempts_for "$TID" pull)" == 0 ]] \
+    || fail "the include wrote rows of its own; it is resolved away before anything runs"
+  daemon_down
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 6: the refusals. Every one is decided in the insert path, so the
+# person creating the task is told before a worktree exists — which is the
+# whole reason includes are resolved at creation rather than mid-run.
+#
+# `deep` needs a lowered ceiling to cross, so this scenario pins
+# include.max_depth to 1 and chains two levels.
+# --------------------------------------------------------------------------
+if run_scenario 6; then
+  echo "=== scenario 6: every include failure is a 400 at creation"
+  scenario_dirs s6
+  REPO="$TMP/s6/repo"; make_repo "$REPO"
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+include:
+  max_depth: 1
+EOF
+  write_workflow ghost "$(cat <<'YAML'
+name: ghost
+steps:
+  - id: pull
+    type: include
+    workflow: nowhere
+YAML
+)"
+  write_workflow alpha "$(cat <<'YAML'
+name: alpha
+steps:
+  - id: pull
+    type: include
+    workflow: beta
+YAML
+)"
+  write_workflow beta "$(cat <<'YAML'
+name: beta
+steps:
+  - id: back
+    type: include
+    workflow: alpha
+YAML
+)"
+  write_workflow shared "$(cat <<'YAML'
+name: shared
+steps:
+  - id: clash
+    type: command
+    max_retries: 0
+    run: exit 0
+YAML
+)"
+  write_workflow collide "$(cat <<'YAML'
+name: collide
+steps:
+  - id: clash
+    type: command
+    max_retries: 0
+    run: exit 0
+  - id: pull
+    type: include
+    workflow: shared
+YAML
+)"
+  write_workflow mid "$(cat <<'YAML'
+name: mid
+steps:
+  - id: pull
+    type: include
+    workflow: shared
+YAML
+)"
+  write_workflow deep "$(cat <<'YAML'
+name: deep
+steps:
+  - id: pull
+    type: include
+    workflow: mid
+YAML
+)"
+  write_workflow innerloop "$(cat <<'YAML'
+name: innerloop
+steps:
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - id: work
+        type: command
+        max_retries: 0
+        run: exit 0
+YAML
+)"
+  write_workflow nests "$(cat <<'YAML'
+name: nests
+steps:
+  - id: outer
+    type: loop
+    count: 2
+    steps:
+      - id: pull
+        type: include
+        workflow: innerloop
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+
+  refuse "$PID" ghost   'not found'
+  refuse "$PID" alpha   'workflow cycle'
+  refuse "$PID" collide 'twice'
+  refuse "$PID" deep    'include.max_depth'
+  refuse "$PID" nests   'expanded'
+  daemon_down
+fi
+
+echo
+echo "M9 GATE PASSED"


### PR DESCRIPTION
Adds `type: include`, the step that makes a workflow reusable inside another: it names a registry workflow whose steps replace it in the caller's snapshot at task creation, each becoming an ordinary top-level step with its own step_index.

```yaml
steps:
  - { id: implement, type: agent, prompt: "{{ .Task.Description }}" }
  - { id: checks, type: include, workflow: go-checks }
  - { id: review, type: agent, prompt: "lint said: {{ .Steps.lint.Result }}" }
```

Splicing rather than nesting (019 decision 1) is what lets a callee itself contain a `loop`, a `parallel` or a `fan_out` — a nested body could not, since two position derivations cannot share one step_index. Nothing survives into the run, so the engine, the scheduler and §12.4 recovery need no knowledge of includes at all, and `review` reads `.Steps.lint` because after the splice those steps *are* the caller's.

Resolution happens once, at creation, for the reason §5.3 gives: a callee read from the registry mid-run would mutate an in-flight task in the one place nobody would look. That is also what makes every failure a 400 in front of the person typing — cycles, `include.max_depth`, a callee's `platforms:`, and a step id the expansion already used. A callee's `defaults:` are materialised onto its steps so a fragment keeps the behaviour it was written with, with the task's own override still outranking them (decision 7).

Deliberately not included: per-call parameters. Two calls with no arguments are the same call, which is why a duplicate step id is refused outright; the trigger for both is the first workflow that must include one callee twice with different values.

**Verification.** `scripts/m9-gate.sh` drives a real daemon over curl through six scenarios — steps running in the caller's own worktree with their `.Steps` entries visible downstream, an edit to the fragment reaching the next task and not the one already created, the fragment's own retry budget travelling with its steps, an include inside a loop body, and every refusal arriving before a worktree exists. Green on ubuntu, macOS and Windows alongside the six existing gates.

Closes 019.