### PR TITLE
fix(pages): stop Liquid parsing Vincent templates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # GitHub Pages builds this repository with Jekyll 3.x. Keep internal engineering
-# records and bundled agent-skill material out of the site build; several of
+# records and template-heavy bundled reference material out of the site build;
 # those files intentionally contain Vincent Go-template expressions (`{{ ... }}`)
 # that Liquid would otherwise try to evaluate.
 exclude:
@@ -10,4 +10,4 @@ exclude:
   - docs/history/
   - docs/spec.md
   - docs/tasks/
-  - skills/
+  - skills/vincent-workflows/references/

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,13 @@
+# GitHub Pages builds this repository with Jekyll 3.x. Keep internal engineering
+# records and bundled agent-skill material out of the site build; several of
+# those files intentionally contain Vincent Go-template expressions (`{{ ... }}`)
+# that Liquid would otherwise try to evaluate.
+exclude:
+  - AGENTS.md
+  - CLAUDE.md
+  - RELEASING.md
+  - docs/gates/
+  - docs/history/
+  - docs/spec.md
+  - docs/tasks/
+  - skills/

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Concepts
 
 Five nouns and one process. Everything else in vincent is a consequence of how
@@ -214,3 +216,5 @@ transcripts already on disk.
 - [Writing workflows](../guides/workflows.md) — the part you will spend time in.
 - [Using the TUI](../guides/tui.md) — operate and inspect active workloads.
 - [Task lifecycle](../reference/task-lifecycle.md) — states and actions in full.
+
+{% endraw %}

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Troubleshooting
 
 The failures people actually hit, what each one means, and what to do.
@@ -571,3 +573,5 @@ Include:
 issues go through
 [private advisories](https://github.com/lezli01/vincent/security/advisories/new)
 instead — see [SECURITY.md](../../SECURITY.md).
+
+{% endraw %}

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Writing workflows
 
 A **workflow** is a YAML file describing an ordered list of steps. Every task
@@ -1766,3 +1768,5 @@ workflow-level problem: see
 - [Configuration](../reference/configuration.md) — the daemon-side defaults
   every workflow inherits.
 - [Security model](../security-model.md) — what `full-auto` really allows.
+
+{% endraw %}

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Workflow schema
 
 The complete YAML field reference. For a practical, pattern-oriented tour, see
@@ -968,3 +970,5 @@ the task-creation response, and in the daemon log.
 - [Writing workflows](../guides/workflows.md) — the guide.
 - [Example workflows](../../examples) — five working files.
 - [Agent CLIs](../guides/agents.md) — what each adapter honors.
+
+{% endraw %}


### PR DESCRIPTION
## Summary
- exclude internal engineering records and template-heavy bundled reference material from the GitHub Pages build
- wrap public documentation that intentionally contains Vincent Go `text/template` expressions in Liquid `raw` guards
- keep the workflow-authoring skill page itself publishable while excluding its copied schema reference

## Why
GitHub Pages is building the repository with Jekyll 3.x, and Liquid is attempting to interpret Vincent examples such as `{{.Task.Title}}` and `{{ eq ... }}`. The current Pages run emits many Liquid syntax warnings and ultimately fails while parsing an internal workflow task document.

## Verification
Compared against `master`: the four public documentation files only gain the Liquid guards; no existing documentation content is removed. The remaining change is the new Pages `_config.yml` exclusion list.