### PR TITLE
Serialize worktree create and remove per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ list with the user-facing context a commit subject cannot carry.
   validates declared values for every client, and additional undeclared fields
   remain accepted and recorded on the task.
 
+### Fixed
+
+- **Simultaneous worktree creation in one project.** Tasks admitted at the same
+  moment in the same project no longer fail each other's `git worktree add`
+  with a `git_error` block — the daemon now serializes worktree creation and
+  cleanup per project, since git leaves its own `.git/worktrees` bookkeeping
+  unprotected while an entry is half-built. A `fan_out` step, whose lanes all
+  live in the parent's repository and all start together, was the reliable way
+  to hit this; a blocked lane left the parent waiting in `awaiting_children`.
+  Creation in *different* projects stays parallel. ([#126](https://github.com/lezli01/vincent/issues/126))
+
 ## [0.4.2](https://github.com/lezli01/vincent/compare/v0.4.1...v0.4.2) (2026-08-21)
 
 ### Fixed

--- a/internal/worktree/concurrency_test.go
+++ b/internal/worktree/concurrency_test.go
@@ -1,0 +1,73 @@
+package worktree
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// TestConcurrentCreateInOneProject pins the invariant behind issue #126: several
+// tasks admitted at the same moment in one project must each get their worktree
+// (spec §10), not a git_error (§18) that has nothing to do with the task.
+//
+// create is not safe to run twice at once against one repository. It mutates
+// state git does not lock for it: the `git worktree prune` it runs first (the
+// prune-then-fail decision, T1.5/T1.6) deletes a peer's `.git/worktrees/{id}`
+// in the window between that peer's mkdir and the `locked` file that would
+// have protected it, and `git worktree add` enumerates `.git/worktrees/*`
+// itself, so it also dies reading a peer that has a `gitdir` but not yet a
+// `commondir`. CreateAndClaim takes only claims.RLock (task 005's reclaim
+// lock), which permits exactly this overlap.
+//
+// A `fan_out` step (§7.6) spawns every lane at once into one repository, which
+// turns this from rare into routine — and a lane blocked on git_error is not
+// settled, so the parent sits in awaiting_children until a human looks.
+//
+// core.fsync=all is the amplifier, not the cause: it widens git's own
+// half-built window from microseconds to milliseconds so the race that CI hits
+// once in dozens of runs is reached in a couple of rounds. Sixteen lanes stand
+// in for a wide fan-out.
+func TestConcurrentCreateInOneProject(t *testing.T) {
+	const (
+		lanes  = 16
+		rounds = 6
+	)
+	for round := range rounds {
+		repo := testrepo.Init(t, "main")
+		testrepo.Run(t, repo, "config", "core.fsync", "all")
+		testrepo.Run(t, repo, "config", "core.fsyncMethod", "fsync")
+		m := NewManager(gitx.New(), t.TempDir())
+
+		errs := make([]error, lanes)
+		gate := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := range lanes {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-gate
+				id := int64(round*100 + i + 1)
+				_, errs[i] = m.CreateAndClaim(t.Context(), repo, id,
+					fmt.Sprintf("vincent/%d-lane", id), "main", nil)
+			}()
+		}
+		close(gate)
+		wg.Wait()
+
+		for i, err := range errs {
+			if err == nil {
+				continue
+			}
+			// Name the reason so a future unrelated failure here is not
+			// mistaken for this one.
+			t.Fatalf("round %d lane %d: reason %q: %v\n"+
+				"concurrent create in one project must not fail; git_error here means\n"+
+				"one lane's prune or add tripped over another's half-built worktree",
+				round, i, ReasonOf(err), strings.TrimSpace(err.Error()))
+		}
+	}
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -115,11 +115,55 @@ type Manager struct {
 	// scan takes it exclusively. An mtime/age heuristic was rejected: a
 	// timing guess has no place in the package whose subject is ownership.
 	claims sync.RWMutex
+
+	// repos serializes the operations that mutate one project repository's
+	// shared `.git/worktrees` bookkeeping — create (its prune *and* its
+	// `git worktree add`) and Remove — one mutex per project path (#126).
+	//
+	// git does not lock that state for us. `git worktree add` creates
+	// `.git/worktrees/{id}` and only *then* writes the `locked` file that
+	// would fend off a peer's prune, and it enumerates the whole directory
+	// before it starts, so it equally dies reading a peer entry that already
+	// has a `gitdir` but not yet a `commondir`. Two admissions into one
+	// project — routine for a fan_out step (§7.6), whose lanes all live in
+	// the parent's repository — then fail each other with git_error (§18)
+	// for tasks that had nothing wrong with them.
+	//
+	// The daemon is the only thing that runs git here (ownership invariant),
+	// so a process-local lock covers it. It is deliberately not m.claims:
+	// that lock is task 005's, about gc versus create/claim, and taking it
+	// exclusively would serialize creation daemon-wide across unrelated
+	// projects. Ordering is claims-then-repo everywhere; nothing takes them
+	// in the other order.
+	reposMu sync.Mutex
+	repos   map[string]*sync.Mutex
 }
 
 // NewManager returns a Manager storing worktrees under dataDir.
 func NewManager(git *gitx.Git, dataDir string) *Manager {
-	return &Manager{git: git, root: filepath.Join(dataDir, "worktrees")}
+	return &Manager{
+		git:   git,
+		root:  filepath.Join(dataDir, "worktrees"),
+		repos: make(map[string]*sync.Mutex),
+	}
+}
+
+// lockRepo blocks until nothing else in this process is mutating
+// projectPath's `.git/worktrees`, and returns the release func.
+//
+// Entries are never dropped: there is one per project the daemon has touched,
+// which is bounded by the project list, and a mutex nobody holds is two words.
+func (m *Manager) lockRepo(projectPath string) func() {
+	key := filepath.Clean(projectPath)
+	m.reposMu.Lock()
+	repo, ok := m.repos[key]
+	if !ok {
+		repo = new(sync.Mutex)
+		m.repos[key] = repo
+	}
+	m.reposMu.Unlock()
+	repo.Lock()
+	return repo.Unlock
 }
 
 // Root is the directory every worktree lives under, and the only directory
@@ -194,6 +238,11 @@ func (m *Manager) WithReclaimLock(fn func() error) error {
 }
 
 func (m *Manager) create(ctx context.Context, projectPath string, taskID int64, branch, base string) (string, error) {
+	// Whole of create, not just the prune: the add is as unsafe against a
+	// peer add as it is against a peer prune (#126, see Manager.repos).
+	unlock := m.lockRepo(projectPath)
+	defer unlock()
+
 	if _, err := os.Stat(projectPath); err != nil {
 		return "", &Error{
 			Reason:  ReasonProjectPathMissing,
@@ -315,6 +364,11 @@ func (m *Manager) IsDirty(ctx context.Context, worktreePath string) (bool, error
 // after this returns (spec §10). Ordering matters — the branch is checked out
 // in the worktree until the worktree is gone.
 func (m *Manager) Remove(ctx context.Context, projectPath, worktreePath string, force bool) error {
+	// Same repository bookkeeping as create, from the other side: an archive
+	// prunes the project repo while an admission may be adding to it (#126).
+	unlock := m.lockRepo(projectPath)
+	defer unlock()
+
 	projectMissing := false
 	if _, err := os.Stat(projectPath); err != nil {
 		projectMissing = true


### PR DESCRIPTION
## Summary

Two tasks admitted at the same moment in the **same project** could make each
other's `git worktree add` fail, blocking a task with `git_error` (§18) when
nothing was wrong with it: the base branch resolved, the branch name was free,
the target directory was empty. A retry succeeded.

**Root cause.** `Manager.create` mutates a project repository's
`.git/worktrees` bookkeeping — it runs `git worktree prune` (the prune-then-fail
decision, `docs/history/v0-tasks.md:131`) and then `git worktree add` — and git
guards neither against a peer process:

- `git worktree add` creates `.git/worktrees/{id}` and only **afterwards**
  writes the `locked` file that would fend off a peer's prune, so the peer's
  prune deletes the directory out from under it
  (`fatal: could not open '.git/worktrees/12/gitdir' for writing`);
- `git worktree add` also enumerates all of `.git/worktrees/*` before it does
  anything, so it dies reading a peer entry that already has a `gitdir` but not
  yet a `commondir` (`fatal: failed to read .git/worktrees/2001/commondir`) —
  that direction is add-against-add, with no prune involved.

Nothing in the manager serialized two `create` calls against one repository.
`CreateAndClaim` takes `m.claims.RLock()`, and read mode is deliberate there:
`claims` is task 005's reclaim lock, it exists to exclude a gc scan, and
concurrent creates are explicitly permitted. That permission was the defect —
the daemon had no lock covering the shared state git leaves unprotected.

**Fix.** A per-project mutex (`Manager.repos`, keyed by cleaned project path),
held across the whole of `create` — its prune *and* its add — and across
`Remove`, which prunes the same repository from the archive side. That is the
smallest change that closes both directions of the race:

- `m.claims` is untouched, so `WithReclaimLock`'s semantics and task 005's
  claim protocol are unchanged;
- creates in **different** projects stay parallel, and both §11 concurrency
  caps are unaffected;
- lock ordering is claims-then-repo on every path (gc takes no repo lock at
  all — `Reclaim` bypasses git), so there is no ordering to invert.

The daemon is the only thing that runs git here, so a process-local lock is the
right scope.

**Why it is reached in practice.** `max_parallel_tasks` defaults to 3 and
unrelated tasks are usually in different projects, so the window is rarely hit —
until `fan_out` (§7.6), whose lanes are real tasks in the parent's repository,
all spawned at once, in one transaction. And a lane blocked on `git_error` is
not settled (`taskstate.Settled` is `done | aborted | archived`), so
`resumeSettledParents` never re-queues the parent and it sits in
`awaiting_children` until a human looks. That rollup is working as designed —
the lane should never have blocked.

**How the regression test catches it coming back.**
`internal/worktree/concurrency_test.go:TestConcurrentCreateInOneProject`
releases sixteen `CreateAndClaim` calls together into one `testrepo`
repository, six rounds; any lane returning an error fails the test, and the
failure prints `ReasonOf(err)` so an unrelated future failure here is not
mistaken for this one. `core.fsync=all` + `core.fsyncMethod=fsync` on the test
repo are an amplifier, not part of the bug: they make git fsync each small
metadata write inside `worktree add`, widening its half-built window from
microseconds to milliseconds. Remove the per-project mutex and the test fails
again — it was run against the unfixed code and failed in round 0 in under a
second (`fatal: failed to read .git/worktrees/12/commondir`); with the fix it
passes, including under `-race`, `-count=3`.

The two rejected alternatives are recorded so they are not re-tried: dropping
the pre-add prune does nothing about the `commondir` failure (add-against-add)
and would relitigate the prune-then-fail decision; promoting `CreateAndClaim`
to the write lock serializes worktree creation daemon-wide across unrelated
projects and puts a checkout inside the lock gc wants.

**No spec amendment.** §10 (worktree creation and the cleanup prune), §7.6,
§11, §18 and §6 all remain true word for word — none of them said a create was
exclusive of another create, so the spec was silent here rather than wrong.
This is a code defect against §10's promise that admission creates the
worktree, not a spec change.

**Note on the PR title.** The instructions for this branch asked for a
Conventional Commits title, but `.github/workflows/pr-title.yml` rejects exactly
that pattern (GitHub copies the title into the merge commit, which would make
Release Please record the change twice). The repo's enforced rule wins:
the title is plain language and the *commits* carry the `fix:`/`test:` prefixes.

**Second, unrelated problem found on the way past (not fixed here).**
`GOOS=linux go tool golangci-lint run ./...` crashes on this machine before it
lints anything — `buildir: panic during analysis: unexpected expr:
*ast.KeyValueExpr` in stdlib package `poll`, from honnef.co/go/tools v0.7.0 via
golangci-lint v2.12.2 against the Go 1.27 linux stdlib. It reproduces on
pristine `090d2de` with an empty worktree, so it predates this branch and is a
toolchain-version interaction, not a code fault. `GOOS=windows` and
`GOOS=darwin` lint clean (0 issues) — CI's Linux runner lints on the Linux
toolchain rather than cross-building, which is presumably why it is unnoticed.

## Related

Closes #126

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — `TestConcurrentCreateInOneProject`,
      committed first and observed failing against the unfixed `create`. Nothing
      about it was weakened to make it pass.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — a
      spurious `git_error` block is something a user hits, so it is a `Fixed` entry.
- [ ] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — **not applicable.** No `Reason*` constant, route, cobra command,
      config key or TUI binding changed; the block-reason list in
      `docs/reference/task-lifecycle.md` is still exactly right. The fix removes a
      cause of `git_error`, it does not change what `git_error` means. `docs/spec.md`
      is unamended for the reason given above.

## Verification

- `go test ./internal/worktree -run TestConcurrentCreateInOneProject` — fails on
  `090d2de`, passes with the fix.
- `go test -race -count=3 ./internal/worktree` — 165 tests pass.
- `go test -race ./internal/worktree/... ./internal/taskrun/... ./internal/scheduler/...`
  — 224 tests pass (the packages that drive the manager and could deadlock on a new lock).
- `go run mage.go test` — whole suite green.
- `GOOS=windows` and `GOOS=darwin` golangci-lint — 0 issues; `GOOS=linux` blocked
  by the pre-existing toolchain crash described above.
