### PR TITLE
fix(pages): repair contributing and changelog pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,8 +48,8 @@
           <a href="{{ '/docs/reference/api.html' | relative_url }}"># API</a>
           <a href="{{ '/docs/security-model.html' | relative_url }}"># Security</a>
           <div class="nav-divider"></div>
-          <a class="nav-muted" href="{{ '/CHANGELOG.html' | relative_url }}">Changelog</a>
-          <a class="nav-muted" href="{{ '/CONTRIBUTING.html' | relative_url }}">Contributing</a>
+          <a class="nav-muted" href="{{ '/changelog.html' | relative_url }}">Changelog</a>
+          <a class="nav-muted" href="{{ '/contributing.html' | relative_url }}">Contributing</a>
         </div>
       </aside>
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,44 @@
+---
+title: Changelog
+description: Product-focused release history for Vincent.
+permalink: /changelog.html
+---
+
+# Changelog
+
+This is the human-readable Vincent release history. The generated [canonical CHANGELOG](https://github.com/lezli01/vincent/blob/master/CHANGELOG.md) remains the source used by release automation, while this page removes duplicate commit subjects and keeps the product impact clear.
+
+## 0.5.0 — Workflow authoring and structured task input
+
+Released 2026-08-22.
+
+### Added
+
+- **Vincent Workflows agent skill.** The portable authoring skill helps agents design cost-aware workflows, prefers deterministic commands and native control flow, and asks about human gates, interaction, acceptance checks, side effects and failure policy before generating a workflow. ([#165](https://github.com/lezli01/vincent/pull/165))
+- **Workflow-declared task fields.** Workflows can define ordered inputs with labels, descriptions, required flags, typed values and optional validation patterns. The TUI pre-renders them while still accepting additional undeclared fields. ([#163](https://github.com/lezli01/vincent/pull/163))
+
+## 0.4.2 — Release verification hardening
+
+- **RPM verification** now normalizes payload paths before extraction, avoiding GNU cpio warning exits while keeping validation isolated. ([#161](https://github.com/lezli01/vincent/pull/161))
+
+## 0.4.1 — Package validation fixes
+
+- **Release package verification** was hardened so provenance generation and Linux, macOS and Windows smoke tests complete correctly for published packages. ([#159](https://github.com/lezli01/vincent/pull/159))
+
+## 0.4.0 — Better TUI workflows and broader distribution
+
+- **Roomier responsive TUI workflows** added guided task creation plus persistent navigation for Projects and Workflows. ([#153](https://github.com/lezli01/vincent/pull/153))
+- **More installation channels** added WinGet, Scoop, mise, deb and rpm distribution with checksummed native release packages. ([#158](https://github.com/lezli01/vincent/pull/158))
+
+## 0.3.0 — Workflow language and task operations
+
+- Reusable workflow composition with `type: include`.
+- Platform restrictions and interactive-agent capability gating.
+- Configurable task-board grouping, bulk actions and file-grouped diffs.
+- Workflow graph visualization for structured control flow.
+- Loops, breaks, conditions and `allow_failure` for data-driven execution.
+- Parallel sub-steps and fan-out child tasks with isolated worktrees and merge-back.
+
+## Older releases
+
+Earlier releases are available in the [canonical changelog](https://github.com/lezli01/vincent/blob/master/CHANGELOG.md) and on [GitHub Releases](https://github.com/lezli01/vincent/releases). This page is intentionally edited for humans; the canonical file remains complete and machine-maintained.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,7 @@
+---
+title: Contributing
+description: How to contribute code, documentation, and fixes to Vincent.
+permalink: /contributing.html
+---
+
+{% include_relative CONTRIBUTING.md %}

--- a/contributing.md
+++ b/contributing.md
@@ -4,4 +4,53 @@ description: How to contribute code, documentation, and fixes to Vincent.
 permalink: /contributing.html
 ---
 
-{% include_relative CONTRIBUTING.md %}
+# Contributing to Vincent
+
+Contributions are welcome. This page covers the public contributor workflow; the repository's [canonical CONTRIBUTING guide](https://github.com/lezli01/vincent/blob/master/CONTRIBUTING.md) remains the detailed source of truth.
+
+## Before you start
+
+For a substantial change, open an issue first and describe the user problem, expected outcome and alternatives. Small fixes and documentation improvements can go straight to a pull request when the intent is obvious.
+
+- Work on a dedicated branch and open a pull request against `master`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages: `type(scope?): summary`.
+- Keep user-facing documentation in sync with behavior changes.
+- CI must pass on Linux, macOS and Windows before merge.
+
+## Development
+
+Vincent is written in Go. Build and verification tasks are exposed through Mage and require no separate Mage installation:
+
+```sh
+go run mage.go build
+go run mage.go test
+go run mage.go testrace
+go run mage.go lint
+go run mage.go vuln
+```
+
+To install the current checkout as your local `vincent` binary:
+
+```sh
+./scripts/install-local.sh
+./scripts/install-local.sh --user
+./scripts/install-local.sh --dry-run
+```
+
+Start with [Concepts](docs/getting-started/concepts.md) for the architecture, then use the [feature overview](docs/features.md), [workflow guide](docs/guides/workflows.md) and [reference documentation](docs/reference/cli.md) for the area you are changing.
+
+## Pull request checklist
+
+- [ ] Commits follow Conventional Commits.
+- [ ] Tests cover behavior changes.
+- [ ] User-visible behavior is documented in the relevant guide or reference page.
+- [ ] Release-impacting changes are represented in the changelog/release notes.
+- [ ] CI is green on all supported platforms.
+
+## Licensing
+
+Vincent uses a dual-license model: the source is available under the [PolyForm Noncommercial 1.0.0 license](https://github.com/lezli01/vincent/blob/master/LICENSE), while commercial use requires a separate [commercial license](https://github.com/lezli01/vincent/blob/master/COMMERCIAL-LICENSE.md).
+
+By submitting a contribution, you agree that it may be distributed under Vincent's current non-commercial license and under separate commercial licenses offered by the project owner. You retain copyright in your contribution unless otherwise agreed.
+
+For the complete contributor policy and maintainer details, read [CONTRIBUTING.md on GitHub](https://github.com/lezli01/vincent/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- publish a real Jekyll-rendered `/contributing.html` page instead of linking to a non-existent generated file
- add a human-edited `/changelog.html` that removes duplicated generated commit subjects and summarizes releases by product impact
- keep the repository `CHANGELOG.md` untouched as the canonical machine-maintained source for Release Please
- update the docs navigation to point at the rendered lowercase pages

## Why
The custom Pages theme linked directly to `/CONTRIBUTING.html` and `/CHANGELOG.html`, but the root Markdown files have no front matter, so Jekyll does not generate those HTML pages. The changelog also surfaced Release Please's mechanical commit list rather than a useful reader-facing release history.

## Verification
The branch only changes the site navigation and adds two rendered Pages entry points. The canonical contribution guide and generated changelog remain unchanged.