### PR TITLE
Re-apply a human action that loses its state swap to the scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **A human action racing scheduler admission no longer fails with a state
+  conflict.** Cancelling or pausing a queued task at the moment the scheduler
+  started it returned `409` (`task 3 is running, not queued`) — in the TUI, a
+  keypress that appeared to do nothing until pressed again — even though both
+  actions are valid from `running` too. An action that loses its compare-and-swap
+  is now re-applied once from the state it lost to, when the lifecycle allows it
+  from there. Fan-out lanes, which are cancelled the moment their rows appear,
+  hit this most. ([#127](https://github.com/lezli01/vincent/issues/127))
+
 - **Simultaneous worktree creation in one project.** Tasks admitted at the same
   moment in the same project no longer fail each other's `git worktree add`
   with a `git_error` block — the daemon now serializes worktree creation and

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -139,6 +139,14 @@ An action the current state does not allow returns `409` with `details.state`
 set to the state actually found — so a client branches on a value rather than
 parsing prose.
 
+An action the state *does* allow never fails on a race. Each one is a
+compare-and-swap on the state the request read, and the task can move under it
+— the scheduler admitting a queued task is the usual way. When it does, the
+action is re-applied once from the state actually found, provided the table
+above allows it from there: `cancel` on a task the scheduler admits at that
+instant aborts the now-running task rather than reporting a conflict, and
+`pause` becomes the deferred kind that holds at the next step boundary.
+
 ## Step outcomes
 
 Each attempt of each step is a **step run** row, and every attempt is kept —

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -407,6 +407,31 @@ state-shaped one for no behavioral gain.
 | `set priority` | queued, paused | Reorders scheduler admission |
 | `archive` | done, aborted | Removes worktree (warns if dirty — uncommitted changes would be lost; requires `force` in that case); → `archived` |
 
+**Amended 2026-08-24 (issue #127): an action that loses a race re-applies itself
+once, when the state it lost to still allows it.** Every action in this table is
+applied as a compare-and-swap on the state the request read. If a concurrent
+transition takes that swap first, the task is re-read and the action applied once
+more — but only when this table allows the action from the state actually found.
+Otherwise the conflict stands and the client gets its `409` with `details.state`
+(§13.1). Once, never in a loop: a second conflict is returned as it stands.
+
+The producer this exists for is scheduler admission (§11). `queued → running` is
+bookkeeping, not intent, and `cancel` and `pause` — the two actions valid from
+`queued` **and** from a slot-holding state — were legal before the admission and
+legal after it, so the human lost a race they could neither see nor influence and
+whose only remedy was to issue the identical request again. Races against another
+human are unaffected: a winning human transition almost always lands somewhere the
+loser's action is invalid, and a cancelled task cannot be cancelled again. A
+deferred row stays deferred across the retry — a `pause` that re-reads `running`
+holds at the next step boundary, it does not park a task whose process is live.
+
+This **supersedes the PR C decision** of 2026-08-07 (`docs/history/v0-tasks.md`,
+the frozen v0 ledger) that a cancel losing the race to admission returns `409` and
+takes no internal retry. That decision was protecting a human's informed consent
+before "kill a live process", but a `409` does not deliver it: `cancel` is one row
+here with one effect whose process-killing half is conditional on state, and the
+remedy the clients document is the same keypress, which performs exactly that kill.
+
 Tasks are `queued` immediately upon creation (no draft state in v1).
 
 ## 7. Step execution semantics

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -100,25 +100,22 @@ func (r *Runner) Cancel(ctx context.Context, id int64) (*store.Task, error) {
 
 // Pause holds a task at its next step boundary (§6). A queued task pauses
 // at once; a running one finishes its current step first, and the request is
-// persisted so a crash — which re-queues the task — cannot discard it.
+// persisted so a crash — which re-queues the task — cannot discard it. Which
+// of the two it is comes from §6's Deferred flag and is decided in applyAction,
+// so a pause that re-reads its state after losing a race decides again.
 func (r *Runner) Pause(ctx context.Context, id int64) (*store.Task, error) {
-	task, err := r.deps.Store.GetTask(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-	tr, ok := taskstate.Next(task.State, taskstate.Pause)
-	if !ok {
-		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Pause, State: task.State}
-	}
-	if !tr.Deferred {
-		return r.transitionFrom(ctx, task, taskstate.Pause, store.TaskChange{})
-	}
+	return r.humanAction(ctx, id, taskstate.Pause, store.TaskChange{})
+}
+
+// requestPause records a deferred pause on a task whose step is still running
+// (§6): the flag is persisted, so a crash — which re-queues the task — cannot
+// discard it, and mirrored onto the live actor, which is what actually reads
+// it at its next step boundary.
+func (r *Runner) requestPause(ctx context.Context, id int64) (*store.Task, error) {
 	updated, err := r.deps.Store.RequestPause(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	// The persisted flag covers the crash path; the live flag is what the
-	// actor actually reads at its next step boundary.
 	if lr, ok := r.lookupRun(id); ok {
 		lr.mu.Lock()
 		lr.pauseRequested = true
@@ -386,15 +383,61 @@ func (r *Runner) humanAction(
 	return r.transitionFrom(ctx, task, action, ch)
 }
 
-// transitionFrom applies an action to a task already loaded and validated.
-// Every human action but `pause` clears a pending pause: each of them is a
-// human saying "go" (§6).
+// transitionFrom applies an action to a task already loaded and validated,
+// and is the one compare-and-swap every §6 human action goes through.
+//
+// The swap is on the state the caller read, so a concurrent writer can take
+// it. Losing it is not by itself a refusal: when the state the task actually
+// reached still allows this action, the action is applied once more from that
+// state (issue #127). The scheduler is why — `queued → running` is
+// bookkeeping, not intent, and a human who asked for something §6 allows from
+// both states learns nothing from a conflict about a race they cannot see or
+// influence. This supersedes the PR C decision that a lost cancel takes no
+// internal retry; see the §6 amendment of 2026-08-24.
+//
+// It stays a no-op for the human-vs-human races `Runner.transition` protects,
+// because a winning human transition almost always lands somewhere the loser's
+// action is invalid — a cancelled task cannot be cancelled again.
+//
+// Three properties of the shape here, each load-bearing:
+//
+//   - The retry re-enters §6 rather than re-issuing the same swap, so a `pause`
+//     that lands on `running` defers at the step boundary instead of parking a
+//     task whose process is still live.
+//   - It resumes at the swap, never at the caller, so pre-CAS work — Archive's
+//     worktree removal, Retry's snapshot rewrite — is never repeated.
+//   - Once, not in a loop: a second conflict is returned as it stands, so no
+//     interleave can spin here.
 func (r *Runner) transitionFrom(
+	ctx context.Context, task *store.Task, action taskstate.Action, ch store.TaskChange,
+) (*store.Task, error) {
+	updated, err := r.applyAction(ctx, task, action, ch)
+	conflict, lost := store.AsStateConflict(err)
+	if !lost || !taskstate.Can(conflict.Got, action) {
+		return updated, err
+	}
+	fresh, err := r.deps.Store.GetTask(ctx, task.ID)
+	if err != nil {
+		return nil, err
+	}
+	return r.applyAction(ctx, fresh, action, ch)
+}
+
+// applyAction is one attempt at an action, from the state the task it is
+// given carries. Every human action but `pause` clears a pending pause: each
+// of them is a human saying "go" (§6).
+func (r *Runner) applyAction(
 	ctx context.Context, task *store.Task, action taskstate.Action, ch store.TaskChange,
 ) (*store.Task, error) {
 	tr, ok := taskstate.Next(task.State, action)
 	if !ok {
 		return nil, &InvalidActionError{TaskID: task.ID, Action: action, State: task.State}
+	}
+	// A deferred action is accepted now and applied by the engine later, so
+	// it is not a swap at all. §6 has exactly one — `pause` from `running`,
+	// which reaches `paused` through Park at the next step boundary.
+	if tr.Deferred {
+		return r.requestPause(ctx, task.ID)
 	}
 	if ch.PauseRequested == nil && action != taskstate.Pause {
 		noPause := false

--- a/internal/taskrun/actions_race_test.go
+++ b/internal/taskrun/actions_race_test.go
@@ -1,0 +1,142 @@
+package taskrun
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// admissionRounds is how many times a race test replays the interleave. One
+// round is enough on most runs — the single store connection serializes the
+// two goroutines so the losing order is the usual one — but a handful of
+// rounds keeps the test from depending on that.
+const admissionRounds = 50
+
+// raceAdmission runs one round of "the scheduler admits the task while a
+// human acts on it": a queued task, the admission CAS `internal/scheduler`
+// performs (scheduler.go `start`: queued → running) and act, released
+// together. It reports whether the admission committed, which is the only
+// round that says anything — when the human wins instead, the scheduler is
+// the one that must tolerate the conflict, and it already does.
+func raceAdmission(t *testing.T, h *actionHarness, act func(int64) error) (admitted bool, actErr error) {
+	t.Helper()
+	task := h.task(t, store.TaskQueued)
+	var (
+		wg       sync.WaitGroup
+		admitErr error
+	)
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, _, admitErr = h.store.TransitionTask(t.Context(), task.ID,
+			store.TaskQueued, store.TaskRunning, store.TaskChange{})
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		actErr = act(task.ID)
+	}()
+	close(start)
+	wg.Wait()
+	if admitErr != nil {
+		if _, conflict := store.AsStateConflict(admitErr); !conflict {
+			t.Fatalf("admission: %v", admitErr)
+		}
+		return false, actErr
+	}
+	return true, actErr
+}
+
+// TestCancelRacingAdmission pins §6's cancel row: `cancel` is valid from
+// `queued` **and** from `running`, so a cancel that the scheduler's admission
+// overtakes asked for something legal before the admission and after it. It
+// must not come back as a state conflict — the human cannot see the race, and
+// the state they lost to is one they were entitled to act from.
+//
+// This is issue #127. `humanAction` (actions.go) reads the task, validates the
+// action against the state it read, and hands that state to `transitionFrom`
+// as the compare-and-swap's `from`; an admission landing in between fails the
+// swap with "task N is running, not queued", which the API answers as 409 and
+// the TUI renders as "cancel: the task is running".
+func TestCancelRacingAdmission(t *testing.T) {
+	h := newActionHarness(t)
+	raced := 0
+	for range admissionRounds {
+		admitted, err := raceAdmission(t, h, func(id int64) error {
+			_, err := h.runner.Cancel(t.Context(), id)
+			return err
+		})
+		if !admitted {
+			continue
+		}
+		raced++
+		if err != nil {
+			var conflict *store.StateConflictError
+			if errors.As(err, &conflict) {
+				t.Fatalf("cancel lost its CAS to the scheduler and gave up: %v — "+
+					"§6 allows cancel from %s as well as from queued", conflict, conflict.Got)
+			}
+			t.Fatalf("cancel: %v", err)
+		}
+	}
+	if raced == 0 {
+		t.Fatal("the scheduler never won a round; the race was not exercised")
+	}
+}
+
+// TestPauseRacingAdmission is the same claim for the other action §6 allows
+// from both `queued` and a slot-holding state. Pause differs in what it does
+// once it re-reads: from `running` it is deferred — the task holds at the next
+// step boundary — so the task legitimately stays `running` with the request
+// persisted, and only a state conflict is a failure.
+func TestPauseRacingAdmission(t *testing.T) {
+	h := newActionHarness(t)
+	raced := 0
+	for range admissionRounds {
+		admitted, err := raceAdmission(t, h, func(id int64) error {
+			_, err := h.runner.Pause(t.Context(), id)
+			return err
+		})
+		if !admitted {
+			continue
+		}
+		raced++
+		if err != nil {
+			var conflict *store.StateConflictError
+			if errors.As(err, &conflict) {
+				t.Fatalf("pause lost its CAS to the scheduler and gave up: %v — "+
+					"§6 allows pause from %s as well as from queued", conflict, conflict.Got)
+			}
+			t.Fatalf("pause: %v", err)
+		}
+	}
+	if raced == 0 {
+		t.Fatal("the scheduler never won a round; the race was not exercised")
+	}
+}
+
+// TestPauseRacingAdmissionDefers guards the half of the fix that is easy to
+// get wrong: re-reading is not the same as re-swapping. `pause` from `running`
+// is deferred (§6) — the step finishes first — so a pause that re-reads
+// `running` must take the deferred path, not swap running → paused and park a
+// task whose process is still live.
+func TestPauseRacingAdmissionDefers(t *testing.T) {
+	h := newActionHarness(t)
+	task := h.task(t, store.TaskRunning)
+	if _, err := h.runner.Pause(t.Context(), task.ID); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	got := h.get(t, task.ID)
+	if got.State != store.TaskRunning || !got.PauseRequested {
+		t.Fatalf("pause from running: state = %s, pause_requested = %v; want running with the request persisted",
+			got.State, got.PauseRequested)
+	}
+	if !taskstate.Can(store.TaskRunning, taskstate.Pause) {
+		t.Fatal("§6 allows pause from running")
+	}
+}

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -69,39 +69,6 @@ func (h *engineHarness) waitForChildren(t *testing.T, parentID int64, want int) 
 	return nil
 }
 
-// cancelRacingAdmission cancels a task, tolerating the one race any test that
-// cancels a freshly spawned lane has.
-//
-// waitForChildren returns as soon as the lane rows exist, and a lane is
-// `queued` for a moment before the scheduler admits it. Cancel reads the task,
-// checks the action against the state it read, and then transitions with a
-// compare-and-swap on that state — so an admission landing in between fails
-// the swap with "task N is running, not queued", even though `cancel` is
-// perfectly legal from `running` too. It failed about one CI run in ten.
-//
-// Retrying is the right fix *for the test*, which asserts nothing about that
-// race: it wants the lane cancelled, from whichever state it has reached by
-// then. Whether a human action that loses a CAS to the scheduler should retry
-// itself is a §6 question about the product, and is deliberately not answered
-// here.
-func (h *engineHarness) cancelRacingAdmission(t *testing.T, id int64) {
-	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		_, err := h.runner.Cancel(t.Context(), id)
-		if err == nil {
-			return
-		}
-		if _, conflict := store.AsStateConflict(err); !conflict {
-			t.Fatalf("cancel task %d: %v", id, err)
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("cancel task %d: still losing the transition race after 10s: %v", id, err)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 // TestFanOutSpawnsLanesAndMerges is the whole of phase 2 in one pass: the
 // parent spawns real child tasks, parks without holding a slot, and — once
 // they finish — merges both branches into its own.
@@ -213,7 +180,9 @@ func TestFanOutBlocksWhenALaneDidNotFinish(t *testing.T) {
 	lanes := h.waitForChildren(t, task.ID, 2)
 	for _, lane := range lanes {
 		if lane.LaneID == "slow" {
-			h.cancelRacingAdmission(t, lane.ID)
+			if _, err := h.runner.Cancel(t.Context(), lane.ID); err != nil {
+				t.Fatalf("cancel lane %d: %v", lane.ID, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

A human action on a `queued` task failed with a state conflict when the
scheduler admitted that task between the action's read and its write — even
when the action was equally legal from the state it lost to. Over HTTP that is
a `409` (`task 3 is running, not queued`); in the TUI it is a `c` that appears
to do nothing until pressed again, because the board refetches on a 409 and the
second keypress performs exactly the act the first one was refused.

**Root cause.** `humanAction` reads the task, validates the action against the
state it read, and hands *that* state to `transitionFrom` as the
compare-and-swap's `from` (`internal/taskrun/actions.go`). `store.TransitionTask`
is a CAS by design and correctly reports the state it actually found; the defect
was that the caller treated every lost swap as terminal. The concurrent writer
is the scheduler's admission (`scheduler.start`, the only `queued → running` in
the codebase, §11) — bookkeeping, not intent. §6 allows `cancel` from `queued`
and `running` both, and `pause` from both, so the request was legal before the
admission and legal after it; only the CAS's `from` value went stale. The
asymmetry was the tell: the scheduler already swallows the mirror-image conflict
("a human acted between the query and now"), while the human side did not.

**The fix**, at the one shared CAS so every §6 human action gets the same rule:
when `TransitionTask` returns a `*store.StateConflictError` whose `Got` state
still satisfies `taskstate.Can(got, action)`, `transitionFrom` re-reads the task
and applies the action once more. Any other conflict is returned untouched.
Three properties are deliberate:

- **Once, never in a loop.** A second conflict is returned as it stands, so no
  pathological interleave can spin.
- **The retry re-enters §6, it does not re-issue the swap.** `pause` from
  `running` is deferred — the step finishes first — so a retry that blindly
  CASed `running → paused` would park a task whose process is still live. The
  deferral decision moved out of `Pause` into the shared `applyAction`, which is
  what lets the retry see it; `Pause` is now the plain human action it describes.
- **It resumes at the swap, not at the caller.** `Archive` removes the worktree
  and `Retry` rewrites the snapshot *before* their CAS; neither is re-run. In
  practice both are human-vs-human races where the rule is a no-op, but the code
  does not depend on that.

Human-vs-human races are unaffected, which is what `Runner.transition`'s
"their transition wins" back-off protects: a winning human transition almost
always lands somewhere the loser's action is invalid — a cancelled task cannot
be cancelled again. It is likewise a no-op for actions that cannot meet a legal
conflicting state; `answer` is valid only from `awaiting_input`, and the
engine's `input_closed` lands on `running`, where `answer` is invalid, so it
still 409s as it should.

**Regression test.** `internal/taskrun/actions_race_test.go` replays the
interleave directly: a `queued` task, the scheduler's `queued → running` CAS and
the action released together, 50 rounds, counting only the rounds the scheduler
won. It was written and observed failing against the unfixed code
(`cancel lost its CAS to the scheduler and gave up: task 4 is running, not
queued`) and passes with the fix; it is committed first, on its own, so that is
checkable. Nothing about it was weakened. If the retry is ever removed, the
scheduler wins a round, `Cancel` returns a `*store.StateConflictError`, and the
test fails with that message rather than with a timing-dependent flake — the
single store connection serializes the two goroutines into the losing order on
nearly every round, so it does not depend on luck to reproduce.
`TestPauseRacingAdmissionDefers` guards the deferral half: it passed before the
fix and still passes, so a retry that turned into a re-swap would fail it.

The workaround this bug forced on the test suite is gone:
`cancelRacingAdmission` (`internal/taskrun/fanout_test.go`, f4c7b65) and its
call site revert to a plain `h.runner.Cancel`, which is the issue's third
done-when. `TestFanOutBlocksWhenALaneDidNotFinish` — the ~1-in-10 CI failure
that surfaced this — passes `-count=5 -race` locally with the workaround
removed.

## Related

Closes #127

This **supersedes the PR C decision** of 2026-08-07 recorded in the closed v0
ledger (`docs/history/v0-tasks.md`): *"Losing the race to admission returns 409
with the current state and no internal retry: silently converting 'cancel a task
that hasn't started' into 'kill a live process' is a different act the human
never saw."* Superseded, not relitigated in passing, for three reasons: §6 does
not treat those as two acts — `cancel` has one row and one effect whose
process-killing half is conditional on state; the 409 does not deliver the
informed consent the decision wanted, since the documented remedy is a second
keypress that performs exactly the kill; and the property the decision was
really protecting — a human transition beats a competing one — is untouched by a
rule scoped to "the state it lost to still permits this action". The ledger is
frozen and unedited; the outcome is recorded as a dated in-place amendment to
**spec §6** (2026-08-24) naming the superseded decision, per the repository's
amend-the-spec-in-the-same-PR rule. No `docs/tasks/` document: this is a single
narrow behaviour change.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

On the last box: the affected pages are `docs/spec.md` §6 (the amendment above)
and `docs/reference/task-lifecycle.md`, which documents the human-action table
and the 409 rule for users. The API reference needed no change — its claim is
that an action *the state does not allow* returns 409 with `details.state`,
which is still exactly true; no route, config key, CLI command, TUI binding or
block reason moved.

## Notes for the reviewer

- **No second bug fixed here.** One neighbouring window is worth recording
  rather than changing: the scheduler commits `queued → running` and *then* calls
  `Admitter.Admit`, so a human action landing between the two commits against a
  task with no live actor yet. That window predates this PR — a human whose read
  saw `running` could already hit it — and this fix widens it slightly without
  changing its kind. The engine's own transitions are CASes from `running` and
  back off when they lose, so an actor started on an already-aborted task stops
  at its next transition rather than corrupting state. Out of scope here.
- **Local lint.** `go tool golangci-lint run ./...` is clean for `GOOS=windows`
  and `GOOS=darwin` (0 issues). The `GOOS=linux` run panics inside
  `honnef.co/go/tools` analysing the *standard library's* `internal/poll` on this
  machine's Go 1.27 toolchain — unrelated to this diff, and not reproducible
  against any file in it. CI's own lint job is the check that matters for it.
- `go test ./...` passes (1739 tests, 28 packages), and
  `go test -race ./internal/taskrun ./internal/scheduler ./internal/api
  ./internal/taskstate` passes.
