### PR TITLE
Add a branch column to task ls and correct the branch-deletion docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,19 @@ list with the user-facing context a commit subject cannot carry.
   to hit this; a blocked lane left the parent waiting in `awaiting_children`.
   Creation in *different* projects stays parallel. ([#126](https://github.com/lezli01/vincent/issues/126))
 
+- **`vincent task ls` reports each task's branch.** The list row carries
+  `BRANCH` in the table and `branch_name` in `--json`, so the documented
+  cleanup path — `vincent task ls --archived` — actually names the branches
+  vincent made. Branch names are configurable, so a `vincent/*` glob is not
+  guaranteed to find them. ([#137](https://github.com/lezli01/vincent/issues/137))
+- **Corrected documentation that promised branches are never deleted.** The FAQ
+  said archiving always keeps the branch; archiving deletes a branch that has no
+  commits past its base, and has since `delete_empty_branch_on_archive` shipped
+  defaulting to true. A branch carrying any commit is still never deleted. The
+  README, quickstart and scripting guide also claimed full TUI/CLI parity, which
+  does not hold for the human actions on a running task.
+  ([#137](https://github.com/lezli01/vincent/issues/137))
+
 ## [0.4.2](https://github.com/lezli01/vincent/compare/v0.4.1...v0.4.2) (2026-08-21)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -431,9 +431,13 @@ The task appears on the board, runs in its own worktree on branch
 TUI, press `a` to approve, and the publish step pushes the branch. `q` quits
 the TUI — the daemon and any running task keep going without it.
 
-Everything the TUI does is also a subcommand (`vincent task show 1`,
-`vincent task cancel 1`), and everything either does is the same localhost
-API. To keep the daemon running across reboots, `vincent service install`.
+The data commands the TUI runs are subcommands too (`vincent task show 1`,
+`vincent task cancel 1`, plus `project`, `workflow` and `daemon`), and
+everything either does is the same localhost API. The remaining human actions —
+approve, reject, retry, skip, pause, resume, answer, archive — are TUI and API
+operations for now ([#89](https://github.com/lezli01/vincent/issues/89)); the
+[CLI reference](docs/reference/cli.md) is the full tree. To keep the daemon
+running across reboots, `vincent service install`.
 
 **Next:** [writing your own workflows](docs/guides/workflows.md), or the
 [longer quickstart](docs/getting-started/quickstart.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,9 +44,21 @@ stash are untouched.
 
 ### Does it delete my branches?
 
-Never. Archiving a task removes its **worktree** and keeps the branch and the
-record. To find what to clean up, ask vincent rather than git — with configurable
-names a glob no longer finds them all:
+Only an empty one. Archiving a task removes its **worktree** and keeps the
+record. It keeps the branch too, unless that branch has no commits past the base
+it was cut from — a workflow that never wrote to the repository leaves nothing
+on its branch, and archiving deletes it rather than leaving an empty ref behind.
+**A branch carrying any commit is never deleted.** Turn the cleanup off with
+[`delete_empty_branch_on_archive: false`](reference/configuration.md#delete_empty_branch_on_archive).
+
+The remote counterpart is left alone unless you also set
+[`delete_remote_branch_on_archive: true`](reference/configuration.md#delete_remote_branch_on_archive)
+— off by default, and even then it runs only after the local delete succeeded,
+only for a branch with a configured upstream, and only when you archive the task
+yourself.
+
+To find what to clean up, ask vincent rather than git — with configurable names a
+glob no longer finds them all:
 
 ```sh
 vincent task ls --archived      # the branch column lists every branch vincent made

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -109,10 +109,11 @@ succeeded, because an agent reporting success is a claim and a build is a fact;
 a failed check retries the step with the failure appended to the prompt. Then a
 human gate, and only after approval does anything get pushed.
 
-The other three examples are
+The other four examples are
 [`fix-and-test`](../../examples/fix-and-test.yaml) (write a failing test, then
 fix it), [`docs-update`](../../examples/docs-update.yaml) (runs `restricted`),
-and [`cursor-review`](../../examples/cursor-review.yaml).
+[`converge`](../../examples/converge.yaml) (loops a repair step until the test
+suite is green), and [`cursor-review`](../../examples/cursor-review.yaml).
 
 `feature-pr` is written for a Go repository — its check is
 `go build ./... && go test ./...`. Open the file and change that line to
@@ -162,13 +163,18 @@ live agent output on the right, with a **Diff** tab beside it.
 | `?` | Every key, in context |
 | `q` | Quit (the daemon and any running task keep going) |
 
-The full tour is in [Using the TUI](../guides/tui.md). Everything the TUI can
-do is also a subcommand:
+The full tour is in [Using the TUI](../guides/tui.md). The data commands are
+subcommands too:
 
 ```sh
 vincent task show 1
 vincent task ls --state running
 ```
+
+The human actions on a running task — approve, reject, retry, skip, pause,
+resume, answer, archive — are TUI and API operations for now
+([#89](https://github.com/lezli01/vincent/issues/89)). The
+[CLI reference](../reference/cli.md) is the full tree.
 
 ## 5. Approve the gate
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -1,9 +1,15 @@
 # Scripting vincent
 
-Everything the TUI does is a subcommand, and everything either does is the same
-localhost API. That makes vincent scriptable three ways, in increasing order of
-control: the CLI with `--json`, the API with `curl`, and the SSE streams for
-anything that needs to react rather than poll.
+Everything the TUI does goes through the same localhost API, and its data
+commands are subcommands too — `task add/ls/show/cancel`, `project`, `workflow`,
+`daemon`. The human actions that act on a running task (approve, reject, retry,
+skip, pause, resume, answer, archive) have no subcommand yet
+([#89](https://github.com/lezli01/vincent/issues/89)), so a script reaches those
+over the API; the [CLI reference](../reference/cli.md) is the full tree.
+
+That makes vincent scriptable three ways, in increasing order of control: the
+CLI with `--json`, the API with `curl`, and the SSE streams for anything that
+needs to react rather than poll.
 
 - [Exit codes](#exit-codes)
 - [JSON output](#json-output)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -262,9 +262,14 @@ vincent task ls [--project ID] [--state STATE] [--archived] [--limit N] [--json]
                 [--include-children] [--parent ID]
 ```
 
-Lists tasks. Archived tasks are excluded unless `--archived` is passed. Rows
-carry the board fields — project name, step progress, and cost and token totals
-rolled up across every attempt.
+Lists tasks. Archived tasks are excluded unless `--archived` is passed. The
+table carries `ID`, `STATE`, `PROJECT`, `WORKFLOW`, `STEP` (the k/n cursor),
+`BRANCH` and `TITLE`; `--json` adds the rest of the board fields, including the
+cost and token totals rolled up across every attempt.
+
+`BRANCH` is the task's own branch, which is how you find what vincent made once
+[`branch_template`](configuration.md#branch_template) has moved branch names off
+the `vincent/` prefix a glob would look for.
 
 Fan-out lanes are excluded too: the list is the work you asked for, and a
 64-task tree would bury it. `--parent ID` lists one fan-out task's lanes in

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -23,6 +23,13 @@ type Task struct {
 	State       string            `json:"state"`
 	Priority    int               `json:"priority"`
 
+	// BranchName is the task's branch (§5.3). It belongs on the list row and
+	// not on TaskDetail alone: with configurable names (task 001) a
+	// `vincent/*` glob no longer finds every branch vincent made, so the
+	// cleanup guidance sends a reader to `vincent task ls --archived` for
+	// them. GET /v1/tasks has always served it; only this struct dropped it.
+	BranchName string `json:"branch_name"`
+
 	// CurrentStep is zero-based; StepTotal is the snapshot's step count.
 	// A board renders them as k/n with k = CurrentStep+1, clamped, because
 	// a finished task's cursor sits one past the last step.
@@ -294,7 +301,6 @@ func (r *ChildrenRollup) Summary() string {
 type TaskDetail struct {
 	Task
 	Description  string          `json:"description"`
-	BranchName   string          `json:"branch_name"`
 	WorktreePath *string         `json:"worktree_path"`
 	PendingInput json.RawMessage `json:"pending_input,omitempty"`
 	Steps        []StepRun       `json:"steps"`

--- a/internal/cli/docs_claims_test.go
+++ b/internal/cli/docs_claims_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// The published pages make claims about this command tree — which
+// subcommands exist, and which columns their tables carry. Nothing enforced
+// them, so both drifted: task 001's cleanup guidance rests on a branch column
+// `vincent task ls` has never rendered (issue #137). These tests hold every
+// user-facing page to what the tree and its tables actually do, in the
+// package that owns both.
+//
+// They are drift checks, not feature checks: a page that stops making the
+// claim satisfies them exactly as well as a command that starts backing it.
+
+// docPages are the user-facing pages. `docs/tasks/` and `docs/history/` are
+// maintainer records of what was planned and decided — they are allowed to
+// describe a surface that does not exist yet — and `docs/spec.md` describes
+// the API rather than the CLI.
+func docPages(t *testing.T) map[string]string {
+	t.Helper()
+	root := filepath.Join("..", "..")
+	pages := map[string]string{"README.md": ""}
+	err := filepath.WalkDir(filepath.Join(root, "docs"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		slashed := filepath.ToSlash(rel)
+		if d.IsDir() {
+			switch slashed {
+			case "docs/tasks", "docs/history", "docs/gates", "docs/assets":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(slashed, ".md") && slashed != "docs/spec.md" {
+			pages[slashed] = ""
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk docs: %v", err)
+	}
+	for name := range pages {
+		b, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		pages[name] = string(b)
+	}
+	return pages
+}
+
+// TestDocsClaimsTaskListShowsBranch: four pages send a reader to `vincent task
+// ls --archived` to find the branches vincent made — the cleanup path task 001
+// adopted when configurable names broke `git branch --list 'vincent/*'`. The
+// table has no such column, and `--json` has no such field, so the claim has
+// never been true.
+func TestDocsClaimsTaskListShowsBranch(t *testing.T) {
+	var claims []string
+	for name, body := range docPages(t) {
+		for i, line := range strings.Split(body, "\n") {
+			if strings.Contains(line, "task ls") && strings.Contains(strings.ToLower(line), "branch") {
+				claims = append(claims, name+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(claims) == 0 {
+		t.Skip("no page claims `task ls` reports a branch")
+	}
+
+	out := runTaskLs(t, "--archived")
+	header, _, _ := strings.Cut(out, "\n")
+	columns := strings.Fields(header)
+	if !slices.Contains(columns, "BRANCH") {
+		t.Errorf("`vincent task ls --archived` columns = %v, want a BRANCH column claimed by:\n  %s",
+			columns, strings.Join(claims, "\n  "))
+	}
+
+	var rows []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(runTaskLs(t, "--archived", "--json")), &rows); err != nil {
+		t.Fatalf("`task ls --json` is not JSON: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("`task ls --json` returned no rows")
+	}
+	if _, ok := rows[0]["branch_name"]; !ok {
+		t.Errorf("`task ls --json` row has no branch_name (keys drop it in apiclient.Task), "+
+			"so no output mode backs:\n  %s", strings.Join(claims, "\n  "))
+	}
+}
+
+// TestDocsClaimsTUIActionsHaveSubcommands: README, quickstart and the
+// scripting guide state that everything the TUI does is also a subcommand.
+// The TUI offers every §6 human action; `vincent task` exposes cancel alone
+// of the nine (#89).
+func TestDocsClaimsTUIActionsHaveSubcommands(t *testing.T) {
+	parity := regexp.MustCompile(`(?i)everything the tui (?:does|can do) is (?:also )?a subcommand`)
+	collapse := regexp.MustCompile(`\s+`)
+	var claims []string
+	for name, body := range docPages(t) {
+		if parity.MatchString(collapse.ReplaceAllString(body, " ")) {
+			claims = append(claims, name)
+		}
+	}
+	if len(claims) == 0 {
+		t.Skip("no page claims TUI/CLI parity")
+	}
+
+	have := map[string]bool{}
+	for _, sub := range taskCmdNames() {
+		have[sub] = true
+	}
+	seen := map[taskstate.Action]bool{}
+	var missing []string
+	for _, state := range taskstate.All {
+		for _, action := range taskstate.HumanActionsFrom(state) {
+			if seen[action] {
+				continue
+			}
+			seen[action] = true
+			if !have[string(action)] {
+				missing = append(missing, string(action))
+			}
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("`vincent task` has no subcommand for the human actions %v, "+
+			"but these pages claim TUI/CLI parity: %v", missing, claims)
+	}
+}
+
+// taskCmdNames lists the `vincent task` subcommands by their invoked name.
+func taskCmdNames() []string {
+	var names []string
+	for _, c := range newTaskCmd().Commands() {
+		names = append(names, c.Name())
+	}
+	return names
+}
+
+// stubTask is one row of GET /v1/tasks as the daemon serves it — the server's
+// listTaskResponse embeds taskResponse, so branch_name is on the wire and only
+// the client drops it.
+const stubTask = `[{
+  "id": 7,
+  "project_id": 1,
+  "project_name": "vincent",
+  "title": "File the release issue",
+  "workflow": "github-create-issue",
+  "state": "archived",
+  "base_branch": "main",
+  "branch_name": "vincent/7-file-the-release-issue",
+  "worktree_path": null,
+  "priority": 0,
+  "current_step": 1,
+  "step_total": 1,
+  "step_name": "file",
+  "block_reason": null,
+  "pause_requested": false,
+  "available_actions": [],
+  "queued_reason": null,
+  "admit_not_before": null,
+  "cost_usd": null,
+  "input_tokens": 0,
+  "output_tokens": 0,
+  "created_at": "2026-08-19T10:00:00Z",
+  "updated_at": "2026-08-19T10:05:00Z",
+  "started_at": null,
+  "finished_at": null,
+  "archived_at": "2026-08-19T10:05:00Z"
+}]`
+
+// runTaskLs runs `vincent task ls` in-process against a stub daemon: the
+// rendering is the assertion, so nothing here needs a real store, worktree or
+// agent.
+func runTaskLs(t *testing.T, args ...string) string {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/health":
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/v1/tasks":
+			_, _ = w.Write([]byte(stubTask))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse stub URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("stub port: %v", err)
+	}
+	if _, err := daemon.EnsureToken(dataDir); err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if err := daemon.WriteRuntimeInfo(dataDir, daemon.RuntimeInfo{
+		Port: port, PID: os.Getpid(), StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("daemon.json: %v", err)
+	}
+
+	var buf bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(append([]string{"task", "ls"}, args...))
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("task ls: %v (%s)", err, buf.String())
+	}
+	return buf.String()
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -168,11 +168,14 @@ func newTaskLsCmd() *cobra.Command {
 				for _, t := range tasks {
 					rows = append(rows, []string{
 						strconv.FormatInt(t.ID, 10), t.State, t.ProjectName,
-						t.Workflow, progress(t), t.Title,
+						t.Workflow, progress(t), t.BranchName, t.Title,
 					})
 				}
+				// BRANCH is what the cleanup guidance reads off `--archived`
+				// (task 001): configurable names mean a `vincent/*` glob no
+				// longer finds every branch vincent made.
 				return table(cmd.OutOrStdout(),
-					[]string{"ID", "STATE", "PROJECT", "WORKFLOW", "STEP", "TITLE"}, rows)
+					[]string{"ID", "STATE", "PROJECT", "WORKFLOW", "STEP", "BRANCH", "TITLE"}, rows)
 			})
 		},
 	}

--- a/internal/config/docs_claims_test.go
+++ b/internal/config/docs_claims_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDocsClaimsArchiveKeepsBranch holds the published pages to this
+// package's archive defaults. `delete_empty_branch_on_archive` has defaulted
+// to true since task 008 (spec §10, amended 2026-08-16), so a page telling a
+// reader that archiving keeps the branch — or that vincent never deletes one
+// — is telling them a branch is safe that the daemon deletes (issue #137).
+//
+// It is a drift check on the pairing, not on the default: flipping the
+// default or qualifying the sentence both satisfy it.
+func TestDocsClaimsArchiveKeepsBranch(t *testing.T) {
+	if !Default().DeleteEmptyBranchOnArchive {
+		t.Skip("archive keeps every branch by default; the unqualified claim is true")
+	}
+
+	// A survival claim: the branch outlives the archive.
+	keeps := regexp.MustCompile(`(?i)keeps the branch|the branch is kept|` +
+		`never deletes? (?:a |your |any )?branch|delete my branches\?`)
+	// The exception task 008 introduced, in any of the spellings the pages use.
+	qualified := regexp.MustCompile(`(?i)delete_empty_branch_on_archive|` +
+		`no commits|carries a commit|carrying a commit|has commits|with commits|` +
+		`commits past|holds a commit`)
+	collapse := regexp.MustCompile(`\s+`)
+
+	var bad []string
+	for name, body := range docPagesForClaims(t) {
+		for _, para := range strings.Split(body, "\n\n") {
+			flat := collapse.ReplaceAllString(para, " ")
+			// Only paragraphs about archiving: `vincent gc` never deletes a
+			// branch, unqualified and true.
+			if !strings.Contains(strings.ToLower(flat), "archiv") {
+				continue
+			}
+			if keeps.MatchString(flat) && !qualified.MatchString(flat) {
+				bad = append(bad, name+": "+strings.TrimSpace(flat))
+			}
+		}
+	}
+	if len(bad) > 0 {
+		t.Errorf("delete_empty_branch_on_archive defaults to true, but these pages promise "+
+			"the branch survives archiving with no exception:\n  %s", strings.Join(bad, "\n  "))
+	}
+}
+
+// docPagesForClaims reads the user-facing pages: everything under docs/ except
+// the maintainer records (`docs/tasks/`, `docs/history/`, `docs/gates/`) and
+// the spec itself, plus the README.
+func docPagesForClaims(t *testing.T) map[string]string {
+	t.Helper()
+	root := filepath.Join("..", "..")
+	pages := map[string]string{"README.md": ""}
+	err := filepath.WalkDir(filepath.Join(root, "docs"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		slashed := filepath.ToSlash(rel)
+		if d.IsDir() {
+			switch slashed {
+			case "docs/tasks", "docs/history", "docs/gates", "docs/assets":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(slashed, ".md") && slashed != "docs/spec.md" {
+			pages[slashed] = ""
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk docs: %v", err)
+	}
+	for name := range pages {
+		b, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", name, readErr)
+		}
+		pages[name] = string(b)
+	}
+	return pages
+}

--- a/internal/workflow/docs_claims_test.go
+++ b/internal/workflow/docs_claims_test.go
@@ -1,0 +1,57 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDocsClaimsQuickstartListsEveryExample: the quickstart walks a reader
+// through one example and names the rest by count ("the other three
+// examples"). Adding an example to examples/ without editing that sentence
+// leaves a reader believing they have seen the whole shelf (issue #137).
+func TestDocsClaimsQuickstartListsEveryExample(t *testing.T) {
+	root := filepath.Join("..", "..")
+	entries, err := filepath.Glob(filepath.Join(root, "examples", "*.yaml"))
+	if err != nil {
+		t.Fatalf("glob examples: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no examples found")
+	}
+
+	page := filepath.Join(root, "docs", "getting-started", "quickstart.md")
+	b, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("read quickstart: %v", err)
+	}
+	body := string(b)
+
+	for _, path := range entries {
+		name := filepath.Base(path)
+		if !strings.Contains(body, name) {
+			t.Errorf("examples/%s is never named in docs/getting-started/quickstart.md", name)
+		}
+	}
+
+	// "The other N examples are …" — N counts everything but the one walked
+	// through above it.
+	words := map[string]int{
+		"one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+		"six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+	}
+	counted := regexp.MustCompile(`(?i)the other (\w+) examples?`)
+	for _, m := range counted.FindAllStringSubmatch(body, -1) {
+		got, ok := words[strings.ToLower(m[1])]
+		if !ok {
+			t.Errorf("quickstart says %q; not a number this test can check", m[0])
+			continue
+		}
+		if want := len(entries) - 1; got != want {
+			t.Errorf("quickstart says %q, but examples/ holds %d workflows, so the others number %d",
+				m[0], len(entries), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Four published claims that the code does not back, plus the one code defect
underneath them. The regression tests were written first, against the unfixed
code, and observed to fail there.

**1. `apiclient.Task` dropped `branch_name` (the code defect).** Task 001 moved
the branch-cleanup guidance off `git branch --list 'vincent/*'` — configurable
names break that glob — and onto `vincent task ls --archived`, on the recorded
premise that the command "already prints the branch column". It never did.
`GET /v1/tasks` has always served `branch_name` (the server's `listTaskResponse`
embeds `taskResponse`), but the client's `Task` had no such field, so the value
was discarded on decode and neither the table nor `--json` could show it. Four
pages send readers there to find what to clean up.

Fixed at the cause: `BranchName` moves onto `apiclient.Task`, `vincent task ls`
renders a `BRANCH` column, and `docs/reference/cli.md` now names the columns the
table carries. `TaskDetail`'s own `branch_name` field is deleted — it is promoted
from the embedded `Task` now, and two fields for one key is how they drift apart.
No API, store or spec change: the wire already had it.

**2. The FAQ promised vincent never deletes a branch.** `docs/faq.md` answered
"Does it delete my branches?" with "Never. Archiving a task removes its
**worktree** and keeps the branch and the record." Task 008 made that false:
archiving deletes a branch with no commits past its base, with
`delete_empty_branch_on_archive` defaulting to `true` (spec §10, amended
2026-08-16). Task 008.7 updated seven other pages and missed this one — the one
phrased as an absolute promise, in the document a worried reader reaches for.
The answer now states the rule the other pages state: **a branch carrying any
commit is never deleted**, an empty one is deleted at archive time, the opt-out
is `delete_empty_branch_on_archive: false`, and the remote counterpart is touched
only under `delete_remote_branch_on_archive` (off by default, local delete first,
configured upstream only, your own archive only).

`docs/features.md` and `docs/reference/cli.md` also say "never deletes a branch"
unqualified, but both are about `vincent gc`, where it is true. Left alone.

**3. TUI/CLI parity is claimed and does not hold.** README, quickstart and the
scripting guide said everything the TUI does is also a subcommand. Of the nine §6
human actions the TUI offers, `vincent task` exposes `cancel` alone —
`docs/reference/cli.md` already said so, and contradicted the other three. The
three sentences are now conditional: the data commands have CLI equivalents, the
remaining human actions are TUI/API operations for now (#89), with a link to the
CLI reference. Adding those subcommands is #89, not this PR.

**4. The quickstart's example count was stale.** "The other three examples" named
three of the four that are not `feature-pr`; `converge.yaml` went unnamed. Now
four, `converge` included.

**Root cause, in one line:** nothing tied the published pages to the surfaces
they describe, so each one drifted the moment its surface moved — the branch
column was documented before it existed, and the archive answer outlived the
default it described.

### Out of scope

Issue item 5 (the absolute statements about credentials and transcripts) is
deliberately not addressed: those sentences must link to limits and failure
semantics defined by sibling issues that are not in this worktree, and guessing
at them would produce wording that has to be rewritten again. Acceptance
criterion 6 stays open.

### How the regression tests catch a recurrence

Four tests, in the packages that own each surface, run by `go test ./internal/cli
./internal/config ./internal/workflow -run TestDocsClaims`. All hermetic — no
network, no daemon, no agent CLI.

- `internal/cli/docs_claims_test.go`
  - `TestDocsClaimsTaskListShowsBranch` collects every user-facing line that
    mentions `task ls` and a branch, then runs `vincent task ls --archived`
    in-process against a stub daemon serving a row that *does* carry
    `branch_name`, and requires both a `BRANCH` column and a `branch_name` key in
    `--json`. Deleting the field from `apiclient.Task` again, or dropping the
    column, fails it and prints the exact doc lines left unbacked.
  - `TestDocsClaimsTUIActionsHaveSubcommands` fires only if some page carries the
    parity sentence, and then requires a `vincent task` subcommand for every
    action in `taskstate.HumanActionsFrom` over `taskstate.All`. Re-adding the
    sentence before #89 lands fails it.
- `internal/config/docs_claims_test.go` — `TestDocsClaimsArchiveKeepsBranch`
  reads `Default().DeleteEmptyBranchOnArchive` and, while it is true, fails any
  paragraph about archiving that promises the branch survives without naming the
  exception. It is a check on the *pairing*: flipping the default and qualifying
  the sentence both satisfy it, so it stays honest if the policy changes.
- `internal/workflow/docs_claims_test.go` —
  `TestDocsClaimsQuickstartListsEveryExample` requires every `examples/*.yaml` to
  be named in the quickstart and "the other N examples" to match the inventory.
  Adding a sixth example without editing that sentence fails it.

No assertion was weakened. All four failed at `090d2de` and pass here.

## Related

Closes #137.

Revisits nothing: it makes task 001's recorded decision
(`docs/tasks/001-configurable-branch-names.md`, "the cleanup docs change
instead") true rather than relitigating it, and it restates task 008's archive
policy on the one page that missed it. The missing action subcommands stay with
#89.

**No spec amendment.** §10 (branch cleanup on archive, amended 2026-08-16) and
§12.3 (both config keys) already describe the behaviour the corrected FAQ now
states — the page was the side that was wrong. §13.2 already puts `branch_name`
on the task list endpoint, and §12.1 describes the command tree without
enumerating table columns, so the new `BRANCH` column makes nothing in the spec
untrue.

## Checklist

- [ ] PR title is plain language (no Conventional Commit prefix) — the title in
      `.vincent-issue/pr-title.txt` is plain language, per `CLAUDE.md` and the
      `PR title` workflow, which reject a Conventional prefix on a PR title
      because GitHub copies it into the merge commit.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `test:` then `fix:`, no co-author trailer.
- [x] Tests added/updated for behavior changes — four drift checks, written and observed failing before the fix.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — both the CLI change and the corrected safety claim.
- [x] Affected page under `docs/` updated — `docs/reference/cli.md` (the `task ls` columns), `docs/faq.md`, `docs/getting-started/quickstart.md`, `docs/guides/scripting.md`, `README.md`.

Verified locally: `go test ./...` (1739 tests, all packages) and
`go tool golangci-lint run ./...` for `GOOS=darwin` and `GOOS=windows`, both
clean. The `GOOS=linux` cross-lint could not be run on this host — staticcheck
panics analysing the stdlib `internal/poll` package under cross-GOOS analysis
(`interface conversion: interface {} is nil, not *buildir.IR`), before reaching
any repository code — it panics the same way linting a single package this PR
does not touch. CI lints Linux natively.
