### PR TITLE
Make crash recovery atomic per task and fail startup closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **Crash recovery no longer re-queues a task whose previous attempt it could
+  not close.** Startup recovery ran as two independent sweeps — finalize every
+  open step run, then re-queue every live task — with nothing carrying a failed
+  finalize forward into the re-queue decision. A storage failure at that one
+  write was logged and walked past, and the owning task went back to `queued`
+  anyway: a `queued` task with a step run the database still called `running`,
+  which the scheduler then admitted, starting a second attempt against a first
+  one that was, durably, still open. Recovery is now atomic per task — the step
+  runs, the task transition and its durable event commit together — and
+  fail-closed: a task that cannot be reconciled is left exactly as found, and
+  the daemon refuses to start rather than running the scheduler over rows it
+  knows are contradictory. Restarting the daemon retries recovery, and nothing
+  is duplicated if it runs twice. Two guards back it up: admission refuses a
+  `queued` task that still has a `running` step run, and `vincent doctor`
+  reports the combination under a new `tasks` problem and a
+  `tasks.unreconciled[]` list.
+  ([#142](https://github.com/lezli01/vincent/issues/142))
 - **Reconnecting to the event stream no longer stalls the daemon.** A client
   resuming `GET /v1/events` or `GET /v1/tasks/{id}/events` with a
   `Last-Event-ID` had its whole backlog read into memory in one query, and

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -78,11 +78,14 @@ esac
 
 What sets exit `1` is a **closed set**: `config.yaml` exists and does not parse,
 the daemon is alive but not answering, `PRAGMA integrity_check` is not `ok`, the
-database is at a schema version this binary does not understand, or orphaned
-worktrees are present. A missing or logged-out agent CLI is reported and does
-*not* set the exit code — most machines have one of three adapters installed, so
-a doctor that exited `1` almost everywhere would be no use here. Neither do task
-counts: twelve blocked tasks is information, not a defect.
+database is at a schema version this binary does not understand, orphaned
+worktrees are present, or a task is unreconciled — `queued` (or finished) while
+one of its step runs is still marked `running`, which is crash recovery having
+failed to close the previous attempt. A missing or logged-out agent CLI is
+reported and does *not* set the exit code — most machines have one of three
+adapters installed, so a doctor that exited `1` almost everywhere would be no
+use here. Neither do task *counts*: twelve blocked tasks is information, not a
+defect.
 
 ## JSON output
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -112,6 +112,12 @@ Read `{data_dir}/logs/daemon.log`. An invalid `config.yaml` at startup is fatal
 and says which key and line. (An invalid config on *hot reload* is not fatal —
 the last good config keeps running and the rejection is logged.)
 
+**Crash recovery is fatal too.** If it cannot close a previous run's open step
+runs, the daemon refuses to start — `startup failed: crash recovery`, with the
+underlying error beside it, a storage failure nearly every time. Nothing is
+half-done: each task is reconciled whole or left exactly as it was found, so
+starting the daemon again simply retries it.
+
 ## Agent CLIs
 
 ### An agent CLI is not found

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -41,10 +41,18 @@ rather than opening SQLite behind the daemon's back.
 
 The bottom of the report is a `PROBLEMS` table — the closed set that makes it
 exit `1`: a `config.yaml` that does not parse, a daemon alive but unresponsive,
-a failed `integrity_check`, a database written by a newer vincent, or orphaned
-worktrees. A missing or logged-out agent CLI is printed plainly and deliberately
-does **not** set the exit code, so doctor stays usable in a script on a machine
-that only ever installs one of the three adapters.
+a failed `integrity_check`, a database written by a newer vincent, orphaned
+worktrees, or an unreconciled task. A missing or logged-out agent CLI is printed
+plainly and deliberately does **not** set the exit code, so doctor stays usable
+in a script on a machine that only ever installs one of the three adapters.
+
+An **unreconciled** task is one whose state and step runs contradict each
+other — it is `queued` (or finished) while one of its step runs is still marked
+`running`. Crash recovery finalizes the old attempt before the task returns to
+the queue, so this means recovery could not complete: the task is refused by
+admission and will sit at `queued` forever. Recovery runs at startup, so
+restarting the daemon retries it; the daemon log says why it failed the first
+time.
 
 ```sh
 vincent doctor --json > doctor.json   # the whole report, for a bug report

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -200,7 +200,8 @@ endpoints can never disagree. Changes are announced by the
                 "worktree_count": 3, "worktree_bytes": 8412736,
                 "orphans_known": true, "orphans": [] },
   "tasks":    { "known": true, "total": 14,
-                "counts": { "queued": 1, "running": 1, "blocked": 12, "…": 0 } },
+                "counts": { "queued": 1, "running": 1, "blocked": 12, "…": 0 },
+                "unreconciled": [] },
   "problems": []
 }
 ```
@@ -208,8 +209,8 @@ endpoints can never disagree. Changes are announced by the
 - **`problems[]` is the daemon's verdict**, not something a client re-derives:
   it is the closed set that makes the CLI exit `1` (config that does not parse,
   an unresponsive daemon, a failed `integrity_check`, a schema newer than the
-  binary, or orphaned worktrees). A missing or logged-out agent CLI and any
-  number of blocked tasks are reported and never appear here.
+  binary, orphaned worktrees, or an unreconciled task). A missing or logged-out
+  agent CLI and any number of blocked tasks are reported and never appear here.
 - **`paths.config_permissions[]` is a warning, not a verdict.** Each entry is a
   config path whose mode grants group or other access — `{ "path", "mode",
   "expected_mode", "remediation" }`, where `remediation` is the exact `chmod`.
@@ -217,6 +218,13 @@ endpoints can never disagree. Changes are announced by the
   daemon re-tightens both paths on every start, so an entry means no daemon has
   started on this config or something widened it since. Always empty on Windows,
   where modes carry no access control.
+- **`tasks.unreconciled[]`** is the §12.4 contradiction: a task holding a step
+  run still marked `running` while sitting in a state that cannot be executing
+  one — `queued`, `done`, `aborted` or `archived`. Each entry carries `task_id`,
+  `state` and `open_step_runs`. Such a task is refused by admission and will not
+  run until crash recovery reconciles it, so it also raises a `tasks` problem.
+  The waiting states are deliberately absent: an open run is correct under
+  `awaiting_input` and `awaiting_gate`.
 - **Agent availability is re-probed unconditionally**, unlike `GET /v1/agents`.
   Authentication is not a function of the binary, so a cached `logged_in: false`
   would survive the user logging in — which would break the endpoint in the loop

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -80,18 +80,22 @@ One report answering "why is nothing running?". Seven groups:
 | Database | path, size, applied schema version, `PRAGMA integrity_check` |
 | Agents | per adapter: found, path, version, and `logged_in` |
 | Storage | disk free under the data dir, worktree count and bytes, orphans |
-| Tasks | counts by state, so "12 blocked" is visible without opening the board |
+| Tasks | counts by state, so "12 blocked" is visible without opening the board, plus any task whose state and step runs contradict each other |
 
 Exit `0` when everything checked is healthy, `1` when problems were found (they
 are listed under `PROBLEMS`), `2` when no daemon answered.
 
 **Unhealthy is a closed set**: `config.yaml` exists and does not parse, the
 daemon is alive but not answering, `integrity_check` is not `ok`, the database
-is at a schema version newer than this binary understands, or orphaned worktrees
-are present. A missing or logged-out agent CLI is reported and deliberately does
+is at a schema version newer than this binary understands, orphaned worktrees
+are present, or a task is **unreconciled** — `queued` (or finished) while one of
+its step runs is still marked `running`, which means crash recovery could not
+close the previous attempt and admission will not run that task until it does
+([Troubleshooting](../guides/troubleshooting.md#start-here-vincent-doctor)).
+A missing or logged-out agent CLI is reported and deliberately does
 *not* set the exit code — most machines have one of three adapters installed,
 and a doctor that exits `1` almost everywhere is no use in a script. Neither do
-task counts: twelve blocked tasks is information, not a defect.
+task *counts*: twelve blocked tasks is information, not a defect.
 
 A `permissions` row names a config path whose mode grants group or other
 access, the mode it should have, and the exact `chmod`. It is a warning: the

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2823,6 +2823,30 @@ edited via `PATCH /v1/projects/{id}`.
   `GET /v1/info`, and it deletes nothing — `vincent gc` does that, with a human behind
   it.
 
+*Amended 2026-08-25 (issue #142).* Recovery is **fail-closed and atomic per
+task**. Finalizing a task's `running` StepRuns and re-queueing the task are one
+store transaction (`store.InterruptTask`), so the order above can never come
+apart: the daemon cannot hand the scheduler a `queued` task whose previous
+attempt the database still calls `running`. A task whose transaction will not
+commit is left exactly as found — recoverable, not re-queued — and the failure
+**stops daemon startup** rather than being logged and walked past; continuing
+past a storage failure is least defensible when storage is what is failing.
+Re-running recovery converges: the second pass finds the same open rows and the
+same `from` state, and the compare-and-swap refuses a task already reconciled,
+so no duplicate StepRun, event or retry consumption is possible. Killing an
+orphan stays outside the transaction and before it — a kill cannot be rolled
+back, and killing then failing to commit is the already-tolerated case, since
+the next recovery finds a dead PID.
+
+Two surfaces guard the same invariant from the other side. Admission (§11)
+refuses a `queued` task that still has a `running` StepRun, leaving it queued
+and logging why once per daemon process; and `GET /v1/doctor`'s `problems[]`
+(§17) reports the impossible combination — a `running` StepRun under a task
+that is `queued`, `done`, `aborted` or `archived` — naming the task. The
+waiting states are excluded deliberately: a `running` row is *correct* under
+`awaiting_input`, where a live process waits for an answer (§7.4), and under
+`awaiting_gate`, whose manual row its actor writes open before exiting (§6).
+
 *Amended 2026-08-17 (task 014).* A `fan_out` join interrupted mid-merge is
 recovered the same way any step is — the attempt is `interrupted` and re-runs
 — with one extra move: if a merge is still in progress in the worktree, it is

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2433,6 +2433,17 @@ would invalidate every one of them.
   expired hold, since nothing commits a state change when one lapses. That is the
   tick's second reason to exist — otherwise it normally finds nothing to do.
 
+  *Amended 2026-08-25 (issue #142).* A fourth check now sits **between the pause
+  and the hold**: a `queued` task that still has a `running` StepRun is refused,
+  left queued, and logged once per daemon process. Its previous attempt was
+  never finalized, so admitting it would start a second attempt against a first
+  the database still calls live — the §12.4 contradiction that recovery now
+  fails startup rather than produce. This is the guard for a row that predates
+  that fix or arrives by a route nobody has thought of. Nothing in the scheduler
+  reconciles such a task, which is why the refusal is permanent for the life of
+  the process, why it is logged once rather than every tick, and why
+  `GET /v1/doctor` reports the same finding (§17).
+
 ## 12. The daemon
 
 ### 12.1 Binary and commands

--- a/internal/api/doctor.go
+++ b/internal/api/doctor.go
@@ -180,6 +180,21 @@ func (s *Server) fillTasks(ctx context.Context, rep *doctor.Report) {
 		byName[string(state)] = n
 	}
 	rep.SetTaskCounts(byName)
+	// The §12.4 contradiction (issue #142). It is asked for separately from
+	// the tally because it is not one: a count of `queued` tasks is
+	// information, and a `queued` task whose previous attempt is still open
+	// is a defect that stops that task running.
+	bad, err := s.deps.Store.UnreconciledTasks(ctx)
+	if err != nil {
+		rep.Tasks.Error = err.Error()
+		return
+	}
+	rep.Tasks.Unreconciled = make([]doctor.UnreconciledTask, 0, len(bad))
+	for _, u := range bad {
+		rep.Tasks.Unreconciled = append(rep.Tasks.Unreconciled, doctor.UnreconciledTask{
+			TaskID: u.TaskID, State: string(u.State), OpenStepRuns: u.OpenStepRuns,
+		})
+	}
 }
 
 // doctorFixRequest is the POST /v1/doctor/fix body. `?force` is accepted too,

--- a/internal/api/doctor_test.go
+++ b/internal/api/doctor_test.go
@@ -231,6 +231,54 @@ func TestDoctorTaskCountsMatchSeededRows(t *testing.T) {
 	}
 }
 
+// A queued task holding a step run the database still calls `running` is the
+// §12.4 contradiction: it cannot be admitted and it will never move on its
+// own, so doctor names it rather than letting it sit invisible on the board
+// (issue #142).
+func TestDoctorReportsUnreconciledTasks(t *testing.T) {
+	h := newDoctorHarness(t)
+	projectID, _ := h.seedProject(t)
+	stuck := h.seedTask(t, projectID, store.TaskQueued, "stuck")
+	h.seedTask(t, projectID, store.TaskRunning, "healthy")
+	run := &store.StepRun{
+		TaskID: stuck.ID, StepIndex: 0, StepID: "s", StepType: "agent",
+		Attempt: 1, State: store.StepRunning,
+	}
+	if err := h.store.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+
+	rep := h.report(t)
+	if len(rep.Tasks.Unreconciled) != 1 {
+		t.Fatalf("unreconciled = %+v, want the one queued task", rep.Tasks.Unreconciled)
+	}
+	got := rep.Tasks.Unreconciled[0]
+	if got.TaskID != stuck.ID || got.State != string(store.TaskQueued) || got.OpenStepRuns != 1 {
+		t.Errorf("unreconciled = %+v, want task %d queued with 1 open run", got, stuck.ID)
+	}
+	if rep.Healthy() {
+		t.Error("an unreconciled task did not set the exit code")
+	}
+	var found bool
+	for _, p := range rep.Problems {
+		if p.Group == doctor.GroupTasks {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no tasks-group problem: %+v", rep.Problems)
+	}
+
+	// A `running` task with an open run is normal operation, not a defect.
+	if _, err := h.store.TerminalizeOpenStepRuns(
+		t.Context(), stuck.ID, store.StepInterrupted, "interrupted"); err != nil {
+		t.Fatalf("TerminalizeOpenStepRuns: %v", err)
+	}
+	if rep := h.report(t); !rep.Healthy() {
+		t.Errorf("still unhealthy once reconciled: %v", rep.Problems)
+	}
+}
+
 func TestDoctorRequiresAuthAndTheRightMethod(t *testing.T) {
 	h := newDoctorHarness(t)
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -391,6 +391,13 @@ func doctorTaskRows(t apiclient.DoctorTasks) [][]string {
 		rows = append(rows, []string{string(s), strconv.Itoa(t.Counts[string(s)])})
 	}
 	rows = append(rows, []string{"total", strconv.Itoa(t.Total)})
+	for _, u := range t.Unreconciled {
+		rows = append(rows, []string{
+			"unreconciled",
+			fmt.Sprintf("task %d is %s with %d step run(s) still running",
+				u.TaskID, u.State, u.OpenStepRuns),
+		})
+	}
 	if t.Error != "" {
 		rows = append(rows, []string{"error", t.Error})
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -261,8 +261,15 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	// belongs to neither the scheduler nor the runner. Orphans are killed
 	// only when PID and start time both match the journal; the owning tasks
 	// re-queue through the FSM, consuming no retries.
+	//
+	// A failure here stops the daemon (issue #142). Recovery reconciles each
+	// task atomically or not at all, so what it leaves behind on failure is
+	// the recoverable state a later start can retry — and starting the
+	// scheduler over rows it could not reconcile is how a second attempt
+	// gets admitted against a first one the database still calls `running`.
 	if n, err := taskrun.Recover(ctx, st, logger); err != nil {
-		logger.Error("startup crash recovery failed", "error", err)
+		logger.Error("startup failed: crash recovery", "error", err)
+		return fmt.Errorf("crash recovery: %w", err)
 	} else if n > 0 {
 		logger.Warn("recovered tasks from a previous run", "tasks", n)
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -39,6 +39,7 @@ const (
 	GroupDaemon   = "daemon"
 	GroupDatabase = "database"
 	GroupStorage  = "storage"
+	GroupTasks    = "tasks"
 )
 
 // Report is one complete diagnostic. Every group is always present: a row
@@ -201,7 +202,20 @@ type Tasks struct {
 	// populated.
 	Counts map[string]int `json:"counts"`
 	Total  int            `json:"total"`
-	Error  string         `json:"error,omitempty"`
+	// Unreconciled is the §12.4 contradiction: a task holding a step run
+	// still marked `running` while sitting in a state that cannot be
+	// executing one. It is a defect, not a tally, which is why it appears in
+	// `problems[]` as well as here (issue #142).
+	Unreconciled []UnreconciledTask `json:"unreconciled"`
+	Error        string             `json:"error,omitempty"`
+}
+
+// UnreconciledTask is one such contradiction, named so an operator can go
+// straight to the task rather than hunting for it.
+type UnreconciledTask struct {
+	TaskID       int64  `json:"task_id"`
+	State        string `json:"state"`
+	OpenStepRuns int    `json:"open_step_runs"`
 }
 
 // Problem is one finding from the closed unhealthy set (decision 7). A
@@ -398,7 +412,7 @@ func zeroStateCounts() map[string]int {
 // half of the report; the map it is given may omit empty states, and the
 // §6 vocabulary is filled in around it.
 func (r *Report) SetTaskCounts(counts map[string]int) {
-	r.Tasks = Tasks{Known: true, Counts: zeroStateCounts()}
+	r.Tasks = Tasks{Known: true, Counts: zeroStateCounts(), Unreconciled: r.Tasks.Unreconciled}
 	for state, n := range counts {
 		r.Tasks.Counts[state] += n
 		r.Tasks.Total += n
@@ -445,6 +459,17 @@ func (r *Report) Evaluate() {
 					r.Database.SchemaVersion, r.Database.NewestMigration),
 			})
 		}
+	}
+	if len(r.Tasks.Unreconciled) > 0 {
+		u := r.Tasks.Unreconciled[0]
+		r.Problems = append(r.Problems, Problem{
+			Group: GroupTasks,
+			Message: fmt.Sprintf(
+				"%d task(s) contradict their own step runs — task %d is %s with %d step run(s) still "+
+					"marked running (§12.4). They will not be admitted; restart the daemon to retry "+
+					"crash recovery, and check the daemon log for why it could not reconcile them",
+				len(r.Tasks.Unreconciled), u.TaskID, u.State, u.OpenStepRuns),
+		})
 	}
 	if r.Storage.OrphansKnown && len(r.Storage.Orphans) > 0 {
 		r.Problems = append(r.Problems, Problem{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,11 +64,18 @@ type Scheduler struct {
 	// persist is detached from shutdown: returning a task that could not be
 	// admitted must still reach the database.
 	persist context.Context //nolint:containedctx // deliberately outlives the run
+
+	// reported remembers which unreconciled tasks have already been logged.
+	// The refusal below is permanent for the life of the process — nothing
+	// here reconciles a task — and the tick is 5 s, so without this the one
+	// line an operator needs would arrive 720 times an hour. Touched only
+	// from the admit walk, which is the single scheduler goroutine.
+	reported map[int64]struct{}
 }
 
 // New returns a stopped scheduler.
 func New(deps Deps) *Scheduler {
-	return &Scheduler{deps: deps, wake: make(chan struct{}, 1)}
+	return &Scheduler{deps: deps, wake: make(chan struct{}, 1), reported: map[int64]struct{}{}}
 }
 
 // Start begins admitting until ctx is canceled or Stop is called.
@@ -155,6 +162,18 @@ func (s *Scheduler) admit(ctx context.Context) {
 			s.park(&c.Task, log)
 			continue
 		}
+		// A queued task with a step run still marked `running` was never
+		// reconciled: §12.4 finalizes the previous attempt *before* the task
+		// returns to the queue, so admitting this one would start a second
+		// attempt against a first the database still calls live (issue #142).
+		// Recovery now fails startup rather than producing such a row; this
+		// is the guard for one that predates the fix or arrived by some route
+		// nobody has thought of. Refusing is safe — the task stays queued —
+		// and the reason has to reach a human, because nothing else will.
+		if c.OpenStepRuns > 0 {
+			s.refuseUnreconciled(&c.Task, c.OpenStepRuns, log)
+			continue
+		}
 		// An admission hold (§11, task 003): the task is queued and waiting on
 		// something other than a slot — an agent's usage window, today.
 		//
@@ -207,6 +226,19 @@ func (s *Scheduler) start(ctx context.Context, task *store.Task, log *slog.Logge
 		return false
 	}
 	return true
+}
+
+// refuseUnreconciled declines to admit a task whose previous attempt is still
+// open, and says so once per task per daemon process.
+func (s *Scheduler) refuseUnreconciled(task *store.Task, open int, log *slog.Logger) {
+	if _, seen := s.reported[task.ID]; seen {
+		return
+	}
+	s.reported[task.ID] = struct{}{}
+	log.Error("admission refused: task is queued but its previous attempt was never finalized; "+
+		"crash recovery (§12.4) could not reconcile it. It will not run until it is. "+
+		"Restart the daemon to retry recovery; `vincent doctor` reports the same finding",
+		"open_step_runs", open, "step", task.CurrentStep)
 }
 
 // park applies a pause that was requested while the task was running and

--- a/internal/scheduler/unreconciled_test.go
+++ b/internal/scheduler/unreconciled_test.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// openRun journals a `running` step run against a task, the way the engine
+// does before spawning a process — and the way a crashed daemon leaves one
+// behind.
+func openRun(t *testing.T, h *harness, taskID int64) *store.StepRun {
+	t.Helper()
+	run := &store.StepRun{
+		TaskID: taskID, StepIndex: 0, StepID: "s", StepType: "agent",
+		Attempt: 1, State: store.StepRunning,
+	}
+	if err := h.store.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return run
+}
+
+// A queued task whose previous attempt is still marked `running` was never
+// reconciled: §12.4 finalizes the old run *before* the task returns to the
+// queue. Admitting it would start a second attempt against a first one the
+// database still calls live, so the scheduler refuses it — and keeps walking,
+// because the rest of the queue is not at fault (issue #142).
+func TestAdmitRefusesUnreconciledTask(t *testing.T) {
+	h := newHarness(t, 4)
+	projectID := h.project(t, "p", nil)
+	// Higher priority, so the refusal is proven not to swallow the walk: this
+	// one is looked at first.
+	stuck := h.task(t, projectID, "stuck", store.TaskQueued, 10, time.Hour)
+	healthy := h.task(t, projectID, "healthy", store.TaskQueued, 0, 0)
+	openRun(t, h, stuck.ID)
+
+	h.sched.admit(t.Context())
+
+	got := h.admitter.ids()
+	if len(got) != 1 || got[0] != healthy.ID {
+		t.Fatalf("admitted = %v, want only the reconciled task %d", got, healthy.ID)
+	}
+	if s := h.state(t, stuck.ID); s != store.TaskQueued {
+		t.Errorf("unreconciled task = %s, want it left queued", s)
+	}
+
+	// The refusal is about the contradiction, not about the task: close the
+	// run and the next walk admits it like any other.
+	if _, err := h.store.TerminalizeOpenStepRuns(
+		t.Context(), stuck.ID, store.StepInterrupted, "interrupted"); err != nil {
+		t.Fatalf("TerminalizeOpenStepRuns: %v", err)
+	}
+	h.sched.admit(t.Context())
+	if got := h.admitter.ids(); len(got) != 2 || got[1] != stuck.ID {
+		t.Errorf("admitted = %v, want %d admitted once reconciled", got, stuck.ID)
+	}
+}

--- a/internal/store/interrupt_test.go
+++ b/internal/store/interrupt_test.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// interruptFixture is one task in `running` with one open step run — the rows
+// a crashed daemon leaves behind (§12.4).
+func interruptFixture(t *testing.T) (*Store, *Task, *StepRun) {
+	t.Helper()
+	s := openTest(t)
+	p := testProject(t, s, "p")
+	task := newTask(p.ID, "t", TaskRunning)
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	pid := 4242
+	run := &StepRun{
+		TaskID: task.ID, StepIndex: 0, StepID: "s", StepType: "agent",
+		Attempt: 1, State: StepRunning, PID: &pid,
+	}
+	if err := s.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return s, task, run
+}
+
+// blockStepRunFinalize aborts exactly the write that moves a step run out of
+// `running`, over a second connection so the store's own single writer is
+// untouched. It is the hermetic stand-in for a storage failure at that one
+// boundary — the case §12.4 never described (issue #142).
+func blockStepRunFinalize(t *testing.T, s *Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite", s.Path())
+	if err != nil {
+		t.Fatalf("open second connection: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TRIGGER store_test_block_interrupt
+		BEFORE UPDATE OF state ON step_runs
+		WHEN NEW.state = 'interrupted'
+		BEGIN SELECT RAISE(ABORT, 'injected storage failure'); END`); err != nil {
+		t.Fatalf("install failure trigger: %v", err)
+	}
+}
+
+// The whole reason InterruptTask exists: the finalize, the transition and the
+// event are one commit, so recovery cannot leave a `queued` task on top of a
+// step run the database still calls `running`.
+func TestInterruptTaskClosesRunsAndTransitionsTogether(t *testing.T) {
+	s, task, run := interruptFixture(t)
+
+	got, ev, err := s.InterruptTask(t.Context(), task.ID, TaskRunning, TaskQueued, "interrupted")
+	if err != nil {
+		t.Fatalf("InterruptTask: %v", err)
+	}
+	if got.State != TaskQueued {
+		t.Errorf("task = %s, want queued", got.State)
+	}
+	if ev == nil || ev.Type != EventTaskStateChanged {
+		t.Errorf("event = %+v, want a task.state_changed", ev)
+	}
+	after, err := s.GetStepRun(t.Context(), run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if after.State != StepInterrupted || after.FailureReason != "interrupted" ||
+		after.PID != nil || after.FinishedAt == nil {
+		t.Errorf("step run = %+v, want interrupted, pid cleared, finished", after)
+	}
+}
+
+// A failure at the step-run write rolls the task move and its event back with
+// it: the caller is handed rows it can retry, not a self-contradictory pair.
+func TestInterruptTaskRollsBackWholeOnFailure(t *testing.T) {
+	s, task, run := interruptFixture(t)
+	before, err := s.ListEvents(t.Context(), EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	blockStepRunFinalize(t, s)
+
+	if _, _, err := s.InterruptTask(
+		t.Context(), task.ID, TaskRunning, TaskQueued, "interrupted"); err == nil {
+		t.Fatal("InterruptTask returned nil error with the finalize write blocked")
+	}
+
+	got, err := s.GetTask(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.State != TaskRunning {
+		t.Errorf("task = %s, want it left running — the transaction did not hold", got.State)
+	}
+	after, err := s.GetStepRun(t.Context(), run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if after.State != StepRunning {
+		t.Errorf("step run = %s, want it left running", after.State)
+	}
+	events, err := s.ListEvents(t.Context(), EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != len(before) {
+		t.Errorf("events grew from %d to %d; a rolled-back transition wrote one anyway",
+			len(before), len(events))
+	}
+}
+
+// Recovery may run again after a crash inside recovery. The compare-and-swap
+// is what makes that converge rather than transition a second time.
+func TestInterruptTaskIsIdempotent(t *testing.T) {
+	s, task, run := interruptFixture(t)
+	if _, _, err := s.InterruptTask(
+		t.Context(), task.ID, TaskRunning, TaskQueued, "interrupted"); err != nil {
+		t.Fatalf("InterruptTask: %v", err)
+	}
+
+	_, _, err := s.InterruptTask(t.Context(), task.ID, TaskRunning, TaskQueued, "interrupted")
+	var conflict *StateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("second InterruptTask err = %v, want a *StateConflictError", err)
+	}
+	if conflict.Got != TaskQueued {
+		t.Errorf("conflict reports %s, want queued", conflict.Got)
+	}
+	runs, err := s.ListStepRuns(t.Context(), task.ID)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].ID != run.ID {
+		t.Errorf("step runs = %+v, want the one original row", runs)
+	}
+}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -333,6 +333,22 @@ type Candidate struct {
 	ProjectSlots int
 	// ProjectCap is the project's max_parallel_tasks; nil = unlimited.
 	ProjectCap *int
+	// OpenStepRuns is how many of the task's step runs are still marked
+	// `running`. A queued task must have none: §12.4 finalizes the previous
+	// attempt before the task returns to the queue. Any other number means
+	// the task was never reconciled, and admitting it would start a second
+	// attempt against a first one the database still calls live (issue #142).
+	OpenStepRuns int
+}
+
+// Unreconciled is one task whose state and its step runs contradict each
+// other — a step run still marked `running` under a task that cannot possibly
+// be executing (§12.4). See UnreconciledTasks for what "cannot possibly" means
+// here.
+type Unreconciled struct {
+	TaskID       int64
+	State        TaskState
+	OpenStepRuns int
 }
 
 // Event is a durable state event (spec §13.3). ID doubles as the SSE

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -24,7 +24,16 @@ const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, it
 func (s *Store) TerminalizeOpenStepRuns(
 	ctx context.Context, taskID int64, state StepRunState, reason string,
 ) (int64, error) {
-	res, err := s.db.ExecContext(ctx, `
+	return terminalizeOpenStepRuns(ctx, s.db, taskID, state, reason)
+}
+
+// terminalizeOpenStepRuns is the statement behind it, taking an execer so the
+// same write composes into a wider transaction: §12.4 recovery closes a task's
+// open runs and moves the task itself in one commit (see InterruptTask).
+func terminalizeOpenStepRuns(
+	ctx context.Context, db execer, taskID int64, state StepRunState, reason string,
+) (int64, error) {
+	res, err := db.ExecContext(ctx, `
 		UPDATE step_runs SET state = ?, failure_reason = ?, pid = NULL, finished_at = ?
 		WHERE task_id = ? AND state = ?`,
 		string(state), nullString(reason), formatTime(time.Now()), taskID, string(StepRunning))

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -415,7 +415,7 @@ func (s *Store) CountSlotHoldersByProject(ctx context.Context, projectID int64) 
 
 // ListAdmissible returns every queued task in admission order — priority
 // DESC, created_at ASC, id ASC (spec §11) — each carrying its project's
-// current slot count and cap.
+// current slot count and cap, plus how many step runs it still has open.
 //
 // Ordering and both caps come from SQL, but the walk itself is the caller's:
 // admitting a task changes the tallies, and a single statement cannot see
@@ -424,11 +424,12 @@ func (s *Store) ListAdmissible(ctx context.Context) ([]Candidate, error) {
 	q := `SELECT ` + prefixed("t", taskColumns) + `,
 			(SELECT COUNT(*) FROM tasks o
 			  WHERE o.project_id = t.project_id AND o.state IN ` + slotPlaceholders + `),
-			p.max_parallel_tasks
+			p.max_parallel_tasks,
+			(SELECT COUNT(*) FROM step_runs r WHERE r.task_id = t.id AND r.state = ?)
 		FROM tasks t JOIN projects p ON p.id = t.project_id
 		WHERE t.state = ?
 		ORDER BY t.priority DESC, t.created_at ASC, t.id ASC`
-	args := append(append([]any{}, slotStates...), string(TaskQueued))
+	args := append(append([]any{}, slotStates...), string(StepRunning), string(TaskQueued))
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list admissible: %w", err)
@@ -440,7 +441,7 @@ func (s *Store) ListAdmissible(ctx context.Context) ([]Candidate, error) {
 			c     Candidate
 			limit sql.NullInt64
 		)
-		t, err := scanTask(scannerWithTail(rows, &c.ProjectSlots, &limit))
+		t, err := scanTask(scannerWithTail(rows, &c.ProjectSlots, &limit, &c.OpenStepRuns))
 		if err != nil {
 			return nil, fmt.Errorf("scan admissible: %w", err)
 		}
@@ -453,6 +454,57 @@ func (s *Store) ListAdmissible(ctx context.Context) ([]Candidate, error) {
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("list admissible: %w", err)
+	}
+	return out, nil
+}
+
+// unreconcilableStates is the set of task states in which no step run can be
+// live, so a `running` one is a contradiction rather than a race (§12.4).
+//
+// It is deliberately narrow. `queued` is the shape issue #142 produced —
+// recovery re-queueing a task whose previous attempt it could not finalize —
+// and the three settled states are the same contradiction after the fact.
+// The waiting states are left out because a `running` row is *correct* in
+// them: `awaiting_input` has a live process waiting for an answer (§7.4), and
+// an `awaiting_gate` task's manual row is written open by an actor that then
+// exits (§6). Reporting those would be reporting normal operation.
+var unreconcilableStates, unreconcilablePlaceholders = func() ([]any, string) {
+	args := []any{
+		string(TaskQueued), string(TaskDone), string(TaskAborted), string(TaskArchived),
+	}
+	return args, "(?" + strings.Repeat(", ?", len(args)-1) + ")"
+}()
+
+// UnreconciledTasks returns every task whose state and step runs contradict
+// each other, ordered by id. It is `GET /v1/doctor`'s view of the §12.4
+// invariant (§17): the combination is impossible, so any row here means a
+// task was never reconciled and the scheduler is refusing to admit it.
+func (s *Store) UnreconciledTasks(ctx context.Context) ([]Unreconciled, error) {
+	args := append([]any{string(StepRunning)}, unreconcilableStates...)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT t.id, t.state, COUNT(r.id)
+		FROM tasks t JOIN step_runs r ON r.task_id = t.id AND r.state = ?
+		WHERE t.state IN `+unreconcilablePlaceholders+`
+		GROUP BY t.id, t.state
+		ORDER BY t.id ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list unreconciled tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Unreconciled
+	for rows.Next() {
+		var (
+			u     Unreconciled
+			state string
+		)
+		if err := rows.Scan(&u.TaskID, &state, &u.OpenStepRuns); err != nil {
+			return nil, fmt.Errorf("scan unreconciled task: %w", err)
+		}
+		u.State = TaskState(state)
+		out = append(out, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list unreconciled tasks: %w", err)
 	}
 	return out, nil
 }

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -135,134 +135,184 @@ func (s *Store) TransitionTask(
 		ev   *Event
 	)
 	err := s.withTx(ctx, func(tx *sql.Tx) error {
-		row := tx.QueryRowContext(ctx, `SELECT `+taskColumns+` FROM tasks WHERE id = ?`, id)
-		t, err := scanTask(row)
-		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("task %d: %w", id, ErrNotFound)
-		}
-		if err != nil {
-			return fmt.Errorf("get task %d: %w", id, err)
-		}
-		if t.State != from {
-			return &StateConflictError{TaskID: id, Want: from, Got: t.State}
-		}
-
-		now := time.Now()
-		t.State = to
-		t.UpdatedAt = now
-		applyChange(t, ch)
-		if from == TaskAwaitingInput {
-			// The §7.4 invariant, enforced in one place: leaving
-			// awaiting_input always discards the pending request.
-			t.PendingInputJSON = ""
-		}
-		if from == TaskBlocked && ch.PendingRepair == nil {
-			// A repair request describes *this* block, so any other way out
-			// of blocked drops it — retry means retry, and skip must not
-			// hand a repair aimed at one step to the step after it. The one
-			// transition that sets a request is the repair action itself,
-			// and it is carved out by having supplied one (task 025).
-			t.PendingRepair = nil
-		}
-		if taskstate.Settled(to) {
-			// A follow-up request describes a *run*, and reaching done,
-			// aborted or archived is that run ending however it ended (task
-			// 027 decision 6). One rule covers all three ways out: the
-			// Complete that returns a done-origin follow-up, the Restore that
-			// returns an aborted-origin one, and the cancel that abandons
-			// either. Nothing else can leave a request behind on a finished
-			// task for the next follow-up to inherit.
-			t.PendingFollowUp = nil
-		}
-		if from == TaskQueued {
-			// The §11 admission-hold invariant, same construction: a hold
-			// describes *this* queued period, so leaving queued always drops
-			// it. Admission, parking and cancel are all covered by the one
-			// rule, and a caller cannot forget it.
-			//
-			// One consequence, recorded rather than fixed (task 003): pausing
-			// a held task and resuming it re-admits at once and re-discovers
-			// the wall. That costs one process spawn, and buys the rule §6
-			// already applies to every other pending flag — a human action
-			// means go.
-			t.AdmitNotBefore, t.QueuedReason = nil, ""
-		}
-		switch to {
-		case TaskRunning:
-			if t.StartedAt == nil {
-				t.StartedAt = &now
-			}
-		case TaskDone, TaskAborted:
-			t.FinishedAt = &now
-		case TaskArchived:
-			t.ArchivedAt = &now
-		case TaskQueued, TaskAwaitingGate, TaskAwaitingInput, TaskAwaitingChildren, TaskBlocked, TaskPaused:
-			// No timestamp of their own; updated_at covers them.
-		}
-		if to != TaskBlocked {
-			t.BlockReason = ""
-		}
-
-		pendingOverride, err := marshalOverride(t.PendingOverride)
-		if err != nil {
-			return err
-		}
-		pendingRepair, err := marshalRepair(t.PendingRepair)
-		if err != nil {
-			return err
-		}
-		pendingFollowUp, err := marshalFollowUp(t.PendingFollowUp)
-		if err != nil {
-			return err
-		}
-		res, err := tx.ExecContext(ctx, `
-			UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
-				workflow_snapshot = ?, pause_requested = ?, retry_cursor_at = ?,
-				pending_override_json = ?, pending_repair_json = ?,
-				pending_follow_up_json = ?, pending_input_json = ?,
-				admit_not_before = ?, queued_reason = ?,
-				updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
-			WHERE id = ? AND state = ?`,
-			string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
-			t.WorkflowSnapshot, t.PauseRequested, formatTimePtr(t.RetryCursorAt), pendingOverride,
-			pendingRepair, pendingFollowUp,
-			nullString(t.PendingInputJSON),
-			formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
-			formatTime(t.UpdatedAt),
-			formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt),
-			id, string(from))
-		if err != nil {
-			return fmt.Errorf("transition task %d: %w", id, err)
-		}
-		if err := oneRowAffected(res, fmt.Sprintf("task %d", id)); err != nil {
-			return err
-		}
-
-		payload, err := statePayload(from, to, t, ch.EventPayload)
-		if err != nil {
-			return err
-		}
-		// Copied, not aliased: t is handed back to the caller as the updated
-		// task, and this event outlives that hand-off inside the broker.
-		taskID, projectID := t.ID, t.ProjectID
-		e := &Event{
-			TS:        now,
-			Type:      EventTaskStateChanged,
-			TaskID:    &taskID,
-			ProjectID: &projectID,
-			Payload:   payload,
-		}
-		if err := appendEventTx(ctx, tx, e); err != nil {
-			return err
-		}
-		task, ev = t, e
-		return nil
+		var err error
+		task, ev, err = transitionTaskTx(ctx, tx, id, from, to, ch)
+		return err
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 	s.notify(ev)
 	return task, ev, nil
+}
+
+// InterruptTask is §12.4 crash recovery for one task, and the reason it is a
+// store method at all: finalizing that task's step runs and re-queueing the
+// task have to be one commit. Every run the task left `running` is
+// terminalized with the given reason and its journaled PID cleared, the task
+// moves from -> to under the same compare-and-swap TransitionTask uses, and
+// the durable state event is appended — all inside one transaction.
+//
+// When any part of that fails the whole thing rolls back and the task is left
+// exactly as it was found: still recoverable, and never re-queued on top of a
+// step run the database still calls `running` (issue #142). Recovery fails
+// startup on that rather than letting the scheduler admit a second attempt
+// against a first one that is, durably, still open.
+//
+// Re-running it is safe: a second pass finds the same open runs and the same
+// `from` state, and a task already reconciled fails the compare-and-swap with
+// a *StateConflictError instead of transitioning — so no duplicate event,
+// step run or retry consumption is possible.
+func (s *Store) InterruptTask(
+	ctx context.Context, id int64, from, to TaskState, reason string,
+) (*Task, *Event, error) {
+	var (
+		task *Task
+		ev   *Event
+	)
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := terminalizeOpenStepRuns(ctx, tx, id, StepInterrupted, reason); err != nil {
+			return err
+		}
+		var err error
+		task, ev, err = transitionTaskTx(ctx, tx, id, from, to, TaskChange{})
+		return err
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	s.notify(ev)
+	return task, ev, nil
+}
+
+// transitionTaskTx is TransitionTask's body without the transaction or the
+// post-commit notify, so a caller that needs further writes in the same commit
+// can compose it. The caller owns the notify — an event is published only
+// after the commit that produced it (the §13.3 post-commit rule).
+func transitionTaskTx(
+	ctx context.Context, tx *sql.Tx, id int64, from, to TaskState, ch TaskChange,
+) (*Task, *Event, error) {
+	row := tx.QueryRowContext(ctx, `SELECT `+taskColumns+` FROM tasks WHERE id = ?`, id)
+	t, err := scanTask(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, fmt.Errorf("task %d: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("get task %d: %w", id, err)
+	}
+	if t.State != from {
+		return nil, nil, &StateConflictError{TaskID: id, Want: from, Got: t.State}
+	}
+
+	now := time.Now()
+	t.State = to
+	t.UpdatedAt = now
+	applyChange(t, ch)
+	if from == TaskAwaitingInput {
+		// The §7.4 invariant, enforced in one place: leaving
+		// awaiting_input always discards the pending request.
+		t.PendingInputJSON = ""
+	}
+	if from == TaskBlocked && ch.PendingRepair == nil {
+		// A repair request describes *this* block, so any other way out
+		// of blocked drops it — retry means retry, and skip must not
+		// hand a repair aimed at one step to the step after it. The one
+		// transition that sets a request is the repair action itself,
+		// and it is carved out by having supplied one (task 025).
+		t.PendingRepair = nil
+	}
+	if taskstate.Settled(to) {
+		// A follow-up request describes a *run*, and reaching done,
+		// aborted or archived is that run ending however it ended (task
+		// 027 decision 6). One rule covers all three ways out: the
+		// Complete that returns a done-origin follow-up, the Restore that
+		// returns an aborted-origin one, and the cancel that abandons
+		// either. Nothing else can leave a request behind on a finished
+		// task for the next follow-up to inherit.
+		t.PendingFollowUp = nil
+	}
+	if from == TaskQueued {
+		// The §11 admission-hold invariant, same construction: a hold
+		// describes *this* queued period, so leaving queued always drops
+		// it. Admission, parking and cancel are all covered by the one
+		// rule, and a caller cannot forget it.
+		//
+		// One consequence, recorded rather than fixed (task 003): pausing
+		// a held task and resuming it re-admits at once and re-discovers
+		// the wall. That costs one process spawn, and buys the rule §6
+		// already applies to every other pending flag — a human action
+		// means go.
+		t.AdmitNotBefore, t.QueuedReason = nil, ""
+	}
+	switch to {
+	case TaskRunning:
+		if t.StartedAt == nil {
+			t.StartedAt = &now
+		}
+	case TaskDone, TaskAborted:
+		t.FinishedAt = &now
+	case TaskArchived:
+		t.ArchivedAt = &now
+	case TaskQueued, TaskAwaitingGate, TaskAwaitingInput, TaskAwaitingChildren, TaskBlocked, TaskPaused:
+		// No timestamp of their own; updated_at covers them.
+	}
+	if to != TaskBlocked {
+		t.BlockReason = ""
+	}
+
+	pendingOverride, err := marshalOverride(t.PendingOverride)
+	if err != nil {
+		return nil, nil, err
+	}
+	pendingRepair, err := marshalRepair(t.PendingRepair)
+	if err != nil {
+		return nil, nil, err
+	}
+	pendingFollowUp, err := marshalFollowUp(t.PendingFollowUp)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := tx.ExecContext(ctx, `
+		UPDATE tasks SET state = ?, current_step = ?, block_reason = ?, worktree_path = ?,
+			workflow_snapshot = ?, pause_requested = ?, retry_cursor_at = ?,
+			pending_override_json = ?, pending_repair_json = ?,
+			pending_follow_up_json = ?, pending_input_json = ?,
+			admit_not_before = ?, queued_reason = ?,
+			updated_at = ?, started_at = ?, finished_at = ?, archived_at = ?
+		WHERE id = ? AND state = ?`,
+		string(t.State), t.CurrentStep, nullString(t.BlockReason), nullString(t.WorktreePath),
+		t.WorkflowSnapshot, t.PauseRequested, formatTimePtr(t.RetryCursorAt), pendingOverride,
+		pendingRepair, pendingFollowUp,
+		nullString(t.PendingInputJSON),
+		formatTimePtr(t.AdmitNotBefore), nullString(t.QueuedReason),
+		formatTime(t.UpdatedAt),
+		formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt),
+		id, string(from))
+	if err != nil {
+		return nil, nil, fmt.Errorf("transition task %d: %w", id, err)
+	}
+	if err := oneRowAffected(res, fmt.Sprintf("task %d", id)); err != nil {
+		return nil, nil, err
+	}
+
+	payload, err := statePayload(from, to, t, ch.EventPayload)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Copied, not aliased: t is handed back to the caller as the updated
+	// task, and this event outlives that hand-off inside the broker.
+	taskID, projectID := t.ID, t.ProjectID
+	e := &Event{
+		TS:        now,
+		Type:      EventTaskStateChanged,
+		TaskID:    &taskID,
+		ProjectID: &projectID,
+		Payload:   payload,
+	}
+	if err := appendEventTx(ctx, tx, e); err != nil {
+		return nil, nil, err
+	}
+	return t, e, nil
 }
 
 // SetTaskProgress writes the step cursor and worktree path without changing

--- a/internal/taskrun/recover.go
+++ b/internal/taskrun/recover.go
@@ -3,6 +3,7 @@ package taskrun
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -28,6 +29,16 @@ const startTimeTolerance = 5 * time.Second
 // the retry budget is untouched (§7.2), and tasks found in `awaiting_input`
 // are treated identically (§7.4). Returns how many tasks were re-queued.
 //
+// It works one task at a time, and that is the whole point (issue #142).
+// Finalizing a task's runs and re-queueing it is a single store transaction
+// (store.InterruptTask), so the two halves of §12.4's order can never come
+// apart: recovery cannot hand the scheduler a `queued` task whose previous
+// attempt is still, durably, `running`. A task whose transaction will not
+// commit is left exactly as found — recoverable, not re-queued, not counted —
+// and the failure is returned so the daemon fails startup on it. Continuing
+// past a storage failure is least defensible precisely when storage is
+// failing.
+//
 // This replaces T1.8's blocking sweep, whose bulk UPDATE also bypassed the
 // TransitionTask compare-and-swap — the invariant that no transition skips
 // the FSM holds here too.
@@ -36,17 +47,17 @@ func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error
 	if err != nil {
 		return 0, err
 	}
+	// The open runs, grouped by the task that owns them, so recovery is driven
+	// per task rather than as two independent sweeps whose outcomes nothing
+	// connects. owners preserves the id ASC order the query returned.
+	open := make(map[int64][]*store.StepRun, len(runs))
+	var owners []int64
 	for i := range runs {
 		run := &runs[i]
-		killOrphan(run, log.With("task", run.TaskID, "run", run.ID))
-		now := time.Now()
-		run.State = store.StepInterrupted
-		run.FailureReason = ReasonInterrupted
-		run.PID = nil
-		run.FinishedAt = &now
-		if err := st.UpdateStepRun(ctx, run); err != nil {
-			log.Error("recovery: finalize step run", "run", run.ID, "error", err)
+		if _, seen := open[run.TaskID]; !seen {
+			owners = append(owners, run.TaskID)
 		}
+		open[run.TaskID] = append(open[run.TaskID], run)
 	}
 
 	requeued := 0
@@ -64,16 +75,44 @@ func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error
 			return requeued, err
 		}
 		for i := range tasks {
-			if _, _, err := st.TransitionTask(ctx, tasks[i].ID, state, tr.To, store.TaskChange{}); err != nil {
-				log.Error("recovery: re-queue task", "task", tasks[i].ID, "error", err)
-				continue
+			id := tasks[i].ID
+			// Killing happens before the transaction and outside it: a kill
+			// cannot be rolled back, and killing then failing to commit is
+			// the already-tolerated case — the row stays `running` and the
+			// next recovery finds a dead PID.
+			killOwned(open[id], id, log)
+			delete(open, id)
+			if _, _, err := st.InterruptTask(ctx, id, state, tr.To, ReasonInterrupted); err != nil {
+				return requeued, fmt.Errorf("recover task %d from %s: %w", id, state, err)
 			}
 			log.Warn("recovered task from a previous run; re-queued",
-				"task", tasks[i].ID, "was", string(state), "step", tasks[i].CurrentStep)
+				"task", id, "was", string(state), "step", tasks[i].CurrentStep)
 			requeued++
 		}
 	}
+
+	// What is left owns a `running` step run while sitting in a state that
+	// re-queues through no Interrupt transition — an `awaiting_gate` task's
+	// manual row, whose actor wrote it before exiting (§6). There is no task
+	// move to pair the write with, so the rows are finalized on their own.
+	for _, id := range owners {
+		runs, ok := open[id]
+		if !ok {
+			continue // already reconciled, with its task, above
+		}
+		killOwned(runs, id, log)
+		if _, err := st.TerminalizeOpenStepRuns(ctx, id, store.StepInterrupted, ReasonInterrupted); err != nil {
+			return requeued, fmt.Errorf("recover task %d: finalize open step runs: %w", id, err)
+		}
+	}
 	return requeued, nil
+}
+
+// killOwned tree-kills the journaled process of each of one task's open runs.
+func killOwned(runs []*store.StepRun, taskID int64, log *slog.Logger) {
+	for _, run := range runs {
+		killOrphan(run, log.With("task", taskID, "run", run.ID))
+	}
 }
 
 // killOrphan tree-kills the process a running step run journaled, when it is

--- a/internal/taskrun/recover_test.go
+++ b/internal/taskrun/recover_test.go
@@ -268,3 +268,98 @@ func TestRecoverDoesNotRequeuePastAFinalizeFailure(t *testing.T) {
 			task.ID, run.ID)
 	}
 }
+
+// Not re-queueing is only half of fail-closed. The other half is that the
+// daemon hears about it: startup aborts on a recovery it could not complete,
+// rather than starting the scheduler over rows it knows are contradictory
+// (§12.4, issue #142).
+func TestRecoverReturnsTheFinalizeFailure(t *testing.T) {
+	st, projectID := recoverStore(t)
+	ctx := context.Background()
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	journalRun(t, st, task.ID, nil, nil)
+
+	failStepRunFinalize(t, st)
+
+	n, err := Recover(ctx, st, discardLog())
+	if err == nil {
+		t.Fatal("Recover returned nil; the daemon would start over unreconciled rows")
+	}
+	if n != 0 {
+		t.Errorf("requeued = %d, want 0 — nothing was reconciled", n)
+	}
+}
+
+// An `awaiting_input` task's process is alive with its step run open (§7.4).
+// Recovery closes the run and re-queues the task in the same commit, exactly
+// as it does for `running` — the two travel the same path.
+func TestRecoverInterruptsAwaitingInputTogetherWithItsRun(t *testing.T) {
+	st, projectID := recoverStore(t)
+	ctx := context.Background()
+	task := recoverTask(t, st, projectID, store.TaskAwaitingInput)
+	run := journalRun(t, st, task.ID, nil, nil)
+
+	if _, err := Recover(ctx, st, discardLog()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	got, err := st.GetStepRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepInterrupted {
+		t.Errorf("step run = %s, want interrupted", got.State)
+	}
+	tk, err := st.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if tk.State != store.TaskQueued {
+		t.Errorf("task = %s, want queued", tk.State)
+	}
+	// Leaving awaiting_input discards the pending request with the process
+	// that would have answered it (§7.4).
+	if tk.PendingInputJSON != "" {
+		t.Errorf("pending input survived recovery: %q", tk.PendingInputJSON)
+	}
+}
+
+// A fan-out lane is a task like any other and is recovered like one — the
+// filter default that hides lanes from the board must not hide them here
+// (task 014, §7.6). The parent is left alone: `awaiting_children` re-queues
+// through ChildrenSettled, not through Interrupt.
+func TestRecoverReconcilesFanOutLanes(t *testing.T) {
+	st, projectID := recoverStore(t)
+	ctx := context.Background()
+	parent := recoverTask(t, st, projectID, store.TaskAwaitingChildren)
+	lane := recoverTask(t, st, projectID, store.TaskRunning)
+	stepIndex := 0
+	lane.ParentTaskID, lane.ParentStepIndex = &parent.ID, &stepIndex
+	lane.LaneID, lane.LaneOrder = "lane-a", 0
+	if err := st.UpdateTask(ctx, lane); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	run := journalRun(t, st, lane.ID, nil, nil)
+
+	if _, err := Recover(ctx, st, discardLog()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	got, err := st.GetStepRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepInterrupted {
+		t.Errorf("lane step run = %s, want interrupted", got.State)
+	}
+	tk, err := st.GetTask(ctx, lane.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if tk.State != store.TaskQueued {
+		t.Errorf("lane = %s, want queued", tk.State)
+	}
+	if pt, _ := st.GetTask(ctx, parent.ID); pt.State != store.TaskAwaitingChildren {
+		t.Errorf("parent = %s, want it left awaiting_children", pt.State)
+	}
+}

--- a/internal/taskrun/recover_test.go
+++ b/internal/taskrun/recover_test.go
@@ -2,6 +2,7 @@ package taskrun
 
 import (
 	"context"
+	"database/sql"
 	"io"
 	"log/slog"
 	"os/exec"
@@ -13,6 +14,8 @@ import (
 	"github.com/lezli01/vincent/internal/procx"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/worktree"
+
+	_ "modernc.org/sqlite" // registers the "sqlite" driver for the injection connection
 )
 
 func recoverStore(t *testing.T) (*store.Store, int64) {
@@ -208,5 +211,60 @@ func TestRecoverToleratesDeadPID(t *testing.T) {
 	}
 	if tk, _ := st.GetTask(context.Background(), task.ID); tk.State != store.TaskQueued {
 		t.Errorf("task = %s, want queued", tk.State)
+	}
+}
+
+// failStepRunFinalize installs a trigger that aborts exactly the write
+// recovery uses to terminalize a `running` step run. It goes in over a second
+// connection so the store's own single connection (phase 1 decision) is
+// untouched, and it is the hermetic stand-in for the storage failure §12.4
+// does not discuss: the row cannot be moved out of `running`.
+func failStepRunFinalize(t *testing.T, st *store.Store) {
+	t.Helper()
+	db, err := sql.Open("sqlite", st.Path())
+	if err != nil {
+		t.Fatalf("open second connection: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TRIGGER vincent_test_block_interrupt
+		BEFORE UPDATE OF state ON step_runs
+		WHEN NEW.state = 'interrupted'
+		BEGIN SELECT RAISE(ABORT, 'injected storage failure'); END`); err != nil {
+		t.Fatalf("install failure trigger: %v", err)
+	}
+}
+
+// A step run that could not be finalized leaves its task recoverable — it
+// must not be re-queued on top of a row that is still durably `running`.
+// §12.4 orders the two: the run is finalized as `interrupted`, *then* the
+// owning task returns to `queued`. Re-queueing anyway lets the scheduler
+// admit a second attempt while the first is still open in the database,
+// which breaks the one-active-attempt invariant precisely during a storage
+// failure.
+func TestRecoverDoesNotRequeuePastAFinalizeFailure(t *testing.T) {
+	st, projectID := recoverStore(t)
+	ctx := context.Background()
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	run := journalRun(t, st, task.ID, nil, nil) // crashed before the PID write
+
+	failStepRunFinalize(t, st)
+
+	_, _ = Recover(ctx, st, discardLog())
+
+	got, err := st.GetStepRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepRunning {
+		t.Fatalf("injection did not hold: step run = %s, want it stuck at running", got.State)
+	}
+	tk, err := st.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if tk.State == store.TaskQueued {
+		t.Errorf("task %d re-queued while step run %d is still durably running: "+
+			"recovery must not requeue a task whose running step run could not be terminalized (§12.4)",
+			task.ID, run.ID)
 	}
 }


### PR DESCRIPTION
## Summary

Startup crash recovery (§12.4) could hand the scheduler a task whose previous
attempt was still, durably, `running`.

**Root cause.** `taskrun.Recover` was two independent bulk sweeps: finalize
every `running` step run, then re-queue every `running`/`awaiting_input` task.
The second sweep's input was the task table (`store.ListTasks`), not the
outcome of the first, so nothing connected them. When the `UPDATE step_runs`
that terminalizes a run failed, the error was logged (`recover.go:47-49`) and
the loop continued — and the owning task was transitioned `running → queued` a
few lines later regardless. That leaves a self-contradictory pair of rows: a
`queued` task with an open `running` step run. `store.ListAdmissible` sees an
ordinary queued task, the scheduler admits it, and a second attempt runs
against a row that says the first one is still live. The one-active-attempt
invariant breaks at exactly the moment — a storage failure — when optimistic
continuation is least defensible. Neither write could be grouped with the other
even in principle: `UpdateStepRun` and `TransitionTask` are separate statements
against separate tables with no enclosing transaction, so error propagation
alone would not have been enough. A failure of `Recover` as a whole was no
better contained — `daemon.go` logged it and started the scheduler and runner
anyway.

**The fix.** Recovery is now driven per task rather than as two global sweeps.

- New `store.InterruptTask` terminalizes that task's open step runs, applies the
  FSM `Interrupt` transition and appends the durable event **in one
  transaction**. To make the two composable, `TransitionTask`'s body is
  extracted verbatim into `transitionTaskTx` (transaction and post-commit
  notify hoisted to the callers); `TerminalizeOpenStepRuns`' statement is
  extracted to take an `execer`. No behaviour of either changes.
- A task whose transaction will not commit is left exactly as found —
  recoverable, not re-queued, not counted in `requeued` — and the failure is
  returned. `internal/daemon` now **fails startup** on it instead of starting
  the scheduler over rows it knows are contradictory.
- `killOrphan` is unchanged and stays outside the transaction, before it: a
  kill cannot be rolled back, and killing then failing to commit is the case
  already tolerated — the row stays `running` and the next recovery finds a
  dead PID.
- Idempotence falls out of the above: a second pass reads the same open rows
  and the same `from` state, and the compare-and-swap refuses a task already
  reconciled, so no duplicate step run, event or retry consumption is possible.

The issue's remaining acceptance criteria are the same invariant seen from the
other side, and are covered here:

- **Admission refuses unreconciled tasks.** `ListAdmissible` now carries each
  candidate's open step-run count, and the scheduler skips a `queued` task that
  has one, leaving it queued and logging why — once per task per daemon
  process, because the tick is 5 s and the condition does not clear on its own.
- **Doctor reports the impossible combination.** `GET /v1/doctor` gains
  `tasks.unreconciled[]` (`task_id`, `state`, `open_step_runs`) and a `tasks`
  problem that sets `vincent doctor`'s exit 1. The set is narrow on purpose:
  `queued`, `done`, `aborted`, `archived`. The waiting states are excluded
  because an open `running` row is *correct* under `awaiting_input` (a live
  process waiting for an answer, §7.4) and under `awaiting_gate` (a manual row
  its actor writes open before exiting, §6) — reporting those would be
  reporting normal operation.

**How the regression test catches this coming back.**
`TestRecoverDoesNotRequeuePastAFinalizeFailure` seeds a `running` task with one
journaled `running` step run, then installs a SQLite trigger over a second
connection that aborts any update setting `step_runs.state = 'interrupted'` — a
hermetic stand-in for a storage failure at that one write boundary, leaving the
task-table write healthy. It asserts the injection held (the run is still
`running`) and then that the task was **not** re-queued. It was run against the
unfixed code and observed to fail on exactly that condition. Any future change
that lets the re-queue decision run independently of the finalize outcome —
reverting to two sweeps, or catching the error at the call site while leaving
the write ungrouped — turns the task `queued` again and fails it.

**Not fixed here.** Recovery marks an `awaiting_gate` task's open manual step
run `interrupted` on every daemon restart, while leaving the task in
`awaiting_gate`. That is pre-existing behaviour (the old code finalized *every*
`running` step run regardless of its task's state) and this change preserves it
exactly rather than widening scope. It looks wrong — the row is not an
interrupted attempt, it is a gate nobody has answered yet — but it is a
separate defect with its own blast radius, and worth its own issue.

Also noted during the documentation pass, and deliberately left alone: an
admission refusal sets no `queued_reason`. The task sits at `queued` looking
exactly like one waiting for a slot, and the reason reaches a human only through
the daemon log and `vincent doctor` — the board and the detail header say
nothing. Giving it a `queued_reason` would be the obvious surface (§11's pair of
columns is generic, and `usage_limit`/`retry_backoff` already use it), but that
is a write from the admission walk into a task the walk is refusing to touch,
which is a design call rather than a docs fix. `docs/guides/troubleshooting.md`
tells the operator where to look instead.

## Related

Closes #142

Parent review: #135. Amends `docs/spec.md` §12.4 in place with a dated note
(2026-08-25) recording the fail-closed rule, the per-task atomicity and both
guards — §12.4 described the *order* of the two writes but never what happens
when the first one fails, so the spec was silent rather than wrong. This
revisits no recorded decision: nothing in `docs/history/v0-tasks.md` (T2.8, PR
D) or any task document settled on continuing past a failed finalize. The one
decision it does touch, PR D's PID-plus-start-time kill guard, is preserved
unchanged.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Tests: the supplied regression test, plus `TestRecoverReturnsTheFinalizeFailure`
(the other half of fail-closed — startup aborts),
`TestRecoverInterruptsAwaitingInputTogetherWithItsRun`,
`TestRecoverReconcilesFanOutLanes`, three `store.InterruptTask` tests
(atomic commit, whole-transaction rollback under the injected failure,
idempotence via the compare-and-swap),
`TestAdmitRefusesUnreconciledTask` and `TestDoctorReportsUnreconciledTasks`.
The supplied regression test was not modified or weakened.

Docs: `docs/reference/api.md` (the `GET /v1/doctor` body and its `problems[]`
description track `internal/api/server.go`'s route table and the report shape),
`docs/guides/troubleshooting.md` (the `PROBLEMS` set, and the second fatal
startup condition under "the daemon starts and immediately exits"),
`docs/reference/cli.md` and `docs/guides/scripting.md` (both enumerate what sets
`vincent doctor`'s exit `1`, and both stopped at orphaned worktrees; their
"neither do task counts" contrast is narrowed to *counts*, since a Tasks-group
finding can now set the exit code), `docs/spec.md` §12.4 and §11 — §11 said the
admission walk "applies the three checks **in this order**", which the
unreconciled refusal, inserted between the pause and the hold, makes false. It
is amended in place with a dated note rather than renumbered. No `Reason*`
constant, config key, cobra command, TUI binding or workflow-schema surface
changed, so `docs/reference/workflow-schema.md`, `docs/reference/configuration.md`,
`docs/guides/tui.md`, `skills/vincent-workflows/SKILL.md` and this repository's
own `.vincent/workflows/*.yaml` are untouched and still true. No task under
`docs/tasks/` covers this work (it is a review issue, like #139), and no
`docs/assets/tui-*.png` is affected — the TUI is not in the diff.

Verified: `go run mage.go test`, `testrace` and `lint` all green, `lint`
additionally cross-run for `GOOS=windows/darwin/linux`, and `./scripts/m1-gate.sh`
passes (it exercises real daemon startup, which this change can now abort).
