### PR TITLE
Follow-up runs on a done or aborted task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Follow-up runs on a finished task, before it is archived.** A `done` or
+  `aborted` task still owns its worktree, its branch and its commits until
+  `archive` tears them down, and until now vincent could do nothing in that
+  window — a branch that needed rebasing onto a `main` that had moved, one more
+  commit a review asked for, or a stray file to drop all meant leaving vincent,
+  finding the worktree by hand, and coming back only to press archive. The new
+  `follow_up` action runs that work inside the daemon's own ledger: give the
+  task an agent prompt, a shell command, or the name of a workflow from the
+  registry, and it runs on that task's own branch in that task's own worktree,
+  with a step run, a transcript, events and token and cost accounting like any
+  other step. It is repeatable — each run is a *round* — and it never changes
+  the task's verdict: a done task returns to `done` and an aborted one to
+  `aborted`, whatever the run did. A follow-up round's rows are recorded past
+  the workflow's last step index, so the workflow snapshot does not grow and
+  `step k of n` still describes the workflow somebody wrote. A follow-up step
+  that fails blocks the task at its own index, where `retry` re-runs the
+  follow-up, `repair` sends an ad-hoc agent at *that* failure, `skip` abandons
+  it and restores the task's original state, and `cancel` aborts. It is
+  available as `POST /v1/tasks/{id}/follow_up`, as `F` in the TUI, and — alone
+  among the human actions, because batches want a command line — as
+  `vincent task follow-up <id> --prompt/--run/--workflow`.
+  ([#181](https://github.com/lezli01/vincent/issues/181))
+
 - **Each agent's usage window is reported in the daemon and TUI.** When an agent
   CLI stops because the account's quota for the window is spent, vincent now
   remembers *which adapter* it was and when it resets, instead of losing that

--- a/README.md
+++ b/README.md
@@ -433,8 +433,10 @@ the TUI — the daemon and any running task keep going without it.
 
 The data commands the TUI runs are subcommands too (`vincent task show 1`,
 `vincent task cancel 1`, plus `project`, `workflow` and `daemon`), and
-everything either does is the same localhost API. The remaining human actions —
-approve, reject, retry, skip, pause, resume, answer, archive — are TUI and API
+everything either does is the same localhost API. One human action has a command
+line of its own — `vincent task follow-up <id>`, because running one more thing
+in each of several finished tasks' worktrees is a batch. The rest — approve,
+reject, retry, repair, skip, pause, resume, answer, archive — are TUI and API
 operations for now ([#89](https://github.com/lezli01/vincent/issues/89)); the
 [CLI reference](docs/reference/cli.md) is the full tree. To keep the daemon
 running across reboots, `vincent service install`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,7 +13,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Workflows | Validated YAML, templates, declared task fields, checks, retries, timeouts, platform restrictions |
 | Control flow | Parallel groups, isolated fan-out and merge, conditions, loops, breaks, reusable workflow includes |
 | Agents | Claude Code, Codex, and Cursor; per-workflow, per-step, and per-task selection |
-| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents |
+| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents, follow-up runs on finished tasks |
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
 | Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks |
@@ -84,6 +84,17 @@ same step with the same reason, so you read the diff and then decide. The repair
 is recorded as its own step run with its own transcript and cost, and does not
 consume the blocked step's retries.
 
+A finished task keeps its worktree, its branch and its commits until you archive
+it, and that window is where the last mile of real work lives — a branch that
+needs rebasing onto a `main` that moved, one more commit a review asked for, a
+stray file to drop. A **follow-up run** does that work inside vincent: give a
+`done` or `aborted` task an agent prompt, a shell command, or the name of a
+workflow, and it runs on that task's own branch in that task's own worktree,
+recorded in its own ledger with a transcript and cost accounting. It is
+repeatable, and it never changes the task's verdict — a done task comes back
+`done` and an aborted one comes back `aborted`. It is the one human action with
+a command line, because "rebase these six finished branches" is a batch.
+
 Every state transition is persisted before execution. If the daemon dies
 mid-step, restart recovery finalizes the interrupted attempt, verifies and
 stops orphan processes, and reruns the step without charging it as a failed
@@ -106,6 +117,8 @@ Human oversight is part of the workflow instead of an informal terminal habit:
   blocked step without discarding its branch or transcript.
 - Send a one-off repair agent into a blocked task's worktree when the fix is a
   file change, and still decide yourself whether the step then re-runs.
+- Follow a finished task up with one more agent run, shell command or workflow
+  in its existing worktree, as many times as it takes, before archiving it.
 - Use bulk selection to act on several eligible tasks while refusals remain
   selected for follow-up.
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -1,11 +1,24 @@
 # Scripting vincent
 
 Everything the TUI does goes through the same localhost API, and its data
-commands are subcommands too — `task add/ls/show/cancel`, `project`, `workflow`,
-`daemon`. The human actions that act on a running task (approve, reject, retry,
-skip, pause, resume, answer, archive) have no subcommand yet
-([#89](https://github.com/lezli01/vincent/issues/89)), so a script reaches those
-over the API; the [CLI reference](../reference/cli.md) is the full tree.
+commands are subcommands too — `task add/ls/show/cancel/follow-up`, `project`,
+`workflow`, `daemon`. The human actions that act on a running task (approve,
+reject, retry, repair, skip, pause, resume, answer, archive) have no subcommand
+yet ([#89](https://github.com/lezli01/vincent/issues/89)), so a script reaches
+those over the API; the [CLI reference](../reference/cli.md) is the full tree.
+
+[`task follow-up`](../reference/cli.md#vincent-task-follow-up) is the exception,
+and it is one because the thing it is for is a batch — running one more agent
+prompt, shell command or workflow in each of several finished tasks' own
+worktrees, before they are archived:
+
+```sh
+vincent task ls --state done --json |
+  jq -r '.[].id' |
+  while read -r id; do
+    vincent task follow-up "$id" --run 'git rebase origin/main'
+  done
+```
 
 That makes vincent scriptable three ways, in increasing order of control: the
 CLI with `--json`, the API with `curl`, and the SSE streams for anything that

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -256,12 +256,13 @@ selected on the board it acts on all of them; see
 | `p` | Pause / resume | `queued`, `running` / `paused` |
 | `c` | Cancel the task (asks first — a running step is killed) | most states |
 | `A` | Archive (asks first — the worktree is removed) | `done`, `aborted` |
+| `F` | Follow up — run more work in this finished task's worktree | `done`, `aborted` |
 
 `E` opens the failing step's prompt or command in your editor, and the override
 applies **to this task's snapshot only** — the workflow file is untouched.
 
-`R` opens the repair form instead of acting straight away; it is the only task
-action that needs something written, which is also why it is not offered for a
+`R` and `F` open a form instead of acting straight away; they are the two task
+actions that need something written, which is also why neither is offered for a
 bulk selection.
 
 What each action means in full is in
@@ -299,6 +300,53 @@ reason — whatever it exited with. That is the point: you look at the diff and
 entry under the blocked step, labelled `repair (ad-hoc agent)`, with its own
 transcript, tokens and cost; it is not an attempt of that step and does not use
 up its retries.
+
+## Following up on a finished task
+
+A `done` or `aborted` task still owns everything it made — its worktree, its
+branch, its commits — until you archive it. `F` is how you do one more thing in
+there without leaving vincent: rebase the branch onto a `main` that moved, add
+the commit a reviewer asked for, drop the stray file the agent left.
+
+| Key | Does |
+|---|---|
+| `↑` / `↓` | Move between the run form, what to run, and the agent / model / effort rows |
+| `enter` | Open the row under the cursor — the run-form list, the text field, or that row's picker |
+| `e` | Write the prompt or command in `$EDITOR` instead |
+| `ctrl+s` | Start the follow-up |
+| `esc` | Close without running anything — the draft is discarded |
+
+The top row picks what kind of run this is, and it decides what the row under it
+means:
+
+| Run form | The row below it is |
+|---|---|
+| `agent` | a prompt — prose, not a template |
+| `command` | a shell command, run under the daemon's shell (`/bin/sh`, or `pwsh` on Windows) |
+| `workflow` | a name picked from the registry, run against this task's worktree instead of a new one |
+
+Switching between the three keeps what you typed in each, so you can look at the
+command form and come back to your prompt.
+
+When the run finishes, the task returns to the state it came from — `done` to
+`done`, `aborted` to `aborted` — whatever it exited with. A follow-up never
+changes a task's verdict; if a successful one could promote an aborted task to
+`done`, any command that exits 0 could undo an abort you made on purpose.
+
+Follow-ups are repeatable, and each one is a **round**. The timeline heads them
+`↳ follow-up 1`, `↳ follow-up 2` under the workflow's own steps, with each step
+of the round named beneath — they are not steps of the workflow, and the
+workflow's `k/n` does not move.
+
+If a follow-up step fails the task blocks at that round, and the usual keys
+mean the usual things there: `r` re-runs the follow-up where it stopped, `R`
+repairs against *that* failure, `s` abandons the follow-up and puts the task
+back where it came from, `c` aborts. `E` is refused — edit-and-retry rewrites a
+step in the task's snapshot, and a follow-up is deliberately not in it.
+
+For more than one task at a time, use the command line:
+`vincent task follow-up <id> --run 'git rebase origin/main'`
+([CLI reference](../reference/cli.md#vincent-task-follow-up)).
 
 ## Answering a question
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -393,6 +393,7 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 | `/reject` | awaiting_gate | |
 | `/answer` | awaiting_input | `{ answers?, allow? }` |
 | `/archive` | done, aborted | `{ force? }` or `?force` |
+| `/follow_up` | done, aborted | `{ prompt? \| run? \| workflow?, agent?, model?, effort? }` — exactly one of the three; runs it in the task's existing worktree, then returns the task to the state it came from |
 
 Anything else returns `409` with `details.state`. See
 [Task lifecycle](task-lifecycle.md).
@@ -422,6 +423,48 @@ recorded as an ordinary step run under the reserved step id `__repair` at the
 blocked step's index, so `GET /v1/tasks/{id}/steps` returns it with its own
 transcript, tokens and cost — and the blocked step's retry budget is untouched
 by it.
+
+`/follow_up` runs one more piece of work in a **finished** task's worktree and
+branch, before you archive it. Exactly one of three fields says what to run:
+
+| Field | Runs |
+|---|---|
+| `prompt` | an agent, with this as its instructions |
+| `run` | a shell command, under the daemon's shell (`/bin/sh`, or `pwsh` on Windows) |
+| `workflow` | a workflow from the registry, against this task's worktree instead of a new one |
+
+Naming none of them, or more than one, is `400 validation_failed`. `prompt` and
+`run` are **literal text**, not templates — the daemon escapes them when it
+compiles the one-step workflow it runs, so a `{{` you type is two characters. If
+you want templating, put it in a workflow and name that.
+
+A `workflow` name is resolved through the registry now, not at admission: an
+unknown name, a workflow that cannot run on this host, one that fails validation
+once its `include`s are expanded, or a fan-out tree past `fan_out.max_depth`
+from this task's own depth are all `400`s. What validates is stored on the task
+and is what runs, so editing the file afterwards does not change the run in
+flight.
+
+The optional `agent` / `model` / `effort` behave exactly as `/repair`'s do,
+except that an explicit agent field on a step of a named workflow still wins —
+that is what a step field means. The response is the task, now `queued`, plus
+`warnings`.
+
+The run returns the task to the state it came from: `done` to `done`, `aborted`
+to `aborted`, whatever it exits with. A follow-up never changes a task's
+verdict. It is repeatable, and each run is a **round**: round *n* of a task
+whose workflow has *k* steps records its rows at `step_index = k + n - 1`, so
+`GET /v1/tasks/{id}/steps` returns them past the workflow's last index and
+`step_total` does not change. A row with `step_index >= step_total` is a
+follow-up row; render it as its own round rather than as a step of the workflow.
+
+A follow-up step that fails blocks the task at that index. `/retry` there
+re-runs the follow-up where it stopped, `/repair` runs an ad-hoc agent against
+that failure, `/skip` abandons the follow-up and restores the task's original
+state, and `/cancel` aborts — which means `done → aborted` is reachable while a
+follow-up is running. `/retry` with `prompt_override` or `run_override` is
+`400`: an override rewrites a step in the task's snapshot, and a follow-up is
+not in it.
 
 `/archive` is the one action whose response is not just the task. When it looks
 at the branch, it adds a `branch` object beside the task fields:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -299,8 +299,46 @@ after 10 seconds). Valid from `queued`, `running`, `awaiting_input`,
 `awaiting_gate`, `blocked` and `paused`; anything else exits 1 with the state it
 actually found.
 
-The remaining human actions — approve, reject, retry, skip, pause, resume,
-answer, archive — are TUI and API operations; see
+### `vincent task follow-up`
+
+```sh
+vincent task follow-up <id> (--prompt TEXT | --run CMD | --workflow NAME)
+                            [--agent NAME] [--model M] [--effort E] [--json]
+```
+
+Runs one more piece of work in a **finished** task's existing worktree and
+branch, before it is archived — recorded in that task's own ledger, with a step
+run, a transcript and cost accounting. Valid from `done` and `aborted` only;
+anything else exits 1 with the state it actually found.
+
+Exactly one of the three run flags is required, and they are mutually exclusive:
+
+| Flag | Runs |
+|---|---|
+| `--prompt` | an agent, with this text as its instructions |
+| `--run` | a shell command, under the daemon's shell (`/bin/sh`, or `pwsh` on Windows) |
+| `--workflow` | a workflow from the registry, against this task's worktree instead of a new one |
+
+`--agent`, `--model` and `--effort` apply to this run and outrank the task's own
+overrides and the workflow's `defaults:`; a value no catalog recognizes is a
+warning on stderr, not a failure.
+
+The command returns as soon as the run is queued — the scheduler admits it like
+anything else. When it ends the task returns to the state it came from: `done`
+to `done`, `aborted` to `aborted`, whatever the run did. A follow-up never
+changes a task's verdict, and it is repeatable.
+
+This is the one human action with a command line, and it has one because
+batches want one:
+
+```sh
+for id in 41 42 43 44 45 46; do
+  vincent task follow-up "$id" --run 'git rebase origin/main'
+done
+```
+
+The remaining human actions — approve, reject, retry, repair, skip, pause,
+resume, answer, archive — are TUI and API operations; see
 [the API reference](api.md#tasks).
 
 ## `vincent workflow`

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -43,6 +43,11 @@ restates it.
 
 Tasks are `queued` immediately on creation. There is no draft state.
 
+`done` and `aborted` have one more edge out of them that the diagram leaves off
+to stay readable: `follow_up` re-queues either of them to run more work in the
+task's existing worktree, and returns it to the state it came from. See
+[human actions](#human-actions).
+
 ## States
 
 | State | Meaning | Holds a slot? |
@@ -54,8 +59,8 @@ Tasks are `queued` immediately on creation. There is no draft state.
 | `awaiting_children` | A `fan_out` step's lanes are running as child tasks; this task owns no process | no |
 | `blocked` | A step failed and retries are exhausted; waiting for a human | no |
 | `paused` | You asked it to hold; takes effect at the next step boundary | no |
-| `done` | Every step succeeded. Worktree and branch retained for inspection | no |
-| `aborted` | You cancelled, or rejected terminally. Worktree and branch retained | no |
+| `done` | Every step succeeded. Worktree and branch retained for inspection. `follow_up` runs more work in them; `archive` tears them down | no |
+| `aborted` | You cancelled, or rejected terminally. Worktree and branch retained, and open to `follow_up` on the same terms as `done` | no |
 | `archived` | Terminal. Worktree removed, record kept. The branch is kept unless it has no commits past its base, in which case it is deleted ([`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)) | no |
 
 Three of these are worth dwelling on.
@@ -114,6 +119,32 @@ worktree existed re-blocks on the same reason without starting an agent, and one
 blocked because its agent CLI is missing has its repair fail the same way — both
 honest outcomes rather than a hidden filter.
 
+**A finished task is not finished with until you archive it.** `done` and
+`aborted` both keep the worktree, the branch and the commits, and `follow_up`
+is how you do one more piece of work in them without leaving vincent. You supply
+one of three things — an agent prompt, a shell command, or the name of a
+workflow from the registry — and the daemon runs it on the task's own branch, in
+the task's own worktree, recorded in the task's own ledger with a step run, a
+transcript, events and cost accounting.
+
+It decides nothing about the verdict: a done task comes back `done` and an
+aborted one comes back `aborted`, whatever the run did. That is deliberate — a
+command that exits 0 should not be able to reverse an abort you made on purpose.
+Follow-ups are repeatable, and each is a **round**: round 1's rows sit one past
+the workflow's last step index, round 2's one past that, so the timeline shows
+`↳ follow-up 1`, `↳ follow-up 2` rather than pretending the workflow grew.
+
+A follow-up step that fails blocks the task at the follow-up's own index. From
+there `retry` re-runs the follow-up where it stopped, `repair` runs an ad-hoc
+agent against *that* failure, `skip` abandons the follow-up and puts the task
+back where it came from, and `cancel` aborts. Edit-and-retry is refused there:
+an override rewrites a step in the task's snapshot, and a follow-up is
+deliberately not in it.
+
+One edge worth knowing about: because a follow-up's process is live while it
+runs, `cancel` during one aborts the task — so `done → aborted` is reachable,
+which it was not before follow-ups existed.
+
 ## Human actions
 
 | Action | Valid from | Effect |
@@ -130,10 +161,11 @@ honest outcomes rather than a hidden filter.
 | `reject` | awaiting_gate | Gate `rejected` → `blocked`, from which you can edit-and-retry an earlier step, skip, or abort |
 | `set priority` | queued, paused | Reorders scheduler admission |
 | `archive` | done, aborted | Removes the worktree → `archived`, then deletes the branch **only** if it has no commits past its base. Refuses on a dirty worktree unless forced — uncommitted work would be lost, and a refusal never reaches the branch |
+| `follow_up` | done, aborted | Runs one more piece of work — an agent prompt, a shell command or a registry workflow — in the task's existing worktree and branch → `queued`, and back to the state it came from when it ends. Repeatable; it never changes the task's verdict and never spends the workflow's retry budgets |
 
 In the TUI these are the action bar keys (`a`, `x`, `r`, `R`, `E`, `s`, `p`,
-`c`, `A`); over the API they are `POST /v1/tasks/{id}/{action}`; from the CLI,
-`vincent task cancel`.
+`c`, `A`, `F`); over the API they are `POST /v1/tasks/{id}/{action}`; from the
+CLI, `vincent task cancel` and `vincent task follow-up`.
 
 An action the current state does not allow returns `409` with `details.state`
 set to the state actually found — so a client branches on a value rather than

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -242,6 +242,7 @@ A unit of work delivered by running a workflow against a project.
 | `state` | §6 |
 | `current_step` | index into the snapshot's step list |
 | `pending_input` | normalized InputRequest (§7.4) while state is `awaiting_input`; cleared on answer, timeout, or process exit |
+| `pending_follow_up` | *Added 2026-08-25 (task 027).* The follow-up run a human asked for from `done` or `aborted` (§6): its compiled workflow, the run form and text it came from, the optional agent/model/effort, the **origin state** the task is returned to, the 1-based **round**, and the run's own **step cursor**. NULL when no follow-up is in flight |
 
 
 *Amended 2026-08-17 (task 014).* A snapshot may carry a whole fan-out tree: a
@@ -250,6 +251,21 @@ written in, so later edits to a lane's workflow file never reach a task that
 already exists. Nesting lives only at authoring time — each lane's steps become
 a **child task's own flat snapshot** when it is spawned, so `edit + retry`,
 `Marshal` and the locator never meet a nested workflow.
+
+*Amended 2026-08-25 (task 027).* A **follow-up run** (§6) never touches
+`workflow_snapshot`. The snapshot is the workflow as authored, and the only
+thing that rewrites it is `edit + retry`'s in-place override of a step that is
+already in it. A follow-up's steps live in `pending_follow_up` and its rows live
+past the snapshot's last index (§5.4), so `step_total`, "step k of n" and the
+task 017 graph go on describing the workflow somebody wrote rather than
+whatever an operator ran afterwards.
+
+`current_step` is left where the finished run put it — one past the last step —
+for the whole of a follow-up, and a follow-up is walked by the cursor inside
+`pending_follow_up` instead. Two cursors rather than one is what lets a `manual`
+gate or a `fan_out` inside a follow-up park the task and be resumed: the gate's
+`approve` advances the follow-up's cursor, and nothing has to decide which of
+two meanings `current_step` carries at that moment.
 
 ### 5.4 StepRun
 
@@ -288,6 +304,33 @@ index and render it as its own entry (§15) — displaying it as an attempt of t
 step would say the opposite of what happened. For the same reason a repair row
 is not visible in `.Steps` (§8.4) to any later step's prompt or guard: it is not
 a step of the workflow, and no workflow author wrote that key.
+
+*Amended 2026-08-25 (task 027).* A **follow-up run** (§6) is likewise a StepRun
+like any other, and is told apart by **position** rather than by a reserved id.
+Round *n* of a task whose snapshot has *k* steps writes every row it produces at
+`step_index = k + n - 1`. That cursor space is unused, so a row at or past *k*
+is unambiguously a follow-up row and its round is legible from the index alone.
+
+The consequences are all things that then need no new mechanism. Distinct rounds
+occupy distinct indices, so the same `(task_id, step_index, step_id, iteration)`
+key that keeps a repair out of a step's retry budget keeps round 2 out of round
+1's — a second follow-up is round 2, not attempt 2. `iteration` keeps its §7.8
+meaning, so a `loop` inside a follow-up numbers its passes normally. And the
+step ids are the ones the follow-up's author wrote, never rewritten, so `if:`
+guards and `.Steps` references *inside* a follow-up workflow keep working. The
+rows of a multi-step round share one index the way a `parallel` group's
+sub-steps do, and are told apart by step id.
+
+Clients must tell a follow-up row apart from an attempt of a workflow step —
+`step_index >= step_total` is the whole test — and render it as its own round
+(§15), never as step *k+1* of a workflow that did not grow.
+
+For `.Steps` (§8.4) a follow-up step sees the **original workflow's** rows and
+its **own round's**, and nothing else. Reading the finished run's results is the
+point of a follow-up; rows from *earlier* rounds are hidden for the reason a
+`__repair` row is, because nobody wrote them into the workflow being run. Where
+a follow-up workflow reuses an id from the original workflow, the round's own
+row shadows it.
 
 ## 6. Task lifecycle
 
@@ -375,6 +418,55 @@ fail with `agent_unavailable`, which is honest. Filtering `available_actions` by
 block reason would put a second, reason-shaped policy beside this section's
 state-shaped one for no behavioral gain.
 
+**Amended 2026-08-25 (task 027): `done` and `aborted` are no longer dead ends
+until `archive`.** A new human action, **`follow_up`**, is valid from those two
+states — the pair `archive` is already scoped to, and the two where the task's
+worktree, branch and commits still exist. It runs one more piece of work in that
+worktree: an agent prompt, a shell command, or a named workflow from the
+registry, chosen at the point of asking. Like a repair it is an ordinary
+admission — the scheduler admits it, both §11 caps apply — and the run lands in
+the task's own ledger with step runs, transcripts, events and token and cost
+accounting.
+
+**A follow-up decides nothing about the task's verdict.** `done` returns to
+`done` and `aborted` returns to `aborted`, whatever the run did. Promoting a
+successful follow-up on an aborted task to `done` was considered and rejected:
+it makes a human's abort reversible by any command that exits 0, and it buys
+nothing — an operator who wants the verdict changed already has the task where
+they can archive it. Returning an aborted-origin task is the engine action
+**`restore`** (`running → aborted`); a done-origin one uses the existing
+`complete`. `restore` exists for this and nothing else, because `cancel` is a
+human action and using it here would report a decision nobody made.
+
+**A failed follow-up step blocks the task**, at the follow-up's own row index,
+carrying that step's `block_reason`. The resolution set is the existing one, and
+the request is what tells the four apart: `retry` re-admits and re-runs the
+follow-up from its persisted cursor (the request survives the block *and* the
+retry — the one place `blocked → queued` keeps it); `repair` runs an ad-hoc
+agent against the follow-up's failure (§7.2); `skip` marks the request abandoned
+and the next admission restores `done` or `aborted` without running anything;
+`cancel` aborts and drains. `edit + retry` is refused with a 400: an override
+rewrites a step **in the snapshot** (§5.3), and a follow-up is deliberately not
+in the snapshot, so there is nothing there to rewrite.
+
+**`done → aborted` is therefore reachable**, which it was not before. `cancel`
+during a running follow-up kills the live process and aborts the task, because
+that is what `cancel` always means and `available_actions` cannot express "this
+one means something else right now" (the same reasoning that refused a
+`repairing` state above). A client author reading the older table would not
+expect that edge, which is why it is called out here.
+
+A follow-up is offered from `done` and `aborted` whatever the origin — no
+filtering, for the reason repair is unfiltered. An `aborted` task that never got
+a worktree has one created on the follow-up admission, or re-blocks on the same
+reason it would have. The one carve-out is a follow-up already abandoned with
+`skip`: it restores the origin state *before* worktree preparation runs, because
+a run with nothing left to do must not be able to block on creating a worktree it
+will never use.
+
+A follow-up is repeatable: a finished task can be followed up any number of
+times before it is archived, and each is a **round** with its own rows (§5.4).
+
 ### States
 
 | State | Meaning | Consumes a concurrency slot? |
@@ -406,6 +498,7 @@ state-shaped one for no behavioral gain.
 | `reject` | awaiting_gate | Gate step → `rejected`; → `blocked` (from which: retry earlier via edit, skip, or abort) |
 | `set priority` | queued, paused | Reorders scheduler admission |
 | `archive` | done, aborted | Removes worktree (warns if dirty — uncommitted changes would be lost; requires `force` in that case); → `archived` |
+| `follow_up` | done, aborted | *Added 2026-08-25 (task 027).* Runs one more piece of work — an agent prompt, a shell command or a registry workflow — in the task's existing worktree and branch (§7.2, §8.3, §8.6, §13.2); → `queued`, and back to the state it came from when the run ends. Repeatable; it decides nothing about the task's verdict and spends none of the workflow's retry budgets |
 
 **Amended 2026-08-24 (issue #127): an action that loses a race re-applies itself
 once, when the state it lost to still allows it.** Every action in this table is
@@ -563,6 +656,26 @@ stdout/stderr are captured to the step transcript.
   decision is about what a workflow author can declare ahead of time; the whole
   point of a repair is that nothing was declared ahead of time. It adds a human
   action, not a workflow field.
+- **A follow-up run spends none of the workflow's budgets, and blocks at its
+  own index.** *Added 2026-08-25 (task 027).* A `follow_up` (§6) on a finished
+  task writes its rows past the snapshot's last step index (§5.4), so the same
+  `(task_id, step_index, step_id, iteration)` count that keeps a repair out of a
+  step's budget keeps a follow-up out of every step's. After any number of
+  follow-ups, the original steps count exactly the attempts they would have
+  counted with none.
+
+  A follow-up step that fails with its budget spent blocks the task **at the
+  follow-up's row index**, carrying that step's reason. The resolution set is
+  this section's existing one: `retry` re-runs the follow-up from its own
+  cursor, `repair` runs an ad-hoc agent against the follow-up's failure —
+  reading that row as its failure context rather than the snapshot's — `skip`
+  abandons the follow-up and restores the task's origin state, and `cancel`
+  aborts. `edit + retry` is refused (§6): the follow-up is not in the snapshot
+  an override rewrites.
+
+  The agent and command forms carry `max_retries: 0`, the repair's reasoning
+  applied to the same shape of one-off run. A workflow-form follow-up uses the
+  budgets its own steps declare, because those are steps somebody wrote.
 
 ### 7.3 Fresh session per step
 
@@ -2289,7 +2402,7 @@ One Go binary, `vincent`:
 | `vincent service install / uninstall / status` | Registers OS-native autostart, always as the invoking user: launchd agent, systemd user unit, Windows Scheduled Task |
 | `vincent workflow ls / validate [file]` | Registry listing / YAML validation |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
-| `vincent task add / ls / show <id> / cancel <id>` | Thin API clients for scripting |
+| `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2) |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent doctor` | One diagnostic report: paths, daemon, log tail, database, agents, storage, task counts (§17). `--json` for scripting and bug reports; `--fix` (`--force`) reclaims orphaned worktrees and compacts the database. Exit 0 healthy · 1 problems found · 2 no daemon answered |
 | `vincent version` | Build info |
@@ -2298,6 +2411,14 @@ One Go binary, `vincent`:
 (`project add`, `task ls`) knowingly: `git gc` is the idiom users already have, and the
 scope spans two directory trees — worktrees and transcripts — so a `worktree` noun
 would have been wrong on the day it shipped.
+
+*Added 2026-08-25 (task 027).* `follow_up` is the one §6 human action with a
+command line. `retry`, `repair`, `skip` and `approve` are deliberately
+TUI-and-API only, and stay that way; the reason to break with them here is that
+"rebase these six finished branches onto current master" is a batch, and a batch
+wants a shell loop rather than six visits to a form. The unevenness that leaves
+is accepted rather than papered over — giving every human action a command line
+is separate work.
 
 *Added 2026-08-15 (task 006).* `vincent doctor` is the one data subcommand that
 still produces a **full report when no daemon answers**, the way
@@ -2862,6 +2983,31 @@ POST   /v1/tasks/{id}/repair           { prompt, agent?, model?, effort? }
                                         queued) plus `warnings`. The repair returns the task
                                         to `blocked` at the same step with the same
                                         `block_reason` whatever the agent exits with
+POST   /v1/tasks/{id}/follow_up        { prompt? | run? | workflow?, agent?, model?, effort? }
+                                        (done/aborted only; added 2026-08-25, task 027). Runs
+                                        one more piece of work in the task's existing worktree
+                                        and branch (§6, §7.2). **Exactly one** of `prompt`
+                                        (an agent run), `run` (a shell command, §8.3) and
+                                        `workflow` (a name from the registry) is required:
+                                        none says nothing to run, and two say two things with
+                                        no rule for which wins — both are 400s. `prompt` and
+                                        `run` are **literal text**, never text/template
+                                        sources; the daemon escapes them when it compiles the
+                                        one-step workflow it runs. A `workflow` name is
+                                        resolved, §8.1.1 platform-checked, include-expanded
+                                        (§7.9) and fan-out-resolved (§7.6, with the depth
+                                        budget re-derived from this task's own depth) now, and
+                                        stored as it will run — an unknown name, a workflow
+                                        that does not validate here, or a tree past its bounds
+                                        is a 400. The optional triple stands in for the step
+                                        level of §8.6's chain for this run and is validated
+                                        exactly as creation validates a task's: an
+                                        unregistered agent or a known-invalid model/effort is
+                                        a 400, a value no catalog knows rides back in
+                                        `warnings[]`. The response is the task (now queued)
+                                        plus `warnings`. The run returns the task to the state
+                                        it came from — done to done, aborted to aborted —
+                                        whatever it exits with
 POST   /v1/tasks/{id}/skip             (blocked/awaiting_gate only)
 POST   /v1/tasks/{id}/approve          (awaiting_gate only)
 POST   /v1/tasks/{id}/reject           (awaiting_gate only)
@@ -3021,6 +3167,10 @@ CREATE TABLE tasks (
   pending_repair_json TEXT,                   -- ad-hoc repair request awaiting its admission (§6, task 025, migration 0010);
                                               -- drained by the transition that returns the task to blocked, not by the
                                               -- step_run insert — an interrupted repair must re-run as a repair (§12.4)
+  pending_follow_up_json TEXT,                -- follow-up run awaiting or in flight (§6, task 027, migration 0012);
+                                              -- carries the compiled workflow, the origin state, the round and the run's
+                                              -- own step cursor. Survives the fail that blocks a follow-up step and the
+                                              -- retry that re-runs it; dropped by any transition into a settled state
   pending_input_json  TEXT,                   -- normalized InputRequest while state='awaiting_input' (§7.4)
   admit_not_before    TEXT,                   -- §11 admission hold; NULL = admissible now (task 003)
   queued_reason       TEXT,                   -- why a queued task waits on more than a slot; NULL = the ordinary queue
@@ -3200,6 +3350,24 @@ stream for the live tail.
    showing it as an attempt would tell the operator the opposite of what
    happened. It also does not make its index read as a `parallel` group, which
    is otherwise what more than one distinct step id at one index means.
+
+   **Follow-up popup (task 027, added 2026-08-25).** On a `done` or `aborted`
+   task, `F` opens a third popup of the same shape, with one row the others do
+   not have: a **run-form chooser** above the text, because the three forms of
+   §13.2's `follow_up` need choosing between and a key that had to guess between
+   "prompt" and "shell command" would guess wrong half the time. The chooser
+   decides what the row under it means — a prompt, a command, or a workflow
+   picked from `GET /v1/workflows` — and the same agent/model/effort pickers
+   follow. `ctrl+s` starts the run, `esc` closes and discards the draft. Like
+   repair it is excluded from bulk actions (task 011): the input is written for
+   one task, and the batch case is `vincent task follow-up` (§12.1).
+
+   The detail timeline must render a follow-up round as **its own tier**, headed
+   as a round rather than numbered as a step: its rows sit at
+   `step_index >= step_total` (§5.4), and numbering round 1 of a four-step
+   workflow "step 5" would say the workflow grew, which it did not (§5.3). A
+   round's steps share one index and are named individually beneath that header,
+   the way a `parallel` group's members are.
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → title → description (inline or
    `$EDITOR`) → fields → base branch (default prefilled) →
@@ -3549,11 +3717,14 @@ Task actions act on the selected task — or on the whole bulk selection when th
 is one (task 011) — and are offered only when the daemon reports them in
 `available_actions`: `p` pause/resume · `a` approve · `x` reject · `r`
 retry · `R` repair · `s` skip · `E` edit+retry in `$EDITOR` · `c` cancel · `A`
-archive. `x`
+archive · `F` follow up. `x`
 rejects because `r` is taken; `r` doubles as *retry connecting* while disconnected,
 where no task is reachable anyway. `R` (*added 2026-08-24, task 025*) opens the
 repair popup rather than acting immediately, and is excluded from bulk actions
-(task 011) — a repair needs a prompt written for one task. Destructive actions confirm inline: `c` kills a
+(task 011) — a repair needs a prompt written for one task. `F` (*added
+2026-08-25, task 027*) opens the follow-up popup on the same terms and for the
+same reason, and is likewise not a bulk action; the capital is free because `f`
+is the panel-scoped follow-output key. Destructive actions confirm inline: `c` kills a
 live process, `A` removes the worktree and a dirty one re-prompts for `force`.
 `set priority` (§6) has no key — priority is chosen in the new-task flow.
 

--- a/docs/tasks/027-follow-up-runs.md
+++ b/docs/tasks/027-follow-up-runs.md
@@ -1,0 +1,270 @@
+# 027 — Follow-up runs on a done or aborted task
+
+**Status:** ✅ done (9/9)
+**Opened:** 2026-08-25
+
+A new human action, `follow_up`, valid from `done` and `aborted` — the two
+unarchived non-terminal states, the pair `archive` is already scoped to. The
+operator supplies what to run in one of three forms (an agent prompt, a shell
+command, or a named workflow from the registry); the daemon runs it in the
+task's *existing* worktree and branch; the runs land in the task's own ledger
+with transcripts, events, and token and cost accounting. A follow-up is
+repeatable any number of times before the task is archived.
+
+The gap is the last mile of real work. `master` moved while the task ran and the
+branch needs a rebase; a review comment wants one more commit; the agent left a
+stray file that should go before the branch is opened as a PR. Every one of
+those meant leaving vincent, finding the worktree by hand, doing the work
+outside the daemon's ledger, and coming back only to press `archive`. Creating a
+new task is not the workaround: task creation allocates a fresh worktree and a
+fresh branch, and cannot reach the finished task's.
+
+Nothing recorded forbids this. §20's future-work list does not mention post-`done`
+work, `docs/history/v0-tasks.md` carries nothing binding on it, and task 025's
+decisions are about `repair`'s scope rather than about the lifecycle's other end.
+Two of 025's decisions are deliberately superseded below, each with its reasoning
+recorded; the rest are followed.
+
+## Decisions
+
+1. **2026-08-25 — The follow-up run is not a step of the workflow snapshot.**
+   The snapshot stays what §5.3 says it is — the workflow as authored, captured
+   at creation and mutated only by `edit + retry`'s in-place override of an
+   existing step. A follow-up appends nothing to it.
+
+   *Alternative rejected:* the issue's own proposal, appending real steps so
+   `current_step` advances past the original last index. It buys describability
+   at the price of every reader of the snapshot: the task 017 graph, the
+   `internal/api/snapcache.go` step totals and every "step k of n" a client
+   renders would start showing operator-appended steps on a finished task, and
+   repeat follow-ups would need an id-collision rule and a growth bound.
+
+2. **2026-08-25 — A follow-up round writes its rows at
+   `step_index = len(snapshot.Steps) + round - 1`.** The cursor space past the
+   end of the snapshot is unused; a row there is unambiguously a follow-up row,
+   and the round is legible from the index alone. Round 1 lands at `len(steps)`,
+   round 2 at `len(steps)+1`, and so on.
+
+   This is what makes full workflow fidelity affordable without a `step_runs`
+   migration. Distinct rounds occupy distinct indices, so `CountStepAttempts`'s
+   existing `(task_id, step_index, step_id, iteration)` key separates the rounds
+   for free, `ListStepRunsAt` reads one round, and `iteration` keeps its loop
+   meaning (§7.8) instead of being commandeered for the round number. Authored
+   step ids are preserved rather than rewritten, so `if:` guards and `.Steps`
+   references *inside* a follow-up workflow keep working.
+
+   *Alternative rejected:* one reserved `__follow_up` step id at a single index,
+   mirroring `__repair` (task 025 decision 3). It cannot describe a multi-step
+   workflow, and numbering rounds by `iteration` collides with a `loop` inside a
+   follow-up.
+
+3. **2026-08-25 — All three run forms ship, and the workflow form is the general
+   case.** The agent and command forms are compiled into a synthetic one-step
+   workflow at request time, so `runFollowUp` has exactly one shape to execute.
+   Every step type is allowed in a follow-up workflow — `agent`, `command`,
+   `manual`, `parallel`, `fan_out`, `condition`, `loop`, `break` — and `include`
+   is spliced at request time exactly as §7.9 splices it at creation.
+
+   This was chosen over the cheaper flat agent/command-only form knowing the
+   cost, which is recorded here rather than discovered later: `manual` and
+   `fan_out` inside a follow-up both need machinery that currently keys on
+   `current_step`, and decision 4 is what pays for them.
+
+4. **2026-08-25 — A follow-up has its own cursor, persisted in the request.**
+   The pending follow-up record carries the spliced follow-up workflow, the
+   round, the origin state, and a step cursor into that workflow. `current_step`
+   on the task is left where the finished run left it and is not used to walk a
+   follow-up; the row index of decision 2 is derived from it plus the round.
+
+   This is what makes `manual` and `fan_out` work inside a follow-up. A gate
+   parks in `awaiting_gate` as usual, and `approve`/`skip` advance the
+   *follow-up* cursor rather than `current_step`; a `fan_out` parks in
+   `awaiting_children` and the join resumes at the follow-up cursor. Crash-first
+   holds: the cursor is persisted as each step is finished with, so §12.4
+   recovery re-runs an interrupted follow-up step as a follow-up step.
+
+5. **2026-08-25 — A follow-up returns the task to the state it came from.**
+   `done → done`, `aborted → aborted`. A follow-up decides nothing about the
+   task's verdict — task 025 decision 1 applied at the other end of the
+   lifecycle.
+
+   *Alternative rejected:* the issue's proposal that a successful follow-up on
+   an `aborted` task promotes it to `done`. It makes a human's abort reversible
+   by any command that exits 0, and it is not needed: an operator who wants the
+   verdict changed has `follow_up` and then nothing left to say — the task is
+   already where they can archive it.
+
+6. **2026-08-25 — A failed follow-up step blocks the task, and the resolution
+   set is the existing one.** The task reaches `blocked` at the follow-up's
+   index carrying that step's block reason. `retry` re-admits and re-runs the
+   follow-up from its persisted cursor, because the request survives the block.
+   `skip` marks the request abandoned but keeps the recorded origin, so the next
+   admission restores `done` or `aborted` without running anything. `cancel`
+   aborts and drains, as every other way out of `blocked` does (task 025
+   decision 9's rule, with `retry` added to the list of transitions that keep
+   the request). `repair` is extended to read a follow-up row as its failure
+   context instead of no-oping — before this, `runRepair` warned and returned
+   whenever `current_step` was past the end of the snapshot, which is every
+   finished task and therefore every blocked follow-up.
+
+   One consequence found while building it and recorded rather than papered
+   over: `edit + retry` on a blocked follow-up is refused with a 400. An
+   override rewrites the step it names *in the snapshot* (§5.3), and decision 1
+   says a follow-up is not in the snapshot — so there is nothing there to
+   rewrite. A plain `retry` is the action that means what the operator wants.
+
+7. **2026-08-25 — One new engine action: `restore`, `running → aborted`.**
+   Returning a done-origin task is `complete`, which already exists. Returning
+   an aborted-origin one has no edge behind it — `cancel` is a human action and
+   would misreport what happened — so §6 gains one engine row, used for nothing
+   else.
+
+8. **2026-08-25 — `done → aborted` becomes reachable, and §6 says so.** `cancel`
+   during a running follow-up aborts the task, which was previously impossible
+   from `done`. This is not a special case to suppress: the follow-up's process
+   is live and `cancel` means what it always means (task 025 decision 2 —
+   `available_actions` cannot express "this cancel means something else right
+   now"). It is called out in the spec amendment because a client author reading
+   the old table would not expect it.
+
+9. **2026-08-25 — `.Steps` shows the original workflow's rows and the current
+   round's own, and nothing else.** Rows at indices below `len(steps)` stay
+   visible — a follow-up agent reading `.Steps.review.Output` is the point. Rows
+   from *earlier* follow-up rounds are hidden, the way `__repair` rows are
+   (task 025 decision 10): they are not steps anyone wrote into the workflow
+   being run. Where a follow-up workflow reuses an id from the original
+   workflow, the round's own row shadows it.
+
+10. **2026-08-25 — Every block reason and every origin is offered a follow-up;
+    no filtering.** An `aborted` task that never got a worktree — cancelled from
+    `queued`, or blocked on `branch_exists` before abort — has `ensureWorktree`
+    create the worktree and branch on the follow-up admission, or re-block on
+    the same reason. That is the right outcome reached by code that already
+    exists, and it is task 025 decision 8's reasoning unchanged.
+
+    The one carve-out is a follow-up a human has already abandoned with `skip`:
+    it restores the origin state *before* `ensureWorktree` runs, because a run
+    with nothing left to do must not be able to block on creating a worktree it
+    will never use.
+
+11. **2026-08-25 — `vincent task follow-up <id>` ships, superseding task 025
+    decision 12 for this action only.** That decision made repair TUI-and-API-only
+    because retry, skip and approve already were. The reason to break with it is
+    that "rebase these six finished branches onto current master" is a batch and
+    a batch wants a command line, which is not true of any of the four actions
+    025.12 covered. The unevenness this leaves — follow-up scriptable, retry and
+    repair not — is accepted rather than papered over; filling the gap for every
+    human action is a separate piece of work and out of scope here.
+
+12. **2026-08-25 — Agent, model and effort resolve request > task override >
+    workflow `defaults` > adapter default**, §8.6's chain with the request
+    standing in for the step level, exactly as `repair` applies it. For the
+    workflow form, an explicit step field in the follow-up workflow still wins
+    over the request, because that is what §8.6 already says about a step field.
+    The request is written into the steps that declare nothing of their own at
+    request time, before the compiled document is re-validated, so what
+    validates is what runs.
+
+## Work
+
+- [x] **027.1 — Store: migration `0012_follow_up.sql`, `FollowUpRequest`, the
+  `TaskChange` field and its drain rules, `SetPendingFollowUp`, `MaxStepIndex`.**
+  ✓ 2026-08-25
+- [x] **027.2 — `taskstate`: the `FollowUp` human action from `done` and
+  `aborted`, the `Restore` engine action, and the restated §6 table.**
+  ✓ 2026-08-25
+- [x] **027.3 — `taskrun`: `followup.go`, the `stepWalk` extraction that lets
+  one walk serve both cursors, `Runner.FollowUp`, and the follow-up-aware
+  `advance`/`Approve`/`Skip`/`Retry`.** ✓ 2026-08-25
+- [x] **027.4 — `taskrun`: `repair.go` reads a follow-up row as its failure
+  context, and `blindTo`/`precedes` learn decision 9's rule.** ✓ 2026-08-25
+- [x] **027.5 — API: `POST /v1/tasks/{id}/follow_up`, its DTO, its compile and
+  splice path, and its 400s and 409s.** ✓ 2026-08-25
+- [x] **027.6 — `apiclient`: `ActionFollowUp`, `FollowUpInput`, `FollowUp`.**
+  ✓ 2026-08-25
+- [x] **027.7 — TUI: the `F` binding, `followupform.go`, and the timeline's own
+  tier for a follow-up round.** ✓ 2026-08-25
+- [x] **027.8 — CLI: `vincent task follow-up <id>` with its three mutually
+  exclusive run forms.** ✓ 2026-08-25
+- [x] **027.9 — Tests across `taskstate`, `store`, `taskrun`, `api`, the TUI
+  live harness and the CLI e2e binary; spec amendments, derived documentation,
+  and an `m2` gate scenario.** ✓ 2026-08-25
+
+## Notes taken while building
+
+- **The migration is `0012`, not the brief's `0011`.** `0011_agent_quota.sql`
+  (task 026) landed first. Migrations are append-only, so the number is
+  whichever is free.
+- **The gate scenario is `m2` scenario 10, not the brief's 9.** Scenario 9 is
+  task 025's repair walkthrough.
+- **`execute`'s step walk was extracted rather than copied.** The ordinary
+  admission and the follow-up differ in exactly three things — where the walk
+  starts, where its rows go, and what ending it reaches — so `stepWalk` carries
+  those three as fields and `runSteps` is written once. Duplicating ninety lines
+  of guard, gate, group, loop, fan-out, retry, pause and interruption handling
+  is how the two would have drifted.
+- **The sweep decision 4's risk note asked for turned up no sixth `CurrentStep`
+  reader.** `advance`, `Approve`, `Skip`, the fan-out join and §12.4 recovery
+  were the five, and of those, recovery needed no change at all: it re-queues
+  through `Interrupt`, which is not a settled state, so the request survives and
+  the next admission is a follow-up admission by construction. `recordStepDecision`
+  was the one that had to learn the follow-up position, because a `skip` on a
+  blocked follow-up would otherwise have written its row against whatever the
+  snapshot holds at `current_step` — which for a finished task is nothing.
+- **A `fan_out` inside a follow-up shares one row index with the rest of its
+  round.** That is decision 2 working as intended, and it means a follow-up
+  workflow with *two* `fan_out` steps in one round cannot tell its lanes apart:
+  `tasks.parent_step_index` is an index, and both steps have the same one. It is
+  a pre-existing shape of that column rather than something this work
+  introduced — a `loop` containing a `fan_out` has the same property — and it is
+  left as it is rather than migrated for a case nobody has asked for.
+
+## Verification
+
+- `go test ./...` passes. The substance is in `internal/taskrun/followup_test.go`:
+  an agent follow-up changes the finished task's existing worktree and the
+  change is visible afterwards; a command follow-up runs under the daemon's
+  shell (§8.3) with no agent; a workflow follow-up runs every step through a
+  `manual` gate that parks and is approved, and a `loop` whose iterations keep
+  their §7.8 numbering; a `fan_out` inside a follow-up spawns lanes off the
+  finished task's branch, parks the parent, and joins on the follow-up's cursor.
+  Rows land at `len(steps)+round-1` with authored step ids, **the original
+  workflow's rows are untouched**, and a second follow-up is round 2 rather than
+  attempt 2 of round 1. A done task returns to `done` and an aborted task
+  returns to `aborted`, on success and on `skip`-after-block alike. A failed
+  follow-up step blocks at its own index; `retry` there re-runs the follow-up
+  and specifically does not complete the task; `edit + retry` there is refused;
+  `repair` there reads the follow-up row's failure rather than no-oping. An
+  interrupted follow-up re-runs as a follow-up from its persisted cursor after
+  recovery, as the same round rather than a new one. Earlier rounds' rows are
+  absent from a later round's `.Steps`.
+- `internal/store/followup_test.go` round-trips the request, proves it survives
+  the `fail` that blocks a follow-up step and the `retry` that re-runs it, that
+  every transition into a settled state drains it, that the cursor is written
+  without a transition, and that `MaxStepIndex` reports what numbers a round.
+- `internal/api/followup_test.go` covers 409 with `details.state` from every
+  non-`done`, non-`aborted` state; 400 on no run form, a blank one and two at
+  once; 400 on an unknown workflow name and an unregistered agent, each naming
+  its cause; 404 for a task that does not exist; the registry form's compile and
+  splice; and `available_actions` carrying `follow_up` exactly on those two
+  states.
+- `internal/tui/followuplive_test.go` runs against the real handlers over
+  `httptest`: the action bar offers follow-up only when the daemon does, `F`
+  opens the form, what was typed is what the daemon stores, each of the three
+  run forms posts its own field and no other, and the timeline renders a
+  follow-up row as `↳ follow-up 1` rather than as an attempt of a workflow step.
+- `internal/cli/commands_e2e_test.go` drives `vincent task follow-up` through
+  the real binary against a real daemon: the three run flags are mutually
+  exclusive and one is required, an unknown workflow is exit 1 naming the
+  workflow, `--prompt` carries `--agent` to the daemon and an unregistered one
+  is exit 1 naming the agent, and `--run` against an `aborted` task queues the
+  follow-up. Only one form is driven to a successful queue, because a second
+  would race the first follow-up's admission; the other two forms' success
+  paths are proven in `internal/api` and `internal/taskrun`.
+- `VINCENT_GATE_SCENARIO=10 ./scripts/m2-gate.sh` drives the whole path against
+  the fake agent: a task reaches `done`, a follow-up commits on that task's own
+  branch and lands as its own row past the snapshot's last index without
+  `step_total` growing, a second follow-up is round 2 at the next index, and
+  `follow_up` from `blocked` is a 409 carrying `details.state`.
+- `golangci-lint run ./...` is clean for `GOOS=windows`, `GOOS=darwin` and
+  `GOOS=linux`.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -40,6 +40,7 @@ the living engineering specification records implementation contracts.
 | [024](024-create-workflow-builtin.md) | `create-workflow`, a built-in that writes workflows | ✅ done (7/7) |
 | [025](025-ad-hoc-repair-agent.md) | An ad-hoc repair agent for a blocked step | ✅ done (8/8) |
 | [026](026-agent-quota-visibility.md) | Reporting each agent's usage-quota state in the daemon and TUI | ✅ done (7/7) |
+| [027](027-follow-up-runs.md) | Follow-up runs on a done or aborted task | ✅ done (9/9) |
 
 ## How to add and update a task document
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -207,6 +208,241 @@ func (s *Server) checkRepairSelection(
 	return warnings, ""
 }
 
+// followUpRequest is the §13.2 body of POST /v1/tasks/{id}/follow_up (§6,
+// task 027). Exactly one of the three run forms is required; the optional
+// triple stands in for the step level of §8.6's chain, exactly as a repair's
+// does.
+//
+// `prompt` and `run` are literal text — prose and a command line typed at a
+// form, not `text/template` sources — and the daemon escapes them when it
+// compiles the one-step workflow it runs. An operator who wants a template
+// writes a workflow and names it in `workflow`.
+type followUpRequest struct {
+	Prompt   *string `json:"prompt"`
+	Run      *string `json:"run"`
+	Workflow *string `json:"workflow"`
+	Agent    *string `json:"agent"`
+	Model    *string `json:"model"`
+	Effort   *string `json:"effort"`
+}
+
+// handleTaskFollowUp runs one more piece of work in a finished task's
+// existing worktree and branch, before it is archived (§13.2, task 027).
+//
+// Like repair and archive it cannot go through runAction: the response
+// carries the §8.2 catalog warnings the run's own agent selection can raise,
+// which taskAction has no room for. Everything the handler rejects is
+// something the person asking can act on — an empty form, an unknown
+// workflow, a follow-up workflow that does not validate here, a model no
+// catalog admits — and every one of them is a 400 rather than a task that
+// blocks six seconds later.
+func (s *Server) handleTaskFollowUp(w http.ResponseWriter, r *http.Request) {
+	var req followUpRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if s.deps.Runner == nil {
+		s.internalError(w, "task actions", errors.New("no task runner is configured"))
+		return
+	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	ctx := r.Context()
+	task, err := s.deps.Store.GetTask(ctx, id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, err.Error())
+		return
+	}
+	if err != nil {
+		s.internalError(w, "get task", err)
+		return
+	}
+	sel, msg := followUpForm(req)
+	if msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return
+	}
+	if sel.Agent != "" && s.deps.Agents != nil {
+		if _, known := s.deps.Agents.Get(sel.Agent); !known {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("unknown agent %q (available: %s)", sel.Agent,
+					strings.Join(s.deps.Agents.Names(), ", ")))
+			return
+		}
+	}
+	wf, msg := s.compileFollowUp(ctx, task, &sel)
+	if msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return
+	}
+	// §8.2 over the compiled document, step by step, exactly as task creation
+	// checks a snapshot: an unregistered agent and a known-invalid model or
+	// effort are 400s, and a value no catalog knows rides back as a warning.
+	warnings, cerr := s.checkTaskCatalog(wf, task)
+	if cerr != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "follow-up: "+cerr)
+		return
+	}
+	// The `on_input: require` gate (§7.4, task 013) over the same document. A
+	// follow-up workflow may declare it, and a run that could only block on
+	// `input_unsupported` is refused in front of the person asking.
+	if mismatch := s.inputMismatch(ctx, wf, task); mismatch != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "follow-up: "+mismatch)
+		return
+	}
+	updated, err := s.deps.Runner.FollowUp(ctx, id, sel)
+	if err != nil {
+		s.writeActionError(w, err)
+		return
+	}
+	resp := toTaskResponse(updated, s.snaps.get(updated.ID, updated.WorkflowSnapshot))
+	resp.Warnings = prefixEach(warnings, "follow-up: ")
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// followUpForm reads which of the three §6 run forms was asked for. Exactly
+// one is required: a request with none says nothing to run, and one with two
+// says two different things with no rule for which wins.
+func followUpForm(req followUpRequest) (store.FollowUpRequest, string) {
+	var (
+		out    store.FollowUpRequest
+		chosen []string
+	)
+	if v := strings.TrimSpace(ptrValue(req.Prompt)); v != "" {
+		out.Form, out.Prompt = store.FollowUpAgent, v
+		chosen = append(chosen, "prompt")
+	}
+	if v := strings.TrimSpace(ptrValue(req.Run)); v != "" {
+		out.Form, out.Run = store.FollowUpCommand, v
+		chosen = append(chosen, "run")
+	}
+	if v := strings.TrimSpace(ptrValue(req.Workflow)); v != "" {
+		out.Form, out.WorkflowName = store.FollowUpWorkflow, v
+		chosen = append(chosen, "workflow")
+	}
+	switch len(chosen) {
+	case 1:
+		out.Agent = strings.TrimSpace(ptrValue(req.Agent))
+		out.Model = strings.TrimSpace(ptrValue(req.Model))
+		out.Effort = strings.TrimSpace(ptrValue(req.Effort))
+		return out, ""
+	case 0:
+		return out, "a follow-up needs something to run: one of prompt, run or workflow"
+	default:
+		return out, fmt.Sprintf(
+			"a follow-up runs one thing: %s were all given", strings.Join(chosen, ", "))
+	}
+}
+
+// compileFollowUp turns a validated request into the document the engine will
+// run, and writes it into sel.Workflow.
+//
+// The workflow form goes through exactly what task creation puts a snapshot
+// through — include expansion (§7.9), fan-out tree resolution (§7.6) and a
+// re-parse against the daemon's real options — for the same reason: §5.3 says
+// execution uses a captured document precisely so that later edits to a
+// workflow file cannot mutate a run in flight, and a follow-up is a run.
+//
+// The one difference is the fan-out depth budget. A follow-up on a task that
+// is already a lane three levels down has three of `fan_out.max_depth`
+// already spent, so the budget is re-derived from the task's own depth rather
+// than taken whole (§7.6).
+func (s *Server) compileFollowUp(
+	ctx context.Context, task *store.Task, sel *store.FollowUpRequest,
+) (*workflow.Workflow, string) {
+	var (
+		wf  *workflow.Workflow
+		err error
+	)
+	if sel.Form == store.FollowUpWorkflow {
+		entry, found := s.deps.Workflows.Lookup(task.ProjectID, sel.WorkflowName)
+		if !found {
+			return nil, fmt.Sprintf("workflow %q not found for project %d",
+				sel.WorkflowName, task.ProjectID)
+		}
+		if !entry.Valid() {
+			return nil, fmt.Sprintf("workflow %q is invalid: %s",
+				sel.WorkflowName, entry.Errors.Error())
+		}
+		if mismatch := entry.Workflow.PlatformMismatch(workflow.HostPlatform()); mismatch != "" {
+			return nil, fmt.Sprintf("workflow %q cannot run here: %s", sel.WorkflowName, mismatch)
+		}
+		wf = entry.Workflow
+	} else {
+		wf, err = taskrun.CompileFollowUp(*sel)
+		if err != nil {
+			return nil, err.Error()
+		}
+	}
+	if workflow.HasInclude(wf) {
+		expanded, xerr := workflow.Expand(wf, workflow.ExpandOptions{
+			Lookup:   s.laneLookup(task.ProjectID),
+			Limits:   workflow.IncludeLimits{MaxDepth: s.deps.Config().Include.MaxDepth},
+			Override: agent.Level{Agent: sel.Agent, Model: sel.Model, Effort: sel.Effort},
+		})
+		if xerr != nil {
+			return nil, xerr.Error()
+		}
+		wf = expanded
+	}
+	if workflow.HasFanOut(wf) {
+		cfg := s.deps.Config()
+		depth, derr := s.taskDepth(ctx, task.ID)
+		if derr != nil {
+			return nil, derr.Error()
+		}
+		resolved, _, terr := workflow.ResolveTree(wf, s.laneLookup(task.ProjectID),
+			workflow.Limits{MaxDepth: cfg.FanOut.MaxDepth - depth, MaxTasks: cfg.FanOut.MaxTasks})
+		if terr != nil {
+			return nil, terr.Error()
+		}
+		wf = resolved
+	}
+	// The request stands in for the step level of §8.6's chain (decision 12),
+	// so it is written into the steps that declare nothing of their own —
+	// before the re-parse, so what validates is what runs.
+	taskrun.ApplyFollowUpSelection(wf.Steps, *sel)
+	out, merr := workflow.Marshal(wf)
+	if merr != nil {
+		return nil, merr.Error()
+	}
+	// Re-validate the finished document against the daemon's real options,
+	// not just its shape: the nesting rules an include can break are decidable
+	// only once the steps are in place, and the §8.1.1 platform list and
+	// §8.1 id rules are checked here rather than at run time.
+	revalidated, _, verr := workflow.Parse(out, s.deps.Workflows.Options())
+	if verr != nil {
+		return nil, fmt.Sprintf("the follow-up does not validate: %s", verr.Error())
+	}
+	sel.Workflow = string(out)
+	return revalidated, ""
+}
+
+// taskDepth is how many fan-out levels sit above a task: 0 for a root, 1 for
+// a lane of a root's fan_out step, and so on.
+func (s *Server) taskDepth(ctx context.Context, id int64) (int, error) {
+	ancestors, err := s.deps.Store.FanOutAncestors(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	return len(ancestors), nil
+}
+
+// prefixEach tags a list of warnings with where they came from, the way
+// checkRepairSelection tags its own.
+func prefixEach(in []string, prefix string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		out = append(out, prefix+v)
+	}
+	return out
+}
+
 // archiveRequest is the §13.2 body of POST /v1/tasks/{id}/archive. `force`
 // is also accepted as a query parameter, matching DELETE /v1/projects/{id}.
 type archiveRequest struct {
@@ -398,6 +634,17 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 		e, _ := taskrun.AsRepairPrompt(err)
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
 
+	// A follow-up that describes nothing to run, or an `edit + retry` aimed
+	// at a follow-up step, which is not part of the snapshot there is
+	// anything to edit in (task 027).
+	case isFollowUpRequest(err):
+		e, _ := taskrun.AsFollowUpRequest(err)
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
+
+	case isFollowUpOverride(err):
+		e, _ := taskrun.AsFollowUpOverride(err)
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
+
 	// A structurally mismatched answer is untranslatable to the live agent
 	// session; the request never reaches the task (§7.4, §13.2).
 	case isAnswerValidation(err):
@@ -428,6 +675,16 @@ func isStateConflict(err error) bool {
 
 func isOverrideMismatch(err error) bool {
 	_, ok := taskrun.AsOverrideMismatch(err)
+	return ok
+}
+
+func isFollowUpRequest(err error) bool {
+	_, ok := taskrun.AsFollowUpRequest(err)
+	return ok
+}
+
+func isFollowUpOverride(err error) bool {
+	_, ok := taskrun.AsFollowUpOverride(err)
 	return ok
 }
 

--- a/internal/api/followup_test.go
+++ b/internal/api/followup_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// finishedTask leaves a task in `done` or `aborted`, the two states a
+// follow-up may be asked for from (§6, task 027).
+func finishedTask(t *testing.T, h *taskHarness, end store.TaskState) taskResponse {
+	t.Helper()
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskRunning)
+	setState(t, h, task.ID, end)
+	return task
+}
+
+func followUpPath(id int64) string { return fmt.Sprintf("/v1/tasks/%d/follow_up", id) }
+
+// TestFollowUpFromDoneAndAborted: the request is persisted with the origin it
+// was launched from and the task re-queues, so the scheduler admits it like
+// anything else and both §11 caps apply.
+func TestFollowUpFromDoneAndAborted(t *testing.T) {
+	for _, origin := range []store.TaskState{store.TaskDone, store.TaskAborted} {
+		t.Run(string(origin), func(t *testing.T) {
+			h := newActionHarness(t)
+			task := finishedTask(t, h, origin)
+
+			resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID),
+				map[string]any{"prompt": "rebase onto main"})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("follow_up: %d %s", resp.StatusCode, body)
+			}
+			if got := decodeTask(t, body); got.State != string(store.TaskQueued) {
+				t.Errorf("state = %s, want queued", got.State)
+			}
+
+			stored, err := h.store.GetTask(t.Context(), task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			req := stored.PendingFollowUp
+			if req == nil {
+				t.Fatal("the follow-up request was not persisted")
+			}
+			if req.Form != store.FollowUpAgent || req.Prompt != "rebase onto main" {
+				t.Errorf("request = %+v, want the agent form carrying what was posted", req)
+			}
+			if req.Origin != origin {
+				t.Errorf("origin = %s, want %s — the task is returned there", req.Origin, origin)
+			}
+			if req.Round != 1 || req.Cursor != 0 {
+				t.Errorf("round/cursor = %d/%d, want 1/0", req.Round, req.Cursor)
+			}
+			if !strings.Contains(req.Workflow, "type: agent") {
+				t.Errorf("compiled workflow is not an agent step:\n%s", req.Workflow)
+			}
+			if stored.RetryCursorAt != nil {
+				t.Error("follow-up moved the retry cursor; the workflow's budgets are not its business (§7.2)")
+			}
+		})
+	}
+}
+
+// TestFollowUpIsOfferedExactlyOnDoneAndAborted: `available_actions` is derived
+// from §6, so the endpoint and the bar a client renders cannot disagree.
+func TestFollowUpIsOfferedExactlyOnDoneAndAborted(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	if hasAction(task.AvailableActions, "follow_up") {
+		t.Errorf("queued actions = %v, must not offer follow_up", task.AvailableActions)
+	}
+	for _, state := range taskstate.All {
+		setState(t, h, task.ID, state)
+		resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/tasks/%d", task.ID), nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("get task in %s: %d %s", state, resp.StatusCode, body)
+		}
+		want := state == store.TaskDone || state == store.TaskAborted
+		if got := decodeTask(t, body); hasAction(got.AvailableActions, "follow_up") != want {
+			t.Errorf("%s actions = %v, follow_up offered = %v, want %v",
+				state, got.AvailableActions, !want, want)
+		}
+	}
+}
+
+// TestFollowUpFromEveryOtherStateIs409: 409 with the state actually found, so
+// a client can re-issue against what it did not expect (§13.1).
+func TestFollowUpFromEveryOtherStateIs409(t *testing.T) {
+	for _, state := range taskstate.All {
+		if state == store.TaskDone || state == store.TaskAborted {
+			continue
+		}
+		t.Run(string(state), func(t *testing.T) {
+			h := newActionHarness(t)
+			task := queuedTask(t, h)
+			setState(t, h, task.ID, state)
+
+			resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID),
+				map[string]any{"prompt": "do it"})
+			if resp.StatusCode != http.StatusConflict {
+				t.Fatalf("follow_up from %s: %d %s, want 409", state, resp.StatusCode, body)
+			}
+			if got := decodeError(t, body).Details["state"]; got != string(state) {
+				t.Errorf("details.state = %v, want %s", got, state)
+			}
+		})
+	}
+}
+
+// TestFollowUpNeedsExactlyOneForm is decision 3's shape at the wire: none
+// says nothing to run, and two say two different things with no rule for
+// which wins.
+func TestFollowUpNeedsExactlyOneForm(t *testing.T) {
+	cases := map[string]map[string]any{
+		"none":                {},
+		"blank":               {"prompt": "   \n\t "},
+		"prompt and run":      {"prompt": "do it", "run": "git status"},
+		"run and workflow":    {"run": "git status", "workflow": "adhoc"},
+		"prompt and workflow": {"prompt": "do it", "workflow": "adhoc"},
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newActionHarness(t)
+			task := finishedTask(t, h, store.TaskDone)
+
+			resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID), payload)
+			wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+
+			stored, err := h.store.GetTask(t.Context(), task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			if stored.State != store.TaskDone || stored.PendingFollowUp != nil {
+				t.Errorf("a refused follow-up moved the task: %s, pending %+v",
+					stored.State, stored.PendingFollowUp)
+			}
+		})
+	}
+}
+
+// TestFollowUpRejectsAnUnknownWorkflow: the name is resolved against the
+// registry now rather than at admission, so the person asking is told.
+func TestFollowUpRejectsAnUnknownWorkflow(t *testing.T) {
+	h := newActionHarness(t)
+	task := finishedTask(t, h, store.TaskDone)
+
+	resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID),
+		map[string]any{"workflow": "no-such-workflow"})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if msg := decodeError(t, body).Message; !strings.Contains(msg, "no-such-workflow") {
+		t.Errorf("message = %q, want it to name the workflow", msg)
+	}
+}
+
+// TestFollowUpAcceptsARegistryWorkflow is the third form's happy path: the
+// built-in `adhoc` workflow is spliced and stored as it will run, so a later
+// edit to the file cannot mutate the run (§5.3).
+func TestFollowUpAcceptsARegistryWorkflow(t *testing.T) {
+	h := newActionHarness(t)
+	task := finishedTask(t, h, store.TaskDone)
+
+	resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID),
+		map[string]any{"workflow": "adhoc", "agent": "claude"})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("follow_up: %d %s", resp.StatusCode, body)
+	}
+	stored, err := h.store.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	req := stored.PendingFollowUp
+	if req == nil || req.Form != store.FollowUpWorkflow || req.WorkflowName != "adhoc" {
+		t.Fatalf("request = %+v, want the workflow form naming adhoc", req)
+	}
+	if req.Workflow == "" || !strings.Contains(req.Workflow, "steps:") {
+		t.Errorf("the compiled workflow was not stored:\n%s", req.Workflow)
+	}
+	// The request stands in for the step level of §8.6's chain, written into
+	// the steps that declare nothing of their own (decision 12).
+	if !strings.Contains(req.Workflow, "agent: claude") {
+		t.Errorf("the request's agent did not reach the compiled steps:\n%s", req.Workflow)
+	}
+}
+
+// TestFollowUpSelectionValidationMatchesCreation applies §8.2 to the run's own
+// triple the way POST /v1/tasks applies it to a task's: an unregistered agent
+// is a 400.
+func TestFollowUpSelectionValidationMatchesCreation(t *testing.T) {
+	h := newActionHarness(t)
+	task := finishedTask(t, h, store.TaskDone)
+
+	resp, body := h.doJSON(t, http.MethodPost, followUpPath(task.ID),
+		map[string]any{"prompt": "fix it", "agent": "not-an-adapter"})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if msg := decodeError(t, body).Message; !strings.Contains(msg, "not-an-adapter") {
+		t.Errorf("message = %q, want it to name the agent", msg)
+	}
+}
+
+// TestFollowUpOnAMissingTaskIs404 keeps the endpoint's not-found shape the
+// same as every other task action's.
+func TestFollowUpOnAMissingTaskIs404(t *testing.T) {
+	h := newActionHarness(t)
+	resp, body := h.doJSON(t, http.MethodPost, followUpPath(9999),
+		map[string]any{"prompt": "do it"})
+	wantError(t, resp, body, http.StatusNotFound, CodeNotFound)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -188,6 +188,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/reject", s.handleTaskReject)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/answer", s.handleTaskAnswer)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/archive", s.handleTaskArchive)
+	rt.handle(http.MethodPost, "/v1/tasks/{id}/follow_up", s.handleTaskFollowUp)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/steps", s.handleTaskSteps)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/steps/{run_id}/transcript", s.handleTranscript)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/diff", s.handleTaskDiff)

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -24,6 +24,10 @@ const (
 	ActionApprove = "approve"
 	ActionReject  = "reject"
 	ActionArchive = "archive"
+	// ActionFollowUp is a run a human launches on a finished task, before it
+	// is archived (task 027). The daemon offers it from `done` and `aborted`
+	// — the two states `archive` is offered from.
+	ActionFollowUp = "follow_up"
 )
 
 // RepairStepID is the reserved step id the daemon records an ad-hoc repair
@@ -105,6 +109,60 @@ func (c *Client) Repair(ctx context.Context, id int64, in RepairInput) (Task, []
 // repairResponse decodes the repair body, whose task fields sit at the top
 // level beside `warnings` — the shape archive's response uses for `branch`.
 type repairResponse struct {
+	Task
+	Warnings []string `json:"warnings"`
+}
+
+// Follow-up run forms (task 027 decision 3). Exactly one is set on a
+// FollowUpInput; the daemon compiles all three into one workflow.
+const (
+	FollowUpFormAgent    = "agent"
+	FollowUpFormCommand  = "command"
+	FollowUpFormWorkflow = "workflow"
+)
+
+// FollowUpInput is the body of POST /v1/tasks/{id}/follow_up (§6, task 027).
+// Exactly one of Prompt, Run and Workflow is required, and the optional
+// triple stands in for the step level of §8.6's chain for that run:
+// request > task override > the workflow's `defaults:` > adapter default.
+//
+// Prompt and Run are literal text, not templates: the daemon escapes them
+// when it compiles the one-step workflow it runs.
+type FollowUpInput struct {
+	Prompt   string `json:"prompt,omitempty"`
+	Run      string `json:"run,omitempty"`
+	Workflow string `json:"workflow,omitempty"`
+	Agent    string `json:"agent,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Effort   string `json:"effort,omitempty"`
+}
+
+// FollowUp runs one more piece of work in a finished task's existing worktree
+// and branch, before it is archived (§6, task 027). The task re-queues, runs
+// what was asked for, and returns to the state it came from — `done` to
+// `done`, `aborted` to `aborted`, whatever the run did. A follow-up decides
+// nothing about a task's verdict.
+//
+// Its rows land past the workflow's last step index rather than inside the
+// snapshot, so a client tells a follow-up row from a workflow step by
+// `step_index >= step_total`.
+//
+// The second return carries the §8.2 catalog warnings the selection raised,
+// the way task creation reports them. A request naming none of the three run
+// forms, or more than one, is a 400; so is an unknown workflow name and a
+// follow-up workflow that does not validate.
+func (c *Client) FollowUp(ctx context.Context, id int64, in FollowUpInput) (Task, []string, error) {
+	var out followUpResponse
+	path := fmt.Sprintf("/v1/tasks/%d/%s", id, ActionFollowUp)
+	if err := c.post(ctx, path, in, &out); err != nil {
+		return Task{}, nil, err
+	}
+	return out.Task, out.Warnings, nil
+}
+
+// followUpResponse decodes the follow-up body, whose task fields sit at the
+// top level beside `warnings` — the shape repair's and archive's use.
+type followUpResponse struct {
 	Task
 	Warnings []string `json:"warnings"`
 }

--- a/internal/cli/commands_e2e_test.go
+++ b/internal/cli/commands_e2e_test.go
@@ -143,6 +143,66 @@ func TestCommandsAgainstLiveDaemon(t *testing.T) {
 		}
 	})
 
+	// `task follow-up` is the one §6 human action with a command line (task
+	// 027 decision 11), and the task cancelled just above is `aborted` — one
+	// of the two states it is valid from.
+	t.Run("task follow-up", func(t *testing.T) {
+		// Exactly one run form. Cobra refuses the other combinations locally,
+		// so the daemon never sees a request that says two things at once.
+		for _, args := range [][]string{
+			{"task", "follow-up", taskID},
+			{"task", "follow-up", taskID, "--prompt", "do it", "--run", "git --version"},
+			{"task", "follow-up", taskID, "--run", "git --version", "--workflow", "adhoc"},
+			{"task", "follow-up", taskID, "--prompt", "do it", "--workflow", "adhoc"},
+		} {
+			out, code := runVincent(t, dataDir, cfgDir, args...)
+			if code == 0 {
+				t.Errorf("%v: code 0, want a refusal (out %q)", args[2:], out)
+			}
+		}
+
+		// A workflow name the registry does not have is a rejected request,
+		// not a broken command: the daemon answered and said no.
+		out, code := runVincent(t, dataDir, cfgDir,
+			"task", "follow-up", taskID, "--workflow", "no-such-workflow")
+		if code != 1 {
+			t.Errorf("task follow-up with an unknown workflow: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "no-such-workflow") {
+			t.Errorf("the refusal does not name the workflow: %q", out)
+		}
+
+		// --prompt reaches the daemon too, and carries the §8.6 triple with
+		// it. An agent the registry does not have is the cheapest proof of
+		// both that does not depend on the task's state — the selection is
+		// validated in front of the state check, so this says nothing about
+		// where the task happens to be by now.
+		out, code = runVincent(t, dataDir, cfgDir,
+			"task", "follow-up", taskID, "--prompt", "do it", "--agent", "no-such-agent")
+		if code != 1 {
+			t.Errorf("task follow-up with an unknown agent: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "no-such-agent") {
+			t.Errorf("the refusal does not name the agent: %q", out)
+		}
+
+		out, code = runVincent(t, dataDir, cfgDir,
+			"task", "follow-up", taskID, "--run", "git --version", "--json")
+		if code != 0 {
+			t.Fatalf("task follow-up --run: code %d, out %q", code, out)
+		}
+		var queued struct {
+			ID    int64  `json:"id"`
+			State string `json:"state"`
+		}
+		if err := json.Unmarshal([]byte(out), &queued); err != nil {
+			t.Fatalf("task follow-up --json is not JSON: %v (%q)", err, out)
+		}
+		if queued.ID == 0 {
+			t.Errorf("follow-up response = %+v, want the task", queued)
+		}
+	})
+
 	t.Run("a rejected request exits 1", func(t *testing.T) {
 		// The daemon answered and said no. That is exit 1 — distinct from
 		// exit 2, which means nothing answered at all.

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -16,7 +16,8 @@ func newTaskCmd() *cobra.Command {
 		Use:   "task",
 		Short: "Create, inspect and cancel tasks",
 	}
-	cmd.AddCommand(newTaskAddCmd(), newTaskLsCmd(), newTaskShowCmd(), newTaskCancelCmd())
+	cmd.AddCommand(newTaskAddCmd(), newTaskLsCmd(), newTaskShowCmd(), newTaskCancelCmd(),
+		newTaskFollowUpCmd())
 	return cmd
 }
 
@@ -287,6 +288,75 @@ func newTaskShowCmd() *cobra.Command {
 			})
 		},
 	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+// newTaskFollowUpCmd is the one human action of §6 with a command line
+// (task 027 decision 11). Retry, repair, skip and approve are deliberately
+// TUI-and-API only (task 025 decision 12) and stay that way; this one breaks
+// with them because "rebase these six finished branches onto current master"
+// is a batch, and a batch wants a shell loop rather than six visits to a
+// form. The unevenness that leaves is accepted rather than papered over.
+func newTaskFollowUpCmd() *cobra.Command {
+	var (
+		prompt   string
+		run      string
+		workflow string
+		agent    string
+		model    string
+		effort   string
+	)
+	cmd := &cobra.Command{
+		Use:   "follow-up <id>",
+		Short: "Run more work in a finished task's worktree, before it is archived",
+		Long: "Run one more piece of work in a done or aborted task's existing worktree and " +
+			"branch, recorded in that task's own ledger. Exactly one of --prompt, --run and " +
+			"--workflow says what to run. The task returns to the state it came from.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("task id must be a number: %q", args[0])
+			}
+			in := apiclient.FollowUpInput{
+				Prompt: prompt, Run: run, Workflow: workflow,
+				Agent: agent, Model: model, Effort: effort,
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, warnings, err := c.FollowUp(ctx, id, in)
+				if err != nil {
+					// A 409 here is the FSM refusing the action (§6) — the
+					// task is neither done nor aborted — which is a rejected
+					// request, not a broken one.
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), t)
+				}
+				if _, err := fmt.Fprintf(cmd.OutOrStdout(),
+					"task %d is now %s: the follow-up is queued\n", t.ID, t.State); err != nil {
+					return err
+				}
+				for _, w := range warnings {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning:", w)
+				}
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&prompt, "prompt", "", "Run an agent with this prompt")
+	cmd.Flags().StringVar(&run, "run", "", "Run this shell command (§8.3: /bin/sh, or pwsh on Windows)")
+	cmd.Flags().StringVar(&workflow, "workflow", "", "Run this registry workflow")
+	cmd.Flags().StringVar(&agent, "agent", "", "Agent for the run (§8.6, request level)")
+	cmd.Flags().StringVar(&model, "model", "", "Model for the run (§8.6, request level)")
+	cmd.Flags().StringVar(&effort, "effort", "", "Effort for the run (§8.6, request level)")
+	// One thing runs. Cobra refuses the combination locally so the daemon
+	// never sees a request that says two things at once, and the message
+	// names the flags rather than the JSON fields behind them.
+	cmd.MarkFlagsMutuallyExclusive("prompt", "run", "workflow")
+	cmd.MarkFlagsOneRequired("prompt", "run", "workflow")
 	jsonFlag(cmd)
 	return cmd
 }

--- a/internal/store/followup.go
+++ b/internal/store/followup.go
@@ -1,0 +1,59 @@
+package store
+
+// The pending follow-up request (task 027, spec §6/§14). Two writes that are
+// deliberately *not* transitions live here: recording a follow-up's own step
+// cursor as it advances, and reading how many rounds a task has already had.
+//
+// Neither changes state, so neither goes through TransitionTask — the same
+// separation SetTaskProgress already makes for `current_step`.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SetPendingFollowUp writes a task's pending follow-up request without
+// changing its state — the actor persisting the run's own step cursor as it
+// advances through the follow-up workflow (task 027 decision 4).
+//
+// A nil or empty request clears the column. It emits no event: the follow-up
+// cursor is not `current_step`, no client renders it, and a durable event per
+// step of a follow-up would double the stream for something nobody reads. The
+// state changes a follow-up produces — the block, the restore — carry their
+// own events as usual.
+func (s *Store) SetPendingFollowUp(ctx context.Context, id int64, req *FollowUpRequest) error {
+	value, err := marshalFollowUp(req)
+	if err != nil {
+		return err
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET pending_follow_up_json = ?, updated_at = ? WHERE id = ?`,
+		value, formatTime(time.Now()), id)
+	if err != nil {
+		return fmt.Errorf("set task %d follow-up: %w", id, err)
+	}
+	return oneRowAffected(res, fmt.Sprintf("task %d", id))
+}
+
+// MaxStepIndex is the highest step_index this task has any row at, and false
+// when it has no rows at all.
+//
+// It is what numbers a follow-up round. Rows at indices below the snapshot's
+// length are the workflow's own; anything at or past it is a previous
+// follow-up round, and the next round is one past the highest (decision 2).
+// Deriving it from the rows rather than storing a counter keeps the round
+// numbering and the rows it places one truth — a stored counter that drifted
+// would put two rounds at one index and merge their attempt numbering.
+func (s *Store) MaxStepIndex(ctx context.Context, taskID int64) (int, bool, error) {
+	var highest sql.NullInt64
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT MAX(step_index) FROM step_runs WHERE task_id = ?`, taskID).Scan(&highest); err != nil {
+		return 0, false, fmt.Errorf("max step index for task %d: %w", taskID, err)
+	}
+	if !highest.Valid {
+		return 0, false, nil
+	}
+	return int(highest.Int64), true, nil
+}

--- a/internal/store/followup_test.go
+++ b/internal/store/followup_test.go
@@ -1,0 +1,197 @@
+package store
+
+import "testing"
+
+// followUpDoc is the compiled workflow a follow-up request carries. Its
+// content is not this file's business — the store neither parses nor
+// validates it — so one is fixed rather than varied.
+const followUpDoc = "name: follow-up\nsteps:\n  - id: follow-up\n    type: command\n    run: git status\n"
+
+// finishedTask is a task at `done` or `aborted`, which are the only two
+// states a follow-up is asked for from (§6, task 027).
+func finishedTask(t *testing.T, s *Store, projectID int64, end TaskState) *Task {
+	t.Helper()
+	task := newTask(projectID, "finished", TaskQueued)
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	out, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, end, TaskChange{})
+	if err != nil {
+		t.Fatalf("finish as %s: %v", end, err)
+	}
+	return out
+}
+
+func followUpRequest(origin TaskState) FollowUpRequest {
+	return FollowUpRequest{
+		Form: FollowUpAgent, Prompt: "rebase onto main", Workflow: followUpDoc,
+		Agent: "claude", Model: "sonnet", Effort: "high",
+		Origin: origin, Round: 1,
+	}
+}
+
+// TestPendingFollowUpRoundTrips: the request written with the done → queued
+// transition is what the admitted actor reads back, and it survives a reload.
+func TestPendingFollowUpRoundTrips(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := finishedTask(t, s, p.ID, TaskDone)
+
+	req := followUpRequest(TaskDone)
+	queued, _, err := s.TransitionTask(t.Context(), task.ID, TaskDone, TaskQueued,
+		TaskChange{PendingFollowUp: &req})
+	if err != nil {
+		t.Fatalf("follow-up transition: %v", err)
+	}
+	if queued.PendingFollowUp == nil || *queued.PendingFollowUp != req {
+		t.Fatalf("pending follow-up = %+v, want %+v", queued.PendingFollowUp, req)
+	}
+	running, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	if running.PendingFollowUp == nil || *running.PendingFollowUp != req {
+		t.Fatalf("pending follow-up after admission = %+v, want it intact", running.PendingFollowUp)
+	}
+	reloaded, err := s.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if reloaded.PendingFollowUp == nil || *reloaded.PendingFollowUp != req {
+		t.Fatalf("pending follow-up did not survive a reload: %+v", reloaded.PendingFollowUp)
+	}
+}
+
+// TestPendingFollowUpSurvivesTheBlockAndTheRetry is the drain rule that is
+// neither the override's nor the repair's (task 027 decision 6): the request
+// is what makes a `retry` on a blocked follow-up re-run the follow-up rather
+// than the workflow, so it must outlive both moves.
+func TestPendingFollowUpSurvivesTheBlockAndTheRetry(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := finishedTask(t, s, p.ID, TaskDone)
+	req := followUpRequest(TaskDone)
+
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskDone, TaskQueued,
+		TaskChange{PendingFollowUp: &req}); err != nil {
+		t.Fatalf("follow-up: %v", err)
+	}
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskQueued, TaskRunning, TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	reason := "nonzero_exit"
+	blocked, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, TaskBlocked,
+		TaskChange{BlockReason: &reason})
+	if err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+	if blocked.PendingFollowUp == nil {
+		t.Fatal("the request was dropped by the block; retry could not re-run the follow-up")
+	}
+	requeued, _, err := s.TransitionTask(t.Context(), task.ID, TaskBlocked, TaskQueued, TaskChange{})
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if requeued.PendingFollowUp == nil {
+		t.Fatal("the request was dropped by the retry; the re-admission would complete the task")
+	}
+}
+
+// TestPendingFollowUpDrainsOnEverySettledEnd is the other half of decision 6.
+// One rule covers all three ways a follow-up ends — the Complete that returns
+// a done-origin run, the Restore that returns an aborted-origin one, and the
+// cancel that abandons either — so no caller can leave a stale request on a
+// finished task for the next follow-up to inherit.
+func TestPendingFollowUpDrainsOnEverySettledEnd(t *testing.T) {
+	for _, end := range []TaskState{TaskDone, TaskAborted} {
+		t.Run(string(end), func(t *testing.T) {
+			s := openTest(t)
+			p := testProject(t, s, "p")
+			task := finishedTask(t, s, p.ID, TaskDone)
+			req := followUpRequest(TaskDone)
+
+			if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskDone, TaskQueued,
+				TaskChange{PendingFollowUp: &req}); err != nil {
+				t.Fatalf("follow-up: %v", err)
+			}
+			if _, _, err := s.TransitionTask(t.Context(), task.ID,
+				TaskQueued, TaskRunning, TaskChange{}); err != nil {
+				t.Fatalf("admit: %v", err)
+			}
+			out, _, err := s.TransitionTask(t.Context(), task.ID, TaskRunning, end, TaskChange{})
+			if err != nil {
+				t.Fatalf("end as %s: %v", end, err)
+			}
+			if out.PendingFollowUp != nil {
+				t.Errorf("reaching %s left the request behind: %+v", end, out.PendingFollowUp)
+			}
+		})
+	}
+}
+
+// TestSetPendingFollowUpWritesTheCursor: the actor persists its own cursor as
+// it advances, without a transition — the same separation SetTaskProgress
+// makes for `current_step` (decision 4).
+func TestSetPendingFollowUpWritesTheCursor(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := finishedTask(t, s, p.ID, TaskAborted)
+	req := followUpRequest(TaskAborted)
+
+	if _, _, err := s.TransitionTask(t.Context(), task.ID, TaskAborted, TaskQueued,
+		TaskChange{PendingFollowUp: &req}); err != nil {
+		t.Fatalf("follow-up: %v", err)
+	}
+	req.Cursor = 2
+	if err := s.SetPendingFollowUp(t.Context(), task.ID, &req); err != nil {
+		t.Fatalf("SetPendingFollowUp: %v", err)
+	}
+	got, err := s.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.PendingFollowUp == nil || got.PendingFollowUp.Cursor != 2 {
+		t.Fatalf("cursor = %+v, want 2", got.PendingFollowUp)
+	}
+	if got.State != TaskQueued {
+		t.Errorf("state = %s, want queued — writing the cursor is not a transition", got.State)
+	}
+	if err := s.SetPendingFollowUp(t.Context(), task.ID, nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got, err = s.GetTask(t.Context(), task.ID); err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.PendingFollowUp != nil {
+		t.Error("a nil request did not clear the column")
+	}
+}
+
+// TestMaxStepIndex is what numbers a follow-up round (decision 2): the round
+// is derived from the rows it will sit beside, never from a counter that
+// could drift away from them.
+func TestMaxStepIndex(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := finishedTask(t, s, p.ID, TaskDone)
+
+	if _, ok, err := s.MaxStepIndex(t.Context(), task.ID); err != nil || ok {
+		t.Fatalf("MaxStepIndex on a task with no rows = %v, %v; want absent", ok, err)
+	}
+	for _, index := range []int{0, 1, 3} {
+		run := &StepRun{
+			TaskID: task.ID, StepIndex: index, StepID: "s", StepType: "command",
+			Attempt: 1, State: StepSucceeded,
+		}
+		if err := s.CreateStepRun(t.Context(), run); err != nil {
+			t.Fatalf("CreateStepRun: %v", err)
+		}
+	}
+	got, ok, err := s.MaxStepIndex(t.Context(), task.ID)
+	if err != nil || !ok || got != 3 {
+		t.Fatalf("MaxStepIndex = %d, %v, %v; want 3", got, ok, err)
+	}
+}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 11
+const latestSchemaVersion = 12
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0012_follow_up.sql
+++ b/internal/store/migrations/0012_follow_up.sql
@@ -1,0 +1,31 @@
+-- 0012_follow_up: the pending follow-up run request (task 027, spec §6/§14).
+--
+-- Third of the "a handler wrote this while the task held no step_runs row"
+-- columns, after pending_override_json and pending_repair_json, and it works
+-- the same way: the API validates and persists, the actor the admission
+-- produces reads it and runs the work (phase 2 decision).
+--
+-- What it carries beyond the repair request is a **cursor**. A follow-up may
+-- be a whole workflow — gates, loops, fan-outs and all — and decision 4 gives
+-- it a step cursor of its own rather than commandeering `current_step`, which
+-- stays where the finished run left it. The cursor is persisted as each step
+-- succeeds, so §12.4 recovery re-runs an interrupted follow-up step as a
+-- follow-up step rather than silently completing the task.
+--
+-- No step_runs change accompanies this either. A follow-up round writes its
+-- rows at `step_index = len(snapshot.steps) + round - 1` (decision 2): the
+-- cursor space past the end of the snapshot is unused, so a row there is
+-- unambiguously a follow-up row, distinct rounds occupy distinct indices, and
+-- CountStepAttempts' existing (task_id, step_index, step_id, iteration) key
+-- separates the rounds for free — leaving `iteration` its §7.8 loop meaning
+-- and preserving the authored step ids that `if:` guards and `.Steps` refer
+-- to.
+--
+-- Draining differs from the repair request's again. A repair is drained by
+-- the re-block that ends it; a follow-up survives `fail` (which blocks it)
+-- and `retry` (which re-runs it), and is dropped by any transition into a
+-- settled state — the Complete or Restore that returns the task to its
+-- origin, and the `cancel` that ends it (decision 6). `skip` neither keeps it
+-- running nor drops it: it sets `abandoned`, so the next admission restores
+-- the origin state without running anything.
+ALTER TABLE tasks ADD COLUMN pending_follow_up_json TEXT; -- NULL = no follow-up requested

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -107,6 +107,14 @@ type Task struct {
 	// `blocked`; leaving `blocked` any other way drops it, so a request can
 	// never outlive the block it was made about.
 	PendingRepair *RepairRequest
+	// PendingFollowUp is a follow-up run a human asked for from `done` or
+	// `aborted` (§6, task 027). Unlike a repair request it carries a cursor
+	// into its own workflow, because a follow-up may be a whole multi-step
+	// workflow and `current_step` stays where the finished run left it
+	// (decision 4). It survives the block a failed follow-up step produces
+	// and the retry that re-runs it, and is dropped by whatever returns the
+	// task to a settled state.
+	PendingFollowUp *FollowUpRequest
 	// PendingInputJSON is the normalized InputRequest while the task is
 	// awaiting_input (§7.4); "" otherwise. TransitionTask clears it on any
 	// transition out of awaiting_input.
@@ -245,6 +253,75 @@ type RepairRequest struct {
 
 // Empty reports whether the request carries no work to do.
 func (r RepairRequest) Empty() bool { return r.Prompt == "" }
+
+// Follow-up run forms (§6, task 027 decision 3). The form says what the
+// operator asked for; the daemon compiles all three into one workflow, so
+// the engine has exactly one shape to execute.
+const (
+	// FollowUpAgent is a free-form agent prompt.
+	FollowUpAgent = "agent"
+	// FollowUpCommand is a shell command, run under the daemon's shell
+	// (§8.3).
+	FollowUpCommand = "command"
+	// FollowUpWorkflow is a named workflow from the registry, run against the
+	// finished task's worktree instead of a new one.
+	FollowUpWorkflow = "workflow"
+)
+
+// FollowUpRequest is one follow-up run a human asked for from `done` or
+// `aborted` (§6, task 027): what to run, how to select an agent for it, where
+// the task must be returned to, and how far through it the daemon has got.
+//
+// Prompt and Run are literal text, never `text/template` sources, for the
+// reason RepairRequest.Prompt is: they are typed at a form, and §8.4 renders
+// with `missingkey=error`. The daemon escapes them when it compiles Workflow.
+//
+// Workflow is the *spliced* follow-up workflow — includes expanded and
+// fan-out lanes resolved, exactly as a task's snapshot is at creation (§7.9,
+// §7.6). It is stored rather than re-derived so a registry edit mid-follow-up
+// cannot mutate a run in flight, which is §5.3's rule applied to this second
+// cursor.
+type FollowUpRequest struct {
+	// Form is one of FollowUpAgent, FollowUpCommand or FollowUpWorkflow. It
+	// is what the operator asked for, kept for clients to render; execution
+	// reads Workflow alone.
+	Form string `json:"form"`
+	// Prompt, Run and WorkflowName are what was typed, one per form.
+	Prompt       string `json:"prompt,omitempty"`
+	Run          string `json:"run,omitempty"`
+	WorkflowName string `json:"workflow_name,omitempty"`
+	// Workflow is the compiled, spliced follow-up workflow's YAML.
+	Workflow string `json:"workflow"`
+	// Agent, Model and Effort stand in for the step level of §8.6's chain,
+	// exactly as a repair's do — except that an explicit field on a step of a
+	// workflow-form follow-up still outranks them, because that is what §8.6
+	// already says about a step field (decision 12).
+	Agent  string `json:"agent,omitempty"`
+	Model  string `json:"model,omitempty"`
+	Effort string `json:"effort,omitempty"`
+	// Origin is the state the follow-up was launched from, and the state the
+	// task is returned to when it ends (decision 5). A follow-up decides
+	// nothing about the task's verdict.
+	Origin TaskState `json:"origin"`
+	// Round is 1-based and is what places this run's rows in the cursor space
+	// past the snapshot's last step: they sit at
+	// `len(snapshot.Steps) + Round - 1` (decision 2).
+	Round int `json:"round"`
+	// Cursor is how many steps of Workflow have finished — the follow-up's
+	// own step cursor (decision 4). `current_step` is left where the finished
+	// run put it and is never walked by a follow-up.
+	Cursor int `json:"cursor"`
+	// Abandoned marks a follow-up a human ended with `skip` from the block a
+	// failed step produced (decision 6). The record is kept rather than
+	// dropped because Origin is still needed: the next admission restores
+	// `done` or `aborted` without running anything.
+	Abandoned bool `json:"abandoned,omitempty"`
+}
+
+// Empty reports whether the request carries no work to do. A request with no
+// compiled workflow can neither run nor say where to return the task, which
+// is the same thing.
+func (r FollowUpRequest) Empty() bool { return r.Workflow == "" }
 
 // Candidate is one queued task considered for admission, carrying the cap
 // context the scheduler needs to decide (spec §11). The slot counts are as

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -15,7 +15,7 @@ import (
 const taskColumns = `id, project_id, title, description, fields_json, workflow_name, workflow_snapshot,
 	base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 	state, current_step, block_reason, pause_requested, retry_cursor_at, pending_override_json,
-	pending_repair_json, pending_input_json, admit_not_before, queued_reason,
+	pending_repair_json, pending_follow_up_json, pending_input_json, admit_not_before, queued_reason,
 	parent_task_id, parent_step_index, lane_id, lane_order,
 	created_at, updated_at, started_at, finished_at, archived_at`
 
@@ -762,26 +762,26 @@ func (s *Store) queryTasks(ctx context.Context, q string, args ...any) ([]Task, 
 
 func scanTask(r rowScanner) (*Task, error) {
 	var (
-		t                           Task
-		fields                      string
-		worktree, blockReason       sql.NullString
-		agentOv, modelOv, effortOv  sql.NullString
-		retryCursor, pendingOv      sql.NullString
-		pendingRepair               sql.NullString
-		pendingInput                sql.NullString
-		admitNotBefore, queuedWhy   sql.NullString
-		parentID, parentStep        sql.NullInt64
-		laneID                      sql.NullString
-		laneOrder                   sql.NullInt64
-		created, updated            string
-		started, finished, archived sql.NullString
+		t                              Task
+		fields                         string
+		worktree, blockReason          sql.NullString
+		agentOv, modelOv, effortOv     sql.NullString
+		retryCursor, pendingOv         sql.NullString
+		pendingRepair, pendingFollowUp sql.NullString
+		pendingInput                   sql.NullString
+		admitNotBefore, queuedWhy      sql.NullString
+		parentID, parentStep           sql.NullInt64
+		laneID                         sql.NullString
+		laneOrder                      sql.NullInt64
+		created, updated               string
+		started, finished, archived    sql.NullString
 	)
 	if err := r.Scan(&t.ID, &t.ProjectID, &t.Title, &t.Description, &fields, &t.WorkflowName,
 		&t.WorkflowSnapshot, &t.BaseBranch, &t.BranchName, &worktree, &t.Priority,
 		&agentOv, &modelOv, &effortOv,
 		(*string)(&t.State), &t.CurrentStep, &blockReason,
 		&t.PauseRequested, &retryCursor, &pendingOv,
-		&pendingRepair, &pendingInput, &admitNotBefore, &queuedWhy,
+		&pendingRepair, &pendingFollowUp, &pendingInput, &admitNotBefore, &queuedWhy,
 		&parentID, &parentStep, &laneID, &laneOrder,
 		&created, &updated, &started, &finished, &archived); err != nil {
 		return nil, err
@@ -816,6 +816,13 @@ func scanTask(r rowScanner) (*Task, error) {
 			return nil, fmt.Errorf("pending_repair_json: %w", err)
 		}
 		t.PendingRepair = &req
+	}
+	if pendingFollowUp.Valid && pendingFollowUp.String != "" {
+		var req FollowUpRequest
+		if err := json.Unmarshal([]byte(pendingFollowUp.String), &req); err != nil {
+			return nil, fmt.Errorf("pending_follow_up_json: %w", err)
+		}
+		t.PendingFollowUp = &req
 	}
 	if err := json.Unmarshal([]byte(fields), &t.Fields); err != nil {
 		return nil, fmt.Errorf("fields_json: %w", err)

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/lezli01/vincent/internal/taskstate"
 )
 
 // Durable task events written outside the engine (spec §13.3).
@@ -81,6 +83,19 @@ type TaskChange struct {
 	// admission. The carve-out is the repair action itself, which is exactly
 	// the blocked → queued transition that writes one.
 	PendingRepair *RepairRequest
+	// PendingFollowUp hands a follow-up run request to the actor the
+	// admission it produces will start, and later records that run's own step
+	// cursor (§6, task 027). An empty request clears the column.
+	//
+	// Its drain rule is neither the override's nor the repair's. A follow-up
+	// survives the `fail` that blocks one of its steps and the `retry` that
+	// re-runs it — the request is what makes the retry a follow-up retry
+	// rather than a plain one — and TransitionTask drops it on any transition
+	// into a settled state, which is exactly the Complete or Restore that
+	// returns the task to its origin and the `cancel` that ends it
+	// (decision 6). `skip` sets `abandoned` on the request instead, so the
+	// next admission restores the origin without running anything.
+	PendingFollowUp *FollowUpRequest
 	// PendingInput stores the normalized InputRequest JSON with the
 	// transition into awaiting_input (§7.4). Clearing is not the caller's
 	// job: TransitionTask NULLs the column on any transition out of
@@ -149,6 +164,16 @@ func (s *Store) TransitionTask(
 			// and it is carved out by having supplied one (task 025).
 			t.PendingRepair = nil
 		}
+		if taskstate.Settled(to) {
+			// A follow-up request describes a *run*, and reaching done,
+			// aborted or archived is that run ending however it ended (task
+			// 027 decision 6). One rule covers all three ways out: the
+			// Complete that returns a done-origin follow-up, the Restore that
+			// returns an aborted-origin one, and the cancel that abandons
+			// either. Nothing else can leave a request behind on a finished
+			// task for the next follow-up to inherit.
+			t.PendingFollowUp = nil
+		}
 		if from == TaskQueued {
 			// The §11 admission-hold invariant, same construction: a hold
 			// describes *this* queued period, so leaving queued always drops
@@ -186,16 +211,21 @@ func (s *Store) TransitionTask(
 		if err != nil {
 			return err
 		}
+		pendingFollowUp, err := marshalFollowUp(t.PendingFollowUp)
+		if err != nil {
+			return err
+		}
 		res, err := tx.ExecContext(ctx, `
 			UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
 				workflow_snapshot = ?, pause_requested = ?, retry_cursor_at = ?,
-				pending_override_json = ?, pending_repair_json = ?, pending_input_json = ?,
+				pending_override_json = ?, pending_repair_json = ?,
+				pending_follow_up_json = ?, pending_input_json = ?,
 				admit_not_before = ?, queued_reason = ?,
 				updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
 			WHERE id = ? AND state = ?`,
 			string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
 			t.WorkflowSnapshot, t.PauseRequested, formatTimePtr(t.RetryCursorAt), pendingOverride,
-			pendingRepair,
+			pendingRepair, pendingFollowUp,
 			nullString(t.PendingInputJSON),
 			formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
 			formatTime(t.UpdatedAt),
@@ -389,6 +419,13 @@ func applyChange(t *Task, ch TaskChange) {
 			t.PendingRepair = ch.PendingRepair
 		}
 	}
+	if ch.PendingFollowUp != nil {
+		if ch.PendingFollowUp.Empty() {
+			t.PendingFollowUp = nil
+		} else {
+			t.PendingFollowUp = ch.PendingFollowUp
+		}
+	}
 	if ch.PendingInput != nil {
 		t.PendingInputJSON = *ch.PendingInput
 	}
@@ -421,6 +458,19 @@ func marshalRepair(r *RepairRequest) (any, error) {
 	b, err := json.Marshal(r)
 	if err != nil {
 		return nil, fmt.Errorf("marshal pending repair: %w", err)
+	}
+	return string(b), nil
+}
+
+// marshalFollowUp renders a pending follow-up request for storage; none is
+// SQL NULL.
+func marshalFollowUp(r *FollowUpRequest) (any, error) {
+	if r == nil || r.Empty() {
+		return nil, nil
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pending follow-up: %w", err)
 	}
 	return string(b), nil
 }

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -49,6 +49,36 @@ func (e *RepairPromptError) Error() string {
 	return fmt.Sprintf("task %d: a repair needs a prompt", e.TaskID)
 }
 
+// FollowUpRequestError reports a follow-up the daemon cannot run: no
+// compiled workflow, or a form it does not know. The API answers 400 — the
+// handler compiles all three §6 forms, so reaching this means the request
+// never described any of them (task 027).
+type FollowUpRequestError struct {
+	TaskID  int64
+	Message string
+}
+
+func (e *FollowUpRequestError) Error() string {
+	return fmt.Sprintf("task %d: %s", e.TaskID, e.Message)
+}
+
+// FollowUpOverrideError reports an `edit + retry` aimed at a blocked
+// follow-up step. The API answers 400.
+//
+// An override rewrites the step it names *in the task's snapshot* (§5.3), and
+// a follow-up is deliberately not in the snapshot (task 027 decision 1) —
+// there is nothing there to rewrite. A plain `retry` re-runs the follow-up
+// from its cursor, which is the action that means what the human wants here.
+type FollowUpOverrideError struct {
+	TaskID int64
+}
+
+func (e *FollowUpOverrideError) Error() string {
+	return fmt.Sprintf(
+		"task %d is blocked in a follow-up run, which is not part of its workflow snapshot: "+
+			"retry without an override, or start another follow-up", e.TaskID)
+}
+
 // Cancel aborts a task and stops any process it is running (§6). The task
 // reaches `aborted` first, so a client that observes the state knows the
 // decision is final even while the process tree is still winding down.
@@ -144,6 +174,12 @@ func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store
 	now := time.Now()
 	ch := store.TaskChange{RetryCursorAt: &now}
 	if !ov.Empty() {
+		if _, inFollowUp := r.followUpOf(task); inFollowUp {
+			// The follow-up survives the retry (task 027 decision 6), so a
+			// plain retry re-runs it from its cursor. An override has nowhere
+			// to land: the follow-up is not a step of the snapshot.
+			return nil, &FollowUpOverrideError{TaskID: id}
+		}
 		target, err := r.overrideTarget(ctx, task)
 		if err != nil {
 			return nil, err
@@ -187,6 +223,44 @@ func (r *Runner) Repair(ctx context.Context, id int64, req store.RepairRequest) 
 	return r.transitionFrom(ctx, task, taskstate.Repair, store.TaskChange{PendingRepair: &req})
 }
 
+// FollowUp runs one more piece of work in a finished task's existing
+// worktree and branch, before it is archived (§6, task 027).
+//
+// It is `repair`'s shape at the other end of the lifecycle: the request is
+// persisted on the task, the task is re-queued, and the scheduler admits it
+// exactly like anything else — so both §11 caps apply and internal/scheduler
+// stays the only producer of `queued → running`. The actor that admission
+// starts walks the request's own workflow and returns the task to the state
+// it came from (decision 5).
+//
+// Like Repair, and unlike Retry, it must not stamp `retry_cursor_at`: the
+// original workflow's retry budgets are none of a follow-up's business, and
+// moving the cursor would hand every step of the finished run a fresh budget
+// nobody asked for (§7.2).
+func (r *Runner) FollowUp(ctx context.Context, id int64, req store.FollowUpRequest) (*store.Task, error) {
+	if req.Empty() {
+		return nil, &FollowUpRequestError{TaskID: id, Message: "a follow-up needs something to run"}
+	}
+	task, err := r.deps.Store.GetTask(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !taskstate.Can(task.State, taskstate.FollowUp) {
+		return nil, &InvalidActionError{TaskID: id, Action: taskstate.FollowUp, State: task.State}
+	}
+	// The origin rides the request because the transition about to happen
+	// leaves `done`/`aborted`, and the ending has to put the same one back: a
+	// follow-up decides nothing about the task's verdict (decision 5).
+	req.Origin = task.State
+	round, err := r.followUpRound(ctx, task)
+	if err != nil {
+		return nil, err
+	}
+	req.Round, req.Cursor, req.Abandoned = round, 0, false
+	return r.transitionFrom(ctx, task, taskstate.FollowUp,
+		store.TaskChange{PendingFollowUp: &req})
+}
+
 // Skip marks the current step skipped and advances (§6). From a gate the
 // open manual row is closed in place; from blocked the failed row stays and
 // a fresh `skipped` row records the decision, so every step index a task
@@ -199,12 +273,26 @@ func (r *Runner) Skip(ctx context.Context, id int64) (*store.Task, error) {
 	if !taskstate.Can(task.State, taskstate.Skip) {
 		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Skip, State: task.State}
 	}
+	at, inFollowUp := r.followUpOf(task)
 	if err := r.recordStepDecision(ctx, task, store.StepSkipped, ""); err != nil {
 		return nil, err
 	}
 	// Skipping moves past the step an edit+retry was aimed at; a surviving
 	// override must not drain onto some later step's attempt.
 	ch := advance(task)
+	switch {
+	case inFollowUp && task.State == store.TaskBlocked:
+		// The one place `skip` does not advance anything (task 027
+		// decision 6): a follow-up step failed, and the human is saying
+		// "stop". The request is marked abandoned and the next admission
+		// restores `done` or `aborted` without running a thing.
+		ch = abandonFollowUp(at)
+	case inFollowUp:
+		// A gate inside a follow-up. Skipping it advances the *follow-up's*
+		// cursor, never `current_step`, which names where the finished
+		// workflow run ended (decision 4).
+		ch = advanceFollowUp(at)
+	}
 	var noOverride store.Override
 	ch.PendingOverride = &noOverride
 	return r.transitionFrom(ctx, task, taskstate.Skip, ch)
@@ -219,10 +307,18 @@ func (r *Runner) Approve(ctx context.Context, id int64) (*store.Task, error) {
 	if !taskstate.Can(task.State, taskstate.Approve) {
 		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Approve, State: task.State}
 	}
+	at, inFollowUp := r.followUpOf(task)
 	if err := r.recordStepDecision(ctx, task, store.StepApproved, ""); err != nil {
 		return nil, err
 	}
-	return r.transitionFrom(ctx, task, taskstate.Approve, advance(task))
+	// A gate inside a follow-up advances the follow-up's own cursor
+	// (task 027 decision 4); `current_step` is left where the finished run
+	// put it.
+	ch := advance(task)
+	if inFollowUp {
+		ch = advanceFollowUp(at)
+	}
+	return r.transitionFrom(ctx, task, taskstate.Approve, ch)
 }
 
 // Reject fails a manual gate: the step is rejected and the task blocks, from
@@ -470,15 +566,15 @@ func (r *Runner) recordStepDecision(
 		// here would record a decision that is about to lose its CAS.
 		return nil
 	}
-	stepID, stepType := describeStep(task, task.CurrentStep)
+	index, stepID, stepType := r.decisionPosition(task)
 	attempts, err := r.deps.Store.CountStepAttempts(ctx,
-		store.StepRef{TaskID: task.ID, StepIndex: task.CurrentStep, StepID: stepID}, time.Time{})
+		store.StepRef{TaskID: task.ID, StepIndex: index, StepID: stepID}, time.Time{})
 	if err != nil {
 		return err
 	}
 	now := time.Now()
 	run := &store.StepRun{
-		TaskID: task.ID, StepIndex: task.CurrentStep, StepID: stepID, StepType: stepType,
+		TaskID: task.ID, StepIndex: index, StepID: stepID, StepType: stepType,
 		Attempt: attempts.Last + 1, State: state, FailureReason: reason,
 		StartedAt: now, FinishedAt: &now,
 	}
@@ -493,6 +589,24 @@ func (r *Runner) recordStepDecision(
 func advance(task *store.Task) store.TaskChange {
 	next := task.CurrentStep + 1
 	return store.TaskChange{CurrentStep: &next}
+}
+
+// decisionPosition names the row a human decision belongs to: the task's own
+// cursor, or — while a follow-up run is in flight — that round's index and
+// the step its cursor points at (task 027 decision 4).
+//
+// Without this a `skip` on a blocked follow-up would write its `skipped` row
+// against whatever the snapshot has at `current_step`, which for a finished
+// task is nothing at all.
+func (r *Runner) decisionPosition(task *store.Task) (index int, stepID, stepType string) {
+	if at, ok := r.followUpOf(task); ok {
+		if at.hasStep {
+			return at.index, at.step.ID, at.step.Type
+		}
+		return at.index, FollowUpStepID, workflow.StepManual
+	}
+	id, typ := describeStep(task, task.CurrentStep)
+	return task.CurrentStep, id, typ
 }
 
 // overrideTarget names the step an `edit + retry` rewrites: the current step,
@@ -604,6 +718,22 @@ func AsOverrideMismatch(err error) (*OverrideMismatchError, bool) {
 // is.
 func AsRepairPrompt(err error) (*RepairPromptError, bool) {
 	var e *RepairPromptError
+	ok := errors.As(err, &e)
+	return e, ok
+}
+
+// AsFollowUpRequest extracts a *FollowUpRequestError from err, if that is
+// what it is.
+func AsFollowUpRequest(err error) (*FollowUpRequestError, bool) {
+	var e *FollowUpRequestError
+	ok := errors.As(err, &e)
+	return e, ok
+}
+
+// AsFollowUpOverride extracts a *FollowUpOverrideError from err, if that is
+// what it is.
+func AsFollowUpOverride(err error) (*FollowUpOverrideError, bool) {
+	var e *FollowUpOverrideError
 	ok := errors.As(err, &e)
 	return e, ok
 }

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -136,6 +136,12 @@ func (h *actionHarness) invoke(
 	case taskstate.Archive:
 		task, _, err := h.runner.Archive(ctx, id, false)
 		return task, err
+	case taskstate.FollowUp:
+		return h.runner.FollowUp(ctx, id, store.FollowUpRequest{
+			Form:     store.FollowUpCommand,
+			Run:      "git status",
+			Workflow: followUpTestWorkflow,
+		})
 	default:
 		t := &InvalidActionError{TaskID: id, Action: action}
 		return nil, t
@@ -176,7 +182,7 @@ func TestActionsFromInvalidStateConflict(t *testing.T) {
 	actions := []taskstate.Action{
 		taskstate.Cancel, taskstate.Pause, taskstate.Resume, taskstate.Retry,
 		taskstate.Repair, taskstate.Skip, taskstate.Approve, taskstate.Reject,
-		taskstate.Archive,
+		taskstate.Archive, taskstate.FollowUp,
 	}
 	for _, action := range actions {
 		// Find a state this action is not valid from.

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -182,7 +182,12 @@ type stepEnv struct {
 	// from — a shared template can therefore tell whether it is in a loop
 	// without the engine keeping a second flag (decision 9).
 	loop *loopEnv
-	log  *slog.Logger
+	// followUp is where this step sits inside a follow-up run, and nil for
+	// every step of an ordinary admission (§6, task 027 decision 4). It is
+	// what makes a round's rows legible to each other and blind to the rows
+	// of earlier rounds — see blindTo and precedes.
+	followUp *followUpEnv
+	log      *slog.Logger
 }
 
 // iteration is the 1-based pass of the enclosing loop, 0 outside one.
@@ -220,14 +225,22 @@ func (e *stepEnv) precedes(run *store.StepRun) bool {
 	if run.StepIndex != e.index {
 		return run.StepIndex < e.index
 	}
-	if e.loop == nil {
-		return false // a group sibling, or this step's own earlier attempt
+	if e.loop != nil {
+		if run.Iteration != e.loop.iteration {
+			return run.Iteration < e.loop.iteration
+		}
+		pos, ok := e.loop.order[run.StepID]
+		return ok && pos < e.loop.pos
 	}
-	if run.Iteration != e.loop.iteration {
-		return run.Iteration < e.loop.iteration
+	if e.followUp != nil {
+		// A follow-up round's steps share one index for the reason a loop
+		// body's do, and are ordered by position for the same reason
+		// (task 027 decision 2). A round is a *sequence*, not a set, so an
+		// earlier step's `allow_failure` row is readable by a later one.
+		pos, ok := e.followUp.order[run.StepID]
+		return ok && pos < e.followUp.pos
 	}
-	pos, ok := e.loop.order[run.StepID]
-	return ok && pos < e.loop.pos
+	return false // a group sibling, or this step's own earlier attempt
 }
 
 // blindTo reports whether run is a row this step's context may not see. Two
@@ -272,6 +285,15 @@ func (e *stepEnv) blindTo(run *store.StepRun) bool {
 	// for every step after it — a key no workflow author wrote, present
 	// exactly when somebody happened to press a key.
 	if run.StepID == RepairStepID {
+		return true
+	}
+	// The fourth: an *earlier* follow-up round's rows (task 027 decision 9).
+	// Rows below the snapshot's length are the original workflow's and stay
+	// visible — a follow-up agent reading `.Steps.review.Output` is the point
+	// — and this round's own rows are its own. Everything else past that line
+	// belongs to a round nobody wrote into the workflow being run, exactly as
+	// a `__repair` row does.
+	if e.followUp != nil && run.StepIndex >= e.followUp.base && run.StepIndex != e.index {
 		return true
 	}
 	if !e.inGroup || e.loop != nil {
@@ -327,6 +349,15 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			errors.New(mismatch))
 		return
 	}
+	// A follow-up a human abandoned with `skip` from the block one of its
+	// steps produced (task 027 decision 6). It restores the origin state and
+	// runs nothing — before ensureWorktree, deliberately: a task with nothing
+	// left to run must not be able to block on creating a worktree it will
+	// never use.
+	if req := task.PendingFollowUp; req != nil && !req.Empty() && req.Abandoned {
+		r.finishFollowUp(task, *req, log)
+		return
+	}
 	if err := r.ensureWorktree(ctx, task, project, log); err != nil {
 		return // ensureWorktree already blocked or re-queued the task
 	}
@@ -343,8 +374,75 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		r.runRepair(ctx, task, project, wf, *req, log)
 		return
 	}
+	// A follow-up run the human asked for from `done` or `aborted` (§6, task
+	// 027). Like a repair it is a whole admission of its own — the snapshot's
+	// steps are finished and are not walked again — and unlike a repair it
+	// walks a workflow of its own, with a cursor of its own, before returning
+	// the task to the state it came from (decisions 4, 5).
+	//
+	// It sits after PendingRepair because a follow-up that blocked and was
+	// then repaired carries both: the repair runs, re-blocks, and leaves the
+	// follow-up request for the retry that comes after it.
+	if req := task.PendingFollowUp; req != nil && !req.Empty() {
+		r.runFollowUp(ctx, task, project, wf, *req, log)
+		return
+	}
 
-	for index := task.CurrentStep; index < len(wf.Steps); index++ {
+	r.runSteps(ctx, project, &stepWalk{
+		task:     task,
+		wf:       wf,
+		steps:    wf.Steps,
+		from:     task.CurrentStep,
+		rowIndex: func(pos int) int { return pos },
+		persist: func(ctx context.Context, pos int, log *slog.Logger) {
+			task.CurrentStep = pos
+			r.persistStepCursor(ctx, task, log)
+		},
+		finish: func() { r.complete(task, log) },
+		log:    log,
+	})
+}
+
+// stepWalk is one pass over a list of steps: where it starts, where its rows
+// go, how its cursor is persisted, and what ending it reaches when it runs
+// off the end.
+//
+// There are exactly two (task 027 decision 4). An ordinary admission walks
+// the task's snapshot from `current_step`, writes a row per step at that
+// step's own index, and ends in `complete`. A follow-up walks its own
+// workflow from the request's cursor, writes every row of the round at one
+// index past the snapshot's end (decision 2), and ends by restoring the state
+// the follow-up came from. Everything between those two ends — guards,
+// gates, groups, loops, fan-outs, retries, pause and interruption — is
+// identical, which is why it is written once here rather than twice.
+type stepWalk struct {
+	task *store.Task
+	// wf is the workflow the steps belong to: its `defaults:` feed §8.6 and
+	// §7.2 resolution, and its name reaches `.Workflow` in §8.4's context.
+	wf    *workflow.Workflow
+	steps []workflow.Step
+	// from is the position in steps to resume at.
+	from int
+	// rowIndex maps a position in steps to the `step_index` its rows are
+	// written at. Identity for an ordinary walk; constant for a follow-up.
+	rowIndex func(pos int) int
+	// persist records the cursor after a step is finished with.
+	persist func(ctx context.Context, pos int, log *slog.Logger)
+	// finish ends the walk: the last step succeeded, or a `condition` stopped
+	// it early (§7.7).
+	finish func()
+	// followUp marks this walk as a follow-up round and carries what its
+	// steps need to know about it; nil for an ordinary admission.
+	followUp *followUpEnv
+	log      *slog.Logger
+}
+
+// runSteps walks a step list until it finishes, parks, or fails. It is the
+// body of one admission for an ordinary run and of one for a follow-up; the
+// two differ only in the stepWalk they are handed.
+func (r *Runner) runSteps(ctx context.Context, project *store.Project, w *stepWalk) {
+	task, wf, log := w.task, w.wf, w.log
+	for pos := w.from; pos < len(w.steps); pos++ {
 		// A cancel or shutdown sets its flag before it terminates the process,
 		// and the run context is only canceled after the grace (§6, §12.4) —
 		// the flag is what stops the actor from starting new work for a task
@@ -357,10 +455,12 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			r.park(task, log)
 			return
 		}
+		index := w.rowIndex(pos)
 		env := &stepEnv{
 			task: task, project: project, wf: wf,
-			step: wf.Steps[index], index: index,
-			log: log.With("step", wf.Steps[index].ID, "step_index", index),
+			step: w.steps[pos], index: index,
+			followUp: w.stepFollowUp(pos),
+			log:      log.With("step", w.steps[pos].ID, "step_index", index),
 		}
 		// Guards run before the dispatch below, so every step type is
 		// guarded by the same code — including the three that never reach
@@ -380,23 +480,20 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 				// finished task runs and no client reads a done task as
 				// mid-run.
 				r.recordGuardOutcome(ctx, env, store.StepStopped, "", "")
-				task.CurrentStep = len(wf.Steps)
-				r.persistStepCursor(ctx, task, env.log)
+				w.persist(ctx, len(w.steps), env.log)
 				env.log.Info("workflow stopped early by a condition step")
-				r.complete(task, log)
+				w.finish()
 				return
 			case env.step.Type == workflow.StepCondition:
 				r.recordGuardOutcome(ctx, env, store.StepSucceeded, "", "")
-				task.CurrentStep = index + 1
-				r.persistStepCursor(ctx, task, env.log)
+				w.persist(ctx, pos+1, env.log)
 				continue
 			case !pass:
 				// Skip and carry on: the step did not run, the workflow did
 				// not stop, and the row says which of the two kinds of skip
 				// this was (decision 9).
 				r.recordGuardOutcome(ctx, env, store.StepSkipped, store.SkipReasonCondition, "")
-				task.CurrentStep = index + 1
-				r.persistStepCursor(ctx, task, env.log)
+				w.persist(ctx, pos+1, env.log)
 				env.log.Info("step skipped by its guard")
 				continue
 			}
@@ -431,8 +528,7 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 		}
 		switch outcome.state {
 		case store.StepSucceeded:
-			task.CurrentStep = index + 1
-			r.persistStepCursor(ctx, task, env.log)
+			w.persist(ctx, pos+1, env.log)
 		case store.StepInterrupted:
 			// A quota stop is interruption-shaped — no retry consumed, the
 			// slot released — but it must not be re-admitted immediately, or
@@ -452,15 +548,25 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 			// guard reads through `.Steps`.
 			if outcome.state == store.StepFailed && allowFailure(env.step, outcome.reason) {
 				env.log.Info("step failed; advancing on allow_failure", "reason", outcome.reason)
-				task.CurrentStep = index + 1
-				r.persistStepCursor(ctx, task, env.log)
+				w.persist(ctx, pos+1, env.log)
 				continue
 			}
 			r.fail(task, outcome.reason, env.log, "step failed", nil)
 			return
 		}
 	}
-	r.complete(task, log)
+	w.finish()
+}
+
+// stepFollowUp is the follow-up position of the step at pos, or nil when this
+// walk is not a follow-up round.
+func (w *stepWalk) stepFollowUp(pos int) *followUpEnv {
+	if w.followUp == nil {
+		return nil
+	}
+	at := *w.followUp
+	at.pos = pos
+	return &at
 }
 
 // ensureWorktree creates the task's worktree on first admission (§10); a

--- a/internal/taskrun/followup.go
+++ b/internal/taskrun/followup.go
@@ -1,0 +1,367 @@
+package taskrun
+
+// Follow-up runs on a finished task (spec §6, task 027).
+//
+// A task that reaches `done` or `aborted` still owns its worktree, its branch
+// and its commits until `archive` runs. A follow-up is how vincent does one
+// more piece of work in that window — rebase the branch, add the commit a
+// review asked for, drop the stray file — inside the daemon's own ledger,
+// with a step run, a transcript, events and cost accounting, instead of
+// someone doing it by hand in the worktree.
+//
+// Three shapes are offered and one is executed. An agent prompt and a shell
+// command are compiled into a synthetic one-step workflow by the handler, so
+// what arrives here is always a workflow (decision 3) — and every step type
+// is allowed in it, including the gates and fan-outs that park a task
+// mid-run.
+//
+// Two invariants make that affordable without a `step_runs` migration:
+//
+//   - **Rows go past the end of the snapshot.** Round n writes at
+//     `step_index = len(snapshot.Steps) + n - 1` (decision 2). That cursor
+//     space is unused, so a row there is unambiguously a follow-up row;
+//     distinct rounds occupy distinct indices, so CountStepAttempts'
+//     `(task_id, step_index, step_id, iteration)` key separates them for
+//     free; and `iteration` keeps its §7.8 loop meaning instead of being
+//     commandeered for the round number. The workflow snapshot is not
+//     touched: §5.3 says it is the workflow as authored, and a follow-up
+//     appends nothing to it.
+//   - **The run has a cursor of its own**, persisted in the request
+//     (decision 4). `current_step` stays where the finished run left it and is
+//     never walked by a follow-up, which is what lets a `manual` gate park and
+//     be approved, and a `fan_out` park and be joined, without two meanings of
+//     one column.
+//
+// A follow-up decides nothing about the task's verdict: `done` returns to
+// `done` and `aborted` to `aborted` (decision 5). Making a human's abort
+// reversible by any command that exits 0 is the thing that rule exists to
+// prevent.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// FollowUpWorkflowName is the name the synthetic workflow compiled from an
+// agent prompt or a shell command carries. It reaches `.Workflow.Name` in
+// §8.4's context, so it says what the run is rather than repeating the
+// finished task's workflow, which is not what is running.
+const FollowUpWorkflowName = "follow-up"
+
+// FollowUpStepID is the step id the synthetic one-step workflow uses. Unlike
+// RepairStepID it is an ordinary slug, not a reserved underscore name: a
+// follow-up row is told from a workflow step by *where* it sits — past the
+// snapshot's last index — and never by its id, because a workflow-form
+// follow-up's rows carry the ids their author wrote (decision 2).
+const FollowUpStepID = "follow-up"
+
+// followUpEnv is where one step sits inside a follow-up round (decision 4).
+// It is the follow-up's answer to loopEnv, and carries the same position pair
+// for the same reason: a round's steps share one step_index, so declaration
+// order is what puts them in sequence.
+type followUpEnv struct {
+	// base is `len(snapshot.Steps)`. Every row below it belongs to the
+	// task's own workflow and stays visible to a follow-up step's context;
+	// every row at or past it belongs to some follow-up round.
+	base int
+	// round is 1-based; this round's rows sit at base+round-1.
+	round int
+	// pos is this step's position in the follow-up workflow, and order maps
+	// every step id in it to its own.
+	pos   int
+	order map[string]int
+}
+
+// followUpRowIndex is decision 2's placement: round n of a task whose
+// snapshot has `base` steps writes its rows at base+n-1. Round 1 lands
+// exactly one past the last step, which is where a finished task's
+// `current_step` already points.
+func followUpRowIndex(base, round int) int {
+	if round < 1 {
+		round = 1
+	}
+	return base + round - 1
+}
+
+// runFollowUp executes one follow-up admission (§6, task 027) and returns the
+// task to the state the follow-up was launched from.
+//
+// snapshot is the *task's* workflow — read only for its length, which is
+// where this round's rows go. What actually runs is the workflow carried by
+// the request, spliced at request time exactly as a task's snapshot is at
+// creation, so a registry edit mid-follow-up cannot mutate a run in flight.
+func (r *Runner) runFollowUp(
+	ctx context.Context, task *store.Task, project *store.Project,
+	snapshot *workflow.Workflow, req store.FollowUpRequest, log *slog.Logger,
+) {
+	// A cancel or shutdown that landed between admission and here must not
+	// spawn a process for a task that is already ending; the request stays
+	// set, so the follow-up resumes from its cursor on the next admission.
+	if ctx.Err() != nil || r.interrupting(task.ID) {
+		r.interrupt(task, log)
+		return
+	}
+	if req.Abandoned {
+		// `skip` from the block a follow-up step produced (decision 6). The
+		// origin is still on the request, which is the whole reason the
+		// record is kept rather than dropped.
+		r.finishFollowUp(task, req, log)
+		return
+	}
+	fu, err := followUpWorkflow(req)
+	if err != nil {
+		// The handler parsed, expanded and re-validated this document before
+		// persisting it, so a failure here is corruption or a vincent
+		// downgrade — the case §12.4 already treats a snapshot that no longer
+		// parses as. The task blocks; a human retries, skips or cancels.
+		r.fail(task, ReasonInvalidSnapshot, log, "parse follow-up workflow", err)
+		return
+	}
+	base := len(snapshot.Steps)
+	index := followUpRowIndex(base, req.Round)
+	log = log.With("follow_up_round", req.Round, "follow_up_index", index, "follow_up_form", req.Form)
+
+	// The cursor is copied, not aliased: `transition` overwrites *task with
+	// the row it read back, and this is what the walk advances and the ending
+	// reads.
+	pending := req
+	r.runSteps(ctx, project, &stepWalk{
+		task:  task,
+		wf:    fu,
+		steps: fu.Steps,
+		from:  clampCursor(req.Cursor, len(fu.Steps)),
+		// Every step of the round writes at the round's own index. Rows are
+		// told apart by step id — and, inside a loop, by iteration — exactly
+		// as a `parallel` group's sub-steps are (decision 2).
+		rowIndex: func(int) int { return index },
+		persist: func(_ context.Context, pos int, log *slog.Logger) {
+			pending.Cursor = pos
+			// persistCtx, not ctx: the cursor must survive the shutdown that
+			// is cancelling this admission, or recovery would re-run a step
+			// the run had finished with.
+			if err := r.deps.Store.SetPendingFollowUp(r.persistCtx(), task.ID, &pending); err != nil {
+				log.Error("persist follow-up cursor", "error", err)
+			}
+		},
+		finish:   func() { r.finishFollowUp(task, pending, log) },
+		followUp: &followUpEnv{base: base, round: req.Round, order: bodyOrder(fu.Steps)},
+		log:      log,
+	})
+}
+
+// finishFollowUp returns the task to the state the follow-up came from
+// (decision 5): `done → done` through the ordinary Complete, `aborted →
+// aborted` through Restore, which exists for this and nothing else
+// (decision 7).
+//
+// The request is not drained here. TransitionTask drops a pending follow-up
+// on any transition into a settled state, which is exactly these two and the
+// `cancel` that ends a follow-up early — one rule rather than three callers
+// remembering to (decision 6).
+func (r *Runner) finishFollowUp(task *store.Task, req store.FollowUpRequest, log *slog.Logger) {
+	action := taskstate.Complete
+	if req.Origin == store.TaskAborted {
+		action = taskstate.Restore
+	}
+	if !r.transition(task, action, store.TaskChange{}, log) {
+		return
+	}
+	if req.Abandoned {
+		log.Info("follow-up abandoned; task restored", "state", string(task.State))
+		return
+	}
+	log.Info("follow-up finished; task restored", "state", string(task.State))
+}
+
+// followUpWorkflow parses the workflow the request carries.
+//
+// Parse runs with zero Options because the document was validated against the
+// daemon's real ones at request time and stored as it will run — the same
+// reason execute() parses a task's snapshot that way.
+func followUpWorkflow(req store.FollowUpRequest) (*workflow.Workflow, error) {
+	wf, _, err := workflow.Parse([]byte(req.Workflow), workflow.Options{})
+	if err != nil {
+		return nil, err
+	}
+	if len(wf.Steps) == 0 {
+		return nil, fmt.Errorf("follow-up workflow %q has no steps", wf.Name)
+	}
+	return wf, nil
+}
+
+// clampCursor keeps a persisted cursor inside the workflow it points into. A
+// cursor past the end means the run finished and the ending transition did
+// not commit; the walk then does nothing and reaches the ending again, which
+// is the idempotence §12.4 asks of every resumed step.
+func clampCursor(cursor, n int) int {
+	if cursor < 0 {
+		return 0
+	}
+	if cursor > n {
+		return n
+	}
+	return cursor
+}
+
+// followUpAt is the follow-up run a human action is about: the request, the
+// index its rows sit at, and the step its cursor points at.
+//
+// Everywhere a human action asks "which step is this about", the answer is
+// `current_step` for an ordinary task and this for one with a follow-up in
+// flight (decision 4). The five callers are Skip, Approve, Reject's row,
+// repair's failure context and the `retry` that refuses an edit.
+type followUpAt struct {
+	req   store.FollowUpRequest
+	index int
+	// step is the step the cursor points at. A cursor past the end leaves it
+	// zero, which is legitimate: the run finished and its ending transition
+	// has not landed yet.
+	step workflow.Step
+	// hasStep reports whether step is a real step rather than the zero value.
+	hasStep bool
+}
+
+// followUpOf reports the follow-up run in flight on a task, and false when
+// there is none — which is every ordinary task, and a task whose follow-up a
+// human has already abandoned with `skip`.
+//
+// A request whose documents no longer parse reports false rather than an
+// error: a human action must not fail because a stored document rotted, and
+// the admission that follows will block the task with `invalid_snapshot`
+// where the reason is legible.
+func (r *Runner) followUpOf(task *store.Task) (followUpAt, bool) {
+	req := task.PendingFollowUp
+	if req == nil || req.Empty() || req.Abandoned {
+		return followUpAt{}, false
+	}
+	snapshot, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		return followUpAt{}, false
+	}
+	fu, err := followUpWorkflow(*req)
+	if err != nil {
+		return followUpAt{}, false
+	}
+	at := followUpAt{req: *req, index: followUpRowIndex(len(snapshot.Steps), req.Round)}
+	if cursor := clampCursor(req.Cursor, len(fu.Steps)); cursor < len(fu.Steps) {
+		at.step, at.hasStep = fu.Steps[cursor], true
+	}
+	return at, true
+}
+
+// advanceFollowUp moves a follow-up's own cursor past the step a human just
+// decided on — the `approve` or gate `skip` of decision 4. `current_step` is
+// deliberately untouched: it names where the finished workflow run ended, and
+// a follow-up never walks it.
+func advanceFollowUp(at followUpAt) store.TaskChange {
+	req := at.req
+	req.Cursor++
+	return store.TaskChange{PendingFollowUp: &req}
+}
+
+// abandonFollowUp records a follow-up a human ended with `skip` from the
+// block one of its steps produced (decision 6).
+//
+// The request is marked rather than dropped, because Origin is still needed:
+// the admission this transition produces restores `done` or `aborted` without
+// running anything. Dropping it would leave the task `queued` with the
+// snapshot's steps all finished, which completes it — turning a `skip` on an
+// aborted task's follow-up into a promotion to `done`.
+func abandonFollowUp(at followUpAt) store.TaskChange {
+	req := at.req
+	req.Abandoned = true
+	return store.TaskChange{PendingFollowUp: &req}
+}
+
+// followUpRound numbers the next follow-up on a task: one past the highest
+// round its rows record, and 1 when it has none.
+//
+// It is derived from the rows rather than counted on the task, so the number
+// and the rows it places can never disagree — a stored counter that drifted
+// would put two rounds at one index and merge their attempt numbering
+// (decision 2).
+func (r *Runner) followUpRound(ctx context.Context, task *store.Task) (int, error) {
+	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		// The snapshot no longer parses, so the admission this request
+		// produces will block with `invalid_snapshot` before the round is
+		// ever used to place a row. Refusing here instead would take the
+		// diagnosis away and give back a worse error.
+		return 1, nil //nolint:nilerr // deliberately tolerated; see above
+	}
+	maxIndex, ok, err := r.deps.Store.MaxStepIndex(ctx, task.ID)
+	if err != nil {
+		return 0, err
+	}
+	base := len(wf.Steps)
+	if !ok || maxIndex < base {
+		return 1, nil
+	}
+	return maxIndex - base + 2, nil
+}
+
+// ApplyFollowUpSelection fills each agent step's blank agent/model/effort
+// from the request, which stands in for the step level of §8.6's chain
+// (decision 12).
+//
+// A field the step declares is left alone: §8.6 already says a step field
+// outranks everything below it, and a workflow-form follow-up's author wrote
+// that field on purpose. The walk descends into `parallel` and `loop` bodies,
+// whose members are steps in every other respect. It stops at `fan_out`
+// lanes, which are not steps at all — a lane becomes a child task and
+// inherits the parent task's own overrides (§7.6 decision 10).
+func ApplyFollowUpSelection(steps []workflow.Step, req store.FollowUpRequest) {
+	for i := range steps {
+		if len(steps[i].Steps) > 0 {
+			ApplyFollowUpSelection(steps[i].Steps, req)
+		}
+		if steps[i].Type != workflow.StepAgent {
+			continue
+		}
+		steps[i].Agent = firstNonEmpty(steps[i].Agent, req.Agent)
+		steps[i].Model = firstNonEmpty(steps[i].Model, req.Model)
+		steps[i].Effort = firstNonEmpty(steps[i].Effort, req.Effort)
+	}
+}
+
+// CompileFollowUp turns an agent prompt or a shell command into the one-step
+// workflow the engine runs, so runFollowUp has exactly one shape to execute
+// (decision 3).
+//
+// The text is escaped, not templated. It is prose or a command line typed at
+// a form, and §8.4 renders with `missingkey=error` — a stray `{{` would fail
+// the run before the process started. This is the same rule a repair prompt
+// follows, and it is why a follow-up is not a workflow-authoring surface: an
+// operator who wants `{{.Task.BranchName}}` writes a workflow and runs that.
+//
+// The budget is one attempt. A failed one-off run blocks and a human decides,
+// rather than silently paying for a second agent run — the built-in `adhoc`
+// workflow's reasoning (phase 2 decision) applied to the same shape of run.
+func CompileFollowUp(req store.FollowUpRequest) (*workflow.Workflow, error) {
+	noRetries := 0
+	step := workflow.Step{
+		ID:         FollowUpStepID,
+		Name:       "follow-up",
+		MaxRetries: &noRetries,
+	}
+	switch req.Form {
+	case store.FollowUpAgent:
+		step.Type = workflow.StepAgent
+		step.Prompt = workflow.EscapeTemplate(req.Prompt)
+	case store.FollowUpCommand:
+		step.Type = workflow.StepCommand
+		step.Run = workflow.EscapeTemplate(req.Run)
+	default:
+		return nil, fmt.Errorf("follow-up form %q has no compiled shape", req.Form)
+	}
+	return &workflow.Workflow{
+		Name:        FollowUpWorkflowName,
+		Description: "an ad-hoc follow-up run on a finished task",
+		Steps:       []workflow.Step{step},
+	}, nil
+}

--- a/internal/taskrun/followup_test.go
+++ b/internal/taskrun/followup_test.go
@@ -1,0 +1,703 @@
+package taskrun
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// followUpTestWorkflow is the compiled document a follow-up request carries:
+// what the API's compile step produces for the `command` form, spelled out
+// here so the action tests need no HTTP handler.
+const followUpTestWorkflow = `name: follow-up
+description: an ad-hoc follow-up run on a finished task
+steps:
+  - id: follow-up
+    name: follow-up
+    type: command
+    run: git status
+    max_retries: 0
+`
+
+// followUpBase is the workflow a follow-up is run *on*: two ordinary command
+// steps that succeed, so the task reaches `done` with its cursor one past the
+// last step and its rows occupying indices 0 and 1. Round 1 therefore lands at
+// index 2 (task 027 decision 2).
+const followUpBase = `name: base
+defaults:
+  agent: claude
+steps:
+  - id: build
+    type: command
+    run: git --version
+  - id: verify
+    type: command
+    run: git --version
+`
+
+// followUpBaseSteps is len(followUpBase.steps) — where round 1's rows go.
+const followUpBaseSteps = 2
+
+// doneTask runs followUpBase to completion and returns the finished task.
+func doneTask(t *testing.T, h *engineHarness) *store.Task {
+	t.Helper()
+	task := h.createTask(t, followUpBase)
+	h.start(t)
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", done.State, done.BlockReason)
+	}
+	return done
+}
+
+// abortedTask runs followUpBase far enough to own a worktree, then cancels it,
+// which is the `aborted` origin a follow-up may also be launched from.
+func abortedTask(t *testing.T, h *engineHarness) *store.Task {
+	t.Helper()
+	done := doneTask(t, h)
+	// Cancel is not valid from `done`, so the aborted origin is manufactured
+	// through the store the way every other state fixture in this package is.
+	aborted, _, err := h.store.TransitionTask(t.Context(), done.ID,
+		store.TaskDone, store.TaskAborted, store.TaskChange{})
+	if err != nil {
+		t.Fatalf("make the task aborted: %v", err)
+	}
+	return aborted
+}
+
+// compileFollowUp is what the API's handler does before persisting a request:
+// build the document, write the §8.6 request level into it, and marshal.
+func compileFollowUp(t *testing.T, req store.FollowUpRequest) store.FollowUpRequest {
+	t.Helper()
+	wf, err := CompileFollowUp(req)
+	if err != nil {
+		t.Fatalf("CompileFollowUp: %v", err)
+	}
+	ApplyFollowUpSelection(wf.Steps, req)
+	out, err := workflow.Marshal(wf)
+	if err != nil {
+		t.Fatalf("marshal follow-up workflow: %v", err)
+	}
+	req.Workflow = string(out)
+	return req
+}
+
+// agentFollowUp is the `agent` form, pinned to the fake adapter.
+func agentFollowUp(t *testing.T, prompt string) store.FollowUpRequest {
+	t.Helper()
+	return compileFollowUp(t, store.FollowUpRequest{
+		Form: store.FollowUpAgent, Prompt: prompt, Agent: "claude",
+	})
+}
+
+// commandFollowUp is the `command` form.
+func commandFollowUp(t *testing.T, run string) store.FollowUpRequest {
+	t.Helper()
+	return compileFollowUp(t, store.FollowUpRequest{Form: store.FollowUpCommand, Run: run})
+}
+
+// workflowFollowUp is the `workflow` form, whose document is written out by
+// the caller exactly as the registry would have held it.
+func workflowFollowUp(t *testing.T, name, yaml string) store.FollowUpRequest {
+	t.Helper()
+	req := store.FollowUpRequest{
+		Form: store.FollowUpWorkflow, WorkflowName: name, Agent: "claude",
+	}
+	wf, _, err := workflow.Parse([]byte(yaml), workflow.Options{})
+	if err != nil {
+		t.Fatalf("parse follow-up workflow: %v", err)
+	}
+	ApplyFollowUpSelection(wf.Steps, req)
+	out, merr := workflow.Marshal(wf)
+	if merr != nil {
+		t.Fatalf("marshal follow-up workflow: %v", merr)
+	}
+	req.Workflow = string(out)
+	return req
+}
+
+// followUpRuns is the rows of one follow-up round: those at the round's own
+// index, which is what tells a follow-up row from a workflow step's (§5.4,
+// decision 2).
+func followUpRuns(runs []store.StepRun, round int) []store.StepRun {
+	index := followUpBaseSteps + round - 1
+	var out []store.StepRun
+	for _, r := range runs {
+		if r.StepIndex == index {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// settle polls until the task is at rest: the follow-up finished, blocked or
+// parked. `queued` and `running` are the two it waits out.
+func (h *engineHarness) settle(t *testing.T, id int64) *store.Task {
+	t.Helper()
+	return h.waitForStateWithin(t, id, 90*time.Second,
+		store.TaskDone, store.TaskAborted, store.TaskBlocked,
+		store.TaskAwaitingGate, store.TaskPaused)
+}
+
+// TestFollowUpAgentRunsInTheWorktreeAndReturnsToDone is the shape of the
+// whole feature: an agent runs in the *finished* task's existing worktree,
+// the change it makes is there afterwards, the row lands past the snapshot's
+// last index, and the task is `done` again.
+func TestFollowUpAgentRunsInTheWorktreeAndReturnsToDone(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	t.Setenv("FAKEAGENT_EDIT_FILE", "README.md")
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+	before := h.stepRuns(t, done.ID)
+
+	if _, err := h.runner.FollowUp(t.Context(), done.ID,
+		agentFollowUp(t, "add a line to the readme")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	after := h.settle(t, done.ID)
+
+	if after.State != store.TaskDone {
+		t.Errorf("task = %s/%q, want done again", after.State, after.BlockReason)
+	}
+	if after.PendingFollowUp != nil {
+		t.Error("the follow-up request survived the restore; it drains with that transition")
+	}
+	if after.CurrentStep != done.CurrentStep {
+		t.Errorf("current_step = %d, want %d — a follow-up never walks the task's own cursor",
+			after.CurrentStep, done.CurrentStep)
+	}
+
+	readme, err := os.ReadFile(filepath.Join(after.WorktreePath, "README.md"))
+	if err != nil {
+		t.Fatalf("read the followed-up worktree: %v", err)
+	}
+	if !strings.Contains(string(readme), fakeAgentMark) {
+		t.Errorf("the follow-up agent did not change the task's worktree: %q", readme)
+	}
+
+	runs := h.stepRuns(t, after.ID)
+	round1 := followUpRuns(runs, 1)
+	if len(round1) != 1 {
+		t.Fatalf("round 1 rows = %d, want 1 at index %d", len(round1), followUpBaseSteps)
+	}
+	if round1[0].StepID != FollowUpStepID || round1[0].State != store.StepSucceeded {
+		t.Errorf("row = %s/%s, want %s/succeeded",
+			round1[0].StepID, round1[0].State, FollowUpStepID)
+	}
+	if round1[0].Iteration != 0 {
+		t.Errorf("iteration = %d, want 0 — iteration keeps its §7.8 loop meaning", round1[0].Iteration)
+	}
+	if round1[0].TranscriptPath == "" {
+		t.Error("the follow-up run has no transcript; it is a step run like any other")
+	}
+	// The original workflow's rows are untouched: a follow-up appends nothing
+	// to the snapshot and spends none of its budgets.
+	if got, want := len(runs)-len(round1), len(before); got != want {
+		t.Errorf("workflow rows = %d, want %d unchanged", got, want)
+	}
+}
+
+// TestFollowUpCommandRunsUnderTheDaemonShell covers the second form: no agent
+// is involved, and the command runs in the task's worktree under §8.3's shell.
+func TestFollowUpCommandRunsUnderTheDaemonShell(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	// `git config -f` writes a file with no `touch`, `printf` or redirection,
+	// so one spelling works in both sh and pwsh (CLAUDE.md).
+	req := commandFollowUp(t, "git config -f follow-up.txt vincent.followup ran")
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, req); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	after := h.settle(t, done.ID)
+
+	if after.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done again", after.State, after.BlockReason)
+	}
+	if _, err := os.Stat(filepath.Join(after.WorktreePath, "follow-up.txt")); err != nil {
+		t.Errorf("the command follow-up did not run in the task's worktree: %v", err)
+	}
+	round1 := followUpRuns(h.stepRuns(t, after.ID), 1)
+	if len(round1) != 1 || round1[0].StepType != workflow.StepCommand {
+		t.Fatalf("round 1 rows = %+v, want one command row", round1)
+	}
+	if round1[0].Agent != "" {
+		t.Errorf("agent = %q, want none — a command follow-up runs no agent", round1[0].Agent)
+	}
+}
+
+// TestFollowUpOnAnAbortedTaskReturnsToAborted is decision 5: a follow-up
+// decides nothing about a task's verdict. A command that exits 0 must not be
+// able to reverse a human's abort.
+func TestFollowUpOnAnAbortedTaskReturnsToAborted(t *testing.T) {
+	h := newEngineHarness(t)
+	aborted := abortedTask(t, h)
+
+	req := commandFollowUp(t, "git --version")
+	if _, err := h.runner.FollowUp(t.Context(), aborted.ID, req); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	after := h.settle(t, aborted.ID)
+
+	if after.State != store.TaskAborted {
+		t.Errorf("task = %s, want aborted — a successful follow-up is not a promotion", after.State)
+	}
+	if len(followUpRuns(h.stepRuns(t, after.ID), 1)) != 1 {
+		t.Error("the follow-up did not run on the aborted task")
+	}
+}
+
+// TestSecondFollowUpIsRoundTwo is decision 2's numbering: repeat follow-ups
+// occupy distinct indices, so they are separate rounds rather than further
+// attempts of the first.
+func TestSecondFollowUpIsRoundTwo(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	for i := range 2 {
+		req := commandFollowUp(t, "git --version")
+		if _, err := h.runner.FollowUp(t.Context(), done.ID, req); err != nil {
+			t.Fatalf("FollowUp %d: %v", i+1, err)
+		}
+		if got := h.settle(t, done.ID); got.State != store.TaskDone {
+			t.Fatalf("after follow-up %d task = %s/%q, want done", i+1, got.State, got.BlockReason)
+		}
+	}
+
+	runs := h.stepRuns(t, done.ID)
+	for round := 1; round <= 2; round++ {
+		rows := followUpRuns(runs, round)
+		if len(rows) != 1 {
+			t.Fatalf("round %d rows = %d, want 1 at index %d",
+				round, len(rows), followUpBaseSteps+round-1)
+		}
+		if rows[0].Attempt != 1 {
+			t.Errorf("round %d attempt = %d, want 1 — a second follow-up is a round, not a retry",
+				round, rows[0].Attempt)
+		}
+	}
+}
+
+// TestFollowUpWorkflowRunsEveryStepThroughAGate is decision 3 and decision 4
+// together: a multi-step follow-up workflow runs to the end, a `manual` gate
+// inside it parks the task and `approve` advances the *follow-up's* cursor
+// rather than the task's.
+func TestFollowUpWorkflowRunsEveryStepThroughAGate(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	yaml := "name: tidy\nsteps:\n" +
+		commandStep("first", "git config -f follow-up-first.txt vincent.first ran", "max_retries: 0") +
+		"  - id: sign-off\n    type: manual\n    instructions: look at it\n" +
+		commandStep("second", "git config -f follow-up-second.txt vincent.second ran", "max_retries: 0")
+
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, workflowFollowUp(t, "tidy", yaml)); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	parked := h.settle(t, done.ID)
+	if parked.State != store.TaskAwaitingGate {
+		t.Fatalf("task = %s/%q, want awaiting_gate at the follow-up's manual step",
+			parked.State, parked.BlockReason)
+	}
+	if parked.CurrentStep != done.CurrentStep {
+		t.Errorf("current_step = %d, want %d — a gate inside a follow-up moves the follow-up's cursor",
+			parked.CurrentStep, done.CurrentStep)
+	}
+	if parked.PendingFollowUp == nil || parked.PendingFollowUp.Cursor != 1 {
+		t.Fatalf("follow-up cursor = %+v, want 1 — the gate is step 2 of the round",
+			parked.PendingFollowUp)
+	}
+
+	if _, err := h.runner.Approve(t.Context(), done.ID); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	after := h.settle(t, done.ID)
+	if after.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done after the gate was approved",
+			after.State, after.BlockReason)
+	}
+	for _, name := range []string{"follow-up-first.txt", "follow-up-second.txt"} {
+		if _, err := os.Stat(filepath.Join(after.WorktreePath, name)); err != nil {
+			t.Errorf("%s missing: the follow-up did not run every step: %v", name, err)
+		}
+	}
+
+	// Every row of the round sits at the round's own index, under the id its
+	// author wrote — never rewritten, because `if:` guards and `.Steps` refer
+	// to those ids (decision 2).
+	rows := followUpRuns(h.stepRuns(t, after.ID), 1)
+	var ids []string
+	for _, r := range rows {
+		ids = append(ids, r.StepID)
+	}
+	for _, want := range []string{"first", "sign-off", "second"} {
+		if !containsString(ids, want) {
+			t.Errorf("round 1 ids = %v, missing %q", ids, want)
+		}
+	}
+}
+
+// TestFollowUpLoopKeepsIterationMeaning is the other half of decision 2: a
+// `loop` inside a follow-up numbers its passes in `iteration`, which the
+// round number does not touch.
+func TestFollowUpLoopKeepsIterationMeaning(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	yaml := "name: twice\nsteps:\n  - id: passes\n    type: loop\n    count: 2\n    steps:\n" +
+		indentBody(commandStep("tick", "git --version", "max_retries: 0"))
+
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, workflowFollowUp(t, "twice", yaml)); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	after := h.settle(t, done.ID)
+	if after.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", after.State, after.BlockReason)
+	}
+	seen := map[int]bool{}
+	for _, r := range followUpRuns(h.stepRuns(t, after.ID), 1) {
+		if r.StepID == "tick" {
+			seen[r.Iteration] = true
+		}
+	}
+	if !seen[1] || !seen[2] {
+		t.Errorf("loop iterations recorded = %v, want passes 1 and 2", seen)
+	}
+}
+
+// TestFollowUpFanOutSpawnsAndJoins is the most expensive thing decision 3
+// bought: a `fan_out` inside a follow-up parks the finished task in
+// `awaiting_children`, its lanes run as ordinary tasks off its branch, and
+// the join resumes at the *follow-up's* cursor rather than at `current_step`.
+func TestFollowUpFanOutSpawnsAndJoins(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	yaml := "name: spread\nsteps:\n  - id: spread\n    type: fan_out\n    lanes:\n" +
+		"      - id: a\n        steps:\n" + indent(writeFileStep("write-a", "a.txt", "a")) +
+		"      - id: b\n        steps:\n" + indent(writeFileStep("write-b", "b.txt", "b"))
+
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, workflowFollowUp(t, "spread", yaml)); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	lanes := h.waitForChildren(t, done.ID, 2)
+	for _, lane := range lanes {
+		if lane.ParentStepIndex == nil || *lane.ParentStepIndex != followUpBaseSteps {
+			t.Fatalf("lane %d parent_step_index = %v, want %d — the follow-up's own index",
+				lane.ID, lane.ParentStepIndex, followUpBaseSteps)
+		}
+		if lane.BaseBranch != done.BranchName {
+			t.Errorf("lane %d base_branch = %q, want the finished task's branch %q",
+				lane.ID, lane.BaseBranch, done.BranchName)
+		}
+	}
+
+	after := h.waitForStateWithin(t, done.ID, fanOutBudget,
+		store.TaskDone, store.TaskAborted, store.TaskBlocked)
+	if after.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done after the join", after.State, after.BlockReason)
+	}
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if !h.fileOnBranch(t, after.BranchName, name) {
+			t.Errorf("%s is not on the task's branch; the join did not merge every lane", name)
+		}
+	}
+	// The join is a row of the round, at the round's index, under the author's
+	// own step id.
+	var joined bool
+	for _, r := range followUpRuns(h.stepRuns(t, after.ID), 1) {
+		if r.StepID == "spread" && r.StepType == workflow.StepFanOut {
+			joined = true
+		}
+	}
+	if !joined {
+		t.Error("no fan_out row at the follow-up's index; the join was recorded somewhere else")
+	}
+}
+
+// TestFailedFollowUpBlocksAtItsOwnIndexAndRetryReRunsIt is decision 6: the
+// block lands at the follow-up's row index, the request survives it, and
+// `retry` re-runs the follow-up rather than completing the task.
+func TestFailedFollowUpBlocksAtItsOwnIndexAndRetryReRunsIt(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+
+	req := commandFollowUp(t, "exit 3")
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, req); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	blocked := h.settle(t, done.ID)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+	if blocked.PendingFollowUp == nil {
+		t.Fatal("the follow-up request did not survive the block; retry could not re-run it")
+	}
+	rows := followUpRuns(h.stepRuns(t, blocked.ID), 1)
+	if len(rows) == 0 || rows[len(rows)-1].State != store.StepFailed {
+		t.Fatalf("round 1 rows = %+v, want a failed row at the follow-up's own index", rows)
+	}
+
+	if _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	again := h.settle(t, blocked.ID)
+	if again.State != store.TaskBlocked {
+		t.Errorf("task = %s, want blocked again — retry re-runs the follow-up, it does not complete the task",
+			again.State)
+	}
+	if got := len(followUpRuns(h.stepRuns(t, again.ID), 1)); got <= len(rows) {
+		t.Errorf("round 1 rows = %d, want more than %d — the retry ran the follow-up again",
+			got, len(rows))
+	}
+}
+
+// TestEditRetryOnABlockedFollowUpIsRefused: an override rewrites a step of
+// the *snapshot*, and a follow-up is deliberately not in the snapshot
+// (decision 1). Refusing says so; the alternative was a 500 from a rewrite
+// with nowhere to land.
+func TestEditRetryOnABlockedFollowUpIsRefused(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, commandFollowUp(t, "exit 3")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	blocked := h.settle(t, done.ID)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+
+	_, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{Run: "git --version"})
+	if _, ok := AsFollowUpOverride(err); !ok {
+		t.Fatalf("Retry with an override: err = %v, want FollowUpOverrideError", err)
+	}
+}
+
+// TestSkipAbandonsAFollowUpAndRestoresTheOrigin is the rest of decision 6:
+// `skip` from a follow-up's block runs nothing more and puts the task back
+// where it came from — `aborted` here, which is the case a promotion bug
+// would show up in.
+func TestSkipAbandonsAFollowUpAndRestoresTheOrigin(t *testing.T) {
+	h := newEngineHarness(t)
+	aborted := abortedTask(t, h)
+	if _, err := h.runner.FollowUp(t.Context(), aborted.ID, commandFollowUp(t, "exit 3")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	blocked := h.settle(t, aborted.ID)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+
+	if _, err := h.runner.Skip(t.Context(), blocked.ID); err != nil {
+		t.Fatalf("Skip: %v", err)
+	}
+	after := h.settle(t, blocked.ID)
+	if after.State != store.TaskAborted {
+		t.Errorf("task = %s, want aborted — skip abandons the follow-up, it does not decide the verdict",
+			after.State)
+	}
+	if after.PendingFollowUp != nil {
+		t.Error("the abandoned request survived the restore")
+	}
+}
+
+// TestCancelDuringAFollowUpAbortsADoneTask is decision 8: `done → aborted`
+// becomes reachable, because the follow-up's process is live and `cancel`
+// means what it always means.
+func TestCancelDuringAFollowUpAbortsADoneTask(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, commandFollowUp(t, "exit 3")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	blocked := h.settle(t, done.ID)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+
+	after, err := h.runner.Cancel(t.Context(), blocked.ID)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if after.State != store.TaskAborted {
+		t.Errorf("task = %s, want aborted", after.State)
+	}
+	if after.PendingFollowUp != nil {
+		t.Error("cancel left the follow-up request behind; it must drop it")
+	}
+}
+
+// TestRepairReadsAFollowUpRowAsItsFailureContext is decision 6's last clause.
+// Before this, `runRepair` warned and no-oped whenever `current_step` was past
+// the end of the snapshot — which is every finished task, and therefore every
+// blocked follow-up.
+func TestRepairReadsAFollowUpRowAsItsFailureContext(t *testing.T) {
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+	if _, err := h.runner.FollowUp(t.Context(), done.ID, commandFollowUp(t, "exit 3")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	blocked := h.settle(t, done.ID)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+	project, err := h.store.GetProject(t.Context(), blocked.ProjectID)
+	if err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	wf, _, perr := workflow.Parse([]byte(blocked.WorkflowSnapshot), workflow.Options{})
+	if perr != nil {
+		t.Fatalf("parse snapshot: %v", perr)
+	}
+
+	target, ok := h.runner.repairTargetOf(blocked, wf)
+	if !ok {
+		t.Fatal("no repair target for a task blocked in a follow-up; the rescue would be unavailable")
+	}
+	if !target.followUp {
+		t.Error("the repair target is not the follow-up's step")
+	}
+	if want := followUpBaseSteps; target.index != want {
+		t.Errorf("repair index = %d, want %d — the follow-up's own row", target.index, want)
+	}
+	prompt := h.runner.repairPrompt(t.Context(), blocked, project, target,
+		store.RepairRequest{Prompt: "make it exit 0", BlockReason: blocked.BlockReason})
+	for _, want := range []string{
+		"follow-up run",          // the prompt says which kind of block this is
+		"blocked-follow-up-step", // and tags the element as one
+		"exit 3",                 // the command that failed
+		string(store.TaskDone),   // nothing about the origin is lost
+		blocked.WorktreePath,     // the worktree the repair agent works in
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("repair prompt is missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+// TestInterruptedFollowUpResumesAsAFollowUp is §12.4 over the second cursor:
+// a daemon that died mid-follow-up must come back and run a follow-up, not
+// silently complete the task.
+func TestInterruptedFollowUpResumesAsAFollowUp(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newEngineHarness(t)
+	done := doneTask(t, h)
+	if _, err := h.runner.FollowUp(t.Context(), done.ID,
+		agentFollowUp(t, "take your time")); err != nil {
+		t.Fatalf("FollowUp: %v", err)
+	}
+	waitForFollowUpRunning(t, h, done.ID)
+
+	// The daemon goes down mid-run and comes back: Recover finalizes the open
+	// row and re-queues the task, and the request is still on it.
+	h.runner.Stop()
+	h.sched.Stop()
+	if _, err := Recover(t.Context(), h.store, h.runner.deps.Logger); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	requeued, err := h.store.GetTask(t.Context(), done.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if requeued.PendingFollowUp == nil {
+		t.Fatal("recovery dropped the follow-up request; the next admission would complete the task")
+	}
+	t.Setenv("FAKEAGENT_SCENARIO", "success")
+	h.restart(t)
+	after := h.settle(t, done.ID)
+	if after.State != store.TaskDone {
+		t.Fatalf("task = %s/%q, want done", after.State, after.BlockReason)
+	}
+	// The re-run is another attempt of the *follow-up* step, at the follow-up's
+	// own index — not a row of the workflow, and not a round of its own.
+	rows := followUpRuns(h.stepRuns(t, after.ID), 1)
+	if len(rows) < 2 {
+		t.Fatalf("round 1 rows = %d, want the interrupted attempt and its re-run", len(rows))
+	}
+	if len(followUpRuns(h.stepRuns(t, after.ID), 2)) != 0 {
+		t.Error("the resumed follow-up became round 2; an interruption is not a new round")
+	}
+}
+
+// TestEarlierRoundsAreInvisibleToALaterRound is decision 9: the original
+// workflow's results stay visible to a follow-up — reading them is the point
+// — while earlier rounds' rows are hidden, the way `__repair` rows are.
+func TestEarlierRoundsAreInvisibleToALaterRound(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, followUpBase)
+	env := &stepEnv{
+		task:     task,
+		index:    followUpBaseSteps + 1, // round 2
+		followUp: &followUpEnv{base: followUpBaseSteps, round: 2, order: map[string]int{"x": 0}},
+		step:     workflow.Step{ID: "x"},
+	}
+	cases := []struct {
+		name string
+		run  store.StepRun
+		want bool
+	}{
+		{"the workflow's own step", store.StepRun{StepIndex: 0, StepID: "build"}, false},
+		{"round 1", store.StepRun{StepIndex: followUpBaseSteps, StepID: "follow-up"}, true},
+		{"this round", store.StepRun{StepIndex: followUpBaseSteps + 1, StepID: "x"}, false},
+	}
+	for _, tc := range cases {
+		if got := env.blindTo(&tc.run); got != tc.want {
+			t.Errorf("blindTo(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestFollowUpRoundIndex pins decision 2's arithmetic on its own, so a change
+// to it fails here rather than in a gate.
+func TestFollowUpRoundIndex(t *testing.T) {
+	for round, want := range map[int]int{1: 4, 2: 5, 3: 6} {
+		if got := followUpRowIndex(4, round); got != want {
+			t.Errorf("followUpRowIndex(4, %d) = %d, want %d", round, got, want)
+		}
+	}
+	// A corrupt round number places the row somewhere real rather than
+	// underneath the workflow's last step.
+	if got := followUpRowIndex(4, 0); got != 4 {
+		t.Errorf("followUpRowIndex(4, 0) = %d, want 4", got)
+	}
+}
+
+// waitForFollowUpRunning polls until a follow-up row has a live process,
+// which is when a crash is worth simulating.
+func waitForFollowUpRunning(t *testing.T, h *engineHarness, id int64) {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, r := range followUpRuns(h.stepRuns(t, id), 1) {
+			if r.State == store.StepRunning && r.PID != nil {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never started a follow-up", id)
+}
+
+// indentBody shifts a commandStep block under a `loop`'s `steps:`, which sits
+// two levels further in than the top level it is written at.
+func indentBody(block string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(block, "\n"), "\n") {
+		sb.WriteString("    " + line + "\n")
+	}
+	return sb.String()
+}
+
+func containsString(haystack []string, want string) bool {
+	for _, v := range haystack {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -94,7 +94,8 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 			subEnv := &stepEnv{
 				task: env.task, project: env.project, wf: env.wf,
 				step: sub, index: env.index, inGroup: true,
-				log: env.log.With("sub_step", sub.ID),
+				followUp: env.followUp,
+				log:      env.log.With("sub_step", sub.ID),
 			}
 			out := r.runStepWithRetries(groupCtx, subEnv)
 			// `allow_failure` on a sub-step keeps its `failed` row and its
@@ -164,7 +165,8 @@ func (r *Runner) applySubStepGuards(
 		subEnv := &stepEnv{
 			task: env.task, project: env.project, wf: env.wf,
 			step: sub, index: env.index, inGroup: true,
-			log: env.log.With("sub_step", sub.ID),
+			followUp: env.followUp,
+			log:      env.log.With("sub_step", sub.ID),
 		}
 		pass, evalErr := r.evaluateGuard(ctx, subEnv)
 		if evalErr != nil {
@@ -187,7 +189,10 @@ func (r *Runner) applySubStepGuards(
 // or a loop body, whose siblings share that index (task 014 decision 16,
 // task 016 decision 13).
 func subStepIDOf(env *stepEnv) string {
-	if env.inGroup || env.loop != nil {
+	// A follow-up round is the third case (task 027 decision 2): every step
+	// of the round shares the round's index, so the id is what keeps two of
+	// them from writing the same transcript file.
+	if env.inGroup || env.loop != nil || env.followUp != nil {
 		return env.step.ID
 	}
 	return ""

--- a/internal/taskrun/join.go
+++ b/internal/taskrun/join.go
@@ -226,6 +226,7 @@ func (r *Runner) handleConflict(
 		task: env.task, project: env.project, wf: env.wf,
 		step: resolver, index: env.index, inGroup: true,
 		conflicts: paths,
+		followUp:  env.followUp,
 		log:       env.log.With("merge_resolver", resolver.ID),
 	}
 	attempt := r.runStepWithRetries(ctx, resolverEnv)

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -175,7 +175,8 @@ func (r *Runner) runIteration(
 				pos:       pos,
 				order:     order,
 			},
-			log: env.log.With("body_step", body.ID, "iteration", iteration),
+			followUp: env.followUp,
+			log:      env.log.With("body_step", body.ID, "iteration", iteration),
 		}
 		outcome, stop := r.runBodyStep(ctx, bodyEnv)
 		if stop {

--- a/internal/taskrun/repair.go
+++ b/internal/taskrun/repair.go
@@ -39,6 +39,29 @@ const repairTranscriptLines = 200
 // the end of it is wanted.
 const repairTranscriptTailBytes = 512 << 10
 
+// The two openings a repair prompt can have. They differ because a follow-up
+// block has no workflow left to re-run (task 027): telling the agent not to
+// re-run one, and that a human will decide whether to retry "the step", would
+// describe a situation that is not the one it is in.
+const (
+	workflowRepairIntro = "A workflow step failed and the task is waiting for a human. " +
+		"Investigate and change the worktree so that step can succeed on its next run. " +
+		"You are working in the task's existing worktree, on its branch: the files are " +
+		"as the failed step left them.\n\n" +
+		"Do not re-run the workflow and do not try to mark the step passed. " +
+		"When you are done, the task returns to its blocked state and a human decides " +
+		"whether to retry the step.\n\n"
+
+	followUpRepairIntro = "A step of a follow-up run failed and the task is waiting for a " +
+		"human. The task's own workflow already finished; this run is extra work somebody " +
+		"asked for in the task's existing worktree, on its branch. Investigate and change " +
+		"the worktree so that step can succeed on its next run: the files are as the failed " +
+		"step left them.\n\n" +
+		"Do not re-run the follow-up and do not try to mark the step passed. When you are " +
+		"done, the task returns to its blocked state and a human decides whether to retry " +
+		"the follow-up, abandon it, or cancel the task.\n\n"
+)
+
 // runRepair executes one ad-hoc repair admission (§6, task 025) and returns
 // the task to `blocked`.
 //
@@ -67,23 +90,22 @@ func (r *Runner) runRepair(
 		r.interrupt(task, log)
 		return
 	}
-	index := task.CurrentStep
-	if index < 0 {
-		index = 0
-	}
-	if index >= len(wf.Steps) {
-		// The cursor is past the end: nothing failed here, so there is no
-		// failure context to gather and nothing sensible to repair.
-		log.Warn("repair requested at a step that does not exist", "step_index", index)
+	target, ok := r.repairTargetOf(task, wf)
+	if !ok {
+		// The cursor is past the end and no follow-up run is in flight:
+		// nothing failed here, so there is no failure context to gather and
+		// nothing sensible to repair.
+		log.Warn("repair requested at a step that does not exist", "step_index", task.CurrentStep)
 		r.finishRepair(task, req, log)
 		return
 	}
-	log = log.With("repair_step_index", index)
+	index := target.index
+	log = log.With("repair_step_index", index, "repair_follow_up", target.followUp)
 
-	prompt := r.repairPrompt(ctx, task, project, wf, index, req)
+	prompt := r.repairPrompt(ctx, task, project, target, req)
 	noRetries := 0
 	env := &stepEnv{
-		task: task, project: project, wf: wf,
+		task: task, project: project, wf: target.wf,
 		index: index,
 		// inGroup is what gives the row and its transcript a name of their
 		// own at an index another step already owns, exactly as a `parallel`
@@ -142,6 +164,46 @@ func (r *Runner) finishRepair(task *store.Task, req store.RepairRequest, log *sl
 	}
 }
 
+// repairTarget is the step a repair is about: which one, where its rows sit,
+// and which workflow it belongs to.
+//
+// There are two (task 027 decision 6). Ordinarily it is the snapshot's step
+// at `current_step`, which is what blocked the task. When a follow-up run is
+// in flight it is that run's own step at its own row index — a finished
+// task's `current_step` is past the end of its snapshot, and before this a
+// repair there simply warned and no-oped, taking the rescue away from the one
+// kind of block a follow-up can produce.
+type repairTarget struct {
+	// wf is the workflow the step belongs to, whose `defaults:` the repair
+	// agent's own selection resolves through and whose name reaches §8.4.
+	wf    *workflow.Workflow
+	index int
+	step  workflow.Step
+	// followUp says the blocked step is a follow-up's rather than the task's
+	// workflow's, which is what the prompt tells the agent it is looking at.
+	followUp bool
+}
+
+// repairTargetOf resolves the step a repair on this task is about, and false
+// when there is none.
+func (r *Runner) repairTargetOf(task *store.Task, wf *workflow.Workflow) (repairTarget, bool) {
+	if at, inFollowUp := r.followUpOf(task); inFollowUp && at.hasStep {
+		fu, err := followUpWorkflow(at.req)
+		if err != nil {
+			return repairTarget{}, false
+		}
+		return repairTarget{wf: fu, index: at.index, step: at.step, followUp: true}, true
+	}
+	index := task.CurrentStep
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(wf.Steps) {
+		return repairTarget{}, false
+	}
+	return repairTarget{wf: wf, index: index, step: wf.Steps[index]}, true
+}
+
 // repairPrompt assembles what the repair agent is told: the task's own
 // context, the blocked step's definition and failure, the tail of the failed
 // attempt's transcript and where the rest of it is, then the operator's
@@ -154,18 +216,16 @@ func (r *Runner) finishRepair(task *store.Task, req store.RepairRequest, log *sl
 // snapshot.
 func (r *Runner) repairPrompt(
 	ctx context.Context, task *store.Task, project *store.Project,
-	wf *workflow.Workflow, index int, req store.RepairRequest,
+	target repairTarget, req store.RepairRequest,
 ) string {
-	step := wf.Steps[index]
+	wf, index, step := target.wf, target.index, target.step
 	var sb strings.Builder
 	sb.WriteString("You are repairing a blocked task in a git worktree.\n\n")
-	sb.WriteString("A workflow step failed and the task is waiting for a human. " +
-		"Investigate and change the worktree so that step can succeed on its next run. " +
-		"You are working in the task's existing worktree, on its branch: the files are " +
-		"as the failed step left them.\n\n")
-	sb.WriteString("Do not re-run the workflow and do not try to mark the step passed. " +
-		"When you are done, the task returns to its blocked state and a human decides " +
-		"whether to retry the step.\n\n")
+	if target.followUp {
+		sb.WriteString(followUpRepairIntro)
+	} else {
+		sb.WriteString(workflowRepairIntro)
+	}
 
 	fmt.Fprintf(&sb, "<task id=%q>\n", fmt.Sprint(task.ID))
 	fmt.Fprintf(&sb, "title: %s\n", task.Title)
@@ -188,8 +248,12 @@ func (r *Runner) repairPrompt(
 	fmt.Fprintf(&sb, "worktree: %s\n", task.WorktreePath)
 	sb.WriteString("</task>\n\n")
 
-	fmt.Fprintf(&sb, "<blocked-step index=%q id=%q type=%q>\n",
-		fmt.Sprint(index+1), step.ID, step.Type)
+	element := "blocked-step"
+	if target.followUp {
+		element = "blocked-follow-up-step"
+	}
+	fmt.Fprintf(&sb, "<%s index=%q id=%q type=%q>\n",
+		element, fmt.Sprint(index+1), step.ID, step.Type)
 	if req.BlockReason != "" {
 		fmt.Fprintf(&sb, "block reason: %s\n", req.BlockReason)
 	}
@@ -205,7 +269,7 @@ func (r *Runner) repairPrompt(
 			fmt.Fprintf(&sb, "check exit code: %d\n", *run.CheckExitCode)
 		}
 	}
-	if body, field := r.renderBlockedStep(ctx, task, project, wf, index); body != "" {
+	if body, field := r.renderBlockedStep(ctx, task, project, target); body != "" {
 		fmt.Fprintf(&sb, "--- %s ---\n", field)
 		sb.WriteString(strings.TrimSuffix(body, "\n"))
 		sb.WriteString("\n")
@@ -225,7 +289,7 @@ func (r *Runner) repairPrompt(
 			sb.WriteString(tail + "\n")
 		}
 	}
-	sb.WriteString("</blocked-step>\n\n")
+	fmt.Fprintf(&sb, "</%s>\n\n", element)
 
 	sb.WriteString("<repair-instructions>\n")
 	sb.WriteString(strings.TrimSuffix(req.Prompt, "\n"))
@@ -239,10 +303,9 @@ func (r *Runner) repairPrompt(
 // back to the raw text: the point is to show the agent what it is looking at,
 // and a render failure is itself worth seeing.
 func (r *Runner) renderBlockedStep(
-	ctx context.Context, task *store.Task, project *store.Project,
-	wf *workflow.Workflow, index int,
+	ctx context.Context, task *store.Task, project *store.Project, target repairTarget,
 ) (body, field string) {
-	step := wf.Steps[index]
+	step := target.step
 	switch step.Type {
 	case workflow.StepAgent:
 		body, field = step.Prompt, "prompt"
@@ -257,7 +320,7 @@ func (r *Runner) renderBlockedStep(
 		return "", field
 	}
 	env := &stepEnv{
-		task: task, project: project, wf: wf, step: step, index: index,
+		task: task, project: project, wf: target.wf, step: step, index: target.index,
 		log: r.deps.Logger,
 	}
 	rc, err := r.renderContext(ctx, env, 1, stepOutcome{})

--- a/internal/taskrun/repair_test.go
+++ b/internal/taskrun/repair_test.go
@@ -284,7 +284,11 @@ func TestRepairPromptCarriesTheFailureContext(t *testing.T) {
 		Prompt: "the operator's own words", BlockReason: blocked.BlockReason,
 	}
 
-	prompt := h.runner.repairPrompt(t.Context(), blocked, project, wf, blocked.CurrentStep, req)
+	target, ok := h.runner.repairTargetOf(blocked, wf)
+	if !ok {
+		t.Fatal("no repair target for a task blocked on a workflow step")
+	}
+	prompt := h.runner.repairPrompt(t.Context(), blocked, project, target, req)
 	for _, want := range []string{
 		"engine test",              // the task title
 		"a task",                   // its description

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -99,6 +99,18 @@ const (
 	// and a recovery path (what task 014 paid for `awaiting_children`) to
 	// buy one nicer `cancel`, which keeps its present meaning throughout.
 	Repair Action = "repair"
+	// FollowUp is a run a human launches from `done` or `aborted`, before the
+	// task is archived (task 027). It is the third producer of `→ queued`
+	// after retry and repair, and the admission it produces runs an agent
+	// prompt, a shell command or a whole registry workflow in the task's
+	// *existing* worktree and branch, then returns the task to the state it
+	// came from — `done → done`, `aborted → aborted`.
+	//
+	// It is scoped to exactly the pair `archive` is scoped to: the two states
+	// where the work still exists and is still reachable. A follow-up decides
+	// nothing about the task's verdict (decision 5), which is why there is no
+	// `aborted → done` edge behind it.
+	FollowUp Action = "follow_up"
 )
 
 // Engine events. They are transitions the daemon performs while running a
@@ -130,12 +142,20 @@ const (
 	// ChildrenSettled is every descendant of a parked parent having settled,
 	// which returns it to the queue to run its join.
 	ChildrenSettled Action = "children_settled"
+	// Restore returns a task whose follow-up run has ended to the state the
+	// follow-up was launched from (task 027 decision 7). It exists for the
+	// `aborted` origin alone: a done-origin follow-up ends with Complete,
+	// which already means "the run finished", while returning an aborted task
+	// had no edge behind it at all. `cancel` would have been the only
+	// candidate and it is a human action — using it here would report a
+	// human decision that nobody made.
+	Restore Action = "restore"
 )
 
 // humanActions is the set of actions a client may invoke, in the order §6
 // lists them.
 var humanActions = []Action{
-	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive,
+	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive, FollowUp,
 }
 
 // Human reports whether a is a human action rather than an engine event.
@@ -183,6 +203,11 @@ var table = map[Action]map[State]Transition{
 	Approve: {AwaitingGate: {To: Queued}},
 	Reject:  {AwaitingGate: {To: Blocked}},
 	Archive: {Done: {To: Archived}, Aborted: {To: Archived}},
+	// A follow-up is offered from exactly the states archive is (task 027):
+	// the two where the task is finished but its worktree and branch are
+	// still there. Both re-queue, so internal/scheduler stays the only
+	// producer of `queued → running` and both §11 caps apply.
+	FollowUp: {Done: {To: Queued}, Aborted: {To: Queued}},
 
 	Admit:        {Queued: {To: Running}},
 	Gate:         {Running: {To: AwaitingGate}},
@@ -203,6 +228,12 @@ var table = map[Action]map[State]Transition{
 	// Its children are ordinary tasks and pause individually.
 	FanOut:          {Running: {To: AwaitingChildren}},
 	ChildrenSettled: {AwaitingChildren: {To: Queued}},
+
+	// Follow-up (task 027). A done-origin follow-up ends through Complete,
+	// which this row is the aborted-origin mirror of. There is no other user
+	// of Restore, and deliberately no `Aborted → Done` anywhere: a follow-up
+	// never changes a task's verdict (decision 5).
+	Restore: {Running: {To: Aborted}},
 }
 
 // Next returns the transition for applying a to a task in state from. ok is

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -7,9 +7,9 @@ import (
 
 // allActions is every action the table may contain, human and engine.
 var allActions = []Action{
-	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive,
+	Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive, FollowUp,
 	Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
-	FanOut, ChildrenSettled,
+	FanOut, ChildrenSettled, Restore,
 }
 
 // wantTransitions is the §6 transition table restated independently of the
@@ -31,6 +31,9 @@ var wantTransitions = map[State]map[Action]State{
 		Fail:         Blocked,
 		Interrupt:    Queued,
 		Park:         Paused,
+		// The aborted-origin end of a follow-up run (task 027 decision 7).
+		// Its done-origin twin is Complete, one line above.
+		Restore: Aborted,
 	},
 	AwaitingGate: {
 		Cancel:  Aborted,
@@ -66,11 +69,16 @@ var wantTransitions = map[State]map[Action]State{
 		Cancel: Aborted,
 		Resume: Queued,
 	},
+	// The two unarchived non-terminal states, and the only two a follow-up
+	// may be asked for from (task 027). Both re-queue; neither gains any
+	// other action.
 	Done: {
-		Archive: Archived,
+		Archive:  Archived,
+		FollowUp: Queued,
 	},
 	Aborted: {
-		Archive: Archived,
+		Archive:  Archived,
+		FollowUp: Queued,
 	},
 	Archived: {},
 }
@@ -163,8 +171,8 @@ func TestHumanActionsFrom(t *testing.T) {
 		AwaitingInput: {Answer, Cancel},
 		Blocked:       {Cancel, Repair, Retry, Skip},
 		Paused:        {Cancel, Resume},
-		Done:          {Archive},
-		Aborted:       {Archive},
+		Done:          {Archive, FollowUp},
+		Aborted:       {Archive, FollowUp},
 		Archived:      nil,
 	}
 	for state, want := range tests {
@@ -181,10 +189,12 @@ func TestHumanActionsFrom(t *testing.T) {
 // TestHumanClassification pins which actions clients may invoke: an engine
 // event must never be reachable through the API.
 func TestHumanClassification(t *testing.T) {
-	human := []Action{Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive}
+	human := []Action{
+		Cancel, Pause, Resume, Retry, Repair, Skip, Answer, Approve, Reject, Archive, FollowUp,
+	}
 	engine := []Action{
 		Admit, Gate, RequestInput, Complete, Fail, Interrupt, InputClosed, Park,
-		FanOut, ChildrenSettled,
+		FanOut, ChildrenSettled, Restore,
 	}
 	for _, a := range human {
 		if !Human(a) {

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -43,6 +43,11 @@ const (
 	// prompt and chooses an adapter — so a single row could only describe
 	// one of them.
 	ctxRepairForm bindingContext = "repair form"
+	// ctxFollowUpForm is the §6 follow-up popup (task 027). Its own context
+	// for the same reason the repair form has one: it is the only popup with
+	// a chooser above its text, and a row shared with the others could only
+	// describe one of them.
+	ctxFollowUpForm bindingContext = "follow-up form"
 )
 
 // binding is one registry row.
@@ -109,6 +114,7 @@ var bindings = []binding{
 	{key: "s", label: "skip the current step", scope: scopeTaskAction, action: apiclient.ActionSkip, priority: 6},
 	{key: "c", label: "cancel the task (asks first — a running step is killed)", scope: scopeTaskAction, action: apiclient.ActionCancel, priority: 7},
 	{key: "A", label: "archive the task (asks first — the worktree is removed)", scope: scopeTaskAction, action: apiclient.ActionArchive, priority: 8},
+	{key: "F", label: "follow up — run an agent prompt, a shell command or a workflow in this finished task's worktree; it returns to the state it came from", scope: scopeTaskAction, action: apiclient.ActionFollowUp, priority: 9},
 
 	// Task table.
 	{key: "down", label: "move the selection (↑/↓ — the panels follow the cursor)", scope: scopePanel, context: ctxTasks, hint: "↑/↓ select", priority: 3},
@@ -186,6 +192,13 @@ var bindings = []binding{
 	{key: "e", label: "write the repair prompt in $EDITOR", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 	{key: "ctrl+s", label: "start the repair agent", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 	{key: "esc", label: "close the popup without repairing (the draft is discarded)", scope: scopePanel, context: ctxRepairForm, noPalette: true},
+
+	// Follow-up form: same again — the popup owns the keyboard while it is
+	// open and prints its own key line.
+	{key: "enter", label: "edit the row under the cursor — the run form, what to run, or the agent/model/effort list", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
+	{key: "e", label: "write the prompt or command in $EDITOR", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
+	{key: "ctrl+s", label: "start the follow-up run", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
+	{key: "esc", label: "close the popup without running anything (the draft is discarded)", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 }
 
 // isHomeContext reports whether a context is one of the home shell's panels —

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -87,6 +87,10 @@ func repairFormFixture() *repairForm {
 	return newRepairForm(7, "check_failed", "build")
 }
 
+func followUpFormFixture() *followUpForm {
+	return newFollowUpForm(7, 1, "done")
+}
+
 // panelKeyProbes proves one panel-scoped binding each. A probe drives the
 // real view with the key the registry publishes and asserts the effect the
 // label promises — not that the key was merely swallowed, which is what `[`
@@ -538,6 +542,49 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			f := repairFormFixture()
 			if _, exit := f.update(registryKey(t, "esc"), nil); !exit {
 				t.Fatal("esc did not close the repair form")
+			}
+		},
+	},
+
+	ctxFollowUpForm: {
+		"enter": func(t *testing.T) {
+			f := followUpFormFixture()
+			// The cursor starts on the run-form chooser, so enter opens its
+			// list; one row down it opens the prompt field instead.
+			f.update(registryKey(t, "enter"), nil)
+			if f.picker == nil {
+				t.Fatal("enter did not open the run-form list")
+			}
+			f.picker = nil
+			f.cursor = fuBody
+			f.update(registryKey(t, "enter"), nil)
+			if !f.editing {
+				t.Fatal("enter did not open the prompt field")
+			}
+		},
+		"e": func(t *testing.T) {
+			f := followUpFormFixture()
+			f.cursor = fuBody
+			opened := false
+			f.openEditor = func(string) tea.Cmd { opened = true; return nil }
+			f.update(registryKey(t, "e"), nil)
+			if !opened {
+				t.Fatal("e did not hand the prompt to $EDITOR")
+			}
+		},
+		"ctrl+s": func(t *testing.T) {
+			f := followUpFormFixture()
+			f.update(registryKey(t, "ctrl+s"), nil)
+			// With nothing typed, submitting is refused — with a reason,
+			// which is what proves the key was handled.
+			if f.err == "" {
+				t.Fatal("ctrl+s neither started the follow-up nor said why it would not")
+			}
+		},
+		"esc": func(t *testing.T) {
+			f := followUpFormFixture()
+			if _, exit := f.update(registryKey(t, "esc"), nil); !exit {
+				t.Fatal("esc did not close the follow-up form")
 			}
 		},
 	},

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -112,7 +112,11 @@ type detail struct {
 	// synthesized from task state: a human opens it with a key, and it closes
 	// when they submit or escape.
 	repair *repairForm
-	diff   diffPane
+	// followUp is the §6 follow-up form (task 027), opened the same way and
+	// on the same terms as the repair form — by a human pressing a key on a
+	// task the daemon offers the action on.
+	followUp *followUpForm
+	diff     diffPane
 	// exec runs $EDITOR for edit+retry, injected so the path is testable
 	// without a terminal.
 	exec execFunc
@@ -238,6 +242,16 @@ func (d *detail) update(msg tea.Msg) tea.Cmd {
 			d.repair.applyEdit(msg)
 		}
 		return nil
+	case followUpLoadedMsg:
+		if d.followUp != nil {
+			d.followUp.applyLoaded(msg)
+		}
+		return nil
+	case followUpEditMsg:
+		if d.followUp != nil {
+			d.followUp.applyEdit(msg)
+		}
+		return nil
 	case transcriptOpenedMsg:
 		// Nothing to apply — the file was only read. A failed viewer is worth
 		// saying, since the terminal handover leaves no other trace of it.
@@ -269,6 +283,16 @@ func (d *detail) applyAction(msg actionResultMsg) tea.Cmd {
 			d.repair = nil
 		}
 	}
+	if msg.action == apiclient.ActionFollowUp && d.followUp != nil {
+		if msg.err != nil {
+			// Same reasoning as the repair form: keep what was typed on
+			// screen rather than making the human write it again.
+			d.followUp.submitting = false
+			d.followUp.err = errString(msg.err)
+		} else {
+			d.followUp = nil
+		}
+	}
 	if msg.action == apiclient.ActionAnswer && msg.err != nil && d.form != nil {
 		// The daemon refused the answer: keep the form and its typed values on
 		// screen, since re-entering them is the last thing a human wants.
@@ -296,7 +320,7 @@ func (d *detail) open(id int64, stateHint string) tea.Cmd {
 	d.focus = focusTimeline
 	d.tab = tabOutput
 	d.actions.clear()
-	d.form, d.repair = nil, nil
+	d.form, d.repair, d.followUp = nil, nil, nil
 	d.diff.openTask(id)
 	return tea.Batch(d.loadCmd(), d.syncStream())
 }
@@ -314,7 +338,7 @@ func (d *detail) deselect() {
 	d.resetOutput()
 	d.buffer = nil
 	d.actions.clear()
-	d.form, d.repair = nil, nil
+	d.form, d.repair, d.followUp = nil, nil, nil
 	d.syncStream()
 }
 
@@ -657,6 +681,10 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 		// `R` is free in the home shell, where the takeover screens that use
 		// it for re-probing never are.
 		return d.openRepair()
+	case "F":
+		// The follow-up form (§6, task 027). `f` is follow-output and is
+		// panel-scoped, so the capital is free in the task-action scope.
+		return d.openFollowUp()
 	case "f":
 		d.setFollowing(true)
 		return nil
@@ -841,6 +869,19 @@ func (d *detail) openRepair() tea.Cmd {
 	d.repair = newRepairForm(d.taskID, reason, d.currentStepName())
 	d.repair.openEditor = d.editRepairPrompt
 	return d.repair.loadAgents(d.client)
+}
+
+// openFollowUp opens the follow-up form for a finished task, fetching the
+// adapter and workflow catalogs its pickers render. It offers nothing the
+// daemon does not: the action has to be on the task's available_actions (§6),
+// which is `done` and `aborted` and no other state.
+func (d *detail) openFollowUp() tea.Cmd {
+	if !d.target().has(apiclient.ActionFollowUp) {
+		return nil
+	}
+	d.followUp = newFollowUpForm(d.taskID, d.task.ProjectID, d.task.State)
+	d.followUp.openEditor = d.editFollowUpBody
+	return d.followUp.load(d.client)
 }
 
 // currentStepName names the step the task is blocked at, for the form's

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -184,6 +184,12 @@ func (d *detail) detailHints() []string {
 	if d.target().has(apiclient.ActionRepair) {
 		hints = append(hints, styleKey.Render("R")+" repair")
 	}
+	// `follow_up` has no row in actionOrder either, and for the same reason:
+	// three run forms need a chooser, so it is a form rather than a key that
+	// acts (task 027).
+	if d.target().has(apiclient.ActionFollowUp) {
+		hints = append(hints, styleKey.Render("F")+" follow-up")
+	}
 	return hints
 }
 
@@ -269,25 +275,16 @@ func (d *detail) renderTimeline(height int) string {
 	lastSub := ""
 	for _, r := range runs {
 		looped := loops[r.StepIndex]
-		grouped := groups[r.StepIndex] && !looped
+		// A follow-up round sits past the workflow's last index and is not a
+		// step of it (task 027). Its steps share the round's index, so they
+		// get the sub-tier a `parallel` group's members get — which is why it
+		// counts as grouped whatever groupedIndexes made of it.
+		round := d.followUpRound(r.StepIndex)
+		grouped := (groups[r.StepIndex] || round > 0) && !looped
 		if r.StepIndex != lastStep {
 			lastStep = r.StepIndex
 			lastSub, lastIteration = "", 0
-			label := stepLabel(r)
-			switch {
-			case looped:
-				label = d.structureLabel(r.StepIndex, "loop")
-			case grouped:
-				label = d.structureLabel(r.StepIndex, "parallel")
-			}
-			header := fmt.Sprintf("  %d %s", r.StepIndex+1, label)
-			if from := d.includedFrom(r.StepIndex); from != "" {
-				// A spliced step is an ordinary step in every other respect,
-				// so the only thing worth saying is where it was written
-				// (§7.9). The full chain is in the workflow graph's inspector.
-				header += styleDim.Render("  from " + from)
-			}
-			lines = append(lines, styleStepHeader.Render(header))
+			lines = append(lines, styleStepHeader.Render(d.timelineHeader(r, round, looped, grouped)))
 			ids = append(ids, 0)
 		}
 		if looped && r.Iteration != lastIteration {
@@ -342,9 +339,52 @@ func (d *detail) renderTimeline(height int) string {
 	return strings.Join(lines[start:end], "\n")
 }
 
+// timelineHeader is the line that opens one step index: its number and name
+// for a workflow step, and a tier of its own for a follow-up round.
+//
+// A round is numbered as a round, not as step `step_total+n`: numbering it
+// "5" on a four-step workflow would say the workflow grew, which is the one
+// thing task 027 decision 1 refused to do.
+func (d *detail) timelineHeader(r apiclient.StepRun, round int, looped, grouped bool) string {
+	if round > 0 {
+		return fmt.Sprintf("  ↳ follow-up %d", round)
+	}
+	label := stepLabel(r)
+	switch {
+	case looped:
+		label = d.structureLabel(r.StepIndex, "loop")
+	case grouped:
+		label = d.structureLabel(r.StepIndex, "parallel")
+	}
+	header := fmt.Sprintf("  %d %s", r.StepIndex+1, label)
+	if from := d.includedFrom(r.StepIndex); from != "" {
+		// A spliced step is an ordinary step in every other respect, so the
+		// only thing worth saying is where it was written (§7.9). The full
+		// chain is in the workflow graph's inspector.
+		header += styleDim.Render("  from " + from)
+	}
+	return header
+}
+
 // isRepairRun reports whether a row is an ad-hoc repair rather than an
 // attempt of the step at its index (§5.4, task 025).
 func isRepairRun(r apiclient.StepRun) bool { return r.StepID == apiclient.RepairStepID }
+
+// followUpRound is the 1-based follow-up round a step index belongs to, and 0
+// when the index is one of the workflow's own steps (§5.4, task 027).
+//
+// Where a repair is told apart by a reserved step id, a follow-up is told
+// apart by *position*: its rows sit at `step_total + round - 1`, and its step
+// ids are the ones its author wrote. A client with no step_total — a task
+// whose snapshot never arrived — reports 0 and renders the rows as ordinary
+// steps, which is the safe way to be wrong.
+func (d *detail) followUpRound(index int) int {
+	total := d.task.StepTotal
+	if total <= 0 || index < total {
+		return 0
+	}
+	return index - total + 1
+}
 
 // groupedIndexes reports which step indexes hold more than one distinct step
 // id — which is exactly the `parallel` groups, since every other step type

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -133,6 +133,39 @@ func (d *detail) editRepairPrompt(text string) tea.Cmd {
 	})
 }
 
+// editFollowUpBody opens a follow-up's prompt or command in $EDITOR (§6,
+// task 027). Same argument as editRepairPrompt: the popup's field is three
+// lines and the text is of a length nobody chose. It posts nothing — what the
+// editor leaves goes back into the form, and the human still has to start the
+// run.
+func (d *detail) editFollowUpBody(text string) tea.Cmd {
+	path, err := writeEditorFile(fmt.Sprintf("task%d-follow-up", d.taskID), ".md", text)
+	if err != nil {
+		if d.followUp != nil {
+			d.followUp.err = errString(err)
+		}
+		return nil
+	}
+	argv := append(editorCommand(), path)
+	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the editor is the user's own choice
+	taskID := d.taskID
+	return d.exec(cmd, func(runErr error) tea.Msg {
+		defer func() { _ = os.Remove(path) }()
+		msg := followUpEditMsg{taskID: taskID}
+		if runErr != nil {
+			msg.err = runErr
+			return msg
+		}
+		edited, readErr := os.ReadFile(path) //nolint:gosec // path is this process's temp file
+		if readErr != nil {
+			msg.err = readErr
+			return msg
+		}
+		msg.text = string(edited)
+		return msg
+	})
+}
+
 // writeEditorFile seeds a temp file with the text an editing session starts
 // from. The caller supplies the extension so the editor picks sensible
 // highlighting, and the name so two concurrent sessions cannot collide. It

--- a/internal/tui/followupform.go
+++ b/internal/tui/followupform.go
@@ -1,0 +1,603 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// fuRow is one line of the follow-up form.
+type fuRow int
+
+const (
+	// fuForm is the run-form chooser. It comes first because it decides what
+	// the row under it means (task 027 decision 3).
+	fuForm fuRow = iota
+	fuBody
+	fuAgent
+	fuModel
+	fuEffort
+	fuRowCount
+)
+
+// followUpLoadedMsg carries the two catalogs the form's pickers render: the
+// adapters, and the workflows visible to this task's project.
+type followUpLoadedMsg struct {
+	taskID    int64
+	agents    apiclient.Agents
+	workflows []apiclient.WorkflowEntry
+}
+
+// followUpEditMsg carries the text an $EDITOR session left behind.
+type followUpEditMsg struct {
+	taskID int64
+	text   string
+	err    error
+}
+
+// followUpForm collects what a §6 follow-up needs (task 027): which of the
+// three run forms, what to run, and optionally which agent, model and effort
+// to run it with.
+//
+// It is a form rather than a key that acts — which is what `a`, `s` and `r`
+// are — for one reason: three run forms need a chooser, and a key that had to
+// guess between "prompt" and "shell command" would guess wrong half the time.
+// It shares repairForm's shape, and differs in having a row above the text
+// that changes what the text means.
+//
+// Prompt and command text go to the daemon literally, never as templates
+// (§8.4 renders with missingkey=error), so a `{{` typed here is two
+// characters and not a broken step.
+type followUpForm struct {
+	taskID    int64
+	projectID int64
+	origin    string
+
+	form     string
+	prompt   string
+	run      string
+	workflow string
+	agent    string
+	model    string
+	effort   string
+
+	cursor  fuRow
+	editor  textarea.Model
+	editing bool
+
+	// agents and workflows feed the pickers; nil until the fetch lands, and
+	// nil forever when it fails. Every picker allows free text, so the form
+	// stays usable without them — the daemon is the authority on what exists
+	// and answers a bad value with a 400 that names it.
+	agents    apiclient.Agents
+	workflows []apiclient.WorkflowEntry
+	picker    *picker
+
+	// openEditor hands the body text to $EDITOR. Injected by the detail view,
+	// which owns the exec path (editor.go), so the form itself needs no
+	// terminal.
+	openEditor func(text string) tea.Cmd
+
+	err        string
+	submitting bool
+}
+
+func newFollowUpForm(taskID, projectID int64, origin string) *followUpForm {
+	ed := textarea.New()
+	ed.Prompt = ""
+	ed.ShowLineNumbers = false
+	ed.DynamicHeight = true
+	ed.MinHeight = 1
+	ed.MaxHeight = editorLines
+	ed.SetHeight(3)
+	ed.SetWidth(40)
+	return &followUpForm{
+		taskID: taskID, projectID: projectID, origin: origin,
+		form: apiclient.FollowUpFormAgent, editor: ed,
+	}
+}
+
+// load fetches the adapter and workflow catalogs the pickers render. Neither
+// failure is reported to the human: the pickers fall back to free text, which
+// is all a follow-up needs.
+func (f *followUpForm) load(client *apiclient.Client) tea.Cmd {
+	if client == nil {
+		return nil
+	}
+	taskID, projectID := f.taskID, f.projectID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		msg := followUpLoadedMsg{taskID: taskID}
+		if agents, err := client.ListAgents(ctx, false); err == nil {
+			msg.agents = agents
+		}
+		if wfs, err := client.ListWorkflows(ctx, projectID); err == nil {
+			msg.workflows = wfs
+		}
+		return msg
+	}
+}
+
+// applyLoaded installs catalogs that arrived for this task.
+func (f *followUpForm) applyLoaded(msg followUpLoadedMsg) {
+	if msg.taskID != f.taskID {
+		return
+	}
+	f.agents, f.workflows = msg.agents, msg.workflows
+}
+
+// applyEdit installs what an $EDITOR session produced.
+func (f *followUpForm) applyEdit(msg followUpEditMsg) {
+	if msg.taskID != f.taskID {
+		return
+	}
+	if msg.err != nil {
+		f.err = errString(msg.err)
+		return
+	}
+	f.setBody(strings.TrimSpace(msg.text))
+	f.err = ""
+}
+
+// paste types into whichever text entry is open.
+func (f *followUpForm) paste(text string) tea.Cmd {
+	if f.picker != nil {
+		return f.picker.paste(text)
+	}
+	if !f.editing {
+		return nil
+	}
+	var cmd tea.Cmd
+	f.editor, cmd = f.editor.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+// update handles one key. exit=true asks the caller to close the form.
+func (f *followUpForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd tea.Cmd, exit bool) {
+	if f.picker != nil {
+		res := f.picker.update(msg)
+		if res.chosen {
+			f.setRow(fuRow(f.picker.row), res.value)
+		}
+		if res.closed {
+			f.picker = nil
+		}
+		return res.cmd, false
+	}
+	if f.editing {
+		switch msg.String() {
+		case "esc":
+			// esc discards, enter is a newline: a prompt is prose and may
+			// well want more than one line, so the field cannot spend enter
+			// on committing. ctrl+s is what leaves it.
+			f.editing = false
+			f.editor.Blur()
+			return nil, false
+		case "ctrl+s":
+			f.commitBody()
+			return nil, false
+		}
+		var c tea.Cmd
+		f.editor, c = f.editor.Update(msg)
+		return c, false
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		f.cursor = max(f.cursor-1, 0)
+	case "down", "j":
+		f.cursor = min(f.cursor+1, fuRowCount-1)
+	case "enter":
+		f.openRow()
+	case "e":
+		if f.cursor == fuBody && f.bodyIsText() && f.openEditor != nil {
+			return f.openEditor(f.body()), false
+		}
+		f.openRow()
+	case "ctrl+s":
+		return f.submit(client), false
+	case "esc":
+		return nil, true
+	}
+	return nil, false
+}
+
+// openRow opens whatever the cursor is on: the form chooser, the body — as a
+// text field for the agent and command forms, as a workflow list for the
+// third — or one of the three §8.6 pickers.
+func (f *followUpForm) openRow() {
+	f.err = ""
+	switch f.cursor {
+	case fuForm:
+		f.picker = newPicker(int(fuForm), "run", followUpFormOptions(), false, f.form)
+	case fuBody:
+		if f.bodyIsText() {
+			f.startBody()
+			return
+		}
+		f.picker = newPicker(int(fuBody), "workflow", f.workflowOptions(), true, f.workflow)
+	case fuAgent:
+		f.picker = newPicker(int(fuAgent), "agent", f.agentOptions(), true, f.agent)
+	case fuModel:
+		f.picker = newPicker(int(fuModel), "model", f.catalogOptions(f.models()), true, f.model)
+	case fuEffort:
+		f.picker = newPicker(int(fuEffort), "effort", f.catalogOptions(f.efforts()), true, f.effort)
+	case fuRowCount:
+	}
+}
+
+func (f *followUpForm) setRow(row fuRow, value string) {
+	switch row {
+	case fuForm:
+		f.form = value
+	case fuBody:
+		f.workflow = value
+	case fuAgent:
+		f.agent = value
+		// The model and effort catalogs belong to an adapter; keeping values
+		// chosen from another one would submit a pair that never existed.
+		f.model, f.effort = "", ""
+	case fuModel:
+		f.model = value
+	case fuEffort:
+		f.effort = value
+	case fuRowCount:
+	}
+}
+
+// bodyIsText reports whether the body row is free text rather than a list.
+// The workflow form names something the registry already has; the other two
+// are typed.
+func (f *followUpForm) bodyIsText() bool {
+	return f.form != apiclient.FollowUpFormWorkflow
+}
+
+// body is what the body row currently holds, for whichever form is chosen.
+func (f *followUpForm) body() string {
+	switch f.form {
+	case apiclient.FollowUpFormCommand:
+		return f.run
+	case apiclient.FollowUpFormWorkflow:
+		return f.workflow
+	default:
+		return f.prompt
+	}
+}
+
+// setBody writes the body row for whichever form is chosen. The three are
+// kept apart rather than sharing one field, so switching forms to look at the
+// other one and switching back does not lose what was typed.
+func (f *followUpForm) setBody(value string) {
+	switch f.form {
+	case apiclient.FollowUpFormCommand:
+		f.run = value
+	case apiclient.FollowUpFormWorkflow:
+		f.workflow = value
+	default:
+		f.prompt = value
+	}
+}
+
+func (f *followUpForm) startBody() {
+	f.editing = true
+	f.cursor = fuBody
+	f.editor.Placeholder = followUpPlaceholder(f.form)
+	f.editor.SetValue(f.body())
+	f.editor.Focus()
+}
+
+func (f *followUpForm) commitBody() {
+	f.editing = false
+	f.editor.Blur()
+	f.setBody(strings.TrimSpace(f.editor.Value()))
+	if f.body() != "" {
+		f.err = ""
+	}
+}
+
+// followUpFormOptions is the chooser. Free text is off: these three are the
+// forms the daemon compiles, and a fourth would be a 400.
+func followUpFormOptions() []pickerOption {
+	return []pickerOption{
+		{value: apiclient.FollowUpFormAgent, label: "agent", note: "a free-form prompt"},
+		{
+			value: apiclient.FollowUpFormCommand, label: "command",
+			note: "a shell command — /bin/sh, or pwsh on Windows",
+		},
+		{
+			value: apiclient.FollowUpFormWorkflow, label: "workflow",
+			note: "a workflow from the registry",
+		},
+	}
+}
+
+func followUpPlaceholder(form string) string {
+	if form == apiclient.FollowUpFormCommand {
+		return "git rebase origin/main"
+	}
+	return "what should the agent do in this worktree?"
+}
+
+// workflowOptions lists what the registry has for this task's project, with
+// the note the workflows view uses: where it came from, and whether it can
+// run on this host at all (§8.1.1).
+func (f *followUpForm) workflowOptions() []pickerOption {
+	out := make([]pickerOption, 0, len(f.workflows))
+	for _, w := range f.workflows {
+		opt := pickerOption{value: w.Name, label: w.Name, note: w.Scope}
+		if w.PlatformSupported != nil && !*w.PlatformSupported {
+			opt.note = "⚠ does not run on this host"
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+// agentOptions is the adapter list, with the same availability notes the
+// repair and new-task pickers carry: an adapter that is installed but not
+// logged in fails every run, and saying so here saves a follow-up that was
+// never going to start (§9.5).
+func (f *followUpForm) agentOptions() []pickerOption {
+	out := []pickerOption{{value: "", label: "(task or workflow default)"}}
+	for _, a := range f.agents {
+		opt := pickerOption{value: a.Name, label: a.Name}
+		switch {
+		case !a.Available:
+			opt.note = "⚠ unavailable: " + firstNonEmpty(a.Error, "not found")
+		case a.NotAuthenticated():
+			opt.note = "⚠ installed but not logged in"
+		case a.Version != "":
+			opt.note = a.Version
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+func (f *followUpForm) models() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agent)
+	if !ok {
+		return nil
+	}
+	return a.Models
+}
+
+func (f *followUpForm) efforts() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agent)
+	if !ok {
+		return nil
+	}
+	return a.Efforts
+}
+
+// catalogOptions renders a catalog with its provenance tags, the way the
+// repair and new-task pickers do: "cli" came from the adapter itself,
+// "curated" from vincent's own list and may be stale.
+func (f *followUpForm) catalogOptions(opts []apiclient.AgentOption) []pickerOption {
+	out := []pickerOption{{value: "", label: "(task or workflow default)"}}
+	for _, o := range opts {
+		out = append(out, pickerOption{value: o.Value, label: o.Value, note: o.Source})
+	}
+	return out
+}
+
+// request is what the form would submit. Only the field the chosen form owns
+// is sent: the daemon refuses a request that names two things to run.
+func (f *followUpForm) request() apiclient.FollowUpInput {
+	in := apiclient.FollowUpInput{Agent: f.agent, Model: f.model, Effort: f.effort}
+	switch f.form {
+	case apiclient.FollowUpFormCommand:
+		in.Run = f.run
+	case apiclient.FollowUpFormWorkflow:
+		in.Workflow = f.workflow
+	default:
+		in.Prompt = f.prompt
+	}
+	return in
+}
+
+// submit posts the follow-up. An empty body is refused here as well as by the
+// daemon: a round trip to be told to type something is a round trip wasted.
+func (f *followUpForm) submit(client *apiclient.Client) tea.Cmd {
+	if f.editing {
+		f.commitBody()
+	}
+	if strings.TrimSpace(f.body()) == "" {
+		f.err = followUpEmptyMessage(f.form)
+		return nil
+	}
+	if client == nil {
+		f.err = "not connected"
+		return nil
+	}
+	f.err = ""
+	f.submitting = true
+	taskID, req := f.taskID, f.request()
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		task, _, err := client.FollowUp(ctx, taskID, req)
+		return actionResultMsg{
+			taskID: taskID, action: apiclient.ActionFollowUp, task: task, err: err,
+		}
+	}
+}
+
+func followUpEmptyMessage(form string) string {
+	switch form {
+	case apiclient.FollowUpFormCommand:
+		return "type the command to run first"
+	case apiclient.FollowUpFormWorkflow:
+		return "choose a workflow first"
+	default:
+		return "type what the agent should do first"
+	}
+}
+
+// height is how many lines the form wants at the width it will be drawn at.
+func (f *followUpForm) height(width int) int { return len(f.lines(width)) }
+
+// render draws the form, windowed on the focused element when it does not
+// fit.
+func (f *followUpForm) render(width, height int) string {
+	lines := f.lines(width)
+	from, to := f.focusRange(width)
+	return strings.Join(windowRange(lines, from, to, height), "\n")
+}
+
+// lines is the whole form at width: what is being followed up, the five rows,
+// whatever entry is open, and the status line.
+func (f *followUpForm) lines(width int) []string {
+	out := make([]string, 0, 18)
+	out = append(out, styleDim.Render("  "+f.subject()))
+	out = append(out, "")
+	for _, row := range fuRows() {
+		out = append(out, f.rowLines(row, width)...)
+	}
+	if f.picker != nil {
+		out = append(out, f.picker.renderBody()...)
+	}
+	switch {
+	case f.err != "":
+		out = append(out, styleBad.Render("  ⚠ "+f.err))
+	case f.editing:
+		out = append(out, styleDim.Render("  ctrl+s keeps this text · esc discards it"))
+	case f.picker != nil:
+		out = append(out, styleDim.Render("  ↑/↓ choose · / filter · enter pick · esc close the list"))
+	case f.submitting:
+		out = append(out, styleDim.Render("  queueing the follow-up…"))
+	default:
+		out = append(out, styleDim.Render(
+			"  enter edit · e $EDITOR · ctrl+s start the follow-up · esc leave the form"))
+	}
+	return out
+}
+
+func fuRows() []fuRow { return []fuRow{fuForm, fuBody, fuAgent, fuModel, fuEffort} }
+
+// subject is the one line saying what this follow-up is about, so the popup
+// does not rely on the panels behind it to explain itself. It names the state
+// the task returns to, because that is the property people get wrong: a
+// follow-up decides nothing about a task's verdict.
+func (f *followUpForm) subject() string {
+	out := fmt.Sprintf("#%d", f.taskID)
+	if f.origin != "" {
+		out += " · " + f.origin
+	}
+	return out + " — runs in this task's existing worktree and branch; the task returns to " +
+		firstNonEmpty(f.origin, "where it was") + " afterwards"
+}
+
+// rowLines draws one row: its label, its value, and — for the body row while
+// it is being typed into — the field itself.
+func (f *followUpForm) rowLines(row fuRow, width int) []string {
+	cursor := "  "
+	if f.cursor == row && !f.editing && f.picker == nil {
+		cursor = styleFocus.Render("› ")
+	}
+	line := cursor + f.rowLabel(row) + " " + f.rowValue(row)
+	out := []string{line}
+	if row == fuBody && f.bodyIsText() {
+		if f.editing {
+			out = append(out, f.editorView(width)...)
+		} else if f.body() != "" {
+			for _, l := range wrapPlain(f.body(), width-editorIndent) {
+				out = append(out, strings.Repeat(" ", editorIndent)+styleOK.Render(l))
+			}
+		}
+	}
+	return out
+}
+
+func (f *followUpForm) rowValue(row fuRow) string {
+	var v string
+	switch row {
+	case fuForm:
+		return styleOK.Render(f.form)
+	case fuBody:
+		if f.body() == "" {
+			if f.bodyIsText() {
+				return styleDim.Render("(nothing typed yet)")
+			}
+			return styleDim.Render("(none chosen yet)")
+		}
+		if f.bodyIsText() {
+			return "" // the text is rendered under the row
+		}
+		return styleOK.Render(f.body())
+	case fuAgent:
+		v = f.agent
+	case fuModel:
+		v = f.model
+	case fuEffort:
+		v = f.effort
+	case fuRowCount:
+	}
+	if v == "" {
+		return styleDim.Render("(task or workflow default)")
+	}
+	return styleOK.Render(v)
+}
+
+// rowLabel names a row. The body row's label changes with the form, which is
+// the whole reason the chooser sits above it.
+func (f *followUpForm) rowLabel(row fuRow) string {
+	switch row {
+	case fuForm:
+		return "run   "
+	case fuBody:
+		switch f.form {
+		case apiclient.FollowUpFormCommand:
+			return "command"
+		case apiclient.FollowUpFormWorkflow:
+			return "workflow"
+		default:
+			return "prompt"
+		}
+	case fuAgent:
+		return "agent "
+	case fuModel:
+		return "model "
+	case fuEffort:
+		return "effort"
+	case fuRowCount:
+	}
+	return ""
+}
+
+// editorView sizes the body field to the popup's width and indents it clear
+// of the cursor gutter, the way the repair form's is.
+func (f *followUpForm) editorView(width int) []string {
+	f.editor.SetWidth(max(width-editorIndent, 8))
+	out := strings.Split(f.editor.View(), "\n")
+	pad := strings.Repeat(" ", editorIndent)
+	for i := range out {
+		out[i] = pad + out[i]
+	}
+	return out
+}
+
+// focusRange is the line range the focused element occupies, so windowing
+// keeps the whole of it on screen. An open picker is the focus; otherwise the
+// cursor's row is.
+func (f *followUpForm) focusRange(width int) (from, to int) {
+	from = 2 // past the subject line and its blank
+	for _, row := range fuRows() {
+		n := len(f.rowLines(row, width))
+		if row == f.cursor {
+			to = from + n
+			if f.picker != nil {
+				to += len(f.picker.renderBody())
+			}
+			return from, to
+		}
+		from += n
+	}
+	return 0, 0
+}

--- a/internal/tui/followuplive_test.go
+++ b/internal/tui/followuplive_test.go
@@ -1,0 +1,202 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// finishTask leaves a task in `done` with the rows a finished run leaves
+// behind, so its cursor sits one past the last step — the position a
+// follow-up round's rows go after (§5.4, task 027 decision 2).
+func (h *actionLiveHarness) finishTask(t *testing.T, id int64, end store.TaskState) {
+	t.Helper()
+	ctx := context.Background()
+	if _, _, err := h.st.TransitionTask(ctx, id, store.TaskQueued, store.TaskRunning,
+		store.TaskChange{}); err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	now := time.Now()
+	run := &store.StepRun{
+		TaskID: id, StepIndex: 0, StepID: "implement", StepType: "agent",
+		Attempt: 1, State: store.StepSucceeded, ResultSummary: "done",
+		StartedAt: now, FinishedAt: &now,
+	}
+	if err := h.st.CreateStepRun(ctx, run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	next := 1
+	if _, _, err := h.st.TransitionTask(ctx, id, store.TaskRunning, end,
+		store.TaskChange{CurrentStep: &next}); err != nil {
+		t.Fatalf("finish as %s: %v", end, err)
+	}
+}
+
+// TestDetailFollowsUpFinishedTaskLive drives the §6 follow-up the way a human
+// does: the bar offers it only when the daemon does, `F` opens the form, the
+// run form is chosen from a list, and what was typed is what the daemon
+// receives (task 027).
+//
+// The follow-up agent hangs, so the request is still on the task when this
+// asserts it — the request drains at the restore, which a hung agent never
+// reaches.
+func TestDetailFollowsUpFinishedTaskLive(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newActionLiveHarness(t)
+	task := h.createTask(t, "finishable")
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the task", func() bool {
+		return detailOf(h.m).taskID == task.ID && detailOf(h.m).loaded
+	})
+	// Queued: the daemon does not offer follow-up, so neither does the bar.
+	if detailOf(h.m).target().has(apiclient.ActionFollowUp) {
+		t.Error("a queued task offers follow_up")
+	}
+	if hintsContain(detailOf(h.m).detailHints(), "follow-up") {
+		t.Error("the bar advertises follow-up on a queued task")
+	}
+	h.press(t, "F")
+	if detailOf(h.m).followUp != nil {
+		t.Fatal("F opened the follow-up form on a task the daemon does not offer it for")
+	}
+
+	h.finishTask(t, task.ID, store.TaskDone)
+	h.p.until(30*time.Second, "the daemon to offer follow-up", func() bool {
+		return detailOf(h.m).target().has(apiclient.ActionFollowUp)
+	})
+	if !hintsContain(detailOf(h.m).detailHints(), "follow-up") {
+		t.Error("the bar does not advertise follow-up on a finished task")
+	}
+
+	h.press(t, "F")
+	form := detailOf(h.m).followUp
+	if form == nil {
+		t.Fatal("F did not open the follow-up form")
+	}
+	if !h.m.views[viewHome].(*shell).popup {
+		t.Fatal("the follow-up form did not take the popup")
+	}
+	if !strings.Contains(content(h.m), "Follow-up") {
+		t.Errorf("the popup is not on screen: %q", content(h.m))
+	}
+
+	// The cursor starts on the run-form chooser, which defaults to `agent`.
+	// One row down is the prompt: enter opens it, ctrl+s keeps it, ctrl+s
+	// again starts the run.
+	const prompt = "rebase this branch onto main"
+	h.press(t, "j")
+	h.press(t, "enter")
+	if !form.editing {
+		t.Fatal("enter did not open the prompt field")
+	}
+	h.typeText(t, prompt)
+	h.pressCtrlS(t)
+	if form.prompt != prompt {
+		t.Fatalf("form prompt = %q, want %q", form.prompt, prompt)
+	}
+	h.pressCtrlS(t)
+
+	h.p.until(60*time.Second, "the follow-up to be admitted", func() bool {
+		return h.state(t, task.ID) != store.TaskDone
+	})
+	stored, err := h.st.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	req := stored.PendingFollowUp
+	if req == nil || req.Prompt != prompt {
+		t.Fatalf("the daemon received %+v, want the prompt that was typed", req)
+	}
+	if req.Form != store.FollowUpAgent {
+		t.Errorf("form = %q, want %q — the chooser's default", req.Form, store.FollowUpAgent)
+	}
+	if req.Origin != store.TaskDone {
+		t.Errorf("origin = %s, want done — the task is returned there", req.Origin)
+	}
+
+	// The form closes on the reply, so the popup goes with it.
+	h.p.until(30*time.Second, "the submitted form to close", func() bool {
+		return detailOf(h.m).followUp == nil && !h.m.views[viewHome].(*shell).popup
+	})
+}
+
+// TestFollowUpFormPostsEachRunForm: the chooser decides which field is sent,
+// and the daemon refuses a request that names two things to run — so exactly
+// one has to arrive.
+func TestFollowUpFormPostsEachRunForm(t *testing.T) {
+	cases := []struct {
+		form string
+		set  func(*followUpForm)
+		want apiclient.FollowUpInput
+	}{
+		{
+			form: apiclient.FollowUpFormAgent,
+			set:  func(f *followUpForm) { f.prompt = "tidy it" },
+			want: apiclient.FollowUpInput{Prompt: "tidy it"},
+		},
+		{
+			form: apiclient.FollowUpFormCommand,
+			set:  func(f *followUpForm) { f.run = "git rebase origin/main" },
+			want: apiclient.FollowUpInput{Run: "git rebase origin/main"},
+		},
+		{
+			form: apiclient.FollowUpFormWorkflow,
+			set:  func(f *followUpForm) { f.workflow = "review" },
+			want: apiclient.FollowUpInput{Workflow: "review"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.form, func(t *testing.T) {
+			f := newFollowUpForm(1, 1, "done")
+			f.form = tc.form
+			tc.set(f)
+			if got := f.request(); got != tc.want {
+				t.Errorf("request = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTimelineRendersAFollowUpAsItsOwnRound: a follow-up's rows sit past the
+// workflow's last index, and the timeline must not number them as steps of a
+// workflow that never grew (task 027 decision 1).
+func TestTimelineRendersAFollowUpAsItsOwnRound(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newActionLiveHarness(t)
+	task := h.createTask(t, "finishable")
+	h.finishTask(t, task.ID, store.TaskDone)
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the task", func() bool {
+		return detailOf(h.m).taskID == task.ID && detailOf(h.m).loaded
+	})
+	h.press(t, "F")
+	h.press(t, "j")
+	h.press(t, "enter")
+	h.typeText(t, "one more commit")
+	h.pressCtrlS(t)
+	h.pressCtrlS(t)
+
+	h.p.until(60*time.Second, "the follow-up row to reach the timeline", func() bool {
+		total := detailOf(h.m).task.StepTotal
+		for _, r := range detailOf(h.m).task.Steps {
+			if total > 0 && r.StepIndex >= total {
+				return true
+			}
+		}
+		return false
+	})
+	h.p.until(30*time.Second, "the timeline to label the round", func() bool {
+		return strings.Contains(content(h.m), "follow-up 1")
+	})
+	if strings.Contains(content(h.m), "(parallel)") {
+		t.Errorf("the follow-up round read as a group:\n%s", content(h.m))
+	}
+}

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -16,6 +16,7 @@ var everyAction = taskActions{id: 9, state: stateRunning, actions: []string{
 	apiclient.ActionPause, apiclient.ActionResume, apiclient.ActionApprove,
 	apiclient.ActionReject, apiclient.ActionRetry, apiclient.ActionRepair,
 	apiclient.ActionSkip, apiclient.ActionCancel, apiclient.ActionArchive,
+	apiclient.ActionFollowUp,
 }}
 
 // TestPaletteReachesEveryRegistryEntry is the T3.11 done-when: every

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -43,9 +43,10 @@ type shell struct {
 	bar *actionBar
 
 	focus panelID
-	// popup shows a form over the panels: the §7.4 answer form, or the §6
-	// repair form (task 025). Neither ever opens itself — `enter` on the
-	// awaiting task opens one and `R` on a blocked task opens the other
+	// popup shows a form over the panels: the §7.4 answer form, the §6 repair
+	// form (task 025), or the §6 follow-up form (task 027). None of the three
+	// ever opens itself — `enter` on the awaiting task opens the first, `R`
+	// on a blocked task the second and `F` on a finished one the third
 	// (§15: a form announces itself and the human opens it).
 	popup bool
 	// connected mirrors the root's connection state: false renders the
@@ -120,6 +121,9 @@ func (s *shell) capturesInput() bool {
 // prompt — or the task filter while it is being typed.
 func (s *shell) paste(text string) tea.Cmd {
 	if s.popup {
+		if f := s.detail.followUp; f != nil {
+			return f.paste(text)
+		}
 		if f := s.detail.repair; f != nil {
 			return f.paste(text)
 		}
@@ -199,13 +203,23 @@ func (s *shell) update(msg tea.Msg) (panel, tea.Cmd) {
 func (s *shell) forward(msg tea.Msg) tea.Cmd {
 	_, bc := s.board.update(msg)
 	dc := s.detail.update(msg)
-	if s.popup && s.detail.form == nil && s.detail.repair == nil {
+	if s.popup && s.detail.form == nil && s.detail.repair == nil && s.detail.followUp == nil {
 		s.popup = false
 	}
 	return tea.Batch(bc, dc)
 }
 
 func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if s.popup && s.detail.followUp != nil {
+		cmd, exit := s.detail.followUp.update(msg, s.detail.client)
+		if exit {
+			// Leaving throws the draft away with it, for the reason the
+			// repair form's does: half a prompt kept behind a popup nobody
+			// can see is worse than retyping it.
+			s.detail.followUp, s.popup = nil, false
+		}
+		return s, cmd
+	}
 	if s.popup && s.detail.repair != nil {
 		cmd, exit := s.detail.repair.update(msg, s.detail.client)
 		if exit {
@@ -285,6 +299,18 @@ func (s *shell) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		s.syncDetailFocus()
 		cmd := s.detail.update(msg)
 		if s.detail.repair != nil {
+			s.popup = true
+		}
+		return s, cmd
+	case "F":
+		// Follow-up (task 027), same shape as repair. It is deliberately not
+		// a bulk action: the three run forms are written for one task, and
+		// "run this prompt against nine finished branches" is a shell loop
+		// over `vincent task follow-up`, which is what decision 11 shipped
+		// the command for.
+		s.syncDetailFocus()
+		cmd := s.detail.update(msg)
+		if s.detail.followUp != nil {
 			s.popup = true
 		}
 		return s, cmd
@@ -577,7 +603,7 @@ func (s *shell) render(width, height int) string {
 				s.renderBox(boxes[1]), s.renderBox(boxes[2])))
 	}
 	out := strings.Join(parts, "\n")
-	if s.popup && (s.detail.form != nil || s.detail.repair != nil) {
+	if s.popup && (s.detail.form != nil || s.detail.repair != nil || s.detail.followUp != nil) {
 		out = s.overlayPopup(out)
 	}
 	return out
@@ -673,7 +699,10 @@ func (s *shell) overlayPopup(bg string) string {
 		render func(int, int) string
 		title  string
 	)
-	if f := s.detail.repair; f != nil {
+	if f := s.detail.followUp; f != nil {
+		height, render = f.height, f.render
+		title = fmt.Sprintf("Follow-up — #%d", s.detail.taskID)
+	} else if f := s.detail.repair; f != nil {
 		height, render = f.height, f.render
 		title = fmt.Sprintf("Repair — #%d", s.detail.taskID)
 	} else {

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -13,7 +13,7 @@
 # that cannot provide it (scenario 8). Runs against the committed fakeagent so CI never calls a real
 # API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
 # (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7|8 runs a single scenario for debugging.
+# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7|8|9|10 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -1102,6 +1102,136 @@ EOF
   echo "=== scenario 9 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 10 — a follow-up run on a finished task (§6, §13.2, task 027).
+#
+# The task 027 brief calls this "scenario 9"; that number was already the
+# ad-hoc repair's by the time this landed, so it is 10.
+#
+# Everything here is a `command` follow-up: no agent process is involved, so
+# "the follow-up ran in the finished task's own worktree" is proved by a commit
+# on that task's branch rather than inferred from an agent's output. Both `run:`
+# bodies are one git command each — the sh∩pwsh intersection the daemon's shell
+# holds every workflow to (§8.3).
+#
+# What it pins is decision 2's placement: a round's rows sit past the
+# snapshot's last index, `step_total` does not grow, and a second follow-up is
+# round 2 rather than attempt 2 of round 1.
+# ---------------------------------------------------------------------------
+scenario10() {
+  echo "=== scenario 10: a follow-up run on a finished task"
+  scenario_dirs s10
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-followup.yaml" <<'EOF'
+name: m2-followup
+description: M2 gate — two steps that pass, so the task reaches done.
+defaults:
+  max_retries: 0
+steps:
+  - id: work
+    type: command
+    run: 'git commit --allow-empty -m "m2 gate: the work"'
+  - id: land
+    type: command
+    run: 'git commit --allow-empty -m "m2 gate: landed"'
+EOF
+  cat > "$CONFIG_DIR/workflows/m2-followup-blocked.yaml" <<'EOF'
+name: m2-followup-blocked
+description: M2 gate — one step that fails, for the 409 half.
+defaults:
+  max_retries: 0
+steps:
+  - id: nope
+    type: command
+    run: 'exit 7'
+EOF
+
+  daemon_up
+
+  local repo="$TMP/s10/repo" proj task_id task steps branch total status
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  task_id="$(api POST /tasks \
+    "{\"project_id\":$proj,\"workflow\":\"m2-followup\",\"title\":\"Follow me up\"}" | jq -r .id)"
+
+  echo "== the workflow finishes"
+  wait_for_state "$task_id" done 90
+  task="$(api GET "/tasks/$task_id")"
+  total="$(jq -r .step_total <<<"$task")"
+  branch="$(jq -r .branch_name <<<"$task")"
+  [[ "$total" == "2" ]] || fail "step_total = $total, want 2: $task"
+  jq -e '.available_actions | index("follow_up")' <<<"$task" >/dev/null \
+    || fail "available_actions misses follow_up on a done task: $task"
+
+  echo "== a follow-up that names nothing to run is refused"
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{}' "$BASE/tasks/$task_id/follow_up")"
+  [[ "$status" == "400" ]] || fail "an empty follow-up should be 400, got $status"
+
+  echo "== a follow-up that names two things to run is refused"
+  status="$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"prompt":"do it","run":"git --version"}' "$BASE/tasks/$task_id/follow_up")"
+  [[ "$status" == "400" ]] || fail "a two-form follow-up should be 400, got $status"
+
+  echo "== round 1: a command runs in the finished task's own worktree"
+  api POST "/tasks/$task_id/follow_up" \
+    '{"run":"git commit --allow-empty -m \"m2 gate: follow-up one\""}' >/dev/null
+  wait_for_state "$task_id" done 90
+
+  task="$(api GET "/tasks/$task_id")"
+  [[ "$(jq -r .step_total <<<"$task")" == "2" ]] \
+    || fail "the follow-up grew the workflow snapshot: $task"
+  steps="$(api GET "/tasks/$task_id/steps")"
+  jq -e --argjson i "$total" \
+    '[.[] | select(.step_index == $i and .state == "succeeded")] | length == 1' \
+    <<<"$steps" >/dev/null || fail "no succeeded follow-up row at index $total: $steps"
+  # A here-string, not a pipe: `grep -q` exits at the first match and closes
+  # the pipe under it, so `git log | grep -q` fails the whole pipeline under
+  # `set -o pipefail` on a *successful* match.
+  grep -q "m2 gate: follow-up one" <<<"$(git -C "$repo" log --format=%s "$branch")" \
+    || fail "the follow-up did not commit on the task's branch"
+
+  echo "== round 2 is a round, not a second attempt of round 1"
+  api POST "/tasks/$task_id/follow_up" \
+    '{"run":"git commit --allow-empty -m \"m2 gate: follow-up two\""}' >/dev/null
+  wait_for_state "$task_id" done 90
+  steps="$(api GET "/tasks/$task_id/steps")"
+  jq -e --argjson i "$((total + 1))" \
+    '[.[] | select(.step_index == $i and .attempt == 1 and .state == "succeeded")] | length == 1' \
+    <<<"$steps" >/dev/null || fail "round 2 is not attempt 1 at index $((total + 1)): $steps"
+  jq -e --argjson i "$total" '[.[] | select(.step_index == $i)] | length == 1' \
+    <<<"$steps" >/dev/null || fail "round 2 was recorded against round 1's index: $steps"
+  grep -q "m2 gate: follow-up two" <<<"$(git -C "$repo" log --format=%s "$branch")" \
+    || fail "the second follow-up did not commit on the task's branch"
+
+  echo "== follow_up is refused outside done and aborted, with the state in the envelope"
+  local other out body
+  other="$(api POST /tasks \
+    "{\"project_id\":$proj,\"workflow\":\"m2-followup-blocked\",\"title\":\"Blocked\"}" | jq -r .id)"
+  wait_for_state "$other" blocked 90
+  out="$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" -d '{"run":"git --version"}' \
+    -w $'\n%{http_code}' "$BASE/tasks/$other/follow_up")"
+  status="${out##*$'\n'}"
+  body="${out%$'\n'*}"
+  [[ "$status" == "409" ]] || fail "follow_up from blocked should be 409, got $status: $body"
+  [[ "$(jq -r .error.details.state <<<"$body")" == "blocked" ]] \
+    || fail "the 409 does not carry details.state: $body"
+
+  "$VINCENT" daemon stop
+  echo "=== scenario 10 PASS"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -1117,8 +1247,9 @@ case "$WHICH" in
   7) scenario7 ;;
   8) scenario8 ;;
   9) scenario9 ;;
+  10) scenario10 ;;
   all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8
-     scenario9 ;;
+     scenario9; scenario10 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 


### PR DESCRIPTION
## Summary

A task that reaches `done` or `aborted` still owns its worktree, its branch and
its commits until `archive` tears them down — and until now vincent could do
nothing in that window. A branch that needed rebasing onto a `main` that had
moved, one more commit a review asked for, a stray file to drop: every one of
those meant leaving vincent, finding the worktree by hand, doing the work
outside the daemon's ledger, and coming back only to press archive.

This adds **`follow_up`**, a human action from those two states. The operator
supplies one of three things — an agent prompt, a shell command, or the name of
a workflow from the registry — and the daemon runs it in the task's *existing*
worktree and branch, recorded in that task's own ledger with step runs,
transcripts, events and token and cost accounting. It is repeatable: each run is
a **round**, and a finished task can be followed up any number of times before
it is archived.

Two decisions from `docs/tasks/027-follow-up-runs.md` carry the design, and both
differ deliberately from what the issue proposed:

- **A follow-up is not a step of the workflow snapshot** (§5.3). Round *n* of a
  task whose snapshot has *k* steps writes its rows at `step_index = k + n - 1`,
  in the unused cursor space past the end. The snapshot stays the workflow as
  authored, so `step_total`, every "step k of n" a client renders and the task
  017 graph go on describing the workflow somebody wrote. It also means the
  existing `(task_id, step_index, step_id, iteration)` attempt key separates the
  rounds for free — a second follow-up is round 2, not attempt 2 of round 1, and
  `iteration` keeps its §7.8 loop meaning. **No `step_runs` migration, and the
  original steps' retry budgets are untouched.**
- **A follow-up has a cursor of its own**, persisted in the request.
  `current_step` is left where the finished run put it. That is what lets a
  `manual` gate park and be approved, and a `fan_out` park and be joined, *inside*
  a follow-up without `current_step` ever carrying two meanings. `execute`'s step
  walk was extracted into `stepWalk` rather than copied, so the ordinary
  admission and the follow-up share one implementation of guards, gates, groups,
  loops, fan-out, retries, pause and interruption.

A follow-up **decides nothing about the task's verdict**: `done` returns to
`done` and `aborted` to `aborted`, whatever the run did. (The issue proposed
promoting a successful follow-up on an aborted task to `done`; decision 5
rejected that — it makes a human's abort reversible by any command that exits
0.) Returning an aborted-origin task is one new engine action, `restore`.

A failed follow-up step blocks the task at the follow-up's own index with that
step's reason, and the resolution set is the existing one: `retry` re-runs the
follow-up from its persisted cursor, `repair` reads the follow-up row as its
failure context instead of no-oping, `skip` abandons the request and restores
the origin state, and `cancel` aborts — which makes **`done → aborted`
reachable** for the first time. `edit + retry` there is refused with a 400: an
override rewrites a step in the snapshot, and a follow-up is not in it.

Surfaces: `POST /v1/tasks/{id}/follow_up`, `F` in the TUI opening a form (the
three run forms need a chooser, so it cannot be a key that acts), and
`vincent task follow-up <id> --prompt/--run/--workflow`. That CLI command
supersedes task 025 decision 12 for this action alone — "rebase these six
finished branches onto current master" is a batch, and a batch wants a command
line. The unevenness that leaves (follow-up scriptable, retry and repair not) is
stated in the spec rather than papered over.

**Verification.** `go test ./...` and `go test -race ./...` pass (1873 tests);
`golangci-lint run ./...` is clean for `GOOS=windows`, `darwin` and `linux`;
`./scripts/m2-gate.sh` passes all ten scenarios, including the new scenario 10
that drives the whole path against the fake agent.

Two things a reviewer should know about, both recorded in the task document
rather than left to be discovered:

- A follow-up workflow containing **two** `fan_out` steps in one round cannot
  tell its lanes apart, because `tasks.parent_step_index` is an index and both
  steps share the round's. This is a pre-existing shape of that column — a
  `loop` containing a `fan_out` has the same property — and is left alone rather
  than migrated for a case nobody has asked for.
- `F`, like `R` for repair, does not appear in the footer's action list:
  `actionOrder` covers keys that act, and both of these open a form. They are
  discoverable through the command palette and `?` help, which is the pattern
  task 025 set.

## Related

Closes #181

Implements `docs/tasks/027-follow-up-runs.md` — closes 027.1 through 027.9.

This revisits `docs/tasks/025-ad-hoc-repair-agent.md` deliberately, and says so
in the spec and the task document. Decision 3 (a reserved `__repair`-style step
id) is superseded by the position-based rows above; decision 12 (human actions
are TUI-and-API only) is superseded for `follow_up` alone, with the reason
recorded and the remaining unevenness accepted. Decisions 1, 2, 8, 9 and 10 of
025 are followed rather than revisited — in particular decision 1's rule that an
ad-hoc run decides nothing about the task's verdict, applied here at the other
end of the lifecycle.

`docs/spec.md` is amended in this branch with dated notes, as the repository
requires: §5.3, §5.4, §6, §7.2, §12.1, §13.2, §14 and §15.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

On the last box: `docs/reference/api.md` (the new route and its errors),
`docs/reference/cli.md` (the new subcommand), `docs/reference/task-lifecycle.md`
(the action table and the two states), `docs/guides/tui.md` (the `F` binding and
the form), `docs/guides/scripting.md` (its opening claim that no human action
has a subcommand was made false by this change), `docs/features.md`, and —
found by the documentation audit afterwards — `README.md`, which carried the
same "the remaining human actions are TUI and API operations" claim as
`scripting.md` and had gone unfixed. `docs/reference/configuration.md` is
untouched because `internal/config` is — this feature adds no setting. No block
reason was added or changed, so the `Reason*` constants and their documentation
are untouched too. `skills/vincent-workflows/SKILL.md` is untouched because the
workflow schema is: no step type, field, validation rule, template variable or
human-interaction mechanism changed, and a follow-up runs an unmodified registry
workflow.

The screenshots under `docs/assets/` were checked rather than assumed:
`tui-diff.png` photographs a `done` task, so it was re-captured with
`scripts/screenshots.sh` to see whether the panel had moved. It had not — the
footer walks `actionOrder`, which covers keys that act and so excludes both `F`
and `R` — so the re-captured file was reverted rather than committed as a binary
diff that changed nothing but the clock in the frame. The documentation audit
re-checked that conclusion against the committed image rather than re-running
the script: `tui-diff.png` is the home shell, whose only two action affordances
are `board.actionLine` and `footerLeftSegs`, and both walk `actionOrder` alone.
No `docs/assets/tui-*.png` is stale.

**One thing found and not fixed, because it is not documentation.**
`detail.detailHints` — the function that would put `R repair` and now
`F follow-up` on a hint line — has no caller outside `*_test.go`. Nothing
renders it, so neither key appears in any hint bar; both are discoverable only
through the command palette and `?` help. That is what the note above says, and
it is what `internal/tui/bindings.go` guarantees, so no page claims otherwise
and nothing here is wrong on screen. But the function's own comment ("shown
beside the task's actions so the bar is the one place that answers *what can I
do here*") describes rendering that does not happen. This predates the branch —
task 025 added the `repair` arm to the same dead function — and is left for a
reviewer to decide on rather than fixed in a documentation commit.
