### PR TITLE
feat: add workflow-declared task fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Release Please creates release entries from Conventional Commit history. Its
 release pull request is the review point for replacing the mechanical commit
 list with the user-facing context a commit subject cannot carry.
 
+## [Unreleased]
+
+### Added
+
+- **Workflow-declared task fields.** Workflows can publish ordered task inputs
+  with labels, descriptions, required flags, string/integer/number/boolean
+  types and Go RE2 patterns. The TUI pre-renders those inputs, the daemon
+  validates declared values for every client, and additional undeclared fields
+  remain accepted and recorded on the task.
+
 ## [0.4.2](https://github.com/lezli01/vincent/compare/v0.4.1...v0.4.2) (2026-08-21)
 
 ### Fixed

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -317,8 +317,17 @@ key.
 
 Opens for the project you are looking at. A guided form: project → workflow
 (with its description and step list, flagging steps whose agent is unavailable)
-→ title → description → custom fields → base branch → priority → optional
+→ title → description → fields → base branch → priority → optional
 agent/model/effort override.
+
+When the selected workflow declares [`fields:`](../reference/workflow-schema.md#fields),
+the Fields row is pre-rendered in declaration order. It shows labels,
+descriptions, type/required badges, and regex help; boolean values toggle between
+`true` and `false`. Workflow-owned names are locked, but their values remain
+editable. You can still add and delete custom key/value rows — additional,
+undeclared fields remain valid and are recorded on the task. Values are kept
+when you switch workflows, including fields that the new workflow does not
+declare.
 
 On a wide terminal those fields are grouped into six stages in the left rail:
 **Project**, **Workflow**, **Task details**, **Git & priority**, **Execution**,
@@ -330,6 +339,7 @@ navigation keys.
 | Key | Does |
 |---|---|
 | `enter` | Open the focused field's editor or picker |
+| `a` / `d` | In Fields, add or delete a custom row (declared rows cannot be deleted) |
 | `e` | Edit the description in `$EDITOR` |
 | `+` / `-` | Nudge the priority (higher runs first) |
 | `R` | Re-probe the adapters (the list is otherwise cache-served) |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -236,6 +236,12 @@ name: feature-pr                 # required — how tasks refer to it
 description: One line, shown in the picker.
 platforms: [posix]               # optional — where this file may run (§10.3)
 
+fields:                          # optional — ordered task inputs (§5.4)
+  - name: ticket
+    label: Ticket
+    required: true
+    pattern: '^OPS-[0-9]+$'
+
 defaults:                        # optional — inherited by every step
   agent: claude
   max_retries: 2
@@ -253,6 +259,7 @@ steps:                           # required, non-empty — runs top to bottom
 | `name` | ✅ | Unique per scope. No whitespace and no `/` or `\` |
 | `description` | | One line; shown in the TUI picker and `vincent workflow ls` |
 | `platforms` | | Empty means anywhere — [§10.3](#103-platforms--declare-what-you-did-not-port) |
+| `fields` | | Expected task inputs — [§5.4](#54-task-fields) |
 | `defaults` | | Workflow-wide fallbacks — [§3.2](#32-defaults) |
 | `steps` | ✅ | Runs strictly in order |
 
@@ -858,9 +865,48 @@ on the tail.
 
 ### 5.4 Task fields
 
-`.Task.Fields` is a free-form `map[string]string` supplied when the task is
-created. It is how one workflow serves many jobs — a ticket id, a module name, a
-"ship it: yes/no" flag.
+`.Task.Fields` is an open `map[string]string` supplied when the task is created.
+It is how one workflow serves many jobs — a ticket id, a module name, a "ship
+it: yes/no" flag. A workflow can predeclare the fields it expects so the TUI
+can render the right rows before a task exists:
+
+```yaml
+fields:
+  - name: ticket
+    label: Ticket
+    description: Issue tracker key.
+    required: true
+    pattern: '^OPS-[0-9]+$'
+  - name: retries
+    type: integer
+  - name: confidence
+    type: number
+  - name: dry-run
+    label: Dry run
+    type: boolean
+```
+
+The definition order is the form order. `string` is the default type;
+`integer` accepts base-10 whole numbers, `number` accepts finite decimal values,
+and `boolean` accepts exactly `true` or `false`. `pattern` is a Go RE2 expression
+for strings only — anchor it with `^` and `$` when the whole value must match.
+`label` and `description` only improve presentation.
+
+The daemon checks required/type/pattern rules at task creation, including for
+CLI and API callers. The selected root workflow owns the contract: fields from
+included workflows and named fan-out lane workflows are not automatically
+merged, so a composing workflow re-declares any input it exposes.
+
+Declarations do **not** close the map. Extra fields remain accepted, recorded,
+inherited by lanes, and visible to templates. Both of these travel together:
+
+```sh
+vincent task add --project 1 --workflow feature-pr --title "Ship it" \
+  --field ticket=OPS-42 --field owner=ana
+```
+
+Here `ticket` may be declared and validated while `owner` is additional
+metadata; both are stored as strings in `.Task.Fields`.
 
 Because rendering is strict, an **optional** field must be read defensively or
 the step fails:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -205,7 +205,13 @@ to disable the sweep.
 | `POST` | `/v1/resolve` | `{ workflow, project_id?, agent?, model?, effort?, title?, fields?, base_branch?, branch_name? }` → resolution per step, plus the previewed branch name |
 
 Registry entries carry
-`{ name, scope, project_id, file, description, steps[], platforms[]?, platform_supported, requires_input, includes[]?, errors[]?, warnings[]?, error? }`.
+`{ name, scope, project_id, file, description, fields[], steps[], platforms[]?, platform_supported, requires_input, includes[]?, errors[]?, warnings[]?, error? }`.
+
+`fields[]` is the selected workflow's ordered
+[`fields:` declaration](workflow-schema.md#fields). Each entry is
+`{ name, label?, description?, type, required, pattern? }`; `type` is always
+explicit (`string` when the YAML omitted it). An empty list means the workflow
+publishes no task-input contract, not that task fields are forbidden.
 
 `platforms[]` is the entry's [platform restriction](workflow-schema.md#platforms)
 as the file declares it, and `platform_supported` is **the daemon's own verdict**
@@ -251,6 +257,10 @@ GET /v1/workflows/definition?name=feature-pr&project_id=3
   "requires_input": false,
   "definition": {
     "name": "feature-pr",
+    "fields": [
+      { "name": "ticket", "label": "Ticket", "type": "string",
+        "required": true, "pattern": "^OPS-[0-9]+$" }
+    ],
     "defaults": { "agent": "claude", "model": "sonnet" },
     "steps": [
       { "id": "plan", "type": "agent", "prompt": "…", "check": "go build ./..." },
@@ -319,6 +329,12 @@ rather than inventing a model name.
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
 | `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based; `0` outside one) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart |
+
+On `POST /v1/tasks`, the daemon validates the selected root workflow's
+declared fields before inserting the task. Missing required values and invalid
+types or patterns return `400 validation_failed`. The `fields` object remains
+open: additional names that the workflow did not declare are accepted, stored,
+and returned with the task.
 
 Human actions, all `POST /v1/tasks/{id}/…`:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,7 +223,7 @@ Lists registered projects with their ids, paths and defaults.
 vincent task add --project ID --title TITLE
                  [--workflow NAME] [--description TEXT] [--base-branch BRANCH]
                  [--branch NAME] [--priority N] [--agent NAME] [--model M]
-                 [--effort E] [--json]
+                 [--effort E] [--field NAME=VALUE]... [--json]
 ```
 
 Creates a task. It is `queued` immediately — there is no draft state.
@@ -236,7 +236,16 @@ Creates a task. It is `queued` immediately — there is no draft state.
 | `--base-branch` | What the task branches **from**. Defaults to the project's default branch |
 | `--branch` | What the task's branch is **called**. Used verbatim and wins over any template; defaults to the project's or the global [`branch_template`](configuration.md#branch_template) |
 | `--priority` | Higher runs first; default 0 |
+| `--field name=value` | Task field; repeat for more. Everything after the first `=` is the value, and a repeated name uses the last value |
 | `--agent` / `--model` / `--effort` | The task-level override. It replaces workflow `defaults`, never an explicit step field |
+
+Declared workflow fields are validated by the daemon, while additional names
+remain valid and are recorded on the same open field map:
+
+```sh
+vincent task add --project 1 --workflow release --title "Release 2.0" \
+  --field ticket=OPS-42 --field owner=ana
+```
 
 Model and effort **only inherit from a level whose agent matches**, so switching
 agent without setting them resets them to the new adapter's default rather than

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -12,6 +12,7 @@ becoming a setting that silently never applied.
 - [File structure](#file-structure)
 - [Top level](#top-level)
   - [`platforms`](#platforms)
+  - [`fields`](#fields)
   - [`defaults`](#defaults)
 
 **Steps**
@@ -48,6 +49,12 @@ becoming a setting that silently never applied.
 name: feature-pr
 description: One line, shown in the picker.
 
+fields:
+  - name: ticket
+    label: Ticket
+    required: true
+    pattern: '^OPS-[0-9]+$'
+
 defaults:
   agent: claude
   max_retries: 2
@@ -72,6 +79,7 @@ built-in workflow, `adhoc`, is always present: a single agent step.
 | `name` | string | ✅ | How tasks refer to it. Unique per scope |
 | `description` | string | | Shown in the TUI's workflow picker |
 | `platforms` | list | | Where this workflow may run. Empty means anywhere — see [`platforms`](#platforms) |
+| `fields` | list | | Ordered task-input declarations — see [`fields`](#fields) |
 | `defaults` | map | | Inherited by every step |
 | `steps` | list | ✅ | Runs in order, top to bottom. Must be non-empty |
 
@@ -112,6 +120,53 @@ POSIX-only workflow validates the same on a Windows CI runner as it does on
 Linux.
 
 The restriction covers the whole workflow; there is no per-step `platforms`.
+
+## `fields`
+
+A workflow can declare the task fields it expects. The TUI pre-renders these
+rows as soon as the workflow is selected, while the daemon validates them for
+every client when the task is created.
+
+```yaml
+fields:
+  - name: ticket
+    label: Ticket
+    description: Issue tracker key, including its project prefix.
+    type: string
+    required: true
+    pattern: '^OPS-[0-9]+$'
+  - name: retries
+    type: integer
+  - name: threshold
+    type: number
+  - name: dry-run
+    label: Dry run
+    type: boolean
+```
+
+Definitions stay in source order. Each definition has:
+
+| Key | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `name` | slug | ✅ | | Key in `.Task.Fields`; unique in this list |
+| `label` | string | | `name` | Presentation text only |
+| `description` | string | | | Help text shown by clients |
+| `type` | `string` \| `integer` \| `number` \| `boolean` | | `string` | Editing and validation contract; stored value is still a string |
+| `required` | bool | | `false` | Missing or whitespace-only values are rejected when true |
+| `pattern` | string | | | Go RE2 expression, valid only for `string`; use `^` and `$` for a whole-value match |
+
+Integers are base-10 whole numbers, numbers must be finite decimals, and
+booleans are exactly `true` or `false`. Optional absent or empty values skip
+type and pattern validation.
+
+The task map remains **open**. A caller may send additional names; vincent
+records them and exposes them to templates just like declared fields. Only the
+declared names receive required, type, and pattern checks.
+
+The selected workflow is the public boundary. Fields declared by an included
+workflow or a named `fan_out` lane are not merged into the caller's form. A
+composing workflow re-declares the inputs it exposes; lane `fields:` remains a
+separate map of values bound for that lane.
 
 ## `defaults`
 
@@ -790,12 +845,16 @@ than lean on that tail:
       Fix exactly those items.
 ```
 
-`.Task.Fields` is free-form per task, so **optional** fields must be read
-defensively or rendering fails:
+`.Task.Fields` remains an open string map per task. A declared **optional**
+field, or an undeclared field that may be absent, must be read defensively or
+rendering fails:
 
 ```yaml
 {{with index .Task.Fields "ticket"}}Ticket: {{.}}{{end}}
 ```
+
+A declared required field may be read directly because task creation rejects a
+missing value before a snapshot can run.
 
 ## Environment
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -180,7 +180,7 @@ A unit of work delivered by running a workflow against a project.
 | `project_id` | FK |
 | `title` | short summary; slugged into the branch name |
 | `description` | markdown, arbitrary length |
-| `fields` | free-form string key/value map (e.g. `ticket: OPS-123`); available to templates |
+| `fields` | open string key/value map (e.g. `ticket: OPS-123`); available to templates. The selected workflow may declare expected names and validate those values (§8.1.2), but undeclared names remain accepted and recorded |
 | `workflow_name` | name as resolved at creation time |
 | `workflow_snapshot` | full YAML content captured at creation; **execution always uses the snapshot**, so later edits to workflow files never mutate in-flight or historical tasks |
 | `base_branch` | defaults to project `default_branch` |
@@ -967,6 +967,16 @@ name: feature-pr                      # required; unique per scope; project shad
 description: Implement, test, review, then push and open a PR.
 platforms: [posix]                    # optional; where this workflow may run (§8.1.1)
 
+fields:                               # optional; ordered task-input contract (§8.1.2)
+  - name: ticket
+    label: Ticket
+    description: Issue tracker key.
+    required: true
+    pattern: '^OPS-[0-9]+$'
+  - name: dry-run
+    label: Dry run
+    type: boolean
+
 defaults:                             # optional; per-step values override
   agent: claude                       # claude | codex | cursor (§9.7)
   model: ""                           # adapter-native id/alias (e.g. sonnet); options via GET /v1/agents (§9.6)
@@ -1060,6 +1070,40 @@ semantics. The whole-workflow `platforms:` stays exactly as described above,
 because it does something a run-time guard cannot — it stops the workflow being
 *offered*, in the picker and at task creation, rather than skipping steps once
 a task exists.
+
+#### 8.1.2 Declared task fields (`fields:`)
+
+*Added 2026-08-21 (task 022).* A workflow may publish the task fields it expects
+as an ordered list. Clients use the order to build a form before the task
+exists; the values themselves remain strings everywhere — in the API, task
+row, templates, branch naming, and fan-out inheritance.
+
+```yaml
+fields:
+  - name: ticket                 # required lowercase slug; .Task.Fields key
+    label: Ticket                # optional presentation label
+    description: Issue tracker key.
+    type: string                 # string (default) | integer | number | boolean
+    required: true               # default false
+    pattern: '^OPS-[0-9]+$'      # optional Go RE2 expression; string only
+```
+
+- `integer` is a base-10 whole number, `number` is a finite decimal, and
+  `boolean` is exactly `true` or `false`. A `pattern` is compiled when the workflow loads;
+  authors use `^` and `$` when the whole value must match.
+- Names are unique within the list. A missing type becomes `string`; a missing
+  `required` becomes false. An optional absent or empty value is valid.
+- `POST /v1/tasks` is the authoritative validation boundary. A required,
+  mistyped, or pattern-mismatched declared value is a 400 before any task is
+  inserted. The TUI mirrors the pure checks to place feedback on its Fields row.
+- The map deliberately stays **open**: additional names not declared by the
+  workflow are accepted, recorded, inherited by fan-out lanes, and available to
+  templates exactly as before. Declarations add a public form contract; they do
+  not mean `additionalProperties: false`.
+- Only the selected root workflow owns this contract. Declarations on included
+  workflows or named fan-out lane workflows are not recursively merged. A
+  composing workflow re-declares any input it wants to expose; a lane's own
+  `fields:` map continues to bind internal values.
 
 ### 8.2 Step types and fields
 
@@ -2368,9 +2412,11 @@ DELETE /v1/projects/{id}                hard-deletes the project and its task hi
 
 GET    /v1/workflows?project_id=        merged registry view: built-in + global + that project's
                                         (shadowing applied); each entry:
-                                        { name, scope, project_id, file, description, steps[],
+                                        { name, scope, project_id, file, description, fields[], steps[],
                                           platforms[]?, platform_supported, requires_input,
                                           includes[]?, errors[]?, warnings[]?, error? }
+                                        fields is the ordered §8.1.2 declaration list; an empty
+                                        list means the workflow publishes no task-input contract
                                         platform_supported is this daemon's own verdict on the
                                         entry's §8.1.1 restriction (task 010, added 2026-08-16);
                                         requires_input marks an entry whose §7.4 `require` steps
@@ -2386,7 +2432,7 @@ GET    /v1/workflows/definition         one workflow's whole recursive structure
                                         { name, scope, project_id, file, platforms[]?,
                                           platform_supported, requires_input, errors[]?,
                                           warnings[]?, error?, definition }
-                                        definition is { name, description, platforms[]?,
+                                        definition is { name, description, platforms[]?, fields[],
                                         defaults, steps[] }, each step carrying every field its
                                         type uses plus nested `steps`, fan-out `lanes`, `merge`,
                                         guards and loop drivers. Steps are reported **as
@@ -2461,6 +2507,9 @@ POST   /v1/tasks                        { project_id, workflow, title, descripti
                                         task-level override (§8.6), validated per §8.2 —
                                         known-invalid = 400, catalog-unknown values are
                                         reported in `warnings[]` on the 201 body
+                                        The selected root workflow's §8.1.2 declarations are
+                                        validated before insert. Additional, undeclared field
+                                        names remain accepted and are recorded on the task
 GET    /v1/tasks/{id}                   full task incl. step runs summary and pending_input (§7.4).
                                         Every task representation carries `available_actions`
                                         (the §6 human actions valid right now) and
@@ -2768,10 +2817,16 @@ stream for the live tail.
    itself with a badge on the row and a footer hint, and the human opens it.
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
-   `$EDITOR`) → custom fields (key/value) → base branch (default prefilled) →
+   `$EDITOR`) → fields → base branch (default prefilled) →
    priority → optional agent/model/effort override (pickers fed by
    `GET /v1/agents` with provenance-tagged options and free-text entry;
    replaces workflow defaults, never explicit step fields, §8.6) → create.
+   **Workflow fields (task 022, added 2026-08-21):** selecting a workflow
+   pre-renders its ordered §8.1.2 declarations with labels, descriptions,
+   type/required badges, pattern help, and a boolean toggle. Declared names are
+   locked but their values remain editable; additional custom key/value rows can
+   still be added and deleted. Values survive workflow switches, and local
+   feedback mirrors the daemon's authoritative create-time validation.
    **Pickers are windowed and type-filterable (M5, §9.7):** through v1 every
    catalog fit on a screen (claude: 3 models, 5 efforts; codex: efforts only),
    so the picker rendered all options unconditionally. Cursor's ~180-model

--- a/docs/tasks/022-workflow-fields.md
+++ b/docs/tasks/022-workflow-fields.md
@@ -1,0 +1,118 @@
+# 022 — Workflow-declared task fields
+
+**Status:** ⚠ verification blocked (6/7) · **Opened:** 2026-08-21
+
+Task fields were previously only a free-form `map[string]string`. That is
+useful for ad-hoc metadata, but a workflow could not tell a client which values
+it expected before the task was created. This task adds an additive field contract
+to workflow YAML, renders that contract in New task, and keeps the daemon as the
+authoritative validation boundary.
+
+## Decisions
+
+### 1. Declarations are an ordered list and values remain strings
+
+*2026-08-21.* A workflow declares `fields:` as an ordered list of definitions
+with `name`, optional `label` and `description`, `type`, `required`, and an
+optional string `pattern`. The declared order is the form order. Task storage,
+the REST body, `.Task.Fields`, branch templates, and lane inheritance remain
+`map[string]string`; the type is a validation and editing contract, not a new
+runtime value system.
+
+**Beat:** changing task fields to heterogeneous JSON values. That would break
+existing templates, snapshots, branch-name inputs, API clients, and persisted
+tasks for no execution benefit.
+
+### 2. The first type vocabulary is string, integer, number, and boolean
+
+*2026-08-21.* `string` is the default. Integers are base-10 whole numbers,
+numbers are finite decimal values, and booleans are exactly `true` or `false`.
+`pattern` is a Go RE2 expression and belongs only to strings; it is compiled at
+workflow load so a broken expression makes the workflow visibly invalid.
+
+**Beat:** an open-ended type name plus a regex for every field. A small enum
+gives the TUI meaningful controls and gives every client identical validation;
+regex remains the escape hatch for domain-specific strings.
+
+### 3. Declared fields do not close the existing map
+
+*2026-08-21.* Additional, undeclared fields remain accepted, recorded on the
+task, inherited by lanes, and available to templates exactly as before. The TUI
+keeps its add/delete route for those custom pairs. Only declared fields receive
+required, type, and pattern validation.
+
+**Beat:** treating the presence of `fields:` as `additionalProperties: false`.
+That would make adding form guidance a breaking change for existing scripts and
+metadata conventions.
+
+### 4. The selected root workflow owns the public field contract
+
+*2026-08-21.* Declarations apply when that workflow is selected for task
+creation. Included workflows and named fan-out lanes do not implicitly merge
+their declarations into the caller. A composing workflow re-declares inputs it
+exposes; lane `fields:` continues to bind internal values.
+
+**Beat:** recursively unioning contracts. Lane-provided values and two
+workflows declaring the same name with different types or patterns make that
+union ambiguous; the root is the one stable public boundary the human picked.
+
+### 5. The daemon validates; clients may validate for placement and speed
+
+*2026-08-21.* `POST /v1/tasks` validates the selected workflow's declarations
+before anything is inserted. The TUI performs the same pure validation locally
+so an error stays on the Fields row, but the server check is the gate for the
+CLI, curl, older clients, and races with workflow reload.
+
+**Beat:** validating only in New task. Vincent's clients are intentionally thin
+and interchangeable; a TUI-only constraint would not be a workflow contract.
+
+## Work
+
+- [x] **022.1 — Add and validate the workflow field schema.** ✓ 2026-08-21
+  Done when strict YAML decoding accepts the ordered definitions, structural
+  mistakes carry source paths, and valid workflows expose a pure task-field
+  validator.
+- [x] **022.2 — Publish and enforce the contract through the API.** ✓ 2026-08-21
+  Depends: 022.1. Done when `GET /v1/workflows` carries definitions and
+  `POST /v1/tasks` rejects missing, mistyped, or pattern-mismatched declared
+  values without rejecting extra fields.
+- [x] **022.3 — Pre-render declared fields in New task.** ✓ 2026-08-21
+  Depends: 022.2. Done when selected workflows seed ordered, locked field names,
+  required/type/help text is visible, booleans use a selector, shared values
+  survive workflow switches, and custom rows still work.
+- [x] **022.4 — Accept fields from the CLI.** ✓ 2026-08-21
+  Depends: 022.2. Done when repeatable `vincent task add --field name=value`
+  sends both declared and additional fields and reports daemon validation.
+- [x] **022.5 — Cover the schema, API, TUI, and CLI.** ✓ 2026-08-21
+  Depends: 022.1–022.4. Done when focused tests cover valid and invalid
+  definitions, authoritative task creation, form rendering/switching, and CLI
+  transport including additional fields.
+- [x] **022.6 — Amend the spec and user documentation.** ✓ 2026-08-21
+  Depends: 022.1–022.5. Done when the workflow schema, API, CLI, workflow guide,
+  and TUI guide describe the shipped contract and its open-map compatibility.
+- [!] **022.7 — Run repository verification and review the final diff.**
+  Depends: 022.1–022.6. Done only when formatting, tests, race tests, lint,
+  cross-platform builds, and the relevant manual TUI walkthrough have actually
+  run; unavailable checks remain explicitly blocked.
+  **Blocked 2026-08-21:** this managed workspace cannot report process start
+  times even for its own PID, so the full and full-race suites fail only in
+  `internal/procx` and the two downstream `internal/taskrun` recovery tests.
+  It also cannot provide the human terminal needed to grade a manual TUI
+  walkthrough; the focused render and navigation tests pass.
+
+## Verification
+
+- `go run mage.go build` — pass (2026-08-21).
+- `go test ./internal/workflow ./internal/api ./internal/apiclient ./internal/tui ./internal/cli` — pass (2026-08-21).
+- `go test -race ./internal/workflow ./internal/api ./internal/apiclient ./internal/tui ./internal/cli` — pass (2026-08-21).
+- `go run mage.go lint` plus host-built lint with `GOOS=linux`, `darwin`, and
+  `windows` — pass, zero findings (2026-08-21).
+- `go build ./...` with `GOOS=linux`, `darwin`, and `windows` — pass
+  (2026-08-21).
+- `go run mage.go test` and `go run mage.go testrace` — all packages pass
+  except `internal/procx` (`StartTime(self): process not found`) and the two
+  `internal/taskrun` orphan-recovery tests that depend on that process lookup;
+  blocked by the workspace process environment (2026-08-21).
+- Focused TUI render, editing, workflow-switch, validation, and daemon-error
+  routing tests — pass; a human visual walkthrough is unavailable in this
+  workspace (2026-08-21).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -36,6 +36,7 @@ description of how the system actually behaves.
 | [019](019-workflow-includes.md) | Including one workflow in another (`type: include`) | ✅ done (10/10) |
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
+| [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
 
 ## How to add and update a task document
 

--- a/internal/api/fields_test.go
+++ b/internal/api/fields_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+const declaredFieldsYAML = `name: release
+description: Prepare a release.
+fields:
+  - name: ticket
+    label: Ticket
+    description: Issue tracker key.
+    required: true
+    pattern: '^OPS-[0-9]+$'
+  - name: retries
+    type: integer
+  - name: ratio
+    type: number
+  - name: dry-run
+    type: boolean
+steps:
+  - {id: approve, type: manual, instructions: review}
+`
+
+func TestWorkflowEndpointsExposeDeclaredFields(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "release", declaredFieldsYAML)
+	h.reg.ReloadGlobal()
+
+	_, body := h.doJSON(t, http.MethodGet, "/v1/workflows", nil)
+	var listed struct {
+		Workflows []workflowResponse `json:"workflows"`
+	}
+	if err := json.Unmarshal(body, &listed); err != nil {
+		t.Fatalf("workflow list: %v (%s)", err, body)
+	}
+	var fields []workflowFieldResponse
+	for _, entry := range listed.Workflows {
+		if entry.Name == "release" {
+			fields = entry.Fields
+		}
+	}
+	if len(fields) != 4 || fields[0].Name != "ticket" || fields[0].Type != "string" ||
+		!fields[0].Required || fields[0].Pattern != `^OPS-[0-9]+$` {
+		t.Fatalf("list fields = %+v", fields)
+	}
+
+	_, body = h.definition(t, "release", 0)
+	definition := decodeDefinition(t, body).Definition
+	if definition == nil || len(definition.Fields) != 4 {
+		t.Fatalf("definition fields = %+v", definition)
+	}
+	if definition.Fields[1].Name != "retries" || definition.Fields[1].Type != "integer" {
+		t.Errorf("second definition field = %+v", definition.Fields[1])
+	}
+}
+
+func TestTaskCreateValidatesDeclaredFieldsAndKeepsAdditionalFields(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "release", declaredFieldsYAML)
+	h.reg.ReloadGlobal()
+	repo := testrepo.Init(t, "main")
+	project := h.mustCreate(t, map[string]any{"path": repo})
+	projectID := int64(project["id"].(float64))
+
+	tests := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{"missing required", nil, `field \"ticket\" is required`},
+		{"pattern", map[string]string{"ticket": "BUG-4"}, "must match pattern"},
+		{"integer", map[string]string{"ticket": "OPS-4", "retries": "many"}, "base-10 integer"},
+		{"number", map[string]string{"ticket": "OPS-4", "ratio": "0x1p2"}, "finite decimal number"},
+		{"boolean", map[string]string{"ticket": "OPS-4", "dry-run": "yes"}, "true or false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+				"project_id": projectID,
+				"workflow":   "release",
+				"title":      "invalid " + tt.name,
+				"fields":     tt.fields,
+			})
+			wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+			if !strings.Contains(string(body), tt.want) {
+				t.Errorf("body %s missing %q", body, tt.want)
+			}
+		})
+	}
+
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": projectID,
+		"workflow":   "release",
+		"title":      "valid release",
+		"fields": map[string]string{
+			"ticket": "OPS-42", "retries": "3", "dry-run": "false",
+			"owner": "alice", // not declared: the task field map remains open
+		},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d %s", resp.StatusCode, body)
+	}
+	var created taskResponse
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("created task: %v (%s)", err, body)
+	}
+
+	resp, body = h.doJSON(t, http.MethodGet, "/v1/tasks/"+strconv.FormatInt(created.ID, 10), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: %d %s", resp.StatusCode, body)
+	}
+	var stored taskResponse
+	if err := json.Unmarshal(body, &stored); err != nil {
+		t.Fatalf("stored task: %v (%s)", err, body)
+	}
+	if stored.Fields["owner"] != "alice" || stored.Fields["ticket"] != "OPS-42" {
+		t.Errorf("stored fields = %v; declared and additional fields must both survive", stored.Fields)
+	}
+}
+
+func TestTaskCreateUsesOnlyTheSelectedWorkflowFieldContract(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "internal", `name: internal
+fields:
+  - {name: secret, required: true}
+steps:
+  - {id: work, type: manual, instructions: review}
+`)
+	writeWorkflowFile(t, h.globalDir, "include-root", `name: include-root
+steps:
+  - {id: nested, type: include, workflow: internal}
+`)
+	writeWorkflowFile(t, h.globalDir, "fanout-root", `name: fanout-root
+steps:
+  - id: spread
+    type: fan_out
+    lanes:
+      - {id: child, workflow: internal}
+`)
+	h.reg.ReloadGlobal()
+	projectID := fanOutProject(t, h)
+
+	for _, name := range []string{"include-root", "fanout-root"} {
+		t.Run(name, func(t *testing.T) {
+			resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+				"project_id": projectID,
+				"workflow":   name,
+				"title":      "run " + name,
+			})
+			if resp.StatusCode != http.StatusCreated {
+				t.Fatalf("create: %d %s; nested declarations must not leak into the root contract",
+					resp.StatusCode, body)
+			}
+		})
+	}
+}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -374,6 +374,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("workflow %q cannot run here: %s", workflowName, mismatch))
 		return
 	}
+	// Workflow-declared fields (§8.1.2, task 022) are a contract on the
+	// selected root workflow. The map remains open: ValidateTaskFields checks
+	// only names the workflow declared, so existing custom metadata continues
+	// to pass through and be snapshotted on the task unchanged.
+	if fieldErrs := entry.Workflow.ValidateTaskFields(req.Fields); len(fieldErrs) > 0 {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, fieldErrs.Error())
+		return
+	}
 	baseBranch := project.DefaultBranch
 	if req.BaseBranch != nil && strings.TrimSpace(*req.BaseBranch) != "" {
 		baseBranch = strings.TrimSpace(*req.BaseBranch)

--- a/internal/api/workflowdef.go
+++ b/internal/api/workflowdef.go
@@ -55,11 +55,12 @@ type workflowDefinitionResponse struct {
 
 // workflowDefinition is the workflow itself, as the file declares it.
 type workflowDefinition struct {
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	Platforms   []string          `json:"platforms,omitempty"`
-	Defaults    workflowDefaults  `json:"defaults"`
-	Steps       []workflowStepDef `json:"steps"`
+	Name        string                  `json:"name"`
+	Description string                  `json:"description,omitempty"`
+	Platforms   []string                `json:"platforms,omitempty"`
+	Fields      []workflowFieldResponse `json:"fields"`
+	Defaults    workflowDefaults        `json:"defaults"`
+	Steps       []workflowStepDef       `json:"steps"`
 }
 
 // workflowDefaults is the §8.1 defaults block, kept separate from the steps
@@ -221,6 +222,7 @@ func toWorkflowDefinition(wf *workflow.Workflow) *workflowDefinition {
 		Name:        wf.Name,
 		Description: wf.Description,
 		Platforms:   wf.Platforms,
+		Fields:      toWorkflowFieldResponses(wf.Fields),
 		Defaults: workflowDefaults{
 			Agent:          wf.Defaults.Agent,
 			Model:          wf.Defaults.Model,

--- a/internal/api/workflowdef_test.go
+++ b/internal/api/workflowdef_test.go
@@ -325,6 +325,7 @@ func TestWorkflowDefinitionCoversEveryField(t *testing.T) {
 		dto   any
 	}{
 		{"Workflow", workflow.Workflow{}, workflowDefinition{}},
+		{"FieldDefinition", workflow.FieldDefinition{}, workflowFieldResponse{}},
 		{"Defaults", workflow.Defaults{}, workflowDefaults{}},
 		{"Step", workflow.Step{}, workflowStepDef{}},
 		{"Lane", workflow.Lane{}, workflowLaneDef{}},

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -13,12 +13,13 @@ import (
 // workflowResponse is one registry entry (spec §13.2). A broken file is
 // listed with its errors instead of being hidden, so the TUI can show it.
 type workflowResponse struct {
-	Name        string                 `json:"name"`
-	Scope       string                 `json:"scope"`
-	ProjectID   *int64                 `json:"project_id"`
-	File        string                 `json:"file,omitempty"`
-	Description string                 `json:"description"`
-	Steps       []workflowStepResponse `json:"steps"`
+	Name        string                  `json:"name"`
+	Scope       string                  `json:"scope"`
+	ProjectID   *int64                  `json:"project_id"`
+	File        string                  `json:"file,omitempty"`
+	Description string                  `json:"description"`
+	Fields      []workflowFieldResponse `json:"fields"`
+	Steps       []workflowStepResponse  `json:"steps"`
 	// Platforms is the §8.1.1 restriction as the file declares it; empty
 	// means the workflow runs anywhere. PlatformSupported is the daemon's verdict
 	// on its own host — the client never re-derives it, because the daemon is
@@ -42,6 +43,15 @@ type workflowResponse struct {
 	Error    *string          `json:"error"`
 }
 
+type workflowFieldResponse struct {
+	Name        string `json:"name"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Pattern     string `json:"pattern,omitempty"`
+}
+
 type workflowStepResponse struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
@@ -54,6 +64,7 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 		Name:              e.Name,
 		Scope:             string(e.Scope),
 		File:              e.File,
+		Fields:            []workflowFieldResponse{},
 		Steps:             []workflowStepResponse{},
 		PlatformSupported: e.RunsHere(),
 		RequiresInput:     e.NeedsInputAgent(),
@@ -66,6 +77,7 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 	if e.Workflow != nil {
 		out.Description = e.Workflow.Description
 		out.Platforms = e.Workflow.Platforms
+		out.Fields = toWorkflowFieldResponses(e.Workflow.Fields)
 		for _, st := range e.Workflow.Steps {
 			out.Steps = append(out.Steps, workflowStepResponse{
 				ID:    st.ID,
@@ -82,6 +94,21 @@ func toWorkflowResponse(e workflow.Entry) workflowResponse {
 	}
 	if len(e.Warnings) > 0 {
 		out.Warnings = e.Warnings
+	}
+	return out
+}
+
+func toWorkflowFieldResponses(fields []workflow.FieldDefinition) []workflowFieldResponse {
+	out := make([]workflowFieldResponse, 0, len(fields))
+	for _, field := range fields {
+		out = append(out, workflowFieldResponse{
+			Name:        field.Name,
+			Label:       field.Label,
+			Description: field.Description,
+			Type:        field.Type,
+			Required:    field.Required,
+			Pattern:     field.Pattern,
+		})
 	}
 	return out
 }

--- a/internal/apiclient/newtask_test.go
+++ b/internal/apiclient/newtask_test.go
@@ -34,6 +34,11 @@ import (
 // claude at the fakeagent binary and codex at a path that does not exist.
 const validWorkflow = `name: two-step
 description: Implement then publish.
+fields:
+  - name: ticket
+    label: Ticket
+    type: string
+    pattern: '^OPS-[0-9]+$'
 defaults:
   agent: claude
 steps:
@@ -182,6 +187,10 @@ func TestListWorkflowsKeepsBrokenEntriesVisible(t *testing.T) {
 	}
 	if good.Description != "Implement then publish." {
 		t.Errorf("Description = %q", good.Description)
+	}
+	if len(good.Fields) != 1 || good.Fields[0].Name != "ticket" ||
+		good.Fields[0].DisplayLabel() != "Ticket" || good.Fields[0].Pattern != `^OPS-[0-9]+$` {
+		t.Errorf("Fields = %+v, want the declared ticket contract", good.Fields)
 	}
 	if len(good.Steps) != 2 {
 		t.Fatalf("steps = %d, want 2", len(good.Steps))

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -14,13 +14,14 @@ import (
 // integration-tested against the real handlers, so drift cannot ship
 // unnoticed, and the API package keeps its DTOs unexported.
 type Task struct {
-	ID          int64  `json:"id"`
-	ProjectID   int64  `json:"project_id"`
-	ProjectName string `json:"project_name"`
-	Title       string `json:"title"`
-	Workflow    string `json:"workflow"`
-	State       string `json:"state"`
-	Priority    int    `json:"priority"`
+	ID          int64             `json:"id"`
+	ProjectID   int64             `json:"project_id"`
+	ProjectName string            `json:"project_name"`
+	Title       string            `json:"title"`
+	Fields      map[string]string `json:"fields,omitempty"`
+	Workflow    string            `json:"workflow"`
+	State       string            `json:"state"`
+	Priority    int               `json:"priority"`
 
 	// CurrentStep is zero-based; StepTotal is the snapshot's step count.
 	// A board renders them as k/n with k = CurrentStep+1, clamped, because

--- a/internal/apiclient/workflowdef.go
+++ b/internal/apiclient/workflowdef.go
@@ -37,6 +37,7 @@ type WorkflowBody struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description,omitempty"`
 	Platforms   []string          `json:"platforms,omitempty"`
+	Fields      []WorkflowField   `json:"fields"`
 	Defaults    WorkflowDefaults  `json:"defaults"`
 	Steps       []WorkflowStepDef `json:"steps"`
 }

--- a/internal/apiclient/workflowdef_live_test.go
+++ b/internal/apiclient/workflowdef_live_test.go
@@ -27,6 +27,11 @@ import (
 
 const laneYAML = `name: shipit
 description: fan out and merge
+fields:
+  - name: environment
+    label: Environment
+    type: string
+    required: true
 defaults:
   agent: claude
   model: sonnet
@@ -109,6 +114,10 @@ func TestGetWorkflowDefinitionOverTheWire(t *testing.T) {
 	}
 	if body.Defaults.Agent != "claude" || body.Defaults.Model != "sonnet" {
 		t.Errorf("defaults = %+v, want the authored block", body.Defaults)
+	}
+	if len(body.Fields) != 1 || body.Fields[0].Name != "environment" ||
+		body.Fields[0].DisplayLabel() != "Environment" || !body.Fields[0].Required {
+		t.Errorf("fields = %+v, want the authored input contract", body.Fields)
 	}
 	if len(body.Steps) != 3 {
 		t.Fatalf("steps = %d, want 3", len(body.Steps))

--- a/internal/apiclient/workflows.go
+++ b/internal/apiclient/workflows.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+// Workflow field types as GET /v1/workflows reports them (§8.1.2).
+const (
+	WorkflowFieldString  = "string"
+	WorkflowFieldInteger = "integer"
+	WorkflowFieldNumber  = "number"
+	WorkflowFieldBoolean = "boolean"
+)
+
 // WorkflowEntry is one row of GET /v1/workflows (§13.2): the merged registry
 // with §5.2 shadowing already applied. A file that failed to parse is listed
 // with its Errors rather than omitted, so a picker can show the human what
@@ -17,6 +25,7 @@ type WorkflowEntry struct {
 	ProjectID   *int64              `json:"project_id"`
 	File        string              `json:"file,omitempty"`
 	Description string              `json:"description"`
+	Fields      []WorkflowField     `json:"fields"`
 	Steps       []WorkflowEntryStep `json:"steps"`
 
 	// Platforms is the workflow's §8.1.1 platform restriction, empty when it
@@ -41,6 +50,26 @@ type WorkflowEntry struct {
 	// Warnings are non-fatal §8.2 catalog findings; the entry stays valid.
 	Warnings []WorkflowFinding `json:"warnings,omitempty"`
 	Error    *string           `json:"error"`
+}
+
+// WorkflowField is one ordered public task input declared by a workflow
+// (§8.1.2, task 022). Values remain strings; Type tells a client how to edit
+// and validate a declared name. Additional task fields are still accepted.
+type WorkflowField struct {
+	Name        string `json:"name"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Pattern     string `json:"pattern,omitempty"`
+}
+
+// DisplayLabel is the presentation label, falling back to the field name.
+func (f WorkflowField) DisplayLabel() string {
+	if f.Label != "" {
+		return f.Label
+	}
+	return f.Name
 }
 
 // WorkflowEntryStep is one step as the registry reports it. Agent is the

--- a/internal/cli/commands_e2e_test.go
+++ b/internal/cli/commands_e2e_test.go
@@ -77,21 +77,26 @@ func TestCommandsAgainstLiveDaemon(t *testing.T) {
 	t.Run("task add ls show cancel", func(t *testing.T) {
 		out, code := runVincent(t, dataDir, cfgDir,
 			"task", "add", "--project", "1", "--title", "cli e2e task",
-			"--description", "created by the CLI test", "--json")
+			"--description", "created by the CLI test",
+			"--field", "ticket=OPS-42", "--field", "url=https://example.test/?a=b", "--json")
 		if code != 0 {
 			t.Fatalf("task add: code %d, out %q", code, out)
 		}
 		var created struct {
-			ID         int64  `json:"id"`
-			Title      string `json:"title"`
-			BranchName string `json:"branch_name"`
-			State      string `json:"state"`
+			ID         int64             `json:"id"`
+			Title      string            `json:"title"`
+			BranchName string            `json:"branch_name"`
+			State      string            `json:"state"`
+			Fields     map[string]string `json:"fields"`
 		}
 		if err := json.Unmarshal([]byte(out), &created); err != nil {
 			t.Fatalf("task add --json is not JSON: %v (%q)", err, out)
 		}
 		if created.ID == 0 || created.Title != "cli e2e task" || created.BranchName == "" {
 			t.Fatalf("created task = %+v, want id, title and branch", created)
+		}
+		if created.Fields["ticket"] != "OPS-42" || created.Fields["url"] != "https://example.test/?a=b" {
+			t.Fatalf("created fields = %v, want both --field values", created.Fields)
 		}
 		taskID = strconv.FormatInt(created.ID, 10)
 

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -32,14 +32,19 @@ func newTaskAddCmd() *cobra.Command {
 		agent       string
 		model       string
 		effort      string
+		fields      []string
 	)
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Create a task",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			fieldMap, err := parseFieldFlags(fields)
+			if err != nil {
+				return err
+			}
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
-				req := apiclient.CreateTaskRequest{ProjectID: projectID, Title: title}
+				req := apiclient.CreateTaskRequest{ProjectID: projectID, Title: title, Fields: fieldMap}
 				for _, f := range []struct {
 					name string
 					dst  **string
@@ -97,10 +102,31 @@ func newTaskAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&agent, "agent", "", "Agent override (§8.6 level 2)")
 	cmd.Flags().StringVar(&model, "model", "", "Model override (§8.6 level 2)")
 	cmd.Flags().StringVar(&effort, "effort", "", "Effort override (§8.6 level 2)")
+	cmd.Flags().StringArrayVar(&fields, "field", nil,
+		"Task field as name=value; repeat for additional fields")
 	_ = cmd.MarkFlagRequired("project")
 	_ = cmd.MarkFlagRequired("title")
 	jsonFlag(cmd)
 	return cmd
+}
+
+// parseFieldFlags preserves everything after the first '=' so URLs, regexes,
+// and other structured values do not need CLI-specific escaping. A repeated
+// name follows the task field editor's existing rule: the later value wins.
+func parseFieldFlags(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	fields := make(map[string]string, len(values))
+	for _, value := range values {
+		name, fieldValue, ok := strings.Cut(value, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("field must be name=value, got %q", value)
+		}
+		fields[name] = fieldValue
+	}
+	return fields, nil
 }
 
 func newTaskLsCmd() *cobra.Command {

--- a/internal/cli/task_fields_test.go
+++ b/internal/cli/task_fields_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFieldFlags(t *testing.T) {
+	got, err := parseFieldFlags([]string{
+		"ticket=OPS-42",
+		"url=https://example.test/?a=b",
+		"ticket=OPS-43",
+	})
+	if err != nil {
+		t.Fatalf("parseFieldFlags: %v", err)
+	}
+	want := map[string]string{
+		"ticket": "OPS-43", // later values win
+		"url":    "https://example.test/?a=b",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("fields = %v, want %v", got, want)
+	}
+
+	for _, value := range []string{"ticket", "=value", "  =value"} {
+		if _, err := parseFieldFlags([]string{value}); err == nil {
+			t.Errorf("parseFieldFlags(%q) succeeded", value)
+		}
+	}
+}

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -97,9 +97,14 @@ type (
 	ntFailedMsg struct{ err error }
 )
 
-// kv is one custom field. Order is preserved so a human sees the rows where
-// they left them; the wire format is a map.
-type kv struct{ key, value string }
+// kv is one task field row. A declared row carries the workflow's presentation
+// and validation contract; a custom row leaves declared false. Both flatten to
+// the same open map on the wire (task 022 decision 3).
+type kv struct {
+	key, value string
+	declared   bool
+	definition apiclient.WorkflowField
+}
 
 // newTask is the §15 new-task flow.
 type newTask struct {
@@ -496,6 +501,7 @@ func (n *newTask) setProject(p apiclient.Project) {
 // the first valid entry — the same fallback handleTaskCreate applies.
 func (n *newTask) selectDefaultWorkflow() {
 	if n.workflow != "" && n.workflowEntry(n.workflow) != nil {
+		n.syncWorkflowFields()
 		return
 	}
 	p, ok := n.project()
@@ -504,16 +510,54 @@ func (n *newTask) selectDefaultWorkflow() {
 		want = p.Workflow()
 	}
 	if e := n.workflowEntry(want); e != nil {
-		n.workflow = e.Name
+		n.setWorkflow(e.Name)
 		return
 	}
 	for _, e := range n.workflows {
 		if e.Valid() && e.RunsHere() {
-			n.workflow = e.Name
+			n.setWorkflow(e.Name)
 			return
 		}
 	}
-	n.workflow = ""
+	n.setWorkflow("")
+}
+
+func (n *newTask) setWorkflow(name string) {
+	n.workflow = name
+	n.syncWorkflowFields()
+}
+
+// syncWorkflowFields rebuilds the declared prefix from the selected workflow
+// while preserving every value already typed. Non-empty rows no longer
+// declared become ordinary custom fields instead of being discarded; untouched
+// declaration chrome disappears. A custom row whose name the new workflow
+// declares becomes that locked declared row (task 022).
+func (n *newTask) syncWorkflowFields() {
+	values := make(map[string]string, len(n.fields))
+	for _, field := range n.fields {
+		values[field.key] = field.value
+	}
+
+	entry := n.workflowEntry(n.workflow)
+	declared := map[string]bool{}
+	out := make([]kv, 0, len(n.fields))
+	if entry != nil && entry.Valid() {
+		out = make([]kv, 0, len(entry.Fields)+len(n.fields))
+		for _, definition := range entry.Fields {
+			declared[definition.Name] = true
+			out = append(out, kv{
+				key: definition.Name, value: values[definition.Name],
+				declared: true, definition: definition,
+			})
+		}
+	}
+	for _, field := range n.fields {
+		if field.key == "" || declared[field.key] || (field.declared && field.value == "") {
+			continue
+		}
+		out = append(out, kv{key: field.key, value: field.value})
+	}
+	n.fields = out
 }
 
 func (n *newTask) project() (apiclient.Project, bool) {
@@ -744,6 +788,9 @@ func (n *newTask) submit() tea.Cmd {
 	if n.titleText() == "" {
 		n.rowErr[ntTitle] = "a title is required"
 	}
+	if message := n.firstFieldError(); message != "" {
+		n.rowErr[ntFields] = message
+	}
 	if e := n.workflowEntry(n.workflow); n.workflow != "" && e != nil {
 		switch {
 		case !e.Valid():
@@ -762,6 +809,15 @@ func (n *newTask) submit() tea.Cmd {
 		}
 	}
 	if len(n.rowErr) > 0 {
+		// In the guided layout only the cursor's stage is visible. Move to the
+		// first invalid row so a required workflow field cannot fail submit on
+		// a different, hidden stage.
+		for row := ntProject; row < ntRowCount; row++ {
+			if _, invalid := n.rowErr[row]; invalid {
+				n.cursor = row
+				break
+			}
+		}
 		return nil
 	}
 	if n.client == nil {
@@ -816,17 +872,22 @@ func (n *newTask) request() apiclient.CreateTaskRequest {
 	return req
 }
 
-// fieldMap flattens the ordered rows. A later duplicate key wins, which is
-// also what the editor shows.
+// fieldMap flattens the ordered rows. Untouched declarations are form chrome,
+// not task data, so they stay absent; an explicitly added custom field keeps
+// its empty value for compatibility. A later duplicate key wins, which is also
+// what the editor shows.
 func (n *newTask) fieldMap() map[string]string {
 	if len(n.fields) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(n.fields))
 	for _, f := range n.fields {
-		if f.key != "" {
+		if f.key != "" && (!f.declared || f.value != "") {
 			out[f.key] = f.value
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }
@@ -841,6 +902,7 @@ func (n *newTask) applyFailure(err error) {
 		needle string
 		row    ntRow
 	}{
+		{"fields.", ntFields},
 		{"base_branch", ntBranch},
 		{"branch", ntBranchName},
 		{"workflow", ntWorkflow},

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -653,6 +653,140 @@ func TestNewTaskFieldsEditorDropsAnAbandonedRow(t *testing.T) {
 	}
 }
 
+func formWithDeclaredFields(t *testing.T) *newTask {
+	t.Helper()
+	n := loadedForm(t)
+	for i := range n.workflows {
+		if n.workflows[i].Name != "two-step" {
+			continue
+		}
+		n.workflows[i].Fields = []apiclient.WorkflowField{
+			{
+				Name: "ticket", Label: "Ticket", Description: "Issue tracker key.",
+				Type: apiclient.WorkflowFieldString, Required: true, Pattern: `^OPS-[0-9]+$`,
+			},
+			{Name: "retries", Type: apiclient.WorkflowFieldInteger},
+			{Name: "dry-run", Label: "Dry run", Type: apiclient.WorkflowFieldBoolean},
+		}
+	}
+	n.setWorkflow("two-step")
+	return n
+}
+
+func TestNewTaskPrerendersWorkflowFields(t *testing.T) {
+	n := formWithDeclaredFields(t)
+	if len(n.fields) != 3 {
+		t.Fatalf("fields = %+v, want the workflow's three declarations", n.fields)
+	}
+	for _, field := range n.fields {
+		if !field.declared {
+			t.Errorf("field = %+v, want a locked declared row", field)
+		}
+	}
+	if got := n.fieldMap(); got != nil {
+		t.Errorf("untouched declarations became task data: %v", got)
+	}
+	if got := n.rowValue(ntFields); !strings.Contains(got, "ticket=") ||
+		!strings.Contains(got, "required") || !strings.Contains(got, "retries=") {
+		t.Errorf("collapsed fields = %q, want required and optional placeholders", got)
+	}
+
+	moveTo(n, ntFields)
+	press(n, "enter")
+	out := n.render(140, 60)
+	for _, want := range []string{
+		"Ticket (ticket)", "string", "required", "Issue tracker key.",
+		"pattern: ^OPS-[0-9]+$", "Dry run", "choose true/false", "add custom",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("field editor is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestNewTaskDeclaredFieldsLockNamesButAllowCustomFields(t *testing.T) {
+	n := formWithDeclaredFields(t)
+	moveTo(n, ntFields)
+	press(n, "enter")
+
+	press(n, "enter") // declared ticket: edit its value, never its key
+	if n.fieldsEd.editing != 2 {
+		t.Fatalf("editing = %d, want the declared value editor", n.fieldsEd.editing)
+	}
+	typeText(n, "OPS-42")
+	press(n, "enter")
+	press(n, "d")
+	if !strings.Contains(n.fieldsEd.err, "cannot be deleted") {
+		t.Errorf("delete error = %q", n.fieldsEd.err)
+	}
+
+	press(n, "down")
+	press(n, "down")
+	press(n, "enter") // boolean declarations toggle instead of opening text
+	if got := n.fieldsEd.rows[2].value; got != "true" {
+		t.Errorf("boolean = %q, want true after the first toggle", got)
+	}
+	press(n, "enter")
+	press(n, "enter")
+	if got := n.fieldsEd.rows[2].value; got != "" {
+		t.Errorf("optional boolean = %q after three toggles, want unset", got)
+	}
+	press(n, "enter") // leave true for the request assertion below
+	addField(n, "owner", "ana")
+	press(n, "esc")
+	if got := n.fieldMap(); got["ticket"] != "OPS-42" || got["dry-run"] != "true" || got["owner"] != "ana" {
+		t.Errorf("fields = %v, want declared values plus the custom field", got)
+	}
+}
+
+func TestNewTaskWorkflowSwitchPreservesFieldValues(t *testing.T) {
+	n := formWithDeclaredFields(t)
+	n.fields[0].value = "OPS-42"
+	n.fields = append(n.fields, kv{key: "owner", value: "ana"})
+
+	n.setWorkflow("adhoc")
+	if len(n.fields) != 2 || n.fields[0].declared {
+		t.Fatalf("fields after adhoc = %+v; typed values should become custom, while untouched declarations disappear", n.fields)
+	}
+	n.setWorkflow("two-step")
+	if len(n.fields) != 4 || !n.fields[0].declared || n.fields[0].value != "OPS-42" {
+		t.Fatalf("fields after switching back = %+v", n.fields)
+	}
+	if n.fields[3].key != "owner" || n.fields[3].declared {
+		t.Errorf("additional field after switching = %+v", n.fields[3])
+	}
+}
+
+func TestNewTaskValidatesDeclaredFieldsBeforeSubmit(t *testing.T) {
+	n := formWithDeclaredFields(t)
+	n.projectID = 1
+	n.titleIn.SetValue("release")
+	n.client = nil
+	if cmd := n.submit(); cmd != nil {
+		t.Fatal("submit posted a task with a missing required field")
+	}
+	if got := n.rowErr[ntFields]; !strings.Contains(got, "Ticket is required") {
+		t.Errorf("fields row error = %q", got)
+	}
+	if n.cursor != ntFields {
+		t.Errorf("cursor = %v, want the fields row", n.cursor)
+	}
+}
+
+func TestNewTaskParksDaemonFieldErrorsOnTheFieldsRow(t *testing.T) {
+	n := loadedForm(t)
+	n.update(ntFailedMsg{err: &apiclient.Error{
+		Status: 400, Code: "validation_failed",
+		Message: `fields.ticket: field "ticket" must match pattern "^OPS-[0-9]+$"`,
+	}})
+	if got := n.rowErr[ntFields]; !strings.Contains(got, "fields.ticket") {
+		t.Errorf("fields row error = %q", got)
+	}
+	if n.cursor != ntFields {
+		t.Errorf("cursor = %v, want the fields row", n.cursor)
+	}
+}
+
 func TestNewTaskCapturesInputOnlyWhileTyping(t *testing.T) {
 	n := loadedForm(t)
 	if n.capturesInput() {

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -10,6 +12,8 @@ import (
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
+
+var taskFieldDecimalNumber = regexp.MustCompile(`^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$`)
 
 // pickerOption is one selectable value. note is the dim suffix — a
 // provenance tag, a scope badge, an availability warning — and disabled
@@ -346,11 +350,11 @@ func (n *newTask) applyPick(row ntRow, value string) tea.Cmd {
 		}
 		// The registry is project-scoped (§5.2), so the workflow list and
 		// the selection made from it are both stale now.
-		n.workflow = ""
 		n.workflows = nil
+		n.setWorkflow("")
 		return n.workflowsCmd(id)
 	case ntWorkflow:
-		n.workflow = value
+		n.setWorkflow(value)
 	case ntAgent:
 		if value == n.agent {
 			return nil
@@ -518,21 +522,32 @@ func (n *newTask) updateFields(msg tea.KeyPressMsg) tea.Cmd {
 	case "up", "k":
 		if f.cursor > 0 {
 			f.cursor--
+			f.err = ""
 		}
 	case "down", "j":
 		if f.cursor < len(f.rows)-1 {
 			f.cursor++
+			f.err = ""
 		}
 	case "a":
 		f.rows = append(f.rows, kv{})
 		f.cursor = len(f.rows) - 1
 		f.startEdit(1)
-	case "enter":
+	case "enter", " ", "left", "right":
 		if len(f.rows) > 0 {
-			f.startEdit(1)
+			if f.rows[f.cursor].declared &&
+				f.rows[f.cursor].definition.Type == apiclient.WorkflowFieldBoolean {
+				f.toggleBoolean()
+			} else if msg.String() == "enter" {
+				f.startEdit(1)
+			}
 		}
 	case "d":
 		if len(f.rows) > 0 {
+			if f.rows[f.cursor].declared {
+				f.err = "workflow-declared fields cannot be deleted"
+				return nil
+			}
 			f.rows = append(f.rows[:f.cursor], f.rows[f.cursor+1:]...)
 			if f.cursor >= len(f.rows) {
 				f.cursor = max(0, len(f.rows)-1)
@@ -540,6 +555,7 @@ func (n *newTask) updateFields(msg tea.KeyPressMsg) tea.Cmd {
 		}
 	case "esc":
 		n.commitFields()
+		return n.resolveCmd()
 	}
 	return nil
 }
@@ -547,6 +563,13 @@ func (n *newTask) updateFields(msg tea.KeyPressMsg) tea.Cmd {
 func (f *fieldsEditor) startEdit(which int) {
 	if f.cursor < 0 || f.cursor >= len(f.rows) {
 		return
+	}
+	if f.rows[f.cursor].declared {
+		if f.rows[f.cursor].definition.Type == apiclient.WorkflowFieldBoolean {
+			f.toggleBoolean()
+			return
+		}
+		which = 2 // the workflow owns a declared field's key
 	}
 	f.editing = which
 	f.err = ""
@@ -583,6 +606,9 @@ func (f *fieldsEditor) updateEditing(msg tea.KeyPressMsg) tea.Cmd {
 		f.editing = 0
 		f.input.Blur()
 		f.dedupe()
+		if f.err == "" && f.cursor < len(f.rows) {
+			f.err = fieldValidationMessage(f.rows[f.cursor])
+		}
 		return nil
 	case "esc":
 		f.editing = 0
@@ -592,6 +618,74 @@ func (f *fieldsEditor) updateEditing(msg tea.KeyPressMsg) tea.Cmd {
 	var cmd tea.Cmd
 	f.input, cmd = f.input.Update(msg)
 	return cmd
+}
+
+func (f *fieldsEditor) toggleBoolean() {
+	if f.cursor < 0 || f.cursor >= len(f.rows) {
+		return
+	}
+	switch f.rows[f.cursor].value {
+	case "true":
+		f.rows[f.cursor].value = "false"
+	case "false":
+		if f.rows[f.cursor].definition.Required {
+			f.rows[f.cursor].value = "true"
+		} else {
+			f.rows[f.cursor].value = ""
+		}
+	default:
+		f.rows[f.cursor].value = "true"
+	}
+	f.err = ""
+}
+
+// fieldValidationMessage mirrors the daemon's pure value checks so the TUI
+// can attach immediate feedback to the Fields row. POST /v1/tasks remains the
+// authoritative gate for every client and for workflow reload races.
+func fieldValidationMessage(field kv) string {
+	if !field.declared {
+		return ""
+	}
+	if field.value == "" {
+		if field.definition.Required {
+			return fmt.Sprintf("%s is required", field.definition.DisplayLabel())
+		}
+		return ""
+	}
+	switch field.definition.Type {
+	case apiclient.WorkflowFieldInteger:
+		if _, err := strconv.ParseInt(field.value, 10, 64); err != nil {
+			return fmt.Sprintf("%s must be a base-10 integer", field.definition.DisplayLabel())
+		}
+	case apiclient.WorkflowFieldNumber:
+		value, err := strconv.ParseFloat(field.value, 64)
+		if !taskFieldDecimalNumber.MatchString(field.value) || err != nil ||
+			math.IsInf(value, 0) || math.IsNaN(value) {
+			return fmt.Sprintf("%s must be a finite decimal number", field.definition.DisplayLabel())
+		}
+	case apiclient.WorkflowFieldBoolean:
+		if field.value != "true" && field.value != "false" {
+			return fmt.Sprintf("%s must be true or false", field.definition.DisplayLabel())
+		}
+	case apiclient.WorkflowFieldString:
+		if field.definition.Pattern != "" {
+			pattern, err := regexp.Compile(field.definition.Pattern)
+			if err != nil || !pattern.MatchString(field.value) {
+				return fmt.Sprintf("%s must match %s",
+					field.definition.DisplayLabel(), field.definition.Pattern)
+			}
+		}
+	}
+	return ""
+}
+
+func (n *newTask) firstFieldError() string {
+	for _, field := range n.fields {
+		if message := fieldValidationMessage(field); message != "" {
+			return message
+		}
+	}
+	return ""
 }
 
 // dedupe collapses a repeated key onto the row that already holds it, and

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -288,7 +288,15 @@ func (n *newTask) rowValue(row ntRow) string {
 		}
 		parts := make([]string, 0, len(n.fields))
 		for _, f := range n.fields {
-			parts = append(parts, f.key+"="+f.value)
+			value := f.value
+			if value == "" && f.declared {
+				if f.definition.Required {
+					value = styleBad.Render("(required)")
+				} else {
+					value = styleDim.Render("(optional)")
+				}
+			}
+			parts = append(parts, f.key+"="+value)
 		}
 		return strings.Join(parts, "  ")
 	case ntBranch:
@@ -505,7 +513,7 @@ func (n *newTask) renderWorkflowDetail(name string) []string {
 
 func (n *newTask) renderFields() []string {
 	f := n.fieldsEd
-	out := []string{styleDim.Render("    custom fields — available to templates as .Task.Fields:")}
+	out := []string{styleDim.Render("    task fields — available to templates as .Task.Fields:")}
 	for i, r := range f.rows {
 		marker := "  "
 		if i == f.cursor {
@@ -518,8 +526,32 @@ func (n *newTask) renderFields() []string {
 		if i == f.cursor && f.editing == 2 {
 			value = f.input.View()
 		}
-		out = append(out, "    "+marker+firstNonEmpty(key, styleDim.Render("(key)"))+" = "+
-			firstNonEmpty(value, styleDim.Render("(empty)")))
+		name := firstNonEmpty(key, styleDim.Render("(key)"))
+		meta := ""
+		if r.declared {
+			name = r.definition.DisplayLabel()
+			if name != r.key {
+				name += " (" + r.key + ")"
+			}
+			tags := []string{r.definition.Type}
+			if r.definition.Required {
+				tags = append(tags, "required")
+			}
+			meta = " " + styleDim.Render("["+strings.Join(tags, " · ")+"]")
+		}
+		placeholder := styleDim.Render("(empty)")
+		if r.declared && r.definition.Type == apiclient.WorkflowFieldBoolean {
+			placeholder = styleDim.Render("(choose true/false)")
+		}
+		out = append(out, "    "+marker+name+meta+" = "+firstNonEmpty(value, placeholder))
+		if i == f.cursor && r.declared {
+			if r.definition.Description != "" {
+				out = append(out, styleDim.Render("        "+r.definition.Description))
+			}
+			if r.definition.Pattern != "" {
+				out = append(out, styleDim.Render("        pattern: "+r.definition.Pattern))
+			}
+		}
 	}
 	if len(f.rows) == 0 {
 		out = append(out, styleDim.Render("      none yet"))
@@ -527,7 +559,8 @@ func (n *newTask) renderFields() []string {
 	if f.err != "" {
 		out = append(out, styleWarn.Render("    ⚠ "+f.err))
 	}
-	out = append(out, styleDim.Render("    a add · enter edit · d delete · esc done"))
+	out = append(out, styleDim.Render(
+		"    a add custom · enter edit/toggle · d delete custom · esc done"))
 	return out
 }
 

--- a/internal/workflow/fields.go
+++ b/internal/workflow/fields.go
@@ -1,0 +1,133 @@
+package workflow
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Field types are a validation and editing vocabulary (§8.1.2, task 022).
+// Task fields remain strings in storage, on the wire, and in templates.
+const (
+	FieldString  = "string"
+	FieldInteger = "integer"
+	FieldNumber  = "number"
+	FieldBoolean = "boolean"
+)
+
+var decimalNumber = regexp.MustCompile(`^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$`)
+
+// FieldDefinition is one ordered task input declared by a workflow. Name is
+// the key in .Task.Fields; Label and Description are presentation hints only.
+// Pattern is a Go RE2 expression and belongs only to string fields.
+type FieldDefinition struct {
+	Name        string `yaml:"name" json:"name"`
+	Label       string `yaml:"label,omitempty" json:"label,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Type        string `yaml:"type,omitempty" json:"type"`
+	Required    bool   `yaml:"required,omitempty" json:"required"`
+	Pattern     string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
+}
+
+// DisplayLabel is the human-facing name, falling back to the map key.
+func (f FieldDefinition) DisplayLabel() string {
+	if f.Label != "" {
+		return f.Label
+	}
+	return f.Name
+}
+
+// validateFieldDefinitions checks the declaration itself while the workflow
+// is loading. It also normalizes an omitted type to string so every API client
+// sees one explicit answer rather than re-deriving the default.
+func validateFieldDefinitions(wf *Workflow, add func(string, string, ...any)) {
+	seen := make(map[string]int, len(wf.Fields))
+	for i := range wf.Fields {
+		field := &wf.Fields[i]
+		base := "fields[" + strconv.Itoa(i) + "]"
+		if field.Name == "" {
+			add(base+".name", "field name is required")
+		} else if !isSlug(field.Name) {
+			add(base+".name", "field name %q must be a lowercase slug", field.Name)
+		} else if previous, ok := seen[field.Name]; ok {
+			add(base+".name", "field name %q is already declared at fields[%d]", field.Name, previous)
+		} else {
+			seen[field.Name] = i
+		}
+
+		if field.Type == "" {
+			field.Type = FieldString
+		}
+		if !isFieldType(field.Type) {
+			add(base+".type", "field type must be one of %s, %s, %s, %s; got %q",
+				FieldString, FieldInteger, FieldNumber, FieldBoolean, field.Type)
+		}
+		if field.Pattern == "" {
+			continue
+		}
+		if field.Type != FieldString {
+			add(base+".pattern", "pattern is only valid for string fields")
+			continue
+		}
+		if _, err := regexp.Compile(field.Pattern); err != nil {
+			add(base+".pattern", "pattern does not compile: %v", err)
+		}
+	}
+}
+
+func isFieldType(value string) bool {
+	return value == FieldString || value == FieldInteger || value == FieldNumber || value == FieldBoolean
+}
+
+// ValidateTaskFields validates only declared fields. Additional keys are
+// deliberately ignored and remain part of the task's open field map (decision
+// 3): adding a form contract must not break existing metadata or scripts.
+func (w *Workflow) ValidateTaskFields(values map[string]string) Errors {
+	if w == nil {
+		return nil
+	}
+	var errs Errors
+	for _, field := range w.Fields {
+		value, present := values[field.Name]
+		if !present || strings.TrimSpace(value) == "" {
+			if field.Required {
+				errs = append(errs, Error{
+					Path:    "fields." + field.Name,
+					Message: "field " + strconv.Quote(field.Name) + " is required",
+				})
+			}
+			continue
+		}
+		if message := validateTaskFieldValue(field, value); message != "" {
+			errs = append(errs, Error{Path: "fields." + field.Name, Message: message})
+		}
+	}
+	return errs
+}
+
+func validateTaskFieldValue(field FieldDefinition, value string) string {
+	switch field.Type {
+	case FieldInteger:
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			return "field " + strconv.Quote(field.Name) + " must be a base-10 integer"
+		}
+	case FieldNumber:
+		number, err := strconv.ParseFloat(value, 64)
+		if !decimalNumber.MatchString(value) || err != nil || math.IsInf(number, 0) || math.IsNaN(number) {
+			return "field " + strconv.Quote(field.Name) + " must be a finite decimal number"
+		}
+	case FieldBoolean:
+		if value != "true" && value != "false" {
+			return "field " + strconv.Quote(field.Name) + " must be true or false"
+		}
+	case FieldString:
+		if field.Pattern != "" {
+			pattern, err := regexp.Compile(field.Pattern)
+			if err != nil || !pattern.MatchString(value) {
+				return "field " + strconv.Quote(field.Name) + " must match pattern " + strconv.Quote(field.Pattern)
+			}
+		}
+	}
+	return ""
+}

--- a/internal/workflow/fields_test.go
+++ b/internal/workflow/fields_test.go
@@ -1,0 +1,149 @@
+package workflow
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const fieldsSource = `name: release
+fields:
+  - name: ticket
+    label: Ticket
+    description: Issue tracker key.
+    required: true
+    pattern: '^OPS-[0-9]+$'
+  - name: retries
+    type: integer
+  - name: ratio
+    type: number
+  - name: dry-run
+    type: boolean
+steps:
+  - {id: gate, type: manual, instructions: review}
+`
+
+func TestParseWorkflowFields(t *testing.T) {
+	wf, _, err := Parse([]byte(fieldsSource), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(wf.Fields) != 4 {
+		t.Fatalf("fields = %d, want 4", len(wf.Fields))
+	}
+	first := wf.Fields[0]
+	if first.Name != "ticket" || first.Type != FieldString || !first.Required ||
+		first.Label != "Ticket" || first.Pattern != `^OPS-[0-9]+$` {
+		t.Errorf("first field = %+v", first)
+	}
+	if got := first.DisplayLabel(); got != "Ticket" {
+		t.Errorf("DisplayLabel = %q, want Ticket", got)
+	}
+	if got := wf.Fields[1].DisplayLabel(); got != "retries" {
+		t.Errorf("fallback DisplayLabel = %q, want retries", got)
+	}
+	wantTypes := []string{FieldString, FieldInteger, FieldNumber, FieldBoolean}
+	gotTypes := make([]string, 0, len(wf.Fields))
+	for _, field := range wf.Fields {
+		gotTypes = append(gotTypes, field.Type)
+	}
+	if !reflect.DeepEqual(gotTypes, wantTypes) {
+		t.Errorf("types = %v, want %v", gotTypes, wantTypes)
+	}
+}
+
+func TestWorkflowFieldDefinitionValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   string
+		wantPath string
+		want     string
+	}{
+		{"missing name", "  - {type: string}\n", "fields[0].name", "name is required"},
+		{"name must be slug", "  - {name: Ticket}\n", "fields[0].name", "lowercase slug"},
+		{"duplicate", "  - {name: ticket}\n  - {name: ticket}\n", "fields[1].name", "already declared"},
+		{"unknown type", "  - {name: ticket, type: date}\n", "fields[0].type", "must be one of"},
+		{"pattern only on strings", "  - {name: retries, type: integer, pattern: x}\n", "fields[0].pattern", "only valid for string"},
+		{"bad pattern", "  - {name: ticket, pattern: '[abc'}\n", "fields[0].pattern", "does not compile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "name: x\nfields:\n" + tt.fields +
+				"steps:\n  - {id: gate, type: manual, instructions: review}\n"
+			_, _, err := Parse([]byte(src), Options{})
+			if err == nil {
+				t.Fatal("Parse succeeded")
+			}
+			var errs Errors
+			if !errors.As(err, &errs) {
+				t.Fatalf("error = %T %v, want workflow.Errors", err, err)
+			}
+			found := false
+			for _, got := range errs {
+				if got.Path == tt.wantPath && strings.Contains(got.Message, tt.want) {
+					found = true
+					if got.Line == 0 {
+						t.Errorf("%s has no source line: %+v", tt.wantPath, got)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("errors = %+v, want %s containing %q", errs, tt.wantPath, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowFieldDefinitionRejectsUnknownKeys(t *testing.T) {
+	src := `name: x
+fields:
+  - name: ticket
+    regex: '^OPS-'
+steps:
+  - {id: gate, type: manual, instructions: review}
+`
+	_, _, err := Parse([]byte(src), Options{})
+	if err == nil || !strings.Contains(err.Error(), "regex") {
+		t.Fatalf("Parse error = %v, want the unknown field key", err)
+	}
+}
+
+func TestValidateTaskFields(t *testing.T) {
+	wf, _, err := Parse([]byte(fieldsSource), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{"valid and additional field", map[string]string{
+			"ticket": "OPS-42", "retries": "-2", "ratio": "0.25", "dry-run": "false", "owner": "alice",
+		}, ""},
+		{"required absent", map[string]string{}, `field "ticket" is required`},
+		{"required blank", map[string]string{"ticket": "  "}, `field "ticket" is required`},
+		{"pattern", map[string]string{"ticket": "BUG-42"}, `must match pattern`},
+		{"integer", map[string]string{"ticket": "OPS-1", "retries": "1.5"}, `base-10 integer`},
+		{"number not finite", map[string]string{"ticket": "OPS-1", "ratio": "NaN"}, `finite decimal number`},
+		{"number not decimal", map[string]string{"ticket": "OPS-1", "ratio": "0x1p2"}, `finite decimal number`},
+		{"boolean", map[string]string{"ticket": "OPS-1", "dry-run": "yes"}, `true or false`},
+		{"optional blank skips type check", map[string]string{"ticket": "OPS-1", "retries": ""}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := wf.ValidateTaskFields(tt.values)
+			if tt.want == "" {
+				if len(errs) != 0 {
+					t.Fatalf("ValidateTaskFields = %v, want valid", errs)
+				}
+				return
+			}
+			if len(errs) == 0 || !strings.Contains(errs.Error(), tt.want) {
+				t.Fatalf("ValidateTaskFields = %v, want %q", errs, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -117,8 +117,13 @@ type Workflow struct {
 	// Platforms restricts where the workflow may run (§8.1.1, task 010).
 	// Empty means every platform; see platform.go for the token set.
 	Platforms []string `yaml:"platforms,omitempty"`
-	Defaults  Defaults `yaml:"defaults"`
-	Steps     []Step   `yaml:"steps"`
+	// Fields declares the ordered public task inputs this workflow expects
+	// (§8.1.2, task 022). The task still stores one open map[string]string:
+	// declarations guide clients and validate named values without rejecting
+	// any additional fields a caller supplies.
+	Fields   []FieldDefinition `yaml:"fields,omitempty"`
+	Defaults Defaults          `yaml:"defaults"`
+	Steps    []Step            `yaml:"steps"`
 }
 
 // Defaults are the workflow-level fallbacks for step fields. Pointer fields
@@ -475,6 +480,7 @@ func validate(wf *Workflow, opts Options, loc *locator) (Errors, Errors) {
 		add("name", "name %q must not contain whitespace or path separators", wf.Name)
 	}
 	validatePlatforms(wf, add)
+	validateFieldDefinitions(wf, add)
 	validateDefaults(wf, opts, add)
 
 	if len(wf.Steps) == 0 {


### PR DESCRIPTION
## Summary

- let workflows declare ordered task fields with labels, descriptions, required flags, `string`, `integer`, `number`, and `boolean` types, plus optional Go RE2 patterns
- expose declarations through workflow APIs and validate declared values at task creation while keeping the field map open
- pre-render declared fields in the TUI, preserve editable custom fields, and add repeatable CLI `--field name=value` support
- document the workflow schema, API, CLI, TUI behavior, compatibility contract, and release note

Additional undeclared fields remain accepted, stored, returned by the API, inherited by fan-out lanes, and available to templates.

## Related

Task 022: `docs/tasks/022-workflow-fields.md`

## Verification

- `go run mage.go build`
- `go test ./internal/workflow ./internal/api ./internal/apiclient ./internal/tui ./internal/cli`
- `go test -race ./internal/workflow ./internal/api ./internal/apiclient ./internal/tui ./internal/cli`
- lint passed on the host and under Linux, macOS, and Windows targets
- `go build ./...` passed for Linux, macOS, and Windows
- `git diff --check`

The managed workspace cannot expose process start times, so the full-suite run still reports the environment-dependent `internal/procx` self-start-time test and two downstream orphan-recovery tests. Focused TUI render/navigation tests pass; a manual visual grading session was not available here.

## Checklist

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
