### PR TITLE
feat(workflow): pace step retries with retry_backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ list with the user-facing context a commit subject cannot carry.
   `vincent task follow-up <id> --prompt/--run/--workflow`.
   ([#181](https://github.com/lezli01/vincent/issues/181))
 
+- **`retry_backoff`: workflow steps can pace their retries.** Retries were
+  immediate and nothing could make them wait, so the default `max_retries: 1`
+  meant a step hitting a transient problem — a flaky network call, a
+  `git index.lock` held by another process — burned both of its attempts inside
+  a few seconds and blocked, needing a human even though nothing was wrong with
+  the work. A step (or a workflow's `defaults:`) may now carry
+  `retry_backoff: 30s`, and the wait costs nothing: the task returns to `queued`
+  showing `queued · retry backoff → 14:20`, **gives up its concurrency slot** so
+  other work keeps running, and re-runs the step by itself when the wait is
+  over. Nothing sleeps and no slot is held. The default is `0s` — an immediate
+  retry — so every existing workflow behaves exactly as it did. The wait only
+  decides *when* an attempt happens, never *whether*: the attempt still counts
+  against `max_retries`, and a step out of budget blocks at once however long
+  its backoff.
+
 - **Each agent's usage window is reported in the daemon and TUI.** When an agent
   CLI stops because the account's quota for the window is spent, vincent now
   remembers *which adapter* it was and when it resets, instead of losing that

--- a/docs/features.md
+++ b/docs/features.md
@@ -104,6 +104,13 @@ When Claude Code reports a usage limit, vincent treats it as a temporary wait
 instead of a failure: the task returns to the queue without consuming a retry or
 slot, shows its next admission time, and starts again when the window reopens.
 
+A step that fails on something transient can borrow the same wait. Give it
+`retry_backoff: 30s` and its retry is paced rather than immediate: the task
+returns to the queue, gives up its slot so other work carries on, shows when it
+will resume, and re-runs the step by itself. Unlike a usage limit the attempt
+still counts against `max_retries` — the wait decides when a retry happens, not
+whether there is one.
+
 ## Keep people in the loop
 
 Human oversight is part of the workflow instead of an informal terminal habit:

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -444,6 +444,7 @@ The block reason names what happened:
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
 | `agent_unauthenticated` | The agent CLI is installed but not logged in (see below) |
 | `usage_limit` | The agent's usage quota for the window is spent — **not** a failure; the task waits and re-runs itself (see below) |
+| `retry_backoff` | Not a block reason: it is what a task shows while a step's [`retry_backoff`](../reference/workflow-schema.md#step-fields) paces the next attempt (see below). The failure itself keeps its own reason |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `template_error` | A template failed to render (see above) |
@@ -497,6 +498,30 @@ Only the claude adapter recognizes usage-limit wording today. On codex and
 cursor a quota stop still surfaces as `agent_error` or `nonzero_exit`, because
 their wordings have not been captured from a real run and vincent will not guess
 at one: a wrong guess would park a genuinely failed task forever.
+
+### `retry_backoff` — also do nothing, but for a different reason
+
+A task showing `queued · retry backoff → 14:20` in the detail header (and
+`queued → 14:20` on the board) is not walled by a quota. Its
+step *failed*, it has retries left, and the workflow asked for a pause between
+attempts with [`retry_backoff`](../reference/workflow-schema.md#step-fields).
+Like a quota hold it gives up its concurrency slot and comes back on its own.
+
+The difference is the cost, and it is the thing to read the row for:
+
+|  | `usage_limit` | `retry_backoff` |
+|---|---|---|
+| The attempt | `interrupted` | `failed`, with the reason it actually failed with |
+| Retry budget | untouched | one spent |
+| What ends the wait | the quota window reopening | the configured duration elapsing |
+| If it keeps happening | it waits again, indefinitely | the budget runs out and the task **blocks** with the step's own reason |
+
+So a task that keeps reappearing on `retry_backoff` is a task on its way to
+being blocked — the transcripts of the attempts already made are what say why.
+A quota hold is not: it will sit there until the window returns.
+
+If you would rather not wait out a paced retry, any human action drops it —
+cancel, or pause and resume.
 
 ### `agent_unauthenticated`
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -67,11 +67,13 @@ Three behaviors matter:
 - **The terminal bell rings when a task enters `awaiting_input`**, so most
   terminals flash or badge the window even when it is not focused.
 - **A task waiting on a clock says when it resumes.** A task whose agent hit a
-  usage limit is `queued` like any other, but its state cell reads
-  `queued → 14:20` — the time vincent will try it again, on its own. It holds no
+  usage limit — or whose failed step is pacing its next attempt with
+  `retry_backoff` — is `queued` like any other, but its state cell reads
+  `queued → 14:20`, the time vincent will try it again, on its own. It holds no
   slot and needs nothing from you; the detail header names the reason in full
-  (`queued · usage limit → 14:20`). See
-  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing).
+  (`queued · usage limit → 14:20`, `queued · retry backoff → 14:20`). See
+  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing) and
+  [`retry_backoff`](troubleshooting.md#retry_backoff--also-do-nothing-but-for-a-different-reason).
 - **The header badges the agent, not just the task.** An adapter vincent has
   watched run out reads `claude ⏳14:20` in place of `claude ✓`, and stays that
   way until a step on that adapter succeeds — so a board full of `queued` rows

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -312,6 +312,7 @@ step, where the step wins.
 | `on_input` | agent steps | `wait` |
 | `input_timeout` | agent steps | `defaults.input_timeout` in config — 24h |
 | `max_retries` | all steps | `1` |
+| `retry_backoff` | all steps | `0s` — an immediate retry ([§8.2](#82-retries)) |
 | `timeout` | all steps | `defaults.agent_timeout` (60m) or `defaults.command_timeout` (15m) in config |
 
 Durations are Go duration strings: `90s`, `45m`, `1h30m`. A bare number is a
@@ -494,8 +495,8 @@ timeline, one thing to retry.
   test suite is not re-run because the linter was unhappy.
 
 Sub-steps are ordinary `agent` and `command` steps with their own `check`,
-`timeout`, `max_retries`, `if:` and agent selection, resolved exactly as at the
-top level. They may not be any other type — see
+`timeout`, `max_retries`, `retry_backoff`, `if:` and agent selection, resolved
+exactly as at the top level. They may not be any other type — see
 [§4.11](#411-where-each-type-may-appear).
 
 > **Sub-steps share one working tree.** Two of them writing the same file is a
@@ -1364,6 +1365,38 @@ Retries are for failures a retry can plausibly fix. `condition_error` is
 excluded by construction, and an `interrupted` attempt does **not** consume
 budget. `parallel` groups and `loop` steps carry no retry budget of their own —
 their members do.
+
+**`retry_backoff:` paces them.** By default a retry is immediate, which is right
+for a compile error the agent can see and fix, and wrong for anything transient
+— a flaky network call, a `git index.lock` held by another process — where two
+guaranteed failures inside a few seconds spend the budget on nothing:
+
+```yaml
+  - id: smoke
+    type: command
+    run: ./scripts/smoke.sh
+    max_retries: 2
+    retry_backoff: 30s   # wait before each retry; 0s (the default) is immediate
+```
+
+A non-zero value does **not** sleep. The task goes back to `queued` with the
+resume time attached, **gives up its concurrency slot** so other work keeps
+running, and re-runs the step by itself when the wait is over — the same
+mechanism a usage limit uses, and it needs nothing from you. The board shows
+`queued → 14:20` and the detail header `queued · retry backoff → 14:20`.
+
+The wait decides *when* an attempt happens, never *whether* there is one. The
+attempt still counts against `max_retries`, and a step out of budget blocks at
+once however long its backoff. So a task that keeps reappearing on a backoff is
+on its way to blocking; see
+[Troubleshooting](troubleshooting.md#retry_backoff--also-do-nothing-but-for-a-different-reason)
+for telling it apart from a quota wall.
+
+It is settable in `defaults:` and per step, where the step wins — including
+`retry_backoff: 0` on one step to opt it out of a workflow-wide default. It is
+refused on `condition`, `break`, `loop` and `include` steps, exactly as
+`max_retries` is, and the [`on_conflict: agent`](#merge-and-conflicts) merge
+resolver never waits: its attempts belong to the join.
 
 ### 8.3 Timeouts
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -495,10 +495,14 @@ Four details worth knowing:
 
 - **A `queued` task may be waiting on a clock, not a slot.** Every task
   representation carries `queued_reason` and `admit_not_before` (RFC3339, or
-  `null`). Both are `null` for an ordinarily queued task; `usage_limit` with a
-  timestamp means the agent's usage window is spent and vincent will try again
-  then, unattended. They are separate from `block_reason`, which still means
-  only "stopped, needs a human" — the task is not blocked.
+  `null`). Both are `null` for an ordinarily queued task. Two reasons set them,
+  and vincent tries again at that timestamp unattended in both cases:
+  `usage_limit`, the agent's usage window being spent, and `retry_backoff`, a
+  step's failed attempt being paced by its
+  [`retry_backoff`](workflow-schema.md#step-fields). They are separate from
+  `block_reason`, which still means only "stopped, needs a human" — the task is
+  not blocked. Treat the set as open: a client should render whatever string it
+  is given rather than switching on the two it knows.
 
 - **List rows carry the board fields** — `project_name`, `step_total`,
   `step_name`, and `cost_usd` / `input_tokens` / `output_tokens` rolled up across

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -66,14 +66,25 @@ task's existing worktree, and returns it to the state it came from. See
 Three of these are worth dwelling on.
 
 **`queued` covers two different waits.** Usually it means "waiting for a free
-slot". But a task whose agent hit a usage limit is also `queued` — waiting on a
-clock rather than on the queue — and says so through two fields: `queued_reason`
-(`usage_limit`) and `admit_not_before`, the instant vincent will try again. It
-holds no slot while it waits, keeps its place in the queue, and needs nothing
-from you: when the window reopens, the step re-runs on its own. The board shows
-the resume time on the row (`queued → 14:20`) and the detail header names the
-reason. Cancelling, pausing or otherwise acting on the task drops the wait
-immediately — a human action always means go.
+slot". But a task can also be `queued` waiting on a *clock* rather than on the
+queue, and it says so through two fields: `queued_reason` and
+`admit_not_before`, the instant vincent will try again. Either way it holds no
+slot while it waits, keeps its place in the queue, and needs nothing from you —
+when the wait is over the step runs on its own. The board shows the resume time
+on the row (`queued → 14:20`) and the detail header names the reason.
+Cancelling, pausing or otherwise acting on the task drops the wait immediately
+— a human action always means go.
+
+Two reasons produce that wait, and they are worth telling apart:
+
+| `queued_reason` | What it means |
+|---|---|
+| `usage_limit` | The agent's usage quota for the window is spent. The attempt is recorded `interrupted` and costs **no** retry; the wait ends at the reset the CLI named, or after [`usage_limit_recheck_interval`](configuration.md#usage_limit_recheck_interval) when it named none |
+| `retry_backoff` | The step failed and its next attempt is being paced by [`retry_backoff`](workflow-schema.md#step-fields). The attempt is recorded `failed` with its own reason and **does** consume a retry; the wait is the configured duration. When the budget runs out the task blocks with the step's own reason, with no wait first |
+
+Both are `queued_reason` values only. Neither is ever a `block_reason`, and
+`retry_backoff` is never a step's failure reason either — the step's row keeps
+whatever actually failed.
 
 **`awaiting_children` holds no slot, and offers only `cancel`.** A fan-out
 parent waiting on its lanes owns no process, so keeping a slot would starve
@@ -205,6 +216,12 @@ attempts). For agent steps the previous failure is appended to the retried promp
 as a structured block, so the agent is told exactly what went wrong rather than
 asked to guess.
 
+The re-run is immediate unless the step sets
+[`retry_backoff`](workflow-schema.md#step-fields), in which case the task waits
+that long in `queued` — holding no slot — and the step re-runs when the wait is
+over. The budget is unchanged either way: the backoff decides *when* an attempt
+happens, never *whether*.
+
 ## Failure reasons
 
 The reason is recorded on the step run and on the task when it blocks. The
@@ -219,6 +236,7 @@ same thing wherever it originated.
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
 | `agent_unauthenticated` | The agent CLI is installed but not logged in. Retries as usual, then blocks — log in and retry |
 | `usage_limit` | The agent's usage quota for the window is spent. **Not a failure:** no retry is consumed, and the task waits `queued` until the window reopens |
+| `retry_backoff` | Not a failure reason at all, and never appears on a step run — it is the `queued_reason` of a task waiting out a step's [`retry_backoff`](workflow-schema.md#step-fields) between two attempts. The attempt that triggered it keeps its own reason |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
 | `input_protocol_error` | A control message the adapter could not parse — it fails, it never hangs |

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -429,7 +429,11 @@ re-queued forever.
 **The join gets one attempt** unless the step declares `max_retries` itself. The
 two ways a join fails — a conflict, and a lane that did not finish — are both
 "a human decides", and an automatic second merge would abort the first, hit the
-same conflict and block anyway.
+same conflict and block anyway. The `on_conflict: agent` resolver below is
+pinned to `retry_backoff: 0` for the same reason, so a workflow-wide
+`defaults.retry_backoff` does not reach it: its attempts are the join's own, and
+a resolver that does not resolve leaves the conflict for a human rather than
+something a wait could fix.
 
 #### `merge` and conflicts
 

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -184,12 +184,23 @@ Every key here is also settable per step, where it wins.
 | `on_input` | `wait` \| `deny` \| `require` | `wait` | agent steps; `require` also gates which agents may run the step |
 | `input_timeout` | duration | `24h` (config) | agent steps |
 | `max_retries` | int | `1` | all steps |
+| `retry_backoff` | duration | `0s` | all steps |
 | `timeout` | duration | `60m` agent / `15m` command (config) | all steps |
 
 Durations are Go duration strings: `45m`, `1h30m`, `90s`.
 
 `max_retries` counts attempts **after** the first, so the default of 1 means up
 to two attempts.
+
+`retry_backoff` is how long to wait before each of them. The default of `0s` is
+an immediate retry — which is right for a compile error the agent can see and
+fix, and wrong for a flaky network call or a `git index.lock` held by another
+process, where two guaranteed failures inside a few seconds spend the budget on
+nothing. A non-zero value does **not** sleep: the task returns to `queued` with
+a wait attached and gives up its slot, so a paced task never stops other work
+from running. See [States](task-lifecycle.md#states) in the lifecycle reference for
+what that looks like from outside. Neither field has a
+`config.yaml` key: retry policy belongs to a workflow.
 
 ## Step fields
 
@@ -201,6 +212,7 @@ Common to every step:
 | `name` | string | | Display name; defaults to `id` |
 | `type` | `agent` \| `command` \| `manual` \| `parallel` \| `fan_out` \| `condition` \| `loop` \| `break` \| `include` | ✅ | `check` is a *field*, not a type |
 | `max_retries` | int | | Overrides `defaults` |
+| `retry_backoff` | duration | | Wait before each retry; overrides `defaults`. `0s` means retry at once, which is the default. Not valid on `condition`, `break`, `loop` or `include` steps, which own no attempt |
 | `timeout` | duration | | Per attempt; overrides `defaults`. On a `parallel` group or a `loop`, bounds the whole thing |
 | `if` | template | | Guard: skip this step unless it renders `true`. See [Conditions](#conditions) |
 
@@ -322,8 +334,10 @@ Runs its sub-steps at the same time, in the task's one worktree.
 ```
 
 Sub-steps are ordinary `agent` and `command` steps: each has its own `check`,
-`timeout`, `max_retries`, `if:` and agent selection, resolved exactly as at the
-top level. Those two types are the whole list — see
+`timeout`, `max_retries`, `retry_backoff`, `if:` and agent selection, resolved
+exactly as at the top level. A sub-step that backs off takes the whole group
+with it — the group waits for its in-flight siblings, then the task waits, and
+the re-admitted group re-runs only what is left. Those two types are the whole list — see
 [Nesting rules](#nesting-rules) for what is refused and why:
 
 - `manual` — a gate releases the task's slot, and there is no such thing as

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -592,6 +592,39 @@ stdout/stderr are captured to the step transcript.
   between attempts a walled step would otherwise spend its whole budget in
   seconds. `usage_limit` is therefore a `queued_reason`, never a `block_reason`.
   Recovery needs no human: the scheduler re-admits the task when the hold expires.
+- **`retry_backoff` paces the retries.** *Added 2026-08-25 (task 028).* A step
+  may carry `retry_backoff`, a duration, settable per step and in
+  `defaults:`. Its default is **zero**, which is an immediate retry — every
+  workflow written before this behaves byte-identically. A non-zero value is
+  spent the way the `usage_limit` hold above is spent: instead of retrying in
+  place, the task returns to `queued` carrying `admit_not_before = now +
+  retry_backoff` and `queued_reason: retry_backoff`, releasing its concurrency
+  slot (§11). Nothing sleeps — a sleeping actor holds its slot for the whole
+  wait, and with `max_parallel_tasks` slots held that way nothing runs at all.
+
+  What separates it from the bullet above is the attempt: it is recorded
+  `failed` with whatever it actually failed with, and it **consumes a retry**.
+  The budget still bounds the work; the backoff only decides *when* an attempt
+  the budget already allows happens. A step out of budget blocks at once,
+  however long its backoff. `retry_backoff` is therefore a `queued_reason` and
+  never a `block_reason` — and never a step's `failure_reason` either.
+
+  It applies to every failure that would be retried, with no per-reason policy:
+  an agent that hits a transient upstream error and one that leaves a compile
+  error both exit non-zero and both classify `nonzero_exit`, so exempting that
+  reason would remove the knob's reach from the failure it exists for. A step
+  that wants an immediate second shot at its own output writes
+  `retry_backoff: 0`. `usage_limit` and `interrupted` are untouched — this
+  section already says they are not failures — and `condition_error` is
+  untouched because a guard never becomes an attempt.
+
+  The delay is fixed, not exponential: a growth curve is per-task state the row
+  would have to carry, which §12.3 rejected for `usage_limit_recheck_interval`
+  and which is not reopened here. There is deliberately **no** `config.yaml`
+  key, mirroring `max_retries`: retry policy is a workflow's business, and
+  `config.Defaults` is timeouts. And the wait is a *minimum* — re-admission
+  competes for slots under the §11 caps and is noticed within the scheduler's
+  5 s tick, so the observed wait is `retry_backoff` plus queueing.
 - **`allow_failure: true` advances instead of blocking.** *Added 2026-08-18
   (task 015).* On an `agent` or `command` step, the failures **the step itself
   produced** — `nonzero_exit`, `check_failed`, `agent_error`, `timeout`,
@@ -1277,6 +1310,7 @@ defaults:                             # optional; per-step values override
   on_input: wait                      # wait | deny | require — agent input requests (§7.4)
   input_timeout: 24h                  # max wait in awaiting_input (§7.4)
   max_retries: 1
+  retry_backoff: 0s                   # wait between attempts (§7.2); 0 retries at once
   timeout: 60m
 
 steps:
@@ -1400,8 +1434,9 @@ fields:
 ### 8.2 Step types and fields
 
 Common to all steps: `id` (required), `name`, `type` (required), `max_retries`,
-`timeout`, and — *added 2026-08-18 (task 015)* — `if` (§7.7). A `condition`
-step is the exception: it takes `id`, `name` and `if` only.
+`timeout`, — *added 2026-08-18 (task 015)* — `if` (§7.7), and — *added
+2026-08-25 (task 028)* — `retry_backoff` (§7.2). A `condition` step is the
+exception: it takes `id`, `name` and `if` only.
 
 | Type | Required | Optional |
 |---|---|---|
@@ -1417,15 +1452,15 @@ step is the exception: it takes `id`, `name` and `if` only.
 
 *`include` added 2026-08-19 (task 019); see §7.9. It takes `id`, `name`,
 `type` and `workflow` and nothing else — not `if`, `timeout`, `max_retries`,
-`allow_failure` or `check` — because it is resolved away at task creation and
-owns no attempt for any of them to bind to. It is the third exception to this
+`retry_backoff`, `allow_failure` or `check` — because it is resolved away at
+task creation and owns no attempt for any of them to bind to. It is the third exception to this
 table's common fields, after `condition` and `break`.*
 
 *`parallel` and `fan_out` added 2026-08-17 (task 014); see §7.5 and §7.6.
 `condition`, `if` and `allow_failure` added 2026-08-18 (task 015); see §7.7.
 `loop` and `break` added 2026-08-18 (task 016); see §7.8. A `loop` also takes
-the common `if` and `timeout`, and rejects `max_retries` and `allow_failure`:
-it has no attempt of its own. A `break` is the exception a `condition` is —
+the common `if` and `timeout`, and rejects `max_retries`, `retry_backoff`
+(*2026-08-25, task 028*) and `allow_failure`: it has no attempt of its own. A `break` is the exception a `condition` is —
 `id`, `name` and `if` only.*
 
 A lane carries `id` plus exactly one of `workflow` (a registry name) or
@@ -1450,8 +1485,8 @@ Constraints (validated on load and via `POST /v1/workflows/validate`):
   own id namespace because each lane becomes a separate task. `merge.agent`
   is required by, and only valid with, `on_conflict: agent`.
 - *Added 2026-08-18 (task 015).* A `condition` step requires `if` and rejects
-  every other field, `timeout`, `max_retries` and `allow_failure` included: it
-  starts no process. `allow_failure` is valid only on `agent` and `command`
+  every other field, `timeout`, `max_retries`, `retry_backoff` (*2026-08-25,
+  task 028*) and `allow_failure` included: it starts no process. `allow_failure` is valid only on `agent` and `command`
   steps, sub-steps of a group included. Every `if` — a step's, a sub-step's and
   a lane's — must parse as a template at load, like every other template field.
   A `condition` step in **last** position is a **warning**, not an error: the
@@ -2374,9 +2409,11 @@ would invalidate every one of them.
   crash, which re-queues the task without clearing the request.
 - **Admission holds** (*added 2026-08-14, task 003*). A queued task may carry
   `admit_not_before` — an instant before which it is not admissible — and a
-  `queued_reason` naming what it is waiting for. `usage_limit` is the only
-  producer today (§7.2); the pair is generic so the next wait-shaped case costs
-  no second mechanism. The walk applies the three checks **in this order**:
+  `queued_reason` naming what it is waiting for. There are two producers, both
+  §7.2's: `usage_limit`, and — *added 2026-08-25 (task 028)* — `retry_backoff`,
+  the wait between two attempts of a step that asked for one. The pair of
+  columns is generic, which is why the second producer cost no migration, no
+  second branch in this walk and no client change. The walk applies the three checks **in this order**:
   1. **pause** — a pending pause parks the task, held or not. This runs first
      because a human asked for `paused`, and a task showing `queued` until a hold
      expired would be the same lie the cap check already avoids. It is also why
@@ -2650,7 +2687,12 @@ respawn loop the hold exists to stop. 15 m bounds a five-hour window at roughly
 twenty wasted spawns, and a user who knows their plan can tighten or widen it.
 There is deliberately **no** exponential backoff: that would be per-task state the
 row has to carry and a second retry-ish concept beside §7.2's. Read per hold, so a
-hot reload reaches the next one.
+hot reload reaches the next one. *Amended 2026-08-25 (task 028):* §7.2's own
+`retry_backoff` does not reopen that. It is a **fixed** delay computed from
+resolved configuration at the moment of the wait, so it carries no per-task
+state either, and it is §7.2's concept rather than a second one beside it. It
+has no key in this file for the same reason `max_retries` has none: retry
+policy is a workflow's business, and `defaults:` here is timeouts.
 
 **`delete_empty_branch_on_archive` / `delete_remote_branch_on_archive` (task 008,
 added 2026-08-16).** The §10 branch-cleanup pair. The local key is the standing
@@ -3901,6 +3943,7 @@ currently true to show (§15 view 6).
 | A `condition` step's guard is false | *Added 2026-08-18 (task 015).* The run ends there: one `stopped` row, the cursor moves to the end of the step list, the task is `done`. The steps after it record nothing, because they were never considered. *Amended 2026-08-18 (task 016):* inside a `loop` body the same step ends **that iteration** and the loop carries on — the sequence it ends is the body's (§7.8) |
 | A `loop` cannot run within `max_iterations` | *Added 2026-08-18 (task 016).* The task blocks with `loop_limit`: a `for_each` list longer than the ceiling blocks before iteration 1 naming the count, and a `count:` the ceiling moved under (config lowered while the task was queued) blocks too. It does not truncate and does not advance — running out of tries is not a decision, and advancing would hand every downstream guard a `.Steps` that says the work is finished (§7.8) |
 | A `break` step's guard is true | *Added 2026-08-18 (task 016).* The loop ends there and **succeeds**: one `stopped` row, the cursor advances past the loop step. A false guard records `succeeded` and the body carries on |
+| A step's retry is paced by `retry_backoff` | *Added 2026-08-25 (task 028).* The attempt is recorded `failed` with its own reason and consumes a retry, and the task returns to `queued` with `queued_reason: retry_backoff` and an `admit_not_before` of `now + retry_backoff` (§7.2, §11) — releasing its slot, so other work keeps running. Recovery is unattended: the scheduler re-admits and the same step re-runs with the budget the recount says is left. Distinct from `usage_limit`, whose attempt is `interrupted` and costs nothing, so a reader can tell a quota wall from a flaky step. It never becomes a `block_reason`: when the budget *is* spent the task blocks with the step's own failure reason, with no wait first |
 | A loop body step exhausts its retry budget | *Added 2026-08-18 (task 016).* The iteration fails and the task blocks with **that step's own** reason, not `loop_limit`. `allow_failure:` (§7.2) is how a probe's red result becomes data a `break` can read instead |
 | The daemon dies mid-iteration | *Added 2026-08-18 (task 016).* §12.4 finalizes the running row as `interrupted`, and the re-admitted loop derives its position from the rows: body steps whose latest attempt succeeded are skipped, and it continues **mid-iteration**. Iterations that already have rows keep the `for_each` item those rows recorded; only new iterations draw from a re-derived list (§7.8) |
 | Every lane of a `fan_out` is guarded off | *Added 2026-08-18 (task 015).* A no-op success: the step records a row saying no lane was selected and advances. It must not park — a parent in `awaiting_children` with no children would be re-queued, spawn nothing and park again (§7.6) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -618,6 +618,14 @@ stdout/stderr are captured to the step transcript.
   section already says they are not failures — and `condition_error` is
   untouched because a guard never becomes an attempt.
 
+  One attempt is exempt by construction and one by pin. `repair` (§6) runs
+  with `max_retries: 0`, so it never reaches the retry branch. The
+  `on_conflict: agent` merge resolver (§7.6) is pinned to zero: its attempts are
+  the join's own, and a resolver that does not resolve leaves the conflict for a
+  human, so there is no failure there for the engine to hold and re-admit.
+  Pinned rather than left alone, because `defaults.retry_backoff` would
+  otherwise reach it and spend half its budget on a wait nothing would honour.
+
   The delay is fixed, not exponential: a growth curve is per-task state the row
   would have to carry, which §12.3 rejected for `usage_limit_recheck_interval`
   and which is not reopened here. There is deliberately **no** `config.yaml`

--- a/docs/tasks/028-retry-backoff.md
+++ b/docs/tasks/028-retry-backoff.md
@@ -20,8 +20,13 @@ The wait primitive was already built. Task 003's migration `0006` added
 `admit_not_before` and `queued_reason` to `tasks` as a deliberately *generic*
 pair — 003 decision 1 names "a git backoff" as the intended next consumer — and
 `holdForUsageLimit` is the working example. This task connects the retry loop to
-it, and does nothing else: no migration, no new column, no store change, no API
-change, no TUI change.
+it, and does nothing else: no migration, no new column, no store change, and
+nothing new on the task wire — `admit_not_before` and `queued_reason` already
+ship and already render generically, so no client had to learn the new reason.
+The only client-visible addition is the field itself: `retry_backoff` joins the
+workflow-definition DTO (`internal/api/workflowdef.go`,
+`internal/apiclient/workflowdef.go`) and the workflow graph's step detail, the
+way every other step field does.
 
 ## Decisions
 
@@ -156,9 +161,11 @@ queueing. Documented in §7.2, not engineered around: a timer per hold is what
   mid-loop, `collectGroup`'s tier order, `usage_limit` unaffected, and zero
   behaving as today. ✓ 2026-08-25
 - [x] **028.5** `scripts/m2-gate.sh` scenario 11 over curl; §7.2, §8.1, §8.2,
-  §11, §12.3 and §18 amended, dated; `workflow-schema.md`,
-  `task-lifecycle.md`, `troubleshooting.md`, `api.md`, `tui.md` and the
-  workflow-authoring skill's schema reference updated. ✓ 2026-08-25
+  §11, §12.3 and §18 amended, dated; `features.md`, `workflow-schema.md`,
+  `task-lifecycle.md`, `troubleshooting.md`, `api.md`, `tui.md`,
+  `guides/workflows.md` (§3.2's `defaults` table, §4's sub-step fields and
+  §8.2) and the workflow-authoring skill's schema reference updated.
+  ✓ 2026-08-25
 
 ## Noted, deliberately not folded in
 

--- a/docs/tasks/028-retry-backoff.md
+++ b/docs/tasks/028-retry-backoff.md
@@ -1,0 +1,169 @@
+# 028 — `retry_backoff`: pacing step retries through task 003's admission hold
+
+**Status:** ✅ done (5/5)
+**Opened:** 2026-08-25
+
+A step's retries were immediate, and no configuration could make them wait.
+`runStepWithRetries` counted the failure, checked the budget, checked for
+cancellation, emitted `step.retrying`, and called `runAttempt` again on the next
+iteration.
+
+That is correct for exactly one class of failure — the deterministic kind, where
+§8.4's failure block gives an agent a second shot at the same compile error. It
+is wrong for every transient one: a network failure during cursor's
+authenticated model probe, a `git index.lock` held by another process, a flaky
+check command. For those the default `max_retries: 1` means two guaranteed
+failures inside a few seconds and a blocked task, with the budget the user would
+have wanted spent thirty seconds later already gone.
+
+The wait primitive was already built. Task 003's migration `0006` added
+`admit_not_before` and `queued_reason` to `tasks` as a deliberately *generic*
+pair — 003 decision 1 names "a git backoff" as the intended next consumer — and
+`holdForUsageLimit` is the working example. This task connects the retry loop to
+it, and does nothing else: no migration, no new column, no store change, no API
+change, no TUI change.
+
+## Decisions
+
+### 1. The backoff applies to every failure that would be retried (2026-08-25)
+
+No per-reason policy. [#88](https://github.com/lezli01/vincent/issues/88)
+proposed exempting `nonzero_exit` on the grounds that "the agent has feedback to
+act on". Rejected: an agent CLI that hits a transient upstream error and one
+that leaves a compile error both exit non-zero and both classify `nonzero_exit`,
+so the exemption would remove the knob's reach from precisely the failure the
+issue opens with.
+
+The field is opt-in and per-step already — a step that wants an immediate second
+shot at its own output writes `retry_backoff: 0`, which beats a workflow-wide
+default. `usage_limit` and `interrupted` are untouched because §7.2 already says
+they are not failures; `agent_unauthenticated` is untouched because §7.2's
+2026-08-14 amendment puts it under the normal budget and that position is
+unchanged here; `condition_error` is untouched because a guard never becomes an
+attempt.
+
+**Beat:** a table of transient-vs-deterministic reasons. It would have to be
+right about every adapter's wording forever, and it moves a policy decision out
+of the workflow — the place that knows whether *this* step is flaky — and into
+vincent.
+
+### 2. The delay is fixed, not linear or exponential (2026-08-25)
+
+`retry_backoff: 30s` means 30 s before every retry of that step.
+
+This does not reopen the recorded no-backoff decision (§12.3,
+`internal/config/config.go`, 003 decision 3). That decision beat *exponential*
+backoff for `usage_limit_recheck_interval`, on the grounds that growth is
+per-task state the row would have to carry and a second retry-ish concept beside
+§7.2's. A fixed delay computed from resolved configuration at the moment of the
+wait carries no per-task state and adds no column, and it is §7.2's own concept
+rather than one beside it. A growth curve would also make the field name a lie.
+
+### 3. Two resolution levels — step, then `workflow.defaults` (2026-08-25)
+
+No `config.yaml` key, mirroring `max_retries`, which has no config-level default
+either. Retry policy is a workflow's business, and `config.Defaults` is recorded
+as timeouts only (PR V decision, `docs/history/v0-tasks.md`). The issue asked for
+a config key; dropping it keeps the PR V decision intact rather than amending
+it, and costs nothing a gate or a user needs, since workflow YAML reaches both
+levels. `resolveRetryBackoff` therefore takes `(step, defaults)` and returns
+zero when neither sets it — one line shorter than `resolveMaxRetries`, and no
+`config.Config` argument.
+
+Zero is the default and is legal to state explicitly; only a negative value is
+refused, which is `max_retries`' rule.
+
+### 4. The requeue reuses `taskstate.Interrupt` (2026-08-25)
+
+`Interrupt` is the only `Running → Queued` edge, and adding a second action for
+the identical edge would buy a truthful name at the cost of a new arm in every
+exhaustive action list.
+
+Its doc comment said "the attempt does not consume a retry", which is wrong for
+this caller, and is amended to say that the *attempt row's state* decides that,
+not the action: `finishStepRun` writes the row and `transition` moves the task,
+and the two are independent. The pairing this task needs — a `failed` row and a
+`running → queued` transition — is therefore permitted and is what ships. This
+was the one thing [#88](https://github.com/lezli01/vincent/issues/88) flagged
+for confirmation before implementing.
+
+`holdForRetry` is `holdForUsageLimit`'s sibling and deliberately does **not**
+call `recordUsageLimit`: a quota window closing is a per-adapter observation
+(task 026), and a flaky step has nothing to say about any adapter's quota.
+
+### 5. The backoff reaches every call site, not just top-level steps (2026-08-25)
+
+`parallel` sub-steps and `loop` body steps are where a flaky check most often
+lives, so a top-level-only version would silently do nothing where it is most
+wanted. A group still waits for its in-flight siblings (`wg.Wait()`) before the
+task requeues — the same shape a `usage_limit` inside a group already has, since
+`collectGroup` runs after the wait. The fan-out join inherits it for free,
+because the join is an ordinary attempt of an ordinary step.
+
+Two exceptions, both because the attempt is not the task's to hold:
+
+- `repair` (task 025) runs with `max_retries: 0`, so it never reaches the retry
+  branch at all.
+- The `on_conflict: agent` merge resolver pins `retry_backoff: 0`. Its attempts
+  are the join's own, and a resolver that does not resolve leaves the conflict
+  for a human — there is no failure there the engine could hold and re-admit.
+  Pinned rather than left alone, because `defaults.retry_backoff` would
+  otherwise reach it and silently spend half its budget on a wait nothing would
+  honour.
+
+### 6. Backoff is checked before `allow_failure`, everywhere (2026-08-25)
+
+The trap this feature had to avoid. The engine's `StepFailed` arm checks
+`allowFailure` first and advances the cursor, which is safe only while
+`runStepWithRetries` returns `failed` exclusively when the budget is spent. With
+a backoff it can return `failed` with budget **remaining**, and an
+`allow_failure` step would then advance on its first failure instead of ever
+retrying.
+
+All three places that swallow a failure into a success test `backoffUntil`
+first: the engine's step loop, `group.go`'s sub-step goroutine, and `loop.go`'s
+`runBodyStep`.
+
+`collectGroup` gets a matching third precedence tier — interrupted, then a
+failure with its budget spent, then a backoff-pending failure. A spent sibling
+must win: waiting on one whose budget is *already* gone only delays the block by
+one hold, with nothing learned.
+
+### 7. A backed-off wait is a minimum, not a schedule (2026-08-25)
+
+The scheduler's safety-net tick is 5 s and re-admission competes for slots under
+the §11 caps, so the observed wait is `retry_backoff` plus up to a tick, plus
+queueing. Documented in §7.2, not engineered around: a timer per hold is what
+003 already decided the tick exists to avoid.
+
+## Tasks
+
+- [x] **028.1** `internal/workflow`: `RetryBackoff` on `Step` and `Defaults`,
+  non-negative validation on both, and the `rejectFields` set — refused on
+  `condition`, `break`, `loop` and `include` exactly as `max_retries` is.
+  `include.go` adds it to the callee-inherits-from list (§7.9). ✓ 2026-08-25
+- [x] **028.2** `internal/taskrun`: `resolveRetryBackoff`,
+  `ReasonRetryBackoff`, `stepOutcome.backoffUntil`, the requeue branch in
+  `runStepWithRetries`, and `holdForRetry`. ✓ 2026-08-25
+- [x] **028.3** The backoff check ahead of `allow_failure` in the step loop, in
+  `group.go` and in `loop.go`; `collectGroup`'s third tier; the merge
+  resolver's pin. `internal/taskstate`: the `Interrupt` comment amendment, and
+  nothing else. ✓ 2026-08-25
+- [x] **028.4** Tests: resolution per level; validation on a step, in
+  `defaults` and on the four step types that refuse it; include inheritance;
+  the requeue, the released slot, the budget preserved across it, a spent
+  budget still blocking, `allow_failure` in all three places, the loop resuming
+  mid-loop, `collectGroup`'s tier order, `usage_limit` unaffected, and zero
+  behaving as today. ✓ 2026-08-25
+- [x] **028.5** `scripts/m2-gate.sh` scenario 11 over curl; §7.2, §8.1, §8.2,
+  §11, §12.3 and §18 amended, dated; `workflow-schema.md`,
+  `task-lifecycle.md`, `troubleshooting.md`, `api.md`, `tui.md` and the
+  workflow-authoring skill's schema reference updated. ✓ 2026-08-25
+
+## Noted, deliberately not folded in
+
+`parallel` and `fan_out` steps accept `retry_backoff` and `max_retries` alike,
+and a `parallel` group ignores both — it owns no attempt of its own. That
+asymmetry predates this task (§8.2 rejects them on `loop` but not on
+`parallel`), and making the two structure types agree is a schema change with
+its own compatibility question. It wants its own issue.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -41,6 +41,7 @@ the living engineering specification records implementation contracts.
 | [025](025-ad-hoc-repair-agent.md) | An ad-hoc repair agent for a blocked step | ✅ done (8/8) |
 | [026](026-agent-quota-visibility.md) | Reporting each agent's usage-quota state in the daemon and TUI | ✅ done (7/7) |
 | [027](027-follow-up-runs.md) | Follow-up runs on a done or aborted task | ✅ done (9/9) |
+| [028](028-retry-backoff.md) | `retry_backoff`: pacing step retries through task 003's admission hold | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/api/workflowdef.go
+++ b/internal/api/workflowdef.go
@@ -75,6 +75,7 @@ type workflowDefaults struct {
 	OnInput        string  `json:"on_input,omitempty"`
 	InputTimeout   *string `json:"input_timeout,omitempty"`
 	MaxRetries     *int    `json:"max_retries,omitempty"`
+	RetryBackoff   *string `json:"retry_backoff,omitempty"`
 	Timeout        *string `json:"timeout,omitempty"`
 }
 
@@ -92,6 +93,7 @@ type workflowStepDef struct {
 	Type string `json:"type"`
 
 	MaxRetries   *int    `json:"max_retries,omitempty"`
+	RetryBackoff *string `json:"retry_backoff,omitempty"`
 	Timeout      *string `json:"timeout,omitempty"`
 	If           string  `json:"if,omitempty"`
 	AllowFailure bool    `json:"allow_failure,omitempty"`
@@ -231,6 +233,7 @@ func toWorkflowDefinition(wf *workflow.Workflow) *workflowDefinition {
 			OnInput:        wf.Defaults.OnInput,
 			InputTimeout:   durationString(wf.Defaults.InputTimeout),
 			MaxRetries:     wf.Defaults.MaxRetries,
+			RetryBackoff:   durationString(wf.Defaults.RetryBackoff),
 			Timeout:        durationString(wf.Defaults.Timeout),
 		},
 		Steps: toWorkflowStepDefs(wf.Steps),
@@ -251,6 +254,7 @@ func toWorkflowStepDef(st workflow.Step) workflowStepDef {
 		Name:           st.Name,
 		Type:           st.Type,
 		MaxRetries:     st.MaxRetries,
+		RetryBackoff:   durationString(st.RetryBackoff),
 		Timeout:        durationString(st.Timeout),
 		If:             st.If,
 		AllowFailure:   st.AllowFailure,

--- a/internal/apiclient/workflowdef.go
+++ b/internal/apiclient/workflowdef.go
@@ -52,6 +52,7 @@ type WorkflowDefaults struct {
 	OnInput        string  `json:"on_input,omitempty"`
 	InputTimeout   *string `json:"input_timeout,omitempty"`
 	MaxRetries     *int    `json:"max_retries,omitempty"`
+	RetryBackoff   *string `json:"retry_backoff,omitempty"`
 	Timeout        *string `json:"timeout,omitempty"`
 }
 
@@ -64,6 +65,7 @@ type WorkflowStepDef struct {
 	Type string `json:"type"`
 
 	MaxRetries   *int    `json:"max_retries,omitempty"`
+	RetryBackoff *string `json:"retry_backoff,omitempty"`
 	Timeout      *string `json:"timeout,omitempty"`
 	If           string  `json:"if,omitempty"`
 	AllowFailure bool    `json:"allow_failure,omitempty"`

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -129,7 +129,17 @@ const (
 	// succeeds when it genuinely has nothing more to do — that is a decision
 	// the workflow made. Running out of tries is not a decision, it is a
 	// wall.
-	ReasonLoopLimit     = "loop_limit"
+	ReasonLoopLimit = "loop_limit"
+	// ReasonRetryBackoff is a step whose next attempt is paced by
+	// `retry_backoff` (§7.2, task 028). Like usage_limit it is a
+	// `queued_reason` and never a `block_reason` — it names why a task is
+	// waiting, not why it stopped.
+	//
+	// Unlike usage_limit it is *not* the attempt's failure reason: the
+	// attempt keeps whatever it actually failed with, its row stays `failed`,
+	// and it consumes a retry. This reason belongs to the task's wait alone,
+	// which is why nothing ever writes it to a step_runs row.
+	ReasonRetryBackoff  = "retry_backoff"
 	ReasonInternalError = "internal_error"
 )
 
@@ -320,6 +330,17 @@ type stepOutcome struct {
 	// and for an aggregated outcome (`parallel`, `loop`) whose collected
 	// attempt was not one.
 	agentName string
+	// backoffUntil is set on a `failed` outcome that has retry budget left
+	// and a non-zero `retry_backoff` (task 028): the instant the next attempt
+	// may start. It is the signal to re-queue the task with a §11 admission
+	// hold rather than to block it.
+	//
+	// Every branch that turns a failure into something else — `allow_failure`
+	// in the step loop, in a group and in a loop body — must test this
+	// *first*. A failure with budget remaining is not the step's verdict yet,
+	// and advancing on it would spend an `allow_failure` step's first failure
+	// as though the budget were gone.
+	backoffUntil *time.Time
 }
 
 // execute runs one admission of a task: it walks the snapshot's steps from
@@ -546,6 +567,14 @@ func (r *Runner) runSteps(ctx context.Context, project *store.Project, w *stepWa
 			// `failed` state and its reason — the failure happened, it just
 			// did not stop the workflow — and that row is what a later
 			// guard reads through `.Steps`.
+			// Before allow_failure, deliberately: a paced retry is a failure
+			// with budget *remaining*, and advancing on it would spend an
+			// allow_failure step's first failure as though it were its last
+			// (§7.2, task 028).
+			if outcome.state == store.StepFailed && outcome.backoffUntil != nil {
+				r.holdForRetry(task, *outcome.backoffUntil, outcome.reason, env.log)
+				return
+			}
 			if outcome.state == store.StepFailed && allowFailure(env.step, outcome.reason) {
 				env.log.Info("step failed; advancing on allow_failure", "reason", outcome.reason)
 				w.persist(ctx, pos+1, env.log)
@@ -646,11 +675,33 @@ func (r *Runner) runStepWithRetries(ctx context.Context, env *stepEnv) stepOutco
 		if ctx.Err() != nil || r.interrupting(env.task.ID) {
 			return stepOutcome{state: store.StepInterrupted, reason: ReasonInterrupted}
 		}
-		env.log.Info("retrying step", "reason", last.reason, "next_attempt", attempts.Last+1)
-		r.emit(env.task, eventStepRetrying, map[string]any{
+		// The retry is due; `retry_backoff` decides whether it happens now or
+		// after a wait (§7.2, task 028). The event is emitted at the same
+		// point either way, carrying the delay, so the timeline reads the
+		// same as an immediate retry.
+		backoff := resolveRetryBackoff(env.step, env.wf.Defaults)
+		payload := map[string]any{
 			"step_id": env.step.ID, "step_index": env.index,
 			"attempt": attempts.Last, "reason": last.reason,
-		})
+		}
+		if backoff <= 0 {
+			env.log.Info("retrying step", "reason", last.reason, "next_attempt", attempts.Last+1)
+			r.emit(env.task, eventStepRetrying, payload)
+			continue
+		}
+		until := r.now().Add(backoff).UTC()
+		payload["backoff"] = backoff.String()
+		payload["admit_not_before"] = until.Format(time.RFC3339)
+		env.log.Info("retrying step after a backoff",
+			"reason", last.reason, "next_attempt", attempts.Last+1,
+			"backoff", backoff, "admit_not_before", until.Format(time.RFC3339))
+		r.emit(env.task, eventStepRetrying, payload)
+		// The failed attempt keeps its row and its reason; only the task's
+		// wait is new. The caller re-queues, this goroutine ends with the
+		// admission (phase 2 decision), and the recount at the top of the
+		// next one resumes with the budget this attempt already spent.
+		last.backoffUntil = &until
+		return last
 	}
 }
 
@@ -984,6 +1035,38 @@ func (r *Runner) holdForUsageLimit(
 		log.Info("agent usage limit reached; task re-queued until it resets",
 			"admit_not_before", until.Format(time.RFC3339),
 			"reported_by_cli", retryAfter != nil)
+	}
+}
+
+// holdForRetry re-queues a task whose failed step is due a paced retry
+// (§7.2, task 028, §11). It is holdForUsageLimit's sibling and differs from it
+// in exactly two ways, both deliberate:
+//
+//   - The attempt row is `failed`, not `interrupted`, and it consumes a retry.
+//     The row's state is what decides that, not the action — finishStepRun
+//     writes the row and this writes the task, and they are independent.
+//   - No usage-limit observation is recorded. A quota window closing is a
+//     per-adapter fact (task 026); a flaky step is not, and has nothing to say
+//     about any adapter's quota.
+//
+// taskstate.Interrupt is reused rather than given a truthfully-named sibling:
+// it is the only Running → Queued edge, and a second action for the identical
+// edge would buy a name at the cost of a new arm in every exhaustive action
+// list.
+func (r *Runner) holdForRetry(task *store.Task, until time.Time, failureReason string, log *slog.Logger) {
+	reason := ReasonRetryBackoff
+	ch := store.TaskChange{
+		AdmitNotBefore: &until,
+		QueuedReason:   &reason,
+		EventPayload: map[string]any{
+			"queued_reason":    reason,
+			"admit_not_before": until.Format(time.RFC3339),
+			"failure_reason":   failureReason,
+		},
+	}
+	if r.transition(task, taskstate.Interrupt, ch, log) {
+		log.Info("step failed; next attempt paced by retry_backoff",
+			"reason", failureReason, "admit_not_before", until.Format(time.RFC3339))
 	}
 }
 

--- a/internal/taskrun/group.go
+++ b/internal/taskrun/group.go
@@ -101,7 +101,12 @@ func (r *Runner) runGroup(ctx context.Context, env *stepEnv) stepOutcome {
 			// `allow_failure` on a sub-step keeps its `failed` row and its
 			// reason — the failure happened — while taking it out of the
 			// group's own verdict (§7.2, task 015 decision 5).
-			if out.state == store.StepFailed && allowFailure(sub, out.reason) {
+			//
+			// A sub-step owed a paced retry is excluded: its budget is not
+			// spent, so this is not its verdict yet, and swallowing it here
+			// would turn `retry_backoff` off for every allow_failure sub-step
+			// (task 028).
+			if out.state == store.StepFailed && out.backoffUntil == nil && allowFailure(sub, out.reason) {
 				subEnv.log.Info("sub-step failed; allowed by allow_failure", "reason", out.reason)
 				out = stepOutcome{state: store.StepSucceeded}
 			}
@@ -215,17 +220,29 @@ func (r *Runner) groupLimit(step workflow.Step) int {
 // declaration order so the same set of failures always reports the same
 // reason.
 //
-// Precedence is interruption, then failure, then success. An interruption
-// means the daemon is stopping or a quota is spent: that attempt consumed no
-// retry and the task will be re-admitted, so reporting a sibling's failure
-// instead would block a task that is only paused.
+// Precedence is interruption, then a failure with its budget spent, then a
+// failure owed a paced retry, then success. An interruption means the daemon
+// is stopping or a quota is spent: that attempt consumed no retry and the task
+// will be re-admitted, so reporting a sibling's failure instead would block a
+// task that is only paused.
+//
+// A spent failure outranks a backoff-pending one (task 028) for the same
+// reason: waiting on a sibling whose budget is *already* gone only delays the
+// block. The task would be held, re-admitted, and blocked anyway — one hold
+// later, with nothing learned.
 func collectGroup(outcomes []stepOutcome) stepOutcome {
-	var failure *stepOutcome
+	var failure, backoff *stepOutcome
 	for i := range outcomes {
 		switch outcomes[i].state {
 		case store.StepInterrupted:
 			return outcomes[i]
 		case store.StepFailed:
+			if outcomes[i].backoffUntil != nil {
+				if backoff == nil {
+					backoff = &outcomes[i]
+				}
+				continue
+			}
 			if failure == nil {
 				failure = &outcomes[i]
 			}
@@ -235,6 +252,9 @@ func collectGroup(outcomes []stepOutcome) stepOutcome {
 	}
 	if failure != nil {
 		return *failure
+	}
+	if backoff != nil {
+		return *backoff
 	}
 	// Every sub-step succeeded, so the group did: that is the whole of its
 	// success condition (014.2).

--- a/internal/taskrun/join.go
+++ b/internal/taskrun/join.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/workflow"
 	"github.com/lezli01/vincent/internal/worktree"
@@ -219,6 +220,14 @@ func (r *Runner) handleConflict(
 	env.log.Info("merge conflict; trying the agent resolver", "lane", lane.LaneID, "files", len(paths))
 	resolver := *env.step.Merge.Agent
 	resolver.Type = workflow.StepAgent
+	// No paced retry for the resolver (§7.2, task 028). Its attempts are the
+	// join's own: a resolver that does not resolve leaves the conflict for a
+	// human, so there is no failure here for the engine to hold and re-admit.
+	// Pinned rather than left alone because `defaults.retry_backoff` would
+	// otherwise reach it and silently spend half its budget on a wait nothing
+	// would honour.
+	noBackoff := config.Duration(0)
+	resolver.RetryBackoff = &noBackoff
 	// The resolver is an ordinary agent step, run by the ordinary executor in
 	// the parent's worktree, with the conflicted files in its context
 	// (decision 24).

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -238,7 +238,13 @@ func (r *Runner) runBodyStep(ctx context.Context, env *stepEnv) (out stepOutcome
 	case store.StepSucceeded:
 		return stepOutcome{}, false
 	case store.StepFailed:
-		if allowFailure(env.step, outcome.reason) {
+		// The backoff test comes first: a body step owed a paced retry has
+		// budget left, so this is not its verdict yet and `allow_failure`
+		// must not advance past it (§7.2, task 028). Ending the loop is how
+		// the wait reaches the task — the engine's step loop re-queues, and
+		// the re-admitted loop resumes at this iteration and this position,
+		// which it derives from the rows (decision 7).
+		if outcome.backoffUntil == nil && allowFailure(env.step, outcome.reason) {
 			// The row keeps its `failed` state and its reason — the failure
 			// happened — and that row is what the `break` guard two lines
 			// below reads (§7.2, task 015 decision 5).

--- a/internal/taskrun/resolve.go
+++ b/internal/taskrun/resolve.go
@@ -61,6 +61,23 @@ func resolveMaxRetries(step workflow.Step, defaults workflow.Defaults) int {
 	return defaultMaxRetries
 }
 
+// resolveRetryBackoff resolves the wait between a step's attempts (§7.2,
+// task 028): step field, then workflow defaults, then zero.
+//
+// Two levels, not three: there is no `config.yaml` key, exactly as there is
+// none for `max_retries`. Retry policy is a workflow's business, and
+// `config.Defaults` is timeouts (PR V decision). Zero is the default and
+// means today's behaviour — an immediate retry.
+func resolveRetryBackoff(step workflow.Step, defaults workflow.Defaults) time.Duration {
+	if step.RetryBackoff != nil {
+		return step.RetryBackoff.Std()
+	}
+	if defaults.RetryBackoff != nil {
+		return defaults.RetryBackoff.Std()
+	}
+	return 0
+}
+
 // resolveTimeout resolves a step's timeout (§7.2): step field, then workflow
 // defaults, then the daemon default for the step type.
 func resolveTimeout(step workflow.Step, defaults workflow.Defaults, cfg config.Config) time.Duration {

--- a/internal/taskrun/resolve_test.go
+++ b/internal/taskrun/resolve_test.go
@@ -42,6 +42,30 @@ func TestResolveStepSettings(t *testing.T) {
 		t.Errorf("fallback max_retries = %d, want %d", got, defaultMaxRetries)
 	}
 
+	// retry_backoff: step, then defaults, then zero — which is an immediate
+	// retry, i.e. every workflow written before task 028.
+	thirtySec := config.Duration(30 * time.Second)
+	twoMin := config.Duration(2 * time.Minute)
+	if got := resolveRetryBackoff(
+		workflow.Step{RetryBackoff: &thirtySec}, workflow.Defaults{RetryBackoff: &twoMin},
+	); got != 30*time.Second {
+		t.Errorf("step retry_backoff = %s, want 30s", got)
+	}
+	if got := resolveRetryBackoff(workflow.Step{}, workflow.Defaults{RetryBackoff: &twoMin}); got != 2*time.Minute {
+		t.Errorf("defaults retry_backoff = %s, want 2m", got)
+	}
+	if got := resolveRetryBackoff(workflow.Step{}, workflow.Defaults{}); got != 0 {
+		t.Errorf("fallback retry_backoff = %s, want 0", got)
+	}
+	// An explicit zero on the step beats a workflow-wide default: that is how
+	// one step asks for an immediate second shot at its own compile error.
+	zeroBackoff := config.Duration(0)
+	if got := resolveRetryBackoff(
+		workflow.Step{RetryBackoff: &zeroBackoff}, workflow.Defaults{RetryBackoff: &twoMin},
+	); got != 0 {
+		t.Errorf("explicit zero retry_backoff = %s, want 0", got)
+	}
+
 	// timeout: step, then defaults, then the per-type daemon default.
 	agentStep := workflow.Step{Type: workflow.StepAgent}
 	commandStep := workflow.Step{Type: workflow.StepCommand}

--- a/internal/taskrun/retrybackoff_test.go
+++ b/internal/taskrun/retrybackoff_test.go
@@ -1,0 +1,340 @@
+package taskrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// Paced retries (§7.2, task 028). `retry_backoff` spends the wait between two
+// attempts the way task 003 spends a quota wall: the task returns to `queued`
+// carrying a §11 admission hold and the actor ends with the admission, so the
+// wait costs no concurrency slot.
+//
+// Two backoffs are used throughout. A test that *observes* a hold uses an
+// hour, so it cannot expire mid-assertion; one that needs the task to come
+// back uses a millisecond, where what is being waited on is the scheduler
+// noticing rather than the hold itself.
+const (
+	longBackoff  = "retry_backoff: 1h"
+	shortBackoff = "retry_backoff: 1ms"
+)
+
+// TestRetryBackoffReQueuesInsteadOfRetryingInPlace is the core claim: the
+// second attempt does not happen in this admission, and the task waits on a
+// clock rather than on a human. The attempt row is what separates it from a
+// usage-limit hold — `failed`, and one retry poorer.
+func TestRetryBackoffReQueuesInsteadOfRetryingInPlace(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: paced\nsteps:\n"+
+		commandStep("flaky", "exit 3", "max_retries: 1", longBackoff))
+	before := time.Now()
+	h.start(t)
+
+	held := h.waitForHold(t, task.ID)
+	if held.QueuedReason != ReasonRetryBackoff {
+		t.Errorf("queued_reason = %q, want %s", held.QueuedReason, ReasonRetryBackoff)
+	}
+	if held.BlockReason != "" {
+		t.Errorf("block_reason = %q; a paced retry is a wait, not a block", held.BlockReason)
+	}
+	if got := held.AdmitNotBefore.Sub(before); got < 55*time.Minute || got > 65*time.Minute {
+		t.Errorf("admit_not_before is %s away, want about the 1h retry_backoff", got)
+	}
+
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1: the second one is what the hold is for", len(runs))
+	}
+	if runs[0].State != store.StepFailed || runs[0].FailureReason != ReasonNonzeroExit {
+		t.Errorf("attempt = %s/%q, want failed/%s — the row keeps what actually failed",
+			runs[0].State, runs[0].FailureReason, ReasonNonzeroExit)
+	}
+	// And it spent a retry, which is the whole difference from `usage_limit`.
+	attempts, err := h.store.CountStepAttempts(t.Context(),
+		store.StepRef{TaskID: task.ID, StepID: "flaky"}, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if attempts.Failed != 1 {
+		t.Errorf("failed attempts = %d, want 1: a paced retry delays the budget, it does not refund it",
+			attempts.Failed)
+	}
+	if !hasEvent(h.eventTypes(t, task.ID), eventStepRetrying) {
+		t.Error("no step.retrying event: a paced retry emits it where an immediate one does")
+	}
+}
+
+// TestRetryBackoffReleasesTheSlot is why the wait is a requeue and not a
+// sleep. With one slot, a paced task must not keep the queue from moving.
+func TestRetryBackoffReleasesTheSlot(t *testing.T) {
+	h := newEngineHarnessWith(t, func(c *config.Config) { c.MaxParallelTasks = 1 })
+	// The paced task is older, so §11 admits it first.
+	paced := h.createTask(t, "name: paced\nsteps:\n"+
+		commandStep("flaky", "exit 3", "max_retries: 1", longBackoff))
+	other := h.createTask(t, "name: other\nsteps:\n"+
+		commandStep("work", script("echo second task ran", "Write-Output 'second task ran'")))
+	h.start(t)
+
+	held := h.waitForHold(t, paced.ID)
+	if held.QueuedReason != ReasonRetryBackoff {
+		t.Fatalf("queued_reason = %q, want %s", held.QueuedReason, ReasonRetryBackoff)
+	}
+	done := h.waitForState(t, other.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("second task = %s (%s), want done — the paced task kept its slot",
+			done.State, done.BlockReason)
+	}
+}
+
+// TestRetryBackoffPreservesTheBudgetAcrossTheRequeue is the test that catches
+// the recount going wrong. `max_retries: 2` means three attempts however many
+// admissions they are spread over — not four, and not forever.
+func TestRetryBackoffPreservesTheBudgetAcrossTheRequeue(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: paced\nsteps:\n"+
+		commandStep("flaky", "exit 3", "max_retries: 2", shortBackoff))
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+	if blocked.QueuedReason != "" || blocked.AdmitNotBefore != nil {
+		t.Errorf("hold survived the block: %q / %v", blocked.QueuedReason, blocked.AdmitNotBefore)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 3 {
+		t.Fatalf("attempts = %d, want exactly 3 (max_retries: 2) across two requeues", len(runs))
+	}
+	for i, run := range runs {
+		if run.Attempt != i+1 {
+			t.Errorf("row %d numbered attempt %d, want %d", i, run.Attempt, i+1)
+		}
+		if run.State != store.StepFailed {
+			t.Errorf("attempt %d = %s, want failed", run.Attempt, run.State)
+		}
+	}
+}
+
+// TestRetryBackoffNeverGrantsARetry: the budget decides *whether* there is
+// another attempt, and only then does the backoff decide *when*. A step out of
+// budget blocks at once, hour-long backoff or not.
+func TestRetryBackoffNeverGrantsARetry(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: paced\nsteps:\n"+
+		commandStep("flaky", "exit 3", "max_retries: 0", longBackoff))
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit with no wait first",
+			blocked.State, blocked.BlockReason)
+	}
+	if blocked.QueuedReason != "" || blocked.AdmitNotBefore != nil {
+		t.Errorf("hold survived the block: %q / %v", blocked.QueuedReason, blocked.AdmitNotBefore)
+	}
+	if runs := h.stepRuns(t, task.ID); len(runs) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(runs))
+	}
+}
+
+// TestRetryBackoffOutranksAllowFailure is the trap this feature had to avoid.
+// The step loop checks `allow_failure` first, which is safe only while a
+// `failed` outcome means the budget is spent. A paced failure has budget left,
+// so advancing on it would spend an allow_failure step's first failure as
+// though it were its last.
+func TestRetryBackoffOutranksAllowFailure(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: paced\nsteps:\n"+
+		commandStep("probe", "exit 3", "allow_failure: true", "max_retries: 1", shortBackoff)+
+		commandStep("after", script("echo after", "Write-Output after")))
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done — allow_failure advances once the budget is spent",
+			done.State, done.BlockReason)
+	}
+	byStep := subRuns(h.stepRuns(t, task.ID))
+	if got := len(byStep["probe"]); got != 2 {
+		t.Errorf("probe attempts = %d, want 2: the retry is paced, not skipped", got)
+	}
+	if got := len(byStep["after"]); got != 1 {
+		t.Errorf("after rows = %d, want 1", got)
+	}
+}
+
+// TestRetryBackoffOutranksAllowFailureInAGroup is the same trap in
+// group.go's sub-step goroutine — and, in passing, that a re-admitted group
+// re-runs only the sub-step that has work left.
+func TestRetryBackoffOutranksAllowFailureInAGroup(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, groupSnapshot("",
+		commandStep("probe", "exit 3", "allow_failure: true", "max_retries: 1", shortBackoff),
+		commandStep("other", script("echo ok", "Write-Output ok")),
+	))
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
+	}
+	byStep := subRuns(h.stepRuns(t, task.ID))
+	if got := len(byStep["probe"]); got != 2 {
+		t.Errorf("probe attempts = %d, want 2", got)
+	}
+	if got := len(byStep["other"]); got != 1 {
+		t.Errorf("other rows = %d, want 1: a succeeded sibling must not re-run on re-admission", got)
+	}
+}
+
+// TestRetryBackoffOutranksAllowFailureInALoopBody is the same trap in
+// loop.go's runBodyStep.
+func TestRetryBackoffOutranksAllowFailureInALoopBody(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, loopSnapshot("count: 1",
+		commandStep("probe", "exit 3", "allow_failure: true", "max_retries: 1", shortBackoff)))
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
+	}
+	if runs := h.stepRuns(t, task.ID); len(runs) != 2 {
+		t.Fatalf("probe attempts = %d, want 2", len(runs))
+	}
+}
+
+// TestRetryBackoffResumesTheSameLoopIteration: the loop derives its position
+// from its rows, so a paced retry must come back to iteration 2 rather than
+// restarting the loop. Only the second iteration fails, so a restart would
+// leave iteration 1 with a second row.
+func TestRetryBackoffResumesTheSameLoopIteration(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, loopSnapshot("count: 2",
+		commandStep("probe", "{{ if eq .Loop.Index 2 }}exit 1{{ else }}exit 0{{ end }}",
+			"max_retries: 1", shortBackoff)))
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+	byIteration := iterationsOf(h.stepRuns(t, task.ID))
+	if got := len(byIteration[1]); got != 1 {
+		t.Errorf("iteration 1 rows = %d, want 1: the re-admitted loop restarted instead of resuming", got)
+	}
+	if got := len(byIteration[2]); got != 2 {
+		t.Errorf("iteration 2 rows = %d, want 2 (max_retries: 1)", got)
+	}
+}
+
+// TestCollectGroupPrefersASpentFailureOverAPacedOne pins the third precedence
+// tier. Waiting on a sibling whose budget is already gone only delays the
+// block: the task would be held, re-admitted, and blocked anyway.
+func TestCollectGroupPrefersASpentFailureOverAPacedOne(t *testing.T) {
+	until := time.Now().Add(time.Hour)
+
+	got := collectGroup([]stepOutcome{
+		{state: store.StepFailed, reason: ReasonNonzeroExit, backoffUntil: &until},
+		{state: store.StepFailed, reason: ReasonCheckFailed},
+	})
+	if got.backoffUntil != nil || got.reason != ReasonCheckFailed {
+		t.Errorf("collectGroup = %s/%q (backoff %v), want the spent failure check_failed",
+			got.state, got.reason, got.backoffUntil)
+	}
+
+	// With no spent failure the paced one is the group's outcome, so the wait
+	// still reaches the task.
+	got = collectGroup([]stepOutcome{
+		{state: store.StepSucceeded},
+		{state: store.StepFailed, reason: ReasonNonzeroExit, backoffUntil: &until},
+	})
+	if got.backoffUntil == nil {
+		t.Errorf("collectGroup = %s/%q, want the paced failure so the group can wait", got.state, got.reason)
+	}
+
+	// An interruption still outranks both: it consumed no retry.
+	got = collectGroup([]stepOutcome{
+		{state: store.StepFailed, reason: ReasonNonzeroExit, backoffUntil: &until},
+		{state: store.StepInterrupted, reason: ReasonUsageLimit},
+	})
+	if got.state != store.StepInterrupted {
+		t.Errorf("collectGroup = %s/%q, want interrupted", got.state, got.reason)
+	}
+}
+
+// TestParallelGroupBlocksRatherThanWaitingOnASpentSibling is the same
+// precedence end to end: `spent` has no budget left and `paced` has an hour to
+// wait, so the group must block now rather than hold for an hour first.
+func TestParallelGroupBlocksRatherThanWaitingOnASpentSibling(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, groupSnapshot("",
+		commandStep("spent", "exit 4", "max_retries: 0"),
+		commandStep("paced", "exit 3", "max_retries: 5", longBackoff),
+	))
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked {
+		t.Fatalf("task = %s, want blocked", blocked.State)
+	}
+	if blocked.QueuedReason != "" || blocked.AdmitNotBefore != nil {
+		t.Errorf("hold survived the block: %q / %v", blocked.QueuedReason, blocked.AdmitNotBefore)
+	}
+}
+
+// TestUsageLimitIgnoresRetryBackoff: a quota wall is not a paced retry, and a
+// workflow that sets one everywhere must not change which path a usage limit
+// takes or what it costs the budget.
+func TestUsageLimitIgnoresRetryBackoff(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		c.UsageLimitRecheckInterval = config.Duration(time.Hour)
+	})
+	task := h.createTask(t, "name: quota\ndefaults:\n  "+shortBackoff+"\nsteps:\n"+
+		"  - id: implement\n    type: agent\n    max_retries: 1\n    prompt: \"Do the work\"\n")
+	before := time.Now()
+	h.start(t)
+
+	held := h.waitForHold(t, task.ID)
+	if held.QueuedReason != ReasonUsageLimit {
+		t.Fatalf("queued_reason = %q, want %s", held.QueuedReason, ReasonUsageLimit)
+	}
+	if got := held.AdmitNotBefore.Sub(before); got < 55*time.Minute || got > 65*time.Minute {
+		t.Errorf("admit_not_before is %s away, want the 1h recheck interval rather than the 1ms backoff", got)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 || runs[0].State != store.StepInterrupted {
+		t.Fatalf("attempts = %d (first %v), want one interrupted row — a quota stop consumes no retry",
+			len(runs), runs)
+	}
+}
+
+// TestNoRetryBackoffIsTodaysBehaviour is the regression bar: with nothing
+// configured the retries happen inside one admission, and the task never
+// enters a hold.
+func TestNoRetryBackoffIsTodaysBehaviour(t *testing.T) {
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: flaky\nsteps:\n"+
+		commandStep("flaky", "exit 3", "max_retries: 1"))
+	h.start(t)
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonNonzeroExit {
+		t.Fatalf("task = %s/%q, want blocked/nonzero_exit", blocked.State, blocked.BlockReason)
+	}
+	if runs := h.stepRuns(t, task.ID); len(runs) != 2 {
+		t.Fatalf("attempts = %d, want 2 (one retry)", len(runs))
+	}
+	// The hold clears on the way out of `queued`, so the finished row cannot
+	// answer "was it ever held" — the state-change payloads can.
+	for _, p := range h.statePayloads(t, task.ID) {
+		if _, held := p["queued_reason"]; held {
+			t.Errorf("task was held (%v) with no retry_backoff configured", p)
+		}
+	}
+}

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -126,8 +126,16 @@ const (
 	Complete Action = "complete"
 	// Fail is a step failing with retries exhausted (§7.2).
 	Fail Action = "fail"
-	// Interrupt is a crash or graceful stop mid-step: the attempt does not
-	// consume a retry and the task is re-queued (§12.4).
+	// Interrupt returns a running task to the queue (§12.4). A crash or a
+	// graceful stop mid-step is the original caller; a usage-limit hold
+	// (task 003) and a paced retry (`retry_backoff`, task 028) are the
+	// others, each adding an admission hold to the same edge.
+	//
+	// Whether the attempt consumed a retry is **not** decided here. The
+	// attempt's own row says so: `interrupted` consumes none, `failed`
+	// consumes one. finishStepRun writes the row and this moves the task, and
+	// the two are independent — which is what lets a paced retry keep a
+	// `failed` attempt while the task goes back to `queued`.
 	Interrupt Action = "interrupt"
 	// InputClosed is a pending input request ending without an answer while
 	// execution continues — input_timeout expiry or agent process death with

--- a/internal/tui/workflowgraph/diagram.go
+++ b/internal/tui/workflowgraph/diagram.go
@@ -469,6 +469,9 @@ func stepDetail(st apiclient.WorkflowStepDef) []DetailField {
 	if st.MaxRetries != nil {
 		add("max_retries", strconv.Itoa(*st.MaxRetries))
 	}
+	if st.RetryBackoff != nil {
+		add("retry_backoff", *st.RetryBackoff)
+	}
 	if st.Timeout != nil {
 		add("timeout", *st.Timeout)
 	}

--- a/internal/workflow/condition_test.go
+++ b/internal/workflow/condition_test.go
@@ -93,6 +93,13 @@ func TestParseConditionValidation(t *testing.T) {
 			wantPath: "steps[0].max_retries",
 		},
 		{
+			name: "condition carrying a retry backoff",
+			src: "name: x\nsteps:\n  - {id: a, type: condition, if: \"{{ true }}\", retry_backoff: 30s}\n" +
+				"  - {id: b, type: manual, instructions: hi}\n",
+			wantSub:  "retry_backoff is not valid on a condition step",
+			wantPath: "steps[0].retry_backoff",
+		},
+		{
 			name:     "allow_failure on a manual gate",
 			src:      "name: x\nsteps:\n  - {id: a, type: manual, instructions: hi, allow_failure: true}\n",
 			wantSub:  "allow_failure is not valid on a manual step",

--- a/internal/workflow/include.go
+++ b/internal/workflow/include.go
@@ -475,9 +475,10 @@ func materialise(step Step, callee Defaults, override agent.Level) Step {
 		step.Merge = &merge
 	}
 
-	// `timeout` and `max_retries` bind to an attempt, which a `condition` and
-	// a `break` do not have — writing either onto one would produce a
-	// snapshot §8.2 rejects. A `loop` has a timeout but no attempt of its own.
+	// `timeout`, `max_retries` and `retry_backoff` bind to an attempt, which a
+	// `condition` and a `break` do not have — writing any of them onto one
+	// would produce a snapshot §8.2 rejects. A `loop` has a timeout but no
+	// attempt of its own.
 	switch step.Type {
 	case StepCondition, StepBreak:
 	case StepLoop:
@@ -487,6 +488,7 @@ func materialise(step Step, callee Defaults, override agent.Level) Step {
 		if step.MaxRetries == nil {
 			step.MaxRetries = callee.MaxRetries
 		}
+		step.RetryBackoff = firstDuration(step.RetryBackoff, callee.RetryBackoff)
 	}
 
 	// The rest of `defaults:` is agent vocabulary, which §8.2 allows only on

--- a/internal/workflow/include_test.go
+++ b/internal/workflow/include_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
 )
@@ -202,13 +203,13 @@ func TestExpandRejectsUnsupportedPlatform(t *testing.T) {
 // caller's.
 func TestExpandMaterialisesCalleeDefaults(t *testing.T) {
 	lookup := registry(t, map[string]string{
-		"strict": "name: strict\ndefaults: {max_retries: 0, timeout: 30m}\n" +
+		"strict": "name: strict\ndefaults: {max_retries: 0, timeout: 30m, retry_backoff: 45s}\n" +
 			"steps:\n  - {id: once, type: command, run: make}\n" +
-			"  - {id: pinned, type: command, run: make two, timeout: 5m}\n",
+			"  - {id: pinned, type: command, run: make two, timeout: 5m, retry_backoff: 5s}\n",
 	})
 	got, err := Expand(mustParse(t, `
 name: root
-defaults: {max_retries: 3}
+defaults: {max_retries: 3, retry_backoff: 10m}
 steps:
   - {id: c, type: include, workflow: strict}
 `), expandOpts(lookup))
@@ -222,10 +223,19 @@ steps:
 	if once.Timeout == nil || once.Timeout.Std() != 30*60*1e9 {
 		t.Errorf("timeout = %v, want the callee's 30m", once.Timeout)
 	}
+	// `retry_backoff` is an inheritable field like every other one (task 028):
+	// the callee's pacing travels with its steps rather than the caller's.
+	if once.RetryBackoff == nil || once.RetryBackoff.Std() != 45*time.Second {
+		t.Errorf("retry_backoff = %v, want the callee's 45s rather than the caller's 10m", once.RetryBackoff)
+	}
 	// A step that set the field itself outranks the defaults that would have
 	// filled it, which is §8.6's order and not a special case.
-	if pinned := got.Steps[1]; pinned.Timeout == nil || pinned.Timeout.Std() != 5*60*1e9 {
+	pinned := got.Steps[1]
+	if pinned.Timeout == nil || pinned.Timeout.Std() != 5*60*1e9 {
 		t.Errorf("pinned timeout = %v, want its own 5m", pinned.Timeout)
+	}
+	if pinned.RetryBackoff == nil || pinned.RetryBackoff.Std() != 5*time.Second {
+		t.Errorf("pinned retry_backoff = %v, want its own 5s", pinned.RetryBackoff)
 	}
 }
 
@@ -452,6 +462,11 @@ func TestIncludeStepFieldValidation(t *testing.T) {
 			"timeout rejected",
 			"name: n\nsteps:\n  - {id: c, type: include, workflow: x, timeout: 5m}\n",
 			"timeout is not valid on a include step",
+		},
+		{
+			"retry_backoff rejected",
+			"name: n\nsteps:\n  - {id: c, type: include, workflow: x, retry_backoff: 30s}\n",
+			"retry_backoff is not valid on a include step",
 		},
 		{
 			"workflow rejected elsewhere",

--- a/internal/workflow/loop_test.go
+++ b/internal/workflow/loop_test.go
@@ -247,6 +247,17 @@ func TestValidateLoop(t *testing.T) {
 			want: "max_retries is not valid on a loop step",
 		},
 		{
+			name: "a loop has no attempt to pace either",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    retry_backoff: 30s
+    steps:
+      - {id: work, type: command, run: "true"}`,
+			want: "retry_backoff is not valid on a loop step",
+		},
+		{
 			name: "allow_failure on a loop would be a silent loop_limit",
 			src: `
   - id: spin
@@ -405,6 +416,16 @@ func TestValidateBreak(t *testing.T) {
     steps:
       - {id: stop, type: break, if: '{{ true }}', timeout: 5m, run: "true"}`,
 			want: "is not valid on a break step",
+		},
+		{
+			name: "break carries no retry backoff",
+			src: `
+  - id: spin
+    type: loop
+    count: 2
+    steps:
+      - {id: stop, type: break, if: '{{ true }}', retry_backoff: 30s}`,
+			want: "retry_backoff is not valid on a break step",
 		},
 		{
 			name: "break at the top level",

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -136,6 +136,7 @@ type Defaults struct {
 	OnInput        string           `yaml:"on_input"`
 	InputTimeout   *config.Duration `yaml:"input_timeout"`
 	MaxRetries     *int             `yaml:"max_retries"`
+	RetryBackoff   *config.Duration `yaml:"retry_backoff"`
 	Timeout        *config.Duration `yaml:"timeout"`
 }
 
@@ -143,11 +144,22 @@ type Defaults struct {
 // fields that do not belong to a step's type are rejected by validation
 // (spec §8.2), which keeps the YAML shape and its errors simple.
 type Step struct {
-	ID         string           `yaml:"id"`
-	Name       string           `yaml:"name"`
-	Type       string           `yaml:"type"`
-	MaxRetries *int             `yaml:"max_retries"`
-	Timeout    *config.Duration `yaml:"timeout"`
+	ID         string `yaml:"id"`
+	Name       string `yaml:"name"`
+	Type       string `yaml:"type"`
+	MaxRetries *int   `yaml:"max_retries"`
+	// RetryBackoff paces this step's retries (§7.2, task 028): how long to
+	// wait after a failed attempt before the next one. Unset and zero both
+	// mean today's behaviour, an immediate retry.
+	//
+	// The wait is spent by re-queueing the task with a §11 admission hold,
+	// never by sleeping in the actor — a sleeping actor holds its
+	// concurrency slot for the whole wait, and with max_parallel_tasks slots
+	// held that way nothing runs at all (task 003's reasoning, applied to the
+	// general case). The attempt is still `failed` and still consumes a
+	// retry, which is what separates it from a `usage_limit` hold.
+	RetryBackoff *config.Duration `yaml:"retry_backoff"`
+	Timeout      *config.Duration `yaml:"timeout"`
 
 	// If guards the step (§7.7, task 015). It renders against the §8.4
 	// context and must produce exactly `true` or `false`. On an ordinary
@@ -591,6 +603,11 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 	if d.MaxRetries != nil && *d.MaxRetries < 0 {
 		add("defaults.max_retries", "max_retries must not be negative, got %d", *d.MaxRetries)
 	}
+	// Zero is legal and is the default: it means an immediate retry, which is
+	// what every workflow written before task 028 gets.
+	if d.RetryBackoff != nil && *d.RetryBackoff < 0 {
+		add("defaults.retry_backoff", "retry_backoff must not be negative, got %s", d.RetryBackoff)
+	}
 	if d.Timeout != nil && *d.Timeout <= 0 {
 		add("defaults.timeout", "timeout must be positive, got %s", d.Timeout)
 	}
@@ -675,7 +692,7 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
-			"lanes", "merge", "allow_failure", "max_retries", "timeout")
+			"lanes", "merge", "allow_failure", "max_retries", "retry_backoff", "timeout")
 	case StepCondition:
 		// The guard *is* the body. `if:` may not also act as a skip-guard
 		// here: "skip the check that decides whether to continue" has two
@@ -683,21 +700,22 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		if step.If == "" {
 			add(base+".if", "condition steps require an if expression")
 		}
-		// Everything else goes, `timeout`, `max_retries` and `allow_failure`
-		// included: a condition step starts no process, so it cannot time
-		// out, has nothing to retry and has no failure of its own to allow.
+		// Everything else goes, `timeout`, `max_retries`, `retry_backoff` and
+		// `allow_failure` included: a condition step starts no process, so it
+		// cannot time out, has nothing to retry, nothing to pace a retry of,
+		// and no failure of its own to allow.
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
-			"lanes", "merge", "allow_failure", "max_retries", "timeout")
+			"lanes", "merge", "allow_failure", "max_retries", "retry_backoff", "timeout")
 	case StepInclude:
 		if step.Workflow == "" {
 			add(base+".workflow", "include steps require the name of the workflow to include")
 		}
 		// An include is resolved away at task creation, so it owns no
 		// step_runs row, no attempt and no process — which is what rejects
-		// `timeout`, `max_retries`, `allow_failure` and `check`: there is
-		// nothing for them to bind to (decision 11).
+		// `timeout`, `max_retries`, `retry_backoff`, `allow_failure` and
+		// `check`: there is nothing for them to bind to (decision 11).
 		//
 		// `if` goes with them, and that one had a real alternative. Honouring
 		// a guard here would mean distributing it onto every spliced step,
@@ -709,7 +727,8 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 		rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 			"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 			"run", "shell", "env", "instructions", "steps", "max_parallel",
-			"lanes", "merge", "if", "allow_failure", "max_retries", "timeout")
+			"lanes", "merge", "if", "allow_failure", "max_retries", "retry_backoff",
+			"timeout")
 	default:
 		add(base+".type", "unknown step type %q (one of %s)", step.Type, stepTypeList)
 	}
@@ -734,6 +753,9 @@ func validateStep(step Step, base string, opts Options, add func(string, string,
 
 	if step.MaxRetries != nil && *step.MaxRetries < 0 {
 		add(base+".max_retries", "max_retries must not be negative, got %d", *step.MaxRetries)
+	}
+	if step.RetryBackoff != nil && *step.RetryBackoff < 0 {
+		add(base+".retry_backoff", "retry_backoff must not be negative, got %s", step.RetryBackoff)
 	}
 	if step.Timeout != nil && *step.Timeout <= 0 {
 		add(base+".timeout", "timeout must be positive, got %s", step.Timeout)
@@ -851,15 +873,15 @@ func validateLoop(step Step, base string, add func(string, string, ...any), opts
 			add(fmt.Sprintf("%s.for_each[%d]", base, i), "template does not parse: %v", err)
 		}
 	}
-	// No `max_retries` and no `allow_failure` (decision 11): a loop has no
-	// attempt of its own to retry, and "allow" on a loop could only mean "a
-	// loop_limit block advances anyway", which is the silent success
-	// decision 5 refused. Both live on the body steps, where they already do
-	// the useful thing.
+	// No `max_retries`, no `retry_backoff` and no `allow_failure`
+	// (decision 11): a loop has no attempt of its own to retry or to pace,
+	// and "allow" on a loop could only mean "a loop_limit block advances
+	// anyway", which is the silent success decision 5 refused. All three live
+	// on the body steps, where they already do the useful thing.
 	rejectFields(step, base, add, "prompt", "agent", "model", "effort",
 		"permission_mode", "on_input", "input_timeout", "check", "check_timeout",
 		"run", "shell", "env", "instructions", "lanes", "merge", "max_parallel",
-		"allow_failure", "max_retries")
+		"allow_failure", "max_retries", "retry_backoff")
 }
 
 // validateBodyStep checks one member of a `loop` body. Four step types cannot
@@ -1095,7 +1117,8 @@ func rejectFields(step Step, base string, add func(string, string, ...any), fiel
 		"lanes": len(step.Lanes) > 0, "merge": step.Merge != nil,
 		"if": step.If != "", "allow_failure": step.AllowFailure,
 		"max_retries": step.MaxRetries != nil, "timeout": step.Timeout != nil,
-		"count": step.Count != nil, "for_each": len(step.ForEach) > 0,
+		"retry_backoff": step.RetryBackoff != nil,
+		"count":         step.Count != nil, "for_each": len(step.ForEach) > 0,
 		"max_iterations": step.MaxIterations != nil,
 		"workflow":       step.Workflow != "",
 	}

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -187,6 +187,20 @@ func TestParseValidation(t *testing.T) {
 			wantPath: "steps[0].max_retries",
 		},
 		{
+			// Zero is legal and is the default: it means an immediate retry.
+			// Negative is the only thing there is to refuse (task 028).
+			name:     "negative retry_backoff",
+			src:      "name: x\nsteps:\n  - {id: a, type: command, run: \"true\", retry_backoff: -30s}\n",
+			wantSub:  "retry_backoff must not be negative",
+			wantPath: "steps[0].retry_backoff",
+		},
+		{
+			name:     "negative retry_backoff in defaults",
+			src:      "name: x\ndefaults: {retry_backoff: -1s}\nsteps:\n  - {id: a, type: command, run: \"true\"}\n",
+			wantSub:  "retry_backoff must not be negative",
+			wantPath: "defaults.retry_backoff",
+		},
+		{
 			name:     "template does not parse",
 			src:      "name: x\nsteps:\n  - {id: a, type: agent, prompt: \"{{.Task.Title\"}\n",
 			wantSub:  "template does not parse",

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -10,10 +10,16 @@
 # commits past its base while keeping every branch that does (scenario 6), and
 # that a workflow restricted to other platforms is listed but never offered here
 # (scenario 7), and that a step requiring mid-run interaction refuses an agent
-# that cannot provide it (scenario 8). Runs against the committed fakeagent so CI never calls a real
+# that cannot provide it (scenario 8), that an ad-hoc repair runs in the blocked
+# task's own worktree and leaves it at the same step (scenario 9), that a
+# follow-up run works on a finished task's own branch before it is archived
+# (scenario 10), and that a step carrying `retry_backoff` paces its retry
+# through the same admission hold — releasing its slot and recovering
+# unattended (scenario 11).
+# Runs against the committed fakeagent so CI never calls a real
 # API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
 # (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1|2|3|4|5|6|7|8|9|10 runs a single scenario for debugging.
+# VINCENT_GATE_SCENARIO=1..11 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -1232,6 +1238,101 @@ EOF
   echo "=== scenario 10 PASS"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 11 — paced retries (task 028, spec §7.2/§11).
+#
+# Scenario 5's shape for a failure rather than a quota wall: a step that fails
+# its first attempt with a 2 s `retry_backoff` returns the task to `queued`
+# carrying `queued_reason: retry_backoff` and an `admit_not_before`, releases
+# the only slot so the queue keeps moving, and comes back on its own. The
+# attempt row is the difference from a quota wall — `failed`, not
+# `interrupted`, because a paced retry costs a retry and a quota wall does not.
+#
+# The step body is one command whose own exit code says everything: pwsh parses
+# `... && exit 0` as a command named `exit`, so the template picks the command
+# rather than composing one (§8.3).
+# ---------------------------------------------------------------------------
+scenario11() {
+  echo "=== scenario 11: retry_backoff — paced retry, slot released, unattended recovery"
+  scenario_dirs s11
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+max_parallel_tasks: 1
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-backoff.yaml" <<'YAML'
+name: m2-backoff
+description: M2 gate — a step that fails once and is retried after a wait.
+steps:
+  - id: flaky
+    type: command
+    max_retries: 1
+    retry_backoff: 2s
+    run: '{{ if eq .Step.Attempt 1 }}exit 1{{ else }}exit 0{{ end }}'
+YAML
+  # Long enough that the hold expiring is not what ends the wait: the paced
+  # task stays queued while this one owns the only slot, which is what gives
+  # the poll below something to see.
+  cat > "$CONFIG_DIR/workflows/m2-sleeper11.yaml" <<'YAML'
+name: m2-sleeper11
+description: M2 gate — occupies the only slot while the paced task waits.
+steps:
+  - id: nap
+    type: command
+    run: sleep 5
+YAML
+
+  daemon_up
+
+  local repo="$TMP/s11/repo" proj paced sleeper
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+
+  # The paced task is created first, so §11 offers it the only slot first.
+  paced="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-backoff\",\"title\":\"Paced retry\"}" | jq -r .id)"
+  sleeper="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-sleeper11\",\"title\":\"Sleeper\"}" | jq -r .id)"
+
+  echo "== wait for the failed attempt to park the task on an admission hold"
+  local task="" ok=0
+  for _ in $(seq 1 90); do
+    task="$(api GET "/tasks/$paced")"
+    if [[ "$(jq -r '.queued_reason // "null"' <<<"$task")" == "retry_backoff" ]]; then ok=1; break; fi
+    [[ "$(jq -r .state <<<"$task")" == "blocked" ]] && { jq . <<<"$task" >&2; fail "task $paced blocked instead of pacing its retry"; }
+    sleep 1
+  done
+  (( ok )) || { jq . <<<"$task" >&2; fail "task $paced never picked up queued_reason=retry_backoff"; }
+  [[ "$(jq -r .state <<<"$task")" == "queued" ]] || fail "paced task is $(jq -r .state <<<"$task"), want queued"
+  [[ "$(jq -r '.admit_not_before // "null"' <<<"$task")" != "null" ]] \
+    || fail "paced task carries no admit_not_before: $task"
+  [[ "$(jq -r '.block_reason // "null"' <<<"$task")" == "null" ]] \
+    || fail "a paced task must not carry a block_reason: $task"
+
+  echo "== assert the attempt is recorded failed, and spent its retry"
+  local steps
+  steps="$(api GET "/tasks/$paced/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "1" ]] || fail "attempts = $(jq 'length' <<<"$steps"), want 1: $steps"
+  [[ "$(jq -r '.[0].state' <<<"$steps")" == "failed" ]] \
+    || fail "attempt is $(jq -r '.[0].state' <<<"$steps"), want failed — a paced retry is still a failure: $steps"
+  [[ "$(jq -r '.[0].failure_reason' <<<"$steps")" == "nonzero_exit" ]] \
+    || fail "attempt reason is $(jq -r '.[0].failure_reason' <<<"$steps"), want nonzero_exit"
+
+  echo "== the released slot lets the next task run"
+  wait_for_state "$sleeper" done 120
+
+  echo "== the paced task recovers with no human action"
+  wait_for_state "$paced" done 120
+  steps="$(api GET "/tasks/$paced/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "2" ]] \
+    || fail "attempts = $(jq 'length' <<<"$steps"), want exactly 2 (max_retries: 1): $steps"
+  [[ "$(jq -r '.[1].state' <<<"$steps")" == "succeeded" ]] || fail "the paced retry did not succeed: $steps"
+  [[ "$(api GET "/tasks/$paced" | jq -r '.queued_reason // "null"')" == "null" ]] \
+    || fail "the hold outlived the queued period it belonged to"
+
+  "$VINCENT" daemon stop
+  echo "=== scenario 11 PASS (task $paced retried after a paced wait)"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -1248,8 +1349,9 @@ case "$WHICH" in
   8) scenario8 ;;
   9) scenario9 ;;
   10) scenario10 ;;
+  11) scenario11 ;;
   all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8
-     scenario9; scenario10 ;;
+     scenario9; scenario10; scenario11 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 

--- a/skills/vincent-workflows/references/workflow-schema.md
+++ b/skills/vincent-workflows/references/workflow-schema.md
@@ -75,13 +75,19 @@ validation. Read an optional value defensively:
 ## Defaults and common fields
 
 Workflow `defaults` may set `agent`, `model`, `effort`, `permission_mode`,
-`on_input`, `input_timeout`, `max_retries`, and `timeout`. Step values win.
-`max_retries` counts attempts after the first: `0` means one attempt and `1`
-means at most two. Durations use Go syntax such as `90s`, `45m`, or `1h30m`.
+`on_input`, `input_timeout`, `max_retries`, `retry_backoff`, and `timeout`.
+Step values win. `max_retries` counts attempts after the first: `0` means one
+attempt and `1` means at most two. `retry_backoff` is how long to wait before
+each retry, default `0s` — an immediate retry. Use it for steps that fail on
+something transient (a network call, a lock held elsewhere); leave it at zero
+where a second attempt would fail the same way immediately. It never grants an
+extra attempt, only delays one `max_retries` already allows, and the waiting
+task holds no concurrency slot. Durations use Go syntax such as `90s`, `45m`,
+or `1h30m`.
 
 Every runtime step has a unique `id` and a `type`; `name`, `max_retries`,
-`timeout`, and `if` are common optional fields where the step type permits
-them. `allow_failure` is limited to `agent` and `command`. Some structural
+`retry_backoff`, `timeout`, and `if` are common optional fields where the step
+type permits them. `allow_failure` is limited to `agent` and `command`. Some structural
 types deliberately reject timeout or retry fields; see the table below.
 
 ## Step selection and fields


### PR DESCRIPTION
## Summary

Retries were immediate, and no configuration could make them wait.
`runStepWithRetries` counted the failure, checked the budget, checked for
cancellation, emitted `step.retrying`, and called `runAttempt` again on the next
iteration. That is right for a compile error an agent can see and fix, and wrong
for everything transient: with the default `max_retries: 1`, a flaky network
call or a `git index.lock` held by another process burns both attempts inside a
few seconds and blocks the task, needing a human even though nothing was wrong
with the work.

A step — and a workflow's `defaults:` — may now carry `retry_backoff`. The wait
is spent the way task 003 spends a quota wall: the task returns to `queued`
carrying `admit_not_before` and `queued_reason: retry_backoff`, releases its
concurrency slot, and the scheduler re-admits it when the hold expires. Nothing
sleeps; a sleeping actor would hold its slot for the whole wait, which with
`max_parallel_tasks` slots held that way means nothing runs at all.

**The default is zero, so every existing workflow behaves byte-identically.**
The existing retry tests keep their timings and pass unchanged.

What separates this from a `usage_limit` hold is the attempt: it is recorded
`failed` with whatever it actually failed with, and it **consumes a retry**. The
backoff decides *when* an attempt the budget already allows happens, never
*whether* there is one — a step out of budget blocks at once, however long its
backoff.

Scope notes:

- **No migration, no new column, no store change, no scheduler change.**
  Migration `0006`'s `admit_not_before`/`queued_reason` pair was built generic by
  task 003 decision 1 for exactly this, and both are already on the wire and
  rendered generically (`apiclient.Held()`), so no client had to learn a new
  reason.
- **The backoff check precedes `allow_failure`** in all three places that swallow
  a failure into a success — the engine's step loop, `group.go`'s sub-step
  goroutine, and `loop.go`'s `runBodyStep`. It has to: a paced failure has budget
  *remaining*, and checking `allow_failure` first would advance an
  `allow_failure` step on its first failure instead of ever retrying it.
  `collectGroup` gains a matching third precedence tier — interrupted, then a
  spent failure, then a paced one — so a sibling whose budget is already gone
  blocks the group rather than costing it a hold first.
- **`taskstate.Interrupt` is reused** rather than given a second action for the
  identical `Running → Queued` edge. Its doc comment claimed "the attempt does
  not consume a retry", which is wrong for this caller; it now says the attempt
  *row's state* decides that, not the action, which is how it already worked.
- **Two attempts are deliberately not paced.** `repair` runs with
  `max_retries: 0` and never reaches the retry branch; the `on_conflict: agent`
  merge resolver pins `retry_backoff: 0`, because its attempts are the join's
  own and a resolver that does not resolve leaves the conflict for a human —
  without the pin, a workflow-level `defaults.retry_backoff` would silently spend
  half its budget on a wait nothing would honour.
- **Two levels of resolution, not three:** step, then `workflow.defaults`. No
  `config.yaml` key, mirroring `max_retries`, which has none either — that keeps
  the PR V decision (`config.Defaults` is timeouts) intact rather than amending
  it. The issue asked for a config key; this is a deliberate departure from it,
  recorded as decision 3 in the task document.
- The delay is **fixed**, not exponential. That does not reopen the recorded
  no-backoff decision (§12.3, 003 decision 3), which beat *growth* on the grounds
  that it is per-task state the row would have to carry; a fixed delay computed
  at the moment of the wait carries none. §12.3 gains a dated note saying so, so
  the two do not read as contradictory.

Verified: `go run mage.go test`, `go test -race ./internal/taskrun ./internal/workflow`,
`go run mage.go lint` for `GOOS=windows|darwin|linux`, and
`VINCENT_GATE_SCENARIO=10 ./scripts/m2-gate.sh`.

## Related

Closes #88
Closes 027.1, 027.2, 027.3, 027.4, 027.5 — `docs/tasks/027-retry-backoff.md` is
new and carries the seven decisions behind this.

Builds directly on `docs/tasks/003-usage-limit-classification.md` decision 1
(the generic `admit_not_before`/`queued_reason` pair, which named "a git backoff"
as its intended next consumer) — extended as that decision anticipated, not
revisited.

Two recorded decisions are addressed explicitly rather than relitigated:

- **003 decision 3 / §12.3's "deliberately no exponential backoff".** Not
  reopened: this is a *fixed* delay carrying no per-task state, and it is §7.2's
  own concept rather than a second one beside it. §12.3 is amended in place with
  a dated note stating that.
- **PR V's "`config.Defaults` is timeouts".** Left intact by dropping the
  `config.yaml` key the issue asked for. Workflow YAML reaches both resolution
  levels, so nothing a user or a gate needs is lost.

## Checklist

- [ ] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

The first box is honestly unticked: this PR's title is
`feat(workflow): pace step retries with retry_backoff`, which carries a
Conventional Commit prefix because that is what the automation opening it was
asked to produce. `CLAUDE.md` wants a plain-language title —
`Pace step retries with retry_backoff` — and the `PR title` workflow will fail
until it is renamed. Please rename on merge. The single commit *is* conventional,
which is the second box.

What the tests cover, for review: resolution per level (step > `defaults` >
zero, and an explicit `0` beating a workflow-wide default); negative
`retry_backoff` refused on a step and in `defaults`; refused outright on
`condition`, `break`, `loop` and `include`, exactly as `max_retries` is; an
included step inheriting the callee's value; the requeue itself
(`running → queued` with `queued_reason: retry_backoff`, a `failed` row, one
retry spent); the slot released so a second task runs; the budget preserved
across two requeues (`max_retries: 2` → exactly three attempt rows, then a
block); a spent budget blocking at once with an hour-long backoff configured;
`allow_failure` still retrying first in the step loop, in a group and in a loop
body; a loop resuming at the same iteration rather than restarting;
`collectGroup`'s tier order as a unit test and end to end; `usage_limit`
unaffected by a workflow-wide backoff; and the zero case never entering a hold.
`scripts/m2-gate.sh` scenario 10 proves the whole thing over curl against a real
daemon on all three platforms.

`docs/reference/configuration.md` is deliberately untouched — there is no config
key.

## Documentation audit

A separate `docs:` commit follows the implementation commit. It found four stale
claims, all fixed:

- **`docs/guides/workflows.md` had been missed entirely.** Its §3.2 `defaults:`
  table is framed as complete — a "three deliberate absences" list follows it —
  so the missing row answered "can `retry_backoff` go in `defaults:`?" with a
  silent no. §8.2 is the guide's retry section and said nothing about pacing,
  and §4's sub-step field list lost a field its twin in
  `reference/workflow-schema.md` had gained. All three fixed.
- **Spec §7.2's new note said the backoff "applies to every failure that would
  be retried".** Two attempts are exempt and only `docs/tasks/027` said so:
  `repair` by construction, and the `on_conflict: agent` merge resolver by the
  explicit pin in `join.go`. §7.2 now names both.
- **The resolver pin is user-visible and was undocumented on the reference
  page.** A workflow-wide `defaults.retry_backoff` does not reach the resolver;
  `workflow-schema.md`'s join paragraph now says so.
- **`docs/tasks/027-retry-backoff.md` opened with "no API change, no TUI
  change",** which `internal/api/workflowdef.go`,
  `internal/apiclient/workflowdef.go` and the graph's `stepDetail` contradict.
  It now states what is actually on the wire. Its 027.5 page list gained
  `features.md` and `guides/workflows.md`.

Checked and already true, so left alone: `reference/configuration.md` (no
config key, no `internal/config` change), `reference/cli.md` (no cobra change),
`reference/api.md`'s route table (no new route; its workflow-definition example
is illustrative, not a field enumeration), `guides/tui.md`'s key tables
(`bindings.go` unchanged), and the block-reason tables in `troubleshooting.md`
and `task-lifecycle.md`, which the implementation had already given a
`retry_backoff` row saying it is a `queued_reason` and never a block reason.
`skills/vincent-workflows/SKILL.md` needs no edit — it carries no field
enumeration; the schema change lands in its `references/workflow-schema.md`,
which the implementation updated. `getting-started/concepts.md` never claimed
retries are immediate. `docs/gates/` holds only the manual walkthroughs (m3, m5,
017) and m2 has none, so the new scenario 10 changed no gate document.

**No screenshot is stale.** The new `retry_backoff` detail row appears in the
workflow graph only when a step sets the field, and the
`queued · retry backoff → 14:20` header only for a task holding on one; neither
exists in what `scripts/screenshots.sh` seeds. The script was not run.

### Found, not fixed

`docs/spec.md`'s event section still says `step.retrying` "[was] listed here
through M2 but never emitted". `engine.go` has emitted it since well before this
branch (`master:internal/taskrun/engine.go:141`), so the sentence was already
wrong — this PR only added two payload keys to the emit. Left alone as
out-of-scope: it sits inside a recorded PR D decision, and correcting it is
someone's deliberate edit, not a docs sweep's.
