### PR TITLE
Run an ad-hoc repair agent on a blocked task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Ad-hoc repair agents for a blocked task.** A blocked task now offers a
+  `repair` action (`R` in the TUI, `POST /v1/tasks/{id}/repair`) that runs one
+  throwaway agent in the task's existing worktree and branch, with the prompt
+  you write and the blocked step's failure context around it. It is the escape
+  hatch for a block that `retry`, `edit + retry` and `skip` cannot clear because
+  the worktree itself is what is wrong. The repair decides nothing: whatever the
+  agent exits with, the task returns to `blocked` at the same step with the same
+  reason, so you read the diff and then choose. It is recorded as its own step
+  run with its own transcript, tokens and cost, shown as its own timeline entry,
+  and it does not consume the blocked step's retry budget.
+
 - **Workflow-declared task fields.** Workflows can publish ordered task inputs
   with labels, descriptions, required flags, string/integer/number/boolean
   types and Go RE2 patterns. The TUI pre-renders those inputs, the daemon

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,7 +13,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Workflows | Validated YAML, templates, declared task fields, checks, retries, timeouts, platform restrictions |
 | Control flow | Parallel groups, isolated fan-out and merge, conditions, loops, breaks, reusable workflow includes |
 | Agents | Claude Code, Codex, and Cursor; per-workflow, per-step, and per-task selection |
-| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry |
+| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents |
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
 | Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks |
@@ -76,6 +76,14 @@ Timeouts are enforced, retry counts are bounded, and exhausted steps become
 `blocked` instead of being silently skipped. From there a person can retry,
 edit the step for this task and retry, skip it, or cancel the task.
 
+When the problem is in the worktree rather than in the step, a blocked task can
+also be **repaired**: one throwaway agent, prompted by you and handed the
+blocked step's failure context, runs in that task's existing worktree and
+branch. It changes files and nothing else — the task returns to `blocked` at the
+same step with the same reason, so you read the diff and then decide. The repair
+is recorded as its own step run with its own transcript and cost, and does not
+consume the blocked step's retries.
+
 Every state transition is persisted before execution. If the daemon dies
 mid-step, restart recovery finalizes the interrupted attempt, verifies and
 stops orphan processes, and reruns the step without charging it as a failed
@@ -96,6 +104,8 @@ Human oversight is part of the workflow instead of an informal terminal habit:
   alive, or require that capability when the workflow depends on it.
 - Pause active work at a step boundary, change task priority, and recover a
   blocked step without discarding its branch or transcript.
+- Send a one-off repair agent into a blocked task's worktree when the fix is a
+  file change, and still decide yourself whether the step then re-runs.
 - Use bulk selection to act on several eligible tasks while refusals remain
   selected for follow-up.
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -425,8 +425,14 @@ codex step, and it is a real mistake.
 ## Tasks that block
 
 A step that exhausts its retries blocks the task and waits for a human. Nothing
-is ever silently abandoned. From `blocked` you can retry, edit-and-retry, skip
-the step, or cancel the task.
+is ever silently abandoned. From `blocked` you can retry, edit-and-retry, repair
+with a one-off agent, skip the step, or cancel the task.
+
+Repair is the one that can change files: it runs a throwaway agent, prompted by
+you and handed the blocked step's failure context, in the task's existing
+worktree and branch. It always returns the task to `blocked` at the same step
+with the same reason, so you look at what it did before deciding to retry. See
+[repairing a blocked task](tui.md#repairing-a-blocked-task).
 
 The block reason names what happened:
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -245,6 +245,7 @@ selected on the board it acts on all of them; see
 | `a` | Approve the gate | `awaiting_gate` |
 | `x` | Reject the gate | `awaiting_gate` |
 | `r` | Retry the blocked step | `blocked` |
+| `R` | Repair with an agent — a one-off run in this task's worktree | `blocked` |
 | `E` | Edit the step's prompt or command in `$EDITOR`, then retry | `blocked` |
 | `s` | Skip the current step | `blocked`, `awaiting_gate` |
 | `p` | Pause / resume | `queued`, `running` / `paused` |
@@ -254,8 +255,45 @@ selected on the board it acts on all of them; see
 `E` opens the failing step's prompt or command in your editor, and the override
 applies **to this task's snapshot only** — the workflow file is untouched.
 
+`R` opens the repair form instead of acting straight away; it is the only task
+action that needs something written, which is also why it is not offered for a
+bulk selection.
+
 What each action means in full is in
 [Task lifecycle](../reference/task-lifecycle.md).
+
+## Repairing a blocked task
+
+`r`, `E` and `s` all leave the worktree exactly as the failed step left it —
+they re-run a step, rewrite its text, or walk past it. When what is wrong is a
+*file*, press `R` on a `blocked` task and a one-off agent goes and fixes it, in
+this task's worktree, on this task's branch.
+
+| Key | Does |
+|---|---|
+| `↑` / `↓` | Move between the prompt and the agent / model / effort rows |
+| `enter` | Open the row under the cursor — the prompt field, or that row's picker |
+| `e` | Write the prompt in `$EDITOR` instead |
+| `ctrl+s` | Start the repair |
+| `esc` | Close without repairing — the draft is discarded |
+
+The prompt is the only required row, and it is prose: write what you want done,
+not a template. The daemon puts the context around it — the task, the blocked
+step's rendered prompt or command, the failure reason and exit codes, the last
+200 lines of the failed attempt's transcript and the path to the whole file, so
+the agent can read further itself.
+
+Inside the prompt field `enter` is a newline (a repair prompt usually wants
+more than one line), `ctrl+s` keeps the text, and `esc` discards it. Agent,
+model and effort are optional; set they apply to this run only and win over the
+task's overrides and the workflow's defaults.
+
+When the repair agent finishes the task returns to `blocked` — same step, same
+reason — whatever it exited with. That is the point: you look at the diff and
+*then* decide whether to `r`. The repair appears in the timeline as its own
+entry under the blocked step, labelled `repair (ad-hoc agent)`, with its own
+transcript, tokens and cost; it is not an attempt of that step and does not use
+up its retries.
 
 ## Answering a question
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -344,6 +344,7 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 | `/pause` | queued, running | |
 | `/resume` | paused | |
 | `/retry` | blocked | `{ prompt_override?, run_override?, branch_override? }` — `branch_override` renames the branch before re-admission, which is how a `branch_exists` block is recovered |
+| `/repair` | blocked | `{ prompt, agent?, model?, effort? }` — runs one ad-hoc agent in the task's existing worktree, then returns the task to `blocked` at the same step with the same reason |
 | `/skip` | blocked, awaiting_gate | |
 | `/approve` | awaiting_gate | |
 | `/reject` | awaiting_gate | |
@@ -352,6 +353,32 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 
 Anything else returns `409` with `details.state`. See
 [Task lifecycle](task-lifecycle.md).
+
+`/repair` runs one throwaway agent against a blocked task's worktree — the
+escape hatch for a block that `retry` cannot clear because the worktree itself
+is wrong. `prompt` is required and is **literal text**, not a template: it is
+prose, and the daemon assembles the failure context around it (the task, the
+blocked step's rendered prompt or command, the reason and exit codes, the last
+200 lines of the failed attempt's transcript and the path to the rest). An empty
+or whitespace-only prompt is `400 validation_failed`.
+
+The optional `agent` / `model` / `effort` apply to that one run and take
+precedence over the task's overrides and the workflow's `defaults:`; they are
+validated exactly as `POST /v1/tasks` validates a task's, so an unregistered
+agent or a known-invalid model is a `400` and a value no catalog recognizes
+comes back in `warnings`:
+
+```json
+{ "id": 7, "state": "queued", "…": "…", "warnings": [] }
+```
+
+The repair decides nothing about the blocked step. Whatever the agent exits
+with, the task goes back to `blocked` at the same step with the same
+`block_reason`, and you retry, repair again, skip or cancel. Its attempt is
+recorded as an ordinary step run under the reserved step id `__repair` at the
+blocked step's index, so `GET /v1/tasks/{id}/steps` returns it with its own
+transcript, tokens and cost — and the blocked step's retry budget is untouched
+by it.
 
 `/archive` is the one action whose response is not just the task. When it looks
 at the branch, it adds a `branch` object beside the task fields:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -599,7 +599,7 @@ vincent project add /path/to/repo --name api --default-branch develop \
 | `VINCENT_CONFIG_DIR` | Override the config directory outright |
 | `VINCENT_DATA_DIR` | Override the data directory outright |
 | `XDG_CONFIG_HOME` / `XDG_DATA_HOME` | Honored on Linux in the normal way |
-| `EDITOR` | Used by the TUI for edit-and-retry and description editing |
+| `EDITOR` | Used by the TUI for edit-and-retry, repair prompts, and description editing |
 
 The two `VINCENT_*` overrides are how the test suite isolates state, and they
 are equally useful for running a second, throwaway instance:

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -92,6 +92,28 @@ session the answer belongs to. So a forgotten question does occupy a slot, until
 a step that exhausts its retries stops and waits for a person, and the task keeps
 its worktree, its branch and its transcripts while it does.
 
+**Repair when the worktree is what is wrong.** `retry` re-runs an unchanged
+step, `edit + retry` can rewrite only that step's own prompt or command, and
+`skip` advances past an unsatisfied check — none of them changes a file. When
+the fix is in the worktree, `repair` runs one throwaway agent there: you write
+what it should do, the daemon hands it the task's context and the blocked step's
+failure (its rendered prompt or command, the reason and exit codes, the tail of
+the failed attempt's transcript and where to read the rest), and it works on the
+task's own branch in the task's own worktree.
+
+It decides nothing. However the repair agent exits, the task comes back to
+`blocked` at the same step with the same reason, so you read the diff and then
+choose — retry, repair again, skip or cancel. It is recorded as a step run of
+its own under the reserved step id `__repair` at the blocked step's index, which
+is why the timeline shows it as its own entry and why it does not eat the
+blocked step's retries: after any number of repairs, a `retry` gets exactly the
+attempts it would have had with none.
+
+Repair is offered from `blocked` whatever the reason. A task blocked before its
+worktree existed re-blocks on the same reason without starting an agent, and one
+blocked because its agent CLI is missing has its repair fail the same way — both
+honest outcomes rather than a hidden filter.
+
 ## Human actions
 
 | Action | Valid from | Effect |
@@ -101,6 +123,7 @@ its worktree, its branch and its transcripts while it does.
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step as a fresh attempt with the retry counter reset → `queued` |
 | `edit + retry` | blocked | Overrides the step's prompt or command **in this task's snapshot only**, then retries. The override is recorded on the step run |
+| `repair` | blocked | Runs one ad-hoc agent, prompted by you, in the task's existing worktree and branch → `queued`, and back to `blocked` at the same step with the same reason when it exits. It does not consume the blocked step's retry budget |
 | `skip` | blocked, awaiting_gate | Marks the step `skipped` and advances → `queued`. A step skipped this way carries no `skip_reason`, which is how it stays distinguishable from one an `if:` guard skipped |
 | `answer` | awaiting_input | Delivers the answer into the live agent session → `running`, and the step clock resumes |
 | `approve` | awaiting_gate | Gate `approved`, advance → `queued` |
@@ -108,8 +131,8 @@ its worktree, its branch and its transcripts while it does.
 | `set priority` | queued, paused | Reorders scheduler admission |
 | `archive` | done, aborted | Removes the worktree → `archived`, then deletes the branch **only** if it has no commits past its base. Refuses on a dirty worktree unless forced — uncommitted work would be lost, and a refusal never reaches the branch |
 
-In the TUI these are the action bar keys (`a`, `x`, `r`, `E`, `s`, `p`, `c`,
-`A`); over the API they are `POST /v1/tasks/{id}/{action}`; from the CLI,
+In the TUI these are the action bar keys (`a`, `x`, `r`, `R`, `E`, `s`, `p`,
+`c`, `A`); over the API they are `POST /v1/tasks/{id}/{action}`; from the CLI,
 `vincent task cancel`.
 
 An action the current state does not allow returns `409` with `details.state`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -269,6 +269,26 @@ its answer was "stop". `skip_reason` says why a `skipped` row is skipped:
 `condition` for a false guard, empty for the human `skip` action (§6), which
 share one state.
 
+*Amended 2026-08-24 (task 025).* An ad-hoc **repair** run (§6) is a StepRun like
+any other — same table, same states, same transcript, same token and cost
+accounting — recorded under the **reserved step id `__repair`** at the *blocked
+step's* `step_index`. `attempt` numbers repairs of that step independently, so a
+second repair is attempt 2 of the repair rather than attempt N+1 of the step.
+
+The reserved id is the whole mechanism. Attempts are counted per
+`(task_id, step_index, step_id, iteration)`, so a row under a different step id
+is invisible to the blocked step's retry budget with no query changing at all
+(§7.2). It begins with an underscore, which no workflow step id may (§8.1), so
+it cannot collide with an id somebody wrote. A `kind` column and a separate
+repair ledger were both considered and rejected: they pay a migration and a
+second history for a separation this composite key already gives.
+
+Clients must tell a `__repair` row apart from an attempt of the step at its
+index and render it as its own entry (§15) — displaying it as an attempt of that
+step would say the opposite of what happened. For the same reason a repair row
+is not visible in `.Steps` (§8.4) to any later step's prompt or guard: it is not
+a step of the workflow, and no workflow author wrote that key.
+
 ## 6. Task lifecycle
 
 ```
@@ -318,6 +338,43 @@ rather than fixed: pausing a held task and resuming it re-admits it at once and 
 re-discovers the wall. That costs one process spawn and buys the rule this section
 already applies to every other pending flag — a human action means go.
 
+**Amended 2026-08-24 (task 025): `blocked → queued` has a second producer.** It
+used to mean only "the human decided — retry or skip". It now also means "the
+human asked for an ad-hoc **repair**": a one-off agent run, prompted by the
+operator, in the task's *existing* worktree and branch (§7.2, §13.2). The
+repair is an ordinary admission in every mechanical respect — the scheduler
+admits it, both §11 caps apply, `internal/scheduler` stays the only producer of
+`queued → running` — and it runs exactly one agent, which is not a step of the
+workflow. When that agent exits, whatever it exited with, the task returns to
+`blocked` at the **same** `current_step` carrying the **same** `block_reason`,
+and the human retries, repairs again, skips or cancels as before.
+
+There is no `repairing` state. A repair is a human action, not a lifecycle
+state: a state of its own would cost an FSM row, a board legend, slot rules and
+a recovery path — what task 014 paid for `awaiting_children` — to buy one nicer
+`cancel`, and `cancel` keeps its present meaning throughout a repair (it kills
+the process and aborts the task) because `available_actions` cannot express
+"this cancel means something else right now".
+
+The request is persisted on the task (`pending_repair_json`, §14) and is drained
+by the transition that returns the task to `blocked`, **not** by the insert of
+the row it produced. That is load-bearing for §12.4: recovery finalizes a
+running row as `interrupted` and re-queues the task, and the actor then walks
+from `current_step`. A request already drained would make a crash mid-repair
+silently become a plain *retry* of the blocked step — consuming its budget and
+possibly unblocking the task without the operator asking. Leaving it set means
+an interrupted repair re-runs as a repair. Every other way out of `blocked`
+drops the request, because it describes exactly the block it was made about.
+
+Repair is offered from `blocked` whatever the block reason — no filtering. A
+task blocked before its worktree existed (`branch_exists`, `base_branch_missing`)
+re-enters worktree preparation on the repair admission and re-blocks on the same
+reason without spawning an agent, which is the right outcome reached by the code
+that already handles it; a task blocked on `agent_unavailable` has its repair
+fail with `agent_unavailable`, which is honest. Filtering `available_actions` by
+block reason would put a second, reason-shaped policy beside this section's
+state-shaped one for no behavioral gain.
+
 ### States
 
 | State | Meaning | Consumes a concurrency slot? |
@@ -342,6 +399,7 @@ already applies to every other pending flag — a human action means go.
 | `resume` | paused | → `queued` |
 | `retry` | blocked | Re-runs the failed step (fresh attempt, retry counter reset); → `queued` |
 | `edit + retry` | blocked | Overrides the step's prompt/command **in this task's snapshot only**, then retries; the override is recorded on the StepRun |
+| `repair` | blocked | *Added 2026-08-24 (task 025).* Runs one ad-hoc agent, prompted by the operator, in the task's existing worktree and branch (§7.2, §8.6, §13.2); → `queued`, and back to `blocked` at the same step with the same reason when it exits. It decides nothing about the blocked step and does not consume its retry budget |
 | `skip` | blocked, awaiting_gate | Marks the step `skipped`, advances to the next step; → `queued` |
 | `answer` | awaiting_input | Delivers the answer to the pending input request into the live agent session (§7.4); → `running` (step clock resumes) |
 | `approve` | awaiting_gate | Gate step → `approved`; advances; → `queued` |
@@ -435,6 +493,33 @@ stdout/stderr are captured to the step transcript.
   cannot fix it, and short-circuiting the budget would make it the only reason in
   vincent that bypasses this section — to save one process spawn at the default
   `max_retries: 1`. Its value is that the reason names the fix.
+- **An ad-hoc repair does not consume the blocked step's budget.** *Added
+  2026-08-24 (task 025).* From `blocked`, `retry` re-runs an unchanged step,
+  `edit + retry` can rewrite only that step's own prompt or command, and `skip`
+  advances past an unsatisfied check — none of them can change the worktree. A
+  `repair` (§6) runs one operator-prompted agent that can, in the task's
+  existing worktree and branch. Its row sits at the blocked step's index under
+  the reserved step id `__repair` (§5.4), and attempts are counted per
+  `(task_id, step_index, step_id, iteration)` — so the blocked step's budget is
+  untouched by construction, not by a special case. After any number of repairs
+  a `retry` gets exactly the attempts it would have got with none.
+
+  The repair itself carries `max_retries: 0`: a failed repair fails fast rather
+  than silently paying for a second agent run, which is the built-in `adhoc`
+  workflow's reasoning applied to the same shape of one-off run.
+
+  A repair decides **nothing** about the blocked step. Whatever the agent exits
+  with, the task returns to `blocked` at the same step with the same reason and
+  a human chooses. Auto-retrying on a repair's success was considered and
+  rejected: the operator would never see the repair's diff before the step
+  re-ran, and a repair agent's exit code is not the right thing to authorize
+  more agent spend with — this section's posture is that a human decides what a
+  machine could not.
+
+  This does not reopen task 018's declined `on_failure:` / try-catch. That
+  decision is about what a workflow author can declare ahead of time; the whole
+  point of a repair is that nothing was declared ahead of time. It adds a human
+  action, not a workflow field.
 
 ### 7.3 Fresh session per step
 
@@ -1331,6 +1416,17 @@ reach codex.
 
 The resolved triple is recorded on every StepRun (§5.4, §14) and passed to the
 adapter via `RunSpec` (§9.1).
+
+*Amended 2026-08-24 (task 025).* An ad-hoc **repair** run (§6) has no step in a
+workflow file to carry level 1, so the **repair request itself** stands in for
+it: `agent` / `model` / `effort` on `POST /v1/tasks/{id}/repair` (§13.2) resolve
+ahead of the task override, the workflow `defaults` and the adapter default,
+with agent-scoped inheritance applying unchanged. The blocked step's own
+selection is deliberately **not** the base — a `command` step has none, and a
+repair is a different job from the step it is repairing. Everything else the
+run needs (permission mode, `on_input`, timeout) resolves exactly as it does for
+a workflow `agent` step, so the workflow's `defaults:` govern it and full-auto,
+`wait` and the agent timeout are the fallbacks.
 
 ## 9. Agent adapters
 
@@ -2585,6 +2681,22 @@ POST   /v1/tasks/{id}/retry            { prompt_override?, run_override?, branch
                                         branch_exists block (§10, task 001); it is validated
                                         and collision-checked exactly as creation is, and
                                         unlike the other two it does not touch the snapshot
+POST   /v1/tasks/{id}/repair           { prompt, agent?, model?, effort? }
+                                        (blocked only; added 2026-08-24, task 025). Runs one
+                                        ad-hoc agent in the task's existing worktree and
+                                        branch (§6, §7.2). `prompt` is required and is
+                                        **literal text**, never a text/template source — it is
+                                        prose typed at a form, and the failure context around
+                                        it is assembled by the daemon; an empty or
+                                        whitespace-only prompt is a 400. The optional triple
+                                        stands in for the step level of §8.6's chain for this
+                                        one run and is validated exactly as creation validates
+                                        a task's: an unregistered agent or a known-invalid
+                                        model/effort is a 400, a value no catalog knows rides
+                                        back in `warnings[]`. The response is the task (now
+                                        queued) plus `warnings`. The repair returns the task
+                                        to `blocked` at the same step with the same
+                                        `block_reason` whatever the agent exits with
 POST   /v1/tasks/{id}/skip             (blocked/awaiting_gate only)
 POST   /v1/tasks/{id}/approve          (awaiting_gate only)
 POST   /v1/tasks/{id}/reject           (awaiting_gate only)
@@ -2730,6 +2842,9 @@ CREATE TABLE tasks (
   pause_requested     INTEGER NOT NULL DEFAULT 0, -- §6 pause accepted, not yet taken effect
   retry_cursor_at     TEXT,                   -- last human `retry`; the retry budget counts failures after it (§7.2)
   pending_override_json TEXT,                 -- edit+retry text awaiting the next attempt's step_run
+  pending_repair_json TEXT,                   -- ad-hoc repair request awaiting its admission (§6, task 025, migration 0010);
+                                              -- drained by the transition that returns the task to blocked, not by the
+                                              -- step_run insert — an interrupted repair must re-run as a repair (§12.4)
   pending_input_json  TEXT,                   -- normalized InputRequest while state='awaiting_input' (§7.4)
   admit_not_before    TEXT,                   -- §11 admission hold; NULL = admissible now (task 003)
   queued_reason       TEXT,                   -- why a queued task waits on more than a slot; NULL = the ordinary queue
@@ -2866,6 +2981,23 @@ stream for the live tail.
    the board pins those tasks and rings the bell. It **never steals focus**:
    auto-opening under a keystroke is how an answer gets lost, so it announces
    itself with a badge on the row and a footer hint, and the human opens it.
+
+   **Repair popup (task 025, added 2026-08-24).** On a `blocked` task, `R` opens
+   a second popup that owns the keyboard the way the answer form does: a
+   required free-text prompt (`enter` edits it inline, `e` opens it in
+   `$EDITOR`) and optional agent/model/effort rows fed by the same
+   `GET /v1/agents` pickers the new-task flow uses (§8.6, with the request
+   standing in for the step level). `ctrl+s` starts the repair, `esc` closes it
+   and discards the draft. It is a popup and not an action key because a repair
+   needs prose written for this one task — which is also why it is excluded from
+   bulk actions.
+
+   The detail timeline must render a repair's StepRun as **its own labeled
+   entry** under the blocked step, never as another attempt of that step (§5.4):
+   its row sits at that step's index under the reserved id `__repair`, and
+   showing it as an attempt would tell the operator the opposite of what
+   happened. It also does not make its index read as a `parallel` group, which
+   is otherwise what more than one distinct step id at one index means.
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
    `$EDITOR`) → fields → base branch (default prefilled) →
@@ -3183,9 +3315,12 @@ focus between panels · `M` toggle mouse.
 Task actions act on the selected task — or on the whole bulk selection when there
 is one (task 011) — and are offered only when the daemon reports them in
 `available_actions`: `p` pause/resume · `a` approve · `x` reject · `r`
-retry · `s` skip · `E` edit+retry in `$EDITOR` · `c` cancel · `A` archive. `x`
+retry · `R` repair · `s` skip · `E` edit+retry in `$EDITOR` · `c` cancel · `A`
+archive. `x`
 rejects because `r` is taken; `r` doubles as *retry connecting* while disconnected,
-where no task is reachable anyway. Destructive actions confirm inline: `c` kills a
+where no task is reachable anyway. `R` (*added 2026-08-24, task 025*) opens the
+repair popup rather than acting immediately, and is excluded from bulk actions
+(task 011) — a repair needs a prompt written for one task. Destructive actions confirm inline: `c` kills a
 live process, `A` removes the worktree and a dirty one re-prompts for `force`.
 `set priority` (§6) has no key — priority is chosen in the new-task flow.
 

--- a/docs/tasks/025-ad-hoc-repair-agent.md
+++ b/docs/tasks/025-ad-hoc-repair-agent.md
@@ -1,0 +1,221 @@
+# 025 — An ad-hoc repair agent for a blocked step
+
+**Status:** ✅ done (8/8)
+**Opened:** 2026-08-24
+
+A new human action, `repair`, valid from `blocked` only. The operator supplies a
+free-form prompt and optionally an agent, model and effort; the daemon runs one
+agent process in the task's *existing* worktree and branch, with the task's own
+context and the blocked step's failure context in the prompt; the run is recorded
+as its own step run; and when it ends the task returns to `blocked` at the same
+step with the same block reason, from which the operator retries, repairs again,
+skips or cancels as before.
+
+The gap is real. From `blocked`, `retry` re-runs an unchanged step, `edit +
+retry` can rewrite only that step's own prompt or command, and `skip` advances
+past an unsatisfied check. Nothing there can change a file. A check that fails
+on a missing fixture, a lint rule the agent could not satisfy, a merge artifact
+in the tree — all of them need the worktree changed, and the only way to do it
+was to leave vincent, open the worktree by hand, and come back.
+
+This does **not** reopen task 018's declined `on_failure:` / try-catch. That
+decision is about what a workflow author can declare ahead of time, and 018
+concluded `allow_failure:` plus an `if:` on the next step composes the same
+thing from parts that already exist. The whole point of a repair is that nothing
+was declared ahead of time: it adds a human action, not a workflow field, and
+the two do not overlap. No other recorded decision covers ad-hoc repair — §20's
+future-work list does not mention it, and `docs/history/v0-tasks.md` carries
+nothing binding on it.
+
+## Decisions
+
+1. **2026-08-24 — A repair decides nothing about the blocked step.** When the
+   repair run ends — succeeded, failed, either way — the task returns to
+   `blocked` at the same step index carrying the block reason it had before. The
+   operator inspects the diff and then chooses.
+
+   *Alternative rejected:* auto-retrying the step when the repair succeeds. It
+   would mean the operator never sees the repair's diff before the step re-ran,
+   and it makes a repair agent's exit code the thing that authorizes more agent
+   spend. This is §7.2's posture unchanged — a human decides what a machine
+   could not.
+
+2. **2026-08-24 — The repair runs as an ordinary admission, in `running`.**
+   `repair` is a human action `blocked → queued` that persists a request on the
+   task; the scheduler admits it exactly like anything else, so both §11
+   concurrency caps apply and `internal/scheduler` remains the only producer of
+   `queued → running`. No new lifecycle state.
+
+   `cancel` keeps its present meaning during a repair — it kills the process and
+   aborts the task — because `available_actions` cannot express "this cancel
+   means something else right now", and a second meaning for one action decided
+   by invisible context is worse than the extra keystroke.
+
+   *Alternative rejected:* a `repairing` state. It would cost an FSM row, a
+   board legend, slot rules and a recovery path — what task 014 paid for
+   `awaiting_children` — to buy one nicer `cancel`.
+
+3. **2026-08-24 — The repair run is a `step_run` row at the blocked step's index
+   under the reserved step id `__repair`.** `step_index` is the blocked step's;
+   `attempt` numbers repairs of that step independently, so a second repair is
+   attempt 2 of the repair rather than attempt N+1 of the step.
+
+   The retry-budget exclusion then falls out of code that already exists:
+   `store.CountStepAttempts` keys on `(task_id, step_index, step_id, iteration)`,
+   so a row under a different step id is invisible to the blocked step's budget
+   without a single query changing. The id starts with an underscore, which no
+   workflow step id may (§8.1), so it cannot collide with one somebody wrote.
+   This is the mechanism the fan-out `on_conflict: agent` resolver already uses
+   (`internal/taskrun/join.go`) — a synthetic step run through the ordinary
+   executor with `inGroup: true` — and reusing it brings transcripts, events,
+   token and cost accounting along for free.
+
+   *Alternatives rejected:* a `kind` column on `step_runs`, and a separate
+   `repair_runs` table. Both pay a migration and a second ledger for a
+   separation the composite key already gives.
+
+4. **2026-08-24 — The repair prompt carries a bounded failure block, assembled
+   by the daemon.** Task title, description and fields; the blocked step's id,
+   type and *rendered* prompt or command; the failure reason, exit code and
+   check exit code; the result summary; the last 200 lines of the failed
+   attempt's transcript (§8.4's existing bound, reused rather than invented);
+   the absolute path of that transcript so the agent can read the rest itself;
+   then the operator's prompt. The whole transcript is not inlined — it is
+   capped at `transcript_max_bytes`, which is megabytes.
+
+5. **2026-08-24 — The operator's prompt is literal text, not a `text/template`
+   source.** It is prose typed at a form, and §8.4 renders with
+   `missingkey=error`, so a `{{` in prose would fail the repair before the
+   process started. It reaches the step escaped, through
+   `workflow.EscapeTemplate` — extracted from `internal/workflow/builtin.go`,
+   where task 024 needed it for the same reason.
+
+   This differs deliberately from `edit + retry`, whose override goes into the
+   task's snapshot and is therefore a workflow-authoring surface. A repair
+   prompt is not.
+
+6. **2026-08-24 — Agent/model/effort resolve request > task override > workflow
+   `defaults` > adapter default.** §8.6's chain with the request standing in for
+   the step level, which is what "the usual optional agent/model settings"
+   means. The blocked step's own selection is deliberately not the base — a
+   `command` step has none, and a repair is a different job from the step it is
+   repairing.
+
+7. **2026-08-24 — The synthetic step carries `max_retries: 0`.** A failed repair
+   fails fast rather than silently paying for a second agent run. This is the
+   built-in `adhoc` workflow's reasoning (phase 2 decision,
+   `internal/workflow/builtin.go`) applied to the same shape of one-off run.
+   Permission mode, `on_input` and timeout resolve through
+   `internal/taskrun/resolve.go` unchanged, so the workflow's `defaults:` govern
+   them and full-auto / `wait` / the agent timeout are the fallbacks.
+
+8. **2026-08-24 — Every block reason offers repair; no filtering.** A task
+   blocked before its worktree existed (`branch_exists`, `base_branch_missing`)
+   re-enters `ensureWorktree` on the repair admission and re-blocks on the same
+   reason without spawning an agent, which is the right outcome reached by
+   existing code. A task blocked on `agent_unavailable` has its repair fail with
+   `agent_unavailable`, which is honest.
+
+   *Alternative rejected:* filtering `available_actions` by block reason. It
+   would put a second, reason-shaped policy next to §6's state-shaped one for no
+   behavioral gain.
+
+9. **2026-08-24 — The request is drained by the re-block, not by the row
+   insert.** `pending_override_json` drains at insert; `pending_repair_json`
+   deliberately does not.
+
+   The difference is load-bearing. Recovery (§12.4) finalizes a running row as
+   `interrupted` and re-queues the task, and the actor then walks from
+   `current_step`. If the request were already drained, a crash mid-repair would
+   silently turn the repair into a plain retry of the blocked step — consuming
+   its budget and possibly unblocking the task without the operator asking.
+   Leaving the request set means an interrupted repair re-runs as a repair,
+   which is exactly what §7.2 and §12.4 already promise for an interrupted step.
+   Every *other* way out of `blocked` drops the request, because it describes
+   exactly the block it was made about.
+
+   A pause requested during a repair needs no handling: the repair's terminal
+   state is `blocked` either way, and the transition clears the flag as every
+   other human action does.
+
+10. **2026-08-24 — The repair row is invisible to the rest of the workflow.**
+    `blindTo` hides a `__repair` row from `.Steps` (§8.4) unconditionally, not
+    only for group members. The existing same-index rule is conditioned on the
+    *reading* step being `inGroup`, so an ordinary later step would otherwise
+    see `__repair` in `.Steps` — a key no workflow author wrote, present exactly
+    when somebody happened to press a key. A test pins this rather than leaving
+    it to inference.
+
+11. **2026-08-24 — `R` in the task-action scope, and a popup rather than a
+    key that acts.** `r` and `E` are retry and edit+retry; `R` was free in that
+    scope (its other binding is new-task re-probe, a different scope). A repair
+    needs prose written for one task, which is also why it is excluded from bulk
+    actions (task 011).
+
+    The detail timeline needed its own change: it groups by `step_index` and
+    prints a sub-step header only when the index is a `parallel` or `loop`
+    group, so a repair row at an ordinary index would have rendered as a bare
+    attempt line of the blocked step — the one thing this work must not say. It
+    gets its own labelled tier, and it is excluded from the group detection that
+    would otherwise make every repaired step read as a `parallel` group of
+    itself.
+
+12. **2026-08-24 — No CLI subcommand.** `internal/cli/task.go` exposes `add`,
+    `ls`, `show` and `cancel`; retry, skip and approve are already TUI-and-API
+    only, and repair follows them.
+
+## Work
+
+- [x] **025.1 — Store: migration `0010_repair.sql`, `RepairRequest`, the
+  `TaskChange` field and its drain rules.** ✓ 2026-08-24
+- [x] **025.2 — `taskstate`: the `Repair` action, `blocked → queued`, in
+  `humanActions`.** ✓ 2026-08-24
+- [x] **025.3 — `taskrun`: `repair.go` (the synthetic step, the prompt assembly,
+  the re-block), `Runner.Repair`, and the `execute` branch.** ✓ 2026-08-24
+- [x] **025.4 — API: `POST /v1/tasks/{id}/repair`, its DTO, its 400s and its
+  agent/model/effort validation.** ✓ 2026-08-24
+- [x] **025.5 — `apiclient`: `ActionRepair`, `RepairInput`, `Repair`,
+  `RepairStepID`.** ✓ 2026-08-24
+- [x] **025.6 — TUI: the `R` binding, `repairform.go`, and the timeline's own
+  entry for a repair row.** ✓ 2026-08-24
+- [x] **025.7 — Tests across `taskstate`, `store`, `taskrun`, `api`,
+  `apiclient` and the TUI live harness.** ✓ 2026-08-24
+- [x] **025.8 — Spec amendments, derived documentation, and an `m2` gate
+  scenario.** ✓ 2026-08-24
+
+## Verification
+
+- `go test ./...` passes. The substance is in `internal/taskrun/repair_test.go`:
+  a repair runs an agent in the task's existing worktree and its change is
+  visible afterwards; the row carries `__repair` at the blocked index and a
+  second repair is attempt 2 under that id; **the blocked step's budget is
+  untouched** — after a repair, a `retry` gets the same number of attempts it
+  would have got with no repair at all; the task returns to `blocked` at the
+  same `current_step` with the same `block_reason` whether the repair succeeded
+  or failed; a successful repair does not re-run the step; after a repair that
+  fixed the underlying problem a `retry` passes the step and the workflow
+  reaches `done`; an interrupted repair re-runs as a repair on restart and
+  specifically does not re-run the blocked step; the repair row never appears in
+  `.Steps` for a later step's prompt or guard; and a repair on a task with no
+  worktree re-blocks on the original reason without starting an agent.
+- `internal/store/repair_test.go` round-trips the request, proves it survives a
+  `blocked → queued` transition, is cleared by the re-block and dropped by every
+  other way out of `blocked`, and that `CountStepAttempts` returns the same
+  numbers with repair rows present as without.
+- `internal/api/repair_test.go` covers 409 with `details.state` from every
+  non-blocked state, 400 on an empty prompt, `available_actions` carrying
+  `repair` exactly while blocked, and agent/model/effort validation matching
+  task creation's.
+- `internal/tui/repairlive_test.go` runs against the real handlers over
+  `httptest`: the action bar offers repair only when the daemon does, the form
+  posts what was typed, and the timeline renders the repair row as its own
+  labelled entry rather than an attempt of the blocked step.
+- `VINCENT_GATE_SCENARIO=8 ./scripts/m2-gate.sh` drives the whole path against
+  the fake agent: a task whose check fails blocks, a repair whose agent writes
+  the file the check wants runs and lands as a separate `__repair` row, the task
+  is `blocked` again with the same reason, and a `retry` then reaches `done`.
+- `golangci-lint run ./...` is clean for `GOOS=windows` and `GOOS=darwin`. The
+  `GOOS=linux` run crashes inside staticcheck's `buildir` while analyzing the
+  standard library's `internal/poll` package; it does so on an unmodified
+  checkout too (task 024 recorded the same), so it is a toolchain/analyzer
+  incompatibility, not a finding against this change.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -38,6 +38,7 @@ the living engineering specification records implementation contracts.
 | [022](022-workflow-fields.md) | Workflow-declared task fields | ⚠ verification blocked (6/7) |
 | [023](023-vincent-workflow-authoring-skill.md) | Portable, cost-aware Vincent workflow authoring skill | ✅ done (10/10) |
 | [024](024-create-workflow-builtin.md) | `create-workflow`, a built-in that writes workflows | ✅ done (7/7) |
+| [025](025-ad-hoc-repair-agent.md) | An ad-hoc repair agent for a blocked step | ✅ done (8/8) |
 
 ## How to add and update a task document
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -3,11 +3,14 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/lezli01/vincent/internal/agent"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/workflow"
 	"github.com/lezli01/vincent/internal/worktree"
 )
 
@@ -97,6 +100,111 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 		}
 		return t, err
 	})
+}
+
+// repairRequest is the §13.2 body of POST /v1/tasks/{id}/repair (§6, task
+// 025). The prompt is required and literal — it is prose typed at a form, not
+// a `text/template` source — and the optional triple stands in for the step
+// level of §8.6's resolution chain for this one run.
+type repairRequest struct {
+	Prompt string  `json:"prompt"`
+	Agent  *string `json:"agent"`
+	Model  *string `json:"model"`
+	Effort *string `json:"effort"`
+}
+
+// handleTaskRepair runs one ad-hoc repair agent in a blocked task's existing
+// worktree (§13.2, task 025). Like archive it cannot go through runAction:
+// the response carries the §8.2 catalog warnings a repair's own agent
+// selection can raise, which taskAction has no room for.
+func (s *Server) handleTaskRepair(w http.ResponseWriter, r *http.Request) {
+	var req repairRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"prompt is required: a repair agent needs something to be told")
+		return
+	}
+	if s.deps.Runner == nil {
+		s.internalError(w, "task actions", errors.New("no task runner is configured"))
+		return
+	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	task, err := s.deps.Store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, err.Error())
+		return
+	}
+	if err != nil {
+		s.internalError(w, "get task", err)
+		return
+	}
+	sel := store.RepairRequest{
+		Prompt: req.Prompt,
+		Agent:  strings.TrimSpace(ptrValue(req.Agent)),
+		Model:  strings.TrimSpace(ptrValue(req.Model)),
+		Effort: strings.TrimSpace(ptrValue(req.Effort)),
+	}
+	// The same §8.2 gate task creation applies, over the one step this run
+	// will have: an unregistered agent and a known-invalid model or effort
+	// are 400s, and a value no catalog knows rides back as a warning.
+	warnings, cerr := s.checkRepairSelection(task, sel)
+	if cerr != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, cerr)
+		return
+	}
+	updated, err := s.deps.Runner.Repair(r.Context(), id, sel)
+	if err != nil {
+		s.writeActionError(w, err)
+		return
+	}
+	resp := toTaskResponse(updated, s.snaps.get(updated.ID, updated.WorkflowSnapshot))
+	resp.Warnings = warnings
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// checkRepairSelection validates a repair's agent/model/effort the way task
+// creation validates a task's (§8.2, §8.6). The repair's own triple stands in
+// for the step level, so the resolved selection is
+// request > task override > the snapshot's `defaults:` > adapter default.
+func (s *Server) checkRepairSelection(
+	t *store.Task, req store.RepairRequest,
+) (warnings []string, errMsg string) {
+	if req.Agent != "" && s.deps.Agents != nil {
+		if _, ok := s.deps.Agents.Get(req.Agent); !ok {
+			return nil, fmt.Sprintf("unknown agent %q (available: %s)", req.Agent,
+				strings.Join(s.deps.Agents.Names(), ", "))
+		}
+	}
+	if s.deps.Catalog == nil {
+		return nil, ""
+	}
+	var defaults agent.Level
+	// A snapshot that no longer parses costs the `defaults:` level and
+	// nothing else: a repair is a rescue, and refusing to launch one because
+	// the snapshot rotted would take the rescue away exactly when it is
+	// needed.
+	if wf, _, perr := workflow.Parse([]byte(t.WorkflowSnapshot), workflow.Options{}); perr == nil {
+		defaults = agent.Level{Agent: wf.Defaults.Agent, Model: wf.Defaults.Model, Effort: wf.Defaults.Effort}
+	}
+	sel := agent.Resolve(
+		agent.Level{Agent: req.Agent, Model: req.Model, Effort: req.Effort},
+		agent.Level{Agent: t.AgentOverride, Model: t.ModelOverride, Effort: t.EffortOverride},
+		defaults,
+	)
+	cerrs, cwarns := s.deps.Catalog.Catalogs().Check(sel)
+	if len(cerrs) > 0 {
+		return nil, "repair: " + cerrs[0].Message
+	}
+	for _, f := range cwarns {
+		warnings = append(warnings, "repair: "+f.Message)
+	}
+	return warnings, ""
 }
 
 // archiveRequest is the §13.2 body of POST /v1/tasks/{id}/archive. `force`
@@ -283,6 +391,13 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 		e, _ := taskrun.AsOverrideMismatch(err)
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
 
+	// A repair with nothing to say (task 025). The handler catches an empty
+	// prompt in front of the runner; this covers the one that arrives as
+	// whitespace the runner trims away.
+	case isRepairPrompt(err):
+		e, _ := taskrun.AsRepairPrompt(err)
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
+
 	// A structurally mismatched answer is untranslatable to the live agent
 	// session; the request never reaches the task (§7.4, §13.2).
 	case isAnswerValidation(err):
@@ -313,6 +428,11 @@ func isStateConflict(err error) bool {
 
 func isOverrideMismatch(err error) bool {
 	_, ok := taskrun.AsOverrideMismatch(err)
+	return ok
+}
+
+func isRepairPrompt(err error) bool {
+	_, ok := taskrun.AsRepairPrompt(err)
 	return ok
 }
 

--- a/internal/api/repair_test.go
+++ b/internal/api/repair_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// blockedTask puts a queued task into `blocked` with a reason, which is the
+// only state a repair may be asked for from (§6, task 025).
+func blockedTask(t *testing.T, h *taskHarness, reason string) taskResponse {
+	t.Helper()
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskRunning)
+	if _, _, err := h.store.TransitionTask(t.Context(), task.ID,
+		store.TaskRunning, store.TaskBlocked, store.TaskChange{BlockReason: &reason}); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+	return task
+}
+
+func TestRepairFromBlocked(t *testing.T) {
+	h := newActionHarness(t)
+	task := blockedTask(t, h, "check_failed")
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/repair", task.ID),
+		map[string]any{"prompt": "fix the failing check"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("repair: %d %s", resp.StatusCode, body)
+	}
+	got := decodeTask(t, body)
+	if got.State != string(store.TaskQueued) {
+		t.Errorf("state = %s, want queued — the scheduler admits a repair like anything else", got.State)
+	}
+
+	stored, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.PendingRepair == nil {
+		t.Fatal("the repair request was not persisted")
+	}
+	if stored.PendingRepair.Prompt != "fix the failing check" {
+		t.Errorf("prompt = %q, want what was posted", stored.PendingRepair.Prompt)
+	}
+	if stored.PendingRepair.BlockReason != "check_failed" {
+		t.Errorf("block reason = %q, want the one the task carried",
+			stored.PendingRepair.BlockReason)
+	}
+	if stored.RetryCursorAt != nil {
+		t.Error("repair moved the retry cursor; a repair is not a retry (§7.2)")
+	}
+}
+
+// TestRepairIsOfferedExactlyWhileBlocked: `available_actions` is derived from
+// §6, so the endpoint and the bar a client renders cannot disagree.
+func TestRepairIsOfferedExactlyWhileBlocked(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	if hasAction(task.AvailableActions, "repair") {
+		t.Errorf("queued actions = %v, must not offer repair", task.AvailableActions)
+	}
+	for _, state := range []store.TaskState{
+		store.TaskRunning, store.TaskAwaitingGate, store.TaskBlocked, store.TaskPaused,
+	} {
+		setState(t, h, task.ID, state)
+		resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/tasks/%d", task.ID), nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("get: %d %s", resp.StatusCode, body)
+		}
+		got := decodeTask(t, body)
+		want := state == store.TaskBlocked
+		if hasAction(got.AvailableActions, "repair") != want {
+			t.Errorf("%s actions = %v, repair offered = %v, want %v",
+				state, got.AvailableActions, !want, want)
+		}
+	}
+}
+
+// TestRepairFromEveryOtherStateIs409: 409 with the state actually found, so a
+// client can re-issue against what it did not expect (§13.1).
+func TestRepairFromEveryOtherStateIs409(t *testing.T) {
+	for _, state := range taskstate.All {
+		if state == store.TaskBlocked {
+			continue
+		}
+		t.Run(string(state), func(t *testing.T) {
+			h := newActionHarness(t)
+			task := queuedTask(t, h)
+			setState(t, h, task.ID, state)
+
+			resp, body := h.doJSON(t, http.MethodPost,
+				fmt.Sprintf("/v1/tasks/%d/repair", task.ID), map[string]any{"prompt": "fix it"})
+			if resp.StatusCode != http.StatusConflict {
+				t.Fatalf("repair from %s: %d %s, want 409", state, resp.StatusCode, body)
+			}
+			if got := decodeError(t, body).Details["state"]; got != string(state) {
+				t.Errorf("details.state = %v, want %s", got, state)
+			}
+		})
+	}
+}
+
+func TestRepairRejectsAnEmptyPrompt(t *testing.T) {
+	h := newActionHarness(t)
+	task := blockedTask(t, h, "check_failed")
+
+	for _, prompt := range []any{"", "   \n\t "} {
+		resp, body := h.doJSON(t, http.MethodPost,
+			fmt.Sprintf("/v1/tasks/%d/repair", task.ID), map[string]any{"prompt": prompt})
+		wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	}
+	stored, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.State != store.TaskBlocked || stored.PendingRepair != nil {
+		t.Errorf("a refused repair moved the task: %s, pending %+v", stored.State, stored.PendingRepair)
+	}
+}
+
+// TestRepairSelectionValidationMatchesCreation applies §8.2 to the repair's
+// own triple the way POST /v1/tasks applies it to a task's: an unregistered
+// agent and a known-invalid value are 400s, an unknown one is a warning.
+func TestRepairSelectionValidationMatchesCreation(t *testing.T) {
+	h := newActionHarness(t)
+	task := blockedTask(t, h, "check_failed")
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/repair", task.ID),
+		map[string]any{"prompt": "fix it", "agent": "not-an-adapter"})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(body), "not-an-adapter") {
+		t.Errorf("message %s must name the agent that was asked for", body)
+	}
+
+	// `minimal` is a codex-only effort, and the repair resolves to claude.
+	resp, body = h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/repair", task.ID),
+		map[string]any{"prompt": "fix it", "agent": "claude", "effort": "minimal"})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(body), "codex") {
+		t.Errorf("message %s must name the owning adapter", body)
+	}
+
+	// A model no catalog knows starts the repair, with a warning on the body.
+	resp, body = h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/repair", task.ID),
+		map[string]any{"prompt": "fix it", "agent": "claude", "model": "made-up-model-x"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("repair with an unknown model: %d %s", resp.StatusCode, body)
+	}
+	got := decodeTask(t, body)
+	if len(got.Warnings) != 1 || !strings.Contains(got.Warnings[0], "made-up-model-x") {
+		t.Errorf("warnings = %v, want one naming the unknown model", got.Warnings)
+	}
+	stored, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.PendingRepair == nil || stored.PendingRepair.Model != "made-up-model-x" {
+		t.Errorf("the selection did not reach the request: %+v", stored.PendingRepair)
+	}
+}
+
+func TestRepairOnAMissingTaskIs404(t *testing.T) {
+	h := newActionHarness(t)
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks/9999/repair",
+		map[string]any{"prompt": "fix it"})
+	wantError(t, resp, body, http.StatusNotFound, CodeNotFound)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -177,6 +177,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/pause", s.handleTaskPause)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/resume", s.handleTaskResume)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/retry", s.handleTaskRetry)
+	rt.handle(http.MethodPost, "/v1/tasks/{id}/repair", s.handleTaskRepair)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/skip", s.handleTaskSkip)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/approve", s.handleTaskApprove)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/reject", s.handleTaskReject)

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -18,12 +18,23 @@ const (
 	ActionPause   = "pause"
 	ActionResume  = "resume"
 	ActionRetry   = "retry"
+	ActionRepair  = "repair"
 	ActionSkip    = "skip"
 	ActionAnswer  = "answer"
 	ActionApprove = "approve"
 	ActionReject  = "reject"
 	ActionArchive = "archive"
 )
+
+// RepairStepID is the reserved step id the daemon records an ad-hoc repair
+// run under (§5.4, task 025). A repair's row sits at the *blocked step's*
+// index, so this is what tells the two apart — a client that rendered it as
+// an attempt of that step would say the opposite of what happened.
+//
+// It is declared here for the reason the action names above are: the client
+// owns its wire types, and a string the daemon sends is keyed onto rather
+// than imported from the engine. A test pins the two together.
+const RepairStepID = "__repair"
 
 // Override is the body of POST /v1/tasks/{id}/retry (§6). Prompt and Run are
 // edit+retry: the text replaces the failing step's prompt or command in this
@@ -60,6 +71,42 @@ func (c *Client) Retry(ctx context.Context, id int64, ov Override) (Task, error)
 		return c.action(ctx, id, ActionRetry, nil)
 	}
 	return c.action(ctx, id, ActionRetry, ov)
+}
+
+// RepairInput is the body of POST /v1/tasks/{id}/repair (§6, task 025).
+// Prompt is required and literal — it is prose, not a template — and the
+// optional triple stands in for the step level of §8.6's chain for that one
+// run: request > task override > the workflow's `defaults:` > adapter
+// default.
+type RepairInput struct {
+	Prompt string `json:"prompt"`
+	Agent  string `json:"agent,omitempty"`
+	Model  string `json:"model,omitempty"`
+	Effort string `json:"effort,omitempty"`
+}
+
+// Repair launches a one-off agent in the blocked task's existing worktree
+// (§6, task 025). The task re-queues, runs the agent, and returns to
+// `blocked` at the same step with the same reason whatever the agent did —
+// the repair changes the worktree, and a human still decides whether to
+// retry.
+//
+// The second return carries the §8.2 catalog warnings the selection raised,
+// the way task creation reports them; an empty prompt is a 400.
+func (c *Client) Repair(ctx context.Context, id int64, in RepairInput) (Task, []string, error) {
+	var out repairResponse
+	path := fmt.Sprintf("/v1/tasks/%d/%s", id, ActionRepair)
+	if err := c.post(ctx, path, in, &out); err != nil {
+		return Task{}, nil, err
+	}
+	return out.Task, out.Warnings, nil
+}
+
+// repairResponse decodes the repair body, whose task fields sit at the top
+// level beside `warnings` — the shape archive's response uses for `branch`.
+type repairResponse struct {
+	Task
+	Warnings []string `json:"warnings"`
 }
 
 // Skip marks the current step skipped and advances (§6).

--- a/internal/apiclient/actions_test.go
+++ b/internal/apiclient/actions_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/apiclient"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
 	"github.com/lezli01/vincent/internal/testrepo"
 )
 
@@ -149,5 +150,66 @@ func TestDiffWithoutWorktree(t *testing.T) {
 	}
 	if apiErr.Status != http.StatusConflict {
 		t.Errorf("status = %d, want 409", apiErr.Status)
+	}
+}
+
+// TestRepairAgainstRealHandlers drives POST /v1/tasks/{id}/repair through the
+// real handler: a blocked task re-queues, and the daemon's own view of it
+// comes back (§6, task 025).
+func TestRepairAgainstRealHandlers(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.block(t, "check_failed")
+
+	got, warnings, err := h.client().Repair(ctx, h.taskID,
+		apiclient.RepairInput{Prompt: "fix the failing check"})
+	if err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	if got.State != string(store.TaskQueued) {
+		t.Errorf("state = %q, want queued", got.State)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want none for a repair with no selection", warnings)
+	}
+}
+
+// TestRepairRejectsAnEmptyPrompt: the daemon answers 400 and the client hands
+// the §13.1 envelope back intact.
+func TestRepairRejectsAnEmptyPrompt(t *testing.T) {
+	h := newHarness(t)
+	h.block(t, "check_failed")
+
+	_, _, err := h.client().Repair(context.Background(), h.taskID, apiclient.RepairInput{})
+	var apiErr *apiclient.Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusBadRequest {
+		t.Fatalf("Repair with no prompt = %v, want a 400", err)
+	}
+}
+
+// TestRepairOutsideBlockedCarriesState: a repair is valid from `blocked`
+// alone, and the 409 says what it found.
+func TestRepairOutsideBlockedCarriesState(t *testing.T) {
+	h := newHarness(t)
+
+	_, _, err := h.client().Repair(context.Background(), h.taskID,
+		apiclient.RepairInput{Prompt: "fix it"})
+	var apiErr *apiclient.Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusConflict {
+		t.Fatalf("Repair from queued = %v, want a 409", err)
+	}
+	if apiErr.Details["state"] != string(store.TaskQueued) {
+		t.Errorf("details.state = %q, want queued", apiErr.Details["state"])
+	}
+}
+
+// TestRepairStepIDMatchesTheEngine pins the client's copy of the reserved
+// step id (§5.4) to the engine's. The client owns its wire types, the same
+// way it owns the action names above — and a copy that drifted would make
+// every repair row render as an attempt of the step it sits beside.
+func TestRepairStepIDMatchesTheEngine(t *testing.T) {
+	if apiclient.RepairStepID != taskrun.RepairStepID {
+		t.Errorf("apiclient.RepairStepID = %q, engine says %q",
+			apiclient.RepairStepID, taskrun.RepairStepID)
 	}
 }

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -123,6 +123,17 @@ func (h *harness) setState(t *testing.T, id int64, to store.TaskState) {
 	}
 }
 
+// block puts the harness task into `blocked` with a reason — the one state a
+// §6 repair may be asked for from (task 025).
+func (h *harness) block(t *testing.T, reason string) {
+	t.Helper()
+	h.setState(t, h.taskID, store.TaskRunning)
+	if _, _, err := h.st.TransitionTask(t.Context(), h.taskID,
+		store.TaskRunning, store.TaskBlocked, store.TaskChange{BlockReason: &reason}); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+}
+
 // snapshotWorkflow is a three-step snapshot covering every step type that
 // carries editable text, plus the manual gate that carries none.
 const snapshotWorkflow = `name: three

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -300,6 +300,8 @@ type TaskDetail struct {
 	Steps        []StepRun       `json:"steps"`
 	// Warnings is set on the POST /v1/tasks 201 only: advisory findings that
 	// did not block creation, such as a model the catalog does not know.
+	// POST /v1/tasks/{id}/repair reports the same findings about its own
+	// selection, in its own body (task 025).
 	Warnings []string `json:"warnings,omitempty"`
 	// WorkflowSteps is the task's snapshot: the text edit+retry opens in an
 	// editor, and a gate's instructions.

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 9
+const latestSchemaVersion = 10
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0010_repair.sql
+++ b/internal/store/migrations/0010_repair.sql
@@ -1,0 +1,24 @@
+-- 0010_repair: the pending ad-hoc repair request (task 025, spec §6/§14).
+--
+-- It mirrors `pending_override_json`'s role exactly: a bridge from a handler
+-- that runs while the task is `blocked` — and therefore has no step_runs row
+-- to write to — across the transition, to the actor that is the sole writer
+-- of this task's rows (phase 2 decision). The API validates and persists; the
+-- admitted actor reads it and runs the repair.
+--
+-- Where it differs from the override is *when* it drains. An override is
+-- drained by the insert of the attempt it belongs to; a repair request is
+-- drained by the transition that returns the task to `blocked` afterwards.
+-- Draining at insert would make a crash mid-repair silently become a plain
+-- retry of the blocked step on the next admission — §12.4 finalizes the
+-- running row as `interrupted` and re-queues the task, and the actor then
+-- walks from `current_step`. Leaving the request set means an interrupted
+-- repair re-runs as a repair, which is what §12.4 already promises for an
+-- interrupted step.
+--
+-- No `kind` column on step_runs accompanies this, and no second ledger. A
+-- repair's row sits at the blocked step's index under the reserved step id
+-- `__repair`, and `CountStepAttempts` keys on (task_id, step_index, step_id,
+-- iteration) — so the row is invisible to the blocked step's retry budget
+-- with no query changing at all (task 025).
+ALTER TABLE tasks ADD COLUMN pending_repair_json TEXT; -- NULL = no repair requested

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -101,6 +101,12 @@ type Task struct {
 	// PendingOverride is edit+retry text waiting for the next attempt's
 	// step run; the actor drains and clears it (§6).
 	PendingOverride *Override
+	// PendingRepair is an ad-hoc repair the human asked for while the task
+	// was blocked (§6, task 025). The actor runs it on the admission it
+	// produced and drains it with the transition that returns the task to
+	// `blocked`; leaving `blocked` any other way drops it, so a request can
+	// never outlive the block it was made about.
+	PendingRepair *RepairRequest
 	// PendingInputJSON is the normalized InputRequest while the task is
 	// awaiting_input (§7.4); "" otherwise. TransitionTask clears it on any
 	// transition out of awaiting_input.
@@ -216,6 +222,29 @@ type Override struct {
 
 // Empty reports whether the override carries nothing.
 func (o Override) Empty() bool { return o.Prompt == "" && o.Run == "" }
+
+// RepairRequest is one ad-hoc repair a human asked for from `blocked` (§6,
+// task 025): what to tell the agent, and optionally which agent to tell.
+//
+// Prompt is literal text, never a `text/template` source. It is prose typed
+// at a form, and §8.4 renders with `missingkey=error` — a stray `{{` in prose
+// would fail the repair before the process started. The surrounding failure
+// context is assembled by the daemon, not templated by the user.
+//
+// BlockReason is the reason the task carried when the repair was launched.
+// It rides the request because `applyChange` clears `block_reason` on any
+// move off `blocked`, and the repair has to put the *same* reason back when
+// it returns the task there: a repair decides nothing about the blocked step.
+type RepairRequest struct {
+	Prompt      string `json:"prompt"`
+	Agent       string `json:"agent,omitempty"`
+	Model       string `json:"model,omitempty"`
+	Effort      string `json:"effort,omitempty"`
+	BlockReason string `json:"block_reason,omitempty"`
+}
+
+// Empty reports whether the request carries no work to do.
+func (r RepairRequest) Empty() bool { return r.Prompt == "" }
 
 // Candidate is one queued task considered for admission, carrying the cap
 // context the scheduler needs to decide (spec §11). The slot counts are as

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// blockedReason is what every task in this file is blocked with. Which reason
+// it is does not matter to any assertion here — a repair carries whatever it
+// found back to `blocked` — so one is fixed rather than varied.
+const blockedReason = "check_failed"
+
+// blockedTask is a task sitting in `blocked` with a reason, which is the only
+// state a repair is asked for from (§6, task 025).
+func blockedTask(t *testing.T, s *Store, projectID int64) *Task {
+	t.Helper()
+	reason := blockedReason
+	task := newTask(projectID, "repairable", TaskQueued)
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	out, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, TaskBlocked,
+		TaskChange{BlockReason: &reason})
+	if err != nil {
+		t.Fatalf("block: %v", err)
+	}
+	return out
+}
+
+// TestPendingRepairRoundTrips: the request written with the blocked → queued
+// transition is what the admitted actor reads back.
+func TestPendingRepairRoundTrips(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := blockedTask(t, s, p.ID)
+
+	req := RepairRequest{
+		Prompt: "fix the failing check", Agent: "claude", Model: "sonnet",
+		Effort: "high", BlockReason: task.BlockReason,
+	}
+	queued, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, TaskQueued,
+		TaskChange{PendingRepair: &req})
+	if err != nil {
+		t.Fatalf("repair transition: %v", err)
+	}
+	if queued.PendingRepair == nil || *queued.PendingRepair != req {
+		t.Fatalf("pending repair = %+v, want %+v", queued.PendingRepair, req)
+	}
+	// It survives the transition off `blocked` that carried it, and the
+	// admission that follows — those two moves are the whole reason the
+	// column exists.
+	running, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	if running.PendingRepair == nil || *running.PendingRepair != req {
+		t.Fatalf("pending repair after admission = %+v, want it intact", running.PendingRepair)
+	}
+	reloaded, err := s.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if reloaded.PendingRepair == nil || *reloaded.PendingRepair != req {
+		t.Fatalf("pending repair did not survive a reload: %+v", reloaded.PendingRepair)
+	}
+}
+
+// TestPendingRepairSurvivesAnInterrupt is why the request is drained by the
+// re-block and not by the row insert (§12.4, task 025): recovery re-queues a
+// running task, and a drained request would make the next admission a plain
+// retry of the blocked step.
+func TestPendingRepairSurvivesAnInterrupt(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := blockedTask(t, s, p.ID)
+	req := RepairRequest{Prompt: "fix it", BlockReason: "check_failed"}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, TaskQueued,
+		TaskChange{PendingRepair: &req}); err != nil {
+		t.Fatalf("repair transition: %v", err)
+	}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+
+	interrupted, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, TaskQueued, TaskChange{})
+	if err != nil {
+		t.Fatalf("interrupt: %v", err)
+	}
+	if interrupted.PendingRepair == nil {
+		t.Fatal("an interrupted repair lost its request; it would re-run as a retry")
+	}
+}
+
+// TestReblockDrainsThePendingRepair: the transition that returns the task to
+// `blocked` is the one that consumes the request.
+func TestReblockDrainsThePendingRepair(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := blockedTask(t, s, p.ID)
+	req := RepairRequest{Prompt: "fix it", BlockReason: "check_failed"}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, TaskQueued,
+		TaskChange{PendingRepair: &req}); err != nil {
+		t.Fatalf("repair transition: %v", err)
+	}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+
+	reason := req.BlockReason
+	var drained RepairRequest
+	out, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, TaskBlocked,
+		TaskChange{BlockReason: &reason, PendingRepair: &drained})
+	if err != nil {
+		t.Fatalf("re-block: %v", err)
+	}
+	if out.PendingRepair != nil {
+		t.Errorf("pending repair = %+v, want it drained", out.PendingRepair)
+	}
+	if out.BlockReason != "check_failed" {
+		t.Errorf("block_reason = %q, want the reason restored", out.BlockReason)
+	}
+}
+
+// TestLeavingBlockedDropsAPendingRepair: a request describes *this* block, so
+// every other way out of `blocked` drops it. Without this a `retry` would run
+// a repair, and a `skip` would run one aimed at a step it had already moved
+// past (task 025).
+func TestLeavingBlockedDropsAPendingRepair(t *testing.T) {
+	for _, to := range []TaskState{TaskQueued, TaskAborted} {
+		t.Run(string(to), func(t *testing.T) {
+			s := openTest(t)
+			p := testProject(t, s, "p")
+			task := blockedTask(t, s, p.ID)
+			req := RepairRequest{Prompt: "fix it", BlockReason: "check_failed"}
+			if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, TaskQueued,
+				TaskChange{PendingRepair: &req}); err != nil {
+				t.Fatalf("repair transition: %v", err)
+			}
+			// Back to blocked without draining, the way a worktree failure
+			// blocks a repair admission before it can run one.
+			reason := "check_failed"
+			if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning,
+				TaskChange{}); err != nil {
+				t.Fatalf("admit: %v", err)
+			}
+			blocked, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, TaskBlocked,
+				TaskChange{BlockReason: &reason})
+			if err != nil {
+				t.Fatalf("re-block: %v", err)
+			}
+			if blocked.PendingRepair == nil {
+				t.Fatal("the fixture lost the request before the case under test")
+			}
+
+			out, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, to, TaskChange{})
+			if err != nil {
+				t.Fatalf("leave blocked → %s: %v", to, err)
+			}
+			if out.PendingRepair != nil {
+				t.Errorf("%s carried the repair request out of blocked: %+v", to, out.PendingRepair)
+			}
+		})
+	}
+}
+
+// TestCountStepAttemptsIgnoresRepairRows is the whole retry-budget argument in
+// one assertion: the reserved step id puts a repair at a position of its own,
+// so the blocked step's numbers are the same with repairs present as without
+// (§7.2, task 025). No query changed to make this true.
+func TestCountStepAttemptsIgnoresRepairRows(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := newTask(p.ID, "budget", TaskBlocked)
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	ref := StepRef{TaskID: task.ID, StepIndex: 3, StepID: "build"}
+	for attempt := 1; attempt <= 2; attempt++ {
+		writeRun(t, s, task.ID, 3, "build", attempt, StepFailed)
+	}
+	before, err := s.CountStepAttempts(t.Context(), ref, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if before.Last != 2 || before.Failed != 2 {
+		t.Fatalf("attempts = %+v, want 2 attempts, 2 failed", before)
+	}
+
+	// Two repairs at the same index, one of which failed.
+	writeRun(t, s, task.ID, 3, repairStepID, 1, StepSucceeded)
+	writeRun(t, s, task.ID, 3, repairStepID, 2, StepFailed)
+
+	after, err := s.CountStepAttempts(t.Context(), ref, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if after != before {
+		t.Errorf("the step's budget saw the repair rows: %+v → %+v", before, after)
+	}
+	// And the repair's own position numbers independently.
+	repairs, err := s.CountStepAttempts(t.Context(),
+		StepRef{TaskID: task.ID, StepIndex: 3, StepID: repairStepID}, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if repairs.Last != 2 {
+		t.Errorf("repair attempts = %+v, want the second repair to be attempt 2", repairs)
+	}
+}
+
+// repairStepID mirrors internal/taskrun's reserved id (§5.4, task 025). The
+// store must not import the engine, and this is a fixture rather than a
+// shared constant: what the store owes the id is that its composite key
+// treats it like any other, which is exactly what the test above asserts.
+const repairStepID = "__repair"
+
+func writeRun(t *testing.T, s *Store, taskID int64, index int, stepID string, attempt int, state StepRunState) {
+	t.Helper()
+	run := &StepRun{
+		TaskID: taskID, StepIndex: index, StepID: stepID, StepType: "agent",
+		Attempt: attempt, State: state,
+	}
+	if err := s.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -15,7 +15,7 @@ import (
 const taskColumns = `id, project_id, title, description, fields_json, workflow_name, workflow_snapshot,
 	base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 	state, current_step, block_reason, pause_requested, retry_cursor_at, pending_override_json,
-	pending_input_json, admit_not_before, queued_reason,
+	pending_repair_json, pending_input_json, admit_not_before, queued_reason,
 	parent_task_id, parent_step_index, lane_id, lane_order,
 	created_at, updated_at, started_at, finished_at, archived_at`
 
@@ -767,6 +767,7 @@ func scanTask(r rowScanner) (*Task, error) {
 		worktree, blockReason       sql.NullString
 		agentOv, modelOv, effortOv  sql.NullString
 		retryCursor, pendingOv      sql.NullString
+		pendingRepair               sql.NullString
 		pendingInput                sql.NullString
 		admitNotBefore, queuedWhy   sql.NullString
 		parentID, parentStep        sql.NullInt64
@@ -780,7 +781,7 @@ func scanTask(r rowScanner) (*Task, error) {
 		&agentOv, &modelOv, &effortOv,
 		(*string)(&t.State), &t.CurrentStep, &blockReason,
 		&t.PauseRequested, &retryCursor, &pendingOv,
-		&pendingInput, &admitNotBefore, &queuedWhy,
+		&pendingRepair, &pendingInput, &admitNotBefore, &queuedWhy,
 		&parentID, &parentStep, &laneID, &laneOrder,
 		&created, &updated, &started, &finished, &archived); err != nil {
 		return nil, err
@@ -808,6 +809,13 @@ func scanTask(r rowScanner) (*Task, error) {
 			return nil, fmt.Errorf("pending_override_json: %w", err)
 		}
 		t.PendingOverride = &ov
+	}
+	if pendingRepair.Valid && pendingRepair.String != "" {
+		var req RepairRequest
+		if err := json.Unmarshal([]byte(pendingRepair.String), &req); err != nil {
+			return nil, fmt.Errorf("pending_repair_json: %w", err)
+		}
+		t.PendingRepair = &req
 	}
 	if err := json.Unmarshal([]byte(fields), &t.Fields); err != nil {
 		return nil, fmt.Errorf("fields_json: %w", err)

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -71,6 +71,16 @@ type TaskChange struct {
 	// PendingOverride hands edit+retry text to the actor that will create
 	// the next attempt's step run; it clears when drained.
 	PendingOverride *Override
+	// PendingRepair hands an ad-hoc repair request to the actor the
+	// admission it produces will start (§6, task 025). An empty request
+	// clears the column, which is how the re-block drains it.
+	//
+	// Clearing is otherwise not the caller's job: TransitionTask NULLs the
+	// column on any transition *out of* blocked that does not set one, so
+	// `retry`, `skip` and `cancel` can never hand a stale request to a later
+	// admission. The carve-out is the repair action itself, which is exactly
+	// the blocked → queued transition that writes one.
+	PendingRepair *RepairRequest
 	// PendingInput stores the normalized InputRequest JSON with the
 	// transition into awaiting_input (§7.4). Clearing is not the caller's
 	// job: TransitionTask NULLs the column on any transition out of
@@ -131,6 +141,14 @@ func (s *Store) TransitionTask(
 			// awaiting_input always discards the pending request.
 			t.PendingInputJSON = ""
 		}
+		if from == TaskBlocked && ch.PendingRepair == nil {
+			// A repair request describes *this* block, so any other way out
+			// of blocked drops it — retry means retry, and skip must not
+			// hand a repair aimed at one step to the step after it. The one
+			// transition that sets a request is the repair action itself,
+			// and it is carved out by having supplied one (task 025).
+			t.PendingRepair = nil
+		}
 		if from == TaskQueued {
 			// The §11 admission-hold invariant, same construction: a hold
 			// describes *this* queued period, so leaving queued always drops
@@ -164,15 +182,20 @@ func (s *Store) TransitionTask(
 		if err != nil {
 			return err
 		}
+		pendingRepair, err := marshalRepair(t.PendingRepair)
+		if err != nil {
+			return err
+		}
 		res, err := tx.ExecContext(ctx, `
 			UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
 				workflow_snapshot = ?, pause_requested = ?, retry_cursor_at = ?,
-				pending_override_json = ?, pending_input_json = ?,
+				pending_override_json = ?, pending_repair_json = ?, pending_input_json = ?,
 				admit_not_before = ?, queued_reason = ?,
 				updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
 			WHERE id = ? AND state = ?`,
 			string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
 			t.WorkflowSnapshot, t.PauseRequested, formatTimePtr(t.RetryCursorAt), pendingOverride,
+			pendingRepair,
 			nullString(t.PendingInputJSON),
 			formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
 			formatTime(t.UpdatedAt),
@@ -359,6 +382,13 @@ func applyChange(t *Task, ch TaskChange) {
 			t.PendingOverride = ch.PendingOverride
 		}
 	}
+	if ch.PendingRepair != nil {
+		if ch.PendingRepair.Empty() {
+			t.PendingRepair = nil
+		} else {
+			t.PendingRepair = ch.PendingRepair
+		}
+	}
 	if ch.PendingInput != nil {
 		t.PendingInputJSON = *ch.PendingInput
 	}
@@ -378,6 +408,19 @@ func marshalOverride(o *Override) (any, error) {
 	b, err := json.Marshal(o)
 	if err != nil {
 		return nil, fmt.Errorf("marshal pending override: %w", err)
+	}
+	return string(b), nil
+}
+
+// marshalRepair renders a pending repair request for storage; none is SQL
+// NULL.
+func marshalRepair(r *RepairRequest) (any, error) {
+	if r == nil || r.Empty() {
+		return nil, nil
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pending repair: %w", err)
 	}
 	return string(b), nil
 }

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lezli01/vincent/internal/store"
@@ -35,6 +36,17 @@ type OverrideMismatchError struct {
 
 func (e *OverrideMismatchError) Error() string {
 	return fmt.Sprintf("%s is not valid for a %s step", e.Field, e.StepType)
+}
+
+// RepairPromptError reports a repair asked for with nothing to say. The API
+// answers 400: an agent launched with no instructions is spend with no
+// question attached (task 025).
+type RepairPromptError struct {
+	TaskID int64
+}
+
+func (e *RepairPromptError) Error() string {
+	return fmt.Sprintf("task %d: a repair needs a prompt", e.TaskID)
 }
 
 // Cancel aborts a task and stops any process it is running (§6). The task
@@ -147,6 +159,35 @@ func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store
 		ch.PendingOverride = &ov
 	}
 	return r.transitionFrom(ctx, task, taskstate.Retry, ch)
+}
+
+// Repair launches a one-off agent in the blocked task's existing worktree
+// (§6, task 025). The request is persisted on the task and the task is
+// re-queued; the scheduler admits it exactly like anything else, so both §11
+// caps apply and internal/scheduler stays the only producer of
+// `queued → running`. The actor that admission starts runs the agent and
+// returns the task to `blocked` at the same step with the same reason.
+//
+// Unlike Retry it must not stamp `retry_cursor_at`: a repair is not a retry,
+// and moving the cursor would silently hand the blocked step a fresh budget
+// the human did not ask for (§7.2).
+func (r *Runner) Repair(ctx context.Context, id int64, req store.RepairRequest) (*store.Task, error) {
+	req.Prompt = strings.TrimSpace(req.Prompt)
+	if req.Prompt == "" {
+		return nil, &RepairPromptError{TaskID: id}
+	}
+	task, err := r.deps.Store.GetTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !taskstate.Can(task.State, taskstate.Repair) {
+		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Repair, State: task.State}
+	}
+	// The reason rides the request because the transition about to happen
+	// clears `block_reason`, and the re-block afterwards has to put the same
+	// one back: a repair decides nothing about the blocked step.
+	req.BlockReason = task.BlockReason
+	return r.transitionFrom(ctx, task, taskstate.Repair, store.TaskChange{PendingRepair: &req})
 }
 
 // Skip marks the current step skipped and advances (§6). From a gate the
@@ -512,6 +553,14 @@ func AsInvalidAction(err error) (*InvalidActionError, bool) {
 // what it is.
 func AsOverrideMismatch(err error) (*OverrideMismatchError, bool) {
 	var e *OverrideMismatchError
+	ok := errors.As(err, &e)
+	return e, ok
+}
+
+// AsRepairPrompt extracts a *RepairPromptError from err, if that is what it
+// is.
+func AsRepairPrompt(err error) (*RepairPromptError, bool) {
+	var e *RepairPromptError
 	ok := errors.As(err, &e)
 	return e, ok
 }

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -125,6 +125,8 @@ func (h *actionHarness) invoke(
 		return h.runner.Resume(ctx, id)
 	case taskstate.Retry:
 		return h.runner.Retry(ctx, id, store.Override{})
+	case taskstate.Repair:
+		return h.runner.Repair(ctx, id, store.RepairRequest{Prompt: "fix it"})
 	case taskstate.Skip:
 		return h.runner.Skip(ctx, id)
 	case taskstate.Approve:
@@ -173,7 +175,8 @@ func TestActionsFromEveryValidState(t *testing.T) {
 func TestActionsFromInvalidStateConflict(t *testing.T) {
 	actions := []taskstate.Action{
 		taskstate.Cancel, taskstate.Pause, taskstate.Resume, taskstate.Retry,
-		taskstate.Skip, taskstate.Approve, taskstate.Reject, taskstate.Archive,
+		taskstate.Repair, taskstate.Skip, taskstate.Approve, taskstate.Reject,
+		taskstate.Archive,
 	}
 	for _, action := range actions {
 		// Find a state this action is not valid from.

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -237,6 +237,14 @@ func (e *stepEnv) blindTo(run *store.StepRun) bool {
 	if run.StepType == workflow.StepLoop {
 		return true
 	}
+	// The third rule, and the plainest: a repair is not a step of the
+	// workflow (task 025). Its row sits at the blocked step's index under a
+	// reserved id, and letting it through would put `__repair` in `.Steps`
+	// for every step after it — a key no workflow author wrote, present
+	// exactly when somebody happened to press a key.
+	if run.StepID == RepairStepID {
+		return true
+	}
 	if !e.inGroup || e.loop != nil {
 		return false
 	}
@@ -286,6 +294,19 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 	}
 	if err := r.ensureWorktree(ctx, task, project, log); err != nil {
 		return // ensureWorktree already blocked or re-queued the task
+	}
+	// An ad-hoc repair the human asked for while the task was blocked (§6,
+	// task 025). It is a whole admission of its own: one agent runs in this
+	// worktree and the task goes back to `blocked` at the same step, so the
+	// step walk below never starts.
+	//
+	// It sits after ensureWorktree deliberately. A task blocked before its
+	// worktree existed (`branch_exists`, `base_branch_missing`) re-blocks on
+	// the same reason above without spawning an agent, which is the right
+	// outcome reached by code that already existed.
+	if req := task.PendingRepair; req != nil && !req.Empty() {
+		r.runRepair(ctx, task, project, wf, *req, log)
+		return
 	}
 
 	for index := task.CurrentStep; index < len(wf.Steps); index++ {
@@ -561,7 +582,14 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 	// insert drains it in the same transaction — it marks the attempt the
 	// human edited, not the automatic retries that may follow, and a crash
 	// cannot clear it without recording it.
-	if err := r.deps.Store.CreateStepRunTakingOverride(r.persistCtx(), run); err != nil {
+	create := r.deps.Store.CreateStepRunTakingOverride
+	if env.step.ID == RepairStepID {
+		// A repair is not the attempt the human edited (task 025): draining
+		// their override onto it would record the edit against a row that is
+		// not the step, and take it away from the retry that is.
+		create = r.deps.Store.CreateStepRun
+	}
+	if err := create(r.persistCtx(), run); err != nil {
 		env.log.Error("create step run", "error", err)
 		return stepOutcome{state: store.StepFailed, reason: ReasonInternalError}
 	}

--- a/internal/taskrun/repair.go
+++ b/internal/taskrun/repair.go
@@ -1,0 +1,341 @@
+package taskrun
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// RepairStepID is the reserved step id every ad-hoc repair run is recorded
+// under (§5.4, task 025). The row sits at the *blocked step's* index, so the
+// composite key `(task_id, step_index, step_id, iteration)` that
+// store.CountStepAttempts already keys on is what keeps a repair out of that
+// step's retry budget — no query changes, and no `kind` column.
+//
+// It starts with an underscore, which no workflow step id may (ids are slugs,
+// §8.1), so it can never collide with a step somebody wrote. `attempt`
+// numbers repairs of one step independently: a second repair is attempt 2 of
+// the repair, not attempt N+1 of the step.
+const RepairStepID = "__repair"
+
+// repairTranscriptLines is how much of the failed attempt's transcript is
+// inlined in the repair prompt. It is §8.4's existing failure-block bound
+// reused rather than invented: the whole file is capped at
+// `transcript_max_bytes`, which is megabytes, and its path goes in the prompt
+// so the agent can read the rest itself.
+const repairTranscriptLines = 200
+
+// repairTranscriptTailBytes bounds how much of the transcript file is read to
+// find those lines. A runaway attempt can leave megabytes of JSONL, and only
+// the end of it is wanted.
+const repairTranscriptTailBytes = 512 << 10
+
+// runRepair executes one ad-hoc repair admission (§6, task 025) and returns
+// the task to `blocked`.
+//
+// The repair is an ordinary agent step in every mechanical respect: it goes
+// through runStepWithRetries, so it gets a step_runs row, a transcript,
+// step.started/step.finished events and token and cost accounting for free.
+// That is the same shape the fan-out `on_conflict: agent` resolver already
+// uses (join.go) — a synthetic step run through the ordinary executor with
+// `inGroup` set.
+//
+// What it deliberately does *not* do is decide anything. Whatever the agent
+// exits with, the task goes back to `blocked` at the same step carrying the
+// reason it was blocked with, and the human retries, repairs again, skips or
+// cancels. Auto-retrying on success was rejected: the operator would never
+// see the repair's diff before the step re-ran, and a repair agent's exit
+// code is not the right thing to authorize more agent spend with (§7.2 — a
+// human decides what a machine could not).
+func (r *Runner) runRepair(
+	ctx context.Context, task *store.Task, project *store.Project,
+	wf *workflow.Workflow, req store.RepairRequest, log *slog.Logger,
+) {
+	// A cancel or shutdown that landed between admission and here must not
+	// spawn a process for a task that is already ending; the request stays
+	// set, so the repair re-runs when the task is admitted again.
+	if ctx.Err() != nil || r.interrupting(task.ID) {
+		r.interrupt(task, log)
+		return
+	}
+	index := task.CurrentStep
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(wf.Steps) {
+		// The cursor is past the end: nothing failed here, so there is no
+		// failure context to gather and nothing sensible to repair.
+		log.Warn("repair requested at a step that does not exist", "step_index", index)
+		r.finishRepair(task, req, log)
+		return
+	}
+	log = log.With("repair_step_index", index)
+
+	prompt := r.repairPrompt(ctx, task, project, wf, index, req)
+	noRetries := 0
+	env := &stepEnv{
+		task: task, project: project, wf: wf,
+		index: index,
+		// inGroup is what gives the row and its transcript a name of their
+		// own at an index another step already owns, exactly as a `parallel`
+		// sub-step gets one (task 014 decision 16).
+		inGroup: true,
+		step: workflow.Step{
+			ID:   RepairStepID,
+			Name: "repair",
+			Type: workflow.StepAgent,
+			// Literal text, escaped: the operator typed prose at a form, and
+			// §8.4 renders with missingkey=error (task 025).
+			Prompt: workflow.EscapeTemplate(prompt),
+			// A failed repair fails fast rather than silently paying for a
+			// second agent run — the built-in `adhoc` workflow's reasoning
+			// (phase 2 decision) applied to the same shape of one-off run.
+			MaxRetries: &noRetries,
+			// The request stands in for the step level of §8.6's chain:
+			// request > task override > workflow `defaults` > adapter
+			// default. The blocked step's own selection is deliberately not
+			// the base — a `command` step has none.
+			Agent:  req.Agent,
+			Model:  req.Model,
+			Effort: req.Effort,
+		},
+		log: log.With("step", RepairStepID),
+	}
+	outcome := r.runStepWithRetries(ctx, env)
+	if outcome.state == store.StepInterrupted {
+		// Crash, shutdown or cancel. The request is *not* drained, so the
+		// next admission runs a repair again rather than silently turning it
+		// into a plain retry of the blocked step (§12.4, task 025).
+		if outcome.reason == ReasonUsageLimit {
+			r.holdForUsageLimit(task, outcome.retryAfter, log)
+			return
+		}
+		r.interrupt(task, log)
+		return
+	}
+	log.Info("repair finished; returning the task to blocked",
+		"outcome", string(outcome.state), "reason", outcome.reason)
+	r.finishRepair(task, req, log)
+}
+
+// finishRepair returns the task to `blocked` at the same step with the reason
+// it was blocked with before, draining the request in the same transition.
+//
+// Restoring the reason is not cosmetic: applyChange clears `block_reason` on
+// any move off `blocked`, so without it a repaired task would come back with
+// no reason at all and every client that keys off one would lose the thread.
+func (r *Runner) finishRepair(task *store.Task, req store.RepairRequest, log *slog.Logger) {
+	reason := req.BlockReason
+	var drained store.RepairRequest // empty clears the column
+	ch := store.TaskChange{BlockReason: &reason, PendingRepair: &drained}
+	if r.transition(task, taskstate.Fail, ch, log) {
+		log.Warn("task blocked again after a repair", "reason", reason)
+	}
+}
+
+// repairPrompt assembles what the repair agent is told: the task's own
+// context, the blocked step's definition and failure, the tail of the failed
+// attempt's transcript and where the rest of it is, then the operator's
+// prompt.
+//
+// Everything but the last part is written by the daemon. The operator's text
+// is appended verbatim (the caller escapes the whole thing once), because it
+// is prose rather than a workflow-authoring surface — which is what separates
+// a repair prompt from `edit + retry`, whose override lands in the task's
+// snapshot.
+func (r *Runner) repairPrompt(
+	ctx context.Context, task *store.Task, project *store.Project,
+	wf *workflow.Workflow, index int, req store.RepairRequest,
+) string {
+	step := wf.Steps[index]
+	var sb strings.Builder
+	sb.WriteString("You are repairing a blocked task in a git worktree.\n\n")
+	sb.WriteString("A workflow step failed and the task is waiting for a human. " +
+		"Investigate and change the worktree so that step can succeed on its next run. " +
+		"You are working in the task's existing worktree, on its branch: the files are " +
+		"as the failed step left them.\n\n")
+	sb.WriteString("Do not re-run the workflow and do not try to mark the step passed. " +
+		"When you are done, the task returns to its blocked state and a human decides " +
+		"whether to retry the step.\n\n")
+
+	fmt.Fprintf(&sb, "<task id=%q>\n", fmt.Sprint(task.ID))
+	fmt.Fprintf(&sb, "title: %s\n", task.Title)
+	if task.Description != "" {
+		sb.WriteString("description:\n")
+		sb.WriteString(task.Description)
+		if !strings.HasSuffix(task.Description, "\n") {
+			sb.WriteString("\n")
+		}
+	}
+	if len(task.Fields) > 0 {
+		sb.WriteString("fields:\n")
+		for _, k := range sortedKeys(task.Fields) {
+			fmt.Fprintf(&sb, "  %s: %s\n", k, task.Fields[k])
+		}
+	}
+	fmt.Fprintf(&sb, "workflow: %s\n", wf.Name)
+	fmt.Fprintf(&sb, "project: %s (%s)\n", project.Name, project.Path)
+	fmt.Fprintf(&sb, "branch: %s (from %s)\n", task.BranchName, task.BaseBranch)
+	fmt.Fprintf(&sb, "worktree: %s\n", task.WorktreePath)
+	sb.WriteString("</task>\n\n")
+
+	fmt.Fprintf(&sb, "<blocked-step index=%q id=%q type=%q>\n",
+		fmt.Sprint(index+1), step.ID, step.Type)
+	if req.BlockReason != "" {
+		fmt.Fprintf(&sb, "block reason: %s\n", req.BlockReason)
+	}
+	run := r.lastAttemptAt(ctx, task.ID, index)
+	if run != nil {
+		if run.FailureReason != "" && run.FailureReason != req.BlockReason {
+			fmt.Fprintf(&sb, "failure reason: %s\n", run.FailureReason)
+		}
+		if run.ExitCode != nil {
+			fmt.Fprintf(&sb, "exit code: %d\n", *run.ExitCode)
+		}
+		if run.CheckExitCode != nil {
+			fmt.Fprintf(&sb, "check exit code: %d\n", *run.CheckExitCode)
+		}
+	}
+	if body, field := r.renderBlockedStep(ctx, task, project, wf, index); body != "" {
+		fmt.Fprintf(&sb, "--- %s ---\n", field)
+		sb.WriteString(strings.TrimSuffix(body, "\n"))
+		sb.WriteString("\n")
+	}
+	if step.Check != "" {
+		sb.WriteString("--- check ---\n")
+		sb.WriteString(strings.TrimSuffix(step.Check, "\n") + "\n")
+	}
+	if run != nil && run.ResultSummary != "" {
+		sb.WriteString("--- result ---\n")
+		sb.WriteString(strings.TrimSuffix(run.ResultSummary, "\n") + "\n")
+	}
+	if run != nil && run.TranscriptPath != "" {
+		fmt.Fprintf(&sb, "--- transcript: %s ---\n", run.TranscriptPath)
+		if tail := tailLines(run.TranscriptPath, repairTranscriptLines, repairTranscriptTailBytes); tail != "" {
+			fmt.Fprintf(&sb, "(last %d lines; read the file above for the rest)\n", repairTranscriptLines)
+			sb.WriteString(tail + "\n")
+		}
+	}
+	sb.WriteString("</blocked-step>\n\n")
+
+	sb.WriteString("<repair-instructions>\n")
+	sb.WriteString(strings.TrimSuffix(req.Prompt, "\n"))
+	sb.WriteString("\n</repair-instructions>\n")
+	return sb.String()
+}
+
+// renderBlockedStep renders the blocked step's prompt or command against the
+// §8.4 context, so the repair agent reads what the step actually ran rather
+// than its un-substituted template. A template that no longer renders falls
+// back to the raw text: the point is to show the agent what it is looking at,
+// and a render failure is itself worth seeing.
+func (r *Runner) renderBlockedStep(
+	ctx context.Context, task *store.Task, project *store.Project,
+	wf *workflow.Workflow, index int,
+) (body, field string) {
+	step := wf.Steps[index]
+	switch step.Type {
+	case workflow.StepAgent:
+		body, field = step.Prompt, "prompt"
+	case workflow.StepCommand:
+		body, field = step.Run, "command"
+	case workflow.StepManual:
+		body, field = step.Instructions, "instructions"
+	default:
+		return "", ""
+	}
+	if body == "" {
+		return "", field
+	}
+	env := &stepEnv{
+		task: task, project: project, wf: wf, step: step, index: index,
+		log: r.deps.Logger,
+	}
+	rc, err := r.renderContext(ctx, env, 1, stepOutcome{})
+	if err != nil {
+		return body, field
+	}
+	rendered, err := workflow.Render(field, body, rc)
+	if err != nil {
+		return body, field
+	}
+	return rendered, field
+}
+
+// lastAttemptAt is the most recent real attempt of the blocked step — the one
+// whose failure the repair is about. Repair rows are skipped: an earlier
+// repair is not what blocked the task, and quoting its transcript back at the
+// next repair would replace the evidence with a copy of the last attempt to
+// remove it.
+func (r *Runner) lastAttemptAt(ctx context.Context, taskID int64, index int) *store.StepRun {
+	runs, err := r.deps.Store.ListStepRunsAt(ctx, taskID, index)
+	if err != nil {
+		r.deps.Logger.Warn("repair: step history unavailable", "task", taskID, "error", err)
+		return nil
+	}
+	for i := len(runs) - 1; i >= 0; i-- {
+		if runs[i].StepID == RepairStepID {
+			continue
+		}
+		return &runs[i]
+	}
+	return nil
+}
+
+// sortedKeys orders a field map so the prompt is byte-identical across runs
+// with the same inputs — Go map order is not.
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// tailLines returns the last n lines of the file at path, reading at most
+// maxBytes from its end. A file that cannot be read yields "" — the prompt
+// still carries the path, and a missing transcript must not fail a repair the
+// human asked for.
+func tailLines(path string, n int, maxBytes int64) string {
+	f, err := os.Open(path) //nolint:gosec // the path comes from this daemon's own step_runs row
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	partial := false
+	if size := info.Size(); size > maxBytes {
+		if _, err := f.Seek(size-maxBytes, io.SeekStart); err != nil {
+			return ""
+		}
+		// The seek lands mid-line; that fragment is not a transcript record
+		// and would be handed to the agent as malformed JSON.
+		partial = true
+	}
+	sc := bufio.NewScanner(f)
+	// A JSONL transcript line can be long (a whole agent message); the
+	// default 64 KiB token bound would stop the scan at the first one.
+	sc.Buffer(make([]byte, 0, 64<<10), int(maxBytes))
+	lines := newOutputTail(n)
+	for sc.Scan() {
+		if partial {
+			partial = false
+			continue
+		}
+		lines.add(sc.Text())
+	}
+	return lines.String()
+}

--- a/internal/taskrun/repair_test.go
+++ b/internal/taskrun/repair_test.go
@@ -1,0 +1,632 @@
+package taskrun
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/scheduler"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// fakeAgentMark is the line cmd/fakeagent appends to FAKEAGENT_EDIT_FILE. The
+// check below greps for it, so the repair agent changing the worktree is what
+// makes the blocked step pass — not a timer and not a retry.
+const fakeAgentMark = "fakeagent was here"
+
+// repairSnapshot is a command step whose check fails until README.md carries
+// the fake agent's line, followed by a step that only runs if the first one
+// passed. Both the run and the check are spelled in the sh ∩ pwsh
+// intersection (§8.3): `git grep -q` exits 1 on no match on every platform.
+const repairSnapshot = `name: repairable
+defaults:
+  agent: claude
+steps:
+  - id: build
+    type: command
+    max_retries: 0
+    run: git --version
+    check: git grep -q "` + fakeAgentMark + `" -- README.md
+  - id: after
+    type: command
+    run: git --version
+`
+
+// blockedOnCheck runs a task until its first step blocks on a failed check,
+// which is the state every repair below starts from.
+func blockedOnCheck(t *testing.T, h *engineHarness) *store.Task {
+	t.Helper()
+	task := h.createTask(t, repairSnapshot)
+	h.start(t)
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonCheckFailed {
+		t.Fatalf("task = %s/%q, want blocked/check_failed", blocked.State, blocked.BlockReason)
+	}
+	return blocked
+}
+
+// repairRuns is the rows recorded under the reserved repair id.
+func repairRuns(runs []store.StepRun) []store.StepRun {
+	var out []store.StepRun
+	for _, r := range runs {
+		if r.StepID == RepairStepID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// stepRunsFor is the rows of one workflow step, repairs excluded.
+func stepRunsFor(runs []store.StepRun, stepID string) []store.StepRun {
+	var out []store.StepRun
+	for _, r := range runs {
+		if r.StepID == stepID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestRepairRunsInTheWorktreeAndReturnsToBlocked is the shape of the whole
+// feature (task 025): one agent runs in the task's existing worktree, the
+// change it makes is there afterwards, and the task comes back to `blocked`
+// at the same step with the same reason — the repair decides nothing.
+func TestRepairRunsInTheWorktreeAndReturnsToBlocked(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	t.Setenv("FAKEAGENT_EDIT_FILE", "README.md")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	before := h.stepRuns(t, blocked.ID)
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "make the check pass"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	after := h.waitForRepair(t, blocked.ID, 1)
+
+	if after.State != store.TaskBlocked {
+		t.Errorf("task = %s, want blocked again", after.State)
+	}
+	if after.BlockReason != ReasonCheckFailed {
+		t.Errorf("block_reason = %q, want the reason it was blocked with", after.BlockReason)
+	}
+	if after.CurrentStep != blocked.CurrentStep {
+		t.Errorf("current_step = %d, want %d — a repair never advances", after.CurrentStep, blocked.CurrentStep)
+	}
+	if after.PendingRepair != nil {
+		t.Error("the repair request survived the re-block; it drains with that transition")
+	}
+
+	// The agent ran in this task's worktree, on its branch.
+	readme, err := os.ReadFile(filepath.Join(after.WorktreePath, "README.md"))
+	if err != nil {
+		t.Fatalf("read the repaired worktree: %v", err)
+	}
+	if !strings.Contains(string(readme), fakeAgentMark) {
+		t.Errorf("the repair agent did not change the task's worktree: %q", readme)
+	}
+
+	runs := h.stepRuns(t, after.ID)
+	repairs := repairRuns(runs)
+	if len(repairs) != 1 {
+		t.Fatalf("repair rows = %d, want 1", len(repairs))
+	}
+	row := repairs[0]
+	if row.StepIndex != blocked.CurrentStep {
+		t.Errorf("repair row step_index = %d, want the blocked step's %d", row.StepIndex, blocked.CurrentStep)
+	}
+	if row.Attempt != 1 || row.State != store.StepSucceeded {
+		t.Errorf("repair row = attempt %d/%s, want attempt 1/succeeded", row.Attempt, row.State)
+	}
+	if row.StepType != "agent" || row.Agent == "" {
+		t.Errorf("repair row = %s/%q, want an agent row naming its adapter", row.StepType, row.Agent)
+	}
+	if row.TranscriptPath == "" {
+		t.Error("the repair has no transcript; it is meant to be as auditable as any other run")
+	}
+
+	// The blocked step itself did not run again: a repair is not a retry.
+	if got, want := len(stepRunsFor(runs, "build")), len(stepRunsFor(before, "build")); got != want {
+		t.Errorf("build attempts = %d, want %d — a successful repair must not re-run the step", got, want)
+	}
+	if len(stepRunsFor(runs, "after")) != 0 {
+		t.Error("the workflow advanced past the blocked step during a repair")
+	}
+}
+
+// TestRepairThenRetryCompletesTheWorkflow is the acceptance criterion the
+// issue names: after a repair that fixed the underlying problem, retrying the
+// blocked step passes it and the workflow carries on.
+func TestRepairThenRetryCompletesTheWorkflow(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	t.Setenv("FAKEAGENT_EDIT_FILE", "README.md")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "make the check pass"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	h.waitForRepair(t, blocked.ID, 1)
+
+	if _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	done := h.waitForState(t, blocked.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done after a repair that fixed the check",
+			done.State, done.BlockReason)
+	}
+	if len(stepRunsFor(h.stepRuns(t, done.ID), "after")) == 0 {
+		t.Error("the workflow did not continue past the repaired step")
+	}
+}
+
+// TestRepairDoesNotConsumeTheStepBudget is the mechanism the whole design
+// rests on: the repair's row sits at the blocked step's index under a
+// reserved id, and CountStepAttempts keys on the composite position — so the
+// step's budget cannot see it (task 025).
+func TestRepairDoesNotConsumeTheStepBudget(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	ref := store.StepRef{TaskID: blocked.ID, StepIndex: blocked.CurrentStep, StepID: "build"}
+	before, err := h.store.CountStepAttempts(t.Context(), ref, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "look around"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	h.waitForRepair(t, blocked.ID, 1)
+
+	after, err := h.store.CountStepAttempts(t.Context(), ref, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if after != before {
+		t.Errorf("the blocked step's attempts changed across a repair: %+v → %+v", before, after)
+	}
+}
+
+// TestSecondRepairIsAttemptTwoOfTheRepair: attempt numbers belong to the
+// position, and the repair's position is its own. A second repair is attempt
+// 2 of the repair, not attempt N+1 of the step.
+func TestSecondRepairIsAttemptTwoOfTheRepair(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+
+	for i := 1; i <= 2; i++ {
+		if _, err := h.runner.Repair(t.Context(), blocked.ID,
+			store.RepairRequest{Prompt: "again"}); err != nil {
+			t.Fatalf("Repair %d: %v", i, err)
+		}
+		h.waitForRepair(t, blocked.ID, i)
+	}
+	repairs := repairRuns(h.stepRuns(t, blocked.ID))
+	if len(repairs) != 2 {
+		t.Fatalf("repair rows = %d, want 2", len(repairs))
+	}
+	if repairs[0].Attempt != 1 || repairs[1].Attempt != 2 {
+		t.Errorf("repair attempts = %d, %d; want 1, 2", repairs[0].Attempt, repairs[1].Attempt)
+	}
+	if repairs[0].TranscriptPath == repairs[1].TranscriptPath {
+		t.Error("both repairs wrote the same transcript file")
+	}
+}
+
+// TestFailedRepairLeavesTheTaskBlockedWithTheSameReason: the repair's exit
+// code decides nothing. A repair that failed leaves exactly what a repair
+// that succeeded leaves — the task blocked where it was, with the reason it
+// had — and the failure is on its own row for a human to read.
+func TestFailedRepairLeavesTheTaskBlockedWithTheSameReason(t *testing.T) {
+	// The blocked step is a command step, so this scenario reaches the repair
+	// agent and nothing else.
+	t.Setenv("FAKEAGENT_SCENARIO", "nonzero-exit")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "try something"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	after := h.waitForRepair(t, blocked.ID, 1)
+
+	if after.State != store.TaskBlocked || after.BlockReason != ReasonCheckFailed {
+		t.Errorf("task = %s/%q, want blocked/check_failed after a failed repair",
+			after.State, after.BlockReason)
+	}
+	repairs := repairRuns(h.stepRuns(t, after.ID))
+	if len(repairs) != 1 || repairs[0].State != store.StepFailed {
+		t.Fatalf("repair rows = %+v, want one failed row", repairs)
+	}
+	// max_retries: 0 on the synthetic step — a failed repair fails fast
+	// rather than silently paying for a second agent run.
+	if repairs[0].Attempt != 1 {
+		t.Errorf("the failed repair ran %d attempts, want 1", repairs[0].Attempt)
+	}
+}
+
+// TestRepairPromptCarriesTheFailureContext asserts the block the daemon
+// assembles: the task's own context, the blocked step's definition and
+// failure, where the transcript is, and the operator's words last.
+//
+// It calls the assembler rather than reading it back off the wire because the
+// fake agent's echo is truncated at 1000 characters, which a real failure
+// block exceeds — the end-to-end leg is
+// TestRepairPromptReachesTheAgentLiterally below.
+func TestRepairPromptCarriesTheFailureContext(t *testing.T) {
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	project, err := h.store.GetProject(t.Context(), blocked.ProjectID)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	wf, _, err := workflow.Parse([]byte(blocked.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		t.Fatalf("parse snapshot: %v", err)
+	}
+	req := store.RepairRequest{
+		Prompt: "the operator's own words", BlockReason: blocked.BlockReason,
+	}
+
+	prompt := h.runner.repairPrompt(t.Context(), blocked, project, wf, blocked.CurrentStep, req)
+	for _, want := range []string{
+		"engine test",              // the task title
+		"a task",                   // its description
+		blocked.BranchName,         // the branch the agent is on
+		blocked.WorktreePath,       // and the worktree it works in
+		"build",                    // the blocked step's id
+		"git --version",            // its rendered command
+		fakeAgentMark,              // its check
+		ReasonCheckFailed,          // why it is blocked
+		"the operator's own words", // and what the human asked for
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("the repair prompt does not carry %q", want)
+		}
+	}
+	run := stepRunsFor(h.stepRuns(t, blocked.ID), "build")[0]
+	if !strings.Contains(prompt, run.TranscriptPath) {
+		t.Error("the repair prompt does not say where the failed attempt's transcript is")
+	}
+	// The operator's words go last, after everything the daemon assembled.
+	if strings.Index(prompt, "the operator's own words") < strings.Index(prompt, ReasonCheckFailed) {
+		t.Error("the operator's prompt does not come after the failure context")
+	}
+}
+
+// TestRepairPromptReachesTheAgentLiterally: the operator types prose, and
+// §8.4 renders with missingkey=error — so a `{{` reaching Render unescaped
+// would fail the repair before the process started.
+func TestRepairPromptReachesTheAgentLiterally(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "replace {{.Nope}} with a literal"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	h.waitForRepair(t, blocked.ID, 1)
+
+	row := repairRuns(h.stepRuns(t, blocked.ID))[0]
+	if row.State != store.StepSucceeded {
+		t.Fatalf("repair row = %s/%q, want a prompt that rendered as prose",
+			row.State, row.FailureReason)
+	}
+	body, err := os.ReadFile(row.TranscriptPath) //nolint:gosec // this test's own transcript
+	if err != nil {
+		t.Fatalf("read repair transcript: %v", err)
+	}
+	if !strings.Contains(string(body), "You are repairing") {
+		t.Error("the assembled prompt never reached the agent")
+	}
+	// And the braces survive Render as the two characters that were typed.
+	rendered, err := workflow.Render("prompt",
+		workflow.EscapeTemplate("replace {{.Nope}} with a literal"), workflow.RenderContext{})
+	if err != nil {
+		t.Fatalf("an escaped prose prompt failed to render: %v", err)
+	}
+	if rendered != "replace {{.Nope}} with a literal" {
+		t.Errorf("escaped prompt rendered as %q", rendered)
+	}
+}
+
+// TestRepairRowIsInvisibleToLaterSteps: the repair's row must not become a
+// `.Steps` entry. A key no workflow author wrote, present exactly when
+// somebody happened to press a key, is worse than no key at all.
+func TestRepairRowIsInvisibleToLaterSteps(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	t.Setenv("FAKEAGENT_EDIT_FILE", "README.md")
+	h := newEngineHarness(t)
+	// The second step's guard reads `.Steps` for the reserved id. Under
+	// missingkey=error an `index` on a map is a lookup, not an error, so the
+	// guard is a real question with a real answer: is the repair visible?
+	snapshot := `name: repairable
+defaults:
+  agent: claude
+steps:
+  - id: build
+    type: command
+    max_retries: 0
+    run: git --version
+    check: git grep -q "` + fakeAgentMark + `" -- README.md
+  - id: after
+    type: command
+    if: '{{ if (index .Steps "` + RepairStepID + `").Status }}true{{ else }}false{{ end }}'
+    run: git --version
+`
+	task := h.createTask(t, snapshot)
+	h.start(t)
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.BlockReason != ReasonCheckFailed {
+		t.Fatalf("task = %s/%q, want blocked/check_failed", blocked.State, blocked.BlockReason)
+	}
+	if _, err := h.runner.Repair(t.Context(), task.ID,
+		store.RepairRequest{Prompt: "fix it"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	h.waitForRepair(t, task.ID, 1)
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	for _, r := range stepRunsFor(h.stepRuns(t, task.ID), "after") {
+		if r.SkipReason != store.SkipReasonCondition {
+			t.Errorf("the `after` guard saw the repair row: %s/%q", r.State, r.SkipReason)
+		}
+	}
+}
+
+// TestRepairWithoutAWorktreeReblocksWithoutAnAgent: a task blocked before its
+// worktree existed re-enters ensureWorktree on the repair admission and
+// re-blocks on the same reason, spawning nothing. Filtering `available_actions`
+// by block reason would put a second, reason-shaped policy next to §6's
+// state-shaped one to reach the same outcome (task 025).
+func TestRepairWithoutAWorktreeReblocksWithoutAnAgent(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h := newEngineHarness(t)
+	task := h.createTask(t, repairSnapshot)
+	// The branch the task resolved to already exists, so `git worktree add -b`
+	// refuses and the task blocks before any step runs (§10, task 001).
+	claimBranch(t, h.repo, task.BranchName)
+	h.start(t)
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.BlockReason != worktree.ReasonBranchExists {
+		t.Fatalf("task = %s/%q, want blocked/branch_exists", blocked.State, blocked.BlockReason)
+	}
+
+	if _, err := h.runner.Repair(t.Context(), task.ID,
+		store.RepairRequest{Prompt: "fix the branch"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	// Repair moved the task to `queued`, so reaching `blocked` again means a
+	// whole admission ran and blocked before any step could.
+	after := h.waitForState(t, task.ID, store.TaskBlocked)
+	if after.BlockReason != worktree.ReasonBranchExists {
+		t.Errorf("block_reason = %q, want branch_exists again", after.BlockReason)
+	}
+	if got := repairRuns(h.stepRuns(t, task.ID)); len(got) != 0 {
+		t.Errorf("an agent ran for a task with no worktree: %+v", got)
+	}
+	// The request survives, because nothing ran it: the next `retry` drains
+	// it, and a second `repair` replaces it. What must not happen is a repair
+	// silently becoming something else.
+	if after.PendingRepair == nil {
+		t.Error("the repair request was drained by a block that never ran it")
+	}
+	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	retried, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if retried.PendingRepair != nil {
+		t.Error("retry left the repair request in place; retry means retry")
+	}
+}
+
+// TestInterruptedRepairRerunsAsARepair is why the request drains at the
+// re-block and not at the row insert (§12.4, task 025). Recovery finalizes
+// the running row as `interrupted` and re-queues the task; the actor then
+// walks from `current_step`. With the request already drained, that walk
+// would silently become a plain retry of the blocked step — consuming its
+// budget, and possibly unblocking the task without the operator asking.
+func TestInterruptedRepairRerunsAsARepair(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	buildBefore := len(stepRunsFor(h.stepRuns(t, blocked.ID), "build"))
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "this one never finishes"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	h.waitForRepairRunning(t, blocked.ID)
+
+	// The daemon goes down mid-repair and comes back up.
+	h.runner.Stop()
+	h.sched.Stop()
+	if _, err := Recover(t.Context(), h.store, discardLog()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	requeued, err := h.store.GetTask(t.Context(), blocked.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if requeued.State != store.TaskQueued {
+		t.Fatalf("task = %s after recovery, want queued", requeued.State)
+	}
+	if requeued.PendingRepair == nil {
+		t.Fatal("recovery discarded the repair request; the next admission would be a plain retry")
+	}
+
+	// The restarted daemon's repair succeeds, so the outcome is observable.
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h.restart(t)
+	// One *completed* repair: waitForRepair does not count the interrupted
+	// row, which is exactly the one the crash left behind.
+	after := h.waitForRepair(t, blocked.ID, 1)
+
+	if after.State != store.TaskBlocked || after.BlockReason != ReasonCheckFailed {
+		t.Errorf("task = %s/%q, want blocked/check_failed", after.State, after.BlockReason)
+	}
+	runs := h.stepRuns(t, after.ID)
+	if got := len(stepRunsFor(runs, "build")); got != buildBefore {
+		t.Errorf("build attempts = %d, want %d — the interrupted repair re-ran the step", got, buildBefore)
+	}
+	repairs := repairRuns(runs)
+	if len(repairs) != 2 {
+		t.Fatalf("repair rows = %d, want the interrupted one and its re-run", len(repairs))
+	}
+	if repairs[0].State != store.StepInterrupted {
+		t.Errorf("the interrupted repair row is %s, want interrupted", repairs[0].State)
+	}
+	if repairs[1].State != store.StepSucceeded {
+		t.Errorf("the re-run repair row is %s, want succeeded", repairs[1].State)
+	}
+}
+
+// TestRepairRejectsAnEmptyPrompt: an agent launched with no instructions is
+// spend with no question attached.
+func TestRepairRejectsAnEmptyPrompt(t *testing.T) {
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "   \n "}); err == nil {
+		t.Fatal("an empty repair prompt was accepted")
+	} else if _, ok := AsRepairPrompt(err); !ok {
+		t.Fatalf("Repair error = %v, want *RepairPromptError", err)
+	}
+	task, err := h.store.GetTask(t.Context(), blocked.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != store.TaskBlocked || task.PendingRepair != nil {
+		t.Errorf("the refused repair moved the task: %s, pending %+v", task.State, task.PendingRepair)
+	}
+}
+
+// TestRepairDoesNotMoveTheRetryCursor: a repair is not a retry, and moving
+// the cursor would hand the blocked step a fresh budget nobody asked for
+// (§7.2).
+func TestRepairDoesNotMoveTheRetryCursor(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h := newEngineHarness(t)
+	blocked := blockedOnCheck(t, h)
+	if blocked.RetryCursorAt != nil {
+		t.Fatalf("fixture already has a retry cursor: %v", blocked.RetryCursorAt)
+	}
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "have a look"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+	after := h.waitForRepair(t, blocked.ID, 1)
+	if after.RetryCursorAt != nil {
+		t.Errorf("retry_cursor_at = %v after a repair; a repair is not a retry", after.RetryCursorAt)
+	}
+}
+
+// claimBranch creates the branch a task resolved to, so its worktree cannot
+// be created (§10, task 001).
+func claimBranch(t *testing.T, repo, branch string) {
+	t.Helper()
+	cmd := gitx.New()
+	if _, err := cmd.Run(t.Context(), repo, "branch", branch); err != nil {
+		t.Fatalf("claim branch %s: %v", branch, err)
+	}
+}
+
+// waitForRepair polls until n repair rows have finished and the task is back
+// in a resting state.
+func (h *engineHarness) waitForRepair(t *testing.T, id int64, n int) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		task, err := h.store.GetTask(t.Context(), id)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		done := 0
+		for _, r := range repairRuns(h.stepRuns(t, id)) {
+			if r.FinishedAt != nil && r.State != store.StepInterrupted {
+				done++
+			}
+		}
+		if done >= n && task.State != store.TaskQueued && task.State != store.TaskRunning {
+			return task
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never finished %d repair(s)", id, n)
+	return nil
+}
+
+// waitForRepairRunning polls until a repair row is live, which is when a
+// crash is worth simulating.
+func (h *engineHarness) waitForRepairRunning(t *testing.T, id int64) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, r := range repairRuns(h.stepRuns(t, id)) {
+			if r.State == store.StepRunning && r.PID != nil {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never started a repair", id)
+}
+
+// restart replaces the harness's runner and scheduler with fresh ones over
+// the same store and data directory — a daemon that went down and came back.
+func (h *engineHarness) restart(t *testing.T) {
+	t.Helper()
+	fake := agenttest.BuildFakeAgent(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	agents := agent.NewRegistry(claude.New(func() string { return fake }))
+	h.runner = New(Deps{
+		Store:     h.store,
+		Config:    func() config.Config { return h.cfg },
+		Worktrees: worktree.NewManager(gitx.New(), h.dataDir),
+		Agents:    agents,
+		Catalog:   agent.NewCatalogCache(agents),
+		DataDir:   h.dataDir,
+		Logger:    log,
+	})
+	sched := scheduler.New(scheduler.Deps{
+		Store:    h.store,
+		Config:   func() config.Config { return h.cfg },
+		Admitter: h.runner,
+		Logger:   log,
+	})
+	h.store.SetEventHook(func(e *store.Event) {
+		if scheduler.WakeOn(e) {
+			sched.Wake()
+		}
+	})
+	h.runner.Start(t.Context())
+	sched.Start(t.Context())
+	h.sched = sched
+	t.Cleanup(h.runner.Stop)
+	t.Cleanup(sched.Stop)
+}

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -88,6 +88,17 @@ const (
 	Approve Action = "approve"
 	Reject  Action = "reject"
 	Archive Action = "archive"
+	// Repair is an ad-hoc repair agent a human launches from `blocked`
+	// (task 025). It is a second producer of `blocked → queued`, and the
+	// admission it produces runs one agent in the task's existing worktree
+	// and returns the task to `blocked` at the same step with the same
+	// reason — the repair decides nothing about the blocked step.
+	//
+	// It is a human action rather than a lifecycle state of its own: a
+	// `repairing` state would cost an FSM row, a board legend, slot rules
+	// and a recovery path (what task 014 paid for `awaiting_children`) to
+	// buy one nicer `cancel`, which keeps its present meaning throughout.
+	Repair Action = "repair"
 )
 
 // Engine events. They are transitions the daemon performs while running a
@@ -123,7 +134,9 @@ const (
 
 // humanActions is the set of actions a client may invoke, in the order §6
 // lists them.
-var humanActions = []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
+var humanActions = []Action{
+	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive,
+}
 
 // Human reports whether a is a human action rather than an engine event.
 func Human(a Action) bool {
@@ -164,6 +177,7 @@ var table = map[Action]map[State]Transition{
 	},
 	Resume:  {Paused: {To: Queued}},
 	Retry:   {Blocked: {To: Queued}},
+	Repair:  {Blocked: {To: Queued}},
 	Skip:    {Blocked: {To: Queued}, AwaitingGate: {To: Queued}},
 	Answer:  {AwaitingInput: {To: Running}},
 	Approve: {AwaitingGate: {To: Queued}},

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -7,7 +7,7 @@ import (
 
 // allActions is every action the table may contain, human and engine.
 var allActions = []Action{
-	Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive,
+	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive,
 	Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
 	FanOut, ChildrenSettled,
 }
@@ -54,9 +54,12 @@ var wantTransitions = map[State]map[Action]State{
 		Cancel:          Aborted,
 		ChildrenSettled: Queued,
 	},
+	// Blocked is the only state `repair` is valid from (task 025): it is a
+	// second producer of blocked → queued, beside retry and skip.
 	Blocked: {
 		Cancel: Aborted,
 		Retry:  Queued,
+		Repair: Queued,
 		Skip:   Queued,
 	},
 	Paused: {
@@ -158,7 +161,7 @@ func TestHumanActionsFrom(t *testing.T) {
 		Running:       {Cancel, Pause},
 		AwaitingGate:  {Approve, Cancel, Reject, Skip},
 		AwaitingInput: {Answer, Cancel},
-		Blocked:       {Cancel, Retry, Skip},
+		Blocked:       {Cancel, Repair, Retry, Skip},
 		Paused:        {Cancel, Resume},
 		Done:          {Archive},
 		Aborted:       {Archive},
@@ -178,7 +181,7 @@ func TestHumanActionsFrom(t *testing.T) {
 // TestHumanClassification pins which actions clients may invoke: an engine
 // event must never be reachable through the API.
 func TestHumanClassification(t *testing.T) {
-	human := []Action{Cancel, Pause, Resume, Retry, Skip, Answer, Approve, Reject, Archive}
+	human := []Action{Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive}
 	engine := []Action{
 		Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
 		FanOut, ChildrenSettled,

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -37,6 +37,12 @@ const (
 	ctxWorkflowGraph bindingContext = "workflow graph"
 	ctxDaemon        bindingContext = "daemon"
 	ctxForm          bindingContext = "answer form"
+	// ctxRepairForm is the §6 repair popup (task 025). Its own context
+	// rather than more ctxForm rows: the two popups share a shape and
+	// nothing else — one picks from what an agent asked, the other types a
+	// prompt and chooses an adapter — so a single row could only describe
+	// one of them.
+	ctxRepairForm bindingContext = "repair form"
 )
 
 // binding is one registry row.
@@ -99,6 +105,7 @@ var bindings = []binding{
 	{key: "x", label: "reject the gate", scope: scopeTaskAction, action: apiclient.ActionReject, priority: 2},
 	{key: "r", label: "retry the blocked step", scope: scopeTaskAction, action: apiclient.ActionRetry, priority: 4},
 	{key: "E", label: "edit the step's prompt or command in $EDITOR, then retry", scope: scopeTaskAction, action: apiclient.ActionRetry, priority: 5},
+	{key: "R", label: "repair with an agent — a one-off run in this task's worktree; the task stays blocked afterwards", scope: scopeTaskAction, action: apiclient.ActionRepair, priority: 5},
 	{key: "s", label: "skip the current step", scope: scopeTaskAction, action: apiclient.ActionSkip, priority: 6},
 	{key: "c", label: "cancel the task (asks first — a running step is killed)", scope: scopeTaskAction, action: apiclient.ActionCancel, priority: 7},
 	{key: "A", label: "archive the task (asks first — the worktree is removed)", scope: scopeTaskAction, action: apiclient.ActionArchive, priority: 8},
@@ -172,6 +179,13 @@ var bindings = []binding{
 	{key: "e", label: "type your own answer — options are suggestions, never a list", scope: scopePanel, context: ctxForm, noPalette: true},
 	{key: "enter", label: "submit the answer; the run resumes where it stopped", scope: scopePanel, context: ctxForm, noPalette: true},
 	{key: "esc", label: "close the popup without answering (what you picked is kept)", scope: scopePanel, context: ctxForm, noPalette: true},
+
+	// Repair form: as with the answer form, these exist only while the popup
+	// owns the keyboard and it prints them itself.
+	{key: "enter", label: "edit the row under the cursor — the prompt, or the agent/model/effort list", scope: scopePanel, context: ctxRepairForm, noPalette: true},
+	{key: "e", label: "write the repair prompt in $EDITOR", scope: scopePanel, context: ctxRepairForm, noPalette: true},
+	{key: "ctrl+s", label: "start the repair agent", scope: scopePanel, context: ctxRepairForm, noPalette: true},
+	{key: "esc", label: "close the popup without repairing (the draft is discarded)", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 }
 
 // isHomeContext reports whether a context is one of the home shell's panels —

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -82,6 +82,11 @@ func diffTabDetail(t *testing.T) *detail {
 	return d
 }
 
+// repairFormFixture is a repair popup as `R` on a blocked task opens it.
+func repairFormFixture() *repairForm {
+	return newRepairForm(7, "check_failed", "build")
+}
+
 // panelKeyProbes proves one panel-scoped binding each. A probe drives the
 // real view with the key the registry publishes and asserts the effect the
 // label promises — not that the key was merely swallowed, which is what `[`
@@ -499,6 +504,40 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			d.updateKey(registryKey(t, "down"))
 			if !d.following {
 				t.Fatal("down did not reach the log pane's scroll path (follow was never re-synced)")
+			}
+		},
+	},
+
+	ctxRepairForm: {
+		"enter": func(t *testing.T) {
+			f := repairFormFixture()
+			f.update(registryKey(t, "enter"), nil)
+			if !f.editing {
+				t.Fatal("enter did not open the prompt field")
+			}
+		},
+		"e": func(t *testing.T) {
+			f := repairFormFixture()
+			opened := false
+			f.openEditor = func(string) tea.Cmd { opened = true; return nil }
+			f.update(registryKey(t, "e"), nil)
+			if !opened {
+				t.Fatal("e did not hand the prompt to $EDITOR")
+			}
+		},
+		"ctrl+s": func(t *testing.T) {
+			f := repairFormFixture()
+			f.update(registryKey(t, "ctrl+s"), nil)
+			// With no prompt typed, submitting is refused — with a reason,
+			// which is what proves the key was handled.
+			if f.err == "" {
+				t.Fatal("ctrl+s neither started the repair nor said why it would not")
+			}
+		},
+		"esc": func(t *testing.T) {
+			f := repairFormFixture()
+			if _, exit := f.update(registryKey(t, "esc"), nil); !exit {
+				t.Fatal("esc did not close the repair form")
 			}
 		},
 	},

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -108,7 +108,11 @@ type detail struct {
 	// while the task is parked on a request.
 	actions *actionBar
 	form    *answerForm
-	diff    diffPane
+	// repair is the §6 repair form (task 025). Unlike form it is never
+	// synthesized from task state: a human opens it with a key, and it closes
+	// when they submit or escape.
+	repair *repairForm
+	diff   diffPane
 	// exec runs $EDITOR for edit+retry, injected so the path is testable
 	// without a terminal.
 	exec execFunc
@@ -224,6 +228,16 @@ func (d *detail) update(msg tea.Msg) tea.Cmd {
 		return d.applyAction(msg)
 	case editRetryMsg:
 		return d.applyEdit(msg)
+	case repairAgentsLoadedMsg:
+		if d.repair != nil {
+			d.repair.applyAgents(msg)
+		}
+		return nil
+	case repairEditMsg:
+		if d.repair != nil {
+			d.repair.applyEdit(msg)
+		}
+		return nil
 	case transcriptOpenedMsg:
 		// Nothing to apply — the file was only read. A failed viewer is worth
 		// saying, since the terminal handover leaves no other trace of it.
@@ -245,6 +259,16 @@ func (d *detail) applyAction(msg actionResultMsg) tea.Cmd {
 		return nil
 	}
 	d.actions.applyResult(msg)
+	if msg.action == apiclient.ActionRepair && d.repair != nil {
+		if msg.err != nil {
+			// Same reasoning as the answer form: keep what was typed on
+			// screen rather than making the human write it again.
+			d.repair.submitting = false
+			d.repair.err = errString(msg.err)
+		} else {
+			d.repair = nil
+		}
+	}
 	if msg.action == apiclient.ActionAnswer && msg.err != nil && d.form != nil {
 		// The daemon refused the answer: keep the form and its typed values on
 		// screen, since re-entering them is the last thing a human wants.
@@ -272,7 +296,7 @@ func (d *detail) open(id int64, stateHint string) tea.Cmd {
 	d.focus = focusTimeline
 	d.tab = tabOutput
 	d.actions.clear()
-	d.form = nil
+	d.form, d.repair = nil, nil
 	d.diff.openTask(id)
 	return tea.Batch(d.loadCmd(), d.syncStream())
 }
@@ -290,7 +314,7 @@ func (d *detail) deselect() {
 	d.resetOutput()
 	d.buffer = nil
 	d.actions.clear()
-	d.form = nil
+	d.form, d.repair = nil, nil
 	d.syncStream()
 }
 
@@ -628,6 +652,11 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 			return d.editRetry()
 		}
 		return nil
+	case "R":
+		// The repair form (§6, task 025). `r` is retry and `E` is edit+retry;
+		// `R` is free in the home shell, where the takeover screens that use
+		// it for re-probing never are.
+		return d.openRepair()
 	case "f":
 		d.setFollowing(true)
 		return nil
@@ -796,6 +825,32 @@ func (d *detail) runByID(id int64) apiclient.StepRun {
 // shell's popup routing before keys reach here.)
 func (d *detail) capturesInput() bool {
 	return d.actions.capturing()
+}
+
+// openRepair opens the repair form for a blocked task, fetching the adapter
+// catalog its pickers render. It offers nothing the daemon does not: the
+// action has to be on the task's available_actions (§6).
+func (d *detail) openRepair() tea.Cmd {
+	if !d.target().has(apiclient.ActionRepair) {
+		return nil
+	}
+	reason := ""
+	if d.task.BlockReason != nil {
+		reason = *d.task.BlockReason
+	}
+	d.repair = newRepairForm(d.taskID, reason, d.currentStepName())
+	d.repair.openEditor = d.editRepairPrompt
+	return d.repair.loadAgents(d.client)
+}
+
+// currentStepName names the step the task is blocked at, for the form's
+// subject line; "" when the snapshot has not arrived.
+func (d *detail) currentStepName() string {
+	step, ok := d.task.Step(d.task.CurrentStep)
+	if !ok {
+		return ""
+	}
+	return step.ID
 }
 
 // target is the slice of the task the action bar works from.

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -179,6 +179,11 @@ func (d *detail) detailHints() []string {
 	if d.target().has(apiclient.ActionRetry) && d.stepEditable() {
 		hints = append(hints, styleKey.Render("E")+" edit+retry")
 	}
+	// `repair` has no row in actionOrder — it is a form, not a key that acts
+	// (task 025) — so its hint is the view's, the way `answer`'s is.
+	if d.target().has(apiclient.ActionRepair) {
+		hints = append(hints, styleKey.Render("R")+" repair")
+	}
 	return hints
 }
 
@@ -297,7 +302,20 @@ func (d *detail) renderTimeline(height int) string {
 			// iteration cannot happen, because it never entered ids.
 			continue
 		}
-		if (grouped || looped) && r.StepID != lastSub {
+		// A repair is not an attempt of the blocked step and must never read
+		// as one (task 025): it gets a tier of its own under the step header,
+		// whatever shape that index otherwise has.
+		repair := isRepairRun(r)
+		if repair && lastSub != r.StepID {
+			lastSub = r.StepID
+			indent := "    · "
+			if looped {
+				indent = "      · "
+			}
+			lines = append(lines, styleDim.Render(indent+"repair (ad-hoc agent)"))
+			ids = append(ids, 0)
+		}
+		if !repair && (grouped || looped) && r.StepID != lastSub {
 			lastSub = r.StepID
 			indent := "    · "
 			if looped {
@@ -306,7 +324,7 @@ func (d *detail) renderTimeline(height int) string {
 			lines = append(lines, styleDim.Render(indent+stepLabel(r)))
 			ids = append(ids, 0)
 		}
-		line := d.attemptLine(r, grouped || looped)
+		line := d.attemptLine(r, grouped || looped || repair)
 		if r.ID == d.selectedRun {
 			cursorLine = len(lines)
 			line = styleSelected.Render(line)
@@ -324,6 +342,10 @@ func (d *detail) renderTimeline(height int) string {
 	return strings.Join(lines[start:end], "\n")
 }
 
+// isRepairRun reports whether a row is an ad-hoc repair rather than an
+// attempt of the step at its index (§5.4, task 025).
+func isRepairRun(r apiclient.StepRun) bool { return r.StepID == apiclient.RepairStepID }
+
 // groupedIndexes reports which step indexes hold more than one distinct step
 // id — which is exactly the `parallel` groups, since every other step type
 // owns its index alone.
@@ -334,6 +356,12 @@ func (d *detail) renderTimeline(height int) string {
 func groupedIndexes(runs []apiclient.StepRun) map[int]bool {
 	seen := map[int]map[string]bool{}
 	for _, r := range runs {
+		if isRepairRun(r) {
+			// A repair sits at the blocked step's index under a reserved id
+			// (task 025), so counting it would make every repaired step read
+			// as a `parallel` group of itself.
+			continue
+		}
 		if seen[r.StepIndex] == nil {
 			seen[r.StepIndex] = map[string]bool{}
 		}

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -99,6 +99,40 @@ func (d *detail) editRetry() tea.Cmd {
 	})
 }
 
+// editRepairPrompt opens the repair prompt in $EDITOR (§6, task 025). A
+// repair prompt is prose of a length nobody chose, and the popup's field is
+// three lines — the same argument edit+retry already makes for its own text.
+//
+// Unlike edit+retry it posts nothing: what the editor leaves goes back into
+// the form, and the human still has to start the repair.
+func (d *detail) editRepairPrompt(text string) tea.Cmd {
+	path, err := writeEditorFile(fmt.Sprintf("task%d-repair", d.taskID), ".md", text)
+	if err != nil {
+		if d.repair != nil {
+			d.repair.err = errString(err)
+		}
+		return nil
+	}
+	argv := append(editorCommand(), path)
+	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the editor is the user's own choice
+	taskID := d.taskID
+	return d.exec(cmd, func(runErr error) tea.Msg {
+		defer func() { _ = os.Remove(path) }()
+		msg := repairEditMsg{taskID: taskID}
+		if runErr != nil {
+			msg.err = runErr
+			return msg
+		}
+		edited, readErr := os.ReadFile(path) //nolint:gosec // path is this process's temp file
+		if readErr != nil {
+			msg.err = readErr
+			return msg
+		}
+		msg.text = string(edited)
+		return msg
+	})
+}
+
 // writeEditorFile seeds a temp file with the text an editing session starts
 // from. The caller supplies the extension so the editor picks sensible
 // highlighting, and the name so two concurrent sessions cannot collide. It

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -63,15 +63,21 @@ func helpText(ctx bindingContext) string {
 	if ctx != "" {
 		writeSection(string(ctx), bindingsFor(ctx))
 	}
-	// The answer form's keys ride along with the panels it pops up over —
-	// it has no focus of its own to be the context.
-	if isHomeContext(ctx) {
-		writeSection("answer form (while a task is waiting on you)", bindingsFor(ctxForm))
-	}
 	if isHomeContext(ctx) {
 		writeSection("task actions (on the selected task, offered only when valid)", actions)
 	}
 	writeSection("global keys", global)
+	// The two popups' keys ride along with the panels they pop up over —
+	// neither has a focus of its own to be the context — and they come after
+	// the keys that work *now* rather than before them. Both popups print
+	// their own keys inside themselves while they own the keyboard, so these
+	// rows are here for completeness; the sheet has no scroll, and what it
+	// drops off the bottom should be the hypothetical rather than `esc`
+	// (task 025 — a second popup section is what made the difference visible).
+	if isHomeContext(ctx) {
+		writeSection("answer form (while a task is waiting on you)", bindingsFor(ctxForm))
+		writeSection("repair form (R on a blocked task)", bindingsFor(ctxRepairForm))
+	}
 	writeSection("go to (from the : palette)", nav)
 	return b.String()
 }

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -14,14 +14,14 @@ import (
 // hide an entry from the reachability sweep.
 var everyAction = taskActions{id: 9, state: stateRunning, actions: []string{
 	apiclient.ActionPause, apiclient.ActionResume, apiclient.ActionApprove,
-	apiclient.ActionReject, apiclient.ActionRetry, apiclient.ActionSkip,
-	apiclient.ActionCancel, apiclient.ActionArchive,
+	apiclient.ActionReject, apiclient.ActionRetry, apiclient.ActionRepair,
+	apiclient.ActionSkip, apiclient.ActionCancel, apiclient.ActionArchive,
 }}
 
 // TestPaletteReachesEveryRegistryEntry is the T3.11 done-when: every
 // registry row surfaces in the palette in its owning context. The palette's
-// own controls and the answer form's keys are exempt by construction
-// (noPalette) — the form prints its keys inside the popup that owns the
+// own controls and the two popups' keys are exempt by construction
+// (noPalette) — a form prints its keys inside the popup that owns the
 // keyboard.
 func TestPaletteReachesEveryRegistryEntry(t *testing.T) {
 	contexts := []bindingContext{

--- a/internal/tui/repairform.go
+++ b/internal/tui/repairform.go
@@ -1,0 +1,467 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// rfRow is one line of the repair form.
+type rfRow int
+
+const (
+	rfPrompt rfRow = iota
+	rfAgent
+	rfModel
+	rfEffort
+	rfRowCount
+)
+
+// repairAgentsLoadedMsg carries the adapter catalog the pickers render.
+type repairAgentsLoadedMsg struct {
+	taskID int64
+	agents apiclient.Agents
+	err    error
+}
+
+// repairEditMsg carries the text an $EDITOR session left behind.
+type repairEditMsg struct {
+	taskID int64
+	text   string
+	err    error
+}
+
+// repairForm collects what a §6 repair needs (task 025): the prompt the agent
+// is given, and optionally which agent, model and effort to run it with.
+//
+// It is modelled on answerForm — a popup that owns the keyboard while it is
+// open — and differs in the one way that matters: the answer form exists
+// because the daemon is asking, so it is synthesized from task state, while
+// this one exists because a human opened it and closes when they submit or
+// escape.
+//
+// The prompt is prose. It goes to the daemon literally, never as a template
+// (§8.4 renders with missingkey=error), so a `{{` typed in here is two
+// characters and not a broken step.
+type repairForm struct {
+	taskID      int64
+	blockReason string
+	stepName    string
+
+	prompt string
+	agent  string
+	model  string
+	effort string
+
+	cursor  rfRow
+	editor  textarea.Model
+	editing bool
+
+	// agents is the catalog the pickers offer; nil until the fetch lands, and
+	// nil forever when it fails. Either way every picker allows free text, so
+	// the form is usable without it — the daemon accepts an unknown value
+	// with a warning rather than refusing it (§9.6).
+	agents apiclient.Agents
+	picker *picker
+
+	// openEditor hands the prompt to $EDITOR. Injected by the detail view,
+	// which owns the exec path (editor.go), so the form itself needs no
+	// terminal.
+	openEditor func(text string) tea.Cmd
+
+	err        string
+	submitting bool
+}
+
+func newRepairForm(taskID int64, blockReason, stepName string) *repairForm {
+	ed := textarea.New()
+	ed.Placeholder = "what should the agent fix?"
+	ed.Prompt = ""
+	ed.ShowLineNumbers = false
+	ed.DynamicHeight = true
+	ed.MinHeight = 1
+	ed.MaxHeight = editorLines
+	ed.SetHeight(3)
+	ed.SetWidth(40)
+	return &repairForm{
+		taskID: taskID, blockReason: blockReason, stepName: stepName, editor: ed,
+	}
+}
+
+// loadAgents fetches the adapter catalog for the pickers. A failure is not
+// reported to the human: the pickers fall back to free text, which is all a
+// repair needs.
+func (f *repairForm) loadAgents(client *apiclient.Client) tea.Cmd {
+	if client == nil {
+		return nil
+	}
+	taskID := f.taskID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		agents, err := client.ListAgents(ctx, false)
+		return repairAgentsLoadedMsg{taskID: taskID, agents: agents, err: err}
+	}
+}
+
+// applyAgents installs a catalog that arrived for this task.
+func (f *repairForm) applyAgents(msg repairAgentsLoadedMsg) {
+	if msg.taskID != f.taskID || msg.err != nil {
+		return
+	}
+	f.agents = msg.agents
+}
+
+// applyEdit installs what an $EDITOR session produced.
+func (f *repairForm) applyEdit(msg repairEditMsg) {
+	if msg.taskID != f.taskID {
+		return
+	}
+	if msg.err != nil {
+		f.err = errString(msg.err)
+		return
+	}
+	f.prompt = strings.TrimSpace(msg.text)
+	f.err = ""
+}
+
+// paste types into whichever text entry is open.
+func (f *repairForm) paste(text string) tea.Cmd {
+	if f.picker != nil {
+		return f.picker.paste(text)
+	}
+	if !f.editing {
+		return nil
+	}
+	var cmd tea.Cmd
+	f.editor, cmd = f.editor.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+// update handles one key. exit=true asks the caller to close the form.
+func (f *repairForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd tea.Cmd, exit bool) {
+	if f.picker != nil {
+		res := f.picker.update(msg)
+		if res.chosen {
+			f.setRow(rfRow(f.picker.row), res.value)
+		}
+		if res.closed {
+			f.picker = nil
+		}
+		return res.cmd, false
+	}
+	if f.editing {
+		switch msg.String() {
+		case "esc":
+			// esc discards, enter is a newline: the prompt is prose and may
+			// well want more than one line, so the field cannot spend enter
+			// on committing. ctrl+s is what leaves it.
+			f.editing = false
+			f.editor.Blur()
+			return nil, false
+		case "ctrl+s":
+			f.commitPrompt()
+			return nil, false
+		}
+		var c tea.Cmd
+		f.editor, c = f.editor.Update(msg)
+		return c, false
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		f.cursor = max(f.cursor-1, 0)
+	case "down", "j":
+		f.cursor = min(f.cursor+1, rfRowCount-1)
+	case "enter":
+		f.openRow()
+	case "e":
+		if f.cursor == rfPrompt && f.openEditor != nil {
+			return f.openEditor(f.prompt), false
+		}
+		f.startPrompt()
+	case "ctrl+s":
+		return f.submit(client), false
+	case "esc":
+		return nil, true
+	}
+	return nil, false
+}
+
+// openRow opens whatever the cursor is on: the prompt field, or the picker
+// for one of the three §8.6 overrides.
+func (f *repairForm) openRow() {
+	if f.cursor == rfPrompt {
+		f.startPrompt()
+		return
+	}
+	f.err = ""
+	switch f.cursor {
+	case rfAgent:
+		f.picker = newPicker(int(rfAgent), "agent", f.agentOptions(), true, f.agent)
+	case rfModel:
+		f.picker = newPicker(int(rfModel), "model", f.catalogOptions(f.models()), true, f.model)
+	case rfEffort:
+		f.picker = newPicker(int(rfEffort), "effort", f.catalogOptions(f.efforts()), true, f.effort)
+	case rfPrompt, rfRowCount:
+	}
+}
+
+func (f *repairForm) setRow(row rfRow, value string) {
+	switch row {
+	case rfAgent:
+		f.agent = value
+		// The model and effort catalogs belong to an adapter; keeping values
+		// chosen from another one would submit a pair that never existed.
+		f.model, f.effort = "", ""
+	case rfModel:
+		f.model = value
+	case rfEffort:
+		f.effort = value
+	case rfPrompt, rfRowCount:
+	}
+}
+
+func (f *repairForm) startPrompt() {
+	f.editing = true
+	f.cursor = rfPrompt
+	f.editor.SetValue(f.prompt)
+	f.editor.Focus()
+}
+
+func (f *repairForm) commitPrompt() {
+	f.editing = false
+	f.editor.Blur()
+	f.prompt = strings.TrimSpace(f.editor.Value())
+	if f.prompt != "" {
+		f.err = ""
+	}
+}
+
+// agentOptions is the adapter list, with the same availability notes the
+// new-task picker carries: an adapter that is installed but not logged in
+// fails every run, and saying so here saves a repair that was never going to
+// start (§9.5).
+func (f *repairForm) agentOptions() []pickerOption {
+	out := []pickerOption{{value: "", label: "(task or workflow default)"}}
+	for _, a := range f.agents {
+		opt := pickerOption{value: a.Name, label: a.Name}
+		switch {
+		case !a.Available:
+			opt.note = "⚠ unavailable: " + firstNonEmpty(a.Error, "not found")
+		case a.NotAuthenticated():
+			opt.note = "⚠ installed but not logged in"
+		case a.Version != "":
+			opt.note = a.Version
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+func (f *repairForm) models() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agent)
+	if !ok {
+		return nil
+	}
+	return a.Models
+}
+
+func (f *repairForm) efforts() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agent)
+	if !ok {
+		return nil
+	}
+	return a.Efforts
+}
+
+// catalogOptions renders a catalog with its provenance tags, the way the
+// new-task pickers do: "cli" came from the adapter itself, "curated" from
+// vincent's own list and may be stale.
+func (f *repairForm) catalogOptions(opts []apiclient.AgentOption) []pickerOption {
+	out := []pickerOption{{value: "", label: "(task or workflow default)"}}
+	for _, o := range opts {
+		out = append(out, pickerOption{value: o.Value, label: o.Value, note: o.Source})
+	}
+	return out
+}
+
+// request is what the form would submit.
+func (f *repairForm) request() apiclient.RepairInput {
+	return apiclient.RepairInput{
+		Prompt: f.prompt, Agent: f.agent, Model: f.model, Effort: f.effort,
+	}
+}
+
+// submit posts the repair. The empty prompt is refused here as well as by the
+// daemon: a round trip to be told to type something is a round trip wasted.
+func (f *repairForm) submit(client *apiclient.Client) tea.Cmd {
+	if f.editing {
+		f.commitPrompt()
+	}
+	if strings.TrimSpace(f.prompt) == "" {
+		f.err = "type what the agent should fix first"
+		return nil
+	}
+	if client == nil {
+		f.err = "not connected"
+		return nil
+	}
+	f.err = ""
+	f.submitting = true
+	taskID, req := f.taskID, f.request()
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		task, _, err := client.Repair(ctx, taskID, req)
+		return actionResultMsg{
+			taskID: taskID, action: apiclient.ActionRepair, task: task, err: err,
+		}
+	}
+}
+
+// height is how many lines the form wants at the width it will be drawn at.
+func (f *repairForm) height(width int) int { return len(f.lines(width)) }
+
+// render draws the form, windowed on the focused element when it does not
+// fit.
+func (f *repairForm) render(width, height int) string {
+	lines := f.lines(width)
+	from, to := f.focusRange(width)
+	return strings.Join(windowRange(lines, from, to, height), "\n")
+}
+
+// lines is the whole form at width: what is being repaired, the four rows,
+// whatever entry is open, and the status line.
+func (f *repairForm) lines(width int) []string {
+	out := make([]string, 0, 16)
+	out = append(out, styleDim.Render("  "+f.subject()))
+	out = append(out, "")
+	for _, row := range []rfRow{rfPrompt, rfAgent, rfModel, rfEffort} {
+		out = append(out, f.rowLines(row, width)...)
+	}
+	if f.picker != nil {
+		out = append(out, f.picker.renderBody()...)
+	}
+	switch {
+	case f.err != "":
+		out = append(out, styleBad.Render("  ⚠ "+f.err))
+	case f.editing:
+		out = append(out, styleDim.Render("  ctrl+s keeps this text · esc discards it"))
+	case f.picker != nil:
+		out = append(out, styleDim.Render("  ↑/↓ choose · / filter · enter pick · esc close the list"))
+	case f.submitting:
+		out = append(out, styleDim.Render("  starting the repair agent…"))
+	default:
+		out = append(out, styleDim.Render(
+			"  enter edit · e $EDITOR · ctrl+s start the repair · esc leave the form"))
+	}
+	return out
+}
+
+// subject is the one line saying what this repair is about, so the popup does
+// not rely on the panels behind it to explain itself.
+func (f *repairForm) subject() string {
+	out := fmt.Sprintf("#%d", f.taskID)
+	if f.stepName != "" {
+		out += " · blocked at " + f.stepName
+	}
+	if f.blockReason != "" {
+		out += " · " + f.blockReason
+	}
+	return out + " — the agent runs in this task's worktree; the task stays blocked afterwards"
+}
+
+// rowLines draws one row: its label, its value, and — for the prompt row
+// while it is being typed into — the field itself.
+func (f *repairForm) rowLines(row rfRow, width int) []string {
+	cursor := "  "
+	if f.cursor == row && !f.editing && f.picker == nil {
+		cursor = styleFocus.Render("› ")
+	}
+	line := cursor + rfLabel(row) + " " + f.rowValue(row)
+	out := []string{line}
+	if row == rfPrompt {
+		if f.editing {
+			out = append(out, f.editorView(width)...)
+		} else if f.prompt != "" {
+			for _, l := range wrapPlain(f.prompt, width-editorIndent) {
+				out = append(out, strings.Repeat(" ", editorIndent)+styleOK.Render(l))
+			}
+		}
+	}
+	return out
+}
+
+func (f *repairForm) rowValue(row rfRow) string {
+	var v string
+	switch row {
+	case rfPrompt:
+		if f.prompt == "" {
+			return styleDim.Render("(nothing typed yet)")
+		}
+		return ""
+	case rfAgent:
+		v = f.agent
+	case rfModel:
+		v = f.model
+	case rfEffort:
+		v = f.effort
+	case rfRowCount:
+	}
+	if v == "" {
+		return styleDim.Render("(task or workflow default)")
+	}
+	return styleOK.Render(v)
+}
+
+func rfLabel(row rfRow) string {
+	switch row {
+	case rfPrompt:
+		return "repair prompt"
+	case rfAgent:
+		return "agent "
+	case rfModel:
+		return "model "
+	case rfEffort:
+		return "effort"
+	case rfRowCount:
+	}
+	return ""
+}
+
+// editorView sizes the prompt field to the popup's width and indents it clear
+// of the cursor gutter, the way the answer form's free-text field is.
+func (f *repairForm) editorView(width int) []string {
+	f.editor.SetWidth(max(width-editorIndent, 8))
+	out := strings.Split(f.editor.View(), "\n")
+	pad := strings.Repeat(" ", editorIndent)
+	for i := range out {
+		out[i] = pad + out[i]
+	}
+	return out
+}
+
+// focusRange is the line range the focused element occupies, so windowing
+// keeps the whole of it on screen. An open picker is the focus; otherwise the
+// cursor's row is.
+func (f *repairForm) focusRange(width int) (from, to int) {
+	from = 2 // past the subject line and its blank
+	for _, row := range []rfRow{rfPrompt, rfAgent, rfModel, rfEffort} {
+		n := len(f.rowLines(row, width))
+		if row == f.cursor {
+			to = from + n
+			if f.picker != nil {
+				to += len(f.picker.renderBody())
+			}
+			return from, to
+		}
+		from += n
+	}
+	return 0, 0
+}

--- a/internal/tui/repairlive_test.go
+++ b/internal/tui/repairlive_test.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// blockTask puts a task into `blocked` with a reason and the failed row that
+// put it there, the way the engine leaves one (§6, §7.2).
+func (h *actionLiveHarness) blockTask(t *testing.T, id int64, reason string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, _, err := h.st.TransitionTask(ctx, id, store.TaskQueued, store.TaskRunning,
+		store.TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	now := time.Now()
+	run := &store.StepRun{
+		TaskID: id, StepIndex: 0, StepID: "implement", StepType: "agent",
+		Attempt: 1, State: store.StepFailed, FailureReason: "nonzero_exit",
+		ResultSummary: "the step did not work", StartedAt: now, FinishedAt: &now,
+	}
+	if err := h.st.CreateStepRun(ctx, run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	if _, _, err := h.st.TransitionTask(ctx, id, store.TaskRunning, store.TaskBlocked,
+		store.TaskChange{BlockReason: &reason}); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+}
+
+// TestDetailRepairsBlockedTaskLive drives the §6 repair the way a human does:
+// the bar offers it only when the daemon does, `R` opens the form, and what
+// was typed is what the daemon receives (task 025).
+//
+// The repair agent hangs, so the request is still on the task when this
+// asserts it — a repair drains at the re-block, which a hung agent never
+// reaches.
+func TestDetailRepairsBlockedTaskLive(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newActionLiveHarness(t)
+	task := h.createTask(t, "repairable")
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the task", func() bool {
+		return detailOf(h.m).taskID == task.ID && detailOf(h.m).loaded
+	})
+	// Queued: the daemon does not offer repair, so neither does the bar.
+	if detailOf(h.m).target().has(apiclient.ActionRepair) {
+		t.Error("a queued task offers repair")
+	}
+	if hintsContain(detailOf(h.m).detailHints(), "repair") {
+		t.Error("the bar advertises repair on a queued task")
+	}
+	h.press(t, "R")
+	if detailOf(h.m).repair != nil {
+		t.Fatal("R opened the repair form on a task the daemon does not offer it for")
+	}
+
+	h.blockTask(t, task.ID, "check_failed")
+	h.p.until(30*time.Second, "the daemon to offer repair", func() bool {
+		return detailOf(h.m).target().has(apiclient.ActionRepair)
+	})
+	if !hintsContain(detailOf(h.m).detailHints(), "repair") {
+		t.Error("the bar does not advertise repair on a blocked task")
+	}
+
+	h.press(t, "R")
+	form := detailOf(h.m).repair
+	if form == nil {
+		t.Fatal("R did not open the repair form")
+	}
+	if !h.m.views[viewHome].(*shell).popup {
+		t.Fatal("the repair form did not take the popup")
+	}
+	if !strings.Contains(content(h.m), "Repair") {
+		t.Errorf("the popup is not on screen: %q", content(h.m))
+	}
+
+	// Type a prompt: enter opens the field, ctrl+s keeps it, ctrl+s again
+	// starts the repair.
+	const prompt = "add the missing file"
+	h.press(t, "enter")
+	if !form.editing {
+		t.Fatal("enter did not open the prompt field")
+	}
+	h.typeText(t, prompt)
+	h.pressCtrlS(t)
+	if form.prompt != prompt {
+		t.Fatalf("form prompt = %q, want %q", form.prompt, prompt)
+	}
+	h.pressCtrlS(t)
+
+	h.p.until(60*time.Second, "the repair to be admitted", func() bool {
+		return h.state(t, task.ID) != store.TaskBlocked
+	})
+	stored, err := h.st.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.PendingRepair == nil || stored.PendingRepair.Prompt != prompt {
+		t.Fatalf("the daemon received %+v, want the prompt that was typed", stored.PendingRepair)
+	}
+
+	// The form closes on the reply, so the popup goes with it.
+	h.p.until(30*time.Second, "the submitted form to close", func() bool {
+		return detailOf(h.m).repair == nil && !h.m.views[viewHome].(*shell).popup
+	})
+}
+
+// TestTimelineRendersARepairAsItsOwnEntry: a repair row sits at the blocked
+// step's index under a reserved id, and the timeline must not render it as an
+// attempt of that step — "distinct from the blocked step's own attempts" is
+// the issue's own criterion (task 025).
+func TestTimelineRendersARepairAsItsOwnEntry(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newActionLiveHarness(t)
+	task := h.createTask(t, "repairable")
+	h.blockTask(t, task.ID, "check_failed")
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the task", func() bool {
+		return detailOf(h.m).taskID == task.ID && detailOf(h.m).loaded
+	})
+	h.press(t, "R")
+	h.press(t, "enter")
+	h.typeText(t, "fix it")
+	h.pressCtrlS(t)
+	h.pressCtrlS(t)
+
+	h.p.until(60*time.Second, "the repair row to reach the timeline", func() bool {
+		for _, r := range detailOf(h.m).task.Steps {
+			if r.StepID == apiclient.RepairStepID {
+				return true
+			}
+		}
+		return false
+	})
+	h.p.until(30*time.Second, "the timeline to label the repair", func() bool {
+		return strings.Contains(content(h.m), "repair (ad-hoc agent)")
+	})
+
+	// The step it sits beside keeps its own shape: one header, its own
+	// attempts, and no `parallel` tier invented by two step ids sharing an
+	// index.
+	if strings.Contains(content(h.m), "(parallel)") {
+		t.Errorf("the repair row made the blocked step read as a group:\n%s", content(h.m))
+	}
+}
+
+// typeText sends one key per rune, the way a terminal delivers typing.
+func (h *actionLiveHarness) typeText(t *testing.T, text string) {
+	t.Helper()
+	for _, r := range text {
+		_, cmd := h.m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		h.p.push(cmd)
+	}
+}
+
+// pressCtrlS sends the repair form's submit chord.
+func (h *actionLiveHarness) pressCtrlS(t *testing.T) {
+	t.Helper()
+	_, cmd := h.m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	h.p.push(cmd)
+}
+
+func hintsContain(hints []string, want string) bool {
+	for _, hint := range hints {
+		if strings.Contains(hint, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -43,9 +43,10 @@ type shell struct {
 	bar *actionBar
 
 	focus panelID
-	// popup shows the §7.4 answer form over the panels. It never opens
-	// itself — `enter` on the awaiting task does (§15: the form announces
-	// itself and the human opens it).
+	// popup shows a form over the panels: the §7.4 answer form, or the §6
+	// repair form (task 025). Neither ever opens itself — `enter` on the
+	// awaiting task opens one and `R` on a blocked task opens the other
+	// (§15: a form announces itself and the human opens it).
 	popup bool
 	// connected mirrors the root's connection state: false renders the
 	// panels marked stale behind a banner instead of hiding them (§15
@@ -114,11 +115,17 @@ func (s *shell) capturesInput() bool {
 	return s.focusedCaptures()
 }
 
-// paste hands pasted text to the surface that owns the keyboard: the answer
-// popup's free-text field, or the task filter while it is being typed.
+// paste hands pasted text to the surface that owns the keyboard: whichever
+// popup is open — the answer form's free-text field or the repair form's
+// prompt — or the task filter while it is being typed.
 func (s *shell) paste(text string) tea.Cmd {
-	if s.popup && s.detail.form != nil {
-		return s.detail.form.paste(text)
+	if s.popup {
+		if f := s.detail.repair; f != nil {
+			return f.paste(text)
+		}
+		if f := s.detail.form; f != nil {
+			return f.paste(text)
+		}
 	}
 	if s.focus == panelTasks {
 		return s.board.paste(text)
@@ -192,13 +199,23 @@ func (s *shell) update(msg tea.Msg) (panel, tea.Cmd) {
 func (s *shell) forward(msg tea.Msg) tea.Cmd {
 	_, bc := s.board.update(msg)
 	dc := s.detail.update(msg)
-	if s.popup && s.detail.form == nil {
+	if s.popup && s.detail.form == nil && s.detail.repair == nil {
 		s.popup = false
 	}
 	return tea.Batch(bc, dc)
 }
 
 func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if s.popup && s.detail.repair != nil {
+		cmd, exit := s.detail.repair.update(msg, s.detail.client)
+		if exit {
+			// Leaving the form throws the draft away with it: a repair is one
+			// prompt for one block, and half a prompt kept behind a popup
+			// nobody can see is worse than retyping it.
+			s.detail.repair, s.popup = nil, false
+		}
+		return s, cmd
+	}
 	if s.popup && s.detail.form != nil {
 		cmd, exit := s.detail.form.update(msg, s.detail.client, s.detail.taskID)
 		if exit {
@@ -261,6 +278,16 @@ func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		// the key acts on the task, so it works from any panel.
 		s.syncDetailFocus()
 		return s, s.detail.update(msg)
+	case "R":
+		// Repair, for the same reason: detail holds the blocked step and the
+		// form posts from there. Opening it raises the popup, which then owns
+		// the keyboard.
+		s.syncDetailFocus()
+		cmd := s.detail.update(msg)
+		if s.detail.repair != nil {
+			s.popup = true
+		}
+		return s, cmd
 	}
 	return s, tea.Batch(s.routeKey(msg), s.checkSelection())
 }
@@ -550,7 +577,7 @@ func (s *shell) render(width, height int) string {
 				s.renderBox(boxes[1]), s.renderBox(boxes[2])))
 	}
 	out := strings.Join(parts, "\n")
-	if s.popup && s.detail.form != nil {
+	if s.popup && (s.detail.form != nil || s.detail.repair != nil) {
 		out = s.overlayPopup(out)
 	}
 	return out
@@ -630,7 +657,6 @@ func (s *shell) detailPlaceholder() (string, bool) {
 // (§15), and the panels stay visible around it — the tail underneath is
 // what says why the agent is asking.
 func (s *shell) overlayPopup(bg string) string {
-	form := s.detail.form
 	// Take nearly the whole body: a §7.4 question is prose and its options are
 	// sentences, so every column the popup gives back to the panels behind it
 	// is another wrapped line to read. The cap is a reading measure, not a
@@ -642,9 +668,21 @@ func (s *shell) overlayPopup(bg string) string {
 	// The form lays itself out at the width it will be drawn at, so a long
 	// question wraps inside the popup instead of losing its tail to frame.
 	inner := pw - 2
-	ph := min(form.height(inner)+2, max(s.bodyH-4, 6))
-	title := fmt.Sprintf("Answer — #%d", s.detail.taskID)
-	popup := frame(title, form.render(inner, ph-2), pw, ph, true)
+	var (
+		height func(int) int
+		render func(int, int) string
+		title  string
+	)
+	if f := s.detail.repair; f != nil {
+		height, render = f.height, f.render
+		title = fmt.Sprintf("Repair — #%d", s.detail.taskID)
+	} else {
+		f := s.detail.form
+		height, render = f.height, f.render
+		title = fmt.Sprintf("Answer — #%d", s.detail.taskID)
+	}
+	ph := min(height(inner)+2, max(s.bodyH-4, 6))
+	popup := frame(title, render(inner, ph-2), pw, ph, true)
 	x := max((s.bodyW-pw)/2, 0)
 	y := max((s.bodyH-ph)/3, 1)
 	return overlay(bg, popup, x, y)

--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -187,7 +187,7 @@ const createWorkflowFooter = `
 // It is a var rather than a const because the skill is spliced in at init.
 // Nothing may reassign it; the built-in scope parses it once.
 var CreateWorkflowSource = createWorkflowHeader +
-	indentBlock(escapeTemplate(skillInstructions(skills.VincentWorkflows)), promptIndent) +
+	indentBlock(EscapeTemplate(skillInstructions(skills.VincentWorkflows)), promptIndent) +
 	createWorkflowFooter
 
 // skillInstructions drops an Agent Skill's YAML front matter, keeping the
@@ -204,15 +204,6 @@ func skillInstructions(src string) string {
 		return src
 	}
 	return strings.TrimLeft(rest[end+len("\n"+fence):], "\n")
-}
-
-// escapeTemplate neutralizes the one sequence that would make embedded prose
-// execute as part of the step's template. Only "{{" opens an action, so a
-// lone "}}" needs nothing. The replacement is itself an action rendering the
-// two literal characters, which is why this must run before the text reaches
-// Render and not after.
-func escapeTemplate(s string) string {
-	return strings.ReplaceAll(s, "{{", `{{"{{"}}`)
 }
 
 // indentBlock prefixes every non-empty line so the text sits inside a YAML

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -158,6 +158,22 @@ func Render(name, text string, rc RenderContext) (string, error) {
 	return sb.String(), nil
 }
 
+// EscapeTemplate neutralizes the one sequence that would make embedded prose
+// execute as part of a step's template. Only "{{" opens an action, so a lone
+// "}}" needs nothing. The replacement is itself an action rendering the two
+// literal characters, which is why this must run before the text reaches
+// Render and not after.
+//
+// Two callers need it, for the same reason: text that was written as prose
+// reaches a field Render will parse. The built-in `create-workflow` prompt
+// splices in an embedded skill (task 024), and a `repair` prompt is what an
+// operator typed at a form (task 025). Neither is a workflow-authoring
+// surface, and §8.4 renders with `missingkey=error` — so an unescaped `{{`
+// would fail the step before anything ran.
+func EscapeTemplate(s string) string {
+	return strings.ReplaceAll(s, "{{", `{{"{{"}}`)
+}
+
 // Env returns the vincent variables added to the environment of command and
 // check steps (spec §8.5). They are appended to the daemon's own environment
 // by the caller, along with any step-declared `env`.

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -715,7 +715,7 @@ func TestCreateWorkflowSkillSplicingIsTemplateSafe(t *testing.T) {
 		t.Fatalf("front matter survived: %q", body)
 	}
 
-	indented := indentBlock(escapeTemplate(body), promptIndent)
+	indented := indentBlock(EscapeTemplate(body), promptIndent)
 	for _, line := range strings.Split(indented, "\n") {
 		if line != "" && !strings.HasPrefix(line, promptIndent) {
 			t.Errorf("line %q is not indented into the block scalar", line)

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -954,6 +954,126 @@ EOF
   echo "=== scenario 8 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 9 — an ad-hoc repair agent unblocks a step nothing else could
+# (§6, §7.2, §13.2, task 025).
+#
+# The blocked step is a `command` step on purpose. It has no agent selection of
+# its own, which is exactly why a repair's agent/model/effort stand in for the
+# step level of §8.6's chain rather than inheriting from the step being
+# repaired — and it means the only agent process this scenario runs is the
+# repair itself, so "the repair is what changed the worktree" needs no
+# inference.
+#
+# The step's check greps a tracked file for a line only the fake agent writes
+# (`FAKEAGENT_EDIT_FILE`, which appends to an existing tracked file). So the
+# task blocks on check_failed, the repair puts the line there, the task returns
+# to blocked with the *same* reason, and only then does a retry pass.
+# ---------------------------------------------------------------------------
+scenario9() {
+  echo "=== scenario 9: an ad-hoc repair agent unblocks a failing check"
+  scenario_dirs s9
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  # Both run: bodies are one git command each — the sh∩pwsh intersection the
+  # daemon's shell holds every workflow to (§8.3). `git grep -q` exits 1 when
+  # the pattern is absent, which is the whole failing condition.
+  cat > "$CONFIG_DIR/workflows/m2-repair.yaml" <<'EOF'
+name: m2-repair
+description: M2 gate — a check only a repair can satisfy.
+defaults:
+  agent: claude
+  max_retries: 0
+steps:
+  - id: work
+    type: command
+    run: 'git commit --allow-empty -m "m2 gate: the work"'
+    check: 'git grep -q "fakeagent was here" -- fixture.txt'
+  - id: land
+    type: command
+    run: 'git commit --allow-empty -m "m2 gate: the repair held"'
+EOF
+
+  export FAKEAGENT_SCENARIO=success
+  export FAKEAGENT_EDIT_FILE=fixture.txt
+  daemon_up
+
+  local repo="$TMP/s9/repo" proj task_id task steps
+  make_repo "$repo"
+  printf 'pending\n' > "$repo/fixture.txt"
+  git -C "$repo" add fixture.txt
+  git -C "$repo" commit -qm fixture
+  proj="$(register_project "$repo")"
+
+  task_id="$(api POST /tasks \
+    "{\"project_id\":$proj,\"workflow\":\"m2-repair\",\"title\":\"Repair me\"}" | jq -r .id)"
+
+  echo "== the check fails and the task blocks"
+  wait_for_state "$task_id" blocked 90
+  task="$(api GET "/tasks/$task_id")"
+  [[ "$(jq -r .block_reason <<<"$task")" == "check_failed" ]] \
+    || fail "expected a check_failed block: $task"
+  jq -e '.available_actions | index("repair")' <<<"$task" >/dev/null \
+    || fail "available_actions misses repair while blocked: $task"
+  local blocked_at
+  blocked_at="$(jq -r .current_step <<<"$task")"
+
+  echo "== a repair with no prompt is refused"
+  local status
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"prompt":"   "}' "$BASE/tasks/$task_id/repair")"
+  [[ "$status" == "400" ]] || fail "an empty repair prompt should be 400, got $status"
+
+  echo "== repair: one agent run in this task's existing worktree"
+  api POST "/tasks/$task_id/repair" \
+    '{"prompt":"Put the line the check is looking for into fixture.txt."}' >/dev/null
+
+  echo "== it comes back to the same step with the same reason"
+  wait_for_state "$task_id" blocked 90
+  task="$(api GET "/tasks/$task_id")"
+  [[ "$(jq -r .block_reason <<<"$task")" == "check_failed" ]] \
+    || fail "the repair changed the block reason: $task"
+  [[ "$(jq -r .current_step <<<"$task")" == "$blocked_at" ]] \
+    || fail "the repair moved the cursor off step $blocked_at: $task"
+
+  echo "== the repair is its own row, not an attempt of the blocked step"
+  steps="$(api GET "/tasks/$task_id/steps")"
+  jq -e --argjson i "$blocked_at" \
+    '[.[] | select(.step_id == "__repair" and .step_index == $i and .state == "succeeded")] | length == 1' \
+    <<<"$steps" >/dev/null || fail "no succeeded __repair row at step $blocked_at: $steps"
+  jq -e '[.[] | select(.step_id == "work")] | length == 1' <<<"$steps" >/dev/null \
+    || fail "the repair was counted as an attempt of the blocked step: $steps"
+
+  echo "== only now does a retry pass, and the workflow finishes"
+  api POST "/tasks/$task_id/retry" >/dev/null
+  wait_for_state "$task_id" done 90
+  steps="$(api GET "/tasks/$task_id/steps")"
+  jq -e '[.[] | select(.step_id == "land" and .state == "succeeded")] | length == 1' \
+    <<<"$steps" >/dev/null || fail "the workflow did not reach the step after the repair: $steps"
+
+  echo "== repair is refused outside blocked, with the state in the envelope"
+  local out body
+  out="$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" -d '{"prompt":"too late"}' \
+    -w $'\n%{http_code}' "$BASE/tasks/$task_id/repair")"
+  status="${out##*$'\n'}"
+  body="${out%$'\n'*}"
+  [[ "$status" == "409" ]] || fail "repair from done should be 409, got $status: $body"
+  [[ "$(jq -r .error.details.state <<<"$body")" == "done" ]] \
+    || fail "the 409 does not carry details.state: $body"
+
+  unset FAKEAGENT_SCENARIO FAKEAGENT_EDIT_FILE
+  "$VINCENT" daemon stop
+  echo "=== scenario 9 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -968,7 +1088,9 @@ case "$WHICH" in
   6) scenario6 ;;
   7) scenario7 ;;
   8) scenario8 ;;
-  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8 ;;
+  9) scenario9 ;;
+  all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8
+     scenario9 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
## Summary

From `blocked`, `retry` re-runs an unchanged step, `edit + retry` can rewrite
only that step's own prompt or command, and `skip` advances past an unsatisfied
check. None of them can change a file, so a block whose cause is in the worktree
had no fix inside vincent — you left, opened the worktree by hand, and came back.

This adds **`repair`**, a human action valid from `blocked` only. You write a
prompt and optionally pick an agent, model and effort; the daemon runs one agent
process in the task's **existing** worktree and branch, with the task's own
context and the blocked step's failure context assembled around your prose.

**A repair decides nothing.** Whatever the agent exits with, the task returns to
`blocked` at the same `current_step` carrying the same `block_reason`, and you
inspect the diff and then choose — retry, repair again, skip or cancel. Auto-
retrying on a repair's success was considered and rejected: you would never see
the repair's diff before the step re-ran, and a repair agent's exit code is not
the right thing to authorize more agent spend with. That is spec §7.2's posture
unchanged.

**It is an ordinary admission**, not a new lifecycle state. `repair` is a
`blocked → queued` transition that persists a request on the task; the scheduler
admits it exactly like anything else, so both §11 caps apply and
`internal/scheduler` remains the only producer of `queued → running`. `cancel`
keeps its present meaning throughout — a `repairing` state would cost an FSM row,
a board legend, slot rules and a recovery path (what task 014 paid for
`awaiting_children`) to buy one nicer cancel.

**It is an ordinary `step_run` row**, at the blocked step's index under the
reserved step id `__repair`. `store.CountStepAttempts` already keys on
`(task_id, step_index, step_id, iteration)`, so the blocked step's retry budget
is untouched *by construction* rather than by a special case — no query changed,
no `kind` column, no second ledger — and transcripts, events, token and cost
accounting come for free. It reuses the mechanism the fan-out `on_conflict:
agent` resolver already uses (`internal/taskrun/join.go`).

**Crash recovery is why the request drains late.** `pending_override_json` drains
at the row insert; `pending_repair_json` deliberately drains with the transition
that returns the task to `blocked`. Recovery (§12.4) finalizes a running row as
`interrupted`, re-queues the task, and the actor walks from `current_step` — so
an already-drained request would silently turn a crash mid-repair into a plain
*retry* of the blocked step, consuming its budget and possibly unblocking the
task without anyone asking. Every other way out of `blocked` drops the request,
because it describes exactly the block it was made about.

Surfaces:

- `POST /v1/tasks/{id}/repair` `{ prompt, agent?, model?, effort? }`. `prompt` is
  required and **literal text**, never a `text/template` source — it is prose,
  and §8.4 renders with `missingkey=error`. Empty is a `400`; outside `blocked`
  is a `409` with `details.state`. The optional triple is validated exactly as
  `POST /v1/tasks` validates a task's, warnings and all.
- `R` in the TUI on a blocked task opens a popup that owns the keyboard: a prompt
  field with an `$EDITOR` escape and the same agent/model/effort pickers the
  new-task flow uses. It is excluded from bulk actions — a repair needs prose
  written for one task.
- The detail timeline renders a repair as its own labelled entry under the
  blocked step, never as another attempt of it, and a repair row is invisible in
  `.Steps` to any later step's prompt or guard.

Agent/model/effort resolve **request > task override > workflow `defaults` >
adapter default** — §8.6's chain with the request standing in for the step level.
The blocked step's own selection is deliberately not the base: a `command` step
has none. The synthetic step carries `max_retries: 0`, so a failed repair fails
fast rather than silently paying for a second agent run.

Repair is offered from `blocked` whatever the reason, with no filtering. A task
blocked before its worktree existed re-blocks on the same reason without spawning
an agent (existing code reaching the right outcome); one blocked on
`agent_unavailable` has its repair fail the same way, which is honest.

`escapeTemplate` moved from `internal/workflow/builtin.go` to
`workflow.EscapeTemplate` — two callers now need it for the same reason (task
024's embedded skill, and a repair prompt), and neither is a workflow-authoring
surface.

**No CLI subcommand.** `internal/cli/task.go` exposes `add`, `ls`, `show` and
`cancel`; retry, skip and approve are already TUI-and-API only, and repair
follows them.

This does **not** reopen task 018's declined `on_failure:` / try-catch. That
decision is about what a workflow author can declare ahead of time; the whole
point of a repair is that nothing was declared ahead of time. It adds a human
action, not a workflow field.

## Related

Closes #173
Closes 025.1–025.8 (`docs/tasks/025-ad-hoc-repair-agent.md`).

Task 018's "considered and declined" `on_failure:` / try-catch decision is
adjacent but not revisited, and is not weakened by this change — see the Summary
and decision 1 of task 025 for why the two do not overlap.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### Tests

`go test ./...` — 1782 tests, 28 packages, green.

- `internal/taskstate` — `repair` is valid from `blocked` and nothing else, and
  appears in `HumanActionsFrom(blocked)`.
- `internal/store/repair_test.go` — the request round-trips, survives a
  `blocked → queued` transition, is cleared by the re-block and dropped by every
  other way out of `blocked`; `CountStepAttempts` returns the same numbers with
  repair rows present as without.
- `internal/taskrun/repair_test.go` — the substance. A repair runs an agent in
  the task's existing worktree and its change is visible afterwards; the row
  carries `__repair` at the blocked index and a second repair is attempt 2 under
  that id; **the blocked step's budget is untouched** (after a repair, a `retry`
  gets the same attempts it would have had with none); the task returns to
  `blocked` at the same step with the same reason whether the repair succeeded or
  failed; a successful repair does not re-run the step; after a repair that fixed
  the problem a `retry` passes and the workflow reaches `done`; an interrupted
  repair re-runs as a repair on restart and specifically does not re-run the
  blocked step; the repair row never appears in `.Steps`; a repair on a task with
  no worktree re-blocks on the original reason without starting an agent; and
  `Repair` does not move `retry_cursor_at`.
- `internal/api/repair_test.go` — 409 with `details.state` from every non-blocked
  state, 400 on an empty prompt, `available_actions` carrying `repair` exactly
  while blocked, and agent/model/effort validation matching task creation's.
- `internal/tui/repairlive_test.go` — against the real handlers over `httptest`:
  the action bar offers repair only when the daemon does, the form posts what was
  typed, and the timeline renders the repair row as its own labelled entry.
- `internal/apiclient` — `Repair` against the real handlers, and a test pinning
  `apiclient.RepairStepID` to the engine's constant.

**Acceptance gate:** `./scripts/m2-gate.sh` passes end to end (all nine
scenarios). New **scenario 9** drives the whole path against the fake agent: a
task whose check fails blocks on `check_failed`, an empty repair prompt is
refused with 400, a repair runs and lands as a separate succeeded `__repair` row
at the blocked index while the blocked step still has exactly one attempt, the
task is `blocked` again at the same step with the same reason, and only then does
a `retry` reach `done`; a repair from `done` is a 409 carrying `details.state`.
The blocked step is a `command` step on purpose — it has no agent selection of
its own, which is exactly why a repair's own selection stands in for the step
level, and it makes the repair the only agent process in the scenario.

### Docs

Spec amended in place with dated notes, in this branch: **§5.4** (the reserved
step id and that a repair row is a StepRun like any other), **§6** (the `repair`
row in the human-actions table, and the second producer of `blocked → queued`
with its no-new-state, no-filtering and drain-timing reasoning), **§7.2** (repair
does not consume the blocked step's budget, with the composite-key reason),
**§8.6** (the request level in the resolution chain), **§13.2** (the endpoint and
its body), **§14** (`pending_repair_json`), **§15** and **§17** (the `R` key and
the repair popup, and the timeline's own entry).

Derived pages moved with them: `docs/reference/api.md` (route table),
`docs/reference/task-lifecycle.md` (blocked actions and the TUI key list),
`docs/guides/tui.md` (key table and a "Repairing a blocked task" section),
`docs/guides/troubleshooting.md`, `docs/reference/configuration.md` (`EDITOR`),
`docs/features.md`. `docs/tasks/025-ad-hoc-repair-agent.md` carries the twelve
decisions with the alternatives they beat, and `docs/tasks/README.md`'s index row
was updated in the same edit.

### Notes for the reviewer

- **No `docs/assets/tui-*.png` was re-captured, deliberately.** `repair` has no
  row in `actionOrder`, so it appears only in the detail panel's own hints, and
  no task any tape selects is `blocked` — `tui-board` filters to a `running`
  task and `tui-diff` to a `done` one. No captured frame changes; nothing was
  redrawn.
- **`GOOS=linux` lint could not be run to completion.** `golangci-lint run` is
  clean for `GOOS=windows` and `GOOS=darwin`. Under `GOOS=linux` it crashes
  inside staticcheck's `buildir` while analyzing the standard library's
  `internal/poll` package — it does so on an unmodified checkout of the same tree
  too, so it is a toolchain/analyzer incompatibility rather than a finding
  against this change. Task 024 recorded the same. CI's own Linux leg is the
  real check.
