### PR TITLE
Page the SSE Last-Event-ID replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **Reconnecting to the event stream no longer stalls the daemon.** A client
+  resuming `GET /v1/events` or `GET /v1/tasks/{id}/events` with a
+  `Last-Event-ID` had its whole backlog read into memory in one query, and
+  written in full, before the stream went live. Event rows are kept
+  indefinitely, so that backlog only grows: on a long-lived installation a
+  single reconnect could allocate tens of mebibytes and hold the daemon's one
+  SQLite connection for the length of the scan, delaying task transitions and
+  every other write behind it. The catch-up now reads in fixed pages up to the
+  newest event id at the moment the stream opened, so the memory and the
+  connection are held for one page no matter how far behind the cursor is.
+  Nothing about what a client receives changed: every event after the cursor
+  is still delivered, in id order, exactly once across the hand-off to live
+  events. ([#138](https://github.com/lezli01/vincent/issues/138))
 - **A request body is now exactly one JSON document, and it is bounded.** The
   daemon read the *first* JSON value in a request body and discarded everything
   after it unread, so a client that framed two documents into one request — a

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -28,6 +28,12 @@ const (
 	// outputSubBuffer is the live-output channel depth; overflow drops
 	// chunks (the transcript is the durable copy).
 	outputSubBuffer = 1024
+	// replayPageSize is how many events one Last-Event-ID catch-up query
+	// reads. It caps what a replay holds and how long it keeps the single
+	// SQLite connection, whatever the backlog behind the cursor is; small
+	// enough that a page is a few hundred KiB of envelopes, large enough
+	// that a realistic catch-up is a handful of queries.
+	replayPageSize = 512
 )
 
 // eventJSON is the SSE `data:` body of a durable event: the full envelope,
@@ -196,17 +202,40 @@ func (s *Server) handleTaskEvents(w http.ResponseWriter, r *http.Request) {
 // replay from the events table, and the first flush. Returns the response
 // controller and the last event id written. Validation must be complete —
 // nothing can be unwritten past this point.
+//
+// The replay is paged: event rows are kept indefinitely (§17), so the
+// backlog behind a cursor has no ceiling and reading it in one query would
+// hold all of it in memory and occupy the daemon's single SQLite connection
+// (phase 1 decision) until the last row was scanned. Paging bounds both to
+// one page and hands the connection back between pages. §13.3's "miss
+// nothing" is untouched — every event behind the cursor is still delivered,
+// in id order, just not all at once.
 func (s *Server) startStream(
 	w http.ResponseWriter, r *http.Request, replay store.EventFilter, cursor int64,
 ) (*http.ResponseController, int64, bool) {
-	var backlog []store.Event
+	// The walk stops at the largest id committed when the stream opened.
+	// Without that bound a replay on a busy daemon could page after its own
+	// tail indefinitely and never reach the live loop. Events committed past
+	// it arrive through the subscription — registered before this call
+	// (phase 2 decision) and deduped by the last id returned here — so the
+	// seam still delivers each one exactly once.
+	var (
+		highWater int64
+		page      []store.Event
+		err       error
+	)
 	if cursor > 0 {
-		evs, err := s.deps.Store.ListEvents(r.Context(), replay)
-		if err != nil {
+		if highWater, err = s.deps.Store.MaxEventID(r.Context()); err != nil {
+			s.internalError(w, "max event id", err)
+			return nil, 0, false
+		}
+		// The first page is read before the headers so a store failure can
+		// still be answered with an error envelope rather than a half-open
+		// stream; later pages have nowhere to report to but the connection.
+		if page, err = s.replayPage(r, replay, cursor); err != nil {
 			s.internalError(w, "list events", err)
 			return nil, 0, false
 		}
-		backlog = evs
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -215,16 +244,40 @@ func (s *Server) startStream(
 	rc := http.NewResponseController(w)
 
 	lastID := cursor
-	for i := range backlog {
-		if !writeSSEEvent(w, &backlog[i]) {
+	for {
+		for i := range page {
+			if !writeSSEEvent(w, &page[i]) {
+				return nil, 0, false
+			}
+			lastID = page[i].ID
+		}
+		if err := rc.Flush(); err != nil {
 			return nil, 0, false
 		}
-		lastID = backlog[i].ID
+		// A short page means the filtered backlog is exhausted (LIMIT applies
+		// after the WHERE), and lastID past the mark means the rest is the
+		// subscription's to deliver.
+		if len(page) < replayPageSize || lastID >= highWater {
+			return rc, lastID, true
+		}
+		// A client that has gone away stops the walk rather than paging
+		// through the remaining backlog for nobody.
+		if r.Context().Err() != nil {
+			return nil, 0, false
+		}
+		if page, err = s.replayPage(r, replay, lastID); err != nil {
+			s.deps.Logger.Error("list events", "error", err)
+			return nil, 0, false
+		}
 	}
-	if err := rc.Flush(); err != nil {
-		return nil, 0, false
-	}
-	return rc, lastID, true
+}
+
+// replayPage reads one page of the Last-Event-ID backlog: the events after
+// `after` that match the stream's filter, at most replayPageSize of them.
+func (s *Server) replayPage(r *http.Request, f store.EventFilter, after int64) ([]store.Event, error) {
+	f.AfterID = after
+	f.Limit = replayPageSize
+	return s.deps.Store.ListEvents(r.Context(), f)
 }
 
 // lastEventID reads the SSE resume cursor. Absent means live-only; our ids

--- a/internal/api/replay_test.go
+++ b/internal/api/replay_test.go
@@ -119,3 +119,34 @@ func liveHeap() uint64 {
 }
 
 func mib(b uint64) float64 { return float64(b) / (1 << 20) }
+
+// TestEventReplayPagesDeliverEveryEvent holds §13.3's "miss nothing" over a
+// backlog that spans several replay pages. Paging is an implementation
+// detail of the catch-up query, never a reason for a resuming client to be
+// handed a short or reordered history — and the walk still has to hand over
+// to the live loop cleanly, which is the seam a paged replay could drop an
+// event through or deliver one twice.
+func TestEventReplayPagesDeliverEveryEvent(t *testing.T) {
+	h := newSSEHarness(t)
+	// Not a multiple of the page size: the last page must be a short one,
+	// which is how the walk learns the backlog is exhausted.
+	backlog := replayPageSize*2 + 7
+	want := make([]int64, 0, backlog)
+	for range backlog {
+		want = append(want, h.append(t, "task.state_changed").ID)
+	}
+
+	// Resume from the first event, so everything after it is replayed.
+	c := openSSE(t, h.ts.URL+"/v1/events", fmt.Sprint(want[0]))
+	for i, id := range want[1:] {
+		if f := c.next(t); f.id != fmt.Sprint(id) {
+			t.Fatalf("replay frame %d id = %s, want %d", i, f.id, id)
+		}
+	}
+
+	live := h.append(t, "task.state_changed")
+	if f := c.next(t); f.id != fmt.Sprint(live.ID) {
+		t.Fatalf("first frame past the replay = %s, want the live event %d "+
+			"(a replayed event was repeated across the seam)", f.id, live.ID)
+	}
+}

--- a/internal/api/replay_test.go
+++ b/internal/api/replay_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// replayBacklog is the number of durable events seeded behind the resume
+// cursor. It is well short of what a long-lived installation accumulates —
+// §17 keeps event rows indefinitely — and is only large enough to make an
+// unbounded replay's heap unmistakable next to a bounded one.
+const replayBacklog = 50000
+
+// maxReplayHeap is the live heap a Last-Event-ID replay may hold once the
+// first byte of the response is on the wire. A replay that reads the backlog
+// in fixed pages holds one page (a few hundred KiB at any sane page size);
+// one that materializes the whole backlog holds ~360 B per event, so this
+// budget is roughly three times a page-shaped implementation's worst case and
+// a third of what replayBacklog events cost when materialized at once.
+const maxReplayHeap = 6 << 20
+
+// TestEventReplayHeapIsBounded pins §13.3's resume path to a memory budget
+// that does not grow with the backlog behind the cursor. The measurement is
+// taken as soon as the first response byte arrives, which is the moment that
+// separates the two shapes: a paged replay has read one page by then, an
+// unbounded one has already read and retained every matching row.
+func TestEventReplayHeapIsBounded(t *testing.T) {
+	h := newSSEHarness(t)
+	seedEvents(t, h, replayBacklog)
+
+	// The same request without a cursor replays nothing, so its heap is the
+	// floor this endpoint costs — subtracting it keeps the budget about the
+	// replay rather than about the server.
+	live := heapAtFirstByte(t, h, "")
+	replay := heapAtFirstByte(t, h, "1")
+
+	if replay > live+maxReplayHeap {
+		t.Fatalf("replay of %d backlog events held %.1f MiB above a live-only stream (%.1f MiB), want at most %.1f MiB: "+
+			"the whole backlog is materialized before the first frame is written",
+			replayBacklog, mib(replay-live), mib(live), mib(maxReplayHeap))
+	}
+}
+
+// seedEvents appends n durable events for the harness task through the real
+// store, so the rows and the id sequence are exactly what a resume queries.
+func seedEvents(t *testing.T, h *sseHarness, n int) {
+	t.Helper()
+	// A state change's payload: ids, the new state, and the one-line summary
+	// §13.3 allows on a transition into awaiting_input.
+	payload := json.RawMessage(`{"from":"running","to":"awaiting_input","summary":"` +
+		strings.Repeat("choose one of the offered branches ", 4) + `"}`)
+	ctx := context.Background()
+	for range n {
+		e := &store.Event{
+			Type:      "task.state_changed",
+			TaskID:    &h.taskID,
+			ProjectID: &h.projectID,
+			Payload:   payload,
+		}
+		if err := h.st.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+}
+
+// heapAtFirstByte opens one SSE stream over a raw connection that is never
+// drained, and reports the process's live heap the moment the server's first
+// byte arrives. Not reading is the point: the handler stays parked inside the
+// response it is writing, so whatever the replay retains is still reachable
+// when the sample is taken.
+func heapAtFirstByte(t *testing.T, h *sseHarness, lastEventID string) uint64 {
+	t.Helper()
+	conn, err := net.Dial("tcp", h.ts.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Closing before the test's cleanup unblocks a parked handler: the write
+	// fails, the handler returns, and httptest's Close does not wait on it.
+	t.Cleanup(func() { _ = conn.Close() })
+
+	req := "GET /v1/events HTTP/1.1\r\nHost: vincent\r\n" +
+		"Authorization: Bearer " + testToken + "\r\nAccept: text/event-stream\r\n"
+	if lastEventID != "" {
+		req += "Last-Event-ID: " + lastEventID + "\r\n"
+	}
+	if _, err := fmt.Fprint(conn, req+"\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	// Peek rather than Read: one byte proves the response has started
+	// without draining what the handler already wrote.
+	if _, err := bufio.NewReaderSize(conn, 256).Peek(1); err != nil {
+		t.Fatalf("first response byte (cursor %q): %v", lastEventID, err)
+	}
+	return liveHeap()
+}
+
+// liveHeap returns HeapAlloc after collecting twice — once to sweep the
+// garbage the request made, once so the first collection's own leftovers do
+// not count against the budget.
+func liveHeap() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.HeapAlloc
+}
+
+func mib(b uint64) float64 { return float64(b) / (1 << 20) }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -82,6 +82,19 @@ type EventFilter struct {
 	Limit     int      // 0 = unlimited
 }
 
+// MaxEventID returns the largest committed event id, or 0 when no event has
+// been written yet. It is the high-water mark an SSE replay pages up to
+// (§13.3): a resume walks only to the id that existed when the stream opened
+// and lets the subscription carry everything after it, so a replay on a busy
+// daemon cannot chase a tail that keeps moving.
+func (s *Store) MaxEventID(ctx context.Context) (int64, error) {
+	var id int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM events`).Scan(&id); err != nil {
+		return 0, fmt.Errorf("max event id: %w", err)
+	}
+	return id, nil
+}
+
 // ListEvents returns events matching f in id order — the catch-up query
 // behind SSE Last-Event-ID resume (spec §13.3).
 func (s *Store) ListEvents(ctx context.Context, f EventFilter) ([]Event, error) {

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -121,3 +121,34 @@ func TestListEventsFilters(t *testing.T) {
 		})
 	}
 }
+
+// TestMaxEventID pins the high-water mark an SSE replay pages up to: zero on
+// an empty table, so a resume on a fresh daemon walks nowhere, and the last
+// assigned id once events exist.
+func TestMaxEventID(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+
+	got, err := s.MaxEventID(ctx)
+	if err != nil {
+		t.Fatalf("MaxEventID: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("MaxEventID on an empty table = %d, want 0", got)
+	}
+
+	var last int64
+	for range 3 {
+		e := &Event{Type: "daemon.shutting_down"}
+		if err := s.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+		last = e.ID
+	}
+	if got, err = s.MaxEventID(ctx); err != nil {
+		t.Fatalf("MaxEventID: %v", err)
+	}
+	if got != last {
+		t.Errorf("MaxEventID = %d, want the last appended id %d", got, last)
+	}
+}


### PR DESCRIPTION
## Summary

`GET /v1/events` and `GET /v1/tasks/{id}/events` answered a `Last-Event-ID`
resume by reading **every** matching event row into one slice and writing all of
it before entering the live loop.

**Root cause:** `startStream` called `store.ListEvents` with the filter it was
handed and never set `Limit`, and `EventFilter.Limit == 0` means *unlimited* —
so the query had no bound, `ListEvents` materialized the whole result, and none
of it was written until the last row had been scanned. `internal/store` is not
the defect: its unlimited mode is correct and other callers want it. The SSE
path was wrong to use it.

That mattered because the backlog has no ceiling. §17 keeps event rows
indefinitely and nothing prunes the table, so an ordinary reconnect on a
long-lived installation allocated ~360 B of live heap per replayed event
(measured: 17.3 MiB at 50 000 events, 34.7 MiB at 100 000) and held the daemon's
**only** SQLite connection (phase 1 decision) for the length of the scan,
delaying task transitions and every other write behind it.

**The fix** pages the replay inside `startStream`:

- A high-water event id is captured when the stream opens (`store.MaxEventID`,
  `SELECT COALESCE(MAX(id), 0) FROM events`). This is load-bearing, not
  decoration — without it a paged replay on a busy daemon chases a moving tail
  and may never reach the live loop.
- The walk reads pages of `replayPageSize` (512) with `AfterID` advancing to the
  last id written, writing and flushing each page and stopping at a short page
  or at the high-water mark. `r.Context()` is checked between pages, so a client
  that goes away stops the walk instead of paging through the rest of the
  backlog for nobody.
- The first page is read *before* the headers go out, so a store failure is
  still answerable with an error envelope rather than a half-open stream.

The seam is untouched, which is the point: the subscription is still registered
before the first replay query (phase 2 decision) and the live loop still skips
`ev.ID <= lastID`, so an event committed *during* the paged replay is delivered
exactly once, after the boundary, with no new machinery. Overflow behaviour is
unchanged — a durable-event subscriber that falls behind during a long replay is
still disconnected and still resumes losslessly.

Nothing a client sees changed. §13.3's "miss nothing" holds: every event behind
the cursor is still delivered, in id order, exactly once.

**Scope held deliberately.** Per the agreed diagnosis, the issue's items 3 and 4
and acceptance criteria 4, 6, 7 and 8 are **not** taken here: a max replay
count/age with a reset signal would make a resuming client lose events, which
§13.3 forbids; retention and compaction (and doctor's retained-span rows) belong
to #98, which owns database growth; a bounded read pool and a load-test gate are
not justified by anything measured, since paging already releases the connection
between pages. No index was added — the per-task replay is already covered by
`idx_events_task`, and a project-filtered index was to be added only if a
measurement at a realistic row count justified one. None was taken, so none was
added.

## Related

Closes #138

Related: #98 owns event retention and database growth, which this change
deliberately does not touch — nothing here prunes an event, so no cursor is ever
invalidated by it.

Bears on, and does not revisit: the phase 1 single-connection decision (it is
*why* the unbounded scan hurt) and the phase 2 subscribe-before-replay and
slow-subscriber decisions (both relied on, neither changed).

## How the regression would be caught coming back

`TestEventReplayHeapIsBounded` (`internal/api/replay_test.go`) seeds 50 000
durable events through the real store, opens one SSE stream over a raw loopback
connection with `Last-Event-ID: 1`, and **never drains it** — so the handler
stays parked inside the response it is writing and whatever the replay retains
is still reachable. It samples live heap at the first response byte, which is
exactly the moment the two shapes diverge: a paged replay has read one page by
then, an unbounded one has read everything. A live-only stream over the same
backlog is measured as the floor and subtracted, so the budget is about the
replay and not about the server.

Verified red before the fix — 17.4 MiB against the 6 MiB budget, with and
without `-race` — and green after. Restoring the unbounded call, or raising the
page size into the tens of thousands, puts it straight back over budget.

Two supporting tests were added with the fix, and neither substitutes for the
one above:

- `TestEventReplayPagesDeliverEveryEvent` holds §13.3's "miss nothing" over a
  backlog of `2×replayPageSize + 7` events — deliberately not a multiple of the
  page size, so the short last page is exercised — asserting the exact id
  sequence and then that the first frame past the replay is a newly committed
  live event, which is where a paged walk could drop one or repeat one. Mutating
  the stop condition so the walk ends after the first page fails it.
- `TestMaxEventID` pins the new store helper at zero on an empty table and at
  the last assigned id otherwise.

The regression test was **not** weakened. It is committed first, in its own
commit, exactly as it was written and observed to fail.

## Second finding, not fixed here

Not a defect and not touched, but worth a reviewer's eye: `startStream`'s paged
walk still writes each page as fast as the connection accepts it, so a client
that reads slowly holds the *response* (not a DB read, and not the connection)
for as long as it likes. That is the existing SSE contract for every stream,
replay or not, and bounding it is a different change from this one.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — **audited, nothing needed.** No route in
      `internal/api/server.go`, config key, cobra command, `internal/tui/bindings.go`
      binding, `Reason*` constant, step type or workflow-schema field changed, so
      none of the pages derived from those changed either. The client-visible SSE
      contract in `docs/reference/api.md`, `docs/guides/scripting.md` and
      `docs/getting-started/concepts.md` is still exactly true word for word:
      durable events resume without gaps, a cursorless connection is live-only,
      live output is not replayable, and the back-pressure split is untouched.
      Neither page ever described the replay as one query, so there was no claim
      to correct. `docs/spec.md` is likewise unamended: §13.3 specifies the
      resume path and never its cost, §17's "DB rows kept indefinitely" is the
      reason this bug existed rather than something the fix changes, and §14's
      single-connection note at spec:3310 stays true. No `docs/tasks/` document
      is advanced or completed — this is a review-queue fix, and the tasks README
      says a fix's record is its commit message. No `docs/gates/` walkthrough
      covers SSE replay, and `m2-gate.sh`'s `Last-Event-ID: 1` assert observes
      the same delivery it always did. `skills/vincent-workflows/SKILL.md` and
      this repository's `.vincent/workflows/*.yaml` are untouched because the
      workflow schema did not move.
- [x] `docs/assets/tui-*.png` unaffected — nothing on this path reaches a TUI
      panel, so no screenshot is stale and `scripts/screenshots.sh` does not need
      re-running.

The documentation audit found no bug in the change itself and nothing else left
unfixed beyond the second finding recorded above.
