### PR TITLE
feat(distribution): add package manager channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  packaging-config:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The release workflow is tag-only, so a malformed package-manager
+      # stanza would otherwise be discovered after the release already exists.
+      - name: Validate GoReleaser configuration
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          version: "~> v2"
+          args: check
+
   ci:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # Tag-driven packaging (T4.5). Normally Release Please creates the tag and the
 # GitHub release; this workflow then uploads the signed artifacts to that
 # release, attaches native Linux packages, and publishes the stable Homebrew,
-# Scoop, WinGet, and AUR metadata. The build runs once on ubuntu
+# Scoop, and WinGet metadata. The build runs once on ubuntu
 # — the binaries are pure Go, so a build matrix would produce identical
 # artifacts three times — and the per-OS jobs afterwards smoke-test what it
 # produced, which is the part a single runner genuinely cannot do.
@@ -73,7 +73,6 @@ jobs:
           # snapshot mode renders manifests but never uses the credentials.
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN || 'unset' }}
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN || 'unset' }}
-          AUR_KEY: ${{ secrets.AUR_KEY || 'unset' }}
 
       - name: Install Linux package inspection tools
         run: |
@@ -89,8 +88,6 @@ jobs:
           [ "$(find dist -maxdepth 1 -type f -name '*.rpm' | wc -l)" -eq 2 ]
           [ "$(find dist/winget -type f -name '*.yaml' | wc -l)" -eq 3 ]
           test -f dist/scoop/vincent.json
-          test -f dist/aur/vincent-agent-bin.pkgbuild
-          test -f dist/aur/vincent-agent-bin.srcinfo
 
           for deb_package in dist/*.deb; do
             [ "$(dpkg-deb --field "$deb_package" Package)" = vincent ]
@@ -138,10 +135,6 @@ jobs:
           [ "$(grep -c '^  - Architecture:' "$winget_installer")" -eq 2 ]
           grep -q '^    - PackageIdentifier: Git.Git$' "$winget_installer"
           grep -q '^License: PolyForm-Noncommercial-1.0.0$' "$winget_locale"
-          grep -q "^pkgname='vincent-agent-bin'$" dist/aur/vincent-agent-bin.pkgbuild
-          grep -q "^license=('PolyForm-Noncommercial-1.0.0')$" dist/aur/vincent-agent-bin.pkgbuild
-          grep -q "^depends=('git')$" dist/aur/vincent-agent-bin.pkgbuild
-          grep -q 'COMMERCIAL-LICENSE.md' dist/aur/vincent-agent-bin.pkgbuild
 
       # Provenance for every archive and native Linux package, so a downloader
       # can prove which workflow and commit produced the file they hold.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 # Tag-driven packaging (T4.5). Normally Release Please creates the tag and the
 # GitHub release; this workflow then uploads the signed artifacts to that
-# release and publishes the stable Homebrew cask. The build runs once on ubuntu
+# release, attaches native Linux packages, and publishes the stable Homebrew,
+# Scoop, WinGet, and AUR metadata. The build runs once on ubuntu
 # — the binaries are pure Go, so a build matrix would produce identical
 # artifacts three times — and the per-OS jobs afterwards smoke-test what it
 # produced, which is the part a single runner genuinely cannot do.
@@ -30,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write # create the release and upload archives
+      contents: write # upload archives/packages and publish repository metadata
       id-token: write # keyless cosign + build attestations
       attestations: write
     outputs:
@@ -67,14 +68,88 @@ jobs:
           # who has no such secret: goreleaser only reads it when it actually
           # publishes, and --snapshot never does.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN || 'unset' }}
+          # Each publisher gets a credential scoped only to its destination.
+          # Placeholder values keep fork/contributor dry runs self-contained;
+          # snapshot mode renders manifests but never uses the credentials.
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN || 'unset' }}
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN || 'unset' }}
+          AUR_KEY: ${{ secrets.AUR_KEY || 'unset' }}
 
-      # Provenance for every archive, so a downloader can prove which workflow
-      # and commit produced the file they hold.
+      - name: Install Linux package inspection tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes cpio jq rpm
+
+      - name: Verify generated packages and manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [ "$(find dist -maxdepth 1 -type f -name '*.deb' | wc -l)" -eq 2 ]
+          [ "$(find dist -maxdepth 1 -type f -name '*.rpm' | wc -l)" -eq 2 ]
+          [ "$(find dist/winget -type f -name '*.yaml' | wc -l)" -eq 3 ]
+          test -f dist/scoop/vincent.json
+          test -f dist/aur/vincent-agent-bin.pkgbuild
+          test -f dist/aur/vincent-agent-bin.srcinfo
+
+          for deb_package in dist/*.deb; do
+            [ "$(dpkg-deb --field "$deb_package" Package)" = vincent ]
+            dpkg-deb --field "$deb_package" Depends | grep -E '(^|, )git([ ,]|$)' >/dev/null
+            dpkg-deb --contents "$deb_package" | grep -E './usr/bin/vincent$' >/dev/null
+            dpkg-deb --contents "$deb_package" | grep -E './usr/share/licenses/vincent/LICENSE$' >/dev/null
+            dpkg-deb --contents "$deb_package" | grep -E './usr/share/doc/vincent/COMMERCIAL-LICENSE.md$' >/dev/null
+          done
+
+          for rpm_package in dist/*.rpm; do
+            [ "$(rpm -qp --queryformat '%{NAME}' "$rpm_package")" = vincent ]
+            [ "$(rpm -qp --queryformat '%{LICENSE}' "$rpm_package")" = PolyForm-Noncommercial-1.0.0 ]
+            rpm -qp --requires "$rpm_package" | grep -x git >/dev/null
+            rpm -qpl "$rpm_package" | grep -E '^/usr/bin/vincent$' >/dev/null
+            rpm -qpl "$rpm_package" | grep -E '^/usr/share/licenses/vincent/LICENSE$' >/dev/null
+            rpm -qpl "$rpm_package" | grep -E '^/usr/share/doc/vincent/COMMERCIAL-LICENSE.md$' >/dev/null
+          done
+
+          deb="$(find dist -maxdepth 1 -type f -name '*_amd64.deb' -print -quit)"
+          rpm_package="$(find dist -maxdepth 1 -type f -name '*.x86_64.rpm' -print -quit)"
+          test -n "$deb"
+          test -n "$rpm_package"
+
+          package_tmp="$(mktemp -d)"
+          trap 'rm -rf -- "$package_tmp"' EXIT
+          mkdir "$package_tmp/deb" "$package_tmp/rpm"
+          dpkg-deb --extract "$deb" "$package_tmp/deb"
+          rpm2cpio "$rpm_package" | (cd "$package_tmp/rpm" && cpio -idm --quiet)
+          "$package_tmp/deb/usr/bin/vincent" version
+          "$package_tmp/rpm/usr/bin/vincent" version
+
+          jq -e '
+            .license == "PolyForm-Noncommercial-1.0.0" and
+            .depends == ["git"] and
+            (.architecture["64bit"].bin | index("vincent.exe")) != null and
+            (.architecture.arm64.bin | index("vincent.exe")) != null
+          ' dist/scoop/vincent.json >/dev/null
+          winget_version="$(find dist/winget -type f -name 'lezli01.Vincent.yaml' -print -quit)"
+          winget_installer="$(find dist/winget -type f -name 'lezli01.Vincent.installer.yaml' -print -quit)"
+          winget_locale="$(find dist/winget -type f -name 'lezli01.Vincent.locale.en-US.yaml' -print -quit)"
+          test -n "$winget_version"
+          test -n "$winget_installer"
+          test -n "$winget_locale"
+          grep -q '^PackageIdentifier: lezli01.Vincent$' "$winget_version"
+          [ "$(grep -c '^  - Architecture:' "$winget_installer")" -eq 2 ]
+          grep -q '^    - PackageIdentifier: Git.Git$' "$winget_installer"
+          grep -q '^License: PolyForm-Noncommercial-1.0.0$' "$winget_locale"
+          grep -q "^pkgname='vincent-agent-bin'$" dist/aur/vincent-agent-bin.pkgbuild
+          grep -q "^license=('PolyForm-Noncommercial-1.0.0')$" dist/aur/vincent-agent-bin.pkgbuild
+          grep -q "^depends=('git')$" dist/aur/vincent-agent-bin.pkgbuild
+          grep -q 'COMMERCIAL-LICENSE.md' dist/aur/vincent-agent-bin.pkgbuild
+
+      # Provenance for every archive and native Linux package, so a downloader
+      # can prove which workflow and commit produced the file they hold.
       - name: Attest build provenance
         if: github.event_name == 'push'
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: "dist/*.tar.gz,dist/*.zip"
+          subject-path: "dist/*.tar.gz,dist/*.zip,dist/*.deb,dist/*.rpm"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -82,6 +157,8 @@ jobs:
           path: |
             dist/*.tar.gz
             dist/*.zip
+            dist/*.deb
+            dist/*.rpm
             dist/checksums.txt
           retention-days: 7
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,19 +49,47 @@ archives:
       - COMMERCIAL-LICENSE.md
       - examples/*.yaml
 
+# Native Linux packages use the same pure-Go binaries as the release archives.
+# There are no maintainer scripts: vincent's service is per-user and captures
+# that user's PATH and data directories, which a root package transaction must
+# not guess or rewrite (task 021).
+nfpms:
+  - id: vincent-linux-packages
+    ids: [vincent]
+    package_name: vincent
+    file_name_template: "{{ .ConventionalFileName }}"
+    vendor: László Szabó
+    homepage: "https://github.com/lezli01/vincent"
+    maintainer: "László Szabó <lezli01@gmail.com>"
+    description: "Vendor-independent control plane for executing native agent tooling"
+    license: PolyForm-Noncommercial-1.0.0
+    formats: [deb, rpm]
+    dependencies: [git]
+    bindir: /usr/bin
+    section: devel
+    priority: optional
+    contents:
+      - src: LICENSE
+        dst: /usr/share/licenses/vincent/LICENSE
+      - src: LICENSE
+        dst: /usr/share/doc/vincent/copyright
+      - src: COMMERCIAL-LICENSE.md
+        dst: /usr/share/doc/vincent/COMMERCIAL-LICENSE.md
+      - src: README.md
+        dst: /usr/share/doc/vincent/README.md
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 
-# Homebrew tap (macOS only), docs/tasks/002. This reverses the X decision's
-# "GitHub Releases only" line, and the reversal's cost is exactly what that
-# decision named: a second repo (lezli01/homebrew-tap) and a release-time
-# publish step. It is a *cask*, not a formula, because goreleaser deprecated
+# Homebrew tap (macOS only), docs/tasks/002. This was the first reversal of the
+# X decision's "GitHub Releases only" line; task 021 now widens that reversal
+# to Windows and Linux. Its cost is exactly what X named: a second repo
+# (lezli01/homebrew-tap) and a release-time publish step. It is a *cask*, not a
+# formula, because goreleaser deprecated
 # `brews` in v2.10 and Homebrew now packages pre-built binaries as casks;
 # formulas are for things brew builds from source.
 #
-# Linux and Windows are unchanged — casks do not exist on Linuxbrew, so the
-# download-and-unpack path stays the only path there.
 homebrew_casks:
   - name: vincent
     ids: [vincent]
@@ -123,6 +151,98 @@ homebrew_casks:
 
       Start the daemon in the background and keep it across reboots with:
         vincent service install
+
+# Windows package-manager manifests consume the same signed, checksummed zip
+# archives as GitHub Releases. Stable releases update our Scoop bucket and
+# submit a versioned branch from our winget-pkgs fork to Microsoft's catalog;
+# prereleases render the manifests in dist but do not move either channel.
+scoops:
+  - name: vincent
+    homepage: "https://github.com/lezli01/vincent"
+    description: "Vendor-independent control plane for executing native agent tooling"
+    license: PolyForm-Noncommercial-1.0.0
+    depends: [git]
+    skip_upload: auto
+    repository:
+      owner: lezli01
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    commit_author:
+      name: goreleaser
+      email: goreleaser@users.noreply.github.com
+    commit_msg_template: "chore: vincent {{ .Tag }}"
+
+winget:
+  - name: vincent
+    ids: [vincent]
+    publisher: László Szabó
+    package_identifier: lezli01.Vincent
+    package_name: Vincent
+    default_locale: en-US
+    short_description: "Vendor-independent control plane for native coding-agent CLIs"
+    description: >-
+      Vincent runs Claude Code, Codex, and Cursor CLI workflows in isolated git
+      worktrees, with a local daemon, terminal UI, audit transcripts, and gates.
+    license: PolyForm-Noncommercial-1.0.0
+    license_url: "https://github.com/lezli01/vincent/blob/{{ .Tag }}/LICENSE"
+    homepage: "https://github.com/lezli01/vincent"
+    publisher_url: "https://lezli01.is-a.dev"
+    publisher_support_url: "https://github.com/lezli01/vincent/issues"
+    author: László Szabó
+    copyright: "Copyright © 2026 László Szabó"
+    release_notes_url: "https://github.com/lezli01/vincent/releases/tag/{{ .Tag }}"
+    installation_notes: >-
+      Vincent requires at least one supported agent CLI. Agents run full-auto
+      by default; read the security model before the first task. Releases are
+      not Authenticode-signed, so Windows may show SmartScreen on first launch.
+    tags: [ai, automation, cli, developer-tools, orchestration]
+    dependencies:
+      - package_identifier: Git.Git
+    skip_upload: auto
+    repository:
+      owner: lezli01
+      name: winget-pkgs
+      branch: "vincent-{{ .Version }}"
+      token: "{{ .Env.WINGET_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+    commit_author:
+      name: goreleaser
+      email: goreleaser@users.noreply.github.com
+    commit_msg_template: "{{ .PackageIdentifier }}: {{ .Tag }}"
+
+# AUR binary packages are generated from the Linux release archives rather
+# than rebuilt from source. The dedicated SSH key may write only
+# vincent-agent-bin; vincent-bin is already an unrelated AUR package.
+aurs:
+  - name: vincent-agent-bin
+    ids: [vincent]
+    homepage: "https://github.com/lezli01/vincent"
+    description: "Vendor-independent control plane for executing native agent tooling"
+    maintainers:
+      - "László Szabó <lezli01 at gmail dot com>"
+    license: PolyForm-Noncommercial-1.0.0
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/vincent-agent-bin.git"
+    skip_upload: auto
+    provides: [vincent]
+    conflicts: [vincent]
+    depends: [git]
+    package: |-
+      install -Dm755 "./vincent" "${pkgdir}/usr/bin/vincent"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/vincent-agent-bin/LICENSE"
+      install -Dm644 "./COMMERCIAL-LICENSE.md" "${pkgdir}/usr/share/doc/vincent-agent-bin/COMMERCIAL-LICENSE.md"
+      install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/vincent-agent-bin/README.md"
+    commit_msg_template: "chore: vincent {{ .Tag }}"
+    commit_author:
+      name: goreleaser
+      email: goreleaser@users.noreply.github.com
 
 # Keyless cosign: an OIDC identity from the workflow itself, verifiable
 # without vincent publishing or rotating a key. Authenticode and Apple

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -217,33 +217,6 @@ winget:
       email: goreleaser@users.noreply.github.com
     commit_msg_template: "{{ .PackageIdentifier }}: {{ .Tag }}"
 
-# AUR binary packages are generated from the Linux release archives rather
-# than rebuilt from source. The dedicated SSH key may write only
-# vincent-agent-bin; vincent-bin is already an unrelated AUR package.
-aurs:
-  - name: vincent-agent-bin
-    ids: [vincent]
-    homepage: "https://github.com/lezli01/vincent"
-    description: "Vendor-independent control plane for executing native agent tooling"
-    maintainers:
-      - "László Szabó <lezli01 at gmail dot com>"
-    license: PolyForm-Noncommercial-1.0.0
-    private_key: "{{ .Env.AUR_KEY }}"
-    git_url: "ssh://aur@aur.archlinux.org/vincent-agent-bin.git"
-    skip_upload: auto
-    provides: [vincent]
-    conflicts: [vincent]
-    depends: [git]
-    package: |-
-      install -Dm755 "./vincent" "${pkgdir}/usr/bin/vincent"
-      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/vincent-agent-bin/LICENSE"
-      install -Dm644 "./COMMERCIAL-LICENSE.md" "${pkgdir}/usr/share/doc/vincent-agent-bin/COMMERCIAL-LICENSE.md"
-      install -Dm644 "./README.md" "${pkgdir}/usr/share/doc/vincent-agent-bin/README.md"
-    commit_msg_template: "chore: vincent {{ .Tag }}"
-    commit_author:
-      name: goreleaser
-      email: goreleaser@users.noreply.github.com
-
 # Keyless cosign: an OIDC identity from the workflow itself, verifiable
 # without vincent publishing or rotating a key. Authenticode and Apple
 # notarization are recurring certificate costs v1 does not take on — §19's ‡

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ scoop install vincent/vincent
 Both install the same Windows zip published on GitHub. Releases are not
 Authenticode-signed, so SmartScreen may still appear on first launch.
 
-### deb, rpm, or AUR (Linux)
+### deb or rpm (Linux)
 
 Download the deb or rpm for your architecture from the
 [latest release](https://github.com/lezli01/vincent/releases/latest), then:
@@ -256,8 +256,6 @@ sudo apt install ./vincent_*_amd64.deb       # Debian / Ubuntu
 sudo dnf install ./vincent-*.x86_64.rpm      # Fedora / RHEL family
 ```
 
-On Arch Linux, install `vincent-agent-bin` from AUR with your normal AUR
-workflow.
 The deb and rpm files are release assets, not hosted apt/dnf repositories, so
 download the next package to upgrade.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,48 @@ vincent`; `brew uninstall --zap vincent` also removes the LaunchAgent and
 
 Homebrew casks are macOS-only — on Linuxbrew, use the archive below.
 
+### WinGet or Scoop (Windows)
+
+```powershell
+winget install --id lezli01.Vincent --exact
+
+# Or, with Scoop:
+scoop bucket add vincent https://github.com/lezli01/scoop-bucket
+scoop install vincent/vincent
+```
+
+Both install the same Windows zip published on GitHub. Releases are not
+Authenticode-signed, so SmartScreen may still appear on first launch.
+
+### deb, rpm, or AUR (Linux)
+
+Download the deb or rpm for your architecture from the
+[latest release](https://github.com/lezli01/vincent/releases/latest), then:
+
+```sh
+sudo apt install ./vincent_*_amd64.deb       # Debian / Ubuntu
+sudo dnf install ./vincent-*.x86_64.rpm      # Fedora / RHEL family
+```
+
+On Arch Linux, install `vincent-agent-bin` from AUR with your normal AUR
+workflow.
+The deb and rpm files are release assets, not hosted apt/dnf repositories, so
+download the next package to upgrade.
+
+### mise (all platforms)
+
+```sh
+mise use -g github:lezli01/vincent
+vincent version
+```
+
+mise selects the matching GitHub release archive for the current OS and
+architecture. Pin a version with `github:lezli01/vincent@0.3.0`.
+
+Package-manager metadata moves on stable releases only. If a newly added
+channel has not received its first stable release yet, use mise or the archive
+path below.
+
 ### Archive (all platforms)
 
 Download the archive for your platform from the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,41 +5,60 @@ release pull request current. Merging that pull request makes Release Please
 create the `vMAJOR.MINOR.PATCH` tag and GitHub release; that tag triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which uses
 [`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, checksum, sign, attest,
-upload, smoke-test on all three OSes, and update the stable Homebrew cask. There
+upload, smoke-test on all three OSes, build deb/rpm packages, update the stable
+Homebrew, Scoop, and AUR metadata, and submit the stable WinGet manifest. There
 is no manual tag or upload step, and no artifact is built on a maintainer's
 machine.
 
 Only a maintainer with push access can cut a release.
 
-## Repository secrets
+## Channel bootstrap and repository secrets
 
-Two narrowly scoped secrets are required.
+Before enabling a stable release, all three external destinations must exist:
+
+- public `lezli01/scoop-bucket`, with `main` as its default branch;
+- a `lezli01/winget-pkgs` fork of `microsoft/winget-pkgs`; and
+- the AUR account/key that may push
+  `ssh://aur@aur.archlinux.org/vincent-agent-bin.git`.
+
+A GoReleaser snapshot renders all three manifests without contacting those
+destinations. That proves the content, not publication. Do not merge a release
+change that names a missing destination: the next stable tag would discover it
+after the GitHub release already exists.
+
+Five secrets are required.
 
 | Secret | Scope and permissions | Why it exists |
 |---|---|---|
 | `RELEASE_PLEASE_TOKEN` | Fine-grained PAT selecting only `lezli01/vincent`, with **Contents**, **Issues**, and **Pull requests: read and write** | Events created by `GITHUB_TOKEN` do not start other workflows. The PAT lets the release PR run normal CI and lets the generated tag trigger the GoReleaser workflow. |
 | `HOMEBREW_TAP_TOKEN` | Fine-grained PAT selecting only [`lezli01/homebrew-tap`](https://github.com/lezli01/homebrew-tap), with **Contents: read and write** | `GITHUB_TOKEN` and the Release Please PAT are scoped to this repository; pushing the cask is a cross-repo write. |
+| `SCOOP_BUCKET_TOKEN` | Fine-grained PAT selecting only `lezli01/scoop-bucket`, with **Contents: read and write** | Push the stable `vincent.json` manifest to the bucket root. |
+| `WINGET_TOKEN` | Dedicated classic PAT with **`public_repo`** | Push a version branch to `lezli01/winget-pkgs` and open its pull request against `microsoft/winget-pkgs`. GitHub cannot express that cross-owner PR as a fine-grained token scoped only to the fork. |
+| `AUR_KEY` | Contents of a dedicated, unencrypted SSH private key whose public key is registered with the maintainer's AUR account | Push only the generated `vincent-agent-bin` PKGBUILD and `.SRCINFO`. Do not reuse a login or workstation key. |
 
 Nothing else needs a secret: cosign signs keylessly with the packaging
 workflow's OIDC identity.
 
-**The single-repository scope of each token is the point.** Each token is handed
-to one pinned third-party action, so its blast radius is whatever it can reach.
-The two actions do not share credentials: Release Please can change vincent but
-not the tap; GoReleaser can change the tap but receives only this workflow's
-short-lived `GITHUB_TOKEN` for vincent itself. A classic PAT cannot express that
-separation because its `repo` scope covers every repository the account owns.
+**Narrow scope is the default, not a claim that WinGet has one.** Release Please,
+Homebrew, and Scoop each have a single-repository token; AUR has a dedicated key.
+`WINGET_TOKEN` is the exception: `public_repo` can change any public repository
+the account can write. Prefer a publisher bot account if that blast radius is
+not acceptable. Every credential is passed to the pinned GoReleaser action only
+for the tag-driven release job; none is available to pull-request workflows.
 
-The token does not expire, which trades a silent standing credential for never
-failing a release on a surprise expiry. Two consequences worth knowing: nothing
-will prompt a rotation, and revoking it is a manual step if the account is ever
-compromised. Rotate at
+Credentials created without expiration trade a silent standing secret for
+never failing a release on a surprise expiry. Nothing will prompt their
+rotation, and revoking them is manual if an account is compromised. Rotate
+GitHub tokens at
 [Settings → Developer settings → Fine-grained tokens](https://github.com/settings/personal-access-tokens).
 Update the repository copies with:
 
 ```sh
 gh secret set RELEASE_PLEASE_TOKEN --repo lezli01/vincent
 gh secret set HOMEBREW_TAP_TOKEN --repo lezli01/vincent
+gh secret set SCOOP_BUCKET_TOKEN --repo lezli01/vincent
+gh secret set WINGET_TOKEN --repo lezli01/vincent
+gh secret set AUR_KEY --repo lezli01/vincent < /path/to/dedicated-aur-private-key
 ```
 
 ## Version numbers
@@ -61,13 +80,15 @@ binary.
 
 The normal Release Please path creates stable releases. If a maintainer cuts an
 exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
-`homebrew_casks.skip_upload: auto` prevents it from moving the stable cask.
+`skip_upload: auto` prevents it from moving the Homebrew, Scoop, WinGet, or AUR
+metadata. The prerelease still carries its deb and rpm assets on GitHub.
 
 ## Cutting a release
 
-1. **Check `master` and the Release Please PR are green.** All three `ci` and all
-   three `gates` checks must pass. `RELEASE_PLEASE_TOKEN` is what lets the bot's
-   pull request trigger those checks.
+1. **Check `master` and the Release Please PR are green.** The
+   `packaging-config` check plus all three `ci` and all three `gates` checks must
+   pass. `RELEASE_PLEASE_TOKEN` is what lets the bot's pull request trigger
+   those checks.
 
 2. **Run the vulnerability sweep** if the last run predates a dependency change:
 
@@ -84,7 +105,9 @@ exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
    the archive contents changed since the last release. Actions → **Release** →
    *Run workflow*, leaving `dry_run` checked. That runs
    `release --snapshot --clean --skip=publish,sign` — real cross-compilation and
-   real archives, published nowhere. Download the `dist` artifact and look at it.
+   real archives/packages/manifests, published nowhere. The job inspects the
+   deb/rpm payloads and generated Scoop, WinGet, and AUR metadata before it
+   uploads the `dist` artifact for a manual look.
 
 5. **Merge the Release Please PR.** This is the release action. Release Please
    creates the tag and GitHub release; do not create or push the tag by hand.
@@ -93,9 +116,10 @@ exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
    - `Release Please` creates the tag and GitHub release from the merged release
      PR. The dedicated PAT makes that tag start the next workflow.
    - `Release` runs GoReleaser, preserves Release Please's notes, builds and
-     signs every archive, attests provenance, uploads the artifacts to the
-     existing GitHub release, and pushes the updated stable cask to
-     `lezli01/homebrew-tap`. A prerelease tag skips the cask automatically.
+     signs the checksum, inspects deb/rpm payloads, attests every archive and
+     native package, uploads the artifacts to the existing GitHub release, and
+     updates Homebrew, Scoop, AUR, and the WinGet submission for a stable tag.
+     A prerelease skips all four manager publishers automatically.
    - `smoke` (one job per OS) downloads the **real published archive**, unpacks
      it, asserts `vincent version` reports the tag rather than `dev`, runs
      `vincent workflow validate` and checks that `vincent task ls` exits 2 with
@@ -117,6 +141,7 @@ exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
      --certificate-oidc-issuer https://token.actions.githubusercontent.com
    sha256sum -c checksums.txt --ignore-missing
    gh attestation verify vincent_X.Y.Z_linux_amd64.tar.gz --repo lezli01/vincent
+   gh attestation verify vincent_X.Y.Z_amd64.deb --repo lezli01/vincent
    ```
 
 8. **Check the Homebrew cask** (skip for a pre-release, which does not publish
@@ -133,7 +158,29 @@ exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
    `com.apple.provenance` is expected and harmless; `com.apple.quarantine` is
    not, and means the cask's `postflight` hook did not run.
 
-9. **Read the published notes.** Release Please generates them from the
+9. **Check the Windows and Linux channels** (skip for a pre-release).
+
+   ```sh
+   # Scoop: the bucket should carry the tag and both Windows architectures.
+   scoop bucket add vincent https://github.com/lezli01/scoop-bucket
+   scoop update
+   scoop info vincent/vincent
+
+   # AUR: pkgver, URLs, and checksums should name this release.
+   git clone https://aur.archlinux.org/vincent-agent-bin.git
+   grep -E '^(pkgver|source_|sha256sums_)' vincent-agent-bin/PKGBUILD
+
+   # WinGet: this can lag while Microsoft's catalog PR is reviewed.
+   winget show --id lezli01.Vincent --exact --versions
+   ```
+
+   Install the deb and rpm on representative clean systems with `apt install
+   ./vincent_*_amd64.deb` and `dnf install ./vincent-*.x86_64.rpm`; run
+   `vincent version` after each. Confirm the GoReleaser log contains the WinGet
+   pull-request URL—cross-repository PR creation errors can be non-fatal, so a
+   green release job alone is not that proof.
+
+10. **Read the published notes.** Release Please generates them from the
    Conventional Commits since the last tag and GoReleaser keeps them unchanged
    while attaching artifacts. If a user-visible change is missing, fix the
    commit convention before merging the release PR or edit the notes after the
@@ -158,16 +205,18 @@ exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
   creates the tag and GitHub release. The tag remains the only version injected
   into the binary; the manifest is automation state, not product state.
 - **GoReleaser owns distribution channels.** It attaches archives, signatures,
-  checksums and attestations to Release Please's existing GitHub release, then
-  updates the Homebrew tap for stable releases. Keeping this in one run means a
-  failed cask update fails the release workflow instead of silently leaving the
-  install channel stale.
+  checksums, deb/rpm packages and attestations to Release Please's existing
+  GitHub release, then updates Homebrew, Scoop and AUR and prepares the WinGet
+  catalog PR for stable releases. mise consumes the GitHub archives directly
+  and needs no publisher. Keeping artifact and manifest generation in one run
+  prevents channel checksums from drifting from the release they name.
 - **OS code signing.** Authenticode and Apple notarization are recurring
   certificate costs v0 does not take on — recorded as a descope in spec §19.
   Releases carry cosign signatures and build provenance instead, and the README
   documents the SmartScreen and Gatekeeper prompts users will meet.
-- **Scoop and winget publishing.** The Homebrew cask *is* automated (see step 6),
-  because it deletes the `xattr -d com.apple.quarantine` step for macOS users.
-  No Windows packager erases the SmartScreen prompt the same way, so Windows
-  keeps `go install` and the release archives — the reasoning is in
-  [docs/tasks/002](docs/tasks/002-homebrew-tap.md).
+- **External catalogs remain external.** Scoop and AUR update repositories the
+  maintainer controls. WinGet is a pull request into Microsoft's catalog and
+  can remain pending after the GitHub release succeeds. The accepted
+  maintenance and credential trade-offs are recorded in
+  [docs/tasks/021](docs/tasks/021-package-distribution-channels.md), which
+  explicitly supersedes task 002's Windows rejection.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ create the `vMAJOR.MINOR.PATCH` tag and GitHub release; that tag triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which uses
 [`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, checksum, sign, attest,
 upload, smoke-test on all three OSes, build deb/rpm packages, update the stable
-Homebrew, Scoop, and AUR metadata, and submit the stable WinGet manifest. There
+Homebrew and Scoop metadata, and submit the stable WinGet manifest. There
 is no manual tag or upload step, and no artifact is built on a maintainer's
 machine.
 
@@ -14,19 +14,17 @@ Only a maintainer with push access can cut a release.
 
 ## Channel bootstrap and repository secrets
 
-Before enabling a stable release, all three external destinations must exist:
+Before enabling a stable release, both external destinations must exist:
 
 - public `lezli01/scoop-bucket`, with `main` as its default branch;
-- a `lezli01/winget-pkgs` fork of `microsoft/winget-pkgs`; and
-- the AUR account/key that may push
-  `ssh://aur@aur.archlinux.org/vincent-agent-bin.git`.
+- a `lezli01/winget-pkgs` fork of `microsoft/winget-pkgs`.
 
-A GoReleaser snapshot renders all three manifests without contacting those
+A GoReleaser snapshot renders both manifests without contacting those
 destinations. That proves the content, not publication. Do not merge a release
 change that names a missing destination: the next stable tag would discover it
 after the GitHub release already exists.
 
-Five secrets are required.
+Four secrets are required.
 
 | Secret | Scope and permissions | Why it exists |
 |---|---|---|
@@ -34,13 +32,12 @@ Five secrets are required.
 | `HOMEBREW_TAP_TOKEN` | Fine-grained PAT selecting only [`lezli01/homebrew-tap`](https://github.com/lezli01/homebrew-tap), with **Contents: read and write** | `GITHUB_TOKEN` and the Release Please PAT are scoped to this repository; pushing the cask is a cross-repo write. |
 | `SCOOP_BUCKET_TOKEN` | Fine-grained PAT selecting only `lezli01/scoop-bucket`, with **Contents: read and write** | Push the stable `vincent.json` manifest to the bucket root. |
 | `WINGET_TOKEN` | Dedicated classic PAT with **`public_repo`** | Push a version branch to `lezli01/winget-pkgs` and open its pull request against `microsoft/winget-pkgs`. GitHub cannot express that cross-owner PR as a fine-grained token scoped only to the fork. |
-| `AUR_KEY` | Contents of a dedicated, unencrypted SSH private key whose public key is registered with the maintainer's AUR account | Push only the generated `vincent-agent-bin` PKGBUILD and `.SRCINFO`. Do not reuse a login or workstation key. |
 
 Nothing else needs a secret: cosign signs keylessly with the packaging
 workflow's OIDC identity.
 
 **Narrow scope is the default, not a claim that WinGet has one.** Release Please,
-Homebrew, and Scoop each have a single-repository token; AUR has a dedicated key.
+Homebrew, and Scoop each have a single-repository token.
 `WINGET_TOKEN` is the exception: `public_repo` can change any public repository
 the account can write. Prefer a publisher bot account if that blast radius is
 not acceptable. Every credential is passed to the pinned GoReleaser action only
@@ -58,7 +55,6 @@ gh secret set RELEASE_PLEASE_TOKEN --repo lezli01/vincent
 gh secret set HOMEBREW_TAP_TOKEN --repo lezli01/vincent
 gh secret set SCOOP_BUCKET_TOKEN --repo lezli01/vincent
 gh secret set WINGET_TOKEN --repo lezli01/vincent
-gh secret set AUR_KEY --repo lezli01/vincent < /path/to/dedicated-aur-private-key
 ```
 
 ## Version numbers
@@ -80,7 +76,7 @@ binary.
 
 The normal Release Please path creates stable releases. If a maintainer cuts an
 exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
-`skip_upload: auto` prevents it from moving the Homebrew, Scoop, WinGet, or AUR
+`skip_upload: auto` prevents it from moving the Homebrew, Scoop, or WinGet
 metadata. The prerelease still carries its deb and rpm assets on GitHub.
 
 ## Cutting a release
@@ -106,7 +102,7 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    *Run workflow*, leaving `dry_run` checked. That runs
    `release --snapshot --clean --skip=publish,sign` — real cross-compilation and
    real archives/packages/manifests, published nowhere. The job inspects the
-   deb/rpm payloads and generated Scoop, WinGet, and AUR metadata before it
+   deb/rpm payloads and generated Scoop and WinGet metadata before it
    uploads the `dist` artifact for a manual look.
 
 5. **Merge the Release Please PR.** This is the release action. Release Please
@@ -118,8 +114,8 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    - `Release` runs GoReleaser, preserves Release Please's notes, builds and
      signs the checksum, inspects deb/rpm payloads, attests every archive and
      native package, uploads the artifacts to the existing GitHub release, and
-     updates Homebrew, Scoop, AUR, and the WinGet submission for a stable tag.
-     A prerelease skips all four manager publishers automatically.
+     updates Homebrew, Scoop, and the WinGet submission for a stable tag.
+     A prerelease skips all three manager publishers automatically.
    - `smoke` (one job per OS) downloads the **real published archive**, unpacks
      it, asserts `vincent version` reports the tag rather than `dev`, runs
      `vincent workflow validate` and checks that `vincent task ls` exits 2 with
@@ -166,10 +162,6 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    scoop update
    scoop info vincent/vincent
 
-   # AUR: pkgver, URLs, and checksums should name this release.
-   git clone https://aur.archlinux.org/vincent-agent-bin.git
-   grep -E '^(pkgver|source_|sha256sums_)' vincent-agent-bin/PKGBUILD
-
    # WinGet: this can lag while Microsoft's catalog PR is reviewed.
    winget show --id lezli01.Vincent --exact --versions
    ```
@@ -206,7 +198,7 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
   into the binary; the manifest is automation state, not product state.
 - **GoReleaser owns distribution channels.** It attaches archives, signatures,
   checksums, deb/rpm packages and attestations to Release Please's existing
-  GitHub release, then updates Homebrew, Scoop and AUR and prepares the WinGet
+  GitHub release, then updates Homebrew and Scoop and prepares the WinGet
   catalog PR for stable releases. mise consumes the GitHub archives directly
   and needs no publisher. Keeping artifact and manifest generation in one run
   prevents channel checksums from drifting from the release they name.
@@ -214,7 +206,7 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
   certificate costs v0 does not take on — recorded as a descope in spec §19.
   Releases carry cosign signatures and build provenance instead, and the README
   documents the SmartScreen and Gatekeeper prompts users will meet.
-- **External catalogs remain external.** Scoop and AUR update repositories the
+- **External catalogs remain external.** Scoop updates a repository the
   maintainer controls. WinGet is a pull request into Microsoft's catalog and
   can remain pending after the GitHub release succeeds. The accepted
   maintenance and credential trade-offs are recorded in

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,7 +9,6 @@ and no database server — the store is an embedded SQLite file.
 - [Scoop (Windows)](#scoop-windows)
 - [mise (all platforms)](#mise-all-platforms)
 - [deb and rpm (Linux)](#deb-and-rpm-linux)
-- [AUR (Arch Linux)](#aur-arch-linux)
 - [Download a release](#download-a-release)
 - [First launch is flagged](#first-launch-is-flagged)
 - [Verify a download](#verify-a-download)
@@ -141,25 +140,7 @@ These files are GitHub release assets, not an apt or dnf repository. The system
 package database records the install, but it cannot discover a newer release;
 download the next deb/rpm and run the same command to upgrade.
 
-## AUR (Arch Linux)
-
-The AUR package is `vincent-agent-bin` (`vincent-bin` belongs to an unrelated
-project). With an AUR helper, install it through that helper's normal flow.
-Without one:
-
-```sh
-git clone https://aur.archlinux.org/vincent-agent-bin.git
-cd vincent-agent-bin
-makepkg -si
-vincent version
-```
-
-`vincent-agent-bin` uses Vincent's published Linux archive rather than
-rebuilding from source, supports x86-64 and ARM64, depends on git, and installs
-both license documents. Pull the AUR checkout and rerun `makepkg -si`, or use
-the helper's normal upgrade command, for a newer stable release.
-
-WinGet, Scoop, and AUR metadata is published only for stable releases. If a
+WinGet and Scoop metadata is published only for stable releases. If a
 newly introduced channel reports that Vincent is not found before its first
 stable publication, use [mise](#mise-all-platforms) or
 [download a release](#download-a-release).
@@ -375,8 +356,8 @@ For the other managers, remove the binary only after `vincent service
 uninstall`: `winget uninstall --id lezli01.Vincent --exact`, `scoop uninstall
 vincent`, `mise unuse -g github:lezli01/vincent` followed by `mise uninstall
 --all github:lezli01/vincent`, `sudo apt remove vincent`, `sudo dnf remove
-vincent`, or the normal AUR removal command. None of these removes Vincent's
-config, database, transcripts, or worktrees.
+vincent`. None of these removes Vincent's config, database, transcripts, or
+worktrees.
 
 **A branch with commits on it is never deleted by vincent.** Archiving a task
 deletes its branch only when that branch has no commits past its base, so

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,6 +5,11 @@ and no database server — the store is an embedded SQLite file.
 
 - [What you need](#what-you-need)
 - [Homebrew (macOS)](#homebrew-macos)
+- [WinGet (Windows)](#winget-windows)
+- [Scoop (Windows)](#scoop-windows)
+- [mise (all platforms)](#mise-all-platforms)
+- [deb and rpm (Linux)](#deb-and-rpm-linux)
+- [AUR (Arch Linux)](#aur-arch-linux)
 - [Download a release](#download-a-release)
 - [First launch is flagged](#first-launch-is-flagged)
 - [Verify a download](#verify-a-download)
@@ -51,6 +56,113 @@ brew uninstall --zap vincent
 
 Plain `brew uninstall vincent` removes the binary and unloads the LaunchAgent
 but leaves `~/Library/Application Support/vincent` intact.
+
+## WinGet (Windows)
+
+```powershell
+winget install --id lezli01.Vincent --exact
+vincent version
+```
+
+The package depends on `Git.Git`, so WinGet installs Git when it is missing.
+The manifest points at the same checksummed zip as the GitHub release; it is a
+portable package, not an MSI. Releases are not Authenticode-signed, so
+SmartScreen may still prompt on first launch.
+
+Upgrade with `winget upgrade --id lezli01.Vincent --exact`. Before uninstalling
+a copy used by the background service, run `vincent service uninstall`, then
+`winget uninstall --id lezli01.Vincent --exact`.
+
+Microsoft reviews submissions to the public WinGet catalog. A new stable
+release can therefore appear here after its GitHub assets do.
+
+## Scoop (Windows)
+
+Add Vincent's bucket once, then install its manifest:
+
+```powershell
+scoop bucket add vincent https://github.com/lezli01/scoop-bucket
+scoop install vincent/vincent
+vincent version
+```
+
+The manifest installs both x86-64 and ARM64 from the matching GitHub release
+zip and declares Scoop's `git` package as a dependency. Upgrade with `scoop
+update vincent`. Before `scoop uninstall vincent`, run `vincent service
+uninstall` if you registered the background service.
+
+## mise (all platforms)
+
+mise can consume the existing GitHub release archives directly; Vincent does
+not need a mise plugin or registry entry:
+
+```sh
+mise use -g github:lezli01/vincent
+vincent version
+```
+
+That records `latest` in mise's global config and selects the archive matching
+the current OS and architecture. For Vincent's releases, mise also verifies the
+GitHub artifact attestation before extracting the archive. Pin a project or
+machine to a specific release instead with:
+
+```sh
+mise use github:lezli01/vincent@0.3.0       # current directory
+mise use -g github:lezli01/vincent@0.3.0    # global
+```
+
+Use `mise upgrade github:lezli01/vincent` to move an unpinned install forward.
+Shell activation or mise shims must be configured for `vincent` to be on
+`PATH`; follow mise's own shell setup if `mise which vincent` succeeds but the
+shell cannot find it.
+
+## deb and rpm (Linux)
+
+Stable releases attach native packages for x86-64 and ARM64. Download the file
+for your system from the [latest release](https://github.com/lezli01/vincent/releases/latest),
+then let the system package tool install it and its `git` dependency:
+
+```sh
+# Debian / Ubuntu, x86-64 (use _arm64.deb on ARM64)
+sudo apt install ./vincent_*_amd64.deb
+
+# Fedora / RHEL family, x86-64 (use .aarch64.rpm on ARM64)
+sudo dnf install ./vincent-*.x86_64.rpm
+
+vincent version
+```
+
+Both formats put the binary at `/usr/bin/vincent` and the license documents
+under `/usr/share`. They deliberately install no system service: Vincent's
+service is per-user and must capture that user's `PATH`, config, and data
+directories, so opt in afterwards with `vincent service install`.
+
+These files are GitHub release assets, not an apt or dnf repository. The system
+package database records the install, but it cannot discover a newer release;
+download the next deb/rpm and run the same command to upgrade.
+
+## AUR (Arch Linux)
+
+The AUR package is `vincent-agent-bin` (`vincent-bin` belongs to an unrelated
+project). With an AUR helper, install it through that helper's normal flow.
+Without one:
+
+```sh
+git clone https://aur.archlinux.org/vincent-agent-bin.git
+cd vincent-agent-bin
+makepkg -si
+vincent version
+```
+
+`vincent-agent-bin` uses Vincent's published Linux archive rather than
+rebuilding from source, supports x86-64 and ARM64, depends on git, and installs
+both license documents. Pull the AUR checkout and rerun `makepkg -si`, or use
+the helper's normal upgrade command, for a newer stable release.
+
+WinGet, Scoop, and AUR metadata is published only for stable releases. If a
+newly introduced channel reports that Vincent is not found before its first
+stable publication, use [mise](#mise-all-platforms) or
+[download a release](#download-a-release).
 
 ## Download a release
 
@@ -119,10 +231,10 @@ you.)
 
 ## Verify a download
 
-The signature is over `checksums.txt`, and `checksums.txt` covers every
-archive — so verifying the signature and then the checksum covers the binary
-you are about to run. Download `checksums.txt`, `checksums.txt.sig` and
-`checksums.txt.pem` from the same release:
+The signature is over `checksums.txt`, and `checksums.txt` covers every archive,
+deb, and rpm — so verifying the signature and then the checksum covers the
+package or binary you are about to run. Download `checksums.txt`,
+`checksums.txt.sig` and `checksums.txt.pem` from the same release:
 
 ```sh
 cosign verify-blob checksums.txt \
@@ -136,9 +248,12 @@ sha256sum -c checksums.txt --ignore-missing
 
 Keyless cosign means there is no vincent public key to trust or rotate: the
 certificate binds the signature to the GitHub Actions workflow that produced
-it. Every archive additionally carries a build provenance attestation, which
-`gh attestation verify vincent_*_linux_amd64.tar.gz --repo lezli01/vincent`
-checks.
+it. Every archive, deb, and rpm additionally carries a build provenance
+attestation. For example:
+
+```sh
+gh attestation verify vincent_*_linux_amd64.tar.gz --repo lezli01/vincent
+```
 
 ## Install an agent CLI
 
@@ -213,11 +328,16 @@ See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the development workflow.
 
 ## Upgrading
 
-Replace the binary and restart the daemon:
+Use the channel's upgrade command, or replace the archive binary and restart
+the daemon:
 
 ```sh
 vincent daemon stop
-# unpack the new archive over the old binary — or: brew upgrade vincent
+# brew upgrade vincent
+# winget upgrade --id lezli01.Vincent --exact
+# scoop update vincent
+# mise upgrade github:lezli01/vincent
+# or unpack/install the new archive, deb, or rpm
 vincent daemon start
 vincent version
 ```
@@ -250,6 +370,13 @@ the data directory removes the database, transcripts and worktrees.
 Installed with Homebrew, `brew uninstall --zap vincent` does all of the above in
 one step — it unloads the LaunchAgent, removes the binary, and trashes the
 config and data directory.
+
+For the other managers, remove the binary only after `vincent service
+uninstall`: `winget uninstall --id lezli01.Vincent --exact`, `scoop uninstall
+vincent`, `mise unuse -g github:lezli01/vincent` followed by `mise uninstall
+--all github:lezli01/vincent`, `sudo apt remove vincent`, `sudo dnf remove
+vincent`, or the normal AUR removal command. None of these removes Vincent's
+config, database, transcripts, or worktrees.
 
 **A branch with commits on it is never deleted by vincent.** Archiving a task
 deletes its branch only when that branch has no commits past its base, so

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -14,6 +14,41 @@ acceptance gates on first.
 
 ## Install
 
+Stable releases attach deb and rpm packages for both supported architectures:
+
+```sh
+# Debian / Ubuntu (use _arm64.deb on ARM64)
+sudo apt install ./vincent_*_amd64.deb
+
+# Fedora / RHEL family (use .aarch64.rpm on ARM64)
+sudo dnf install ./vincent-*.x86_64.rpm
+```
+
+Download the package from the
+[latest release](https://github.com/lezli01/vincent/releases/latest) first.
+These are release assets rather than an apt/dnf repository, so install the next
+downloaded package the same way to upgrade. Both formats put the binary at
+`/usr/bin/vincent`, depend on git, carry the license documents, and deliberately
+do not create a root-owned service for Vincent's per-user daemon.
+
+On Arch Linux, install the AUR binary package with your normal helper or build
+it directly:
+
+```sh
+git clone https://aur.archlinux.org/vincent-agent-bin.git
+cd vincent-agent-bin
+makepkg -si
+```
+
+mise works across distributions without a distro package:
+
+```sh
+mise use -g github:lezli01/vincent
+```
+
+Package-manager metadata moves on stable releases only. If a newly introduced
+channel has not received its first stable release, use mise or the archive:
+
 ```sh
 tar -xzf vincent_*_linux_amd64.tar.gz       # or _linux_arm64
 sudo mv vincent /usr/local/bin/

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -31,15 +31,6 @@ downloaded package the same way to upgrade. Both formats put the binary at
 `/usr/bin/vincent`, depend on git, carry the license documents, and deliberately
 do not create a root-owned service for Vincent's per-user daemon.
 
-On Arch Linux, install the AUR binary package with your normal helper or build
-it directly:
-
-```sh
-git clone https://aur.archlinux.org/vincent-agent-bin.git
-cd vincent-agent-bin
-makepkg -si
-```
-
 mise works across distributions without a distro package:
 
 ```sh

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -16,7 +16,26 @@ different.
 
 ## Install
 
-Unzip the release archive and put `vincent.exe` somewhere on your `PATH`:
+WinGet is the shortest system-managed path:
+
+```powershell
+winget install --id lezli01.Vincent --exact
+```
+
+Or use Vincent's Scoop bucket:
+
+```powershell
+scoop bucket add vincent https://github.com/lezli01/scoop-bucket
+scoop install vincent/vincent
+```
+
+Both support x86-64 and ARM64, install Git when it is missing, and consume the
+same release zip as the manual path. Stable releases update Scoop immediately;
+WinGet can lag while Microsoft reviews the catalog pull request. mise is also
+supported: `mise use -g github:lezli01/vincent`.
+
+To install without a manager, unzip the release archive and put `vincent.exe`
+somewhere on your `PATH`:
 
 ```powershell
 Expand-Archive vincent_*_windows_amd64.zip -DestinationPath $env:LOCALAPPDATA\Programs\vincent
@@ -28,7 +47,11 @@ vincent version
 **More info** → **Run anyway**. Releases carry cosign signatures, SHA-256
 checksums and GitHub build attestations, but not Authenticode code signing,
 which is a recurring certificate cost this project does not take on. The prompt
-appears once per binary.
+appears once per binary and can also appear for WinGet, Scoop, or mise: those
+channels verify the archive but do not add Authenticode signing.
+
+Package-manager metadata moves on stable releases only. If a newly introduced
+channel has not received its first stable release, use mise or the archive.
 
 Full detail, including how to verify a download: [Installation](../getting-started/installation.md).
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3319,17 +3319,16 @@ the same way, so Scoop and winget stay rejected. Reasoning in
 **Amended 2026-08-20 — package-manager distribution is now accepted on
 Windows and Linux.** This explicitly supersedes the final two sentences above
 and task 002's Windows-only rejection. Stable releases generate deb and rpm
-assets, update the AUR `vincent-agent-bin` package and
-`lezli01/scoop-bucket`, and submit `lezli01.Vincent` from
+assets, update `lezli01/scoop-bucket`, and submit `lezli01.Vincent` from
 `lezli01/winget-pkgs` to Microsoft's public catalog. Prereleases may carry
-deb/rpm assets but never move the Homebrew,
-Scoop, WinGet, or AUR stable channels. mise uses the standard
+deb/rpm assets but never move the Homebrew, Scoop, or WinGet stable channels.
+mise uses the standard
 `github:lezli01/vincent` backend over the existing archives and therefore adds
 no repository or release-time publisher.
 
 The maintenance cost named by the original X decision is accepted: the Scoop
-bucket, WinGet fork and AUR repository are release dependencies with separate
-credentials. Scoop and AUR are destination-scoped; WinGet's cross-owner catalog
+bucket and WinGet fork are release dependencies with separate credentials.
+Scoop is destination-scoped; WinGet's cross-owner catalog
 pull request requires the explicitly documented classic-`public_repo`
 exception. All formats consume the same GoReleaser build, checksums and release
 tag. None changes the security boundary: binaries remain

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3316,6 +3316,29 @@ path most macOS users take. Windows is untouched: no packager erases SmartScreen
 the same way, so Scoop and winget stay rejected. Reasoning in
 `docs/tasks/002-homebrew-tap.md`.
 
+**Amended 2026-08-20 — package-manager distribution is now accepted on
+Windows and Linux.** This explicitly supersedes the final two sentences above
+and task 002's Windows-only rejection. Stable releases generate deb and rpm
+assets, update the AUR `vincent-agent-bin` package and
+`lezli01/scoop-bucket`, and submit `lezli01.Vincent` from
+`lezli01/winget-pkgs` to Microsoft's public catalog. Prereleases may carry
+deb/rpm assets but never move the Homebrew,
+Scoop, WinGet, or AUR stable channels. mise uses the standard
+`github:lezli01/vincent` backend over the existing archives and therefore adds
+no repository or release-time publisher.
+
+The maintenance cost named by the original X decision is accepted: the Scoop
+bucket, WinGet fork and AUR repository are release dependencies with separate
+credentials. Scoop and AUR are destination-scoped; WinGet's cross-owner catalog
+pull request requires the explicitly documented classic-`public_repo`
+exception. All formats consume the same GoReleaser build, checksums and release
+tag. None changes the security boundary: binaries remain
+without Authenticode/Apple notarization, package metadata preserves the
+PolyForm Noncommercial license, and no root package script registers Vincent's
+per-user service. External bootstrap and first-release proof are tracked in
+`docs/tasks/021-package-distribution-channels.md`; documentation must not infer
+catalog availability from a successful local manifest render.
+
 **M4's acceptance is met, 2026-08-11.** The T4.6 walkthrough ran on a clean VM
 per OS with no Go toolchain, against the `v0.1.0-rc1` artifacts: **5:00** on
 Windows 11, **4:30** on macOS, **3:35** on Linux — every run under half the

--- a/docs/tasks/002-homebrew-tap.md
+++ b/docs/tasks/002-homebrew-tap.md
@@ -33,6 +33,11 @@ it beat.
   so Windows would pay the X decision's cost and get only a shorter command. The
   Windows and Linux install paths are unchanged.
 
+  **Superseded 2026-08-20 by [task 021](021-package-distribution-channels.md).**
+  The owner now accepts the second-repository and release-publisher cost for
+  discoverability and one-command upgrades on Windows and Linux. The historical
+  reasoning remains here; task 021 is the current distribution decision.
+
 - **A cask, not a formula.** GoReleaser deprecated `brews` in v2.10 and Homebrew
   packages pre-built binaries as casks; formulas are for what brew builds from
   source. Not a stylistic choice — `goreleaser check` fails the config on the

--- a/docs/tasks/021-package-distribution-channels.md
+++ b/docs/tasks/021-package-distribution-channels.md
@@ -1,9 +1,9 @@
 # 021 — Package distribution channels
 
-**Status:** ⚠ verification blocked (6/8) · **Opened:** 2026-08-20
+**Status:** ⚠ verification blocked (5/7) · **Opened:** 2026-08-20
 
 Vincent releases should meet people in the package manager they already use:
-WinGet and Scoop on Windows; deb, rpm, and AUR on Linux; and mise on every
+WinGet and Scoop on Windows; deb and rpm on Linux; and mise on every
 platform mise supports. GitHub release archives and the Homebrew cask remain
 available and remain the source artifacts behind those channels.
 
@@ -22,8 +22,8 @@ configuration and user documentation.
 
 - **GoReleaser remains the single artifact and manifest producer.** nFPM emits
   deb and rpm packages from the existing Linux binaries; GoReleaser emits the
-  Scoop manifest, the WinGet submission, and `vincent-agent-bin`'s PKGBUILD
-  from the same checksummed archives. A second release workflow would make
+  Scoop manifest and the WinGet submission from the same checksummed archives.
+  A second release workflow would make
   version, checksum, and license drift possible. Stable tags publish manager
   metadata; prerelease tags render it for inspection but do not move stable
   channels.
@@ -51,8 +51,7 @@ configuration and user documentation.
 
 - **Publishing credentials stay separate, with one explicit WinGet
   exception.** Scoop gets a fine-grained token scoped only to
-  `lezli01/scoop-bucket`; AUR gets a dedicated unencrypted SSH key used only
-  for `vincent-agent-bin`. WinGet must both push the owner's fork and open a
+  `lezli01/scoop-bucket`. WinGet must both push the owner's fork and open a
   pull request in Microsoft's repository, which a fine-grained token scoped to
   the fork cannot express; its dedicated classic PAT therefore needs
   `public_repo` and can write other public repositories as that account. A bot
@@ -61,15 +60,9 @@ configuration and user documentation.
   permission boundary.
 
 - **The commercial-license boundary is visible in every format.** Package
-  metadata names `PolyForm-Noncommercial-1.0.0`, and deb/rpm/AUR installs carry
+  metadata names `PolyForm-Noncommercial-1.0.0`, and deb/rpm installs carry
   both `LICENSE` and `COMMERCIAL-LICENSE.md`. A package manager making install
   easier does not broaden the rights granted by the release.
-
-- **The AUR name is `vincent-agent-bin`, not `vincent-bin`.** The shorter name
-  is already maintained by an unrelated terminal color-scheme project. The
-  collision cannot be solved by overwriting someone else's package, so the
-  descriptive free name owns this PKGBUILD while `provides=('vincent')` and
-  `conflicts=('vincent')` preserve the installed command's identity.
 
 ## Tasks
 
@@ -81,31 +74,27 @@ configuration and user documentation.
   WinGet metadata from the existing zip archives, stable-only publishing,
   isolated credentials, and a cross-repository WinGet pull request.
   ✓ 2026-08-20
-- [x] **021.3 — Generate `vincent-agent-bin` and wire publishing.** Add a
-  stable-only AUR PKGBUILD that installs the binary and both license documents
-  and depends on git. ✓ 2026-08-20
-- [x] **021.4 — Add the mise path.** Document and execute an isolated install
+- [x] **021.3 — Add the mise path.** Document and execute an isolated install
   through mise's standard GitHub backend, including version pinning and
   upgrades. ✓ 2026-08-20
-- [x] **021.5 — Extend release provenance and smoke checks.** Upload and attest
+- [x] **021.4 — Extend release provenance and smoke checks.** Upload and attest
   deb/rpm artifacts, inspect their payloads, and make CI reject an invalid
   GoReleaser schema. ✓ 2026-08-20
-- [x] **021.6 — Amend product and operator documentation.** Update §19, README,
+- [x] **021.5 — Amend product and operator documentation.** Update §19, README,
   installation/platform guides, and RELEASING without claiming an unpublished
   channel is already live. ✓ 2026-08-20
-- [!] **021.7 — Run repository verification and review the final diff.** — the
+- [!] **021.6 — Run repository verification and review the final diff.** — the
   container's PID namespace makes the existing `procx` live-process tests and
   dependent `taskrun` recovery tests fail; the same four failures reproduce
   without `-race` and are already recorded by task 020.
   Done only when GoReleaser check/snapshot, package payload checks, docs/link
   lint, and the repository's required code checks have actually run;
   unavailable checks remain explicit.
-- [!] **021.8 — Bootstrap and prove the external channels.** — requires the
+- [!] **021.7 — Bootstrap and prove the external channels.** — requires the
   owner's authorization and credentials for external repository/account writes.
-  Create the public
-  Scoop bucket and WinGet fork, register `vincent-agent-bin` in AUR, install
-  the three destination credentials, publish a stable tag, and install that
-  version through all six new paths. This is an external repository/account
+  Confirm the Scoop bucket and WinGet fork, install the two destination
+  credentials, publish a stable tag, and install that version through all five
+  new paths. This is an external repository/account
   mutation and must not be inferred from a successful local snapshot.
 
 ## Verification (2026-08-20)
@@ -115,8 +104,8 @@ Run with Go 1.26.6, GoReleaser 2.17.1, actionlint 1.7.12, and mise 2026.8.9:
 - `goreleaser check` — pass.
 - `goreleaser release --snapshot --clean --skip=publish,sign` — pass. It
   produced six OS/architecture archives, two debs, two rpms, three WinGet
-  manifests, one Scoop manifest, `vincent-agent-bin`'s PKGBUILD and `.SRCINFO`,
-  and the existing Homebrew cask. `checksums.txt` contains all ten binary
+  manifests, one Scoop manifest, and the existing Homebrew cask.
+  `checksums.txt` contains all ten binary
   artifacts.
 - Debian inspection — both architectures present; the amd64 control data names
   package `vincent`, architecture `amd64`, and dependency `git`; its payload
@@ -131,9 +120,7 @@ Run with Go 1.26.6, GoReleaser 2.17.1, actionlint 1.7.12, and mise 2026.8.9:
   a normal GitHub runner.
 - Generated metadata — Scoop JSON parses and contains x86-64/ARM64, `git`, and
   the PolyForm license; all three WinGet YAML files name
-  `lezli01.Vincent`; the AUR PKGBUILD passes `bash -n` and `.SRCINFO` carries
-  both architectures, release URLs, checksums, dependency, provides, conflicts,
-  and license.
+  `lezli01.Vincent`.
 - mise isolated install — `mise use -g github:lezli01/vincent@0.3.0` selected
   `vincent_0.3.0_linux_amd64.tar.gz`, verified its GitHub artifact attestation,
   installed it, and ran the real binary. `mise unuse` and `mise uninstall`
@@ -146,12 +133,13 @@ Run with Go 1.26.6, GoReleaser 2.17.1, actionlint 1.7.12, and mise 2026.8.9:
 - `GOOS=windows CGO_ENABLED=0 go build ./...` and the equivalent Darwin build
   — pass.
 - `go run mage.go testrace` — all other packages pass; the four existing
-  live-PID/recovery tests fail for the environment reason on 021.7. `go test
+  live-PID/recovery tests fail for the environment reason on 021.6. `go test
   ./internal/procx ./internal/taskrun -count=1` reproduces the same failures
   without the race detector.
 
-External readiness checks found that `lezli01/scoop-bucket` and
-`lezli01/winget-pkgs` do not yet exist. AUR's `vincent-bin` is already an
-unrelated package, so this task uses the currently unclaimed
-`vincent-agent-bin`; no AUR package was registered and no destination
-credential or stable tag was created in this task.
+The owner has since created `lezli01/scoop-bucket` and the
+`lezli01/winget-pkgs` fork and configured their destination credentials. No
+stable tag has yet proved publication and installation through these channels.
+AUR support is intentionally deferred to
+[#157](https://github.com/lezli01/vincent/issues/157) because new AUR account
+registration is temporarily suspended.

--- a/docs/tasks/021-package-distribution-channels.md
+++ b/docs/tasks/021-package-distribution-channels.md
@@ -1,0 +1,157 @@
+# 021 — Package distribution channels
+
+**Status:** ⚠ verification blocked (6/8) · **Opened:** 2026-08-20
+
+Vincent releases should meet people in the package manager they already use:
+WinGet and Scoop on Windows; deb, rpm, and AUR on Linux; and mise on every
+platform mise supports. GitHub release archives and the Homebrew cask remain
+available and remain the source artifacts behind those channels.
+
+Conventions for this file are in [the tasks README](README.md). Behaviour lands
+in [the spec](../spec.md) as dated amendments, in the same PR as the release
+configuration and user documentation.
+
+## Decisions (2026-08-20)
+
+- **This explicitly supersedes task 002's Windows rejection and the v0 X
+  distribution decision.** Both decisions correctly priced a bucket, a WinGet
+  fork, and release-time publishing as permanent maintenance. That cost is now
+  accepted for discoverability and one-command upgrades on Windows and Linux;
+  it is not being re-described as free. GitHub archives stay the fallback and
+  the provenance source for every manager.
+
+- **GoReleaser remains the single artifact and manifest producer.** nFPM emits
+  deb and rpm packages from the existing Linux binaries; GoReleaser emits the
+  Scoop manifest, the WinGet submission, and `vincent-agent-bin`'s PKGBUILD
+  from the same checksummed archives. A second release workflow would make
+  version, checksum, and license drift possible. Stable tags publish manager
+  metadata; prerelease tags render it for inspection but do not move stable
+  channels.
+
+- **mise needs documentation, not another registry.** mise's GitHub backend
+  understands the repository's existing GoReleaser archive names, so
+  `mise use -g github:lezli01/vincent` installs the same release without a
+  checked-in plugin or a repository write. Creating a bespoke mise backend
+  would duplicate behavior the standard backend already owns.
+
+- **Linux packages install one binary and documentation, not a system
+  service.** Vincent's service is deliberately per-user and captures that
+  user's config/data paths and `PATH`. A root deb/rpm maintainer script cannot
+  safely choose a desktop user, and package removal must not erase that user's
+  task history. Package managers install `/usr/bin/vincent`; users continue to
+  opt into `vincent service install` themselves.
+
+- **Package-manager upgrades do not guess about a registered service.** The
+  service records the resolved executable path at registration time. Channels
+  whose install path can move therefore document the existing idempotent
+  `vincent service install` command after an upgrade, and document
+  `vincent service uninstall` before package removal. Manager hooks that
+  silently rewrite per-user service state would be surprising and cannot cover
+  all five channels consistently.
+
+- **Publishing credentials stay separate, with one explicit WinGet
+  exception.** Scoop gets a fine-grained token scoped only to
+  `lezli01/scoop-bucket`; AUR gets a dedicated unencrypted SSH key used only
+  for `vincent-agent-bin`. WinGet must both push the owner's fork and open a
+  pull request in Microsoft's repository, which a fine-grained token scoped to
+  the fork cannot express; its dedicated classic PAT therefore needs
+  `public_repo` and can write other public repositories as that account. A bot
+  account is the tighter long-term option. Reusing the Release Please token
+  would add private repository scope without solving this cross-owner
+  permission boundary.
+
+- **The commercial-license boundary is visible in every format.** Package
+  metadata names `PolyForm-Noncommercial-1.0.0`, and deb/rpm/AUR installs carry
+  both `LICENSE` and `COMMERCIAL-LICENSE.md`. A package manager making install
+  easier does not broaden the rights granted by the release.
+
+- **The AUR name is `vincent-agent-bin`, not `vincent-bin`.** The shorter name
+  is already maintained by an unrelated terminal color-scheme project. The
+  collision cannot be solved by overwriting someone else's package, so the
+  descriptive free name owns this PKGBUILD while `provides=('vincent')` and
+  `conflicts=('vincent')` preserve the installed command's identity.
+
+## Tasks
+
+- [x] **021.1 — Build deb and rpm packages.** Add nFPM packaging for Linux
+  amd64 and arm64, including git as a runtime dependency and both license
+  documents. Done when a snapshot produces two packages per format and their
+  payloads install `/usr/bin/vincent` with the expected metadata. ✓ 2026-08-20
+- [x] **021.2 — Generate Windows manifests and wire publishing.** Add Scoop and
+  WinGet metadata from the existing zip archives, stable-only publishing,
+  isolated credentials, and a cross-repository WinGet pull request.
+  ✓ 2026-08-20
+- [x] **021.3 — Generate `vincent-agent-bin` and wire publishing.** Add a
+  stable-only AUR PKGBUILD that installs the binary and both license documents
+  and depends on git. ✓ 2026-08-20
+- [x] **021.4 — Add the mise path.** Document and execute an isolated install
+  through mise's standard GitHub backend, including version pinning and
+  upgrades. ✓ 2026-08-20
+- [x] **021.5 — Extend release provenance and smoke checks.** Upload and attest
+  deb/rpm artifacts, inspect their payloads, and make CI reject an invalid
+  GoReleaser schema. ✓ 2026-08-20
+- [x] **021.6 — Amend product and operator documentation.** Update §19, README,
+  installation/platform guides, and RELEASING without claiming an unpublished
+  channel is already live. ✓ 2026-08-20
+- [!] **021.7 — Run repository verification and review the final diff.** — the
+  container's PID namespace makes the existing `procx` live-process tests and
+  dependent `taskrun` recovery tests fail; the same four failures reproduce
+  without `-race` and are already recorded by task 020.
+  Done only when GoReleaser check/snapshot, package payload checks, docs/link
+  lint, and the repository's required code checks have actually run;
+  unavailable checks remain explicit.
+- [!] **021.8 — Bootstrap and prove the external channels.** — requires the
+  owner's authorization and credentials for external repository/account writes.
+  Create the public
+  Scoop bucket and WinGet fork, register `vincent-agent-bin` in AUR, install
+  the three destination credentials, publish a stable tag, and install that
+  version through all six new paths. This is an external repository/account
+  mutation and must not be inferred from a successful local snapshot.
+
+## Verification (2026-08-20)
+
+Run with Go 1.26.6, GoReleaser 2.17.1, actionlint 1.7.12, and mise 2026.8.9:
+
+- `goreleaser check` — pass.
+- `goreleaser release --snapshot --clean --skip=publish,sign` — pass. It
+  produced six OS/architecture archives, two debs, two rpms, three WinGet
+  manifests, one Scoop manifest, `vincent-agent-bin`'s PKGBUILD and `.SRCINFO`,
+  and the existing Homebrew cask. `checksums.txt` contains all ten binary
+  artifacts.
+- Debian inspection — both architectures present; the amd64 control data names
+  package `vincent`, architecture `amd64`, and dependency `git`; its payload
+  contains `/usr/bin/vincent` plus both license documents, and the extracted
+  binary reports `0.3.1-next`.
+- RPM inspection — an independent `go-rpmutils` 0.4.0 reader confirms name
+  `vincent`, architecture `x86_64`, license
+  `PolyForm-Noncommercial-1.0.0`, dependency `git`, executable mode, both
+  license documents, and a runnable `0.3.1-next` binary. The container cannot
+  install Ubuntu's `rpm` command because its user namespace rejects apt's
+  `setgroups`; the release workflow installs and runs the native query tools on
+  a normal GitHub runner.
+- Generated metadata — Scoop JSON parses and contains x86-64/ARM64, `git`, and
+  the PolyForm license; all three WinGet YAML files name
+  `lezli01.Vincent`; the AUR PKGBUILD passes `bash -n` and `.SRCINFO` carries
+  both architectures, release URLs, checksums, dependency, provides, conflicts,
+  and license.
+- mise isolated install — `mise use -g github:lezli01/vincent@0.3.0` selected
+  `vincent_0.3.0_linux_amd64.tar.gz`, verified its GitHub artifact attestation,
+  installed it, and ran the real binary. `mise unuse` and `mise uninstall`
+  removed it cleanly.
+- `actionlint .github/workflows/ci.yml .github/workflows/release.yml` — pass.
+- `git diff --check` and relative-link validation over all changed Markdown —
+  pass.
+- `go run mage.go lint` — pass, `0 issues`.
+- `go run mage.go build` — pass; the built binary runs.
+- `GOOS=windows CGO_ENABLED=0 go build ./...` and the equivalent Darwin build
+  — pass.
+- `go run mage.go testrace` — all other packages pass; the four existing
+  live-PID/recovery tests fail for the environment reason on 021.7. `go test
+  ./internal/procx ./internal/taskrun -count=1` reproduces the same failures
+  without the race detector.
+
+External readiness checks found that `lezli01/scoop-bucket` and
+`lezli01/winget-pkgs` do not yet exist. AUR's `vincent-bin` is already an
+unrelated package, so this task uses the currently unclaimed
+`vincent-agent-bin`; no AUR package was registered and no destination
+credential or stable tag was created in this task.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -35,7 +35,7 @@ description of how the system actually behaves.
 | [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
 | [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | ✅ done (10/10) |
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
-| [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, rpm, and AUR distribution | ⚠ verification blocked (6/8) |
+| [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -35,6 +35,7 @@ description of how the system actually behaves.
 | [018](018-control-flow-review.md) | Control-flow review: four correctness fixes | ✅ done (9/9) |
 | [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | ✅ done (10/10) |
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
+| [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, rpm, and AUR distribution | ⚠ verification blocked (6/8) |
 
 ## How to add and update a task document
 


### PR DESCRIPTION
## Summary

- add Scoop and WinGet publishing from the existing Windows release archives
- add deb and rpm release packages for x86-64 and ARM64
- document mise installation through its standard GitHub backend
- extend release validation, package inspection, provenance, and operator documentation
- defer AUR support to #157 while new AUR account registration is suspended

## Validation

- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish,sign`
- Actionlint for CI and release workflows
- YAML parsing and `git diff --check`
- generated two debs, two rpms, one Scoop manifest, and three WinGet manifests
- confirmed the snapshot generates no AUR output
