### PR TITLE
fix(release): verify RPM packages through tar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install Linux package inspection tools
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends --yes cpio jq rpm
+          sudo apt-get install --no-install-recommends --yes jq rpm
 
       - name: Verify generated packages and manifests
         shell: bash
@@ -115,11 +115,9 @@ jobs:
           trap 'rm -rf -- "$package_tmp"' EXIT
           mkdir "$package_tmp/deb" "$package_tmp/rpm"
           dpkg-deb --extract "$deb" "$package_tmp/deb"
-          # RPM payload names are absolute; keep extraction inside the temp root.
-          rpm2cpio "$rpm_package" | (
-            cd "$package_tmp/rpm"
-            cpio --extract --make-directories --quiet --no-absolute-filenames
-          )
+          # rpm2archive normalizes payload paths to ./..., keeping tar in the temp root.
+          rpm2archive "$rpm_package" |
+            tar --extract --gzip --file - --directory "$package_tmp/rpm"
           "$package_tmp/deb/usr/bin/vincent" version
           "$package_tmp/rpm/usr/bin/vincent" version
 


### PR DESCRIPTION
## Summary

- replace cpio extraction with `rpm2archive | tar` in release verification
- remove the now-unused cpio package from the runner setup
- keep the extracted RPM payload under the temporary verification root

## Root cause

`cpio --no-absolute-filenames` safely extracted every RPM payload file but GNU cpio 2.15 returned status 1 for its expected “Removing leading `/`” warning. With `pipefail`, that stopped the release before provenance and smoke tests.

## Reproduction

Against the published `v0.4.1` x86-64 RPM:

- cpio: extracted all five expected files and ran `vincent version`, but pipeline status was 1
- rpm2archive/tar: emitted `./usr/...` member paths, extracted the same files, exited 0, and reported `vincent version 0.4.1`

## Validation

- GitHub Actions required checks
- the next immutable patch tag will exercise package verification, provenance, upload, and all three OS smoke tests