### PR TITLE
feat: add Vincent workflow authoring skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,18 @@ Full documentation lives in **[docs/](docs/README.md)**.
 - [Using the TUI](docs/guides/tui.md) · [Scripting vincent](docs/guides/scripting.md)
 - [Running at login](docs/guides/running-at-login.md) · [Troubleshooting](docs/guides/troubleshooting.md)
 
+**Agent skill**
+
+Install the portable workflow-authoring skill for Claude Code, Codex, Cursor,
+or another Agent Skills client:
+
+```sh
+npx skills add lezli01/vincent --skill vincent-workflows -g
+```
+
+It asks about human gates and cost constraints, prefers deterministic commands
+and native control flow, and validates generated workflow YAML.
+
 **Platforms** — [Windows](docs/platforms/windows.md) ·
 [macOS](docs/platforms/macos.md) · [Linux](docs/platforms/linux.md)
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -17,6 +17,20 @@ rather read one working workflow than a guide, start with
 [`feature-pr.yaml`](../../examples/feature-pr.yaml) and come back here for the
 parts you want to change.
 
+## Agent-assisted authoring
+
+The portable [Vincent Workflows skill](../../skills/vincent-workflows/SKILL.md)
+helps supporting coding agents design and validate these files:
+
+```sh
+npx skills add lezli01/vincent --skill vincent-workflows -g
+```
+
+It asks only for decisions that change the workflow, including possible human
+gates and interaction needs. It prefers deterministic command steps and native
+control flow, and reserves prompt-based agent steps for work that actually
+requires reasoning.
+
 ---
 
 ## Contents

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,6 +1,6 @@
 # 023 — Vincent workflow authoring skill
 
-**Status:** 🚧 in progress (4/5)  
+**Status:** 🚧 in progress (4/5)
 **Opened:** 2026-08-21
 
 Create a portable Agent Skill that helps coding agents design, write, review, and

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,0 +1,47 @@
+# 023 — Vincent workflow authoring skill
+
+**Status:** 🚧 in progress (0/5)  
+**Opened:** 2026-08-21
+
+Create a portable Agent Skill that helps coding agents design, write, review, and
+validate Vincent workflow YAML. The skill must select Vincent's control-flow
+primitives deliberately, reserve prompt-based agent steps for work that requires
+reasoning, and surface meaningful human-gate and interaction choices before the
+workflow is committed.
+
+## Decisions
+
+1. **2026-08-21 — Publish the canonical skill at
+   `skills/vincent-workflows/` in the open Agent Skills format.** This keeps the
+   source installable from GitHub with `npx skills` across supporting clients.
+   It beats adding another entry to `.claude/skills/`, which is a vendored,
+   Claude-specific collection, and beats maintaining an npm package whose only
+   purpose would be copying Markdown files.
+2. **2026-08-21 — Choose the cheapest correct workflow primitive.** Prefer
+   deterministic command steps, express orchestration with native control flow,
+   and use manual steps for human judgment or authorization. Every agent step
+   must have a stated reason that deterministic commands or structure cannot
+   satisfy. This beats treating an agent prompt as the default implementation
+   mechanism.
+3. **2026-08-21 — Ask targeted questions when answers materially change the
+   workflow.** In particular, resolve required inputs, acceptance checks,
+   platforms, failure policy, side effects, concurrency, and whether a human
+   gate or live agent interaction is required. This beats either a fixed
+   questionnaire or silently assuming that all workflows should be unattended.
+4. **2026-08-21 — Use progressive references and Vincent's own validator.** Keep
+   the entrypoint focused, put schema and design detail in references, and make
+   `vincent workflow validate` the final deterministic check. This beats
+   duplicating the entire documentation set or adding a helper script around an
+   existing command.
+5. **2026-08-21 — Bundle the repository's license with the skill.** Standalone
+   installers must retain the same terms as the source repository. This beats
+   relying on consumers to discover a parent-directory license after the skill
+   has been copied elsewhere.
+
+## Work
+
+- [~] **023.1 — Define the portable skill entrypoint and interaction/step-selection process.**
+- [ ] **023.2 — Add compact schema and control-flow/cost references.**
+- [ ] **023.3 — Document GitHub and `npx skills` installation/discovery.**
+- [ ] **023.4 — Validate skill structure, discovery, and representative workflow behavior.**
+- [ ] **023.5 — Review the final diff and repository verification.**

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,6 +1,6 @@
 # 023 — Vincent workflow authoring skill
 
-**Status:** 🚧 in progress (5/10)
+**Status:** ✅ done (10/10)
 **Opened:** 2026-08-21
 
 Create a portable Agent Skill that helps coding agents design, write, review, and
@@ -64,11 +64,11 @@ workflow is committed.
 - [x] **023.3 — Document GitHub and `npx skills` installation/discovery.** ✓ 2026-08-21
 - [x] **023.4 — Validate skill structure, discovery, and representative workflow behavior.** ✓ 2026-08-21
 - [x] **023.5 — Review the final diff and repository verification.** ✓ 2026-08-21
-- [~] **023.6 — Correct manual-gate, choice, and credential guidance.**
-- [ ] **023.7 — Add Vincent version and schema-drift handling.**
-- [ ] **023.8 — Add a conservative agent-session cost envelope.**
-- [ ] **023.9 — Strengthen secret and external-effect safety guidance.**
-- [ ] **023.10 — Add the final workflow design summary and re-verify the skill.**
+- [x] **023.6 — Correct manual-gate, choice, and credential guidance.** ✓ 2026-08-21
+- [x] **023.7 — Add Vincent version and schema-drift handling.** ✓ 2026-08-21
+- [x] **023.8 — Add a conservative agent-session cost envelope.** ✓ 2026-08-21
+- [x] **023.9 — Strengthen secret and external-effect safety guidance.** ✓ 2026-08-21
+- [x] **023.10 — Add the final workflow design summary and re-verify the skill.** ✓ 2026-08-21
 
 ## Verification
 
@@ -79,3 +79,10 @@ workflow is committed.
   fan-out workflows without warnings. It also rejects
   `on_input: require` inside a loop at the documented validation boundary.
 - CI run 364 passes all seven Linux, macOS, Windows, gate, and packaging jobs.
+- The updated source and a clean `npx skills` copy both pass the skill-creator
+  validator and compare byte-for-byte.
+- Vincent v0.4.2 accepts the four-session convergence and external-effect
+  reconciliation examples without warnings. It rejects a made-up manual
+  `value` field and the newer workflow `fields` key, exercising both corrected
+  gate semantics and explicit version-mismatch handling.
+- CI run 367 passes all seven Linux, macOS, Windows, gate, and packaging jobs.

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,6 +1,6 @@
 # 023 — Vincent workflow authoring skill
 
-**Status:** ✅ done (5/5)
+**Status:** 🚧 in progress (5/10)
 **Opened:** 2026-08-21
 
 Create a portable Agent Skill that helps coding agents design, write, review, and
@@ -37,6 +37,25 @@ workflow is committed.
    installers must retain the same terms as the source repository. This beats
    relying on consumers to discover a parent-directory license after the skill
    has been copied elsewhere.
+6. **2026-08-21 — Treat `manual` as a binary gate, not a data-input step.** Use
+   task fields for choices known at creation and supported mid-run agent input
+   only when the same reasoning session needs an answer. This beats implying
+   that approval can return an arbitrary choice or credential.
+7. **2026-08-21 — Make schema-version drift visible.** Prefer repository-local
+   workflow documentation, record the installed Vincent version, and rely on
+   that binary's validator for the final compatibility verdict. This beats
+   silently treating the bundled reference as timeless.
+8. **2026-08-21 — Report a conservative agent-session cost envelope.** Count
+   retry, loop, parallel, and fan-out multipliers before presenting a design.
+   This beats calling a workflow cost-effective without quantifying its maximum
+   planned AI use.
+9. **2026-08-21 — Handle secrets and external effects explicitly.** Keep
+   credentials out of persisted task data and transcripts, prefer preflight or
+   dry-run support, disable unsafe retries, and verify remote state separately.
+   This beats relying on a manual gate as the whole safety model.
+10. **2026-08-21 — Return a compact design summary with every workflow.** State
+    agent justifications, the session envelope, gates, effects, compatibility,
+    and validation result. This beats leaving those decisions implicit in YAML.
 
 ## Work
 
@@ -45,6 +64,11 @@ workflow is committed.
 - [x] **023.3 — Document GitHub and `npx skills` installation/discovery.** ✓ 2026-08-21
 - [x] **023.4 — Validate skill structure, discovery, and representative workflow behavior.** ✓ 2026-08-21
 - [x] **023.5 — Review the final diff and repository verification.** ✓ 2026-08-21
+- [~] **023.6 — Correct manual-gate, choice, and credential guidance.**
+- [ ] **023.7 — Add Vincent version and schema-drift handling.**
+- [ ] **023.8 — Add a conservative agent-session cost envelope.**
+- [ ] **023.9 — Strengthen secret and external-effect safety guidance.**
+- [ ] **023.10 — Add the final workflow design summary and re-verify the skill.**
 
 ## Verification
 

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,6 +1,6 @@
 # 023 — Vincent workflow authoring skill
 
-**Status:** 🚧 in progress (4/5)
+**Status:** ✅ done (5/5)
 **Opened:** 2026-08-21
 
 Create a portable Agent Skill that helps coding agents design, write, review, and
@@ -44,7 +44,7 @@ workflow is committed.
 - [x] **023.2 — Add compact schema and control-flow/cost references.** ✓ 2026-08-21
 - [x] **023.3 — Document GitHub and `npx skills` installation/discovery.** ✓ 2026-08-21
 - [x] **023.4 — Validate skill structure, discovery, and representative workflow behavior.** ✓ 2026-08-21
-- [~] **023.5 — Review the final diff and repository verification.**
+- [x] **023.5 — Review the final diff and repository verification.** ✓ 2026-08-21
 
 ## Verification
 
@@ -54,4 +54,4 @@ workflow is committed.
 - Vincent v0.4.2 accepts representative probe/gate, bounded-loop, parallel, and
   fan-out workflows without warnings. It also rejects
   `on_input: require` inside a loop at the documented validation boundary.
-- Final repository verification remains under 023.5.
+- CI run 364 passes all seven Linux, macOS, Windows, gate, and packaging jobs.

--- a/docs/tasks/023-vincent-workflow-authoring-skill.md
+++ b/docs/tasks/023-vincent-workflow-authoring-skill.md
@@ -1,6 +1,6 @@
 # 023 — Vincent workflow authoring skill
 
-**Status:** 🚧 in progress (0/5)  
+**Status:** 🚧 in progress (4/5)  
 **Opened:** 2026-08-21
 
 Create a portable Agent Skill that helps coding agents design, write, review, and
@@ -40,8 +40,18 @@ workflow is committed.
 
 ## Work
 
-- [~] **023.1 — Define the portable skill entrypoint and interaction/step-selection process.**
-- [ ] **023.2 — Add compact schema and control-flow/cost references.**
-- [ ] **023.3 — Document GitHub and `npx skills` installation/discovery.**
-- [ ] **023.4 — Validate skill structure, discovery, and representative workflow behavior.**
-- [ ] **023.5 — Review the final diff and repository verification.**
+- [x] **023.1 — Define the portable skill entrypoint and interaction/step-selection process.** ✓ 2026-08-21
+- [x] **023.2 — Add compact schema and control-flow/cost references.** ✓ 2026-08-21
+- [x] **023.3 — Document GitHub and `npx skills` installation/discovery.** ✓ 2026-08-21
+- [x] **023.4 — Validate skill structure, discovery, and representative workflow behavior.** ✓ 2026-08-21
+- [~] **023.5 — Review the final diff and repository verification.**
+
+## Verification
+
+- The skill-creator structural validator passes.
+- `npx skills` discovers the skill, installs it into a clean test directory,
+  and copies its entrypoint, references, metadata, and license unchanged.
+- Vincent v0.4.2 accepts representative probe/gate, bounded-loop, parallel, and
+  fan-out workflows without warnings. It also rejects
+  `on_input: require` inside a loop at the documented validation boundary.
+- Final repository verification remains under 023.5.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,7 +37,7 @@ description of how the system actually behaves.
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
-| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (4/5) |
+| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,6 +37,7 @@ description of how the system actually behaves.
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
+| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (0/5) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,7 +37,7 @@ description of how the system actually behaves.
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
-| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (5/10) |
+| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | ✅ done (10/10) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,7 +37,7 @@ description of how the system actually behaves.
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
-| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | ✅ done (5/5) |
+| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (5/10) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,7 +37,7 @@ description of how the system actually behaves.
 | [020](020-guided-takeover-layouts.md) | Guided takeover layouts for task, project, and workflow views | ⚠ verification blocked (6/7) |
 | [021](021-package-distribution-channels.md) | WinGet, Scoop, mise, deb, and rpm distribution | ⚠ verification blocked (5/7) |
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
-| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (0/5) |
+| [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | 🚧 in progress (4/5) |
 
 ## How to add and update a task document
 

--- a/skills/vincent-workflows/LICENSE.txt
+++ b/skills/vincent-workflows/LICENSE.txt
@@ -81,4 +81,3 @@ The **licensor** is the individual or entity offering these terms, and the **sof
 **Your licenses** are all the licenses granted to you for the software under these terms.
 
 **Use** means anything you do with the software requiring one of your licenses.
-

--- a/skills/vincent-workflows/LICENSE.txt
+++ b/skills/vincent-workflows/LICENSE.txt
@@ -1,0 +1,84 @@
+Required Notice: Copyright © 2026 László Szabó (https://lezli01.is-a.dev)
+
+This license covers noncommercial use only. Commercial or business use of
+vincent requires a separate commercial license — see COMMERCIAL-LICENSE.md.
+Releases published before this license change remain available under the MIT
+License they were originally published under; see COMMERCIAL-LICENSE.md for
+the cutover.
+
+----------------------------------------------------------------------------
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+

--- a/skills/vincent-workflows/SKILL.md
+++ b/skills/vincent-workflows/SKILL.md
@@ -21,12 +21,19 @@ set of questions only when an answer changes the YAML, especially:
 - What deliverable ends the run, and which commands prove it is correct?
 - Which task inputs are required, optional, typed, or pattern-constrained?
 - Which host platforms and shells must the commands support?
+- Which Vincent version and environment will execute the workflow, and is the
+  locally available binary representative of that target?
 - Does any step publish, deploy, push, delete, spend money, mutate an external
   service, or otherwise become difficult to reverse?
-- Where does a person need to judge quality, authorize an effect, supply a
-  secret outside the workflow, or choose among alternatives?
+- Which choices must be known when the task is created and declared as typed
+  task fields?
+- Where does a person need a binary approve/reject gate for quality or an
+  external effect?
 - Must a person answer an agent during the same reasoning session, or is a
   between-step approval gate sufficient?
+- Which credentials must already be available through the daemon environment,
+  an OS credential store, or an authenticated CLI without entering workflow
+  data or transcripts?
 - Can independent work safely share one worktree, or does it require isolated
   child branches? Is the extra concurrency worth its compute and merge cost?
 - Which failures are observations, which should retry, and which should block?
@@ -36,17 +43,28 @@ For an external or irreversible effect, ask a concrete gate question such as:
 before publishing, run that step unattended, or omit publishing?" Do not add a
 ritual gate when the user has already made the policy clear.
 
-## Read the relevant references
+## Establish compatibility and read references
 
-Read [references/workflow-schema.md](references/workflow-schema.md) before
-writing or reviewing YAML. It contains the supported fields, nesting rules,
-template context, and validation contract.
+If this work is inside a Vincent source checkout, read its current
+`docs/reference/workflow-schema.md`; it is newer and more authoritative than a
+bundled snapshot. Otherwise use
+[references/workflow-schema.md](references/workflow-schema.md) as the design
+reference.
 
-Also read
+Run `vincent version` when the binary is available and retain the exact output
+for the final summary. The installed binary's
+`vincent workflow validate <file>` result is the compatibility verdict. If it
+rejects a feature described by the reference, explain the version mismatch and
+ask whether to upgrade Vincent or target the installed feature set. Do not
+silently claim compatibility or rewrite the requested design. If execution
+targets another host or version, identify local validation as provisional until
+the target binary validates it.
+
+Read
 [references/control-flow-and-cost.md](references/control-flow-and-cost.md) when
 the workflow involves branching, repetition, concurrency, composition,
-side-effects, human interaction, or more than one agent step. Use its patterns
-and cost review before finalizing the design.
+side effects, human interaction, or any agent step. Use its patterns,
+agent-session envelope, and cost review before finalizing the design.
 
 ## Choose the cheapest correct primitive
 
@@ -56,7 +74,7 @@ Apply this order for every unit of work:
    operation, structured query, API call, or other deterministic action.
 2. Use `if`, `condition`, `loop`/`break`, `parallel`, `fan_out`, or `include`
    for orchestration. Never ask an agent to simulate control flow.
-3. Use `manual` for human judgment or authorization between steps.
+3. Use `manual` for binary human judgment or authorization between steps.
 4. Use `agent` only for work whose correct execution requires interpreting
    ambiguous context, synthesizing a plan or prose, modifying code based on
    intent, or reviewing unstructured material.
@@ -74,10 +92,20 @@ agent sessions for trivial phases; every agent step and retry is a fresh
 session. Split only when an intermediate result is independently useful,
 separately checkable, or must feed a later prompt.
 
+Calculate a conservative upper bound for automatic agent sessions before a
+human manually retries anything. Count `1 + max_retries` per agent, multiply
+loop bodies by their maximum iterations, add parallel members and fan-out lanes,
+expand includes, and include an agent merge resolver. If referenced workflows
+or dynamic structure cannot be inspected, report the envelope as unknown rather
+than guessing. See the cost reference for the full rules.
+
 ## Choose the human mechanism deliberately
 
-- Use `manual` for review, approval, credentials, or choices between steps. It
-  puts the task in `awaiting_gate` and releases its concurrency slot.
+- Use `manual` only for a binary approve/reject decision between steps. It
+  returns no arbitrary value or credential, puts the task in `awaiting_gate`,
+  and releases its concurrency slot.
+- Use declared task `fields` for typed choices known when the task is created.
+  Vincent has no generic between-step form that returns a new value.
 - Use `on_input: require` only when an agent must ask a question and continue
   the same reasoning session. It requires an adapter that supports mid-run
   input and cannot be nested in `parallel` or `loop` or used by a merge
@@ -87,8 +115,16 @@ separately checkable, or must feed a later prompt.
 
 Place a manual gate immediately before the effect it authorizes. Make the
 instructions name the artifact or change to inspect and the next action that
-approval permits. Set `max_retries: 0` on non-idempotent side effects such as
-publish, push, release, comment, or delete.
+approval permits.
+
+Assume task fields, rendered prompts, instructions, command output, and agent
+transcripts are persisted or inspectable. Never put a secret in them. Use
+preconfigured environment credentials, credential stores, or authenticated
+CLIs, and avoid commands that echo sensitive values. For an external effect,
+prefer preflight or dry-run → optional manual approval → one effect attempt → a
+separate read-only postcondition check. Set `max_retries: 0` when replay is not
+provably safe. After an ambiguous failure, inspect remote state before any
+human-triggered retry.
 
 ## Author and validate
 
@@ -100,12 +136,22 @@ publish, push, release, comment, or delete.
    prompt's claim of success is not verification.
 4. Make loops bounded, concurrent writes disjoint, fan-out lanes independent,
    and platform assumptions explicit.
-5. Run `vincent workflow validate <file>`. Use `--json` when structured output
-   helps. Resolve warnings as design findings, not just syntax noise.
+5. Run `vincent version`, then `vincent workflow validate <file>`. Use `--json`
+   when structured output helps. Resolve warnings as design findings, not just
+   syntax noise.
 6. If the binary is unavailable, say validation was not run; do not substitute
    a generic YAML parser or claim the workflow is valid.
+7. Calculate and review the maximum automatic agent-session envelope.
 
-Return the created or edited path, the validator result, material assumptions,
-and a short explanation of every retained agent step and human gate. When
-reviewing an existing workflow, lead with concrete correctness, safety, and
-cost findings before offering a revised file.
+Return a compact design summary with:
+
+- the created or edited path;
+- Vincent version, schema source, and validator result;
+- every retained agent step's necessity, check, and maximum automatic sessions;
+- the workflow's total session envelope and any unknown dynamic contribution;
+- task fields, binary manual gates, and live interaction separately;
+- external effects, credential source category, retry policy, and postcondition;
+- material assumptions and unresolved warnings.
+
+When reviewing an existing workflow, lead with concrete correctness, safety,
+and cost findings before offering a revised file.

--- a/skills/vincent-workflows/SKILL.md
+++ b/skills/vincent-workflows/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: vincent-workflows
+description: Create, edit, review, and validate Vincent workflow YAML under .vincent/workflows. Use for Vincent workflow fields, step selection, templates, checks, human gates, retries, conditions, loops, parallel work, fan-out, includes, or validation errors. Do not use for GitHub Actions or other workflow systems.
+license: LICENSE.txt
+metadata:
+  author: lezli01
+---
+
+# Vincent Workflows
+
+Design the smallest reliable Vincent workflow for the requested outcome. Spend
+agent tokens only where reasoning is part of the work; express everything else
+with deterministic steps and Vincent's native control flow.
+
+## Gather only decisions that matter
+
+Inspect the repository, its instructions, and existing workflows before asking
+questions. Infer obvious answers and state material assumptions. Ask a compact
+set of questions only when an answer changes the YAML, especially:
+
+- What deliverable ends the run, and which commands prove it is correct?
+- Which task inputs are required, optional, typed, or pattern-constrained?
+- Which host platforms and shells must the commands support?
+- Does any step publish, deploy, push, delete, spend money, mutate an external
+  service, or otherwise become difficult to reverse?
+- Where does a person need to judge quality, authorize an effect, supply a
+  secret outside the workflow, or choose among alternatives?
+- Must a person answer an agent during the same reasoning session, or is a
+  between-step approval gate sufficient?
+- Can independent work safely share one worktree, or does it require isolated
+  child branches? Is the extra concurrency worth its compute and merge cost?
+- Which failures are observations, which should retry, and which should block?
+
+For an external or irreversible effect, ask a concrete gate question such as:
+"The workflow can publish the release. Should it pause for approval immediately
+before publishing, run that step unattended, or omit publishing?" Do not add a
+ritual gate when the user has already made the policy clear.
+
+## Read the relevant references
+
+Read [references/workflow-schema.md](references/workflow-schema.md) before
+writing or reviewing YAML. It contains the supported fields, nesting rules,
+template context, and validation contract.
+
+Also read
+[references/control-flow-and-cost.md](references/control-flow-and-cost.md) when
+the workflow involves branching, repetition, concurrency, composition,
+side-effects, human interaction, or more than one agent step. Use its patterns
+and cost review before finalizing the design.
+
+## Choose the cheapest correct primitive
+
+Apply this order for every unit of work:
+
+1. Use `command` for a known CLI invocation, build, test, formatter, file
+   operation, structured query, API call, or other deterministic action.
+2. Use `if`, `condition`, `loop`/`break`, `parallel`, `fan_out`, or `include`
+   for orchestration. Never ask an agent to simulate control flow.
+3. Use `manual` for human judgment or authorization between steps.
+4. Use `agent` only for work whose correct execution requires interpreting
+   ambiguous context, synthesizing a plan or prose, modifying code based on
+   intent, or reviewing unstructured material.
+
+Before keeping an `agent` step, complete this test: "This needs an agent because
+___ cannot be decided reliably by a command or control-flow step." Replace the
+step if the blank cannot be filled concretely. Git operations, compilation,
+tests, linting, formatting, copying, releases, and deterministic checks are not
+agent work.
+
+Prefer a cheap command probe and guard before an expensive agent. Use a bounded
+loop for probe → break → repair, not retries as iteration. Keep model and effort
+unset unless the task requires a specific capability. Do not create separate
+agent sessions for trivial phases; every agent step and retry is a fresh
+session. Split only when an intermediate result is independently useful,
+separately checkable, or must feed a later prompt.
+
+## Choose the human mechanism deliberately
+
+- Use `manual` for review, approval, credentials, or choices between steps. It
+  puts the task in `awaiting_gate` and releases its concurrency slot.
+- Use `on_input: require` only when an agent must ask a question and continue
+  the same reasoning session. It requires an adapter that supports mid-run
+  input and cannot be nested in `parallel` or `loop` or used by a merge
+  resolver. Codex and Cursor do not support it.
+- `on_input: wait` keeps the agent process and task slot alive while waiting;
+  it is not a substitute for a deliberate approval gate.
+
+Place a manual gate immediately before the effect it authorizes. Make the
+instructions name the artifact or change to inspect and the next action that
+approval permits. Set `max_retries: 0` on non-idempotent side effects such as
+publish, push, release, comment, or delete.
+
+## Author and validate
+
+1. Write the workflow to `.vincent/workflows/<descriptive-name>.yaml` unless
+   the user specifies another registry location.
+2. Give every step a meaningful, unique `id`. Keep templates defensive and
+   quote YAML scalars that contain `:`.
+3. Put a `check` on agent or command steps that change verifiable state. A
+   prompt's claim of success is not verification.
+4. Make loops bounded, concurrent writes disjoint, fan-out lanes independent,
+   and platform assumptions explicit.
+5. Run `vincent workflow validate <file>`. Use `--json` when structured output
+   helps. Resolve warnings as design findings, not just syntax noise.
+6. If the binary is unavailable, say validation was not run; do not substitute
+   a generic YAML parser or claim the workflow is valid.
+
+Return the created or edited path, the validator result, material assumptions,
+and a short explanation of every retained agent step and human gate. When
+reviewing an existing workflow, lead with concrete correctness, safety, and
+cost findings before offering a revised file.

--- a/skills/vincent-workflows/agents/openai.yaml
+++ b/skills/vincent-workflows/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vincent Workflows"
+  short_description: "Design efficient, validated Vincent workflows"
+  default_prompt: "Use $vincent-workflows to design and validate a cost-effective Vincent workflow."

--- a/skills/vincent-workflows/references/control-flow-and-cost.md
+++ b/skills/vincent-workflows/references/control-flow-and-cost.md
@@ -16,7 +16,8 @@ sessions, while genuine reasoning should not be forced into brittle shell code.
 | Run independent read-only or disjoint work in one worktree | `parallel` | Sequential execution without a dependency |
 | Isolate concurrent branches and merge later | `fan_out` | Parallel writers in one worktree |
 | Reuse a stable workflow fragment | `include` | Copying steps into every workflow |
-| Human review or authorization between steps | `manual` | `on_input` or a long-running idle agent |
+| Typed choice known before the run | Declared task `field` | Hiding the choice in a prompt |
+| Binary human review or authorization between steps | `manual` | Treating approval as a data-entry form |
 | A question must continue the same reasoning session | Supported agent with `on_input: require` | A manual gate that loses necessary conversation state |
 | Interpret ambiguity, modify code from intent, synthesize, review prose | `agent` with a concrete prompt and check | Encoding semantic judgment in fragile shell heuristics |
 
@@ -60,17 +61,35 @@ Ask, for each distinct authority boundary:
 - What should the reviewer inspect?
 - May it run unattended when the requested fields or conditions are present?
 - Is dry-run or preview output available before approval?
+- Is there an authoritative read-only command that proves the effect happened?
+- Is replay idempotent, and what happens if the command times out after the
+  remote system accepts it?
 
 Default recommendation: generate and verify locally, expose the diff or preview,
 then place one `manual` gate directly before a consolidated side-effect step.
 Respect an explicit unattended policy; make it visible in the final explanation.
 
+### Credentials and persisted data
+
+Assume task fields, rendered prompts and instructions, command output, agent
+transcripts, and step results can be stored or inspected. Never put passwords,
+tokens, private keys, or other secret material in them. In particular, do not
+declare a `token` field and render it into `env` or a command.
+
+Use credentials already supplied through the daemon environment, an OS
+credential store, or an authenticated CLI. A manual gate may confirm that a
+person completed out-of-band credential setup, but the approval itself carries
+no credential. Avoid shell tracing and commands that print sensitive
+environment variables.
+
 ### Interaction mode
 
-Ask whether a human must answer during the agent's live reasoning. If the person
-only approves an artifact or supplies a choice used by the next fresh step, use
-`manual`. If the same agent session must incorporate the answer, verify a
-question-capable adapter and consider `on_input: require`.
+Ask whether a human must answer during the agent's live reasoning. Use `manual`
+only for binary approve/reject decisions; it cannot return a choice, comment, or
+credential. Declare choices known before execution as task fields. Vincent has
+no generic between-step input form, so redesign a later-discovered value as a
+pre-run field, split the work into another task, or—only when the same agent
+session needs it—use `on_input: require` on a question-capable adapter.
 
 Claude can support mid-run questions. Codex and Cursor cannot. `on_input: wait`
 keeps a process and task slot alive, whereas `manual` parks the task and releases
@@ -89,6 +108,42 @@ Use concurrency for wall-clock benefit, not as a default. Multiple independent
 command checks are cheap parallel candidates. Multiple agent reviewers often
 multiply spend without adding distinct evidence; give each a non-overlapping
 purpose or keep one.
+
+## Calculate the agent-session envelope
+
+Report the maximum automatic agent sessions Vincent may start before any human
+chooses retry. This is a planned-cost upper bound, not a token or currency
+estimate. Human-triggered retries can make lifetime use unbounded and are
+reported separately.
+
+Calculate recursively:
+
+| Structure | Maximum automatic sessions |
+|---|---|
+| Agent step | `1 + effective max_retries` |
+| Sequence | Sum of its members |
+| Parallel group | Sum of its members; concurrency changes time, not total sessions |
+| Loop | Maximum iterations × sum of body members |
+| Fan-out | Sum of all possible lanes, nested descendants, and a configured agent merge resolver |
+| Include | Cost of its expanded steps |
+| Command, manual, condition, break | 0 |
+
+Use the effective inherited retry value, not only fields written directly on a
+step. For a `for_each` loop, use `max_iterations` unless the rendered list has a
+smaller proven bound. Count guarded agents in the upper bound unless the guard
+is statically impossible. Count a conflict resolver because conflict is
+possible, even though its expected cost may be zero.
+
+Inspect named lane workflows and includes recursively. If any referenced
+workflow is unavailable, or structural retry behavior cannot be bounded from
+the available definition, report the total as `unknown` with the known subtotal
+and missing contributor. Never turn a dynamic graph into a reassuring but false
+number.
+
+Example: a four-iteration loop with one repair agent at `max_retries: 0` has a
+maximum of four automatic agent sessions. At the default retry value of 1, the
+same YAML permits eight. A command probe that breaks early lowers actual use but
+does not lower that upper bound.
 
 ## Cost-aware patterns
 
@@ -143,6 +198,7 @@ steps:
 
       - id: repair
         type: agent
+        max_retries: 0
         prompt: |
           The test suite failed:
 
@@ -156,8 +212,9 @@ steps:
     max_retries: 0
 ```
 
-The command decides whether repair is needed. The final command prevents the
-loop ceiling from turning an unverified last repair into success.
+The command decides whether repair is needed. This design permits at most four
+automatic agent sessions; the final command prevents the loop ceiling from
+turning an unverified last repair into success.
 
 ### Gate immediately before an external effect
 
@@ -177,11 +234,22 @@ steps:
   - id: publish
     type: command
     run: ./scripts/publish-release.sh
+    allow_failure: true
+    max_retries: 0
+
+  - id: verify-published
+    type: command
+    run: ./scripts/verify-published.sh
     max_retries: 0
 ```
 
 Prepare and verify before occupying a person's attention. Keep authorization
-adjacent to the effect so later work cannot invalidate what was reviewed.
+adjacent to the effect so later work cannot invalidate what was reviewed. Here,
+`allow_failure` is safe only because the following read-only command is the
+authoritative postcondition: a timeout after a successful remote publish can
+still reconcile to success, while an absent release blocks at verification. If
+no authoritative postcondition exists, omit `allow_failure`, block on the
+effect, and inspect remote state before a human retries it.
 
 ### Parallel checks in one worktree
 
@@ -240,6 +308,7 @@ For each retained agent:
    justifies the override.
 5. Avoid redundant reviewers. If two are needed, make their scopes distinct.
 6. Remember that each retry and each loop iteration starts a fresh session.
+7. Include the step's retry and structural multipliers in the session envelope.
 
 ## Final cost and safety review
 
@@ -252,11 +321,18 @@ Before returning a workflow, verify:
 - Parallel substeps have no write collision; `max_parallel` fits the machine.
 - Fan-out has enough isolated work to justify child tasks and merge overhead.
 - Each agent has a one-sentence necessity and an objective completion signal.
+- The maximum automatic agent-session envelope is calculated; unresolved named
+  workflows make it explicitly unknown rather than guessed.
 - No model or high-effort override is present without a capability reason.
 - Every external, destructive, or irreversible effect has the user-selected
-  gate policy and `max_retries: 0` when replay is unsafe.
-- `manual` is used for between-step authority; mid-run input is used only for
-  essential same-session dialogue on a supported adapter.
+  gate policy, a preflight where useful, `max_retries: 0` when replay is unsafe,
+  and a separate read-only postcondition where available.
+- No secret appears in a field, prompt, instruction, command, output, or
+  transcript; credentials are supplied out of band.
+- `manual` is used only for binary between-step authority; task fields handle
+  pre-run choices, and mid-run input is reserved for essential same-session
+  dialogue on a supported adapter.
 - Templates read optional values defensively and do not assume parallel sibling
   output.
-- `vincent workflow validate` passes without unresolved warnings.
+- The schema source and `vincent version` are recorded, and that binary's
+  workflow validator passes without unresolved warnings.

--- a/skills/vincent-workflows/references/control-flow-and-cost.md
+++ b/skills/vincent-workflows/references/control-flow-and-cost.md
@@ -1,0 +1,262 @@
+# Control flow, human gates, and AI cost
+
+Use this reference to turn intent into an efficient execution graph. Optimize
+for total reliable work: deterministic actions should not consume agent
+sessions, while genuine reasoning should not be forced into brittle shell code.
+
+## Step decision table
+
+| Need | Prefer | Avoid |
+|---|---|---|
+| Known CLI, build, test, lint, format, copy, structured API call | `command` | An agent narrating or typing the command |
+| Skip one step and continue | `if` | Prompting an agent to decide whether to act |
+| End the successful run when there is no work | `condition` after a probe | Running every later step anyway |
+| Observe a nonzero result and branch | `allow_failure` command, then a guard | A failing probe that blocks the task |
+| Repair until a deterministic check passes | Bounded `loop`: probe → `break` → repair | High retries on a repair agent |
+| Run independent read-only or disjoint work in one worktree | `parallel` | Sequential execution without a dependency |
+| Isolate concurrent branches and merge later | `fan_out` | Parallel writers in one worktree |
+| Reuse a stable workflow fragment | `include` | Copying steps into every workflow |
+| Human review or authorization between steps | `manual` | `on_input` or a long-running idle agent |
+| A question must continue the same reasoning session | Supported agent with `on_input: require` | A manual gate that loses necessary conversation state |
+| Interpret ambiguity, modify code from intent, synthesize, review prose | `agent` with a concrete prompt and check | Encoding semantic judgment in fragile shell heuristics |
+
+Control flow is orchestration, not agent work. A prompt such as "run the tests,
+and if they fail fix them, otherwise publish" hides a probe, branch, repair,
+gate, and side effect inside one expensive and hard-to-audit session. Represent
+those decisions as visible steps.
+
+## Ask questions at design forks
+
+Ask only unresolved questions whose answers alter the graph. Group related
+questions and offer concrete choices.
+
+### Outcome and verification
+
+- What must exist or change when the workflow succeeds?
+- Which deterministic command proves each writable step worked?
+- Is a red test expected input to a repair cycle, or a blocking failure?
+
+If no acceptance command is known, ask for one before inventing an agent-based
+review. A subjective output can legitimately require a manual review.
+
+### Inputs and portability
+
+- Which values should be declared fields rather than embedded in prompts?
+- Which are required or constrained, and which may be omitted?
+- Must the workflow run on POSIX, Windows, or both?
+- Are external tools guaranteed on the target hosts?
+
+Do not claim cross-platform support for shell syntax that was not ported and
+tested. Restrict `platforms`, split commands by `.Host.OS`, or ask the user to
+choose a supported target.
+
+### Side effects and human authority
+
+Identify push, publish, deploy, release, delete, payment, notification, issue
+mutation, production access, and other external or hard-to-reverse effects.
+Ask, for each distinct authority boundary:
+
+- Should the workflow stop immediately before this effect?
+- What should the reviewer inspect?
+- May it run unattended when the requested fields or conditions are present?
+- Is dry-run or preview output available before approval?
+
+Default recommendation: generate and verify locally, expose the diff or preview,
+then place one `manual` gate directly before a consolidated side-effect step.
+Respect an explicit unattended policy; make it visible in the final explanation.
+
+### Interaction mode
+
+Ask whether a human must answer during the agent's live reasoning. If the person
+only approves an artifact or supplies a choice used by the next fresh step, use
+`manual`. If the same agent session must incorporate the answer, verify a
+question-capable adapter and consider `on_input: require`.
+
+Claude can support mid-run questions. Codex and Cursor cannot. `on_input: wait`
+keeps a process and task slot alive, whereas `manual` parks the task and releases
+the slot. `on_input: require` is invalid in parallel groups, loop bodies, and
+merge resolvers.
+
+### Concurrency and budget
+
+- Are units truly independent?
+- Do they write the same files?
+- Does each unit justify another agent session?
+- Is branch isolation worth child-task scheduling, worktrees, and merge risk?
+- What machine-level `max_parallel` is safe?
+
+Use concurrency for wall-clock benefit, not as a default. Multiple independent
+command checks are cheap parallel candidates. Multiple agent reviewers often
+multiply spend without adding distinct evidence; give each a non-overlapping
+purpose or keep one.
+
+## Cost-aware patterns
+
+### Probe before invoking an agent
+
+Run a cheap deterministic probe, treat its nonzero result as data, and stop the
+workflow successfully when there is no work.
+
+```yaml
+steps:
+  - id: probe
+    type: command
+    run: git diff --quiet HEAD~1
+    allow_failure: true
+    max_retries: 0
+
+  - id: changes-exist
+    type: condition
+    if: '{{ ne (index .Steps "probe").ExitCode 0 }}'
+
+  - id: review
+    type: agent
+    prompt: |
+      Review the current diff for correctness and make necessary fixes.
+      Preserve the intended behavior and report the files changed.
+    check: git diff --check
+```
+
+This spends no agent session when the diff is empty.
+
+### Converge with a bounded loop
+
+Retries repeat a failed attempt. Iterations represent a successful observation
+followed by another cycle. Use the latter for repair:
+
+```yaml
+steps:
+  - id: converge
+    type: loop
+    count: 4
+    max_iterations: 4
+    steps:
+      - id: suite
+        type: command
+        run: go test ./...
+        allow_failure: true
+        max_retries: 0
+
+      - id: green
+        type: break
+        if: '{{ eq (index .Steps "suite").ExitCode 0 }}'
+
+      - id: repair
+        type: agent
+        prompt: |
+          The test suite failed:
+
+          {{ (index .Steps "suite").Result }}
+
+          Fix the underlying defect. Do not weaken, skip, or delete tests.
+
+  - id: verify
+    type: command
+    run: go test ./...
+    max_retries: 0
+```
+
+The command decides whether repair is needed. The final command prevents the
+loop ceiling from turning an unverified last repair into success.
+
+### Gate immediately before an external effect
+
+```yaml
+steps:
+  - id: build
+    type: command
+    run: ./scripts/build-release.sh
+    check: ./scripts/verify-release.sh
+
+  - id: approve-release
+    type: manual
+    instructions: |
+      Inspect the release artifacts and verification output for task
+      #{{.Task.ID}}. Approval permits the next step to publish them.
+
+  - id: publish
+    type: command
+    run: ./scripts/publish-release.sh
+    max_retries: 0
+```
+
+Prepare and verify before occupying a person's attention. Keep authorization
+adjacent to the effect so later work cannot invalidate what was reviewed.
+
+### Parallel checks in one worktree
+
+```yaml
+- id: checks
+  type: parallel
+  max_parallel: 3
+  steps:
+    - { id: test, type: command, run: go test ./... }
+    - { id: lint, type: command, run: go run mage.go lint }
+    - { id: vet, type: command, run: go vet ./... }
+```
+
+Use this for independent reads or disjoint outputs. Do not place two agents
+that may edit the same source files in one parallel group. Siblings cannot use
+one another's `.Steps` output.
+
+### Fan out only for real branch isolation
+
+Use `fan_out` when lanes are independently schedulable work products that need
+their own branches, not merely because they can be named separately. Good
+candidates are modules with non-overlapping ownership or a large task whose
+parallel speedup outweighs merge cost. Prefer `parallel` for commands sharing
+one worktree and sequential steps when outputs depend on each other.
+
+Default `merge.on_conflict: block`. An agent conflict resolver adds another
+session at the most safety-sensitive point; use one only when conflicts are
+expected, mechanically reviewable, and protected by a strong check.
+
+### Include stable mechanics
+
+Put repeated build, test, or policy steps in a named workflow and `include` it.
+Do not extract a fragment just to reduce a few YAML lines: included ids share
+the caller's namespace, conditions can end the caller, and registry resolution
+occurs only when a task is created.
+
+## Agent-step design
+
+Keep an agent step only with a concrete justification. Suitable reasons include:
+
+- translating a goal across a codebase whose required edits are not known;
+- synthesizing a design or prose from unstructured evidence;
+- semantic review where rules alone do not define correctness;
+- repairing a failure whose cause requires code reasoning.
+
+Unsuitable reasons include running git, invoking a build, waiting for CI,
+formatting, copying, uploading, publishing, checking an exit code, selecting a
+branch based on known data, or retrying until a command passes.
+
+For each retained agent:
+
+1. Give it only the context and responsibility it needs.
+2. Define done and prohibited shortcuts in the prompt.
+3. Add a deterministic `check` when the result changes verifiable state.
+4. Leave `model` and `effort` at inherited defaults unless a requirement
+   justifies the override.
+5. Avoid redundant reviewers. If two are needed, make their scopes distinct.
+6. Remember that each retry and each loop iteration starts a fresh session.
+
+## Final cost and safety review
+
+Before returning a workflow, verify:
+
+- Every deterministic operation is a `command`, not an agent prompt.
+- Branching and repetition use native control flow.
+- Cheap probes guard expensive steps and use `max_retries: 0`.
+- Loops are bounded and end with deterministic verification when needed.
+- Parallel substeps have no write collision; `max_parallel` fits the machine.
+- Fan-out has enough isolated work to justify child tasks and merge overhead.
+- Each agent has a one-sentence necessity and an objective completion signal.
+- No model or high-effort override is present without a capability reason.
+- Every external, destructive, or irreversible effect has the user-selected
+  gate policy and `max_retries: 0` when replay is unsafe.
+- `manual` is used for between-step authority; mid-run input is used only for
+  essential same-session dialogue on a supported adapter.
+- Templates read optional values defensively and do not assume parallel sibling
+  output.
+- `vincent workflow validate` passes without unresolved warnings.

--- a/skills/vincent-workflows/references/workflow-schema.md
+++ b/skills/vincent-workflows/references/workflow-schema.md
@@ -4,6 +4,23 @@ Use this compact reference while authoring or reviewing. The repository's
 `docs/reference/workflow-schema.md` remains authoritative if Vincent has evolved
 since this skill was installed.
 
+## Compatibility and authority
+
+This file is a schema snapshot, not a promise that every released Vincent
+binary supports every listed feature. Establish the target before writing:
+
+1. Inside a Vincent source checkout, prefer its current
+   `docs/reference/workflow-schema.md`.
+2. Run `vincent version` and record the exact output when a binary is available.
+3. Run that binary's `vincent workflow validate`; its result is the final local
+   compatibility verdict.
+
+If the validator rejects a referenced feature, report the mismatch and ask
+whether to upgrade Vincent or author against the installed version. A generic
+YAML parser cannot answer this question. When another host or version will run
+the workflow, treat local validation as provisional until that target binary
+also accepts the file.
+
 ## File and top-level fields
 
 Project workflows normally live in `.vincent/workflows/*.yaml`.
@@ -73,7 +90,7 @@ types deliberately reject timeout or retry fields; see the table below.
 |---|---|---|---|
 | `command` | `run` | `shell`, `env`, `check`, `check_timeout`, `allow_failure` | Deterministic shell work |
 | `agent` | `prompt` | agent selection, input policy, `check`, `allow_failure` | Reasoning or synthesis |
-| `manual` | `instructions` | none | Human approval or judgment |
+| `manual` | `instructions` | none | Binary human approval or judgment |
 | `condition` | `if` | nothing else | False finishes the run successfully |
 | `parallel` | `steps` | `max_parallel`, group `timeout` | Same-worktree concurrent commands/agents |
 | `fan_out` | `lanes` | `merge` | Child tasks, branches, worktrees, then merge |
@@ -112,6 +129,20 @@ not resume the previous conversation.
 
 `manual` takes only templated `instructions`. It enters `awaiting_gate` and
 releases the task's concurrency slot. Approval continues; rejection blocks.
+It is a binary gate: it cannot return free-form text, a selected option, or a
+credential. Downstream steps can observe approval status but receive no new
+human-supplied value.
+
+Use the mechanisms according to when and how a value is needed:
+
+| Need | Mechanism |
+|---|---|
+| Typed value or choice known at task creation | Declared task `field` |
+| Binary review or authorization between steps | `manual` |
+| Answer required by the same live agent session | `on_input: require` on a supported adapter |
+
+Vincent has no generic between-step data-entry step. Do not model a runtime
+choice as a manual gate and then assume `.Steps` contains the answer.
 
 ### Parallel
 
@@ -243,6 +274,7 @@ Common guards:
 Run locally without a daemon, network, or agent installation:
 
 ```sh
+vincent version
 vincent workflow validate .vincent/workflows/example.yaml
 vincent workflow validate .vincent/workflows/example.yaml --json
 ```
@@ -253,4 +285,5 @@ and platform tokens. Unknown model values can be warnings because the live CLI
 is the final authority. Include resolution is deferred until task creation.
 
 Treat a warning as a review item. The file being syntactically valid YAML is
-not evidence that Vincent accepts or safely executes it.
+not evidence that Vincent accepts or safely executes it. Report the exact
+Vincent version with the verdict so a future reader can reproduce the result.

--- a/skills/vincent-workflows/references/workflow-schema.md
+++ b/skills/vincent-workflows/references/workflow-schema.md
@@ -1,0 +1,256 @@
+# Vincent workflow schema
+
+Use this compact reference while authoring or reviewing. The repository's
+`docs/reference/workflow-schema.md` remains authoritative if Vincent has evolved
+since this skill was installed.
+
+## File and top-level fields
+
+Project workflows normally live in `.vincent/workflows/*.yaml`.
+
+```yaml
+name: feature
+description: Implement and verify a feature.
+platforms: [posix]
+fields:
+  - name: ticket
+    type: string
+    required: true
+defaults:
+  max_retries: 0
+steps:
+  - id: test
+    type: command
+    run: go test ./...
+```
+
+| Key | Type | Required | Purpose |
+|---|---|:---:|---|
+| `name` | string | yes | Unique registry name |
+| `description` | string | no | Picker and workflow description |
+| `platforms` | list | no | Whole-workflow host restriction |
+| `fields` | list | no | Ordered task-input declarations |
+| `defaults` | map | no | Values inherited by steps |
+| `steps` | nonempty list | yes | Ordered workflow body |
+
+`platforms` accepts `linux`, `darwin`, `windows`, and `posix`; `posix` means
+non-Windows. It restricts the whole workflow. For a per-step platform guard,
+use `.Host.OS` in `if:`. Vincent never translates shell syntax.
+
+Each field declaration supports:
+
+| Key | Values | Notes |
+|---|---|---|
+| `name` | slug | Required and unique; key in `.Task.Fields` |
+| `label` | string | Presentation only; defaults to `name` |
+| `description` | string | Help shown by clients |
+| `type` | `string`, `integer`, `number`, `boolean` | Defaults to `string`; stored value remains a string |
+| `required` | boolean | Whitespace-only counts as absent |
+| `pattern` | Go RE2 string | Only for strings; use `^...$` for whole values |
+
+Undeclared fields remain allowed. Optional absent values skip type and pattern
+validation. Read an optional value defensively:
+
+```gotemplate
+{{with index .Task.Fields "ticket"}}Ticket: {{.}}{{end}}
+```
+
+## Defaults and common fields
+
+Workflow `defaults` may set `agent`, `model`, `effort`, `permission_mode`,
+`on_input`, `input_timeout`, `max_retries`, and `timeout`. Step values win.
+`max_retries` counts attempts after the first: `0` means one attempt and `1`
+means at most two. Durations use Go syntax such as `90s`, `45m`, or `1h30m`.
+
+Every runtime step has a unique `id` and a `type`; `name`, `max_retries`,
+`timeout`, and `if` are common optional fields where the step type permits
+them. `allow_failure` is limited to `agent` and `command`. Some structural
+types deliberately reject timeout or retry fields; see the table below.
+
+## Step selection and fields
+
+| Type | Required body | Important fields | Role |
+|---|---|---|---|
+| `command` | `run` | `shell`, `env`, `check`, `check_timeout`, `allow_failure` | Deterministic shell work |
+| `agent` | `prompt` | agent selection, input policy, `check`, `allow_failure` | Reasoning or synthesis |
+| `manual` | `instructions` | none | Human approval or judgment |
+| `condition` | `if` | nothing else | False finishes the run successfully |
+| `parallel` | `steps` | `max_parallel`, group `timeout` | Same-worktree concurrent commands/agents |
+| `fan_out` | `lanes` | `merge` | Child tasks, branches, worktrees, then merge |
+| `loop` | `steps` and one driver | `count` or `for_each`, `max_iterations`, group `timeout` | Bounded sequential repetition |
+| `break` | `if` | nothing else | End the enclosing loop successfully |
+| `include` | `workflow` | nothing else | Splice another registry workflow at task creation |
+
+### Command
+
+`run`, `check`, and `env` execute in the worktree. Default shells are
+`/bin/sh -c` on POSIX and PowerShell on Windows. `shell` accepts exactly `sh`,
+`pwsh`, or `cmd`; `bash` is not a valid value, though `run` may invoke it
+explicitly. Pinning an unavailable shell fails instead of falling back.
+
+Quote a `run` scalar containing a colon:
+
+```yaml
+- id: commit
+  type: command
+  run: 'git commit -m "fix: validate input"'
+  max_retries: 0
+```
+
+### Agent
+
+An agent step supports `agent` (`claude`, `codex`, or `cursor`), `model`,
+`effort`, `permission_mode` (`full-auto` or `restricted`), `on_input` (`wait`,
+`deny`, or `require`), `input_timeout`, `check`, and `check_timeout`. Cursor
+ignores `effort`. Every attempt is a fresh agent session.
+
+Success requires a successful process and terminal event plus a successful
+`check`, when present. A retry receives `.LastFailure` automatically, but does
+not resume the previous conversation.
+
+### Manual
+
+`manual` takes only templated `instructions`. It enters `awaiting_gate` and
+releases the task's concurrency slot. Approval continues; rejection blocks.
+
+### Parallel
+
+Parallel substeps may be only `agent` or `command`, including compatible steps
+spliced by `include`. They share one worktree, so concurrent writes must be
+disjoint. Siblings cannot read one another through `.Steps`. A group waits for
+everything it starts; retries rerun only failed substeps. Size `max_parallel`
+for the machine because it counts processes inside one task, not task slots.
+
+### Fan-out
+
+Each lane has an `id`, exactly one of `workflow` or inline `steps`, and may have
+`if`, `fields`, `agent`, `model`, `effort`, or `priority`. Each spawned lane is
+a real child task with an isolated worktree and branch. The parent parks in
+`awaiting_children`, releases its slot, and merges successful lane branches in
+declared order.
+
+```yaml
+- id: modules
+  type: fan_out
+  lanes:
+    - id: api
+      workflow: implement-module
+      fields: { module: api }
+    - id: docs
+      steps:
+        - id: write-docs
+          type: agent
+          prompt: Document the implemented API.
+  merge:
+    on_conflict: block
+```
+
+`merge.on_conflict` is `block` by default or `agent`. Agent resolution requires
+`merge.agent`, a complete agent step with its own `id`; it may use
+`.Conflicts`, must leave no markers, and cannot require mid-run input.
+
+### Loop and break
+
+A loop has a nonempty `steps` sequence and exactly one of:
+
+- `count`: positive fixed iteration count; or
+- `for_each`: a YAML list or templated scalar split into trimmed nonempty lines.
+
+Set `max_iterations` explicitly when the chosen bound differs from the default
+10. Bodies may contain `agent`, `command`, `condition`, `break`, and compatible
+included steps. They may not contain `manual`, `parallel`, `fan_out`, another
+`loop`, or a step resolving to `on_input: require`.
+
+`break` requires `if` and is valid only in a loop. A false `condition` inside a
+loop ends the current iteration (continue). Exhausting the loop driver succeeds;
+exceeding the maximum blocks. Retry budgets belong to body steps, not the loop.
+
+### Include
+
+An include has only `id`, `type: include`, and `workflow`. At task creation it
+is replaced by the referenced workflow's steps. Those steps share the caller's
+id namespace and keep the included workflow's defaults. Vincent's local
+validator cannot resolve registry-dependent include names; task creation does.
+
+## Nesting rules
+
+| Type | Top level | `parallel` | `loop` body | Inline lane |
+|---|:---:|:---:|:---:|:---:|
+| `agent` | yes | yes | yes | yes |
+| `command` | yes | yes | yes | yes |
+| `manual` | yes | no | no | yes |
+| `parallel` | yes | no | no | yes |
+| `fan_out` | yes | no | no | yes |
+| `condition` | yes | no | yes | yes |
+| `loop` | yes | no | no | yes |
+| `break` | no | no | yes | no |
+| `include` | yes | yes* | yes* | yes* |
+
+`include` is accepted only when its expanded steps are valid at that location.
+Step ids are unique across the whole file, including parallel and loop bodies;
+inline fan-out lanes have their own child-task namespaces.
+
+## Conditions, failures, and checks
+
+`if` must render, after trimming, exactly `true` or `false`. False skips that
+step and continues. A `condition` contains only `id`, optional `name`, `type`,
+and required `if`; false stops the remaining run successfully. A `break`
+similarly contains only identification, type, and `if`.
+
+Use `allow_failure: true` when a failed command or agent is intentional data
+for a later decision. Give probes `max_retries: 0`. It advances only after
+failures the process itself produced; startup, template, CLI availability, and
+authentication failures still block.
+
+`check` is a post-step shell command, not a step type. Its nonzero exit fails
+the attempt and participates in retries. `check_timeout` defaults to the daemon
+command timeout, independently of the main step timeout.
+
+## Template context
+
+`prompt`, `run`, `check`, `instructions`, and `if` use Go `text/template` with
+`missingkey=error`.
+
+| Value | Useful fields |
+|---|---|
+| `.Task` | `ID`, `Title`, `Description`, `Fields`, `BaseBranch`, `BranchName` |
+| `.Project` | `Name`, `Path`, `DefaultBranch` |
+| `.Workflow` | `Name`, `Description` |
+| `.Step` | `ID`, `Name`, `Index`, `Attempt` |
+| `.Loop` | `Index`, `Item`, `IsFirst`, `IsLast` |
+| `.Steps` | completed step ids → `Status`, `Result`, `ExitCode` |
+| `.Host` | `OS`, `Arch` |
+| `.Worktree` | `Path` |
+| `.LastFailure` | `Reason`, `Output` during retries |
+| `.Conflicts` | conflicted paths during an agent merge resolution |
+
+Only completed steps are visible in `.Steps`. Parallel siblings are not
+visible to one another. Within a loop, later body steps see earlier steps from
+the current iteration; repeated ids resolve to the latest iteration. Command
+`Result` is the last 200 stdout lines, so filter producer output at its source.
+
+Common guards:
+
+```gotemplate
+{{ eq (index .Task.Fields "ship") "yes" }}
+{{ ne (index .Steps "probe").ExitCode 0 }}
+{{ eq (index .Steps "review").Status "approved" }}
+{{ ne .Host.OS "windows" }}
+```
+
+## Validate
+
+Run locally without a daemon, network, or agent installation:
+
+```sh
+vincent workflow validate .vincent/workflows/example.yaml
+vincent workflow validate .vincent/workflows/example.yaml --json
+```
+
+Exit 0 means valid; exit 1 means invalid. Validation checks known keys and
+types, templates, ids, durations, agent/model compatibility, nesting, bounds,
+and platform tokens. Unknown model values can be warnings because the live CLI
+is the final authority. Include resolution is deferred until task creation.
+
+Treat a warning as a review item. The file being syntactically valid YAML is
+not evidence that Vincent accepts or safely executes it.


### PR DESCRIPTION
## Summary

- add a portable `vincent-workflows` Agent Skill at `skills/vincent-workflows`
- make deterministic commands and native control flow the default, with an explicit justification required for every prompt-based agent step
- ask targeted questions about acceptance checks, fields, target version, portability, side effects, human gates, live interaction, concurrency, and failure policy
- treat `manual` strictly as a binary approve/reject gate; use task fields for pre-run choices and supported live-agent input only for same-session questions
- check the installed Vincent version, prefer source-checkout schema docs, and make cross-version validation limits explicit
- calculate a conservative maximum automatic agent-session envelope across retries, loops, parallel work, fan-out, includes, and merge resolvers
- keep secrets out of persisted workflow data and pair unsafe external effects with preflight, one-shot execution, and read-only reconciliation
- return a compact design summary covering compatibility, cost, gates, interaction, effects, credentials, and validation
- document installation with `npx skills add lezli01/vincent --skill vincent-workflows -g`

## Verification

- skill-creator structural validation passes for the source and a clean installed copy
- `npx skills` discovers and installs `vincent-workflows`; the copy compares byte-for-byte with the source
- Vincent v0.4.2 accepts the four-session convergence and external-effect reconciliation fixtures without warnings
- Vincent v0.4.2 rejects a made-up manual `value` field and the newer workflow `fields` key, exercising manual-gate and version-mismatch guidance
- `git diff --check origin/master...HEAD`
- bundled `LICENSE.txt` compares byte-for-byte with the root `LICENSE`
- GitHub Actions CI runs 367 and 368: all seven jobs pass on the implementation and final documentation heads

## Tasks

Closes 023.1
Closes 023.2
Closes 023.3
Closes 023.4
Closes 023.5
Closes 023.6
Closes 023.7
Closes 023.8
Closes 023.9
Closes 023.10
