### PR TITLE
docs(pages): match the lezli01 visual style

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,13 @@
+title: vincent
+description: Durable local orchestration for agentic development workloads.
+repository: lezli01/vincent
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
 # GitHub Pages builds this repository with Jekyll 3.x. Keep internal engineering
 # records and template-heavy bundled reference material out of the site build;
 # those files intentionally contain Vincent Go-template expressions (`{{ ... }}`)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#282828">
+  <meta name="color-scheme" content="dark">
+  <title>{% if page.title %}{{ page.title }} · {% endif %}vincent</title>
+  <meta name="description" content="{{ page.description | default: site.description | escape }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;700&family=Roboto+Slab:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  <a class="skip-link" href="#content">Skip to content</a>
+  <div class="ambient" aria-hidden="true"></div>
+
+  <div class="site-shell">
+    <header class="site-header framed">
+      <div class="brand-block">
+        <a class="brand" href="{{ '/' | relative_url }}" aria-label="vincent documentation home">
+          <span class="eyebrow">// lezli01 / agentic tooling</span>
+          <span class="brand-mark"><span>#</span> vincent</span>
+        </a>
+        <p class="tagline">durable local orchestration for agentic development</p>
+      </div>
+
+      <nav class="top-nav" aria-label="Primary">
+        <a href="{{ '/docs/features.html' | relative_url }}">Features</a>
+        <a href="{{ '/docs/getting-started/quickstart.html' | relative_url }}">Quickstart</a>
+        <a href="https://github.com/lezli01/vincent">GitHub ↗</a>
+        <a href="https://lezli01.is-a.dev/">Portfolio ↗</a>
+        <a href="https://blog.lezli01.is-a.dev/">Blog ↗</a>
+      </nav>
+    </header>
+
+    <div class="site-grid">
+      <aside class="docs-nav" aria-label="Documentation">
+        <div class="nav-card framed">
+          <div class="nav-label">// navigate</div>
+          <a href="{{ '/docs/features.html' | relative_url }}"># Features</a>
+          <a href="{{ '/docs/getting-started/quickstart.html' | relative_url }}"># Quickstart</a>
+          <a href="{{ '/docs/getting-started/concepts.html' | relative_url }}"># Concepts</a>
+          <a href="{{ '/docs/guides/workflows.html' | relative_url }}"># Workflows</a>
+          <a href="{{ '/docs/guides/tui.html' | relative_url }}"># TUI</a>
+          <a href="{{ '/docs/reference/cli.html' | relative_url }}"># CLI</a>
+          <a href="{{ '/docs/reference/api.html' | relative_url }}"># API</a>
+          <a href="{{ '/docs/security-model.html' | relative_url }}"># Security</a>
+          <div class="nav-divider"></div>
+          <a class="nav-muted" href="{{ '/CHANGELOG.html' | relative_url }}">Changelog</a>
+          <a class="nav-muted" href="{{ '/CONTRIBUTING.html' | relative_url }}">Contributing</a>
+        </div>
+      </aside>
+
+      <main id="content" class="content-card framed">
+        <div class="page-chrome">
+          <span class="page-path">// {{ page.path | default: 'docs' }}</span>
+          <span class="page-status"><i aria-hidden="true"></i> docs online</span>
+        </div>
+        <article class="prose">
+          {{ content }}
+        </article>
+      </main>
+    </div>
+
+    <footer class="site-footer">
+      <span>// built by László Szabó — <a href="https://lezli01.is-a.dev/">lezli01.is-a.dev ↗</a></span>
+      <span>vincent · agentic workload orchestration</span>
+    </footer>
+  </div>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,409 @@
+/*
+  vincent docs — aligned with lezli01.is-a.dev / blog.lezli01.is-a.dev
+  Gruvbox-dark, retro-terminal, square geometry, flat sticker shadows.
+*/
+
+:root {
+  --bg: #282828;
+  --canvas: #282828;
+  --panel: #32302f;
+  --card: #504945;
+  --fg: #fbf1c7;
+  --muted: #a89984;
+  --subtle: #928374;
+  --divider: rgba(168, 153, 132, 0.24);
+  --accent: #83a598;
+  --accent-soft: rgba(131, 165, 152, 0.09);
+  --orange: #fe8019;
+  --error: #cc241d;
+  --code-bg: #23241f;
+  --border: 1px solid var(--accent);
+  --hard-shadow: 5px 5px 0 0 var(--accent);
+  --font-sans: 'Roboto Slab', Georgia, 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', ui-monospace, 'SFMono-Regular', Menlo, Consolas, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--fg);
+  font: 400 16px/1.6 var(--font-sans);
+  letter-spacing: 0.35px;
+  -webkit-font-smoothing: antialiased;
+  overflow-wrap: anywhere;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    linear-gradient(rgba(131, 165, 152, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(131, 165, 152, 0.035) 1px, transparent 1px);
+  background-size: 36px 36px;
+  pointer-events: none;
+}
+
+.ambient {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 12% 12%, rgba(131, 165, 152, 0.12), transparent 28rem),
+    radial-gradient(circle at 88% 30%, rgba(254, 128, 25, 0.06), transparent 25rem),
+    linear-gradient(to bottom, rgba(40, 40, 40, 0.24), rgba(40, 40, 40, 0.92));
+}
+
+::selection { background: var(--accent); color: var(--bg); }
+:focus-visible { outline: 2.5px solid var(--accent); outline-offset: 3px; }
+a { color: inherit; }
+img { max-width: 100%; height: auto; }
+
+.skip-link {
+  position: fixed;
+  left: 12px;
+  top: -80px;
+  z-index: 99;
+  padding: 8px 12px;
+  background: var(--fg);
+  color: var(--bg);
+  border: var(--border);
+  font: 700 13px/1.3 var(--font-mono);
+}
+.skip-link:focus { top: 12px; }
+
+.site-shell {
+  width: min(1280px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: 14px 0 26px;
+}
+
+.framed {
+  background: rgba(40, 40, 40, 0.94);
+  border: var(--border);
+  border-radius: 0;
+  box-shadow: var(--hard-shadow);
+}
+
+.site-header {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) auto;
+  gap: 28px;
+  align-items: center;
+  padding: 18px 20px;
+  margin: 0 5px 18px 0;
+}
+
+.brand { display: inline-flex; flex-direction: column; gap: 1px; text-decoration: none; }
+.eyebrow, .nav-label, .page-path, .page-status, .site-footer {
+  font-family: var(--font-mono);
+}
+.eyebrow {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.brand-mark {
+  font-size: clamp(34px, 4vw, 52px);
+  line-height: 1.02;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+}
+.brand-mark > span { color: var(--accent); }
+.tagline {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.top-nav a {
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.045em;
+}
+.top-nav a:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.site-grid {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.docs-nav { position: sticky; top: 14px; }
+.nav-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 13px;
+  margin-right: 5px;
+}
+.nav-label {
+  margin: 0 4px 9px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+.nav-card a {
+  display: block;
+  padding: 7px 8px;
+  color: var(--fg);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 600;
+}
+.nav-card a:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.nav-card a::first-letter { color: var(--accent); }
+.nav-card .nav-muted { color: var(--muted); font-weight: 500; }
+.nav-divider { height: 1px; background: var(--divider); margin: 8px 3px; }
+
+.content-card {
+  min-width: 0;
+  margin-right: 5px;
+  overflow: hidden;
+}
+.page-chrome {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 15px;
+  border-bottom: 1px solid var(--divider);
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 11px;
+}
+.page-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.page-status { white-space: nowrap; text-transform: uppercase; letter-spacing: 0.06em; }
+.page-status i {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 6px;
+  background: var(--accent);
+  box-shadow: 2px 2px 0 rgba(131, 165, 152, 0.32);
+}
+
+.prose {
+  max-width: 980px;
+  padding: clamp(20px, 4vw, 46px);
+  color: var(--fg);
+}
+.prose > :first-child { margin-top: 0 !important; }
+.prose > :last-child { margin-bottom: 0 !important; }
+
+.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-weight: 700;
+  line-height: 1.2;
+  scroll-margin-top: 22px;
+}
+.prose h1 {
+  margin: 0 0 0.75em;
+  font-size: clamp(34px, 5vw, 50px);
+  letter-spacing: -0.035em;
+}
+.prose h1::before { content: '# '; color: var(--accent); }
+.prose h2 {
+  margin: 1.8em 0 0.55em;
+  padding-top: 0.2em;
+  font-size: clamp(25px, 3vw, 30px);
+  text-transform: uppercase;
+  border-top: 1px solid var(--divider);
+}
+.prose h2::before { content: '# '; color: var(--accent); }
+.prose h3 { margin: 1.55em 0 0.5em; font-size: 22px; }
+.prose h3::before { content: '## '; color: var(--accent); }
+.prose h4 { margin: 1.4em 0 0.45em; font-size: 18px; }
+.prose h5, .prose h6 { margin: 1.3em 0 0.4em; font-size: 16px; }
+
+.prose p { margin: 0 0 1.15em; }
+.prose strong { font-weight: 700; }
+.prose em { color: #ebdbb2; }
+.prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+.prose a:hover { text-decoration-thickness: 2px; }
+.prose ul, .prose ol { margin: 0 0 1.2em; padding-left: 1.5em; }
+.prose li { margin: 0.32em 0; }
+.prose li::marker { color: var(--accent); font-weight: 700; }
+.prose hr { border: 0; border-top: 1px solid var(--divider); margin: 2em 0; }
+
+.prose blockquote {
+  margin: 1.5em 0;
+  padding: 12px 16px;
+  border: 0;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+.prose blockquote > :last-child { margin-bottom: 0; }
+
+.prose code, .prose pre, .prose kbd { font-family: var(--font-mono); }
+.prose :not(pre) > code {
+  padding: 2px 5px;
+  background: var(--code-bg);
+  color: var(--fg);
+  border: 1px solid var(--divider);
+  font-size: 0.84em;
+}
+.prose pre {
+  position: relative;
+  max-width: 100%;
+  margin: 1.45em 5px 1.6em 0;
+  padding: 15px 16px;
+  overflow: auto;
+  background: var(--code-bg) !important;
+  color: #f8f8f2;
+  border: var(--border);
+  border-radius: 0;
+  box-shadow: var(--hard-shadow);
+  font-size: 12.5px;
+  line-height: 1.62;
+  tab-size: 2;
+}
+.prose pre::before {
+  content: 'lezliEdit';
+  display: block;
+  width: max-content;
+  margin: -15px -16px 12px;
+  padding: 5px 10px;
+  color: var(--accent);
+  background: #212121;
+  border-right: 1px solid var(--divider);
+  border-bottom: 3px solid var(--accent);
+  font: 700 10px/1.4 var(--font-mono);
+  letter-spacing: 0.05em;
+}
+.prose pre code { padding: 0; border: 0; background: transparent; color: inherit; }
+.prose kbd {
+  padding: 2px 6px;
+  background: var(--panel);
+  border: 1px solid var(--accent);
+  box-shadow: 2px 2px 0 var(--accent);
+  font-size: 0.8em;
+}
+
+.prose table {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1.4em 0;
+  font-size: 13.5px;
+}
+.prose th, .prose td {
+  padding: 8px 10px;
+  border: 1px solid var(--divider);
+  text-align: left;
+  vertical-align: top;
+}
+.prose th {
+  color: var(--muted);
+  background: var(--panel);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+.prose tr:nth-child(even) td { background: rgba(80, 73, 69, 0.12); }
+
+.prose img {
+  display: block;
+  max-width: min(100%, 980px);
+  margin: 1.5em auto;
+  border: var(--border);
+  border-radius: 0;
+  box-shadow: var(--hard-shadow);
+}
+.prose details {
+  margin: 1.2em 0;
+  padding: 10px 12px;
+  border: 1px solid var(--divider);
+  background: rgba(50, 48, 47, 0.6);
+}
+.prose summary { cursor: pointer; font-weight: 700; color: var(--accent); }
+.prose input[type='checkbox'] { accent-color: var(--accent); }
+
+/* GitHub-flavored README content frequently uses centered HTML blocks. */
+.prose p[align='center'] { text-align: center; }
+.prose p[align='center'] img { display: inline-block; margin: 8px 4px; box-shadow: none; }
+.prose div[align='center'], .prose h1[align='center'] { text-align: center; }
+
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  margin-top: 18px;
+  padding: 14px 5px 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+.site-footer a { color: var(--accent); text-underline-offset: 3px; }
+
+@media (max-width: 920px) {
+  .site-header { grid-template-columns: 1fr; gap: 14px; }
+  .top-nav { justify-content: flex-start; }
+  .site-grid { grid-template-columns: 1fr; }
+  .docs-nav { position: static; }
+  .nav-card {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-right: 5px;
+  }
+  .nav-label, .nav-divider { display: none; }
+  .nav-card a { padding: 6px 8px; border: 1px solid var(--divider); }
+}
+
+@media (max-width: 620px) {
+  .site-shell { width: min(100% - 18px, 1280px); padding-top: 9px; }
+  .site-header { padding: 14px; margin-bottom: 13px; }
+  .brand-mark { font-size: 36px; }
+  .top-nav { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .top-nav a { padding: 7px 8px; border-color: var(--divider); text-align: center; font-size: 11px; }
+  .site-grid { gap: 13px; }
+  .page-chrome { padding: 8px 11px; }
+  .page-status { display: none; }
+  .prose { padding: 20px 16px 26px; }
+  .prose h1 { font-size: 32px; }
+  .prose h2 { font-size: 24px; }
+  .prose h3 { font-size: 20px; }
+  .prose pre { margin-right: 5px; font-size: 11.5px; }
+  .site-footer { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition: none !important; animation: none !important; }
+}


### PR DESCRIPTION
## Summary
- replace the generic GitHub Pages presentation with a custom Vincent documentation shell
- match the visual language used by `lezli01.is-a.dev` and `blog.lezli01.is-a.dev`: Gruvbox-dark surfaces, cream text, muted stone tones, `#83a598` accent, Roboto Slab + Roboto Mono, square frames, and the flat 5px sticker shadow
- add a responsive docs navigation rail with direct links to Features, Quickstart, Concepts, Workflows, TUI, CLI, API, and Security
- give Markdown content first-class styling for headings, tables, code blocks, blockquotes, images, keyboard keys, and mobile layouts
- keep the Liquid-safety exclusions from the previous Pages fix and apply the custom layout to all rendered pages

## Design details
The theme intentionally follows the existing lezli01 design system rather than introducing a separate Vincent brand language. Code blocks use the same `lezliEdit` treatment, and the site links back to the portfolio and developer blog.

## Verification
The branch is based on the merged GitHub Pages/Liquid fix. No documentation prose is changed; this PR adds only the custom layout/CSS and Pages metadata/defaults.