### PR TITLE
Audit the docs, repair a red verify, and merge behind a second gate

### DIFF
--- a/.vincent/workflows/github-resolve-issue.yaml
+++ b/.vincent/workflows/github-resolve-issue.yaml
@@ -23,6 +23,7 @@
 #   triage (stop on reject / needs-info)
 #     └─ confirm-red (bug only)  prove the test fails on the unfixed code
 #   implement (write it, commit it, draft the PR)
+#   docs-sync (audit what the source derives: pages, spec, the embedded skill)
 #   verify    (the expensive cross-platform legs, repaired in a bounded loop)
 #   gate      (a human reads the diff)
 #   publish → report
@@ -71,6 +72,51 @@
 # The shared 80% — commit conventions, the PR template's four claims, the spec
 # amendment rule, the scratch-directory rule, the two PR artifacts — is written
 # once, which is the point of merging.
+#
+# ## Documentation is a step, not a checkbox
+#
+# `implement` is told to update the affected page, and a step doing something
+# else does that badly: the page is the last thing it touches, it is judged by
+# a checklist it ticked itself, and it never sees the finished change — only
+# the one it is partway through writing. `docs-sync` is the audit, and it has
+# exactly one job.
+#
+# What it audits is not "the docs" in general. `CLAUDE.md` says public
+# documentation is **derived from the source**, and each derivation is a
+# checkable claim: the config reference tracks `internal/config`, the CLI page
+# the cobra tree, the API page `internal/api/server.go`'s route table, the TUI
+# key tables `internal/tui/bindings.go`, the block reasons the `Reason*`
+# constants. Alongside those sit the records that are derived from nothing and
+# are amended by hand: `docs/spec.md` in place with a dated note in this same
+# PR, `docs/tasks/` with its index row in the same edit, `docs/gates/` when the
+# behaviour a walkthrough walks through has changed.
+#
+# `skills/vincent-workflows/SKILL.md` is in scope and is **not documentation**:
+# `skills/embed.go` embeds it and `internal/workflow/builtin.go` splices it into
+# the built-in `create-workflow` prompt at build time (task 024), so a schema
+# change that does not reach it leaves the daemon telling agents something
+# false. That is also why this step runs *before* `verify` rather than after:
+# what it may edit includes Go, and the cross-platform legs have to see it.
+#
+# `docs-scope` in front of it is a data step first and a guard second. Its
+# stdout is the changed-file list the prompt reads; its exit code skips the
+# audit only for a change that touched nothing but tests — the one kind that
+# cannot make a documented claim false. That is a narrow saving, and it is
+# honest about being narrow.
+#
+# The check is what keeps an audit from becoming a rewrite: this step's own
+# commits (everything after `pre-docs.sha`) may touch only `docs/`, `skills/`,
+# `CHANGELOG.md`, `README.md` and `internal/workflow/builtin.go`, the repo's own
+# `.vincent/workflows/*.yaml` must still validate against the schema, and the
+# four packages whose tests assert what the published pages and the embedded
+# skill say must still pass. `docs: none needed` is a first-class outcome —
+# what it may not be is empty.
+#
+# Screenshots are the one thing it may not fix. Every `docs/assets/tui-*.png`
+# is a capture from `scripts/screenshots.sh`, which needs VHS, ttyd and ffmpeg
+# and seeds a throwaway daemon; documentation never *draws* a screen. So a
+# stale panel is reported into `docs.md` and into the PR body, and a person
+# re-runs the script.
 #
 # ## When the cross-platform legs fail
 #
@@ -673,6 +719,168 @@ steps:
       go run mage.go lint
     check_timeout: 15m
 
+  - id: docs-scope
+    name: List what the change touched
+    type: command
+    shell: sh
+    timeout: 2m
+    max_retries: 0
+    # This is a data step first and a guard second. Its stdout is the list of
+    # behaviour-bearing files the audit prompt reads, and its exit code is what
+    # skips the audit for a change that touched nothing but tests — the only
+    # kind that cannot make a documented claim false.
+    #
+    # `pre-docs.sha` is taken here rather than derived later: the audit's check
+    # needs to know which commits are *its own*, and `implement` may well have
+    # left several.
+    allow_failure: true
+    run: |
+      set -e
+      git rev-parse HEAD > .vincent-issue/pre-docs.sha
+      git diff --name-only {{.Task.BaseBranch}}..HEAD > .vincent-issue/changed.txt
+      # grep's exit code is the step's: 1 means nothing outside tests changed.
+      grep -vE '(_test\.go$|(^|/)testdata/)' .vincent-issue/changed.txt
+
+  - id: docs-sync
+    name: Bring the documentation up to date
+    type: agent
+    if: '{{ eq (index .Steps "docs-scope").ExitCode 0 }}'
+    timeout: 30m
+    max_retries: 1
+    # `implement` is already told to update the affected page, and this step
+    # exists because a step that is doing something else does that badly. This
+    # one has one job, sees the finished change rather than the one it is
+    # partway through writing, and is checked against the derived-source rules
+    # in CLAUDE.md rather than against a checklist it wrote itself.
+    #
+    # It runs *before* `verify` on purpose: it may edit
+    # `skills/vincent-workflows/SKILL.md`, which `skills/embed.go` embeds into
+    # the built-in `create-workflow` workflow at build time, or the header in
+    # `internal/workflow/builtin.go`. Those are code. Putting the audit after
+    # the cross-platform legs would mean the legs never saw them.
+    prompt: |
+      The change for this issue is written, committed and passing
+      `go run mage.go test` and `go run mage.go lint`. Your job is the
+      documentation, and nothing else.
+
+      This is an **audit**. "Nothing needed changing" is a normal and frequent
+      outcome — say so and stop. Do not rewrite prose that is still true, do
+      not restructure a page you happen to be reading, and do not add a
+      paragraph about the change to a page that never mentioned that area.
+
+      What the change touched:
+
+      {{ (index .Steps "docs-scope").Result }}
+
+      The plan it was written against is `.vincent-issue/brief.md`, the drafted
+      pull request body is `.vincent-issue/pr.md`, and the original issue is
+      `.vincent-issue/issue.json`.
+
+      Read `CLAUDE.md` first. Public documentation there is **derived from the
+      source, not from planning records**, and each derivation is a rule you
+      check one at a time:
+
+      - `internal/config` → `docs/reference/configuration.md`
+      - the cobra tree → `docs/reference/cli.md`
+      - the route table in `internal/api/server.go` → `docs/reference/api.md`
+      - `internal/tui/bindings.go` → the key tables in `docs/guides/tui.md`
+      - the `Reason*` constants in `internal/worktree` and
+        `internal/taskrun/engine.go` → the block-reason tables
+      - `internal/workflow` and `internal/taskrun`'s step types →
+        `docs/reference/workflow-schema.md` and `docs/reference/task-lifecycle.md`
+      - `internal/agent/*` → `docs/guides/agents.md` and spec §9.x. A capability
+        an adapter lacks is **stated, never emulated** — if this change altered
+        what an adapter can do, the page says so plainly.
+      - anything a user can see → `docs/features.md`, the relevant
+        `docs/guides/` page, and `## [Unreleased]` in `CHANGELOG.md`
+
+      Then the records that are not derived from anything:
+
+      - **`docs/spec.md`** is the only spec, is deliberately unversioned, and is
+        amended **in place with a dated note, in the same PR as the code that
+        makes the amendment true**. If this change made a sentence in it false,
+        that is a hard rule of this repository, not a nicety. Its section
+        numbers are cited from code comments, so never renumber one.
+      - **`docs/tasks/`** — if this change completes or advances a task, update
+        its status marker and the index row in `docs/tasks/README.md` **in the
+        same edit**. Never delete a task.
+      - **`docs/gates/`** — if the behaviour a gate walks through changed, the
+        walkthrough changed.
+      - `docs/history/v0-tasks.md` is **closed and frozen**. Read it, never
+        edit it.
+
+      One file is not documentation at all:
+
+      - **`skills/vincent-workflows/SKILL.md` is runtime text.**
+        `skills/embed.go` embeds it and `internal/workflow/builtin.go` splices
+        it into the built-in `create-workflow` workflow's prompt at build time
+        (task 024). Editing it changes what the daemon tells an agent to do. If
+        this change altered the workflow schema — a step type, a field, a
+        validation rule, a template variable, a human-interaction mechanism —
+        that file is out of date and is part of this pull request. The three
+        standing corrections the prompt applies to it live in
+        `createWorkflowHeader` in `internal/workflow/builtin.go` and **never in
+        the skill**; if one of those needs to change, change it there.
+
+      Two things you must **not** do:
+
+      - **Never draw a screen.** No ASCII mock-up of a panel, no hand-written
+        "example" frame. Every `docs/assets/tui-*.png` is a capture of the
+        running TUI produced by `scripts/screenshots.sh`, and that script needs
+        VHS, ttyd and ffmpeg and seeds a throwaway daemon. Do not run it. If a
+        panel in the pictures no longer matches the code, write that down in
+        the report below and in `.vincent-issue/pr.md`, and leave the images
+        alone — a person re-runs the script.
+      - **Do not touch anything outside** `docs/`, `skills/`, `CHANGELOG.md`,
+        `README.md` and `internal/workflow/builtin.go`. If you find a bug in
+        the change itself, report it rather than fixing it here; this step's
+        commits are documentation commits.
+
+      This repository's own `.vincent/workflows/*.yaml` are consumers of the
+      schema too. If the schema changed under them, fix them — they are
+      validated after this step.
+
+      Then:
+
+      1. **Commit** whatever you changed, `docs:` (or `chore:` for the skill),
+         separately from the implementation commits.
+      2. Update `.vincent-issue/pr.md` so its checklist tells the truth about
+         the documentation and CHANGELOG boxes, and so anything you found but
+         did not fix — a stale screenshot, a bug in the change — is written in
+         the body where the reviewer will see it.
+      3. Write `.vincent-issue/docs.md`. Its **first line** must be exactly one
+         of:
+
+             docs: updated
+             docs: none needed
+
+         Below it, list every page you changed and what claim was stale, or —
+         on `none needed` — name the derivations you checked and why each was
+         already true. A `none needed` that names nothing is not an audit.
+
+      Never stage or commit `.vincent-issue/`.
+    # Four assertions. The report exists and is machine-readable, because the
+    # gate step reads it. The worktree is committed and the scratch directory
+    # is still untracked. The step stayed inside its lane — the offenders
+    # clause names the paths on stderr rather than exiting silently, because
+    # §8.4 hands the retry this output and "check failed" tells an agent
+    # nothing. And the tree still builds, the repo's own workflow files still
+    # parse against the schema, and the packages whose tests assert what the
+    # published pages and the embedded skill say still pass.
+    #
+    # It deliberately does not re-run the full suite: `verify` is next.
+    check: >
+      test -s .vincent-issue/docs.md &&
+      head -n 1 .vincent-issue/docs.md | grep -Eq '^docs: (updated|none needed)$' &&
+      ! git ls-files .vincent-issue | grep -q . &&
+      git diff --quiet &&
+      git diff --cached --quiet &&
+      { offenders=$(git diff --name-only "$(cat .vincent-issue/pre-docs.sha)"..HEAD | grep -vE '^(docs/|skills/|CHANGELOG\.md$|README\.md$|internal/workflow/builtin\.go$)'); test -z "$offenders" || { echo 'docs-sync changed files outside docs/, skills/, CHANGELOG.md, README.md and internal/workflow/builtin.go:' >&2; echo "$offenders" >&2; false; }; } &&
+      go build -o .vincent-issue/vincent ./cmd/vincent &&
+      { for f in .vincent/workflows/*.yaml; do .vincent-issue/vincent workflow validate "$f" || exit 1; done; } &&
+      go test ./internal/config ./internal/cli ./internal/workflow ./internal/api
+    check_timeout: 15m
+
   - id: verify
     name: Verify across platforms
     type: loop
@@ -766,9 +974,11 @@ steps:
             this branch broke.
 
           **Commit your fix.** The next pass re-runs the legs against what is
-          committed, and the pull request body in `.vincent-issue/pr.md` should
-          still be true afterwards — update it if this repair changed what the
-          change does.
+          committed, and two files should still be true afterwards: update
+          `.vincent-issue/pr.md` if this repair changed what the change does,
+          and the affected page under `docs/` if it changed a documented claim.
+          A documentation audit already ran on the code you are repairing, so
+          anything you make stale here is stale for good.
 
           Never stage or commit `.vincent-issue/`.
         # Cheap, and deliberately not a re-run of the legs — that is the next
@@ -842,6 +1052,20 @@ steps:
       The implementation reported:
 
       {{ (index .Steps "implement").Result }}
+
+      {{ if eq (index .Steps "docs-sync").Status "skipped" -}}
+      The documentation audit was skipped: the change touched nothing but
+      tests, so no documented claim can have gone stale.
+      {{- else -}}
+      The documentation audit reported:
+
+      {{ (index .Steps "docs-sync").Result }}
+
+      `.vincent-issue/docs.md` has the long form. If it says a screenshot under
+      `docs/assets/` is now stale, nothing automated will fix that —
+      `./scripts/screenshots.sh` is a person's job, and this is the moment to
+      notice.
+      {{- end }}
 
       Approve to push and open the PR. Reject if the change is wrong, out of
       scope, or not worth shipping.

--- a/.vincent/workflows/github-resolve-issue.yaml
+++ b/.vincent/workflows/github-resolve-issue.yaml
@@ -23,9 +23,11 @@
 #   triage (stop on reject / needs-info)
 #     └─ confirm-red (bug only)  prove the test fails on the unfixed code
 #   implement (write it, commit it, draft the PR)
-#   verify    (the expensive cross-platform legs)
+#   verify    (the expensive cross-platform legs, repaired in a bounded loop)
 #   gate      (a human reads the diff)
 #   publish → report
+#   gate-merge (a human reads the pull request)
+#   rebase → resolve? → repush → wait-checks → merge → merged
 #
 # ## How the branch is expressed
 #
@@ -70,6 +72,55 @@
 # amendment rule, the scratch-directory rule, the two PR artifacts — is written
 # once, which is the point of merging.
 #
+# ## When the cross-platform legs fail
+#
+# `verify` is a bounded repair loop rather than a single command: probe →
+# break → repair, four iterations, so the expensive legs get up to **three**
+# agent repair passes and every one of them is re-probed. `repair` carries
+# `if: not .Loop.IsLast` for exactly that reason — a repair on the last pass
+# would never be probed again, so its work would reach the human gate
+# unverified while costing a full session.
+#
+# A loop that runs out of iterations **succeeds** (§7.8: only exceeding
+# `max_iterations` blocks), so the loop itself cannot be the assertion.
+# `verify-final` is: it reads the last probe's exit code back out of `.Steps` —
+# an id under repetition resolves to its latest iteration — and fails the task
+# if the legs are still red. Without it, a branch whose race detector never
+# passed would arrive at the gate looking verified.
+#
+# The loop declares its own `timeout:` because `defaults.timeout` (30m) bounds
+# the *whole* loop rather than one iteration, and four probes plus three
+# 45-minute repairs do not fit inside it.
+#
+# ## After the PR: the merge tail
+#
+# Opening the pull request is not the end of the run. `gate-merge` is a second
+# manual gate, and it authorizes a different thing than the first: `gate` says
+# "make this branch public", `gate-merge` says "put it in the base branch".
+# Everything after it is deterministic except a conflict resolver:
+#
+#   rebase       fetch the base and rebase onto it, under `allow_failure` so a
+#                conflict is data rather than a blocked task
+#   resolve      an agent, and only if the rebase stopped on a conflict
+#   repush       assert the branch really sits on top of the base, force-push
+#   wait-checks  poll the *required* checks until they pass
+#   merge        `gh pr merge --merge`
+#   merged       read the PR back, confirm MERGED, clear the scratch directory
+#
+# `--merge` is not a preference: this repository has squash and rebase merges
+# disabled and merges everything with a merge commit, because a branch's
+# history becomes master's history (CLAUDE.md).
+#
+# The wait is a poll rather than `gh pr checks --watch`: `--required` narrows
+# it to the protected checks, exit code 8 means "pending" and is the one code
+# worth sleeping on, and a force-push opens a window in which GitHub has not
+# created the runs yet and answers "no checks reported" — which is pending too,
+# but only for the first few minutes.
+#
+# Nothing in the tail retries. A `gh pr merge` whose response was lost is not a
+# call to repeat, and neither is a force-push. `merged` is what says whether it
+# landed, and it asks GitHub rather than trusting an exit code.
+#
 # ## Why the brief and the implementation are two steps
 #
 # `diagnose`/`digest` run with `on_input: wait`, so they park the task in
@@ -110,7 +161,7 @@
 # (verbatim), the project's template, `branch_template` in config.yaml, then the
 # built-in (task 001, internal/worktree/branch.go).
 name: github-resolve-issue
-description: Read a GitHub bug or enhancement issue, clarify it with the author, deliver the fix or feature, and open the PR.
+description: Read a GitHub bug or enhancement issue, clarify it with the author, deliver the fix or feature, open the PR, then rebase and merge it once you approve.
 
 defaults:
   agent: claude
@@ -624,31 +675,135 @@ steps:
 
   - id: verify
     name: Verify across platforms
+    type: loop
+    # Four probes and three repairs. `defaults.timeout` bounds the *whole* loop
+    # (§7.8), not an iteration, so it has to be stated here or the loop is
+    # killed 30 minutes in, mid-repair.
+    count: 4
+    timeout: 5h
+    steps:
+      - id: verify-probe
+        name: Run the cross-platform legs
+        type: command
+        shell: sh
+        timeout: 20m
+        # A probe never retries — a second identical run is the same run — and
+        # `allow_failure` is what turns a red leg into something the `break`
+        # guard and the repair prompt can read instead of a blocked task.
+        max_retries: 0
+        allow_failure: true
+        # These are the legs CLAUDE.md requires before pushing but that are too
+        # slow to put in `implement`'s check. `testrace` needs cgo and a C
+        # compiler; on a machine without one this fails, and that is the honest
+        # answer rather than a silently skipped race detector — which matters
+        # more for a bug fix than for a feature, since "intermittent" is how
+        # half of them are reported. That failure is also not one an agent can
+        # repair, which is what `verify-final` exists to stop.
+        #
+        # The GOOS loop is not decorative: `go tool golangci-lint` cross-*builds*
+        # the linter and then cannot run it, so the linter is built for the host
+        # once and re-run per target. A host-only lint hides every finding in a
+        # build-tagged file — exactly where a platform-specific bug fix lands.
+        run: |
+          set -e
+          go run mage.go testrace
+          LINT=$(go tool -n golangci-lint)
+          for os in windows darwin linux; do
+            echo "--- golangci-lint GOOS=$os ---"
+            GOOS=$os "$LINT" run ./...
+          done
+
+      - id: verify-ok
+        name: Stop once the legs are green
+        type: break
+        if: '{{ eq (index .Steps "verify-probe").ExitCode 0 }}'
+
+      - id: repair
+        name: Repair the failing legs
+        type: agent
+        # Never on the last pass: nothing would probe it, so its work would
+        # reach the gate unverified while costing a whole session.
+        if: '{{ not .Loop.IsLast }}'
+        timeout: 45m
+        # An iteration *is* the retry here, and the next probe is a better
+        # judge than a retry of this step's own budget would be. One session
+        # per iteration, three at most.
+        max_retries: 0
+        prompt: |
+          The cross-platform verification legs are red on this branch. This is
+          the command that ran, and it failed:
+
+              go run mage.go testrace
+              LINT=$(go tool -n golangci-lint)
+              for os in windows darwin linux; do GOOS=$os "$LINT" run ./...; done
+
+          Its output (this is pass {{.Loop.Index}} of the repair loop):
+
+          {{ (index .Steps "verify-probe").Result }}
+
+          You are on branch {{.Task.BranchName}}, based on
+          {{.Task.BaseBranch}}, in a dedicated worktree at
+          {{.Worktree.Path}}. The change under repair is the one described in
+          `.vincent-issue/brief.md`; the original issue is in
+          `.vincent-issue/issue.json`.
+
+          Fix the underlying cause:
+
+          - **Do not weaken, skip, delete or `t.Skip` a test**, and do not
+            relax a lint rule or add a `//nolint` to silence a finding. If a
+            finding is genuinely a false positive, `nolintlint` requires the
+            directive to carry a reason — write the reason, and say so in
+            `.vincent-issue/pr.md` too.
+          - A **race** the detector found is a real bug in the change, not
+            noise. Fix the synchronisation, do not serialise the test to hide
+            it.
+          - A finding under `GOOS=windows` or `GOOS=darwin` is usually a
+            build-tagged file the host lint never compiled. Cross-platform is
+            a hard requirement (`CLAUDE.md`): platform-specific code belongs in
+            `_unix.go` / `_windows.go` / `_darwin.go` / `_linux.go`.
+          - Stay inside the scope the brief agreed. If the legs are red for a
+            reason that predates this branch, say so plainly and fix only what
+            this branch broke.
+
+          **Commit your fix.** The next pass re-runs the legs against what is
+          committed, and the pull request body in `.vincent-issue/pr.md` should
+          still be true afterwards — update it if this repair changed what the
+          change does.
+
+          Never stage or commit `.vincent-issue/`.
+        # Cheap, and deliberately not a re-run of the legs — that is the next
+        # iteration's job, and paying for it twice is what makes a repair loop
+        # expensive. This only asserts the repair left the worktree in a state
+        # the probe can judge: committed, scratch untracked, and still building.
+        check: >
+          ! git ls-files .vincent-issue | grep -q . &&
+          git diff --quiet &&
+          git diff --cached --quiet &&
+          test "$(git rev-list --count {{.Task.BaseBranch}}..HEAD)" -gt 0 &&
+          go build ./...
+        check_timeout: 5m
+
+  - id: verify-final
+    name: Refuse an unverified branch
     type: command
     shell: sh
-    timeout: 20m
-    # `max_retries: 0`: nothing here is flaky in a way a second identical run
-    # fixes, and each attempt is expensive. A failure blocks the task for you to
-    # read rather than silently buying another 45-minute agent attempt.
+    timeout: 1m
     max_retries: 0
-    # These are the legs CLAUDE.md requires before pushing but that are too slow
-    # to put in `implement`'s check. `testrace` needs cgo and a C compiler; on a
-    # machine without one this step fails, and that is the honest answer rather
-    # than a silently skipped race detector — which matters more for a bug fix
-    # than for a feature, since "intermittent" is how half of them are reported.
+    # A loop that runs out of iterations *succeeds* — only exceeding
+    # `max_iterations` blocks (§7.8) — so the loop cannot be the assertion.
+    # This is. `.Steps` resolves a repeated id to its latest iteration, so the
+    # guard reads the fourth probe, the one no repair ran after.
     #
-    # The GOOS loop is not decorative: `go tool golangci-lint` cross-*builds*
-    # the linter and then cannot run it, so the linter is built for the host
-    # once and re-run per target. A host-only lint hides every finding in a
-    # build-tagged file — exactly where a platform-specific bug fix lands.
+    # False guard ⇒ skipped ⇒ the workflow carries on, which is the green path.
+    if: '{{ ne (index .Steps "verify-probe").ExitCode 0 }}'
+    # The probe's output is not interpolated here on purpose: it is compiler and
+    # linter text, full of quotes and backticks, and rendering it into a shell
+    # script is how a diagnostic becomes a syntax error. It is already in the
+    # transcript under `verify-probe`, which is where you read it.
     run: |
-      set -e
-      go run mage.go testrace
-      LINT=$(go tool -n golangci-lint)
-      for os in windows darwin linux; do
-        echo "--- golangci-lint GOOS=$os ---"
-        GOOS=$os "$LINT" run ./...
-      done
+      echo "the cross-platform legs are still red after three repair passes." >&2
+      echo "read the last 'verify-probe' run in this task's transcript for the failure." >&2
+      exit 1
 
   - id: gate
     name: Approve the pull request
@@ -691,6 +846,10 @@ steps:
       Approve to push and open the PR. Reject if the change is wrong, out of
       scope, or not worth shipping.
 
+      This is the first of two gates. Approving here publishes the branch; it
+      does not merge anything. A second gate, after the PR exists, is what
+      authorizes rebasing it onto {{.Task.BaseBranch}} and merging it.
+
   - id: publish
     name: Push and open the PR
     type: command
@@ -717,13 +876,233 @@ steps:
     type: command
     shell: sh
     timeout: 2m
+    max_retries: 0
     # stdout becomes this step's Result and lands in the transcript — that is
-    # where you read the PR url. Clearing the scratch directory afterwards
-    # leaves the worktree clean, so archiving the task does not warn about a
-    # dirty tree.
+    # where you read the PR url, and it is also what `gate-merge` puts in front
+    # of you.
     #
-    # `&&`, not two lines: sh reports the last command's status, so an unchained
-    # `rm` would mask a failed `view` and leave the step green. It also means
-    # the drafts survive for inspection when the report fails — which is the
-    # same reason nothing deletes them if `publish` fails.
-    run: gh pr view "$(cat .vincent-issue/url.txt)" && rm -rf .vincent-issue
+    # It no longer deletes `.vincent-issue/`: the merge tail below still needs
+    # `url.txt`, so the scratch directory now lives until `merged`.
+    run: gh pr view "$(cat .vincent-issue/url.txt)"
+
+  - id: gate-merge
+    name: Approve the merge
+    type: manual
+    # The second authority boundary. `gate` said "make this branch public";
+    # this one says "put it in the base branch". Everything after it is
+    # deterministic — a rebase, a force-push, a wait, one merge call — so this
+    # is the last point at which a person decides anything.
+    instructions: |
+      The pull request for task #{{.Task.ID}} is open:
+
+      {{ (index .Steps "report").Result }}
+
+      Approving here rebases {{.Task.BranchName}} onto the current
+      {{.Task.BaseBranch}}, **force-pushes it** — rewriting the branch anyone
+      else may have pulled — waits for the required checks to pass, and then
+      merges the pull request with a merge commit. Merging closes the issue,
+      because the body says `Closes #…`, and GitHub deletes the remote branch.
+
+      Read the PR itself, not just the diff you already approved: the review
+      thread, and whether the base branch has moved under it in a way that
+      makes this change wrong rather than merely conflicted.
+
+      Reject to leave the pull request open and unmerged. Nothing is undone by
+      rejecting — the branch stays pushed and the PR stays up.
+
+  - id: rebase
+    name: Rebase onto the base branch
+    type: command
+    shell: sh
+    timeout: 10m
+    max_retries: 0
+    # `allow_failure` because a conflict is the expected other outcome, not an
+    # error: `resolve` reads this exit code. A failed row here is normal.
+    #
+    # A failure leaves the worktree mid-rebase, which is exactly the state
+    # `resolve` needs to finish the job — so nothing aborts it here.
+    allow_failure: true
+    run: |
+      set -e
+      git fetch origin {{.Task.BaseBranch}}
+      git rebase origin/{{.Task.BaseBranch}}
+
+  - id: resolve
+    name: Resolve the rebase conflicts
+    type: agent
+    if: '{{ ne (index .Steps "rebase").ExitCode 0 }}'
+    timeout: 45m
+    # One session, no retry: a second attempt inherits whatever state the first
+    # left behind, which is not the state this prompt describes. If it cannot
+    # finish, the task blocks and you finish the rebase by hand.
+    max_retries: 0
+    prompt: |
+      The rebase of {{.Task.BranchName}} onto `origin/{{.Task.BaseBranch}}`
+      stopped. It said:
+
+      {{ (index .Steps "rebase").Result }}
+
+      You are in the worktree at {{.Worktree.Path}}, most likely mid-rebase.
+      Run `git status` first and find out what is actually true before you
+      change anything — it may be a conflict, or it may be that the fetch
+      itself failed, in which case there is nothing here to resolve and you
+      should say so rather than inventing a fix.
+
+      If it is a conflict, resolve it:
+
+      - The change being rebased is described in `.vincent-issue/brief.md`, and
+        the pull request body is in `.vincent-issue/pr.md`. Both say what this
+        branch is *for*; that is what decides how a conflict resolves.
+      - Keep both sides' intent. Do not resolve a conflict by discarding the
+        base branch's side because it is in the way — someone else's change
+        landed there on purpose. If the two are genuinely incompatible, stop
+        and leave the rebase in place rather than picking a winner.
+      - `git add` the resolved files and `git rebase --continue` for each
+        conflicted commit until the rebase is finished. Do not `git rebase
+        --skip` a commit of this branch.
+      - Never `git rebase --abort` and never `git merge` the base branch
+        instead: the next step asserts that the base is an ancestor of HEAD.
+      - Do not push. A later step does that.
+
+      When the rebase is finished, run `go run mage.go test` and
+      `go run mage.go lint` and fix what the rebase broke — a conflict resolved
+      so that it compiles is not the same thing as one resolved correctly.
+
+      Never stage or commit `.vincent-issue/`.
+    # Asserts the rebase is actually finished (no rebase state directory in
+    # this worktree — `--git-path` resolves the linked worktree's own, not the
+    # main repo's), that nothing was left half-resolved, that the branch really
+    # does sit on top of the base rather than having been merged or aborted,
+    # and that the tree still passes the bar.
+    check: >
+      test ! -d "$(git rev-parse --git-path rebase-merge)" &&
+      test ! -d "$(git rev-parse --git-path rebase-apply)" &&
+      git diff --quiet &&
+      git diff --cached --quiet &&
+      ! git ls-files .vincent-issue | grep -q . &&
+      git merge-base --is-ancestor origin/{{.Task.BaseBranch}} HEAD &&
+      go run mage.go test &&
+      go run mage.go lint
+    check_timeout: 20m
+
+  - id: repush
+    name: Force-push the rebased branch
+    type: command
+    shell: sh
+    timeout: 5m
+    # Load-bearing and not repeatable in any meaningful sense: if the push
+    # succeeded and the response was lost, a second one is either a no-op or a
+    # lease failure, and neither is worth automating.
+    max_retries: 0
+    # The ancestor test is the postcondition of the whole rebase leg, checked
+    # once here whether `resolve` ran or not: if the base is not an ancestor of
+    # HEAD, the branch was not rebased and there is nothing to force-push.
+    #
+    # `--force-with-lease` rather than `--force`: it refuses if `origin`'s copy
+    # of this branch is not the commit `publish` left there — which is the case
+    # exactly when someone else pushed to it while the gate was open.
+    #
+    # A rebase that changed nothing makes this a no-op push, which is fine.
+    run: |
+      set -e
+      if ! git merge-base --is-ancestor origin/{{.Task.BaseBranch}} HEAD; then
+        echo "{{.Task.BranchName}} is not on top of origin/{{.Task.BaseBranch}}:" >&2
+        echo "the rebase did not finish, or it was aborted. nothing was pushed." >&2
+        git status --short --branch >&2
+        exit 1
+      fi
+      git push --force-with-lease origin {{.Task.BranchName}}
+
+  - id: wait-checks
+    name: Wait for the required checks
+    type: command
+    shell: sh
+    # 120 polls at 30s is an hour of CI, plus the initial settle. The step's
+    # own timeout is the outer bound; the loop's is what produces a legible
+    # message instead of a `timeout` block reason.
+    timeout: 90m
+    max_retries: 0
+    # `--required` narrows this to the checks that actually gate a merge, so a
+    # non-required job neither blocks the wait nor fails it. The exit codes are
+    # the API here: 0 all passed, 8 still pending, anything else a real answer
+    # to stop on (`gh help exit-codes`).
+    #
+    # The "no checks reported" window is the one exception: for the first few
+    # minutes after a force-push GitHub has not created the workflow runs yet,
+    # and that is pending too. Bounded to five minutes so a branch that truly
+    # has no required checks fails rather than sleeping for an hour.
+    run: |
+      set -e
+      url=$(cat .vincent-issue/url.txt)
+      echo "waiting for the required checks on $url"
+
+      i=0
+      while :; do
+        i=$((i + 1))
+        if [ "$i" -gt 120 ]; then
+          echo "required checks still pending after an hour; not merging." >&2
+          exit 1
+        fi
+
+        set +e
+        gh pr checks "$url" --required > .vincent-issue/checks.txt 2>&1
+        code=$?
+        set -e
+
+        if [ "$code" -eq 0 ]; then
+          cat .vincent-issue/checks.txt
+          echo "--- all required checks passed ---"
+          break
+        fi
+
+        if [ "$code" -ne 8 ]; then
+          if [ "$i" -le 10 ] && grep -qi 'no checks reported' .vincent-issue/checks.txt; then
+            :
+          else
+            echo "a required check did not pass; not merging:" >&2
+            cat .vincent-issue/checks.txt >&2
+            exit 1
+          fi
+        fi
+
+        sleep 30
+      done
+
+  - id: merge
+    name: Merge the pull request
+    type: command
+    shell: sh
+    timeout: 10m
+    # The one irreversible step in the tail, and the reason nothing above it
+    # retries either. A retried merge is a merge attempted against a state this
+    # workflow no longer knows; `merged` reads the real answer back instead.
+    max_retries: 0
+    # `--merge` is the repository's rule, not a preference: squash and rebase
+    # merges are disabled on this repo because a branch's history becomes
+    # master's history (CLAUDE.md). No `--delete-branch`: the repository
+    # deletes the remote branch itself, and gh's flag would also delete the
+    # local branch this worktree is sitting on.
+    run: gh pr merge "$(cat .vincent-issue/url.txt)" --merge
+
+  - id: merged
+    name: Confirm the merge
+    type: command
+    shell: sh
+    timeout: 3m
+    max_retries: 0
+    # The read-only postcondition: `gh pr merge` exiting 0 is a claim, and this
+    # is the check of it. Clearing the scratch directory last leaves the
+    # worktree clean, so archiving the task does not warn about a dirty tree —
+    # and leaves the drafts in place for inspection if anything above failed,
+    # which is the same reason nothing deletes them when `publish` fails.
+    run: |
+      set -e
+      url=$(cat .vincent-issue/url.txt)
+      gh pr view "$url" --json state,mergedAt,mergeCommit,url \
+        --jq '"state:   \(.state)\nmerged:  \(.mergedAt)\ncommit:  \(.mergeCommit.oid)\npr:      \(.url)"'
+      state=$(gh pr view "$url" --json state --jq .state)
+      if [ "$state" != "MERGED" ]; then
+        echo "the pull request is $state, not MERGED; the scratch directory is left in place." >&2
+        exit 1
+      fi
+      rm -rf .vincent-issue


### PR DESCRIPTION
## Summary

`github-resolve-issue` stopped at the pull request, and a red cross-platform leg blocked the task outright. Two changes, either side of the gate that was already there.

**A documentation audit, before the verification rather than after it.**

`implement` was already told to update the affected page, and a step doing something else does that badly: the page is the last thing it touches, it is judged by a checklist it ticked itself, and it never sees the finished change — only the one it is partway through writing.

```
implement → docs-scope → docs-sync → verify → …
```

`docs-sync` has one job and the finished change in front of it. What it audits is not "the docs" but each derivation `CLAUDE.md` names as one — config reference against `internal/config`, CLI page against the cobra tree, API page against `server.go`'s route table, TUI key tables against `bindings.go`, block reasons against the `Reason*` constants — and then the records derived from nothing: `docs/spec.md` amended in place with a dated note in this same PR, `docs/tasks/` with its index row in the same edit, `docs/gates/` when the behaviour a walkthrough walks has changed. `docs/history/v0-tasks.md` it reads and never edits.

`skills/vincent-workflows/SKILL.md` is in scope and is **not documentation**: `skills/embed.go` embeds it and `builtin.go` splices it into the built-in `create-workflow` prompt at build time (task 024), so a schema change that does not reach it leaves the daemon telling agents something false. That is also why the step sits **before** `verify` — what it may edit includes Go, and the cross-platform legs have to see it.

`docs-scope` in front of it is a data step first and a guard second: its stdout is the changed-file list the prompt reads, and its exit code skips the audit only for a change that touched nothing but tests. A narrow saving, and the comment says so.

The check is what keeps an audit from becoming a rewrite. This step's own commits — everything after the `pre-docs.sha` it recorded — may touch only `docs/`, `skills/`, `CHANGELOG.md`, `README.md` and `internal/workflow/builtin.go`; the repo's own `.vincent/workflows/*.yaml` must still validate against the schema; and `internal/config`, `internal/cli`, `internal/workflow` and `internal/api` — the packages whose tests assert what the published pages and the embedded skill say — must still pass. Measured on this branch, that whole check runs in about twenty seconds, which is why it does not re-run the full suite: `verify` is next.

`docs: none needed` is a first-class outcome. What it may not be is empty — the report has to name the derivations it checked.

Screenshots are the one thing it may not fix: every `docs/assets/tui-*.png` is a capture from `scripts/screenshots.sh`, which needs VHS, ttyd and ffmpeg, and documentation never *draws* a screen. A stale panel is reported into `docs.md` and into `pr.md`, and `gate` puts it in front of the human who approves.

**`verify` becomes a bounded repair loop.** Probe → break → repair, four iterations, so `testrace` and the three `GOOS` lints get up to three agent repair passes and every one of them is re-probed.

```
verify (loop, count: 4, timeout: 5h)
  verify-probe   testrace + golangci-lint × 3 GOOS   allow_failure, max_retries 0
  verify-ok      break if the probe exited 0
  repair         agent, max_retries 0, if: {{ not .Loop.IsLast }}
verify-final     command, if: the last probe exited non-zero → fail the task
```

Two things there are not obvious:

- `repair` is skipped on the last pass. A repair nobody probes afterwards would reach the human gate unverified, and cost a full session to get there.
- `verify-final` has to exist. A loop that runs out of iterations **succeeds** — only exceeding `max_iterations` blocks (§7.8) — so the loop itself cannot be the assertion. It reads the last probe's exit code back out of `.Steps`, where a repeated id resolves to its latest iteration. Without it a branch whose race detector never passed arrives at the gate looking verified.

The loop states its own `timeout:` because `defaults.timeout` (30m) bounds the *whole* loop rather than one iteration.

**After the PR, a second gate and a merge tail.**

```
gate → publish → report → gate-merge → rebase → resolve? → repush → wait-checks → merge → merged
```

`gate-merge` authorizes a different thing than `gate` does: the first says *make this branch public*, the second says *put it in the base branch*. Behind it everything is deterministic except a conflict resolver.

- `rebase` fetches the base and rebases under `allow_failure`, so a conflict is data rather than a blocked task, and leaves the worktree mid-rebase on purpose.
- `resolve` is an agent, and only when the rebase actually stopped on a conflict. Its check asserts the rebase is finished (`git rev-parse --git-path`, so it looks at this linked worktree's state and not the main repo's), that nothing was left half-resolved, that `origin/<base>` really is an ancestor of `HEAD` — which catches an abort or a merge-instead-of-rebase — and that the tree still passes `mage test` and `mage lint`.
- `repush` re-asserts the ancestor relation with a legible message before force-pushing with `--force-with-lease`, which refuses if someone else pushed to the branch while the gate was open.
- `wait-checks` polls `gh pr checks --required` rather than `--watch`: `--required` narrows it to the checks that actually gate a merge, exit code 8 is "pending" and the one code worth sleeping on, and a force-push opens a window in which GitHub has not created the runs yet and answers "no checks reported" — pending too, but bounded to the first five minutes so a branch with genuinely no required checks fails instead of sleeping for an hour.
- `merge` is `gh pr merge --merge`. Not a preference: squash and rebase merges are disabled on this repository because a branch's history becomes `master`'s history. No `--delete-branch` — the repository deletes the remote branch itself, and gh's flag would also delete the local branch the worktree is sitting on.
- `merged` is the read-only postcondition. `gh pr merge` exiting 0 is a claim; this asks GitHub whether the PR is `MERGED`.

Nothing in the tail retries. A merge whose response was lost is not a call to repeat, and neither is a force-push.

`report` no longer deletes `.vincent-issue/` — the tail still needs `url.txt` — so `merged` clears it, which keeps the drafts in place for inspection whenever something above failed.

**Cost.** Eleven agent sessions at the ceiling, up from five.

| step | sessions | why an agent |
|---|---|---|
| `diagnose` *or* `digest` | 2 | mutually exclusive; reads an issue thread and asks the author |
| `implement` | 3 | writes code from intent |
| `docs-sync` | 2 | decides whether a prose claim is still true of the code |
| `repair` | 3 | reads compiler, linter and race output |
| `resolve` | 1 | semantic conflict resolution; only when the rebase hits one |

`vincent workflow validate` reports ok, 21 steps, 0 warnings against `v0.5.0-49-ge02409a`.

## Related

No issue. Follows `fa18796`, which merged `github-bug` and `github-enhancement` into this file.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added/updated for behavior changes — no code changed; this is one project-local workflow file, and nothing in the suite parses this repo's own `.vincent/workflows/`. `vincent workflow validate` is the check that applies, and it passes.
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — not shipped in the binary; the built-in workflows live in `internal/workflow/builtin.go` and are untouched. Consistent with every earlier `chore(workflows):` commit.
- [ ] Affected page under `docs/` updated — no documentation page tracks the content of this repository's own workflow registry.
