### PR TITLE
Bound request bodies and require exactly one JSON document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **A request body is now exactly one JSON document, and it is bounded.** The
+  daemon read the *first* JSON value in a request body and discarded everything
+  after it unread, so a client that framed two documents into one request — a
+  retry that re-wrote the body, a `jq -c` loop piped into a single `curl -d @-`,
+  a buggy generator — got a `201` for work vincent never saw, with nothing in the
+  response to distinguish it from the single-document call. Trailing content is
+  now `400 invalid_json`; trailing whitespace stays valid. Bodies are also read
+  under a fixed bound instead of into memory whole (64 KiB, or 4 MiB on the
+  routes that carry a prompt or a workflow source), over which is a new
+  `413 payload_too_large` naming the limit and never echoing the body, and long
+  strings, big maps and prompt or run overrides are bounded field by field with a
+  `400` naming the field. `POST /v1/workflows/validate` now honours the same
+  1 MiB workflow-source limit the registry applies to a file, so a source too
+  large to be catalogued no longer validates cleanly. A body labelled a clearly
+  non-JSON `Content-Type` — what a plain `curl -d` sends — is `415`; an absent
+  header and any `*/json` are still accepted. The daemon additionally sets read
+  and idle timeouts, so a client that sends headers and then dribbles a body no
+  longer holds a connection indefinitely; SSE streams are unaffected and keep
+  their unbounded response lifetime.
+  ([#140](https://github.com/lezli01/vincent/issues/140))
+
 - **A step whose output vincent could not capture is no longer reported as a
   success.** Command output was read a line at a time with a one-mebibyte
   ceiling; a longer line — minified JSON, a base64 blob, a `git diff` of a

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -264,7 +264,8 @@ Two ways out. Give the task a different name and let it re-admit, which keeps it
 history and transcripts:
 
 ```sh
-curl -X POST .../v1/tasks/7/retry -d '{"branch_override":"feat/second-attempt"}'
+curl -X POST .../v1/tasks/7/retry -H 'Content-Type: application/json' \
+  -d '{"branch_override":"feat/second-attempt"}'
 ```
 
 Or delete the leftover branch yourself, then retry:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,6 +5,7 @@ The daemon serves REST + SSE on loopback. Every client — the TUI, the
 
 - [Transport and auth](#transport-and-auth)
 - [Errors](#errors)
+- [Request bodies](#request-bodies)
 - [Daemon](#daemon)
 - [Doctor](#doctor)
 - [Projects](#projects)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -45,6 +45,53 @@ Codes are stable `snake_case` strings; HTTP status codes are used properly.
 parse out of prose — an invalid state transition is always `409` with
 `details.state` set to the state actually found. It is omitted when empty.
 
+## Request bodies
+
+Three rules apply to every request body, before the endpoint sees it.
+
+**One JSON document.** A body is one JSON value followed only by whitespace.
+Two concatenated documents — a retry that rewrites the body, a `jq -c` loop
+piped into one `curl -d @-` — are `400 invalid_json`. Nothing after the first
+document is ever acted on, and nothing is silently discarded.
+
+**Bounded.** Bodies are read up to a fixed limit and no further. Over it is
+`413 payload_too_large` with a message naming the limit; the body is never
+echoed back.
+
+| Limit | Bytes | Applies to |
+|---|---|---|
+| Ordinary request body | 64 KiB | every route not listed below |
+| Large request body | 4 MiB | `POST /v1/tasks`, `POST /v1/resolve`, `POST /v1/tasks/{id}/retry`, `/repair`, `/answer`, `POST /v1/workflows/validate` — the bodies that carry a prompt or a workflow source |
+| `yaml` in `POST /v1/workflows/validate` | 1 MiB | the same bound a workflow file gets when the registry loads it |
+
+Individual fields are bounded too — over one is `400 validation_failed` naming
+the field and the limit:
+
+| Field | Bytes / count |
+|---|---|
+| `title` | 1 KiB |
+| `description` | 64 KiB |
+| project `name`, `branch_name`, `base_branch`, `branch_override` | 512 B |
+| `prompt`, `prompt_override` | 1 MiB |
+| `run_override` | 16 KiB |
+| one `fields` / `answers` key | 256 B |
+| one `fields` / `answers` value | 64 KiB |
+| `fields` / `answers` entries, values per answer | 100 |
+
+These are fixed constants, not configuration: a body larger than one of them is
+a buggy client rather than a workload to tune for.
+
+**Labelled JSON, leniently.** Send `Content-Type: application/json`. A body with
+*no* `Content-Type` is accepted (so `curl --data-binary @file.json` with no
+header still works), as is any `*/json` or `*+json` type with any parameters. A
+non-empty body labelled something clearly not JSON — `text/html`, or the
+`application/x-www-form-urlencoded` that a plain `curl -d` sends without `-H` —
+is `415 unsupported_media_type`.
+
+The server also bounds how long a request may take to arrive (read-header, whole
+request, and idle-connection timeouts). Responses are not bounded: SSE streams
+are long-lived by contract and no write deadline is set.
+
 ---
 
 ## Daemon

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -98,8 +98,10 @@ anybody picks a workflow. Cataloguing is therefore bounded (spec §5.2): only
 **regular files** are sourced, so a symlink, FIFO, socket or device named `*.yaml`
 is rejected without being opened or followed, and a source is capped at **1 MiB**.
 A rejected file is listed as an invalid entry naming the path and the reason; its
-valid siblings stay available. What the parsed content is then allowed to *do* is
-unchanged — a `command` step is still a shell command.
+valid siblings stay available. The same 1 MiB bound applies to a source posted to
+`POST /v1/workflows/validate`, so the API is not a way around it. What the parsed
+content is then allowed to *do* is unchanged — a `command` step is still a shell
+command.
 
 ## Restricted mode
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2837,8 +2837,8 @@ in §13.2 sees the body:
   stopped at the end of the first value and the request was answered `2xx`.)
 - **Bounded.** A body is read up to a fixed limit and no further: **64 KiB** for an
   ordinary request, and **4 MiB** for the routes that legitimately carry a workflow
-  source or an agent prompt (`POST /v1/tasks`, `PATCH`/`retry`/`repair`/`answer` on
-  a task, `POST /v1/resolve`, `POST /v1/workflows/validate`). Over the bound is
+  source or an agent prompt (`POST /v1/tasks`, `retry`/`repair`/`answer` on a task,
+  `POST /v1/resolve`, `POST /v1/workflows/validate`). Over the bound is
   `413` `payload_too_large`, naming the limit and never echoing the body. Fixed, not
   configurable — the same treatment §5.2 gives a workflow source, and for the same
   reason. Individual fields are bounded too (title, description, `fields` and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2826,6 +2826,41 @@ attempt ended, read before the new attempt's row exists.
   "details": {"state": "running"}}}`. `details` is omitted when empty, so responses
   that carry no structured detail are unchanged.
 
+*Amended 2026-08-25 (issue #140).* A request body is **exactly one JSON document,
+bounded, and labelled JSON** — three rules the transport applies before any endpoint
+in §13.2 sees the body:
+
+- **One document.** The body carries one JSON value, followed only by whitespace.
+  Two concatenated documents, or a document followed by anything else, are `400`
+  `invalid_json`; the second document is never acted on and never silently
+  discarded. (Discarding it is what happened before this amendment: the decoder
+  stopped at the end of the first value and the request was answered `2xx`.)
+- **Bounded.** A body is read up to a fixed limit and no further: **64 KiB** for an
+  ordinary request, and **4 MiB** for the routes that legitimately carry a workflow
+  source or an agent prompt (`POST /v1/tasks`, `PATCH`/`retry`/`repair`/`answer` on
+  a task, `POST /v1/resolve`, `POST /v1/workflows/validate`). Over the bound is
+  `413` `payload_too_large`, naming the limit and never echoing the body. Fixed, not
+  configurable — the same treatment §5.2 gives a workflow source, and for the same
+  reason. Individual fields are bounded too (title, description, `fields` and
+  `answers` keys, values and entry counts, prompt and run overrides, names and
+  branch names); over a field bound is `400` `validation_failed` naming the field
+  and the limit.
+- **Labelled JSON, leniently.** A body with no `Content-Type`, or any `*/json` or
+  `*+json` type with any parameters, is accepted. A non-empty body labelled a
+  clearly non-JSON type — `text/html`, or the `application/x-www-form-urlencoded`
+  a plain `curl -d` sends — is `415` `unsupported_media_type`.
+
+`POST /v1/workflows/validate` bounds its `yaml` at §5.2's 1 MiB source limit, the
+same artifact under the same bound wherever it enters the daemon; a source of
+exactly the limit still validates.
+
+The server also bounds how long a request may take to arrive: a read-header
+timeout, a whole-request read timeout, and an idle timeout on kept-alive
+connections. There is deliberately **no write timeout** — §13.3's streams are
+long-lived by contract and a server-wide write deadline would sever every one of
+them. The read deadline covers reading the *request*, so it does not shorten an
+SSE response.
+
 ### 13.2 Endpoints
 
 ```

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -74,8 +74,18 @@ type retryRequest struct {
 
 func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 	var req retryRequest
-	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
+	if r.ContentLength != 0 && !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
+	}
+	for _, b := range []string{
+		boundString("prompt_override", req.PromptOverride, maxPromptBytes),
+		boundString("run_override", req.RunOverride, maxCommandBytes),
+		boundString("branch_override", req.BranchOverride, maxNameBytes),
+	} {
+		if b != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
+			return
+		}
 	}
 	if branch := strings.TrimSpace(req.BranchOverride); branch != "" {
 		if !s.renameBranchForRetry(w, r, branch) {
@@ -120,12 +130,16 @@ type repairRequest struct {
 // selection can raise, which taskAction has no room for.
 func (s *Server) handleTaskRepair(w http.ResponseWriter, r *http.Request) {
 	var req repairRequest
-	if !decodeJSON(w, r, &req) {
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
 	}
 	if strings.TrimSpace(req.Prompt) == "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			"prompt is required: a repair agent needs something to be told")
+		return
+	}
+	if b := boundString("prompt", req.Prompt, maxPromptBytes); b != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
 		return
 	}
 	if s.deps.Runner == nil {
@@ -548,9 +562,38 @@ func (v *answerValues) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// boundAnswers bounds an answer map: §13.1's entry count on the map itself,
+// on the values of any one answer, and on each question and answer string. The
+// values are templated into a resumed step's prompt, so they are bounded like
+// any other prompt input.
+func boundAnswers(answers map[string]answerValues) string {
+	if msg := boundCount("answers", len(answers), maxFieldCount); msg != "" {
+		return msg
+	}
+	for text, vals := range answers {
+		if msg := boundString("answers key", text, maxFieldKeyBytes); msg != "" {
+			return msg
+		}
+		field := fmt.Sprintf("answers[%s]", truncKey(text))
+		if msg := boundCount(field, len(vals), maxValueCount); msg != "" {
+			return msg
+		}
+		for _, v := range vals {
+			if msg := boundString(field, v, maxFieldValueBytes); msg != "" {
+				return msg
+			}
+		}
+	}
+	return ""
+}
+
 func (s *Server) handleTaskAnswer(w http.ResponseWriter, r *http.Request) {
 	var req answerRequest
-	if !decodeJSON(w, r, &req) {
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
+		return
+	}
+	if b := boundAnswers(req.Answers); b != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
 		return
 	}
 	in := taskrun.AnswerInput{Allow: req.Allow}

--- a/internal/api/bodybounds_test.go
+++ b/internal/api/bodybounds_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// postRaw sends an authenticated POST with the body verbatim, which is what a
+// bound has to be proven against: json.Marshal cannot express two concatenated
+// documents, and a marshalled body is by construction one the decoder accepts.
+func (h *projectHarness) postRaw(t *testing.T, path, body string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, h.ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	out, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+// oversizeBytes is far above any bound this could plausibly be fixed with, so
+// the assertion is "a bound exists" rather than a guess at its value — the same
+// device internal/workflow's registry bounds test uses for §5.2.
+const oversizeBytes = 32 << 20
+
+// TestRequestOneJSONDocument pins the first half of issue #140: a request body
+// is exactly one JSON document.
+//
+// decodeJSON (internal/api/projects.go) runs a single json.Decoder.Decode and
+// returns, so everything after the first value is discarded unread: a client
+// that sends two documents has the first one acted on and is told nothing.
+func TestRequestOneJSONDocument(t *testing.T) {
+	t.Run("concatenated documents", func(t *testing.T) {
+		h, one := newBodyBoundsHarness(t)
+		resp, out := h.postRaw(t, "/v1/projects", one+one)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("two JSON documents: status %d, want 400 — body %s", resp.StatusCode, out)
+		}
+		wantError(t, resp, out, http.StatusBadRequest, CodeInvalidJSON)
+	})
+
+	t.Run("trailing garbage", func(t *testing.T) {
+		h, one := newBodyBoundsHarness(t)
+		resp, out := h.postRaw(t, "/v1/projects", one+" nonsense")
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("trailing garbage: status %d, want 400 — body %s", resp.StatusCode, out)
+		}
+		wantError(t, resp, out, http.StatusBadRequest, CodeInvalidJSON)
+	})
+
+	t.Run("trailing whitespace stays valid", func(t *testing.T) {
+		// The other side of the same rule: one document followed only by
+		// whitespace is well-formed and must keep working.
+		h, one := newBodyBoundsHarness(t)
+		resp, out := h.postRaw(t, "/v1/projects", one+"\n\t ")
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("one document plus whitespace: status %d, want 201 — body %s", resp.StatusCode, out)
+		}
+	})
+}
+
+// TestRequestBodyBounded pins the second half of issue #140: nothing wraps the
+// request body in an http.MaxBytesReader, so a body of any size is read into
+// memory whole and acted on.
+func TestRequestBodyBounded(t *testing.T) {
+	t.Run("oversized json body", func(t *testing.T) {
+		h, _ := newBodyBoundsHarness(t)
+		repo := testrepo.Init(t, "main")
+		body := `{"path":` + jsonQuote(repo) + `,"name":"` + strings.Repeat("x", oversizeBytes) + `"}`
+		resp, out := h.postRaw(t, "/v1/projects", body)
+		if resp.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("%d-byte body: status %d, want 413 — body %s", len(body), resp.StatusCode, head(out))
+		}
+	})
+
+	t.Run("oversized workflow source", func(t *testing.T) {
+		// §5.2 bounds one workflow source at 1 MiB where the registry
+		// catalogues it. The validate endpoint parses the same artifact out of
+		// a request body, so it must not be the way around that bound.
+		h, _ := newBodyBoundsHarness(t)
+		yaml := "name: big\ndescription: big\n# " + strings.Repeat("x", oversizeBytes) +
+			"\nsteps:\n  - {id: gate, type: manual, instructions: fine}\n"
+		resp, out := h.postRaw(t, "/v1/workflows/validate",
+			`{"yaml":`+jsonQuote(yaml)+`}`)
+		if resp.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("%d-byte workflow source: status %d, want 413 — body %s",
+				len(yaml), resp.StatusCode, head(out))
+		}
+	})
+}
+
+// newBodyBoundsHarness returns a server with an empty store plus a valid
+// one-document create body for it. Each subtest gets its own so a duplicate
+// registration from a neighbour cannot stand in for the failure under test.
+func newBodyBoundsHarness(t *testing.T) (*projectHarness, string) {
+	t.Helper()
+	repo := testrepo.Init(t, "main")
+	return newProjectHarness(t), `{"path":` + jsonQuote(repo) + `}`
+}
+
+// jsonQuote quotes s as a JSON string literal without pushing the whole body
+// through json.Marshal, which the concatenated cases cannot use.
+func jsonQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// head keeps a failure message readable when the response echoes a body this
+// large back.
+func head(b []byte) string {
+	if len(b) > 200 {
+		return string(b[:200]) + "…"
+	}
+	return string(b)
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -15,6 +15,12 @@ const (
 	CodeValidationFailed = "validation_failed"
 	CodeInvalidState     = "invalid_state"
 	CodeInternal         = "internal"
+	// CodePayloadTooLarge accompanies 413: the request body, or one artifact
+	// inside it, is over a fixed bound (§13.1, amended 2026-08-25).
+	CodePayloadTooLarge = "payload_too_large"
+	// CodeUnsupportedMediaType accompanies 415: a non-empty body is labelled a
+	// Content-Type that is not JSON.
+	CodeUnsupportedMediaType = "unsupported_media_type"
 )
 
 // errorBody is the §13.1 error envelope:

--- a/internal/api/limits.go
+++ b/internal/api/limits.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// Request bounds (§13.1, amended 2026-08-25 for issue #140). They are fixed
+// constants rather than configuration, following §5.2's workflow-source bound:
+// a body larger than these is a buggy or confused client, not a workload to
+// tune for. The daemon is the only writer of every resource behind them, so a
+// body it refuses costs a caller nothing it could not resend smaller.
+const (
+	// maxRequestBytes bounds an ordinary request body: ids, names, paths,
+	// flags. Everything the API accepts on these routes is a short scalar a
+	// human typed or a client copied out of a previous response.
+	maxRequestBytes = 64 << 10
+	// maxLargeRequestBytes bounds the routes that legitimately carry something
+	// written at length — a workflow source (§5.2 fixes one at
+	// workflow.MaxSourceBytes) or an agent prompt. It sits well above that 1
+	// MiB because the artifact travels as a JSON string, where every newline
+	// and quote costs a second byte.
+	maxLargeRequestBytes = 4 << 20
+)
+
+// Per-field bounds. The body bound above stops the daemon reading an
+// unbounded stream; these stop one field of a within-bound body from being the
+// whole of it, because these values are persisted, rendered into prompts and
+// handed to subprocesses long after the request is answered.
+const (
+	maxNameBytes        = 512      // project name, branch name or override
+	maxTitleBytes       = 1 << 10  // task title
+	maxDescriptionBytes = 64 << 10 // task description
+	maxPromptBytes      = 1 << 20  // repair prompt, retry prompt override
+	maxCommandBytes     = 16 << 10 // retry run override — one shell command
+	maxFieldKeyBytes    = 256      // one fields/answers key
+	maxFieldValueBytes  = 64 << 10 // one fields/answers value
+	maxFieldCount       = 100      // fields/answers entries in one request
+	maxValueCount       = 100      // values in one answer
+)
+
+// boundString reports the §13.1 validation message for a field longer than
+// limit, and "" when it fits. The bound is in bytes rather than runes: what it exists
+// to cap is what the daemon stores, templates into a prompt and passes to a
+// subprocess, and those are all counted in bytes.
+func boundString(field, v string, limit int) string {
+	if len(v) <= limit {
+		return ""
+	}
+	return fmt.Sprintf("%s must be at most %d bytes (got %d)", field, limit, len(v))
+}
+
+// boundMap bounds an object field: how many entries it carries, and how long
+// one key and one value may be. The message names the field and the limit and
+// never echoes the value — a bound is reported, not the body that broke it.
+func boundMap(field string, m map[string]string, maxEntries, maxKey, maxValue int) string {
+	if msg := boundCount(field, len(m), maxEntries); msg != "" {
+		return msg
+	}
+	for k, v := range m {
+		if msg := boundString(field+" key", k, maxKey); msg != "" {
+			return msg
+		}
+		if msg := boundString(fmt.Sprintf("%s[%s]", field, truncKey(k)), v, maxValue); msg != "" {
+			return msg
+		}
+	}
+	return ""
+}
+
+// boundCount reports the message for a map or array carrying more than limit
+// entries.
+func boundCount(field string, n, limit int) string {
+	if n <= limit {
+		return ""
+	}
+	return fmt.Sprintf("%s must have at most %d entries (got %d)", field, limit, n)
+}
+
+// truncKey keeps a key readable in an error message without letting an
+// oversized one become the message.
+func truncKey(k string) string {
+	if len(k) <= 64 {
+		return k
+	}
+	return k[:64] + "…"
+}
+
+// boundTaskFields bounds the inputs a task carries from its creation into
+// every prompt it renders: the title, the optional description and the open
+// `fields` map (§8.1.2). POST /v1/tasks and POST /v1/resolve take the same
+// inputs and bound them identically — a draft that resolves has to be one that
+// can then be created.
+func boundTaskFields(title, description string, fields map[string]string) string {
+	if msg := boundString("title", title, maxTitleBytes); msg != "" {
+		return msg
+	}
+	if msg := boundString("description", description, maxDescriptionBytes); msg != "" {
+		return msg
+	}
+	return boundMap("fields", fields, maxFieldCount, maxFieldKeyBytes, maxFieldValueBytes)
+}
+
+// checkContentType applies §13.1's lenient content-type rule. An absent or
+// empty header is accepted — a body with no label is decoded and stands or
+// falls as JSON — as is any JSON media type, parameters and all
+// (`application/json; charset=utf-8`, `application/merge-patch+json`). Only a
+// body explicitly labelled something else is refused: `text/html`, or the
+// `application/x-www-form-urlencoded` that a plain `curl -d` sends, which is
+// the confused client this catches. Every in-repo client already sends
+// `application/json`, so nothing legitimate pays for it.
+func checkContentType(w http.ResponseWriter, r *http.Request) bool {
+	raw := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if raw == "" {
+		return true
+	}
+	if mt, _, err := mime.ParseMediaType(raw); err == nil && isJSONMediaType(mt) {
+		return true
+	}
+	writeError(w, http.StatusUnsupportedMediaType, CodeUnsupportedMediaType,
+		fmt.Sprintf("Content-Type %q is not JSON; send application/json", raw))
+	return false
+}
+
+// isJSONMediaType reports whether mt is a JSON media type: `*/json` or one of
+// the structured `+json` suffixes.
+func isJSONMediaType(mt string) bool {
+	return strings.HasSuffix(mt, "/json") || strings.HasSuffix(mt, "+json")
+}

--- a/internal/api/limits_test.go
+++ b/internal/api/limits_test.go
@@ -1,0 +1,252 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// postTyped is postRaw with the Content-Type under test — including none at
+// all, which the §13.1 policy accepts.
+func postTyped(t *testing.T, h *projectHarness, path, contentType, body string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, h.ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := h.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	out, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+// TestRequestContentType pins §13.1's lenient content-type rule: JSON in any
+// spelling and no label at all are accepted, and only a body that says it is
+// something else is refused.
+func TestRequestContentType(t *testing.T) {
+	accepted := []string{"", "application/json", "application/json; charset=utf-8", "text/json"}
+	for _, ct := range accepted {
+		t.Run("accepts "+labelOf(ct), func(t *testing.T) {
+			repo := testrepo.Init(t, "main")
+			h := newProjectHarness(t)
+			resp, out := postTyped(t, h, "/v1/projects", ct, `{"path":`+jsonQuote(repo)+`}`)
+			if resp.StatusCode != http.StatusCreated {
+				t.Fatalf("Content-Type %q: status %d, want 201 — body %s", ct, resp.StatusCode, out)
+			}
+		})
+	}
+	refused := []string{"application/x-www-form-urlencoded", "text/html", "multipart/form-data"}
+	for _, ct := range refused {
+		t.Run("refuses "+labelOf(ct), func(t *testing.T) {
+			repo := testrepo.Init(t, "main")
+			h := newProjectHarness(t)
+			resp, out := postTyped(t, h, "/v1/projects", ct, `{"path":`+jsonQuote(repo)+`}`)
+			wantError(t, resp, out, http.StatusUnsupportedMediaType, CodeUnsupportedMediaType)
+		})
+	}
+}
+
+func labelOf(ct string) string {
+	if ct == "" {
+		return "no content type"
+	}
+	return ct
+}
+
+// TestRequestBodyAtLimit pins the inclusive edge of the body bound, which is
+// the half a 413 test cannot see: a body of exactly the limit is a good
+// request, and one byte more is not. Padding is trailing whitespace, so the
+// document itself is identical on both sides of the edge.
+func TestRequestBodyAtLimit(t *testing.T) {
+	body := func(repo string, size int) string {
+		doc := `{"path":` + jsonQuote(repo) + `}`
+		return doc + strings.Repeat(" ", size-len(doc))
+	}
+	t.Run("exactly at the limit", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		h := newProjectHarness(t)
+		resp, out := h.postRaw(t, "/v1/projects", body(repo, maxRequestBytes))
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("%d-byte body: status %d, want 201 — body %s", maxRequestBytes, resp.StatusCode, head(out))
+		}
+	})
+	t.Run("one byte over the limit", func(t *testing.T) {
+		repo := testrepo.Init(t, "main")
+		h := newProjectHarness(t)
+		resp, out := h.postRaw(t, "/v1/projects", body(repo, maxRequestBytes+1))
+		wantError(t, resp, out, http.StatusRequestEntityTooLarge, CodePayloadTooLarge)
+	})
+}
+
+// TestRequestBodyMalformed covers the bodies that are neither one document nor
+// over the bound: nothing at all, and a document that stops mid-way.
+func TestRequestBodyMalformed(t *testing.T) {
+	for _, tt := range []struct{ name, body string }{
+		{"empty body", ""},
+		{"truncated document", `{"path":`},
+		{"whitespace only", "  \n\t"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newProjectHarness(t)
+			resp, out := h.postRaw(t, "/v1/projects", tt.body)
+			wantError(t, resp, out, http.StatusBadRequest, CodeInvalidJSON)
+		})
+	}
+}
+
+// TestFieldBounds pins the per-field bounds: a body inside the transport bound
+// still cannot make one field the whole of it, and the 400 names the field and
+// the limit without echoing what was sent.
+func TestFieldBounds(t *testing.T) {
+	for _, tt := range []struct {
+		name, path, body, wantMsg string
+	}{
+		{
+			name:    "task title",
+			path:    "/v1/tasks",
+			body:    `{"project_id":1,"title":` + jsonQuote(strings.Repeat("t", maxTitleBytes+1)) + `}`,
+			wantMsg: "title must be at most",
+		},
+		{
+			name:    "task description",
+			path:    "/v1/tasks",
+			body:    `{"project_id":1,"title":"ok","description":` + jsonQuote(strings.Repeat("d", maxDescriptionBytes+1)) + `}`,
+			wantMsg: "description must be at most",
+		},
+		{
+			name:    "one field value",
+			path:    "/v1/tasks",
+			body:    `{"project_id":1,"title":"ok","fields":{"k":` + jsonQuote(strings.Repeat("v", maxFieldValueBytes+1)) + `}}`,
+			wantMsg: "fields[k] must be at most",
+		},
+		{
+			name:    "field count",
+			path:    "/v1/tasks",
+			body:    `{"project_id":1,"title":"ok","fields":` + manyFields(maxFieldCount+1) + `}`,
+			wantMsg: "fields must have at most",
+		},
+		{
+			name:    "resolve title",
+			path:    "/v1/resolve",
+			body:    `{"workflow":"adhoc","title":` + jsonQuote(strings.Repeat("t", maxTitleBytes+1)) + `}`,
+			wantMsg: "title must be at most",
+		},
+		{
+			name:    "repair prompt",
+			path:    "/v1/tasks/1/repair",
+			body:    `{"prompt":` + jsonQuote(strings.Repeat("p", maxPromptBytes+1)) + `}`,
+			wantMsg: "prompt must be at most",
+		},
+		{
+			name:    "retry run override",
+			path:    "/v1/tasks/1/retry",
+			body:    `{"run_override":` + jsonQuote(strings.Repeat("r", maxCommandBytes+1)) + `}`,
+			wantMsg: "run_override must be at most",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newProjectHarness(t)
+			resp, out := h.postRaw(t, tt.path, tt.body)
+			wantError(t, resp, out, http.StatusBadRequest, CodeValidationFailed)
+			if !strings.Contains(string(out), tt.wantMsg) {
+				t.Errorf("message %s does not mention %q", head(out), tt.wantMsg)
+			}
+		})
+	}
+}
+
+// TestProjectNameBounded is the same rule on the one string a project carries
+// that a client chooses freely.
+func TestProjectNameBounded(t *testing.T) {
+	repo := testrepo.Init(t, "main")
+	h := newProjectHarness(t)
+	resp, out := h.postRaw(t, "/v1/projects",
+		`{"path":`+jsonQuote(repo)+`,"name":`+jsonQuote(strings.Repeat("n", maxNameBytes+1))+`}`)
+	wantError(t, resp, out, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(out), "name must be at most") {
+		t.Errorf("message %s does not name the bound", head(out))
+	}
+}
+
+// TestWorkflowValidateSourceBound pins the validate endpoint to §5.2's source
+// bound, on both sides: a source of exactly workflow.MaxSourceBytes still
+// validates — the same inclusive edge the registry honours for a file — and a
+// larger one is refused rather than parsed.
+func TestWorkflowValidateSourceBound(t *testing.T) {
+	source := func(size int) string {
+		src := "name: big\ndescription: big\nsteps:\n  - {id: gate, type: manual, instructions: fine}\n# "
+		return src + strings.Repeat("x", size-len(src))
+	}
+	t.Run("exactly at the bound", func(t *testing.T) {
+		h := newProjectHarness(t)
+		yaml := source(workflow.MaxSourceBytes)
+		resp, out := h.postRaw(t, "/v1/workflows/validate", `{"yaml":`+jsonQuote(yaml)+`}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%d-byte source: status %d, want 200 — body %s", len(yaml), resp.StatusCode, head(out))
+		}
+		var got validateResponse
+		if err := json.Unmarshal(out, &got); err != nil {
+			t.Fatalf("decode response: %v (%s)", err, head(out))
+		}
+		if !got.Valid {
+			t.Errorf("a %d-byte workflow should still validate: %s", len(yaml), head(out))
+		}
+	})
+	t.Run("one byte over the bound", func(t *testing.T) {
+		h := newProjectHarness(t)
+		yaml := source(workflow.MaxSourceBytes + 1)
+		resp, out := h.postRaw(t, "/v1/workflows/validate", `{"yaml":`+jsonQuote(yaml)+`}`)
+		wantError(t, resp, out, http.StatusRequestEntityTooLarge, CodePayloadTooLarge)
+	})
+}
+
+// TestServerTimeoutPolicy pins §13.3's side of the timeout bargain. The read
+// bounds are set, and WriteTimeout is deliberately **not**: it is a
+// server-wide deadline, and the state and per-task streams are long-lived by
+// contract, so setting one would sever every open stream at the deadline.
+func TestServerTimeoutPolicy(t *testing.T) {
+	s := New(Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+	if s.httpSrv.ReadHeaderTimeout <= 0 {
+		t.Error("ReadHeaderTimeout is unset")
+	}
+	if s.httpSrv.ReadTimeout <= 0 {
+		t.Error("ReadTimeout is unset: a dribbled body holds a connection indefinitely")
+	}
+	if s.httpSrv.IdleTimeout <= 0 {
+		t.Error("IdleTimeout is unset: an idle connection lives as long as the daemon")
+	}
+	if s.httpSrv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v, want 0: it would cut §13.3's streams", s.httpSrv.WriteTimeout)
+	}
+}
+
+// manyFields renders a fields object with n distinct keys.
+func manyFields(n int) string {
+	var b strings.Builder
+	b.WriteByte('{')
+	for i := range n {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`"k` + strconv.Itoa(i) + `":"v"`)
+	}
+	b.WriteByte('}')
+	return b.String()
+}

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -496,6 +496,9 @@ func validateName(existing []store.Project, name string, selfID int64) string {
 	if name == "" {
 		return "name cannot be empty"
 	}
+	if msg := boundString("name", name, maxNameBytes); msg != "" {
+		return msg
+	}
 	for _, p := range existing {
 		if p.ID != selfID && p.Name == name {
 			return fmt.Sprintf("project name %q is already in use; pass a different name", name)
@@ -569,21 +572,70 @@ func (o *opt[T]) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// decodeJSON decodes the request body strictly (unknown fields rejected),
-// writing the error response itself on failure.
+// decodeJSON decodes the request body strictly (unknown fields rejected) under
+// the ordinary body bound, writing the error response itself on failure.
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	return decodeJSONLimit(w, r, v, maxRequestBytes)
+}
+
+// decodeJSONLimit decodes exactly one JSON document from at most limit bytes of
+// the request body (§13.1, amended 2026-08-25 for issue #140). It is the single
+// decode path for the whole API, so each rule it applies is API-wide:
+//
+//   - The body is labelled JSON, or not labelled at all (checkContentType).
+//   - The body is bounded. r.Body is wrapped in an http.MaxBytesReader, so an
+//     oversized body stops the read *at* the bound instead of being buffered
+//     whole and then measured; over it is 413.
+//   - The body is exactly one JSON document. json.Decoder.Decode is a streaming
+//     API: it decodes the next value and leaves the reader positioned after it,
+//     so a lone Decode cannot see anything that follows and silently discards
+//     it. A second Decode that must report io.EOF is what makes trailing
+//     content observable — a client framing two documents into one request used
+//     to get a 2xx for work the daemon never saw. Trailing whitespace is still
+//     a well-formed body: the decoder skips it and reports EOF.
+func decodeJSONLimit(w http.ResponseWriter, r *http.Request, v any, limit int64) bool {
+	if !checkContentType(w, r) {
+		return false
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(v); err != nil {
-		var syn *json.SyntaxError
-		if errors.As(err, &syn) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-			writeError(w, http.StatusBadRequest, CodeInvalidJSON, "request body is not valid JSON")
-			return false
-		}
-		writeError(w, http.StatusBadRequest, CodeValidationFailed, "invalid request body: "+err.Error())
+		return decodeFailed(w, err, limit)
+	}
+	err := dec.Decode(new(json.RawMessage))
+	switch {
+	case errors.Is(err, io.EOF):
+		return true
+	case err == nil:
+		writeError(w, http.StatusBadRequest, CodeInvalidJSON,
+			"request body must contain exactly one JSON document")
+		return false
+	default:
+		return decodeFailed(w, err, limit)
+	}
+}
+
+// decodeFailed maps a decode error onto the §13.1 envelope. It always returns
+// false, so callers can `return decodeFailed(...)` from the decode path.
+//
+// The 413 message names the bound and never echoes the body: what broke it is
+// by definition too large to quote, and quoting a caller's payload back is not
+// this API's job.
+func decodeFailed(w http.ResponseWriter, err error, limit int64) bool {
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		writeError(w, http.StatusRequestEntityTooLarge, CodePayloadTooLarge,
+			fmt.Sprintf("request body must be at most %d bytes", limit))
 		return false
 	}
-	return true
+	var syn *json.SyntaxError
+	if errors.As(err, &syn) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		writeError(w, http.StatusBadRequest, CodeInvalidJSON, "request body is not valid JSON")
+		return false
+	}
+	writeError(w, http.StatusBadRequest, CodeValidationFailed, "invalid request body: "+err.Error())
+	return false
 }
 
 func (s *Server) internalError(w http.ResponseWriter, what string, err error) {

--- a/internal/api/resolve.go
+++ b/internal/api/resolve.go
@@ -82,8 +82,20 @@ type resolvedBranch struct {
 // decision that resolution stays server-side is honored, not relitigated).
 func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
 	var req resolveRequest
-	if !decodeJSON(w, r, &req) {
+	// The same bound as POST /v1/tasks: this body is that body's draft, and a
+	// draft the daemon refuses to read is one the form could still submit.
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
+	}
+	for _, b := range []string{
+		boundTaskFields(req.Title, "", req.Fields),
+		boundString("base_branch", req.BaseBranch, maxNameBytes),
+		boundString("branch_name", req.BranchName, maxNameBytes),
+	} {
+		if b != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
+			return
+		}
 	}
 	name := strings.TrimSpace(req.Workflow)
 	if name == "" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -130,6 +130,19 @@ func New(deps Deps) *Server {
 	s.httpSrv = &http.Server{
 		Handler:           s.handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		// ReadTimeout bounds reading a whole request, headers and body. Without
+		// it a client that sends headers and then dribbles a body holds a
+		// connection and a goroutine for as long as it likes (§13.1, amended
+		// 2026-08-25). It does not reach §13.3's streams: the deadline covers
+		// reading the *request*, and an SSE response outlives it — a client
+		// disconnect is still noticed, by the write that then fails.
+		ReadTimeout: 30 * time.Second,
+		// IdleTimeout closes a kept-alive connection nobody is using; without
+		// one an idle connection lives as long as the daemon.
+		IdleTimeout: 120 * time.Second,
+		// No WriteTimeout, deliberately. §13.3's state and per-task streams are
+		// long-lived by contract, and a server-wide write deadline would sever
+		// every one of them at the deadline.
 	}
 	return s
 }

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -332,8 +332,21 @@ type taskCreateRequest struct {
 // catalog-unknown value passes with a warning on the 201 body (T2.11).
 func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	var req taskCreateRequest
-	if !decodeJSON(w, r, &req) {
+	// The large bound: a task's description and fields are what the workflow
+	// templates into an agent's prompt, so this body legitimately carries prose
+	// (§13.1, amended 2026-08-25).
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
+	}
+	for _, b := range []string{
+		boundTaskFields(req.Title, ptrValue(req.Description), req.Fields),
+		boundString("base_branch", ptrValue(req.BaseBranch), maxNameBytes),
+		boundString("branch_name", ptrValue(req.BranchName), maxNameBytes),
+	} {
+		if b != "" {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
+			return
+		}
 	}
 	ctx := r.Context()
 	project, err := s.deps.Store.GetProject(ctx, req.ProjectID)

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -188,11 +188,21 @@ type validateResponse struct {
 // catalog warnings.
 func (s *Server) handleWorkflowValidate(w http.ResponseWriter, r *http.Request) {
 	var req validateRequest
-	if !decodeJSON(w, r, &req) {
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
 	}
 	if req.YAML == "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, "yaml is required")
+		return
+	}
+	// The same artifact, the same bound. §5.2 fixes a workflow source at 1 MiB
+	// where the registry catalogues it; a source too large to be catalogued
+	// must not validate cleanly through the endpoint the authoring flow uses
+	// (issue #140).
+	if len(req.YAML) > workflow.MaxSourceBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, CodePayloadTooLarge,
+			fmt.Sprintf("a workflow source must be at most %d bytes (got %d)",
+				workflow.MaxSourceBytes, len(req.YAML)))
 		return
 	}
 	wf, warns, err := workflow.Parse([]byte(req.YAML), s.deps.Workflows.Options())

--- a/internal/workflow/registry.go
+++ b/internal/workflow/registry.go
@@ -271,7 +271,7 @@ func (r *Registry) notify() {
 // processed in name order so a duplicate `name:` deterministically keeps the
 // first file and reports each later one.
 //
-// Only regular files under maxSourceBytes are sourced (§5.2): the directory is
+// Only regular files under MaxSourceBytes are sourced (§5.2): the directory is
 // daemon-owned, but its entries are whatever a registered repository contains.
 // A file that fails either bound is catalogued as an invalid entry.
 func (r *Registry) loadDir(dir string, scope Scope, projectID int64) scopeEntries {
@@ -405,11 +405,15 @@ func (r *Registry) Lookup(projectID int64, name string) (Entry, bool) {
 	return Entry{}, false
 }
 
-// maxSourceBytes bounds one workflow file (§5.2). A workflow is a
+// MaxSourceBytes bounds one workflow source (§5.2). A workflow is a
 // human-written definition and a megabyte is far past any real one; the bound
 // exists because a project scope is whatever a registered repository happens
 // to contain, and loading it must not be able to exhaust the daemon.
-const maxSourceBytes = 1 << 20
+//
+// It is exported because the same artifact reaches the daemon by a second
+// route: POST /v1/workflows/validate parses a source out of a request body, and
+// a bound the API did not share would be a way around this one (issue #140).
+const MaxSourceBytes = 1 << 20
 
 // yamlFile is one candidate found in a scope directory. reject is empty for a
 // regular file, and otherwise says why the file cannot be a workflow source.
@@ -451,7 +455,7 @@ func yamlFiles(dir string) ([]yamlFile, error) {
 }
 
 // readSource reads one discovered workflow file. A non-empty reject is a file
-// the registry must not source — the wrong type, or more than maxSourceBytes —
+// the registry must not source — the wrong type, or more than MaxSourceBytes —
 // leaving err for a genuine I/O failure.
 //
 // The type is checked twice: once on the directory entry, and once on the
@@ -482,12 +486,12 @@ func readSource(f yamlFile) ([]byte, string, error) {
 	}
 	// One byte past the limit: enough to know the file is over it, without
 	// allocating it, and a file of exactly the limit still parses.
-	src, err := io.ReadAll(io.LimitReader(file, maxSourceBytes+1))
+	src, err := io.ReadAll(io.LimitReader(file, MaxSourceBytes+1))
 	if err != nil {
 		return nil, "", err
 	}
-	if len(src) > maxSourceBytes {
-		return nil, fmt.Sprintf("%s: a workflow file must be at most %d bytes", f.path, maxSourceBytes), nil
+	if len(src) > MaxSourceBytes {
+		return nil, fmt.Sprintf("%s: a workflow file must be at most %d bytes", f.path, MaxSourceBytes), nil
 	}
 	return src, "", nil
 }

--- a/internal/workflow/registry_bounds_test.go
+++ b/internal/workflow/registry_bounds_test.go
@@ -42,15 +42,15 @@ func TestLoadDirRejectsOversizedFile(t *testing.T) {
 }
 
 // TestLoadDirAcceptsFileAtSizeLimit pins the other side of that bound: the
-// limit is inclusive, so a file of exactly maxSourceBytes still parses. It is
+// limit is inclusive, so a file of exactly MaxSourceBytes still parses. It is
 // what stops the read from being one byte short of what the docs promise.
 func TestLoadDirAcceptsFileAtSizeLimit(t *testing.T) {
 	reg, globalDir := newTestRegistry(t)
 
 	src := manualWorkflow("exact", "at-the-limit") + "# "
-	src += strings.Repeat("x", maxSourceBytes-len(src))
-	if len(src) != maxSourceBytes {
-		t.Fatalf("padded source is %d bytes, want %d", len(src), maxSourceBytes)
+	src += strings.Repeat("x", MaxSourceBytes-len(src))
+	if len(src) != MaxSourceBytes {
+		t.Fatalf("padded source is %d bytes, want %d", len(src), MaxSourceBytes)
 	}
 	path := filepath.Join(globalDir, "exact.yaml")
 	if err := os.MkdirAll(globalDir, 0o700); err != nil {
@@ -66,7 +66,7 @@ func TestLoadDirAcceptsFileAtSizeLimit(t *testing.T) {
 	if !ok || !e.Valid() {
 		t.Fatalf(`Lookup("exact") = %+v, %v; a file of exactly the limit must parse`, e, ok)
 	}
-	if len(e.Source) != maxSourceBytes {
-		t.Errorf("entry source is %d bytes, want the whole %d-byte file", len(e.Source), maxSourceBytes)
+	if len(e.Source) != MaxSourceBytes {
+		t.Errorf("entry source is %d bytes, want the whole %d-byte file", len(e.Source), MaxSourceBytes)
 	}
 }


### PR DESCRIPTION
## Summary

The localhost API read request bodies with no upper bound and treated "the first
JSON value in the stream" as "the request". This fixes both.

**Root cause.** `decodeJSON` (`internal/api/projects.go`) built a
`json.NewDecoder(r.Body)`, called `DisallowUnknownFields`, called `Decode` once
and returned `true`. `json.Decoder.Decode` is a *streaming* API — it is specified
to decode the next value and leave the reader positioned after it — so
everything past the first document was never read and never reported, and
`r.Body` was never wrapped, so the reader was whatever the client chose to send.
`DisallowUnknownFields` gave the decoder an air of strictness that hid the gap:
the existing tests cover an unknown field and a malformed document, and both of
those fail *inside* the first value. Because this is the single decode path
behind twelve call sites, both faults were API-wide rather than per-route.

A client that framed two documents into one request — a retry that re-wrote the
body, a `jq -c` loop piped into one `curl -d @-`, a buggy generator — therefore
got a `201` for work the daemon never saw, with nothing in the response to
distinguish it from the single-document call.

**The fix, at the defect.** `decodeJSON` now decodes a second time into a
`json.RawMessage` and requires `io.EOF`; anything else is `400 invalid_json`.
Trailing whitespace decodes to EOF, so it stays valid. It also wraps `r.Body` in
an `http.MaxBytesReader`, so an oversized body stops *at* the bound instead of
being buffered whole and then measured. Every call site inherits both rules.

Around that, the rest of #140 (the brief's decision 3 — this PR carries the whole
issue):

- **Limits are fixed constants in `internal/api`** (`limits.go`), following
  §5.2's precedent rather than §12.3's configurable `transcript_max_bytes`:
  64 KiB per ordinary body, 4 MiB via `decodeJSONLimit` for the routes that
  legitimately carry a prompt or a workflow source. Over the bound is a new
  additive `413 payload_too_large` that names the limit and never echoes body
  content.
- **`POST /v1/workflows/validate` honours §5.2's 1 MiB source bound**, sharing
  `workflow.MaxSourceBytes` (exported for this, not restated) with the registry
  that catalogues the identical artifact. A source of exactly the bound still
  validates, matching the registry's inclusive edge.
- **Content-Type is enforced leniently**, per the brief's decision 1: absent or
  empty passes, any `*/json` or `*+json` with any parameters passes, and only a
  non-empty body labelled a clearly non-JSON type (`text/html`, or the
  `application/x-www-form-urlencoded` a plain `curl -d` sends) is `415
  unsupported_media_type`. Every in-repo caller already sends
  `application/json`; all seven gates pass unchanged.
- **Per-field bounds** on titles, descriptions, `fields`/`answers` keys, values
  and entry counts, prompt and run overrides, names and branch names, each a
  `400 validation_failed` naming the field and the limit.
- **`ReadTimeout` and `IdleTimeout`** on the `http.Server`, so headers followed
  by a dribbled body no longer hold a connection and a goroutine indefinitely.
  **No `WriteTimeout`**, deliberately: §13.3's streams are long-lived by contract
  and a server-wide write deadline would sever every one of them.

`docs/spec.md` §13.1 carries the framing, bound and Content-Type rules as a
dated amendment (2026-08-25) — the section was silent on all three, and it grows
additively. §5.2 needed no amendment: the validate endpoint not honouring its
bound was a code-versus-spec mismatch, and the code is now the side that moved.

## Related

Closes #140

Diagnosis: `.vincent-issue/brief.md` (scratch, not in this diff). No recorded
decision in the v0 ledger or in `docs/tasks/` covers request framing or body
size, so nothing here revisits one.

## How the regression test catches this coming back

`internal/api/bodybounds_test.go` is committed first, in its own `test:` commit,
and was observed failing against the unfixed decoder: four of its five subtests
fail at `e02409a` — two concatenated documents and a document plus trailing
garbage both answered `201`, a 32 MiB body stored, and a 32 MiB workflow source
answered `{"valid":true}`. It sends bodies **verbatim** rather than through
`json.Marshal`, which is the only way to express two concatenated documents at
all and which is what makes the assertion about framing rather than about
marshalling.

Its fifth subtest is the guard against over-correcting: one document followed by
`"\n\t "` must stay a `201`. A future "fix" that rejected any trailing byte, or
that reverted to a single `Decode`, fails one side or the other of that pair.

**No assertion was weakened, moved, or reinterpreted.** The test asserts exactly
what the brief diagnosed, and it passes on the fix as written.

`internal/api/limits_test.go` adds the acceptance criteria the regression test
does not reach: the inclusive edge of the body bound (exactly `maxRequestBytes`
is a `201`, one byte more is a `413`), empty, whitespace-only and truncated
bodies, the accepted and refused Content-Types, each per-field bound, and the
1 MiB workflow source edge on both sides. Unknown fields and malformed JSON were
already covered in `projects_test.go` and still pass unchanged.

## Three things a reviewer should judge rather than take on trust

- **No client code changed.** The brief asks for 413/415 to be surfaced in
  `internal/cli` and the TUI. Both already render the daemon's envelope message
  verbatim for any non-2xx (`cli/output.go:apiMessage`,
  `tui/actionbar.go`), so the surfacing came from writing messages that name the
  limit rather than from new client code. Adding a status-specific branch would
  have been a second rendering path for no new information.
- **The SSE-under-`ReadTimeout` criterion has no automated test.** Proving it
  in-repo would mean a real listener plus a stream outliving a 30 s deadline —
  minutes of CI for a config line. Instead it was verified against `net/http`
  with a standalone probe before being relied on: with `ReadTimeout` set, an SSE
  response streamed well past the deadline and a client disconnect was still
  detected immediately. `TestServerTimeoutPolicy` pins the part that *would*
  break streams if someone later "completed" the timeout set — `WriteTimeout`
  must stay zero.
- **`vincent workflow validate` still reads its file unbounded.** The issue's
  criterion "workflow validation uses the same source-size limit as registry
  loading" is met on the daemon side: `POST /v1/workflows/validate` now shares
  `workflow.MaxSourceBytes` with the registry. The CLI subcommand is a different
  path — `internal/cli/workflow.go` reads the file the user named with
  `os.ReadFile` and parses it in the user's own process, with no daemon and no
  daemon-owned resource to exhaust — so it was deliberately left alone. Called
  out because a reviewer checking that criterion will look at both; deciding it
  should be bounded too is a separate change.

## Verification

- `go test ./...` — 1849 pass; `go test -race` on `api`, `workflow`,
  `apiclient`, `tui`.
- `go run mage.go lint` clean, and `golangci-lint` re-run for `GOOS=windows`,
  `darwin`, `linux` (host-built linter, per `CLAUDE.md`).
- All seven gates pass locally against the fake agent: `m1`, `m2`, `m5`, `m6`,
  `m7`, `m8`, `m9`.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated — `docs/reference/api.md` (a new
      "Request bodies" section with every limit, listed in the page contents),
      `docs/spec.md` §13.1 (dated amendment), `docs/security-model.md` (the
      1 MiB workflow-source claim is now true of the API path too), and
      `docs/guides/troubleshooting.md` (its branch-collision remedy was a plain
      `curl -d`, which sends `application/x-www-form-urlencoded` and is now a
      `415` — it sends `Content-Type: application/json`)

### Documentation audit

A separate `docs:` commit follows the implementation commits. It corrected three
drifts and changed nothing else:

- **`docs/spec.md` §13.1 named the wrong routes.** The amendment listed `PATCH`
  on a task among the 4 MiB routes. `handleTaskPatch` decodes through
  `decodeJSON`, so it gets the ordinary 64 KiB bound, and its body is
  `{"priority": N}` — neither a workflow source nor a prompt. The six routes that
  do pass `maxLargeRequestBytes` are the six `docs/reference/api.md` already
  listed, so the reference was right and the spec was not.
- **`docs/guides/troubleshooting.md` documented a request that is now `415`** —
  see the checklist item above. It is the only `curl -d` carrying a body
  anywhere in `docs/`; `docs/guides/scripting.md` already sent the header.
- **`docs/reference/api.md`'s contents list** omitted the new "Request bodies"
  section while listing every other `##` heading.

Checked and already true, so untouched: `docs/reference/configuration.md` (the
limits are fixed constants in `internal/api` per the brief's decision 2 — the
issue's "and configuration references" was settled the other way, and nothing new
reaches `internal/config`), `docs/reference/cli.md` (the cobra tree is
unchanged), `docs/reference/workflow-schema.md` and
`skills/vincent-workflows/SKILL.md` (no step type, field, validation rule,
template variable or human-interaction mechanism changed — `registry.go` only
exported a constant that already existed, so this repo's own
`.vincent/workflows/*.yaml` need nothing either),
`docs/reference/task-lifecycle.md` and the block-reason tables (no `Reason*`
constant added or changed), `docs/guides/tui.md` (`bindings.go` untouched),
`docs/guides/agents.md` and spec §9.x (no adapter capability moved),
`docs/features.md` (it points at the API reference and makes no claim about
request framing), `docs/gates/` (no walkthrough posts a body), and `docs/tasks/`
(no task document covers this issue — per `docs/tasks/README.md`, a fix whose
reasoning fits in its commit message does not open one).

No screenshot under `docs/assets/` is stale: no TUI code changed.
