### PR TITLE
fix(release): constrain RPM package extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,11 @@ jobs:
           trap 'rm -rf -- "$package_tmp"' EXIT
           mkdir "$package_tmp/deb" "$package_tmp/rpm"
           dpkg-deb --extract "$deb" "$package_tmp/deb"
-          rpm2cpio "$rpm_package" | (cd "$package_tmp/rpm" && cpio -idm --quiet)
+          # RPM payload names are absolute; keep extraction inside the temp root.
+          rpm2cpio "$rpm_package" | (
+            cd "$package_tmp/rpm"
+            cpio --extract --make-directories --quiet --no-absolute-filenames
+          )
           "$package_tmp/deb/usr/bin/vincent" version
           "$package_tmp/rpm/usr/bin/vincent" version
 


### PR DESCRIPTION
## Summary

- force GNU cpio to strip absolute RPM payload paths during release verification
- keep the extracted package under the workflow's temporary directory
- allow provenance, artifact upload, and cross-platform smoke tests to run

## Root cause

The `v0.4.0` packaging run reached verification after publishing its artifacts and manifests, but GNU cpio preserves absolute pathnames by default. It therefore tried to write `/usr/bin/vincent` on the hosted runner and failed with `Permission denied`.

## Validation

- GitHub Actions required checks
- the next immutable patch tag will run the complete release and smoke-test workflow