### PR TITLE
Create and keep config.yaml owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,23 @@ list with the user-facing context a commit subject cannot carry.
   longer holds a connection indefinitely; SSE streams are unaffected and keep
   their unbounded response lifetime.
   ([#140](https://github.com/lezli01/vincent/issues/140))
-
+- **`config.yaml` is no longer created world-readable.** On Linux and macOS the
+  daemon created `{config_dir}/` `0755` and `config.yaml` `0644`, so any other
+  local account could read the one file vincent creates that can hold your
+  secrets — `environment.set` values are literal, which is where an API token or
+  a license key ends up. Both are now created `0700`/`0600`, subject only to a
+  stricter umask, and **every daemon start re-tightens an existing installation**
+  the way it already re-tightens `{data_dir}/token`: group and other access is
+  dropped, owner bits are kept and the file's contents are never rewritten. The
+  change is announced rather than silent — the daemon logs the path and the mode
+  it found, and `vincent doctor` grows a `permissions` warning row carrying the
+  path, the observed mode, the expected mode and the exact `chmod`. That warning
+  is not part of the closed set that makes `vincent doctor` exit `1`. Windows is
+  unaffected: modes carry no access control there and access comes from the
+  per-user ACL `%APPDATA%` inherits. The docs now also say plainly that
+  "vincent stores no credentials" is about *vendor* credentials, and that
+  `environment.set` is not a secret store.
+  ([#141](https://github.com/lezli01/vincent/issues/141))
 - **A step whose output vincent could not capture is no longer reported as a
   success.** Command output was read a line at a time with a one-mebibyte
   ceiling; a longer line — minified JSON, a base64 blob, a `git diff` of a

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -25,9 +25,10 @@ below you are in, run one command:
 vincent doctor          # 0 healthy · 1 problems found · 2 no daemon answered
 ```
 
-It prints, in one pass: the config and data directories and whether
-`config.yaml` parses; the daemon's status, pid, port, uptime and version; the
-daemon log's size and last lines; the database's size, schema version and
+It prints, in one pass: the config and data directories, whether `config.yaml`
+parses and whether either is readable beyond its owner (with the `chmod` that
+fixes it); the daemon's status, pid, port, uptime and version; the daemon log's
+size and last lines; the database's size, schema version and
 `PRAGMA integrity_check`; every agent CLI with its path, version and
 [`logged_in`](agents.md#found-is-not-usable); free disk, worktree count and
 bytes, and any orphaned worktrees; and task counts by state — so "12 blocked" is

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -63,7 +63,7 @@ XDG, with the standard fallbacks:
 | Data | `~/.local/share/vincent/` | `XDG_DATA_HOME` |
 
 ```
-~/.config/vincent/config.yaml
+~/.config/vincent/config.yaml            # 0600, in a 0700 directory
 ~/.config/vincent/workflows/*.yaml
 ~/.local/share/vincent/vincent.db
 ~/.local/share/vincent/token             # 0600

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -59,7 +59,7 @@ macOS is the one platform where config and data are nested under the same root:
 | Data | `~/Library/Application Support/vincent/data/` |
 
 ```
-~/Library/Application Support/vincent/config.yaml
+~/Library/Application Support/vincent/config.yaml         # 0600, dir 0700
 ~/Library/Application Support/vincent/workflows/*.yaml
 ~/Library/Application Support/vincent/data/vincent.db
 ~/Library/Application Support/vincent/data/token          # 0600

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -75,8 +75,11 @@ So, concretely:
 %LOCALAPPDATA%\vincent\transcripts\{task_id}\
 ```
 
-The API token is protected by the per-user ACL that `%LOCALAPPDATA%` inherits;
-vincent writes no DACL of its own. On POSIX the equivalent is an explicit `0600`.
+The API token is protected by the per-user ACL that `%LOCALAPPDATA%` inherits,
+and `config.yaml` by the one `%APPDATA%` inherits; vincent writes no DACL of its
+own. On POSIX the equivalent is an explicit `0600` on both, re-tightened on every
+daemon start — which is also why `vincent doctor` never prints a `permissions`
+row here: a mode carries no access control on Windows.
 
 Both can be overridden with `VINCENT_CONFIG_DIR` and `VINCENT_DATA_DIR` — see
 [Files and directories](../reference/files.md).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -183,7 +183,8 @@ endpoints can never disagree. Changes are announced by the
 {
   "generated_at": "2026-08-15T10:00:00Z",
   "paths":    { "config_dir": "…", "data_dir": "…", "config_file": "…",
-                "config_file_exists": true, "config_parses": true },
+                "config_file_exists": true, "config_parses": true,
+                "config_permissions": [] },
   "daemon":   { "status": "running", "pid": 4021, "port": 51234,
                 "started_at": "2026-08-15T09:00:00Z", "uptime_seconds": 3600,
                 "version": "0.1.1" },
@@ -209,6 +210,13 @@ endpoints can never disagree. Changes are announced by the
   an unresponsive daemon, a failed `integrity_check`, a schema newer than the
   binary, or orphaned worktrees). A missing or logged-out agent CLI and any
   number of blocked tasks are reported and never appear here.
+- **`paths.config_permissions[]` is a warning, not a verdict.** Each entry is a
+  config path whose mode grants group or other access — `{ "path", "mode",
+  "expected_mode", "remediation" }`, where `remediation` is the exact `chmod`.
+  It never reaches `problems[]` and never changes the CLI's exit code: the
+  daemon re-tightens both paths on every start, so an entry means no daemon has
+  started on this config or something widened it since. Always empty on Windows,
+  where modes carry no access control.
 - **Agent availability is re-probed unconditionally**, unlike `GET /v1/agents`.
   Authentication is not a function of the binary, so a cached `logged_in: false`
   would survive the user logging in — which would break the endpoint in the loop

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,7 +74,7 @@ One report answering "why is nothing running?". Seven groups:
 
 | Group | Rows |
 |---|---|
-| Paths | config dir, data dir, config file, and whether it parses |
+| Paths | config dir, data dir, config file, whether it parses, and any config path readable beyond its owner |
 | Daemon | running / not running / unresponsive, pid, port, version, uptime |
 | Log | daemon log path, size, mtime, and the last 20 lines |
 | Database | path, size, applied schema version, `PRAGMA integrity_check` |
@@ -92,6 +92,12 @@ are present. A missing or logged-out agent CLI is reported and deliberately does
 *not* set the exit code — most machines have one of three adapters installed,
 and a doctor that exits `1` almost everywhere is no use in a script. Neither do
 task counts: twelve blocked tasks is information, not a defect.
+
+A `permissions` row names a config path whose mode grants group or other
+access, the mode it should have, and the exact `chmod`. It is a warning: the
+daemon tightens both paths on every start, so a row means no daemon has started
+on this config or something widened it since — not a reason to exit `1`. There
+are no such rows on Windows, where modes carry no access control.
 
 **Without a daemon** the report is still printed in full — paths, whether the
 config parses, adapter detection, the log tail, disk free and the worktree

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -468,6 +468,15 @@ ask it to.
 expanded, so `PATH: "${PATH}:/opt/bin"` sets that string verbatim rather than
 appending.
 
+**`set` is not a secret store.** A literal value is exactly where an API token
+would go, and nothing here encrypts one: it is plaintext in a file you may hand
+to version control or sync between machines. vincent creates `config.yaml`
+`0600` inside a `0700` directory and re-tightens both on every daemon start on
+POSIX — see [Files and directories](files.md#the-config-directory) — but that
+only keeps other local accounts out. Prefer naming the variable under `inherit`
+and letting the value come from the environment that starts the daemon; see
+[Security model](../security-model.md#credentials).
+
 Command and check steps layer the [`VINCENT_*` variables](../guides/workflows.md#55-environment-variables)
 and then their own `env:` on top. Neither `unset` nor `set` can touch those —
 they are facts about the run, not inherited state — and a step's `env:` still

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -45,9 +45,11 @@ modes carry no access control and the per-user ACL of `%APPDATA%` applies
 instead.
 
 Everything here is yours: it is safe to put under version control, sync between
-machines, or hand-edit. Nothing in this directory is generated after first start
-— the modes above are the one thing a later start touches, and it touches no
-content.
+machines, or hand-edit — with one caveat from the modes above: a literal
+[`environment.set`](configuration.md#environment) value travels with the file,
+so prefer inheriting the name. Nothing in this directory is generated after
+first start — the modes above are the one thing a later start touches, and it
+touches no content.
 
 Project-scoped workflows live in the repository instead, at
 `.vincent/workflows/*.yaml`, and shadow a global file of the same name.

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -26,16 +26,28 @@ platform where data nests inside config's directory.
 ## The config directory
 
 ```
-{config_dir}/
-  config.yaml          # daemon configuration — you edit this
+{config_dir}/          # created 0700
+  config.yaml          # daemon configuration — you edit this, created 0600
   workflows/*.yaml     # global workflows, available to every project
 ```
 
 Both are watched. Editing `config.yaml` hot-reloads valid changes; saving a
 workflow file reloads the registry. Neither needs a restart.
 
+**The directory and `config.yaml` are owner-only**, because
+[`environment.set`](configuration.md#environment) values are literal and people
+put tokens in them. On POSIX every daemon start drops group and other access
+from both — the same re-tightening the `token` file gets — and logs the path
+and the mode it found; `vincent doctor` reports the same as a warning with the
+exact `chmod`. Your file's *contents* are never rewritten, and if you widened
+those modes on purpose, the next start will narrow them again. On Windows the
+modes carry no access control and the per-user ACL of `%APPDATA%` applies
+instead.
+
 Everything here is yours: it is safe to put under version control, sync between
-machines, or hand-edit. Nothing in this directory is generated after first start.
+machines, or hand-edit. Nothing in this directory is generated after first start
+— the modes above are the one thing a later start touches, and it touches no
+content.
 
 Project-scoped workflows live in the repository instead, at
 `.vincent/workflows/*.yaml`, and shadow a global file of the same name.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -151,9 +151,27 @@ is the boundary that matters.
 
 ## Credentials
 
-vincent stores **none**. It has no vendor API keys, no OAuth flow and no
-keychain entries of its own. An agent step spawns the CLI you installed, which
+**vincent has no credential store of its own.** No vendor API keys, no OAuth
+flow, no keychain entries. An agent step spawns the CLI you installed, which
 authenticates however it already does.
+
+That is a statement about *vincent's* credentials, not about yours. Two files
+vincent owns can hold sensitive data because you put it there:
+
+- **`{config_dir}/config.yaml`**, through
+  [`environment.set`](reference/configuration.md#environment), whose values are
+  literal — an API token, a proxy credential or a license key written there is
+  plaintext on disk. The file is created `0600` inside a `0700` directory, and
+  every daemon start re-tightens both on POSIX (contents untouched) and says in
+  the log what it changed. `vincent doctor` reports a broad mode with the exact
+  `chmod`. On Windows the per-user ACL of `%APPDATA%` applies instead.
+- **Transcripts**, which record what your agent and commands actually printed.
+  They are `0600` for the same reason.
+
+`environment.set` is **not a secret store** — nothing is encrypted, and the file
+is one you may sync between machines. Prefer naming a variable under
+`environment.inherit` and letting the value come from the environment that
+starts the daemon.
 
 The token file gates only vincent's own API. It is not an agent credential and
 grants no model access.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2614,8 +2614,8 @@ platform the standing answer to an agent that will not resolve is the §12.3
 | Data | `~/.local/share/vincent/` | `~/Library/Application Support/vincent/data/` | `%LOCALAPPDATA%\vincent\` |
 
 ```
-{config_dir}/
-  config.yaml                # §12.3
+{config_dir}/                # created 0700 (§12.2 amendment below)
+  config.yaml                # §12.3, created 0600
   workflows/*.yaml           # global workflows
 {data_dir}/
   vincent.db                 # SQLite, WAL mode
@@ -2629,6 +2629,31 @@ platform the standing answer to an agent that will not resolve is the §12.3
   transcripts/{task_id}/{step_index}-i{iteration}-{step_id}-{attempt}.jsonl  # loop body step (§7.8)
   logs/daemon.log            # rotated, size-capped
 ```
+
+**The config directory and `config.yaml` are owner-only.** *Added 2026-08-25
+(#141).* On POSIX the daemon creates `{config_dir}/` `0700` and
+`{config_dir}/config.yaml` `0600`, subject only to a stricter umask. This
+section was previously silent on both, and the code created them `0755`/`0644`.
+`config.yaml` is the one file vincent creates that can hold user-supplied
+secrets — values under `environment.set` are literal (§12.3), which is where an
+API token or a license key ends up — so it matches `{data_dir}/token` rather
+than being the outlier.
+
+- **Existing installations are re-tightened, not warned about.** Every daemon
+  start drops group and other access from both paths, the way the token file is
+  chmodded back to `0600` on every start. Owner bits are kept and *contents are
+  never rewritten*. Because this can undo a mode a user set deliberately, it is
+  never silent: the daemon logs the path, the mode it found and the mode §12.2
+  asks for, and `vincent doctor` reports the same as a warning row carrying the
+  exact `chmod` (§13.2). The warning is **not** part of the closed unhealthy set
+  and does not change `vincent doctor`'s exit code.
+- **Windows is unchanged and stays that way.** The mode argument is ignored
+  there; access comes from the per-user ACL `%APPDATA%` inherits, which is the
+  story already recorded for the token file (T1.3). No DACL code, and no
+  mode-based warning a reader has no `chmod` to act on.
+- **Scope is the config directory and `config.yaml`.** `{data_dir}` is already
+  `0700` in practice — the daemon creates `{data_dir}/logs` `0700` before the
+  store opens — and `vincent.db` keeps the driver's mode.
 
 **What a transcript promises, exactly.** *Added 2026-08-24 (#139).* A
 transcript is the complete record of one attempt: agent stream lines verbatim,
@@ -3899,6 +3924,16 @@ currently true to show (§15 view 6).
 - Worktrees provide *collision* isolation, not *security* isolation.
 - The daemon stores no secrets; agent CLIs use their own auth (keychain/config). The
   token file gates only the vincent API itself.
+- **"Stores no secrets" is about vendor credentials, not about the user's own.**
+  *Amended 2026-08-25 (#141).* vincent has no key store and no vendor
+  credentials of its own, but `config.yaml` takes literal `environment.set`
+  values (§12.3) and a user can reasonably put an API token there. That file and
+  its directory are therefore owner-only on POSIX and re-tightened on every
+  daemon start (§12.2). `environment.set` is still not a secret store: it is
+  plaintext on disk, and inheriting a name from the surrounding environment is
+  the better answer. A secret-provider design is out of scope here and tracked
+  separately. Transcripts are the other place user-supplied sensitive data
+  lands, and are `0600` for the same reason.
 - Command steps and checks execute user-authored workflow content — same trust level
   as the user's own shell; no additional sandboxing is attempted or implied.
 - **Adapter full-auto switches are all equivalent in blast radius**:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3931,9 +3931,10 @@ currently true to show (§15 view 6).
   its directory are therefore owner-only on POSIX and re-tightened on every
   daemon start (§12.2). `environment.set` is still not a secret store: it is
   plaintext on disk, and inheriting a name from the surrounding environment is
-  the better answer. A secret-provider design is out of scope here and tracked
-  separately. Transcripts are the other place user-supplied sensitive data
-  lands, and are `0600` for the same reason.
+  the better answer. A secret-provider design — a keychain or an external
+  provider — is out of scope here and is not what this amendment provides.
+  Transcripts are the other place user-supplied sensitive data lands, and are
+  `0600` for the same reason.
 - Command steps and checks execute user-authored workflow content — same trust level
   as the user's own shell; no additional sandboxing is attempted or implied.
 - **Adapter full-auto switches are all equivalent in blast radius**:

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -232,12 +232,19 @@ func doctorPathRows(p apiclient.DoctorPaths) [][]string {
 	case p.ConfigError != "":
 		state = p.ConfigError
 	}
-	return [][]string{
+	rows := [][]string{
 		{"config dir", p.ConfigDir},
 		{"data dir", p.DataDir},
 		{"config file", p.ConfigFile},
 		{"config", state},
 	}
+	// A config.yaml readable by other local accounts, with the chmod that
+	// fixes it: the file can hold literal environment.set values (§12.3).
+	for _, w := range p.ConfigPermissions {
+		rows = append(rows, []string{"permissions", fmt.Sprintf(
+			"%s is %s, want %s — run: %s", w.Path, w.Mode, w.ExpectedMode, w.Remediation)})
+	}
+	return rows
 }
 
 func doctorDaemonRows(d apiclient.DoctorDaemon) [][]string {

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -109,19 +109,27 @@ tui:
 `
 
 // EnsureDefaultFile writes the commented default config.yaml into dir when
-// none exists, creating dir if needed. It reports whether the file was
-// created. An existing file is never touched.
+// none exists, creating dir if needed, both owner-only (§12.2). It reports
+// whether the file was created. An existing file's *contents* are never
+// touched, but its mode is re-tightened on every call the way
+// daemon.EnsureToken re-tightens {data_dir}/token: an installation created
+// before the modes were tightened would otherwise keep a group- and
+// world-readable config.yaml forever, and that file can hold literal
+// environment.set values (§12.3). The daemon logs what it changed — see
+// CheckPermissions — rather than reshaping a user's file in silence.
 func EnsureDefaultFile(dir string) (created bool, err error) {
 	path := filepath.Join(dir, FileName)
 	if _, err := os.Stat(path); err == nil {
-		return false, nil
+		return false, tightenPermissions(dir)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return false, fmt.Errorf("stat %s: %w", path, err)
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// MkdirAll leaves an existing directory's mode alone, so a config dir that
+	// predates this and has lost only its config.yaml is tightened below.
+	if err := os.MkdirAll(dir, DirPerm); err != nil {
 		return false, fmt.Errorf("create config dir: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, FilePerm)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {
 			return false, nil // lost a create race; the existing file wins
@@ -135,5 +143,5 @@ func EnsureDefaultFile(dir string) (created bool, err error) {
 	if err := f.Close(); err != nil {
 		return false, fmt.Errorf("write default config: %w", err)
 	}
-	return true, nil
+	return true, tightenPermissions(dir)
 }

--- a/internal/config/bootstrap_perm_unix_test.go
+++ b/internal/config/bootstrap_perm_unix_test.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// The config directory and config.yaml may hold user-supplied secrets:
+// environment.set takes literal values (§12.3), which is where an API token or
+// a license key ends up. Both are created for the owner only, like every other
+// file the daemon owns — {data_dir}/token, transcripts, logs (§12.2, §16).
+//
+// The umask is pinned to the common 022 so the assertion measures the modes
+// requested by EnsureDefaultFile rather than the ones the developer's shell
+// happened to allow. No test in this package runs in parallel, so the
+// process-global umask is safe to move and restore here.
+func TestEnsureDefaultFilePermissions(t *testing.T) {
+	old := syscall.Umask(0o022)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	dir := filepath.Join(t.TempDir(), "cfg") // exercise dir creation too
+	created, err := EnsureDefaultFile(dir)
+	if err != nil {
+		t.Fatalf("EnsureDefaultFile: %v", err)
+	}
+	if !created {
+		t.Fatal("created = false on first call, want true")
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := di.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("config dir mode = %#o, want no group/other access (0700)", perm)
+	}
+
+	path := filepath.Join(dir, FileName)
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("%s mode = %#o, want no group/other access (0600)", FileName, perm)
+	}
+}
+
+// An installation created before the modes were tightened keeps a 0755 dir and
+// a 0644 config.yaml forever: EnsureDefaultFile returns early on an existing
+// file. The daemon re-tightens what it owns on every start, the way
+// daemon.EnsureToken does for {data_dir}/token — and the file's contents stay
+// exactly as the user left them.
+func TestEnsureDefaultFileTightensExistingModes(t *testing.T) {
+	old := syscall.Umask(0o022)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	dir := filepath.Join(t.TempDir(), "cfg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, FileName)
+	const custom = "max_parallel_tasks: 42\n"
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := EnsureDefaultFile(dir)
+	if err != nil {
+		t.Fatalf("EnsureDefaultFile: %v", err)
+	}
+	if created {
+		t.Error("created = true for an existing file, want false")
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != custom {
+		t.Errorf("existing config rewritten: %q, want %q", raw, custom)
+	}
+
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := di.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("existing config dir left at %#o, want group/other access dropped", perm)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("existing %s left at %#o, want group/other access dropped", FileName, perm)
+	}
+}

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DirPerm and FilePerm are the modes the config directory and config.yaml are
+// created with (§12.2).
+//
+// config.yaml is the one file the daemon creates that can carry user-supplied
+// secrets: values under environment.set are literal (§12.3), which is where an
+// API token, a proxy credential or a license key ends up. It is owner-only for
+// the same reason every other file the daemon owns already is — {data_dir}/token,
+// transcripts, logs, tui.json. A stricter umask still applies; nothing here
+// widens a mode.
+const (
+	DirPerm  os.FileMode = 0o700
+	FilePerm os.FileMode = 0o600
+)
+
+// PermissionIssue is a config path whose mode grants access to group or other.
+type PermissionIssue struct {
+	Path string
+	// Mode is the mode the path has, Want the mode §12.2 asks for.
+	Mode os.FileMode
+	Want os.FileMode
+}
+
+// Remediation is the exact command that fixes the issue, so a warning about a
+// mode is one a reader can act on without looking anything up.
+func (p PermissionIssue) Remediation() string {
+	return fmt.Sprintf("chmod %04o %s", p.Want.Perm(), p.Path)
+}
+
+// CheckPermissions reports the config directory and config.yaml when either
+// grants group or other access. It is read-only — `vincent doctor` warns from
+// it, and the daemon logs from it before EnsureDefaultFile tightens what it
+// found — and always empty on Windows, where the mode bits carry no access
+// control. A path that does not exist yet is not an issue: the defaults apply
+// until first start writes the file.
+func CheckPermissions(dir string) ([]PermissionIssue, error) {
+	var issues []PermissionIssue
+	for _, want := range []PermissionIssue{
+		{Path: dir, Want: DirPerm},
+		{Path: filepath.Join(dir, FileName), Want: FilePerm},
+	} {
+		fi, err := os.Stat(want.Path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat %s: %w", want.Path, err)
+		}
+		perm := fi.Mode().Perm()
+		if perm&sharedBits == 0 {
+			continue
+		}
+		want.Mode = perm
+		issues = append(issues, want)
+	}
+	return issues, nil
+}
+
+// tightenPermissions drops group and other access from the config directory
+// and config.yaml. Owner bits are kept and contents are never touched: this
+// runs on every daemon start over a file the user edits by hand, so the only
+// thing it may change is who else can read it.
+func tightenPermissions(dir string) error {
+	issues, err := CheckPermissions(dir)
+	if err != nil {
+		return err
+	}
+	for _, issue := range issues {
+		if err := os.Chmod(issue.Path, issue.Mode&^sharedBits); err != nil {
+			return fmt.Errorf("tighten permissions on %s: %w", issue.Path, err)
+		}
+	}
+	return nil
+}

--- a/internal/config/permissions_unix.go
+++ b/internal/config/permissions_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package config
+
+import "os"
+
+// sharedBits are the mode bits that grant access to anyone but the owner.
+const sharedBits os.FileMode = 0o077

--- a/internal/config/permissions_windows.go
+++ b/internal/config/permissions_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package config
+
+import "os"
+
+// sharedBits is empty on Windows: the mode bits carry no access control there,
+// and access to {config_dir} comes from the per-user ACL %APPDATA% inherits —
+// the same story as {data_dir}/token, which grew no DACL code either (T1.3).
+// A mode-based warning would be advice a reader cannot act on: there is no
+// chmod to run.
+const sharedBits os.FileMode = 0

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -92,6 +92,20 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	}
 	defer func() { _ = lock.Unlock() }()
 
+	// Observed before EnsureDefaultFile, because that is what tightens them and
+	// afterwards there is nothing left to report. Never silent: the mode of a
+	// config file is something a user could have widened deliberately, so the
+	// change says which path it touched and what it found (§12.2).
+	if issues, err := config.CheckPermissions(dirs.Config); err != nil {
+		logger.Warn("cannot inspect config permissions", "error", err)
+	} else {
+		for _, issue := range issues {
+			logger.Warn("config permissions tightened to owner-only",
+				"path", issue.Path,
+				"mode", fmt.Sprintf("%04o", issue.Mode.Perm()),
+				"want", fmt.Sprintf("%04o", issue.Want.Perm()))
+		}
+	}
 	if _, err := config.EnsureDefaultFile(dirs.Config); err != nil {
 		logger.Error("startup failed", "error", err)
 		return err

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -75,6 +75,24 @@ type Paths struct {
 	// is for.
 	ConfigParses bool   `json:"config_parses"`
 	ConfigError  string `json:"config_error,omitempty"`
+	// ConfigPermissions lists config paths that grant group or other access,
+	// which config.yaml must not: environment.set values are literal and can
+	// be credentials (§12.2, §12.3). Always empty on Windows, where the mode
+	// bits carry no access control. It is a warning and not a Problem — the
+	// daemon tightens what it owns on every start, so a row here means either
+	// no daemon has started on this config or something widened it since, and
+	// neither is worth changing the exit code the closed unhealthy set defines
+	// (task 005 decision 7).
+	ConfigPermissions []PermissionWarning `json:"config_permissions"`
+}
+
+// PermissionWarning is one config path whose mode is broader than §12.2 asks
+// for, carrying the exact command that fixes it.
+type PermissionWarning struct {
+	Path         string `json:"path"`
+	Mode         string `json:"mode"`
+	ExpectedMode string `json:"expected_mode"`
+	Remediation  string `json:"remediation"`
 }
 
 // Daemon is the liveness picture. It is supplied by the caller rather than
@@ -258,8 +276,25 @@ func Compose(ctx context.Context, opts Options) *Report {
 // re-reading the file would be a second chance to disagree with this row.
 func inspectPaths(dirs config.Dirs) (config.Config, Paths) {
 	file := filepath.Join(dirs.Config, config.FileName)
-	p := Paths{ConfigDir: dirs.Config, DataDir: dirs.Data, ConfigFile: file}
+	p := Paths{
+		ConfigDir: dirs.Config, DataDir: dirs.Data, ConfigFile: file,
+		ConfigPermissions: []PermissionWarning{},
+	}
 	cfg := config.Default()
+	// Answered before the parse question and independently of it: a mode is
+	// worth reporting on a config that does not parse, and on a directory
+	// whose config.yaml is not there yet. A stat that fails here is not
+	// reported twice — the rows below carry it.
+	if issues, err := config.CheckPermissions(dirs.Config); err == nil {
+		for _, issue := range issues {
+			p.ConfigPermissions = append(p.ConfigPermissions, PermissionWarning{
+				Path:         issue.Path,
+				Mode:         fmt.Sprintf("%04o", issue.Mode.Perm()),
+				ExpectedMode: fmt.Sprintf("%04o", issue.Want.Perm()),
+				Remediation:  issue.Remediation(),
+			})
+		}
+	}
 	if _, err := os.Stat(file); err != nil {
 		// Absent is not a fault: the daemon writes the commented default on
 		// first start, and until then the defaults are what is in force.

--- a/internal/doctor/permissions_unix_test.go
+++ b/internal/doctor/permissions_unix_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// A config directory or config.yaml other local accounts can read is worth a
+// row of a user's attention: environment.set values are literal, so that file
+// is where an API token ends up (§12.3). The row carries the exact chmod, and
+// it is a warning rather than a Problem — the closed set that sets the exit
+// code is unchanged (task 005 decision 7).
+func TestConfigPermissionsWarn(t *testing.T) {
+	d := dirs(t)
+	path := filepath.Join(d.Config, config.FileName)
+	write(t, path, "max_parallel_tasks: 2\n")
+	if err := os.Chmod(d.Config, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := Compose(t.Context(), Options{Dirs: d, Agents: []Agent{}})
+
+	want := map[string]PermissionWarning{
+		d.Config: {Path: d.Config, Mode: "0755", ExpectedMode: "0700", Remediation: "chmod 0700 " + d.Config},
+		path:     {Path: path, Mode: "0644", ExpectedMode: "0600", Remediation: "chmod 0600 " + path},
+	}
+	if len(rep.Paths.ConfigPermissions) != len(want) {
+		t.Fatalf("ConfigPermissions = %+v, want one row per broad path", rep.Paths.ConfigPermissions)
+	}
+	for _, got := range rep.Paths.ConfigPermissions {
+		if got != want[got.Path] {
+			t.Errorf("warning for %s = %+v, want %+v", got.Path, got, want[got.Path])
+		}
+	}
+	if hasProblem(rep, GroupPaths) {
+		t.Errorf("a broad mode set a problem: %v", rep.Problems)
+	}
+}
+
+// The same report on an owner-only installation says nothing — which is what
+// every installation looks like once a daemon has started on it, since
+// config.EnsureDefaultFile tightens the modes it finds.
+func TestOwnerOnlyConfigWarnsAboutNothing(t *testing.T) {
+	d := dirs(t)
+	write(t, filepath.Join(d.Config, config.FileName), "max_parallel_tasks: 2\n")
+	// t.TempDir subdirectories are 0755 under the usual umask, so the owner-only
+	// state this test is about has to be asked for.
+	if err := os.Chmod(d.Config, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := Compose(t.Context(), Options{Dirs: d, Agents: []Agent{}})
+
+	if len(rep.Paths.ConfigPermissions) != 0 {
+		t.Errorf("ConfigPermissions = %+v, want none", rep.Paths.ConfigPermissions)
+	}
+}


### PR DESCRIPTION
## Summary

On POSIX the daemon created `{config_dir}/` `0755` and `{config_dir}/config.yaml`
`0644` under the usual `022` umask, so any other local account could read them.
That is the one file vincent creates which can hold user-supplied secrets:
values under `environment.set` are **literal** (§12.3), which is exactly where an
API token, a proxy credential or a license key ends up. Every other file the
daemon owns is already owner-only — `{data_dir}/token` `0600`, transcripts
`0600`, `logs/` and `worktrees/` `0700`, `tui.json` `0600` — and neither the spec
nor the v0 ledger recorded a decision that this one should differ.

**Root cause.** `config.EnsureDefaultFile` predates the `environment` key
(T4.23). When it was written `config.yaml` held ports, timeouts and caps —
nothing sensitive — and `0755`/`0644` was an unremarkable default. T4.23 added a
key whose values are literal and credentials-grade, and hardened *logging*
against it (only names are logged), but the file's own mode was never revisited.
The early return on an existing file compounded it: an installation created
before any fix would keep its broad modes forever, because nothing on the startup
path ever re-inspected them.

**The fix**, all of it in the function that was wrong:

- `EnsureDefaultFile` creates the directory `0700` and the file `0600`, subject
  only to a stricter umask. No guard was added at the call site; the caller is
  unchanged apart from logging.
- On an existing config it re-tightens both paths on every call — group and
  other access dropped, owner bits kept, **contents never rewritten** — which is
  the precedent `daemon.EnsureToken` already sets for `{data_dir}/token`.
- Because that can undo a mode a user set deliberately, it is never silent. The
  daemon logs the path, the mode it found and the mode §12.2 asks for (observed
  *before* `EnsureDefaultFile`, since afterwards there is nothing left to see),
  and `vincent doctor` grows a `permissions` warning row carrying path, observed
  mode, expected mode and the exact `chmod`.
- The doctor warning is deliberately **not** a `Problem`: it does not change the
  exit code, so the closed unhealthy set from task 005 decision 7 — and the four
  pages that document it — stay as they are. A row means either no daemon has
  started on this config or something widened it since.
- Windows is unchanged by construction. The shared-access mask is a build-tagged
  constant that is `0o077` on POSIX and `0` on Windows, so the check finds
  nothing and the `chmod` never runs. Access there comes from the per-user ACL
  `%APPDATA%` inherits — the story already recorded for the token file (T1.3) —
  and no DACL code was added.
- Scope is the config directory and `config.yaml` only, per the brief.
  `internal/store/store.go:42` and the SQLite file mode are untouched; the data
  dir is already `0700` in practice because `daemon.go` creates `{data_dir}/logs`
  `0700` before the store opens.

Nothing changed for "never emit `environment.set` values": `GET /v1/config` does
not carry the `environment` block, `internal/doctor` never reads it, and startup
logs the resolved variables by name only. That was verified, not re-implemented.

**How the regression test catches this coming back.**
`internal/config/bootstrap_perm_unix_test.go` (`//go:build !windows`) pins the
process umask to `022` so it measures the modes `EnsureDefaultFile` *requests*,
not the ones the developer's shell happens to allow.
`TestEnsureDefaultFilePermissions` covers fresh creation and
`TestEnsureDefaultFileTightensExistingModes` a pre-existing `0755`/`0644`
install; both fail the moment either path grants a group or other bit. Against
the unfixed code they fail with `config dir mode = 0755` / `config.yaml mode =
0644` and, for the existing install, `left at 0755` / `left at 0644` — verified
by reverting `bootstrap.go` to its `HEAD` version and re-running. The second test
also asserts the file's bytes are unchanged, so the tightening cannot quietly
regress into an overwrite. The test was neither weakened nor edited; it is
committed first, unmodified.

`internal/doctor/permissions_unix_test.go` covers the new warning row: the two
paths, their observed and expected modes, the exact `chmod`, that it sets no
`Problem`, and that an owner-only installation reports nothing.

Verified locally beyond the unit tests: a daemon started on a `0755`/`0644`
config logs both `config permissions tightened to owner-only` lines and leaves
the directory `0700` and the file `0600` with its contents intact; `vincent
doctor` on an untightened config prints both `permissions` rows and still exits
`0`. `go test ./...`, `go run mage.go lint` for `GOOS=windows`, `darwin` and
`linux` (0 issues each), and `./scripts/m1-gate.sh` all pass.

**Spec amended in the same branch**, as the repository requires — the spec was
the silent side, not the wrong side:

- **§12.2** now states both modes, the re-tightening on every start, the
  Windows-ACL position and the scope, dated *2026-08-25 (#141)*.
- **§16** now separates "the daemon stores no secrets" (true of *vendor*
  credentials) from a config file the user may fill with their own, dated
  *Amended 2026-08-25 (#141)*.

Docs: `docs/security-model.md` makes the same distinction and says plainly that
`environment.set` is not a secret store; `docs/reference/configuration.md` says
it in the `environment` section and points at inheriting the name instead;
`docs/reference/files.md` documents the two modes and the re-tightening;
`docs/reference/cli.md` and `docs/reference/api.md` document the new doctor
warning row and that it is not part of the exit-code set. A documentation audit
then caught four pages derived from the same facts that had been left behind:
`docs/platforms/linux.md` and `docs/platforms/macos.md` annotate `token` with
its mode in their layout listings and said nothing about `config.yaml`;
`docs/platforms/windows.md` gave the per-user ACL story for `%LOCALAPPDATA%`
and the token only, though the config directory is `%APPDATA%` and has the same
story — the one the issue asked to have verified rather than assumed;
`docs/guides/troubleshooting.md` enumerates everything `vincent doctor` prints
in one pass, and doctor now prints one more thing; and
`docs/reference/files.md` called the config directory safe to put under version
control two paragraphs after saying people put tokens in it.

**One thing left out on purpose.** The issue's acceptance criteria also asked for
symlink-refusal and concurrent-creation tests; the brief narrowed the scope to
the two reproduction tests above and I kept to that. No second bug was found on
the way past.

**One thing a reviewer has to do outside this branch.** The issue's last
acceptance criterion asks that a future secret-provider design be *tracked
separately*. Nothing in the tracker covers one — a search of open and closed
issues for a keychain or a secret provider turns up only this issue — so the
spec amendment no longer claims it is tracked: it says only that this amendment
does not provide it. Opening that follow-up issue is still outstanding.

No image under `docs/assets/` is affected. Nothing in `internal/tui` changed and
no TUI surface reports config permissions, so no screenshot went stale.

**One deviation worth flagging:** the workflow that produced this branch asked
for a Conventional Commits PR title, but this repository's `PR title` workflow
rejects exactly that and `CLAUDE.md` requires plain language, so the title is
plain and the prefixes are on the commits.

## Related

Closes #141

Parent review: #135. Follows the T1.3 decision on Windows ACLs (no DACL code)
and task 005 decision 7 on the closed unhealthy set — neither is revisited here,
both are relied on.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
