### PR TITLE
Fail closed when step output capture or persistence is incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **A step whose output vincent could not capture is no longer reported as a
+  success.** Command output was read a line at a time with a one-mebibyte
+  ceiling; a longer line — minified JSON, a base64 blob, a `git diff` of a
+  generated file — stopped capture dead, sent the rest of the stream to
+  `/dev/null`, and left the step `succeeded` on its exit code alone, with a
+  megabyte of evidence gone and nothing a client could query saying so.
+  Over-long lines are now captured in bounded `partial` pieces that rejoin in
+  order, so an ordinary big-output command stays a success *with* its output.
+  Genuine evidence loss now fails the attempt instead: transcript write, encode
+  and close errors (a full disk, a revoked permission, a short write — `Close`
+  is checked, because that is where a buffered filesystem reports ENOSPC) fail
+  it with the new `transcript_io_error` reason, and a stream an agent adapter
+  could not read to the end fails it with `agent_protocol_error` rather than
+  blaming the CLI. Both retry normally and neither can be swallowed by
+  `allow_failure:`. `transcript_max_bytes` is unchanged and remains the only
+  size-based failure. ([#139](https://github.com/lezli01/vincent/issues/139))
+
 - **Workflow loading is bounded and refuses non-regular files.** A `*.yaml`
   entry in a workflow directory that is a symlink, named pipe, socket or device
   is no longer opened or followed, and a source is capped at 1 MiB. Previously a

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -453,6 +453,8 @@ The block reason names what happened:
 | `platform_unsupported` | The workflow's `platforms:` list does not admit this host |
 | `input_unsupported` | A step needs an agent that can answer questions mid-run, and this one cannot (see below) |
 | `transcript_limit` | The attempt's transcript hit `transcript_max_bytes` |
+| `transcript_io_error` | The attempt's transcript could not be written or closed (see below) |
+| `agent_protocol_error` | vincent could not read the agent's stream to the end (see below) |
 | `rejected` | You rejected a manual gate |
 | `shell_unavailable` | The requested shell is not installed |
 | `interrupted` | The daemon stopped mid-step — **not** a failure; the step re-runs and does not consume a retry |
@@ -503,6 +505,27 @@ One attempt produced more output than `transcript_max_bytes` (default 512MB).
 vincent kills the process rather than filling your disk, and writes the tripping
 annotation into the file so it records *why* it ends. Usually this means an agent
 or command is in a loop; fix that rather than raising the cap.
+
+### `transcript_io_error` — check the disk
+
+vincent could not write, encode or close the attempt's transcript, so the record
+of the run is incomplete. The step **fails** rather than reporting a success it
+cannot evidence: the usual cause is a full disk or a data directory whose
+permissions changed under the daemon. `df` the data directory (`vincent doctor`
+prints it), fix the cause, and retry — a new attempt writes a new file, so this
+clears on its own once there is room.
+
+It is **not** what a very long line of output produces. Those are captured in
+`partial` pieces and the step succeeds normally; only `transcript_limit` fails a
+step for size.
+
+### `agent_protocol_error` — vincent's reader, not the CLI's fault
+
+vincent could not read the agent's event stream to the end, so its transcript is
+missing lines the CLI wrote. The reason is named separately from `agent_error`
+on purpose: the agent may have completed its work perfectly, and there is
+usually nothing to fix in the CLI. Retry the task; if it repeats on the same
+step, the transcript up to the cut is the thing to attach to a bug report.
 
 ### A task is stuck in `awaiting_input`
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1051,8 +1051,10 @@ row is what the next guard reads.
 **It only swallows failures the step itself produced:** a nonzero exit, a failed
 `check`, an agent error, a timeout, a transcript-cap kill. It never swallows
 vincent failing to *run* the step — a missing CLI, an expired login, a template
-error, an unavailable shell. Branching on "the agent is not installed" as though
-it were a test result is not something a workflow should be able to do.
+error, an unavailable shell — nor vincent failing to *record* it
+(`transcript_io_error`, `agent_protocol_error`). Branching on "the agent is not
+installed", or on "the disk filled up", as though either were a test result is
+not something a workflow should be able to do.
 
 It is valid on `agent` and `command` steps only, sub-steps of a group included,
 and it is not available in `defaults:`.

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -195,6 +195,8 @@ same thing wherever it originated.
 | `loop_limit` | A `loop` step cannot run within `max_iterations`: a `for_each` list longer than the ceiling, or a `count:` the ceiling moved under. It blocks rather than truncating or advancing — running out of tries is not a decision the workflow made, and advancing would tell every later guard the work is finished. Raise `max_iterations:` on the step or `loop.max_iterations` in config, or narrow the list at its source |
 | `restricted_unsupported` | The adapter cannot restrict on this platform (cursor on Windows) |
 | `transcript_limit` | The attempt hit `transcript_max_bytes` |
+| `transcript_io_error` | The attempt's transcript could not be written, encoded or closed — a full disk, a revoked permission, a short write. The step fails rather than reporting a success over a record that is missing the run it describes. Retries as usual (a new attempt writes a new file), then blocks. **Not** what an over-long line produces: those are captured in `partial` pieces |
+| `agent_protocol_error` | vincent could not read the agent's stream to the end, so the transcript is missing lines the CLI wrote. Not `agent_error` — the CLI may have behaved perfectly; the reader that failed is vincent's |
 | `shell_unavailable` | The requested shell is not installed |
 | `rejected` | You rejected a manual gate |
 | `canceled` | You cancelled the task |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -54,10 +54,21 @@ What limits the damage, and what does not:
 | Mitigation | Real |
 |---|---|
 | Nothing is pushed, merged or deployed unless a **workflow step does it** | ✅ — put a `manual` gate in front of any such step |
-| Everything is transcripted: every prompt, tool call and command | ✅ |
+| Everything is transcripted: every prompt, tool call and command | ✅ — and when it cannot be, the step **fails** rather than passing (see below) |
 | Any step can run `permission_mode: restricted` | ✅ — see below |
 | The git worktree | ⚠️ collision isolation, **not** security isolation |
 | Running under a service | ❌ changes nothing — it is still you |
+
+**"Everything is transcripted" is a promise about completeness, not about
+durability.** A transcript vincent could not finish writing does not quietly
+become a shorter transcript: a failed write, encode or close fails the attempt
+with `transcript_io_error`, and a stream an adapter could not read to the end
+fails it with `agent_protocol_error`. Output too long for one record is split
+across `partial` records rather than dropped, so length alone never costs you
+evidence; only `transcript_max_bytes` deliberately stops a runaway, and it says
+so in the file. What is *not* promised: vincent writes and closes the file and
+checks both, but does not fsync per line, so a host that loses power can still
+lose the tail of a transcript. See [spec §12.2](spec.md#122-directories-platform-native).
 
 The TUI shows this warning **once**, on first run. The acknowledgment persists in
 `{data_dir}/tui.json` and is written when the notice is *dismissed*, never when

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -519,8 +519,9 @@ stdout/stderr are captured to the step transcript.
   more: "the disk filled up" is not a test result either, and a guard that
   reads a row whose evidence is missing is reading nothing. Both run this
   section's budget in full — a new attempt writes a new transcript, which is
-  exactly what clears a transient one. `usage_limit` and `interrupted` are untouched for a different
-  reason: this section already says they are not failures.
+  exactly what clears a transient one. `usage_limit` and `interrupted` are
+  untouched for a different reason: this section already says they are not
+  failures.
 
   It is orthogonal to the retry budget, which runs first and in full. A probe
   that should not retry says `max_retries: 0`. There is no

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -462,6 +462,17 @@ A step **succeeds** iff:
 2. **`command` step:** the command exits 0; **and** any declared `check` exits 0.
 3. **`manual` step:** the engineer approves the gate.
 
+**…and in every case its output was captured and persisted.** *Added 2026-08-24
+(#139).* Success is a claim about the run *and* about the record of it. An
+attempt whose stream vincent could not read to the end, or whose transcript
+could not be written or closed, fails with `transcript_io_error` (§12.2, §18)
+rather than being judged from its exit status alone. The original wording made
+exit 0 sufficient, which let a step whose megabyte-long output was thrown away
+land as `succeeded` with nothing a client could query saying the record was
+incomplete. Note the limit this is *not*: an over-long line is captured in
+bounded pieces, not failed — `transcript_max_bytes` (§12.3) remains the only
+size-based failure.
+
 Checks run in the worktree with the same environment as command steps (§8.5). Check
 stdout/stderr are captured to the step transcript.
 
@@ -500,9 +511,15 @@ stdout/stderr are captured to the step transcript.
   Everything else is vincent failing to **run** the step —
   `agent_unavailable`, `agent_unauthenticated`, `restricted_unsupported`,
   `input_unsupported`, `platform_unsupported`, `invalid_snapshot`,
-  `template_error`, `condition_error` — and is never swallowed: a workflow must
-  not be able to branch on "the CLI is not installed" as though that were a
-  test result. `usage_limit` and `interrupted` are untouched for a different
+  `template_error`, `condition_error`, and (*added 2026-08-24, #139*)
+  `transcript_io_error` and `agent_protocol_error` — and is never swallowed: a
+  workflow must not be able to branch on "the CLI is not installed" as though
+  that were a test result. The two added reasons are vincent failing to
+  **record** the step rather than to run it, which is the same rule read once
+  more: "the disk filled up" is not a test result either, and a guard that
+  reads a row whose evidence is missing is reading nothing. Both run this
+  section's budget in full — a new attempt writes a new transcript, which is
+  exactly what clears a transient one. `usage_limit` and `interrupted` are untouched for a different
   reason: this section already says they are not failures.
 
   It is orthogonal to the retry budget, which runs first and in full. A probe
@@ -2350,6 +2367,32 @@ platform the standing answer to an agent that will not resolve is the §12.3
   logs/daemon.log            # rotated, size-capped
 ```
 
+**What a transcript promises, exactly.** *Added 2026-08-24 (#139).* A
+transcript is the complete record of one attempt: agent stream lines verbatim,
+command and check output, and vincent's own `vincent.*` annotations. Three
+limits are stated rather than assumed:
+
+- **A line is not a unit of capture.** Command output longer than one record
+  is written as a run of `vincent.output` records marked `partial`, in order,
+  on one stream. Rejoining them in order reproduces the line. Nothing is
+  dropped and nothing is truncated to make a line fit.
+- **Incompleteness is never silent.** A failed write, encode or close latches
+  on the transcript, and the attempt fails `transcript_io_error` (§7.1, §18)
+  instead of reporting a success over a record that is missing the run it
+  describes. `Close` is checked, because a buffered filesystem reports ENOSPC
+  there and nowhere else.
+- **Persisted, not fsynced.** vincent writes and closes, and checks both. It
+  does not fsync per line; a transcript can therefore lose its tail to a host
+  that loses power, and an audit-grade durability mode is a separate decision.
+
+The one size-based exception stays §12.3's `transcript_max_bytes`: past the cap
+the run is killed and the attempt fails `transcript_limit`, with the partial
+transcript kept.
+
+Live-output offsets (§13.3) never over-claim: an append advances the published
+offset by the bytes the write actually returned, so an offset always names a
+position the file has reached.
+
 ### 12.3 Configuration (`config.yaml`)
 
 ```yaml
@@ -3500,6 +3543,9 @@ currently true to show (§15 view 6).
 | Step declaring `on_input: require` on an agent that cannot ask | *Added 2026-08-17 (task 013).* A workflow pinning an adapter with no control channel (codex, cursor) fails §8.2 validation outright. Otherwise creation is refused with a `400` naming the step and the agent, and the TUI's picker will not select that agent; `GET /v1/agents` publishes the `input_verdict` the gate uses. A task that reaches the engine anyway — claude upgraded past the §9.3 ceiling, a data directory moved — fails the attempt with `input_unsupported` under the §7.2 budget, before anything is spawned. Only a positive "cannot" refuses: an absent or unprobed binary is unknown, and unknown never blocks (§9.6) |
 | Workflow restricted to platforms this host is not | *Added 2026-08-16 (task 010).* Creation is refused with a `400` naming the restriction and the host (§8.1.1); the entry stays listed and says why, and the TUI's picker will not select it. A task that *already* holds such a snapshot — the data directory moved to another OS, or the workflow narrowed after the task was queued — blocks at admission with `platform_unsupported`, before a worktree or any step. Not `invalid_snapshot`: the snapshot is valid, just not here |
 | Runaway step output (agent or command) | Past `transcript_max_bytes` (§12.3) the process tree is killed and the attempt fails `transcript_limit`, under the retry policy. The line that trips the cap is written **whole** — a truncated line would turn a size failure into a parse failure for every later reader of the JSONL — and the partial transcript is kept with a closing `vincent.transcript_limit` annotation, because the lines that got there are what explain the runaway |
+| A command emits a single line larger than one output record | *Added 2026-08-24 (#139).* Captured, not failed: the line becomes a run of `vincent.output` records marked `partial`, in order, on one stream, preserving phase, stream identity and live offsets. Minified JSON, a base64 blob and a `git diff` of a generated file all reach a megabyte on one line, so this is an ordinary command; failing it would only retry it into the same wall until the task blocked. It was previously a *silent success* — a line-bound reader stopped dead on the first such line, the rest of the stream went to `io.Discard`, and the attempt was judged from exit 0 alone |
+| A transcript write, encode or close fails | *Added 2026-08-24 (#139).* The failure latches on the transcript and the attempt fails `transcript_io_error` under the §7.2 budget — disk full, a revoked permission, a short write, and ENOSPC surfaced at `Close`, which is where a buffered filesystem reports it. Never swallowed by `allow_failure:` (§7.2): vincent failing to record a step is not an outcome the step produced. Only a *success* is overridden — an attempt that already failed keeps the more useful reason. `transcript_max_bytes` is unaffected and stays the only size-based failure (§12.3) |
+| An adapter cannot read its agent's stream to the end | *Added 2026-08-24 (#139).* The adapter latches its reader's error, drains the pipe so the CLI is not left blocked on it until the step timeout, and reports `agent.FailureStreamError`; the engine fails the attempt `agent_protocol_error` under the §7.2 budget. Deliberately not `agent_error`, which means "the CLI reported a failure" and would send a user to inspect a CLI that did nothing wrong — the reader that failed is vincent's. Deliberately not `input_protocol_error` either: that names a control message vincent could not render, and such a message arrived intact |
 | Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). DB rows are never deleted; retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |
 | Base branch doesn't exist | Task creation fails fast |
 | Branch already exists (or a ref hierarchy conflict blocks the name) | Rejected at creation with `400` where the name is known then; otherwise the task blocks with `branch_exists` at admission, which stays the authority. Never reused, never auto-renamed. Recover with `retry { branch_override }` (§10, task 001) |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -314,6 +314,15 @@ const (
 	// logged in. Waiting cannot fix it — re-authenticating is a human action —
 	// so it stays an ordinary failure under the §7.2 budget (§18).
 	FailureUnauthenticated FailureKind = "unauthenticated"
+	// FailureStreamError is a run whose stream the adapter could not read to
+	// the end: its line reader stopped on an error, so normalization ended
+	// early and the transcript is missing lines the CLI wrote (#139).
+	//
+	// It is the adapter naming its *own* reader, which is why it is not
+	// folded into the generic agent_error bucket: the CLI may have behaved
+	// perfectly, and sending a user to look at it wastes their time. The
+	// engine maps it to `agent_protocol_error` (§18).
+	FailureStreamError FailureKind = "stream_error"
 )
 
 // Failure is an adapter's verdict about a stopped run (task 003, §9.1).

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -208,7 +208,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 		}
 	}
 	go r.mux()
-	go r.readLoop(bufio.NewScanner(stdout))
+	go r.readLoop(stdout)
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -245,7 +245,12 @@ type run struct {
 
 	mu       sync.Mutex
 	terminal *agent.RunResult // parsed result event, if any
-	pending  *pendingRequest  // the one the engine is answering; guarded by mu
+	// streamErr is readLoop's own reader failing, latched for Wait. It is
+	// vincent losing the stream, not the CLI failing, and Wait says so with
+	// agent.FailureStreamError rather than letting the exit code speak for a
+	// transcript that is missing lines (#139).
+	streamErr error
+	pending   *pendingRequest // the one the engine is answering; guarded by mu
 	// queue holds requests that arrived while another was pending. The real
 	// CLI does issue concurrent control requests — it batches parallel tool
 	// calls, so a restricted run can ask about several at once — and failing
@@ -292,10 +297,11 @@ func (r *run) mux() {
 	}
 }
 
-func (r *run) readLoop(sc *bufio.Scanner) {
+func (r *run) readLoop(rd io.Reader) {
 	defer close(r.readerDone)
 	defer close(r.raw)
 	defer r.closeStdin()
+	sc := bufio.NewScanner(rd)
 	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
 	for sc.Scan() {
 		line := make([]byte, len(sc.Bytes()))
@@ -315,8 +321,16 @@ func (r *run) readLoop(sc *bufio.Scanner) {
 		}
 		r.raw <- ev
 	}
-	// A scanner error (over-long line, pipe error) ends normalization; the
-	// process itself is still waited on and its exit code judged.
+	// A reader that stopped before the stream did leaves the CLI writing into
+	// a pipe nobody empties, which would hang it until the step timeout.
+	// Drain it, then let Wait name the failure — normalization ended early,
+	// so the transcript is missing lines the CLI wrote (#139).
+	if err := sc.Err(); err != nil {
+		r.mu.Lock()
+		r.streamErr = err
+		r.mu.Unlock()
+		_, _ = io.Copy(io.Discard, rd)
+	}
 }
 
 // parseStreamLine handles the control-protocol lines that need run state
@@ -443,7 +457,7 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal := r.terminal
+		terminal, streamErr := r.terminal, r.streamErr
 		r.mu.Unlock()
 		if terminal != nil {
 			res.IsError = terminal.IsError
@@ -463,6 +477,17 @@ func (r *run) Wait() (agent.RunResult, error) {
 		// It happens here because this is the one place that holds both the
 		// terminal result and the stderr tail; the engine sees neither.
 		res.Failure = classify(res, r.stderr.String())
+		// A stream vincent could not read to the end outranks whatever the
+		// exit code says: the run may well have finished cleanly, but the
+		// record of it is missing lines, and §7.1 success is a claim about
+		// both (#139). It is set last so it wins over `classify`'s verdict —
+		// a usage limit whose transcript is broken is still a broken
+		// transcript, and the retry that follows rewrites the file.
+		if streamErr != nil {
+			res.IsError = true
+			res.ErrorMessage = "agent stream capture failed: " + streamErr.Error()
+			res.Failure = &agent.Failure{Kind: agent.FailureStreamError}
+		}
 		r.waitRes = res
 	})
 	return r.waitRes, r.waitErr

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -194,7 +195,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 		readerDone: make(chan struct{}),
 		procDone:   make(chan struct{}),
 	}
-	go r.readLoop(bufio.NewScanner(stdout))
+	go r.readLoop(stdout)
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -217,6 +218,11 @@ type run struct {
 
 	mu       sync.Mutex
 	terminal *agent.RunResult // assembled from turn.completed / turn.failed
+	// streamErr is readLoop's own reader failing, latched for Wait. It is
+	// vincent losing the stream, not the CLI failing, and Wait says so with
+	// agent.FailureStreamError rather than letting the exit code speak for a
+	// transcript that is missing lines (#139).
+	streamErr error
 
 	waitOnce sync.Once
 	waitRes  agent.RunResult
@@ -227,9 +233,10 @@ type run struct {
 // so lines can be large.
 const maxLineBytes = 16 * 1024 * 1024
 
-func (r *run) readLoop(sc *bufio.Scanner) {
+func (r *run) readLoop(rd io.Reader) {
 	defer close(r.readerDone)
 	defer close(r.events)
+	sc := bufio.NewScanner(rd)
 	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
 	st := &stream{}
 	for sc.Scan() {
@@ -247,8 +254,16 @@ func (r *run) readLoop(sc *bufio.Scanner) {
 		}
 		r.events <- ev
 	}
-	// A scanner error (over-long line, pipe error) ends normalization; the
-	// process itself is still waited on and its exit code judged.
+	// A reader that stopped before the stream did leaves the CLI writing into
+	// a pipe nobody empties, which would hang it until the step timeout.
+	// Drain it, then let Wait name the failure — normalization ended early,
+	// so the transcript is missing lines the CLI wrote (#139).
+	if err := sc.Err(); err != nil {
+		r.mu.Lock()
+		r.streamErr = err
+		r.mu.Unlock()
+		_, _ = io.Copy(io.Discard, rd)
+	}
 }
 
 // Events implements agent.RunHandle.
@@ -294,7 +309,7 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal := r.terminal
+		terminal, streamErr := r.terminal, r.streamErr
 		r.mu.Unlock()
 		if terminal != nil {
 			res.IsError = terminal.IsError
@@ -309,6 +324,15 @@ func (r *run) Wait() (agent.RunResult, error) {
 			if tail := r.stderr.String(); tail != "" {
 				res.ErrorMessage += ": " + tail
 			}
+		}
+		// A stream vincent could not read to the end outranks whatever the
+		// exit code says: the run may well have finished cleanly, but the
+		// record of it is missing lines, and §7.1 success is a claim about
+		// both (#139).
+		if streamErr != nil {
+			res.IsError = true
+			res.ErrorMessage = "agent stream capture failed: " + streamErr.Error()
+			res.Failure = &agent.Failure{Kind: agent.FailureStreamError}
 		}
 		r.waitRes = res
 	})

--- a/internal/agent/cursor/cursor.go
+++ b/internal/agent/cursor/cursor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -253,7 +254,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 		readerDone: make(chan struct{}),
 		procDone:   make(chan struct{}),
 	}
-	go r.readLoop(bufio.NewScanner(stdout))
+	go r.readLoop(stdout)
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -276,6 +277,11 @@ type run struct {
 
 	mu       sync.Mutex
 	terminal *agent.RunResult // assembled from the result event
+	// streamErr is readLoop's own reader failing, latched for Wait. It is
+	// vincent losing the stream, not the CLI failing, and Wait says so with
+	// agent.FailureStreamError rather than letting the exit code speak for a
+	// transcript that is missing lines (#139).
+	streamErr error
 
 	waitOnce sync.Once
 	waitRes  agent.RunResult
@@ -286,9 +292,10 @@ type run struct {
 // and command output, so lines can be large.
 const maxLineBytes = 16 * 1024 * 1024
 
-func (r *run) readLoop(sc *bufio.Scanner) {
+func (r *run) readLoop(rd io.Reader) {
 	defer close(r.readerDone)
 	defer close(r.events)
+	sc := bufio.NewScanner(rd)
 	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
 	// One parser per run: thinking deltas are accumulated across lines, so
 	// the state belongs to this stream and nothing else (§9.7).
@@ -308,8 +315,16 @@ func (r *run) readLoop(sc *bufio.Scanner) {
 		}
 		r.events <- ev
 	}
-	// A scanner error (over-long line, pipe error) ends normalization; the
-	// process itself is still waited on and its exit code judged.
+	// A reader that stopped before the stream did leaves the CLI writing into
+	// a pipe nobody empties, which would hang it until the step timeout.
+	// Drain it, then let Wait name the failure — normalization ended early,
+	// so the transcript is missing lines the CLI wrote (#139).
+	if err := sc.Err(); err != nil {
+		r.mu.Lock()
+		r.streamErr = err
+		r.mu.Unlock()
+		_, _ = io.Copy(io.Discard, rd)
+	}
 }
 
 // Events implements agent.RunHandle.
@@ -359,7 +374,7 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal := r.terminal
+		terminal, streamErr := r.terminal, r.streamErr
 		r.mu.Unlock()
 		if terminal != nil {
 			res.IsError = terminal.IsError
@@ -374,6 +389,15 @@ func (r *run) Wait() (agent.RunResult, error) {
 			if tail := r.stderr.String(); tail != "" {
 				res.ErrorMessage += ": " + tail
 			}
+		}
+		// A stream vincent could not read to the end outranks whatever the
+		// exit code says: the run may well have finished cleanly, but the
+		// record of it is missing lines, and §7.1 success is a claim about
+		// both (#139).
+		if streamErr != nil {
+			res.IsError = true
+			res.ErrorMessage = "agent stream capture failed: " + streamErr.Error()
+			res.Failure = &agent.Failure{Kind: agent.FailureStreamError}
 		}
 		r.waitRes = res
 	})

--- a/internal/taskrun/capture.go
+++ b/internal/taskrun/capture.go
@@ -1,0 +1,83 @@
+package taskrun
+
+import (
+	"bufio"
+	"errors"
+	"io"
+)
+
+// outputChunkBytes bounds one captured output record (#139).
+//
+// A `command` step's output is recorded a line at a time, but a line is not a
+// bound: minified JSON, a base64 blob and a `git diff` of a generated file all
+// reach a megabyte on one line. A line longer than this becomes a run of
+// records rather than a capture failure — see scanOutput.
+//
+// The size is chosen so that everything downstream keeps reading records the
+// way it always has: it is well inside the live-chunk shapes of §13.3 and the
+// buffers the API's transcript reader works in.
+const outputChunkBytes = 64 * 1024
+
+// scanOutput reads rd to the end and calls emit once per output record.
+//
+// A line shorter than outputChunkBytes produces one record with more=false,
+// exactly as a line-oriented scanner produced. A longer line produces a run of
+// records, each at most outputChunkBytes, all but the last with more=true:
+// they are pieces of one line, in order, on one stream. Nothing is dropped and
+// nothing is truncated.
+//
+// It replaces a `bufio.Scanner` capped at one mebibyte per token, which did
+// not truncate an over-long line — it stopped capture dead on the first one
+// and discarded the rest of the stream, while the step still reported success
+// from its exit code (#139, §7.1).
+//
+// The trailing "\r" of a CRLF is dropped, the way `bufio.ScanLines` did: a
+// command step runs under pwsh on Windows (§8.3). A "\r" that lands on a chunk
+// boundary is held back rather than emitted, because the "\n" that would make
+// it a line ending is in the next read.
+//
+// The returned error is a read failure on rd — the stream ended early and
+// output that the process wrote was never seen. Reaching io.EOF is not one.
+func scanOutput(rd io.Reader, emit func(text string, more bool)) error {
+	br := bufio.NewReaderSize(rd, outputChunkBytes)
+	var line []byte
+	for {
+		frag, err := br.ReadSlice('\n')
+		switch {
+		case err == nil:
+			line = append(line, dropCR(frag[:len(frag)-1])...)
+			emit(string(line), false)
+			line = line[:0]
+		case errors.Is(err, bufio.ErrBufferFull):
+			// No newline in a whole buffer: this is a piece of a long line.
+			line = append(line, frag...)
+			keepCR := line[len(line)-1] == '\r'
+			if keepCR {
+				line = line[:len(line)-1]
+			}
+			emit(string(line), true)
+			line = line[:0]
+			if keepCR {
+				line = append(line, '\r')
+			}
+		default:
+			// A last line with no terminator is still a line.
+			line = append(line, frag...)
+			if len(line) > 0 {
+				emit(string(dropCR(line)), false)
+			}
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// dropCR trims the "\r" of a CRLF line ending.
+func dropCR(b []byte) []byte {
+	if len(b) > 0 && b[len(b)-1] == '\r' {
+		return b[:len(b)-1]
+	}
+	return b
+}

--- a/internal/taskrun/capture_test.go
+++ b/internal/taskrun/capture_test.go
@@ -1,0 +1,140 @@
+package taskrun
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// Command bodies that emit a single line longer than the 1 MiB
+// `bufio.Scanner` token the command capture installs
+// (`steps.go`'s `scanner.Buffer(…, 1024*1024)`). Minified JSON, a base64
+// blob or a `git diff` of a generated file all reach that on one line, so
+// this is an ordinary command rather than a hostile one. The sentinel rides
+// at the end of the line so its presence in the transcript means the *whole*
+// line was captured, not a prefix.
+const (
+	overlongSentinel = "VINCENT-CAPTURE-SENTINEL"
+
+	// `%1100000s` right-aligns the sentinel in a 1.1 MB field: one line,
+	// well past the scanner's cap, and the shell writes it in one go.
+	overlongLineCmdPosix   = `printf '%1100000s\n' ` + overlongSentinel
+	overlongLineCmdWindows = `Write-Output (("x" * 1100000) + "` + overlongSentinel + `")`
+)
+
+func overlongLineSnapshot(cmd string) string {
+	return "name: overlong\nsteps:\n" + commandStep("emit", cmd, "max_retries: 0")
+}
+
+// TestOverlongLineSnapshotParses keeps the Windows branch of the snapshot
+// honest on POSIX, the way TestSnapshotsParseOnEveryPlatform does for the
+// engine tests' own bodies.
+func TestOverlongLineSnapshotParses(t *testing.T) {
+	for name, src := range map[string]string{
+		"posix":   overlongLineSnapshot(overlongLineCmdPosix),
+		"windows": overlongLineSnapshot(overlongLineCmdWindows),
+	} {
+		if _, _, err := workflow.Parse([]byte(src), workflow.Options{}); err != nil {
+			t.Errorf("%s does not parse: %v\n%s", name, err, src)
+		}
+	}
+}
+
+// TestCommandOverlongLineNeverSucceedsSilently: a command step whose output
+// vincent could not capture must not be reported as a success.
+//
+// `runShellCommand` scans each stream with a `bufio.Scanner` capped at 1 MiB
+// per token. A longer line stops the scanner with `bufio.Scanner: token too
+// long`; the recovery path writes a `vincent.error` note, drains the rest of
+// the pipe to `io.Discard`, and then judges the attempt from the exit status
+// alone. A command that emits one long line and exits 0 therefore lands as
+// `succeeded` with its output silently thrown away — the transcript is
+// neither the lossless record §12.2 promises nor the "everything is
+// transcripted" of the security model, and §7.1's exit-0 rule is the only
+// thing consulted.
+//
+// Either fix satisfies this test: capture the line in bounded chunks so the
+// evidence survives, or terminalize the attempt so the loss is visible.
+// Reporting success while the bytes are gone is what must not happen.
+func TestCommandOverlongLineNeverSucceedsSilently(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, overlongLineSnapshot(
+		script(overlongLineCmdPosix, overlongLineCmdWindows)))
+	h.start(t)
+
+	final := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1 (max_retries 0)", len(runs))
+	}
+	body, err := os.ReadFile(runs[0].TranscriptPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if runs[0].ExitCode == nil || *runs[0].ExitCode != 0 {
+		t.Fatalf("setup: command exit code = %v, want 0 — the shell did not emit the line "+
+			"(transcript: %s)", runs[0].ExitCode, tailOf(body))
+	}
+
+	// The whole line reaching the transcript means capture held and success
+	// is honest; nothing more to check. It is looked for inside an output
+	// record rather than anywhere in the file, because `vincent.command_started`
+	// quotes the command — which contains the sentinel too.
+	if capturedOutputContains(t, body, overlongSentinel) {
+		return
+	}
+
+	// It did not, so vincent lost the output. Success is then a lie about
+	// the evidence.
+	if runs[0].State == store.StepSucceeded {
+		t.Errorf("step succeeded with its output discarded: the %d-byte line never reached "+
+			"the transcript (%d bytes on disk) and the attempt was judged from exit 0 alone",
+			1100000, len(body))
+	}
+	if final.State == store.TaskDone {
+		t.Errorf("task = done with a step whose output was discarded; want the loss surfaced "+
+			"(block_reason %q)", final.BlockReason)
+	}
+}
+
+// capturedOutputContains reports whether any `vincent.output` record in the
+// transcript carries want, whatever form the capture path chose to record it
+// in — one line, or several bounded chunks.
+func capturedOutputContains(t *testing.T, body []byte, want string) bool {
+	t.Helper()
+	var joined strings.Builder
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 0, 64*1024), 8<<20)
+	for sc.Scan() {
+		var rec struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Errorf("transcript line is not parseable JSON: %v", err)
+			continue
+		}
+		if rec.Type == "vincent.output" {
+			joined.WriteString(rec.Text)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan transcript: %v", err)
+	}
+	return strings.Contains(joined.String(), want)
+}
+
+// tailOf keeps a failure message readable when the transcript is large.
+func tailOf(body []byte) string {
+	const keep = 512
+	if len(body) <= keep {
+		return string(body)
+	}
+	return "…" + string(body[len(body)-keep:])
+}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -47,6 +47,35 @@ const (
 	// allowed to fill the disk; the partial transcript is kept, because the
 	// lines that got there are exactly what explains the runaway.
 	ReasonTranscriptLimit = "transcript_limit"
+	// ReasonTranscriptIOError is an attempt whose evidence did not land: a
+	// transcript write, JSON encode or close that failed (§12.2, §18, #139).
+	// Disk-full, a revoked permission and a short write all arrive as this.
+	//
+	// It exists because the alternative is worse than a failure. Judging a
+	// `command` step from its exit code alone reports success over a record
+	// that is missing the run it claims to describe, and "everything is
+	// transcripted" (docs/security-model.md) is then false with nothing
+	// saying so. It runs the ordinary §7.2 budget — the next attempt writes a
+	// new file, and a transient ENOSPC is exactly the kind of thing a retry
+	// clears — and it is absent from allowFailure's set on §7.2's own rule:
+	// vincent failing to record the step is not an outcome the step produced,
+	// so a workflow must not be able to branch on "the disk filled up" as
+	// though it were a test result (task 015 decision 5).
+	//
+	// It is not the reason for an over-long line. Capture keeps those, in
+	// bounded chunks; `transcript_max_bytes` stays the single size-based
+	// failure (§12.3).
+	ReasonTranscriptIOError = "transcript_io_error"
+	// ReasonAgentProtocolError is an agent run whose stream vincent could not
+	// read to the end: the adapter's line reader stopped on an error (§9.1,
+	// §18, #139).
+	//
+	// Deliberately not `agent_error`, which means "the CLI reported a
+	// failure" and would send the reader to a CLI that did nothing wrong —
+	// the reader that failed is vincent's. Deliberately not
+	// `input_protocol_error` either: that names a control message vincent
+	// could not render, which is a message that arrived intact.
+	ReasonAgentProtocolError = "agent_protocol_error"
 	// ReasonUsageLimit is an agent run the CLI stopped because the account's
 	// usage quota is spent (task 003, §7.2, §18). It is the one reason in this
 	// vocabulary that is *not* a failure: the attempt is recorded
@@ -626,11 +655,27 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		outcome.reason = ReasonCanceled
 	}
 
-	r.finishStepRun(run, outcome, env.log)
 	tr.Note("step_finished", map[string]any{
 		"state": string(outcome.state), "failure_reason": outcome.reason,
 		"exit_code": outcome.exitCode, "check_exit_code": outcome.checkExitCode,
 	})
+	// Close before the attempt is judged, not after it. A buffered filesystem
+	// reports ENOSPC at close and nowhere else, so a close error is part of
+	// the answer to "did the evidence land" — and a discarded one is the
+	// difference between a transcript that is short and one that is *known*
+	// to be short (§12.2, #139). The deferred Close above stays as the guard
+	// for the early returns; this one is idempotent with it.
+	tr.Close()
+	// Only a success is overridden. A failure already names something that
+	// went wrong, and replacing `nonzero_exit` with the reason the record of
+	// it could not be written would hide the more useful fact.
+	if err := tr.Err(); err != nil && outcome.state == store.StepSucceeded {
+		env.log.Error("transcript incomplete; attempt cannot be called a success",
+			"step", env.step.ID, "attempt", attempt, "path", tr.Path(), "error", err)
+		outcome.state, outcome.reason = store.StepFailed, ReasonTranscriptIOError
+		outcome.result = "transcript incomplete: " + err.Error()
+	}
+	r.finishStepRun(run, outcome, env.log)
 	r.emit(env.task, eventStepFinished, map[string]any{
 		"step_id": env.step.ID, "step_index": env.index, "attempt": attempt,
 		"run_id": run.ID, "state": string(outcome.state), "failure_reason": outcome.reason,

--- a/internal/taskrun/input.go
+++ b/internal/taskrun/input.go
@@ -29,6 +29,7 @@ var (
 	errInputTimeout    = errors.New("input timeout")
 	errInputProtocol   = errors.New("input protocol error")
 	errTranscriptLimit = errors.New("transcript limit")
+	errTranscriptIO    = errors.New("transcript i/o error")
 )
 
 // PendingInput is the normalized input request as persisted in

--- a/internal/taskrun/repair.go
+++ b/internal/taskrun/repair.go
@@ -329,7 +329,9 @@ func tailLines(path string, n int, maxBytes int64) string {
 	// A JSONL transcript line can be long (a whole agent message); the
 	// default 64 KiB token bound would stop the scan at the first one.
 	sc.Buffer(make([]byte, 0, 64<<10), int(maxBytes))
-	lines := newOutputTail(n)
+	// maxBytes, not §8.4's own tail bound: this reader has already narrowed
+	// the file to the window the repair prompt asked for.
+	lines := newOutputTailBytes(n, int(maxBytes))
 	for sc.Scan() {
 		if partial {
 			partial = false

--- a/internal/taskrun/repairtail_test.go
+++ b/internal/taskrun/repairtail_test.go
@@ -1,0 +1,53 @@
+package taskrun
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRepairTailKeepsItsOwnByteWindow pins the bound the repair prompt's
+// transcript excerpt reads to (task 025), which is its own and not §8.4's.
+//
+// outputTail gained a byte ceiling when capture stopped dropping over-long
+// lines (#139). tailLines has already narrowed the file to
+// repairTranscriptTailBytes before the tail sees a line, so applying §8.4's
+// smaller outputTailBytes on top of it would halve the excerpt without
+// anything saying so — a silent narrowing is exactly what #139 is about.
+func TestRepairTailKeepsItsOwnByteWindow(t *testing.T) {
+	t.Parallel()
+
+	if outputTailBytes >= repairTranscriptTailBytes {
+		t.Skip("the two bounds no longer differ; there is nothing to narrow")
+	}
+
+	// Lines that are individually small, so only the byte bounds — not the
+	// line count and not the single-line cut — can decide what survives. The
+	// file is written past repairTranscriptTailBytes so the read window, not
+	// the file, is what bounds the answer.
+	const lineBytes = 4 << 10
+	const lines = 2 * repairTranscriptTailBytes / lineBytes
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	var sb strings.Builder
+	for range lines {
+		sb.WriteString(strings.Repeat("x", lineBytes-1))
+		sb.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The seek lands on a line boundary here, and that whole line is dropped
+	// as the fragment it cannot be told apart from.
+	want := repairTranscriptTailBytes - lineBytes
+
+	got := tailLines(path, lines, repairTranscriptTailBytes)
+	if len(got)+1 != want {
+		t.Fatalf("tail = %d bytes, want %d: the repair excerpt was narrowed past its own bound", len(got)+1, want)
+	}
+	if len(got) <= outputTailBytes {
+		t.Fatalf("tail = %d bytes, which fits inside outputTailBytes (%d); §8.4's ceiling is being applied to the repair excerpt",
+			len(got), outputTailBytes)
+	}
+}

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -1,7 +1,6 @@
 package taskrun
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"io"
@@ -169,6 +168,14 @@ func (r *Runner) runAgentStep(
 			env.log.Warn("transcript limit exceeded", "task", env.task.ID, "step", env.step.ID)
 			cancelCause(errTranscriptLimit)
 		}
+		// A transcript that stopped landing is polled in the same place and
+		// kills for the same reason: the record this run is being kept for
+		// is no longer being kept, so running on produces nothing (§12.2,
+		// #139). classifyAgent turns the cause into transcript_io_error.
+		if err := tr.Err(); err != nil {
+			env.log.Error("transcript i/o error", "task", env.task.ID, "step", env.step.ID, "error", err)
+			cancelCause(errTranscriptIO)
+		}
 	}
 	// protocolError fails the attempt rather than wait on a request vincent
 	// cannot render (§18): kill the tree, let the stream drain.
@@ -331,6 +338,8 @@ func classifyAgent(daemonCtx, runCtx context.Context, interrupting bool, res *ag
 		return stepOutcome{state: store.StepFailed, reason: ReasonInputProtocolError}
 	case causeIs(runCtx, errTranscriptLimit):
 		return stepOutcome{state: store.StepFailed, reason: ReasonTranscriptLimit}
+	case causeIs(runCtx, errTranscriptIO):
+		return stepOutcome{state: store.StepFailed, reason: ReasonTranscriptIOError}
 	case interrupting && (waitErr != nil || res.ExitCode != 0 || res.IsError):
 		return stepOutcome{state: store.StepInterrupted, reason: ReasonInterrupted}
 	case waitErr != nil:
@@ -346,6 +355,12 @@ func classifyAgent(daemonCtx, runCtx context.Context, interrupting bool, res *ag
 		}
 	case res.Failure != nil && res.Failure.Kind == agent.FailureUnauthenticated:
 		return stepOutcome{state: store.StepFailed, reason: ReasonAgentUnauthenticated}
+	case res.Failure != nil && res.Failure.Kind == agent.FailureStreamError:
+		// vincent's own reader stopped before the stream did, so the
+		// transcript is missing lines the CLI wrote (§9.1, #139). Named
+		// separately from agent_error, which would blame a CLI that did
+		// nothing wrong.
+		return stepOutcome{state: store.StepFailed, reason: ReasonAgentProtocolError}
 	case res.ExitCode != 0:
 		return stepOutcome{state: store.StepFailed, reason: ReasonNonzeroExit}
 	case res.IsError:
@@ -500,23 +515,29 @@ func (r *Runner) runShellCommand(
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	// limitOnce keeps the cap's annotation and kill to one, though both
-	// stream goroutines can observe the overflow.
-	var limitOnce sync.Once
+	// stream goroutines can observe the overflow. ioOnce does the same for a
+	// transcript that stopped landing.
+	var limitOnce, ioOnce sync.Once
+	// captureErr latches a stream vincent could not read to the end. Output
+	// the process wrote and vincent never saw is evidence loss, exactly like
+	// a transcript write that failed, and the classification below refuses to
+	// call it a success (#139).
+	var captureErr error
 	stream := func(rd io.Reader, name string) {
 		defer wg.Done()
-		scanner := bufio.NewScanner(rd)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			offset := tr.Output(sc.phase, name, line)
-			r.publishOutput(env.task.ID, run.ID, offset, "command.output", map[string]any{
-				"phase": sc.phase, "stream": name, "text": line,
-			})
+		err := scanOutput(rd, func(text string, more bool) {
+			// more marks a piece of a line longer than outputChunkBytes:
+			// the next record on this stream continues it (#139). Marked
+			// rather than joined silently, so a reader can tell one long
+			// line from several short ones.
+			fields := outputFields(sc.phase, name, text, more)
+			offset := tr.Note("output", fields)
+			r.publishOutput(env.task.ID, run.ID, offset, "command.output", fields)
 			mu.Lock()
-			tail.add(line)
+			tail.add(text)
 			mu.Unlock()
 			// A command that floods stdout is capped like a runaway agent
-			// (§12.3, §18). Cancelling here rather than after the scanner
+			// (§12.3, §18). Cancelling here rather than after the reader
 			// finishes is the point: the whole failure mode is a process that
 			// never stops producing, so waiting for it to stop is waiting
 			// forever. Cancelling runCtx wakes the tree-killer above.
@@ -529,15 +550,32 @@ func (r *Runner) runShellCommand(
 					cancel()
 				})
 			}
-		}
-		if err := scanner.Err(); err != nil {
-			// A single line past the buffer cap stops the scanner but not the
-			// process. Keep draining the pipe: left full, it would block the
-			// child until the timeout kill and misreport the attempt.
+			// A transcript that stopped landing kills the run for a related
+			// reason: the attempt is already doomed (the classification below
+			// fails it either way), and every further minute of a 15-minute
+			// command produces work that nothing records and a retry redoes.
+			// The agent path does the same at its own Exceeded poll.
+			if err := tr.Err(); err != nil {
+				ioOnce.Do(func() {
+					env.log.Error("transcript i/o error",
+						"task", env.task.ID, "step", env.step.ID, "error", err)
+					cancel()
+				})
+			}
+		})
+		if err != nil {
+			// The pipe itself failed. Draining it cannot help — a reader that
+			// errored will error again — and the process is about to be
+			// waited on, so record the loss and let the classification below
+			// terminalize the attempt.
 			tr.Note("error", map[string]any{
 				"error": "output capture stopped for " + name + ": " + err.Error(),
 			})
-			_, _ = io.Copy(io.Discard, rd)
+			mu.Lock()
+			if captureErr == nil {
+				captureErr = err
+			}
+			mu.Unlock()
 		}
 	}
 	wg.Add(2)
@@ -555,6 +593,15 @@ func (r *Runner) runShellCommand(
 	// cap, so its nonzero exit is a consequence, not the diagnosis (§18).
 	case tr.Exceeded():
 		outcome.state, outcome.reason = store.StepFailed, ReasonTranscriptLimit
+	// Below the cap, above the exit code: an attempt whose output was not
+	// captured or not persisted cannot be judged from its exit status alone
+	// (§7.1, §12.2, #139). It sits under transcript_limit because a run the
+	// cap killed may well break its pipe on the way out, and the cap is the
+	// diagnosis there.
+	case captureErr != nil || tr.Err() != nil:
+		outcome.state, outcome.reason = store.StepFailed, ReasonTranscriptIOError
+		env.log.Error("step output incomplete", "task", env.task.ID, "step", env.step.ID,
+			"capture_error", captureErr, "transcript_error", tr.Err())
 	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
 		outcome.state, outcome.reason = store.StepFailed, ReasonTimeout
 	case exitCode != 0 && r.interrupting(env.task.ID):

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -3,12 +3,14 @@ package taskrun
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 // transcript is one attempt's transcript file (spec §12.2:
@@ -30,6 +32,13 @@ type transcript struct {
 	// the attempt (§18 transcript_limit).
 	max      int64
 	exceeded bool
+	// err is the first write, encode or close failure. A transcript that
+	// could not record what happened is not the lossless record §12.2
+	// promises, and the step executors turn it into transcript_io_error
+	// rather than let an attempt claim success over evidence that is not
+	// there (§7.1, §18).
+	err    error
+	closed bool
 }
 
 // openTranscript creates the transcript file for one attempt.
@@ -86,6 +95,26 @@ func (t *transcript) Exceeded() bool {
 	return t.exceeded
 }
 
+// Err reports the first write, encode or close failure, or nil.
+//
+// Like Exceeded it latches, and for a stronger reason: a line that failed to
+// land is gone, and a later successful write does not put it back. Disk-full,
+// permission and short-write faults all arrive here, and ENOSPC on a buffered
+// filesystem usually arrives at Close and nowhere else — which is why Close
+// feeds this latch too.
+func (t *transcript) Err() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+// fail latches the first error. The caller holds t.mu.
+func (t *transcript) fail(err error) {
+	if t.err == nil {
+		t.err = err
+	}
+}
+
 // Raw appends a verbatim stream line and reports the file offset just past
 // it. A short or failed write still advances by what landed, so the offset
 // never claims more of the file than exists.
@@ -105,8 +134,18 @@ func (t *transcript) write(line []byte, force bool) int64 {
 	if t.exceeded && !force {
 		return t.size
 	}
-	n, _ := t.f.Write(append(line, '\n'))
+	want := len(line) + 1
+	n, err := t.f.Write(append(line, '\n'))
 	t.size += int64(n)
+	switch {
+	case err != nil:
+		t.fail(err)
+	case n < want:
+		// io.Writer's contract says a short write reports an error, and
+		// os.File honours it; checking anyway costs a comparison and is the
+		// difference between trusting the contract and having checked.
+		t.fail(io.ErrShortWrite)
+	}
 	if t.max > 0 && t.size > t.max {
 		t.exceeded = true
 	}
@@ -136,39 +175,98 @@ func (t *transcript) note(kind string, fields map[string]any, force bool) int64 
 	if err != nil {
 		t.mu.Lock()
 		defer t.mu.Unlock()
+		t.fail(err)
 		return t.size
 	}
 	return t.write(b, force)
 }
 
-// Output appends one line of process output, tagged with its stream and the
-// phase that produced it (the step's own command, or its check), and reports
-// the offset past it.
-func (t *transcript) Output(phase, stream, text string) int64 {
-	return t.Note("output", map[string]any{"phase": phase, "stream": stream, "text": text})
+// outputFields is one record of process output, tagged with its stream and
+// the phase that produced it (the step's own command, or its check).
+//
+// partial marks a piece of a line too long to record whole: the next output
+// record on the same phase and stream continues it (#139, §12.2). It is
+// absent rather than false on an ordinary line, so the common record keeps
+// the shape every reader already knows.
+//
+// One map serves the transcript record and the §13.3 live chunk, which is
+// what keeps the durable and live shapes from drifting.
+func outputFields(phase, stream, text string, partial bool) map[string]any {
+	f := map[string]any{"phase": phase, "stream": stream, "text": text}
+	if partial {
+		f["partial"] = true
+	}
+	return f
 }
 
-// Close closes the file.
+// Close closes the file, latching a close failure into Err.
+//
+// It is idempotent, because runAttempt closes explicitly — before it judges
+// the attempt, so a close-time ENOSPC still reaches the outcome — while the
+// deferred close stays as the guard for every early return.
 func (t *transcript) Close() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	_ = t.f.Close()
+	if t.closed {
+		return
+	}
+	t.closed = true
+	if err := t.f.Close(); err != nil {
+		t.fail(err)
+	}
 }
 
-// outputTail keeps the last n lines of a process's output for the step's
-// result summary (§8.4 `.Steps`) and for the retry failure block (§8.4).
+// outputTailBytes bounds the tail by size as well as by line count.
+//
+// A line count alone stopped being a bound once capture kept over-long lines
+// instead of dropping them (#139): 200 chunks of `outputChunkBytes`, or 200
+// agent events each carrying a megabyte of text, is not a tail. What this
+// feeds is a template field and a prompt block (§8.4), so the size that
+// matters is bytes.
+const outputTailBytes = 256 * 1024
+
+// outputTail keeps the last n lines of a process's output, bounded by
+// outputTailBytes, for the step's result summary (§8.4 `.Steps`) and for the
+// retry failure block (§8.4).
 type outputTail struct {
-	limit int
-	lines []string
+	limit    int
+	maxBytes int
+	lines    []string
+	bytes    int
 }
 
-func newOutputTail(limit int) *outputTail { return &outputTail{limit: limit} }
+func newOutputTail(limit int) *outputTail {
+	return &outputTail{limit: limit, maxBytes: outputTailBytes}
+}
 
 func (o *outputTail) add(line string) {
 	o.lines = append(o.lines, line)
-	if len(o.lines) > o.limit {
-		o.lines = o.lines[len(o.lines)-o.limit:]
+	o.bytes += len(line) + 1
+	for len(o.lines) > 1 && (len(o.lines) > o.limit || o.bytes > o.maxBytes) {
+		o.bytes -= len(o.lines[0]) + 1
+		o.lines = o.lines[1:]
 	}
+	// One line over the bound on its own is cut to its own tail rather than
+	// dropped: dropping it would leave the tail empty, which says less than
+	// its last kilobytes do.
+	if len(o.lines) == 1 && len(o.lines[0]) > o.maxBytes {
+		o.lines[0] = tailBytes(o.lines[0], o.maxBytes)
+		o.bytes = len(o.lines[0]) + 1
+	}
+}
+
+// tailBytes returns the last n bytes of s, moved forward to a rune boundary
+// so the result is still valid UTF-8 — it lands in JSON and in a SQLite TEXT
+// column, and half a rune is not text.
+func tailBytes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	cut := len(s) - n
+	for cut < len(s) && !utf8.RuneStart(s[cut]) {
+		cut++
+	}
+	return s[cut:]
 }
 
 func (o *outputTail) String() string { return strings.Join(o.lines, "\n") }

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -225,9 +225,9 @@ func (t *transcript) Close() {
 // matters is bytes.
 const outputTailBytes = 256 * 1024
 
-// outputTail keeps the last n lines of a process's output, bounded by
-// outputTailBytes, for the step's result summary (§8.4 `.Steps`) and for the
-// retry failure block (§8.4).
+// outputTail keeps the last n lines of a process's output, bounded by a byte
+// ceiling, for the step's result summary (§8.4 `.Steps`) and for the retry
+// failure block (§8.4).
 type outputTail struct {
 	limit    int
 	maxBytes int
@@ -235,8 +235,15 @@ type outputTail struct {
 	bytes    int
 }
 
+// newOutputTail bounds by outputTailBytes. A caller that already reads from a
+// bound of its own — the repair prompt's transcript excerpt (task 025) — uses
+// newOutputTailBytes so this one does not silently narrow it.
 func newOutputTail(limit int) *outputTail {
-	return &outputTail{limit: limit, maxBytes: outputTailBytes}
+	return newOutputTailBytes(limit, outputTailBytes)
+}
+
+func newOutputTailBytes(limit, maxBytes int) *outputTail {
+	return &outputTail{limit: limit, maxBytes: maxBytes}
 }
 
 func (o *outputTail) add(line string) {


### PR DESCRIPTION
## Summary

A step could be reported `succeeded` over evidence that had been thrown away.
Three defects with one shape: the code that lost the output never told the code
that judged the attempt.

**Root cause — command output capture.** `runShellCommand` scanned each stream
with a `bufio.Scanner` whose token ceiling was `1024*1024`. A longer line does
not truncate; it stops the scanner permanently with `bufio.ErrTooLong`, so **no**
line is emitted, not even a prefix. The recovery path wrote a `vincent.error`
note, drained the rest of the pipe to `io.Discard` (correctly — a full pipe would
block the child until the timeout kill) and returned. The scanner error never
left that goroutine. The classification switch consults `ctx.Err()`,
`tr.Exceeded()`, `runCtx.Err()` and the exit code, none of which know capture
failed, so an exit-0 command landed `succeeded`. Reproduced at `090d2de`: a step
running `printf '%1100000s\n' VINCENT-CAPTURE-SENTINEL` produced a 680-byte
transcript, task `done`, step `succeeded`, 1.1 MB of evidence gone, and nothing
a client could query saying the record was incomplete. Minified JSON, a base64
blob and a `git diff` of a generated file all reach a megabyte on one line, so
this is an ordinary command rather than a hostile one.

**Root cause — transcript persistence.** `transcript.write` was
`n, _ := t.f.Write(...)`; `note` swallowed a `json.Marshal` failure by returning
the unchanged offset; `Close` was `_ = t.f.Close()`, so ENOSPC surfaced at close —
where a buffered filesystem usually reports it — was invisible. `transcript`
exposed no error state at all: `Exceeded()` means "too big", not "broken", so a
step executor could not ask whether its evidence had landed, and disk-full,
permission and short-write faults all ended as `succeeded`.

**Root cause — agent adapters.** `claude`, `codex` and `cursor` each ended
`readLoop` on `sc.Err()` with no drain and no named failure. An overflow before
the terminal result failed the attempt, but as `agent_error` — which names the
CLI rather than vincent's own reader; an overflow after it lost lines while the
step succeeded.

### What changed

- **Over-long lines are captured, not failed.** New `scanOutput` reads in
  bounded chunks: a line longer than `outputChunkBytes` (64 KiB) becomes a run
  of `vincent.output` records marked `partial`, in order, on one stream,
  preserving phase, stream identity and the offsets live chunks publish.
  Rejoining them in order reproduces the line. A command that prints one large
  JSON document stays a success — failing it would only retry it into the same
  wall until the task blocked — and `transcript_max_bytes` remains the single
  size-based failure (§12.3). `\r\n` is still stripped the way `bufio.ScanLines`
  did, including a `\r` that lands on a chunk boundary, because a command step
  runs under pwsh on Windows (§8.3).
- **`outputTail` gains a byte bound**, since one "line" can now be a chunk and
  200 of them is not a tail. A single over-long line is cut to its own last
  256 KiB on a rune boundary rather than dropped.
- **One reason for genuine evidence loss: `transcript_io_error`.** `transcript`
  latches the first write, encode or close error and exposes it as `Err()`
  beside `Exceeded()`. The step executors poll it exactly where they poll
  `Exceeded()` and kill the doomed run; `runAttempt` then closes the file
  **before** judging the attempt, so a close-time ENOSPC still reaches the
  outcome. Only a *success* is overridden — an attempt that already failed keeps
  the more useful reason. It runs the ordinary §7.2 budget (a new attempt writes
  a new file, which is what clears a transient fault) and is absent from
  `allowFailure`'s set on §7.2's own rule: vincent failing to *record* a step is
  not an outcome the step produced, so a workflow must not be able to branch on
  "the disk filled up" as though it were a test result.
- **Adapters name their own reader's failure.** All three latch `sc.Err()`,
  drain the pipe so the CLI is not left blocked on it until the step timeout,
  and report the new `agent.FailureStreamError`, which the engine maps to
  `agent_protocol_error` — deliberately not `agent_error`, which would send a
  user to inspect a CLI that did nothing wrong.

One acceptance criterion was already met and was left alone: live-output offsets
never over-claim, because `transcript.write` advances `size` by the `n` the write
actually returned.

**fsync is out of scope**, as the brief settled: always checking `Close` is the
floor this issue asks for, and an audit-grade durability mode is a separate
decision. §12.2 now says so in the document rather than leaving it implied.

### Spec amendment

Read literally, §7.1 made exit 0 sufficient for a `command` step, so the old
behaviour was *compliant* — the spec was the side that was wrong. Amended in this
branch, dated 2026-08-24:

- **§7.1** now also requires that the step's output was captured and persisted.
- **§7.2** lists `transcript_io_error` and `agent_protocol_error` in the
  never-swallowed set, with the reasoning that puts them there.
- **§12.2** states the completeness limit exactly — a line is not a unit of
  capture, incompleteness is never silent, and vincent writes and closes and
  checks both but does not fsync.
- **§18** gains a row for each of the three cases.

## Related

Closes #139

Parent review: #135. Related: #92 (CLI access to the resulting evidence) is
untouched.

### How the regression test catches this coming back

`internal/taskrun/capture_test.go` —
`TestCommandOverlongLineNeverSucceedsSilently` drives the real engine,
scheduler, store and git repo through `newEngineHarness`, runs a command step
emitting one 1.1 MB line and exiting 0, and asserts the step is not `succeeded`
**unless** the line's sentinel actually reached a `vincent.output` record. It
does not assert *how* the loss is avoided, so it survives either fix direction:
reintroducing a per-line ceiling that drops the line would fail the sentinel
check and then the success check, and any future path that judges a `command`
attempt from its exit status without consulting capture would fail the second
assertion the same way. The sentinel rides at the *end* of the line, so a
truncating fix does not pass it either. It was run against `090d2de` and
observed to fail on both assertions.

Committed test-first, so the red is in the history. `TestOverlongLineSnapshotParses`
keeps the Windows branch of the snapshot parseable when the suite runs on POSIX.
No assertion was weakened; the test is unmodified from how it arrived.

### A second bug found on the way past, not fixed here

`transcript.write` does `t.f.Write(append(line, '\n'))`, which can write into the
caller's backing array when it has spare capacity. Today every caller passes a
freshly marshalled buffer or an adapter's `ev.Raw` copy, so nothing observes it,
and it predates this change. Left alone rather than folded into a bug fix.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `test:` for the failing test, `fix:` for the fix
- [x] Tests added/updated for behavior changes — the regression test above; the full suite and `-race` on `internal/taskrun` and `internal/agent/...` pass, as do `m1-gate.sh` and `m2-gate.sh` locally on macOS
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated — block reasons in `docs/reference/task-lifecycle.md` and `docs/guides/troubleshooting.md` (two new `Reason*` constants), `allow_failure`'s never-swallowed set in `docs/guides/workflows.md`, the transcript claim in `docs/security-model.md`, and `docs/spec.md` §7.1/§7.2/§12.2/§18. No config, CLI, API-route or TUI-key surface changed

**Verification note.** `golangci-lint` is clean for `GOOS=darwin` (native) and
`GOOS=windows`. The `GOOS=linux` cross-run panics inside staticcheck while
analysing the Go 1.27 stdlib's `internal/poll` (`interface conversion: interface
{} is nil, not *buildir.IR`); it reproduces on untouched packages on this branch
and is a toolchain/host issue, not a finding. CI lints natively on each platform.
