### PR TITLE
Add daemon backup and restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,28 @@ list with the user-facing context a commit subject cannot carry.
   agent re-probe; the default is unchanged and `vincent doctor` still forces it.
   ([#98](https://github.com/lezli01/vincent/issues/98))
 
+- **`vincent daemon backup` and `vincent daemon restore` — a supported way to
+  copy daemon state.** `vincent.db` holds every project, task, step run, cost
+  record and transcript pointer, and until now nothing documented how to copy
+  it and no command did. The obvious workaround was actively unsafe: under WAL
+  a committed row lives in `vincent.db-wal` until a checkpoint, so `cp
+  vincent.db` while the daemon runs produces a file missing recent work, and
+  copying the three files separately produces a set that can restore into a
+  torn database — a backup that looks fine until the day you need it.
+  `vincent daemon backup <path.tar.gz>` writes one archive holding a
+  `VACUUM INTO` copy of the database, every transcript, `config.yaml`, your
+  global workflows and a manifest. The daemon takes it, so it is consistent
+  **while tasks are running**, and it prints the bytes it wrote broken down by
+  database and transcripts rather than pretending the artifact is small.
+  `vincent daemon restore <path.tar.gz>` is the reverse and runs against a
+  **stopped** daemon; it refuses a running one, an archive whose schema is
+  newer than your binary, and a destination that already holds state unless
+  `--force` — which moves the old state aside as `<name>.bak-<timestamp>` and
+  deletes nothing. Worktrees are not in the archive (the branches they held are
+  in your repositories) and neither is the API token, so a restored
+  installation mints a fresh one at next start.
+  ([#99](https://github.com/lezli01/vincent/issues/99))
+
 - **Follow-up runs on a finished task, before it is archived.** A `done` or
   `aborted` task still owns its worktree, its branch and its commits until
   `archive` tears them down, and until now vincent could do nothing in that

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,7 +16,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents, follow-up runs on finished tasks |
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
-| Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks |
+| Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks, backup and restore |
 | Platforms | Windows, macOS, and Linux; Homebrew, WinGet, Scoop, mise, deb/rpm, and archives |
 
 ## Orchestrate work instead of terminals
@@ -195,8 +195,19 @@ run, refuses to remove dirty or unknown work without an explicit force, and
 never deletes a branch or anything outside vincent's data roots. The daemon
 also reports orphaned paths at startup.
 
-See [Troubleshooting](guides/troubleshooting.md) for the diagnostic workflow and
-the [CLI reference](reference/cli.md) for exact flags and exit codes.
+`vincent daemon backup` writes one `.tar.gz` holding a consistent copy of the
+database, every transcript, your `config.yaml` and your global workflows. The
+daemon takes the copy with SQLite's own `VACUUM INTO`, so it can be taken
+**while tasks are running** — unlike copying `vincent.db` by hand, which under
+WAL is missing whatever has not been checkpointed. `vincent daemon restore` is
+the reverse, runs against a stopped daemon, and deletes nothing: a destination
+that already holds state needs `--force`, which moves the old state aside as
+`<name>.bak-<timestamp>`.
+
+See [Troubleshooting](guides/troubleshooting.md) for the diagnostic workflow,
+[Files](reference/files.md#backup-and-restore) for what an archive holds and
+what it leaves out, and the [CLI reference](reference/cli.md) for exact flags
+and exit codes.
 
 ## Run it on your platform
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -236,8 +236,10 @@ the states are the same, the latency is not.
 - **Nothing pushes unless a step pushes.** A script that creates tasks is not a
   script that publishes anything; that is still whatever your workflow's
   `command` steps do, after whatever gates you put in front of them.
-- **`vincent workflow validate` is the only command that works with no daemon.**
-  Everything else exits 2.
+- **Two commands work with no daemon: `vincent workflow validate` and
+  `vincent daemon restore`.** Everything else exits 2. Validate never wants one;
+  restore *requires* the daemon to be stopped, since it replaces the files a
+  running daemon has open.
 - **The API is versioned by path** (`/v1`) and changes additively within a
   version, so a client written against it keeps working.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -106,6 +106,7 @@ are long-lived by contract and no write deadline is set.
 | `GET` | `/v1/doctor` | The whole diagnostic report. Read-only. `?probe=false` skips the forced adapter re-probe — see [Doctor](#doctor) |
 | `POST` | `/v1/doctor/fix` | Removes orphaned worktrees and compacts the database |
 | `POST` | `/v1/daemon/stop` | Graceful shutdown → `202`, then the daemon exits |
+| `POST` | `/v1/daemon/backup` | `{ path }` — writes a `.tar.gz` of daemon state to `path`. See [Backup](#backup) |
 | `GET` | `/v1/maintenance/orphans` | Directories under the data dir no task claims, with sizes. Removes nothing |
 | `POST` | `/v1/maintenance/gc` | `{ force?, dry_run? }` — reclaims them. Same body shape as the list |
 
@@ -131,6 +132,37 @@ surface) and a definite boolean where it does (**codex** via `login status`,
 **cursor** via `status`) — because an installed-but-unauthenticated CLI probes
 as healthy and then fails every run. It is never guessed: a probe that times out
 or cannot be spawned reports `null`, not `false`.
+
+### Backup
+
+`POST /v1/daemon/backup` writes one archive of everything the daemon owns and
+answers with what it wrote:
+
+```json
+{ "path": "/home/you/vincent-2026-08-25.tar.gz",
+  "bytes": 1503238553,
+  "database_bytes": 8601600,
+  "transcript_bytes": 1494360064,
+  "schema_version": 12,
+  "created_at": "2026-08-25T14:05:00.000000000Z" }
+```
+
+- `path` must be **absolute** and must not exist. The daemon resolves it
+  against its own working directory, not the caller's, and it never overwrites
+  a file that is by construction somebody's backup. A path inside
+  `{data_dir}/transcripts` is refused too — the archive would read itself.
+  Every one of these is a `400 validation_failed`.
+- The **daemon** assembles the whole archive: the database copy *and* the two
+  directory trees. That keeps exactly one process walking daemon-owned state,
+  and it is why there is no cold-copy mode — only the daemon opens SQLite.
+- The database copy is `VACUUM INTO`, which runs in a read transaction, so a
+  backup may be taken **while tasks are running**. It costs the store's single
+  connection for the duration of the copy: other queries queue behind it,
+  bounded by the size of the database.
+- The archive layout, what it excludes, and the restore rules are in
+  [Files](files.md#backup-and-restore). There is no restore endpoint —
+  `vincent daemon restore` runs client-side, because the daemon it would
+  overwrite has to be down.
 
 ### Usage quota
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -448,7 +448,9 @@ vincent workflow validate <file> [--json]
 
 Validates a workflow file. **This is the one command that needs no daemon** — no
 network, no agent CLI installed — which makes it usable from a pre-commit hook or
-a CI job.
+a CI job. ([`vincent daemon restore`](#vincent-daemon-restore) also runs without
+one, but it *refuses* to run while a daemon is up rather than merely tolerating
+its absence.)
 
 Exit `0` valid, `1` invalid. Warnings (a model in no catalog) print but do not
 fail the command.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -195,6 +195,59 @@ vincent daemon status [--json]
 Reports whether the daemon is running, its identity, and which agent CLIs it
 resolved. Exit `0` healthy, `1` not running, `2` unresponsive.
 
+### `vincent daemon backup`
+
+```sh
+vincent daemon backup <path.tar.gz> [--json]
+```
+
+Writes one `.tar.gz` holding the database, every transcript, `config.yaml` and
+the global workflows. The database copy is taken with SQLite's own
+`VACUUM INTO`, so it is consistent even while tasks are running — unlike
+copying `vincent.db`, which under WAL is missing whatever has not been
+checkpointed.
+
+**Needs a running daemon**, and exits `2` without one: only the daemon opens
+the database, the same rule [`doctor --fix`](#vincent-doctor---fix) follows.
+The destination must be a path that does not exist yet; vincent never
+overwrites a backup.
+
+Transcripts are included in full, so the archive is as large as your history
+is. The command prints the bytes it wrote:
+
+```
+wrote /home/you/vincent-2026-08-25.tar.gz (1.4GB: database 8.2MB, transcripts 1.4GB)
+```
+
+What the archive does **not** carry, and why, is in
+[Files](files.md#backup-and-restore).
+
+### `vincent daemon restore`
+
+```sh
+vincent daemon restore <path.tar.gz> [--force] [--json]
+```
+
+Unpacks an archive into the config and data directories in effect. This is the
+one command that touches the data directory directly rather than through the
+API — the daemon it would overwrite has to be down for the restore to be safe.
+
+Refused, exit `1`, when:
+
+| Situation | Why |
+|---|---|
+| The daemon is running | Restore replaces the files it has open. Stop it first |
+| The manifest's schema version is newer than this binary's | Migrations are up-only; a newer database cannot be stepped back |
+| The destination already holds `vincent.db` (or a stray `-wal`/`-shm`), `transcripts/`, `config.yaml` or `workflows/` | Use `--force` |
+
+`--force` **moves** each of those aside as `<name>.bak-<timestamp>` and
+restores over the gap. Nothing is deleted on any path, and the command prints
+where everything went.
+
+Worktrees are not in a backup and are not restored; the branches they held are
+in your repositories. A fresh API token is minted at next start, so every
+client re-reads it.
+
 ## `vincent service`
 
 Registers the daemon with the OS so it starts at login. Always as the invoking

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -10,6 +10,7 @@ it owns). Both are platform-native, and both can be overridden.
 - [Transcripts](#transcripts)
 - [Overriding the locations](#overriding-the-locations)
 - [What is safe to delete](#what-is-safe-to-delete)
+- [Backup and restore](#backup-and-restore)
 
 ---
 
@@ -180,8 +181,66 @@ vincent daemon --config-dir /srv/v-cfg --data-dir /srv/v-data
 | `worktrees/{task_id}/` | Effectively an unregistered archive — prefer archiving the task, which does it properly. For a directory whose task no longer exists, prefer `vincent gc`, which checks it is not somebody's live worktree first |
 | `daemon.json`, `daemon.lock` | Only safe while the daemon is stopped; both are recreated |
 | `token` | Recreated at next start, and every existing client must re-read it |
-| `vincent.db` | **Everything is gone** — projects, tasks, history. Branches in your repositories survive |
+| `vincent.db` | **Everything is gone** — projects, tasks, history. Branches in your repositories survive. This is the row [Backup and restore](#backup-and-restore) exists for |
 | `{config_dir}/` | Your config and global workflows; defaults are rewritten at next start |
+
+## Backup and restore
+
+```sh
+vincent daemon backup ~/vincent-2026-08-25.tar.gz     # needs a running daemon
+vincent daemon restore ~/vincent-2026-08-25.tar.gz    # needs a stopped one
+```
+
+One `.tar.gz`, four things in it:
+
+| Entry | What it is |
+|---|---|
+| `vincent.db` | A consistent copy of the database, taken with SQLite's own `VACUUM INTO` |
+| `transcripts/` | `{data_dir}/transcripts/`, in full |
+| `config/config.yaml`, `config/workflows/` | Your config and global workflows |
+| `manifest.json` | The vincent version, the schema version, and when it was taken |
+
+**Do not copy `vincent.db` by hand while the daemon runs.** Under WAL a
+committed row lives in `vincent.db-wal` until a checkpoint, so a copy of
+`vincent.db` alone is missing recent work, and copying the three files
+separately gives a set that can restore into a torn database. The backup
+command exists because the obvious thing is the wrong thing. If you have no
+vincent binary to hand, the honest fallback is to **stop the daemon first**,
+then copy `vincent.db`, `vincent.db-wal` and `vincent.db-shm` together.
+
+**Backup needs a running daemon and refuses without one.** Only the daemon
+opens the database, so only the daemon can copy it — the same rule
+[`vincent doctor --fix`](cli.md#vincent-doctor---fix) follows. It does not
+need a *quiet* daemon: `VACUUM INTO` writes elsewhere under a read
+transaction, so a backup may be taken while tasks are running.
+
+**The archive is as large as your history is.** Transcripts are included in
+full and are not opt-out; the per-attempt cap alone is 512 MB
+([`transcript_max_bytes`](configuration.md)). The command prints the bytes it
+wrote, broken down by database and transcripts, rather than pretending the
+artifact is small.
+
+**Not in the archive, and recoverable without it:** `worktrees/` (disposable —
+the branches they held are in your repositories), `token`, `daemon.json`,
+`daemon.lock`, `logs/` and `tui.json`. A restored installation mints a **fresh
+API token** at next start, so every client re-reads it.
+
+**Restore is the only vincent command that touches the data directory
+directly**, because the daemon it would overwrite has to be down for it to be
+safe. It refuses:
+
+- while a daemon is running — stop it first;
+- when the manifest's schema version is newer than the binary you are running,
+  since migrations are up-only and cannot be stepped back;
+- when the destination already holds `vincent.db` (or a leftover `-wal`/`-shm`),
+  `transcripts/`, `config.yaml` or `workflows/` — unless `--force`.
+
+With `--force` each of those is **moved aside** as `<name>.bak-<timestamp>`.
+Nothing is deleted on any path, and the command prints where everything went.
+
+To move an installation to another machine, restore into an empty pair of
+directories and start the daemon; your repositories and their branches are the
+other half, and vincent recreates worktrees as tasks need them.
 
 To remove vincent entirely: `vincent service uninstall`, `vincent daemon stop`,
 delete the binary, delete both directories, then clean up any branches left in

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -144,6 +144,13 @@ review, a summarization step. See
   authenticator. There is nothing on the wire that does not already require local
   account access to reach.
 - `GET /v1/health` is the single unauthenticated endpoint.
+- **`POST /v1/daemon/backup` writes a file at a path the caller names**, as the
+  daemon's user, anywhere that user can write. That is stated here rather than
+  left to be discovered — but it is not an *additional* grant: the same token
+  already starts agents that run full-auto as that user (above), which is a
+  strictly larger capability. The endpoint refuses a relative path, refuses to
+  overwrite an existing file, and refuses a destination inside
+  `{data_dir}/transcripts`.
 
 Anyone who can read your token file can drive your daemon — which, on a machine
 where they are already you, is not an additional grant. On a shared machine, it
@@ -195,7 +202,13 @@ overwrites the model you last picked in an interactive `cursor-agent` session.
 
 Everything else vincent writes lives in its
 [config and data directories](reference/files.md), plus the git branches and
-worktrees it creates in your repositories.
+worktrees it creates in your repositories — and the one file you name yourself
+when you run [`vincent daemon backup`](reference/files.md#backup-and-restore).
+
+**A backup archive is sensitive.** It carries every transcript, which means
+every rendered prompt and everything the agents did, plus your `config.yaml`.
+It does *not* carry the API token. Treat the file the way you would treat the
+data directory it came from.
 
 ## Tightening it
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2466,6 +2466,7 @@ One Go binary, `vincent`:
 | `vincent` | Launches the TUI; auto-starts the daemon in the background if unreachable |
 | `vincent daemon` | Runs the daemon in the foreground (logs to stderr; for debugging/service managers). `--config-dir`/`--data-dir` pin the §12.2 directories for a manager with no per-process environment |
 | `vincent daemon start / stop / status` | Background daemon management (start detaches; stop = graceful shutdown) |
+| `vincent daemon backup <path.tar.gz> / restore <path.tar.gz>` | *Added 2026-08-25 (task 030).* One `.tar.gz` of the database (`VACUUM INTO`, §14), `transcripts/`, `config.yaml` and `workflows/`, plus a manifest. `backup` is a thin API client and needs a **running** daemon; `restore` runs client-side and needs a **stopped** one, and refuses a newer schema or an occupied destination without `--force` |
 | `vincent service install / uninstall / status` | Registers OS-native autostart, always as the invoking user: launchd agent, systemd user unit, Windows Scheduled Task |
 | `vincent workflow ls / validate [file]` | Registry listing / YAML validation |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
@@ -2486,6 +2487,23 @@ TUI-and-API only, and stay that way; the reason to break with them here is that
 wants a shell loop rather than six visits to a form. The unevenness that leaves
 is accepted rather than papered over — giving every human action a command line
 is separate work.
+
+*Added 2026-08-25 (task 030).* `daemon restore` is a **stated exception** to
+"clients never touch the DB" (§4), and is written down here rather than left to
+be noticed. The invariant is that only the daemon *opens* SQLite; restore opens
+nothing. It probes the single-instance lock, refuses unless the daemon is down,
+reads the archive's `manifest.json` for the schema version — never the database
+— and then moves files. It cannot be an endpoint for the same reason: the
+daemon whose files it replaces has to be gone before it is safe to run.
+
+`daemon backup` takes the opposite side of the same rule and refuses without a
+daemon, in `doctor --fix`'s words: only the daemon opens the database, so only
+the daemon can copy it. There is no `--cold` flag. That is not a hardship in
+§18's corrupt-database case — what rescues a corrupt database is an *earlier*
+good copy, not a fresh copy of the damage — and the documentation keeps "stop
+the daemon, then copy `vincent.db`, `vincent.db-wal` and `vincent.db-shm`
+together" as the no-binary fallback, which is also the honest answer for a
+daemon that will not start.
 
 *Added 2026-08-15 (task 006).* `vincent doctor` is the one data subcommand that
 still produces a **full report when no daemon answers**, the way
@@ -2990,6 +3008,19 @@ POST   /v1/doctor/fix                   { force? } or ?force — runs gc's recla
                                         report (task 005)
 POST   /v1/daemon/stop                  graceful shutdown (§12.4); 202, then the daemon exits.
                                         `vincent daemon stop` calls this and waits for exit
+POST   /v1/daemon/backup                { path } → { path, bytes, database_bytes,
+                                        transcript_bytes, schema_version, created_at }.
+                                        Writes one .tar.gz holding a `VACUUM INTO` copy of the
+                                        database (§14), `transcripts/`, `config/config.yaml`,
+                                        `config/workflows/` and `manifest.json`. `path` must be
+                                        absolute, must not exist, and must not sit under
+                                        `{data_dir}/transcripts` — each a 400. The daemon
+                                        assembles the whole archive, so exactly one process
+                                        walks daemon-owned state; taking it needs no quiet
+                                        moment, but it holds the store's single connection for
+                                        the duration of the copy. There is no restore endpoint:
+                                        restore runs client-side, against a stopped daemon
+                                        (§12.1, task 030)
 
 GET    /v1/maintenance/orphans          what gc would consider, with sizes; removes nothing
                                         (§10, task 005) → { orphans[], mismatches[], bytes,
@@ -3243,6 +3274,15 @@ GET    /v1/events                       SSE stream (§13.3)
 GET    /v1/tasks/{id}/events            SSE, single task incl. live output
 ```
 
+*Added 2026-08-25 (task 030).* `/v1/daemon/*` is no longer only process
+lifecycle: it now holds `backup` beside `stop`. That is accepted knowingly and
+recorded here rather than left for a reader to notice. `/v1/maintenance/*` was
+the alternative and was rejected — maintenance is the family that reconciles
+what is on disk against what the rows say (§10), while a backup is the daemon
+copying its own state out, which reads correctly beside `daemon stop` and
+spells the same way on the command line (`vincent daemon backup`). The
+grouping's meaning widens from "the daemon process" to "the daemon itself".
+
 ### 13.3 Events (SSE)
 
 Two kinds of streams:
@@ -3438,6 +3478,21 @@ CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT
 
 WAL mode, `busy_timeout` set, all writes through the daemon's single connection pool.
 Migrations are embedded in the binary and applied at startup.
+
+*Added 2026-08-25 (task 030).* A **backup is a `VACUUM INTO` copy, never a file
+copy.** Under WAL a committed row lives in `vincent.db-wal` until a checkpoint,
+so copying `vincent.db` while the daemon runs yields a file missing recent
+commits, and copying the three files separately yields a non-atomic set that can
+restore into a torn database. `VACUUM INTO` runs in a read transaction and emits
+one self-contained file with no `-wal`/`-shm` sidecar. It is also the only
+mechanism available: the driver is `modernc.org/sqlite`, which does not expose
+SQLite's C online-backup API through `database/sql`. It refuses an existing
+destination, so the copy is staged under a fresh name. Unlike `VACUUM` — which
+task 005 decision 4 skips while work is in flight because it rewrites the live
+file under an exclusive lock — this takes no such lock and needs no quiet
+moment; its cost is that the store's single connection is held for the duration
+of the copy, so every other daemon query queues behind it, bounded by the size
+of the database.
 
 *Added 2026-08-14 (task 003).* `admit_not_before` / `queued_reason` carry no index:
 `ListAdmissible` already returns the whole queued set in §11 order and the hold is
@@ -4123,7 +4178,8 @@ currently true to show (§15 view 6).
 | Dirtiness of an orphan cannot be determined | *Added 2026-08-15 (task 005).* An orphan's `.git` file points at `{repo}/.git/worktrees/{n}`, so a deleted or pruned repository makes `git status --porcelain` fail outright. Reported as `dirty_unknown` — distinct from `worktree_dirty`, because "git says you have local changes" and "nobody can tell what is in here" are different facts — and skipped until `vincent gc --force`. This is the *common* case where the projects really are gone, so a default run there reclaims little; that is the deliberate trade for never deleting work nobody can vouch for |
 | Project path missing | New/step-starting tasks in that project → blocked with `project_path_missing` |
 | Daemon port taken | Ephemeral port by default makes this nearly impossible; pinned-port conflict fails startup with a clear message |
-| DB corruption | Startup fails loudly, points at the file, never auto-deletes |
+| User wants a copy of daemon state | *Added 2026-08-25 (task 030).* `vincent daemon backup <path.tar.gz>` — one archive holding a `VACUUM INTO` copy of the database (§14), `transcripts/`, `config.yaml`, `workflows/` and a manifest. It needs a **running** daemon and refuses without one, in `doctor --fix`'s words: only the daemon opens the database. It needs no quiet daemon, so a backup may be taken while tasks run. `vincent daemon restore` is the reverse and needs a **stopped** daemon; it refuses a manifest whose schema version exceeds the binary's, and an occupied destination without `--force`, which moves the displaced state aside as `<name>.bak-<ts>` rather than deleting it — the same posture as the row below |
+| DB corruption | Startup fails loudly, points at the file, never auto-deletes. *Amended 2026-08-25 (task 030):* what rescues this case is an **earlier** good copy, which is what `vincent daemon backup` is for; a fresh copy of the damage is not a remedy, and taking one is not offered as a cold-copy mode |
 | Agent emits gigabytes of output | Transcript writes are streamed to disk; SSE output chunks are rate-limited/coalesced (~10 Hz); per-run transcript size cap (`transcript_max_bytes`, default 512 MB) fails the step past the cap with `transcript_limit` |
 | Template references missing field | Step fails at render time (before any process starts) with the template error |
 | A step's `if:` does not render, or renders something that is not `true`/`false` | *Added 2026-08-18 (task 015).* The step blocks with `condition_error` and records one `failed` row naming it. The only reason in this table that does **not** run the §7.2 retry budget: a guard is evaluated before the step becomes an attempt, so there is no attempt to retry, and re-rendering an unchanged template cannot answer differently (§7.7). A human `retry` re-evaluates it |

--- a/docs/tasks/030-daemon-backup-and-restore.md
+++ b/docs/tasks/030-daemon-backup-and-restore.md
@@ -1,0 +1,195 @@
+# 030 — `vincent daemon backup` / `restore`
+
+**Status:** ✅ done (6/6)
+**Opened:** 2026-08-25
+**Issue:** [#99](https://github.com/lezli01/vincent/issues/99)
+
+`vincent.db` holds every project, task, step run, durable event, cost record and
+transcript pointer, and `docs/reference/files.md` said plainly that losing it
+means "everything is gone". Nothing documented how to copy it, and no command
+did. `rg -i backup` over `internal/` and `docs/` returned only log rotation's
+`MaxBackups` and task 027's task-state `Restore` action. Backups appeared in
+neither §2's non-goals nor §20's future work, and `docs/history/v0-tasks.md`
+carries no decision on them — a gap rather than a deferral.
+
+The workaround a user would reach for is actively unsafe. Under WAL a committed
+row lives in `vincent.db-wal` until a checkpoint, so `cp vincent.db` while the
+daemon runs copies a file missing recent commits, and copying `.db`/`-wal`/`-shm`
+separately gives a non-atomic set that can restore into a torn database. §18
+already promised the right posture on corruption — *"startup fails loudly, points
+at the file, never auto-deletes"* — and that posture assumes the user has
+something to restore from.
+
+Two commands, one endpoint, one new leaf package. No scheduling, no retention,
+no new config key, no migration.
+
+## Decisions
+
+### 1. The archive carries everything, transcripts included (2026-08-25)
+
+`vincent.db`, `transcripts/`, `config/config.yaml`, `config/workflows/`,
+`manifest.json` — one artifact that restores full fidelity. Transcripts are not
+opt-in and there is no `--exclude-transcripts` flag in this task.
+
+The size consequence is met by **reporting** rather than by trimming: the
+response carries `bytes`, `database_bytes` and `transcript_bytes` separately,
+the command prints all three, and `docs/reference/files.md` says plainly that a
+data directory with large transcripts produces a large archive. A vincent
+installation is megabytes of database beside gigabytes of transcripts, and a
+user surprised by the total is owed the breakdown, not a smaller lie.
+
+Excluded, and documented as excluded: `worktrees/` (disposable, and the branches
+survive in the repositories), `token`, `daemon.json`, `daemon.lock`, `logs/`,
+`tui.json`. A restored installation mints a fresh token at next start, so every
+client re-reads it — said in the docs rather than discovered.
+
+### 2. Backup needs a live daemon and refuses without one (2026-08-25)
+
+No cold-copy fallback and no `--cold` flag. This follows task 006's rule
+verbatim — *"every repair is a write, and only the daemon writes"*
+(`docs/spec.md` §12.1, `internal/cli/doctor.go`) — and the refusal text echoes
+`doctor --fix`'s wording so the two read as one policy.
+
+The `--fix`-style refusal is not a hardship in §18's corrupt-database case: what
+rescues a corrupt database is an *earlier* good copy, not a fresh copy of the
+damage. The documentation keeps "stop the daemon, then copy `vincent.db`,
+`vincent.db-wal` and `vincent.db-shm` together" as the no-binary fallback, which
+is also the honest answer for a daemon that will not start.
+
+**Beat:** a cold mode that opens the database read-only from the CLI. It hands a
+second process a handle to the file and breaks the one-writer invariant to buy a
+worse copy.
+
+### 3. The daemon assembles the whole archive (2026-08-25)
+
+The CLI resolves the destination to an absolute path client-side, POSTs it, and
+prints what came back. The daemon runs `VACUUM INTO` into a staging directory
+beside the destination, writes the `.tar.gz`, removes the staging directory, and
+returns the byte counts. The CLI stays the thin API client §12.1 describes for
+every other data subcommand, and exactly one process walks daemon-owned state.
+
+**Beat:** daemon copies the database, CLI tars the rest. It puts two processes
+in the data directory and leaves the staging file without a clear owner.
+
+**Beat:** the daemon streams the archive back over HTTP and the CLI writes it.
+That would matter if the daemon were ever remote; the API is loopback-only
+(§16), so it only adds a copy and a second path-resolution story.
+
+### 4. `POST /v1/daemon/backup`, `vincent daemon backup` / `restore` (2026-08-25)
+
+Chosen over `/v1/maintenance/backup` and a top-level `vincent backup`. This is
+the daemon's own state, and it reads correctly beside `daemon stop`;
+`/v1/maintenance/*` is the family that reconciles what is on disk against what
+the rows say (§10), which a backup is not.
+
+The consequence, accepted knowingly and written into the §13.2 amendment rather
+than left for a reader to notice: `/v1/daemon/*` now holds more than process
+lifecycle. Its meaning widens from "the daemon process" to "the daemon itself".
+
+### 5. Restore is client-side, and that is a stated exception (2026-08-25)
+
+§4's "clients never touch the DB" holds because the daemon is the process that
+*opens SQLite*. Restore opens nothing: it probes the single-instance lock,
+refuses unless the daemon is down, reads `manifest.json` for the schema version
+— never the database — and then moves files. It cannot be an endpoint for the
+same reason it is safe: the daemon whose files it replaces has to be gone first.
+
+The exception is written into §12.1 explicitly. An unremarked exception to an
+ownership invariant is how the invariant erodes.
+
+### 6. Restore's conflict rule extends to the config directory — and to the WAL (2026-08-25)
+
+The issue specified `vincent.db` and `transcripts/`. `config.yaml` and
+`workflows/` get the same treatment: written when absent, refused when present
+without `--force`, moved aside as `config.yaml.bak-<ts>` / `workflows.bak-<ts>`
+with it. Nothing is deleted on any path, matching §18's never-auto-delete
+posture — and `moveAside` uniquifies a colliding `.bak-<ts>` name, because
+`os.Rename` onto an existing path would replace it and replacing a displaced
+file *is* a delete.
+
+`vincent.db-wal` and `vincent.db-shm` are in the conflict set with the database
+they belong to. That is not tidiness: leaving the old installation's write-ahead
+log beside a freshly restored `vincent.db` is how a good backup becomes a corrupt
+database at first open.
+
+### 7. Backup does not adopt task 005 decision 4's "skip while work is in flight" (2026-08-25)
+
+That decision governs `VACUUM`, which rewrites the live file under an exclusive
+lock and would stall a step mid-write. `VACUUM INTO` writes elsewhere under a
+read transaction, and the issue's acceptance criteria require a backup **while a
+task runs**.
+
+The real cost is different and is named here rather than discovered: the store
+holds one connection (`SetMaxOpenConns(1)`, phase 1 decision), so every other
+daemon query queues behind the copy for its duration. Bounded by database size,
+and a vincent database is megabytes where its transcripts are gigabytes.
+
+### 8. Two live-data hazards are handled, not hoped about (2026-08-25)
+
+- **A transcript being appended while the tar is written** makes the entry's
+  declared size wrong, and `archive/tar` rejects both ends of that — overrun and
+  underrun. `copyExactly` stats first, copies at most that many bytes, and pads a
+  short read. The tail written after the stat is simply not in this backup.
+- **The pruner (§17) or a project delete can remove a directory mid-walk**, so
+  `os.ErrNotExist` during the walk is a skip, not a failure.
+
+A failure part-way through removes the partial archive: an unrestorable archive
+is worse than none, because it is the one a user reaches for on the day they
+need it.
+
+### 9. An archive is untrusted input, even one vincent wrote (2026-08-25)
+
+Entry names are relative, forward-slashed, with no leading `/` and no `..`.
+Restore rejects any entry that escapes the destination after cleaning — checked
+twice, once on the name and once on the joined result — any entry that is not a
+regular file or a directory (a symlink is exactly how an archive reaches outside
+the directory it was told to write to), and any top-level name outside the known
+layout. The last one is strict on purpose: a newer vincent that adds an entry
+produces an archive this binary cannot restore faithfully, and saying so beats
+restoring most of it in silence.
+
+The destination guard is the mirror image: a backup path under
+`{data_dir}/transcripts` is refused, because the archive would otherwise feed
+itself.
+
+### 10. No gate script (2026-08-25)
+
+The acceptance here is assertable end to end in Go — `internal/cli`'s e2e tests
+already build the real binary and drive real daemons — which is what
+`scripts/*-gate.sh` exists to avoid duplicating.
+
+## Tasks
+
+- [x] **030.1** `internal/store`: `BackupTo(ctx, dst)` wrapping `VACUUM INTO ?`,
+  beside `Vacuum` and `IntegrityCheck`. ✓ 2026-08-25
+- [x] **030.2** `internal/backup`: the archive layout as a leaf package —
+  `Manifest`, `Create`, `ReadManifest`, `Occupied`, `Restore`, `copyExactly`,
+  the entry-safety checks and `moveAside`. ✓ 2026-08-25
+- [x] **030.3** `internal/api`: `backup.go`, the route in `server.go`'s table,
+  destination validation, the staging directory. No new `Deps` — `Dirs` carries
+  the §12.2 directories and `Store` carries the rest. ✓ 2026-08-25
+- [x] **030.4** `internal/apiclient`: `Backup` plus its wire types;
+  `internal/cli`: `newDaemonBackupCmd` and `newDaemonRestoreCmd`, wired into
+  `daemon.go`'s `AddCommand`. ✓ 2026-08-25
+- [x] **030.5** Tests: the store copy's self-containment; the archive layout,
+  exclusions and forward-slashed names; `copyExactly` both ways plus a real
+  concurrent appender; the hostile-archive set; every refusal on both commands;
+  `--force` displacement asserted on the *bytes*; an `apiclient` live test
+  against the real handler; and an `internal/cli` e2e round trip that backs up
+  **while a task is running** and restores into a clean installation.
+  ✓ 2026-08-25
+- [x] **030.6** Docs: §12.1 row and the client-side-restore amendment, §13.2
+  route and the `/v1/daemon/*` note, §14's `VACUUM INTO` amendment, §18's two
+  rows; `files.md`, `cli.md`, `api.md`, `security-model.md`; `CHANGELOG.md`.
+  ✓ 2026-08-25
+
+## Noted, deliberately not folded in
+
+**Scheduled backups with retention.** Deferred, as the issue proposed: cron and
+Task Scheduler cover the scheduling, and a daemon-side timer with a retention
+policy is its own decision with its own configuration surface. Manual command
+first.
+
+**Restoring a single task.** The archive is whole-installation. Pulling one
+task's rows and transcripts out of a backup is a different feature with a
+different shape, and nothing here forecloses it.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -43,6 +43,7 @@ the living engineering specification records implementation contracts.
 | [027](027-follow-up-runs.md) | Follow-up runs on a done or aborted task | ✅ done (9/9) |
 | [028](028-retry-backoff.md) | `retry_backoff`: pacing step retries through task 003's admission hold | ✅ done (5/5) |
 | [029](029-database-size-reporting.md) | Reporting the database's footprint, row counts and retention span | ✅ done (6/6) |
+| [030](030-daemon-backup-and-restore.md) | `vincent daemon backup` / `restore` | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -35,7 +35,7 @@ type backupResponse struct {
 	CreatedAt       string `json:"created_at"`
 }
 
-// handleBackup serves POST /v1/daemon/backup (task 029).
+// handleBackup serves POST /v1/daemon/backup (task 030).
 //
 // The daemon assembles the whole archive — the database copy *and* the two
 // directory trees — rather than copying the database and letting the client

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lezli01/vincent/internal/backup"
+	"github.com/lezli01/vincent/internal/version"
+)
+
+// backupRequest is the body of POST /v1/daemon/backup. One field: where to
+// write. The client resolves it to an absolute path before sending, because
+// the daemon's working directory is not the caller's and a relative path
+// would land somewhere neither of them chose.
+type backupRequest struct {
+	Path string `json:"path"`
+}
+
+// backupResponse reports what was written. The three sizes are separate
+// because a vincent installation is a database of megabytes beside
+// transcripts of gigabytes (§12.3's per-run cap alone is 512 MB), and a user
+// surprised by the total wants to know which half it came from.
+type backupResponse struct {
+	Path            string `json:"path"`
+	Bytes           int64  `json:"bytes"`
+	DatabaseBytes   int64  `json:"database_bytes"`
+	TranscriptBytes int64  `json:"transcript_bytes"`
+	SchemaVersion   int    `json:"schema_version"`
+	CreatedAt       string `json:"created_at"`
+}
+
+// handleBackup serves POST /v1/daemon/backup (task 029).
+//
+// The daemon assembles the whole archive — the database copy *and* the two
+// directory trees — rather than copying the database and letting the client
+// tar the rest. That keeps exactly one process walking daemon-owned state, and
+// leaves the staging copy with an unambiguous owner. It is also why backup
+// needs a running daemon at all: only the daemon opens SQLite (§4), so only
+// the daemon can take a consistent copy while work is in flight.
+func (s *Server) handleBackup(w http.ResponseWriter, r *http.Request) {
+	var req backupRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if s.deps.Store == nil {
+		s.internalError(w, "backup", errors.New("no store is configured"))
+		return
+	}
+	if s.deps.Dirs.Data == "" || s.deps.Dirs.Config == "" {
+		s.internalError(w, "backup", errors.New("no data directory is configured"))
+		return
+	}
+	dst, ok := s.backupDestination(w, req.Path)
+	if !ok {
+		return
+	}
+
+	schemaVersion, err := s.deps.Store.SchemaVersion(r.Context())
+	if err != nil {
+		s.internalError(w, "backup", err)
+		return
+	}
+
+	// VACUUM INTO refuses an existing path, so the copy is staged under a
+	// name nothing else can hold — a fresh directory beside the destination,
+	// which also means one RemoveAll cleans up on every exit path.
+	staging, err := os.MkdirTemp(filepath.Dir(dst), ".vincent-backup-")
+	if err != nil {
+		s.internalError(w, "backup", err)
+		return
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	dbCopy := filepath.Join(staging, backup.DatabaseEntry)
+	if err := s.deps.Store.BackupTo(r.Context(), dbCopy); err != nil {
+		s.internalError(w, "backup", err)
+		return
+	}
+
+	created := backup.FormatTime(time.Now())
+	res, err := backup.Create(dst, backup.Source{
+		Database:  dbCopy,
+		DataDir:   s.deps.Dirs.Data,
+		ConfigDir: s.deps.Dirs.Config,
+		Manifest: backup.Manifest{
+			VincentVersion: version.Version(),
+			SchemaVersion:  schemaVersion,
+			CreatedAt:      created,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, backup.ErrDestinationExists) {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, err.Error())
+			return
+		}
+		s.internalError(w, "backup", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, backupResponse{
+		Path:            res.Path,
+		Bytes:           res.Bytes,
+		DatabaseBytes:   res.DatabaseBytes,
+		TranscriptBytes: res.TranscriptBytes,
+		SchemaVersion:   schemaVersion,
+		CreatedAt:       created,
+	})
+}
+
+// backupDestination validates the requested path, answering the client itself
+// when it is unusable. Every rejection here is a 400: the request named a
+// place the daemon will not write, which is the caller's to fix.
+func (s *Server) backupDestination(w http.ResponseWriter, raw string) (string, bool) {
+	if strings.TrimSpace(raw) == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "path is required")
+		return "", false
+	}
+	if !filepath.IsAbs(raw) {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"path must be absolute: the daemon resolves it against its own working directory, not yours")
+		return "", false
+	}
+	dst := filepath.Clean(raw)
+
+	// A destination inside the transcript tree would be walked by the archive
+	// it is being written into — the file feeding itself.
+	transcripts := filepath.Join(s.deps.Dirs.Data, backup.TranscriptsPrefix)
+	if pathUnder(transcripts, dst) {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("path is inside %s, which the backup itself reads", transcripts))
+		return "", false
+	}
+
+	switch _, err := os.Lstat(dst); {
+	case err == nil:
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("%s: %s — vincent never overwrites a backup", dst, backup.ErrDestinationExists))
+		return "", false
+	case !errors.Is(err, fs.ErrNotExist):
+		s.internalError(w, "backup", err)
+		return "", false
+	}
+	if fi, err := os.Stat(filepath.Dir(dst)); err != nil || !fi.IsDir() {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			fmt.Sprintf("%s is not an existing directory", filepath.Dir(dst)))
+		return "", false
+	}
+	return dst, true
+}
+
+// pathUnder reports whether p sits at or under root.
+func pathUnder(root, p string) bool {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -1,0 +1,319 @@
+package api
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/backup"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// backupHarness is the API over a real store in a real data dir. Nothing here
+// can be faked usefully: the endpoint's whole subject is a file on disk taken
+// from a live SQLite connection.
+type backupHarness struct {
+	ts    *httptest.Server
+	dirs  config.Dirs
+	st    *store.Store
+	inbox string // a scratch directory for archives
+}
+
+func newBackupHarness(t *testing.T) *backupHarness {
+	t.Helper()
+	dirs := config.Dirs{Config: t.TempDir(), Data: t.TempDir()}
+	st, err := store.Open(filepath.Join(dirs.Data, backup.DatabaseEntry))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// The two directory trees a backup carries besides the database.
+	writeFile(t, filepath.Join(dirs.Data, "transcripts", "1", "0-1.jsonl"), `{"type":"start"}`+"\n")
+	writeFile(t, filepath.Join(dirs.Config, "config.yaml"), "listen: \"127.0.0.1:0\"\n")
+	writeFile(t, filepath.Join(dirs.Config, "workflows", "review.yaml"), "name: review\n")
+	// And the running-identity files it must not.
+	writeFile(t, filepath.Join(dirs.Data, "token"), "secret")
+
+	s := New(Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now().Add(-time.Minute),
+		ListenAddr:  "127.0.0.1:12345",
+		Dirs:        dirs,
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return &backupHarness{ts: ts, dirs: dirs, st: st, inbox: t.TempDir()}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func (h *backupHarness) post(t *testing.T, path string) (*http.Response, []byte) {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"path": path})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		h.ts.URL+"/v1/daemon/backup", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/daemon/backup: %v", err)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, raw
+}
+
+func (h *backupHarness) take(t *testing.T, name string) (string, backupResponse) {
+	t.Helper()
+	dst := filepath.Join(h.inbox, name)
+	resp, raw := h.post(t, dst)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("backup = %d: %s", resp.StatusCode, raw)
+	}
+	var got backupResponse
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("backup body is not JSON: %v (%s)", err, raw)
+	}
+	return dst, got
+}
+
+// archiveNames lists an archive's entries.
+func archiveNames(t *testing.T, archive string) []string {
+	t.Helper()
+	f, err := os.Open(archive)
+	if err != nil {
+		t.Fatalf("open %s: %v", archive, err)
+	}
+	defer func() { _ = f.Close() }()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip %s: %v", archive, err)
+	}
+	tr := tar.NewReader(zr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return names
+		}
+		if err != nil {
+			t.Fatalf("read %s: %v", archive, err)
+		}
+		names = append(names, hdr.Name)
+	}
+}
+
+// TestBackupWritesAnOpenableDatabase is the acceptance criterion: the copy in
+// the archive is a database, not a snapshot of a WAL-mode file missing its
+// recent commits — and there is no `-wal`/`-shm` beside it, because
+// VACUUM INTO emits one self-contained file.
+func TestBackupWritesAnOpenableDatabase(t *testing.T) {
+	h := newBackupHarness(t)
+	if err := h.st.AppendEvent(t.Context(), &store.Event{Type: store.EventDaemonShuttingDown}); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+
+	dst, got := h.take(t, "backup.tar.gz")
+	if got.Path != dst || got.Bytes <= 0 || got.DatabaseBytes <= 0 {
+		t.Errorf("response = %+v, want the path and non-zero sizes", got)
+	}
+	if got.SchemaVersion != store.NewestMigration() {
+		t.Errorf("schema_version = %d, want %d", got.SchemaVersion, store.NewestMigration())
+	}
+	if got.CreatedAt == "" {
+		t.Error("created_at is empty")
+	}
+
+	names := archiveNames(t, dst)
+	for _, name := range names {
+		if strings.HasSuffix(name, "-wal") || strings.HasSuffix(name, "-shm") {
+			t.Errorf("archive carries %q; VACUUM INTO emits a single file", name)
+		}
+		if name == "token" {
+			t.Error("archive carries the API token")
+		}
+	}
+
+	into := backup.Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	if _, err := backup.Restore(dst, into, false); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	copied, err := store.Open(filepath.Join(into.Data, backup.DatabaseEntry))
+	if err != nil {
+		t.Fatalf("the archived database does not open: %v", err)
+	}
+	defer func() { _ = copied.Close() }()
+	verdict, err := copied.IntegrityCheck(t.Context())
+	if err != nil {
+		t.Fatalf("integrity check: %v", err)
+	}
+	if verdict != "ok" {
+		t.Fatalf("integrity_check = %q, want ok", verdict)
+	}
+	events, err := copied.ListEvents(t.Context(), store.EventFilter{Limit: 10})
+	if err != nil || len(events) == 0 {
+		t.Fatalf("archived database has no events: %v (%d)", err, len(events))
+	}
+}
+
+// TestBackupWhileTheDatabaseIsBeingWritten is why the daemon takes the backup
+// rather than a second process copying the file: VACUUM INTO runs in a read
+// transaction on the daemon's own connection, so committed rows cannot be
+// half-copied however busy the store is.
+func TestBackupWhileTheDatabaseIsBeingWritten(t *testing.T) {
+	h := newBackupHarness(t)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := h.st.AppendEvent(t.Context(),
+				&store.Event{Type: store.EventDaemonShuttingDown}); err != nil {
+				return
+			}
+		}
+	}()
+
+	dst, _ := h.take(t, "busy.tar.gz")
+	close(stop)
+	wg.Wait()
+
+	into := backup.Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	if _, err := backup.Restore(dst, into, false); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	copied, err := store.Open(filepath.Join(into.Data, backup.DatabaseEntry))
+	if err != nil {
+		t.Fatalf("open the archived database: %v", err)
+	}
+	defer func() { _ = copied.Close() }()
+	verdict, err := copied.IntegrityCheck(t.Context())
+	if err != nil || verdict != "ok" {
+		t.Fatalf("integrity_check = %q (%v), want ok", verdict, err)
+	}
+}
+
+func TestBackupRefusals(t *testing.T) {
+	h := newBackupHarness(t)
+	taken := filepath.Join(h.inbox, "taken.tar.gz")
+	writeFile(t, taken, "somebody else's backup")
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"empty path", ""},
+		{"relative path", filepath.Join("relative", "backup.tar.gz")},
+		{"destination exists", taken},
+		{"inside the transcript tree", filepath.Join(h.dirs.Data, "transcripts", "backup.tar.gz")},
+		{"parent directory missing", filepath.Join(h.inbox, "nope", "backup.tar.gz")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, raw := h.post(t, tc.path)
+			wantError(t, resp, raw, http.StatusBadRequest, CodeValidationFailed)
+		})
+	}
+
+	// The refused run left nothing behind, staging directory included.
+	entries, err := os.ReadDir(h.inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "taken.tar.gz" {
+		t.Errorf("inbox = %v, want only the pre-existing file", names(entries))
+	}
+	body, err := os.ReadFile(taken)
+	if err != nil || string(body) != "somebody else's backup" {
+		t.Errorf("the pre-existing file was touched: %q (%v)", body, err)
+	}
+}
+
+func names(entries []os.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// TestBackupLeavesNoStagingDirectory: the VACUUM INTO copy is staged beside
+// the destination, and a user who lists that directory afterwards must see
+// one file.
+func TestBackupLeavesNoStagingDirectory(t *testing.T) {
+	h := newBackupHarness(t)
+	h.take(t, "backup.tar.gz")
+	entries, err := os.ReadDir(h.inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox = %v, want only the archive", names(entries))
+	}
+}
+
+func TestBackupWithoutAStore(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	body := fmt.Appendf(nil, `{"path":%q}`, filepath.Join(t.TempDir(), "backup.tar.gz"))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+		ts.URL+"/v1/daemon/backup", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	wantError(t, resp, raw, http.StatusInternalServerError, CodeInternal)
+}
+
+func TestBackupRejectsAWrongMethod(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := doRequest(t, ts, http.MethodGet, "/v1/daemon/backup", testToken)
+	wantError(t, resp, body, http.StatusMethodNotAllowed, CodeMethodNotAllowed)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -176,6 +176,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodGet, "/v1/doctor", s.handleDoctor)
 	rt.handle(http.MethodPost, "/v1/doctor/fix", s.handleDoctorFix)
 	rt.handle(http.MethodPost, "/v1/daemon/stop", s.handleStop)
+	rt.handle(http.MethodPost, "/v1/daemon/backup", s.handleBackup)
 	rt.handle(http.MethodGet, "/v1/maintenance/orphans", s.handleOrphans)
 	rt.handle(http.MethodPost, "/v1/maintenance/gc", s.handleGC)
 	rt.handle(http.MethodGet, "/v1/projects", s.handleProjectList)

--- a/internal/apiclient/backup.go
+++ b/internal/apiclient/backup.go
@@ -2,7 +2,7 @@ package apiclient
 
 import "context"
 
-// BackupResult is the body of POST /v1/daemon/backup (task 029).
+// BackupResult is the body of POST /v1/daemon/backup (task 030).
 //
 // The sizes are reported rather than trimmed: the archive carries transcripts
 // in full, so it is as large as the installation is, and a command that

--- a/internal/apiclient/backup.go
+++ b/internal/apiclient/backup.go
@@ -1,0 +1,40 @@
+package apiclient
+
+import "context"
+
+// BackupResult is the body of POST /v1/daemon/backup (task 029).
+//
+// The sizes are reported rather than trimmed: the archive carries transcripts
+// in full, so it is as large as the installation is, and a command that
+// printed only "done" would leave a user to discover that from `du`.
+type BackupResult struct {
+	Path            string `json:"path"`
+	Bytes           int64  `json:"bytes"`
+	DatabaseBytes   int64  `json:"database_bytes"`
+	TranscriptBytes int64  `json:"transcript_bytes"`
+	// SchemaVersion is the database's migration high-water mark, the same
+	// number the archive's manifest carries and restore checks against the
+	// binary's own ceiling.
+	SchemaVersion int `json:"schema_version"`
+	// CreatedAt is RFC3339 UTC with fixed-width nanoseconds (§14's format).
+	CreatedAt string `json:"created_at"`
+}
+
+// Backup asks the daemon to write a `.tar.gz` of its state to path
+// (POST /v1/daemon/backup). path must be absolute and must not exist: the
+// daemon resolves it against its own working directory, and it never
+// overwrites a file that is by construction somebody's backup.
+//
+// There is no client-side counterpart. Restore runs entirely in the client,
+// because its precondition is that the daemon is down.
+func (c *Client) Backup(ctx context.Context, path string) (BackupResult, error) {
+	var out BackupResult
+	if err := c.post(ctx, "/v1/daemon/backup", backupRequest{Path: path}, &out); err != nil {
+		return BackupResult{}, err
+	}
+	return out, nil
+}
+
+type backupRequest struct {
+	Path string `json:"path"`
+}

--- a/internal/apiclient/backup_live_test.go
+++ b/internal/apiclient/backup_live_test.go
@@ -1,0 +1,117 @@
+package apiclient_test
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/backup"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// newBackupClient wires the client to the real backup handler over a real
+// store and data dir. A stub would prove nothing here: the endpoint's answer
+// is derived from bytes it wrote to disk, and the wire types are exactly what
+// this test exists to hold together.
+func newBackupClient(t *testing.T) *apiclient.Client {
+	t.Helper()
+	dirs := config.Dirs{Config: t.TempDir(), Data: t.TempDir()}
+	st, err := store.Open(filepath.Join(dirs.Data, backup.DatabaseEntry))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	transcript := filepath.Join(dirs.Data, backup.TranscriptsPrefix, "1", "0-1.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o700); err != nil {
+		t.Fatalf("mkdir transcripts: %v", err)
+	}
+	if err := os.WriteFile(transcript, []byte(`{"type":"start"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dirs.Config, "config.yaml"),
+		[]byte("listen: \"127.0.0.1:0\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	s := api.New(api.Deps{
+		Token:       testToken,
+		Config:      config.Default,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		Dirs:        dirs,
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store:       st,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	return apiclient.New(ts.URL, testToken)
+}
+
+func TestBackupOverTheWire(t *testing.T) {
+	c := newBackupClient(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+
+	res, err := c.Backup(t.Context(), dst)
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if res.Path != dst {
+		t.Errorf("Path = %q, want %q", res.Path, dst)
+	}
+	if res.Bytes <= 0 || res.DatabaseBytes <= 0 || res.TranscriptBytes <= 0 {
+		t.Errorf("result = %+v, want every size filled in", res)
+	}
+	if res.SchemaVersion != store.NewestMigration() {
+		t.Errorf("SchemaVersion = %d, want %d", res.SchemaVersion, store.NewestMigration())
+	}
+	if res.CreatedAt == "" {
+		t.Error("CreatedAt is empty")
+	}
+
+	// The manifest the daemon embedded says the same things the response did:
+	// two encodings of one fact, and the pair only stays honest if something
+	// compares them.
+	m, err := backup.ReadManifest(dst)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if m.SchemaVersion != res.SchemaVersion || m.CreatedAt != res.CreatedAt {
+		t.Errorf("manifest = %+v, response = %+v", m, res)
+	}
+	if m.VincentVersion == "" {
+		t.Error("manifest carries no vincent version")
+	}
+}
+
+// TestBackupErrorOverTheWire: a refusal arrives as the §13.1 envelope, so the
+// CLI can print the daemon's own words rather than a transport error.
+func TestBackupErrorOverTheWire(t *testing.T) {
+	c := newBackupClient(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	if err := os.WriteFile(dst, []byte("taken"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := c.Backup(t.Context(), dst)
+	var apiErr *apiclient.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Backup over an existing file = %v, want *apiclient.Error", err)
+	}
+	if apiErr.Status != http.StatusBadRequest || apiErr.Code != "validation_failed" {
+		t.Errorf("error = %+v, want a 400 validation_failed", apiErr)
+	}
+	if apiErr.Message == "" {
+		t.Error("error carries no message for the CLI to print")
+	}
+}

--- a/internal/backup/archive.go
+++ b/internal/backup/archive.go
@@ -1,0 +1,338 @@
+package backup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+)
+
+// Archive entry names. These are the wire format between a backup written by
+// one vincent and a restore run by another, so they are constants rather than
+// literals spelled twice.
+const (
+	// ManifestEntry is written **first**, so a restore can read it after
+	// decompressing one block rather than streaming a multi-gigabyte archive
+	// to reach it. Nothing else depends on entry order.
+	ManifestEntry = "manifest.json"
+	// DatabaseEntry is the store.BackupTo output, not a copy of the live file.
+	DatabaseEntry = "vincent.db"
+	// TranscriptsPrefix and ConfigPrefix are the two directory trees.
+	TranscriptsPrefix = "transcripts"
+	ConfigPrefix      = "config"
+)
+
+// configFile is the one file taken from the config directory besides the
+// workflows tree.
+const configFile = "config.yaml"
+
+// workflowsDir is the global workflow scope (§5.2), under both ConfigPrefix in
+// the archive and the config directory on disk.
+const workflowsDir = "workflows"
+
+// timeFormat matches internal/store's: RFC3339 UTC with fixed-width
+// nanoseconds. A manifest timestamp therefore compares and sorts exactly like
+// one read out of the database it describes.
+const timeFormat = "2006-01-02T15:04:05.000000000Z07:00"
+
+// entryMode / dirMode are what restore recreates. vincent stores no
+// executables and no group-readable state, and a mode carried across from a
+// POSIX host would mean nothing on Windows anyway — so the archive declares
+// one owner-only mode rather than preserving whatever the source had.
+const (
+	entryMode = 0o600
+	dirMode   = 0o700
+)
+
+// ErrDestinationExists is returned when the archive path is already taken.
+// Overwriting is never right here: the file it would destroy is, by
+// construction, somebody's backup.
+var ErrDestinationExists = errors.New("destination already exists")
+
+// Manifest is the archive's first entry: enough to decide whether this binary
+// may restore it, without opening the database inside.
+type Manifest struct {
+	VincentVersion string `json:"vincent_version"`
+	// SchemaVersion is the `schema_migrations` high-water mark of the
+	// database in the archive. Migrations are up-only and append-only, so a
+	// value above what the restoring binary embeds cannot be stepped back.
+	SchemaVersion int `json:"schema_version"`
+	// CreatedAt is RFC3339 UTC in store's fixed-width nanosecond format.
+	CreatedAt string `json:"created_at"`
+}
+
+// FormatTime renders t the way the manifest and the API response both spell a
+// timestamp, so the two can never disagree about one backup's creation time.
+func FormatTime(t time.Time) string { return t.UTC().Format(timeFormat) }
+
+// Source is what Create reads.
+type Source struct {
+	// Database is the file to store as DatabaseEntry — a consistent copy
+	// (store.BackupTo), never `{data_dir}/vincent.db` itself.
+	Database string
+	// DataDir supplies transcripts/. Its other contents are excluded (see the
+	// package doc).
+	DataDir string
+	// ConfigDir supplies config.yaml and workflows/.
+	ConfigDir string
+	// Manifest is written verbatim as ManifestEntry.
+	Manifest Manifest
+}
+
+// Result reports what Create wrote. The three sizes are separate because a
+// vincent installation is megabytes of database beside gigabytes of
+// transcripts, and a user looking at a surprising total wants to know which.
+type Result struct {
+	Path            string
+	Bytes           int64
+	DatabaseBytes   int64
+	TranscriptBytes int64
+}
+
+// Create writes the archive at dst. dst must not exist.
+//
+// A failure part-way through removes the partial file: an archive that cannot
+// be restored is worse than no archive, because it is the one a user reaches
+// for on the day they need it.
+func Create(dst string, src Source) (Result, error) {
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, entryMode)
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return Result{}, fmt.Errorf("%s: %w", dst, ErrDestinationExists)
+		}
+		return Result{}, fmt.Errorf("create %s: %w", dst, err)
+	}
+	res, err := writeArchive(f, src)
+	closeErr := f.Close()
+	if err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(dst)
+		return Result{}, err
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		return Result{}, fmt.Errorf("stat %s: %w", dst, err)
+	}
+	res.Path = dst
+	res.Bytes = info.Size()
+	return res, nil
+}
+
+func writeArchive(w io.Writer, src Source) (Result, error) {
+	var res Result
+	zw := gzip.NewWriter(w)
+	tw := tar.NewWriter(zw)
+
+	if err := writeManifest(tw, src.Manifest); err != nil {
+		return res, err
+	}
+	dbBytes, err := writeRegular(tw, DatabaseEntry, src.Database)
+	if err != nil {
+		return res, err
+	}
+	res.DatabaseBytes = dbBytes
+
+	if src.DataDir != "" {
+		n, err := writeTree(tw, filepath.Join(src.DataDir, TranscriptsPrefix), TranscriptsPrefix)
+		if err != nil {
+			return res, err
+		}
+		res.TranscriptBytes = n
+	}
+	if src.ConfigDir != "" {
+		// A config directory whose defaults have never been written is an
+		// ordinary state, not a failure: the daemon rewrites them at start.
+		_, err := writeRegular(tw, path.Join(ConfigPrefix, configFile), filepath.Join(src.ConfigDir, configFile))
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return res, err
+		}
+		if _, err := writeTree(tw, filepath.Join(src.ConfigDir, workflowsDir), path.Join(ConfigPrefix, workflowsDir)); err != nil {
+			return res, err
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return res, fmt.Errorf("finish archive: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return res, fmt.Errorf("finish archive: %w", err)
+	}
+	return res, nil
+}
+
+func writeManifest(tw *tar.Writer, m Manifest) error {
+	body, err := marshalManifest(m)
+	if err != nil {
+		return err
+	}
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     ManifestEntry,
+		Size:     int64(len(body)),
+		Mode:     entryMode,
+		ModTime:  time.Now().UTC().Truncate(time.Second),
+		Format:   tar.FormatPAX,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write %s: %w", ManifestEntry, err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		return fmt.Errorf("write %s: %w", ManifestEntry, err)
+	}
+	return nil
+}
+
+// writeRegular copies one file in under the given archive name. The
+// fs.ErrNotExist from a missing source is returned unwrapped enough for
+// errors.Is, so a caller can decide whether absence is a failure.
+func writeRegular(tw *tar.Writer, name, src string) (int64, error) {
+	f, err := os.Open(src)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", src, err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("stat %s: %w", src, err)
+	}
+	if err := writeEntry(tw, name, info, f); err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+// writeTree adds root's contents under prefix, returning the bytes of file
+// payload written. A missing root contributes nothing.
+func writeTree(tw *tar.Writer, root, prefix string) (int64, error) {
+	var bytes int64
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// The transcript pruner and a project delete both remove
+			// directories under a data root while this walk is running
+			// (§17, §10). A path that vanished mid-walk is not in the
+			// backup and is not a failure either.
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("walk %s: %w", p, err)
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return fmt.Errorf("relativize %s: %w", p, err)
+		}
+		name := prefix
+		if rel != "." {
+			name = path.Join(prefix, filepath.ToSlash(rel))
+		}
+		info, err := d.Info()
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+		if d.IsDir() {
+			return writeDir(tw, name, info)
+		}
+		if !d.Type().IsRegular() {
+			// vincent writes only directories and regular files under its
+			// data roots; anything else was put there by something else and
+			// is not restorable state.
+			return nil
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("open %s: %w", p, err)
+		}
+		defer func() { _ = f.Close() }()
+		if err := writeEntry(tw, name, info, f); err != nil {
+			return err
+		}
+		bytes += info.Size()
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return bytes, nil
+}
+
+func writeDir(tw *tar.Writer, name string, info fs.FileInfo) error {
+	hdr := &tar.Header{
+		Typeflag: tar.TypeDir,
+		Name:     name + "/",
+		Mode:     dirMode,
+		ModTime:  info.ModTime().UTC().Truncate(time.Second),
+		Format:   tar.FormatPAX,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	return nil
+}
+
+func writeEntry(tw *tar.Writer, name string, info fs.FileInfo, r io.Reader) error {
+	hdr := &tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     name,
+		Size:     info.Size(),
+		Mode:     entryMode,
+		ModTime:  info.ModTime().UTC().Truncate(time.Second),
+		Format:   tar.FormatPAX,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	if err := copyExactly(tw, r, info.Size()); err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	return nil
+}
+
+// copyExactly writes exactly size bytes from r, padding a short read.
+//
+// This is the live-data case, and it is not hypothetical: a transcript is
+// being appended to while the archive is written, so the file is already
+// longer than the size the header declared. archive/tar refuses both ends of
+// that — ErrWriteTooLong on an overrun, a short-write error at the next
+// header on an underrun — and the declared length is the only number that is
+// true at both. The tail written after the stat is simply not in this backup.
+//
+// A short read means the file shrank instead (truncated, rotated, replaced).
+// Padding keeps the archive well-formed; failing the whole backup because one
+// transcript moved under the walk would not.
+func copyExactly(w io.Writer, r io.Reader, size int64) error {
+	n, err := io.CopyN(w, r, size)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if n == size {
+		return nil
+	}
+	if _, err := io.CopyN(w, zeroReader{}, size-n); err != nil {
+		return err
+	}
+	return nil
+}
+
+// zeroReader is an endless run of NUL bytes, for copyExactly's padding.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}

--- a/internal/backup/archive_test.go
+++ b/internal/backup/archive_test.go
@@ -1,0 +1,576 @@
+package backup
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// seed lays out a data dir and a config dir the way a real installation looks,
+// plus a standalone file standing in for the store.BackupTo output.
+func seed(t *testing.T) (dbCopy string, dirs Dirs) {
+	t.Helper()
+	staging, dataDir, cfgDir := t.TempDir(), t.TempDir(), t.TempDir()
+
+	dbCopy = filepath.Join(staging, DatabaseEntry)
+	write(t, dbCopy, "SQLite format 3\x00pretend-database")
+
+	write(t, filepath.Join(dataDir, TranscriptsPrefix, "1", "0-1.jsonl"), `{"type":"start"}`+"\n")
+	write(t, filepath.Join(dataDir, TranscriptsPrefix, "12", "3-2.jsonl"), `{"type":"result"}`+"\n")
+	write(t, filepath.Join(cfgDir, configFile), "listen: \"127.0.0.1:0\"\n")
+	write(t, filepath.Join(cfgDir, workflowsDir, "review.yaml"), "name: review\nsteps: []\n")
+
+	// Excluded by construction — the assertions below prove they stay out.
+	write(t, filepath.Join(dataDir, "token"), "secret")
+	write(t, filepath.Join(dataDir, "daemon.json"), "{}")
+	write(t, filepath.Join(dataDir, "tui.json"), "{}")
+	write(t, filepath.Join(dataDir, "logs", "daemon.log"), "log line")
+	write(t, filepath.Join(dataDir, "worktrees", "1", "README.md"), "# work")
+	write(t, filepath.Join(dataDir, DatabaseEntry+"-wal"), "wal")
+
+	return dbCopy, Dirs{Data: dataDir, Config: cfgDir}
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func create(t *testing.T, dst, dbCopy string, dirs Dirs) Result {
+	t.Helper()
+	res, err := Create(dst, Source{
+		Database:  dbCopy,
+		DataDir:   dirs.Data,
+		ConfigDir: dirs.Config,
+		Manifest: Manifest{
+			VincentVersion: "v9.9.9",
+			SchemaVersion:  17,
+			CreatedAt:      FormatTime(time.Now()),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return res
+}
+
+// entries lists every archive entry name, in order.
+func entries(t *testing.T, archive string) []string {
+	t.Helper()
+	var names []string
+	eachEntry(t, archive, func(hdr *tar.Header, _ io.Reader) {
+		names = append(names, hdr.Name)
+	})
+	return names
+}
+
+func eachEntry(t *testing.T, archive string, fn func(*tar.Header, io.Reader)) {
+	t.Helper()
+	f, err := os.Open(archive)
+	if err != nil {
+		t.Fatalf("open %s: %v", archive, err)
+	}
+	defer func() { _ = f.Close() }()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip %s: %v", archive, err)
+	}
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("read %s: %v", archive, err)
+		}
+		fn(hdr, tr)
+	}
+}
+
+// TestCreateLayout pins the archive's contents: the four things that are in
+// it, the running-identity files that are not, and forward-slashed names on
+// every platform — an archive taken on Windows has to restore on Linux.
+func TestCreateLayout(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	res := create(t, dst, dbCopy, dirs)
+
+	names := entries(t, dst)
+	if len(names) == 0 || names[0] != ManifestEntry {
+		// Restore reads the manifest by decompressing one block; that is only
+		// cheap while it is first.
+		t.Fatalf("first entry = %q, want %s", names, ManifestEntry)
+	}
+	for _, want := range []string{
+		DatabaseEntry,
+		"transcripts/1/0-1.jsonl",
+		"transcripts/12/3-2.jsonl",
+		"config/config.yaml",
+		"config/workflows/review.yaml",
+	} {
+		if !slices.Contains(names, want) {
+			t.Errorf("archive is missing %q; has %v", want, names)
+		}
+	}
+	for _, name := range names {
+		if strings.ContainsRune(name, '\\') {
+			t.Errorf("entry %q is not forward-slashed", name)
+		}
+		if strings.HasPrefix(name, "/") || strings.Contains(name, "..") {
+			t.Errorf("entry %q is not relative", name)
+		}
+		for _, excluded := range []string{
+			"token", "daemon.json", "daemon.lock", "tui.json", "logs/", "worktrees/",
+			DatabaseEntry + "-wal", DatabaseEntry + "-shm",
+		} {
+			if name == excluded || strings.HasPrefix(name, excluded) {
+				t.Errorf("archive carries excluded entry %q", name)
+			}
+		}
+	}
+
+	if res.DatabaseBytes == 0 || res.TranscriptBytes == 0 || res.Bytes == 0 {
+		t.Errorf("Result = %+v, want non-zero sizes", res)
+	}
+	if res.Path != dst {
+		t.Errorf("Result.Path = %q, want %q", res.Path, dst)
+	}
+}
+
+func TestCreateRefusesAnExistingDestination(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	write(t, dst, "somebody else's backup")
+
+	_, err := Create(dst, Source{Database: dbCopy, DataDir: dirs.Data, ConfigDir: dirs.Config})
+	if !errors.Is(err, ErrDestinationExists) {
+		t.Fatalf("Create over an existing file = %v, want ErrDestinationExists", err)
+	}
+	body, err := os.ReadFile(dst)
+	if err != nil || string(body) != "somebody else's backup" {
+		t.Fatalf("the existing file was touched: %q, %v", body, err)
+	}
+}
+
+func TestCreateRemovesAPartialArchive(t *testing.T) {
+	dirs := Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+
+	// A database copy that is not there fails the archive part-way, after the
+	// manifest entry is already written.
+	_, err := Create(dst, Source{
+		Database: filepath.Join(t.TempDir(), "missing.db"), DataDir: dirs.Data, ConfigDir: dirs.Config,
+	})
+	if err == nil {
+		t.Fatal("Create with no database = nil, want an error")
+	}
+	if _, statErr := os.Stat(dst); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("a partial archive was left at %s (%v)", dst, statErr)
+	}
+}
+
+func TestCreateToleratesAMissingConfigFile(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	if err := os.Remove(filepath.Join(dirs.Config, configFile)); err != nil {
+		t.Fatalf("remove config.yaml: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dirs.Config, workflowsDir)); err != nil {
+		t.Fatalf("remove workflows: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	names := entries(t, func() string { create(t, dst, dbCopy, dirs); return dst }())
+	if slices.Contains(names, "config/config.yaml") {
+		t.Errorf("archive carries a config.yaml that does not exist: %v", names)
+	}
+	if !slices.Contains(names, DatabaseEntry) {
+		t.Errorf("archive lost the database: %v", names)
+	}
+}
+
+// TestCopyExactlyHonorsTheDeclaredSize is the growing-file defect in
+// isolation. archive/tar rejects both an overrun and an underrun, and a
+// transcript is appended to while the walk runs, so neither branch is
+// hypothetical.
+func TestCopyExactlyHonorsTheDeclaredSize(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		size int64
+	}{
+		{"file grew after the stat", "0123456789abcdef", 10},
+		{"file shrank after the stat", "0123", 10},
+		{"exact", "0123456789", 10},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := copyExactly(&buf, strings.NewReader(tc.body), tc.size); err != nil {
+				t.Fatalf("copyExactly: %v", err)
+			}
+			if int64(buf.Len()) != tc.size {
+				t.Fatalf("wrote %d bytes, want exactly %d", buf.Len(), tc.size)
+			}
+		})
+	}
+}
+
+// TestCreateWhileTranscriptsAreAppended is the same defect end to end: the
+// only place it shows up is a busy machine, so the test makes one. The
+// assertion is that the archive is well-formed — every entry's declared size
+// matches its payload, which is what tar's own reader checks.
+func TestCreateWhileTranscriptsAreAppended(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	transcripts := filepath.Join(dirs.Data, TranscriptsPrefix)
+
+	var files []string
+	for i := range 40 {
+		p := filepath.Join(transcripts, "9", string(rune('a'+i%26))+string(rune('a'+i/26))+".jsonl")
+		write(t, p, strings.Repeat(`{"type":"output"}`+"\n", 64))
+		files = append(files, p)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		line := []byte(strings.Repeat(`{"type":"output","text":"appended"}`+"\n", 16))
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for _, p := range files {
+				f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o600)
+				if err != nil {
+					return
+				}
+				_, _ = f.Write(line)
+				_ = f.Close()
+			}
+		}
+	}()
+
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	res := create(t, dst, dbCopy, dirs)
+	close(stop)
+	wg.Wait()
+
+	// tar's reader validates every declared size against the bytes that
+	// follow it, so draining the archive is the well-formedness assertion.
+	var seen int
+	eachEntry(t, dst, func(hdr *tar.Header, r io.Reader) {
+		n, err := io.Copy(io.Discard, r)
+		if err != nil {
+			t.Fatalf("entry %s: %v", hdr.Name, err)
+		}
+		if hdr.Typeflag == tar.TypeReg && n != hdr.Size {
+			t.Fatalf("entry %s declared %d bytes and carries %d", hdr.Name, hdr.Size, n)
+		}
+		seen++
+	})
+	if seen < len(files) {
+		t.Errorf("archive has %d entries, want at least the %d transcripts", seen, len(files))
+	}
+	if res.TranscriptBytes == 0 {
+		t.Error("Result.TranscriptBytes = 0")
+	}
+}
+
+func TestRoundTripIntoCleanDirectories(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	create(t, dst, dbCopy, dirs)
+
+	into := Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	rep, err := Restore(dst, into, false)
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if rep.Manifest.SchemaVersion != 17 || rep.Manifest.VincentVersion != "v9.9.9" {
+		t.Errorf("manifest = %+v, want the values Create was given", rep.Manifest)
+	}
+	if len(rep.Displaced) != 0 {
+		t.Errorf("Displaced = %v on a clean restore", rep.Displaced)
+	}
+
+	for _, pair := range [][2]string{
+		{dbCopy, filepath.Join(into.Data, DatabaseEntry)},
+		{
+			filepath.Join(dirs.Data, TranscriptsPrefix, "1", "0-1.jsonl"),
+			filepath.Join(into.Data, TranscriptsPrefix, "1", "0-1.jsonl"),
+		},
+		{filepath.Join(dirs.Config, configFile), filepath.Join(into.Config, configFile)},
+		{
+			filepath.Join(dirs.Config, workflowsDir, "review.yaml"),
+			filepath.Join(into.Config, workflowsDir, "review.yaml"),
+		},
+	} {
+		want, err := os.ReadFile(pair[0])
+		if err != nil {
+			t.Fatalf("read source %s: %v", pair[0], err)
+		}
+		got, err := os.ReadFile(pair[1])
+		if err != nil {
+			t.Fatalf("read restored %s: %v", pair[1], err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s restored as %q, want %q", pair[1], got, want)
+		}
+	}
+	// The excluded files stay excluded on the way back too.
+	for _, gone := range []string{"token", "daemon.json", "tui.json", DatabaseEntry + "-wal"} {
+		if _, err := os.Stat(filepath.Join(into.Data, gone)); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("restore wrote %s, which is not in a backup", gone)
+		}
+	}
+}
+
+func TestRestoreRefusesOccupiedState(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	create(t, dst, dbCopy, dirs)
+
+	for _, occupant := range []string{
+		DatabaseEntry,
+		// A leftover write-ahead log is as dangerous as the database itself:
+		// restoring a fresh vincent.db beside a stale -wal is how a good
+		// backup becomes a corrupt database at first open.
+		DatabaseEntry + "-wal",
+		DatabaseEntry + "-shm",
+	} {
+		t.Run(occupant, func(t *testing.T) {
+			into := Dirs{Data: t.TempDir(), Config: t.TempDir()}
+			write(t, filepath.Join(into.Data, occupant), "existing")
+			if _, err := Restore(dst, into, false); !errors.Is(err, ErrOccupied) {
+				t.Fatalf("Restore over %s = %v, want ErrOccupied", occupant, err)
+			}
+			if _, err := os.Stat(filepath.Join(into.Data, TranscriptsPrefix)); !errors.Is(err, os.ErrNotExist) {
+				t.Error("a refused restore still wrote transcripts")
+			}
+		})
+	}
+
+	t.Run("config.yaml", func(t *testing.T) {
+		into := Dirs{Data: t.TempDir(), Config: t.TempDir()}
+		write(t, filepath.Join(into.Config, configFile), "mine")
+		if _, err := Restore(dst, into, false); !errors.Is(err, ErrOccupied) {
+			t.Fatalf("Restore over config.yaml = %v, want ErrOccupied", err)
+		}
+	})
+}
+
+// TestRestoreForceMovesAsideAndDeletesNothing is the §18 posture applied to
+// the one command whose job is to overwrite. The assertion is on the *bytes*
+// at the displaced path, not on a name existing: a rename that clobbered the
+// old file would satisfy the weaker check.
+func TestRestoreForceMovesAsideAndDeletesNothing(t *testing.T) {
+	dbCopy, dirs := seed(t)
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+	create(t, dst, dbCopy, dirs)
+
+	into := Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	write(t, filepath.Join(into.Data, DatabaseEntry), "the database that was here")
+	write(t, filepath.Join(into.Data, DatabaseEntry+"-wal"), "the wal that was here")
+	write(t, filepath.Join(into.Data, TranscriptsPrefix, "77", "0-1.jsonl"), "an older transcript")
+	write(t, filepath.Join(into.Config, configFile), "the config that was here")
+	write(t, filepath.Join(into.Config, workflowsDir, "mine.yaml"), "name: mine")
+
+	rep, err := Restore(dst, into, true)
+	if err != nil {
+		t.Fatalf("Restore --force: %v", err)
+	}
+	if len(rep.Displaced) != 5 {
+		t.Fatalf("Displaced = %+v, want all five occupied paths", rep.Displaced)
+	}
+	want := map[string]string{
+		filepath.Join(into.Data, DatabaseEntry):                        "the database that was here",
+		filepath.Join(into.Data, DatabaseEntry+"-wal"):                 "the wal that was here",
+		filepath.Join(into.Config, configFile):                         "the config that was here",
+		filepath.Join(into.Data, TranscriptsPrefix, "77", "0-1.jsonl"): "an older transcript",
+		filepath.Join(into.Config, workflowsDir, "mine.yaml"):          "name: mine",
+	}
+	for _, d := range rep.Displaced {
+		if !strings.Contains(d.To, ".bak-") {
+			t.Errorf("displaced %s to %s, want a .bak- name", d.From, d.To)
+		}
+		// A displaced directory keeps its contents; a displaced file keeps
+		// its bytes. Either way the old state is readable.
+		probe := d.To
+		if rel, err := filepath.Rel(d.From, findKey(want, d.From)); err == nil && rel != "." {
+			probe = filepath.Join(d.To, rel)
+		}
+		body, err := os.ReadFile(probe)
+		if err != nil {
+			t.Errorf("displaced state at %s is unreadable: %v", probe, err)
+			continue
+		}
+		if got := string(body); got != want[findKey(want, d.From)] {
+			t.Errorf("displaced %s reads %q, want the pre-restore bytes", probe, got)
+		}
+	}
+	// And the restore itself landed.
+	body, err := os.ReadFile(filepath.Join(into.Data, DatabaseEntry))
+	if err != nil || !strings.Contains(string(body), "pretend-database") {
+		t.Fatalf("restored database = %q, %v", body, err)
+	}
+}
+
+// findKey returns the want-map key that from covers: the path itself for a
+// displaced file, or the file inside it for a displaced directory.
+func findKey(want map[string]string, from string) string {
+	for k := range want {
+		if k == from || strings.HasPrefix(k, from+string(filepath.Separator)) {
+			return k
+		}
+	}
+	return from
+}
+
+func TestMoveAsideNeverOverwritesAnEarlierBackup(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "vincent.db")
+	write(t, p, "first")
+	first, err := moveAside(p, "20260825T120000Z")
+	if err != nil {
+		t.Fatalf("moveAside: %v", err)
+	}
+	write(t, p, "second")
+	second, err := moveAside(p, "20260825T120000Z")
+	if err != nil {
+		t.Fatalf("moveAside again: %v", err)
+	}
+	if first == second {
+		t.Fatalf("two displacements in one second collided on %s", first)
+	}
+	for path, want := range map[string]string{first: "first", second: "second"} {
+		body, err := os.ReadFile(path)
+		if err != nil || string(body) != want {
+			t.Errorf("%s = %q (%v), want %q", path, body, err, want)
+		}
+	}
+}
+
+// tarball builds an archive by hand, so a restore can be shown what a hostile
+// or corrupted file looks like. Create can never emit these.
+func tarball(t *testing.T, headers []*tar.Header, bodies []string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(zw)
+	for i, hdr := range headers {
+		body := ""
+		if i < len(bodies) {
+			body = bodies[i]
+		}
+		hdr.Size = int64(len(body))
+		if hdr.Typeflag == tar.TypeDir || hdr.Typeflag == tar.TypeSymlink {
+			hdr.Size = 0
+			body = ""
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", hdr.Name, err)
+		}
+		if _, err := io.WriteString(tw, body); err != nil {
+			t.Fatalf("write body %s: %v", hdr.Name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	p := filepath.Join(t.TempDir(), "hostile.tar.gz")
+	write(t, p, buf.String())
+	return p
+}
+
+func manifestHeader() *tar.Header {
+	return &tar.Header{Typeflag: tar.TypeReg, Name: ManifestEntry, Mode: entryMode, Format: tar.FormatPAX}
+}
+
+// TestRestoreRejectsUnsafeEntries: an archive is untrusted input even when
+// this package wrote it. Nothing may land outside the two destinations.
+func TestRestoreRejectsUnsafeEntries(t *testing.T) {
+	manifest := `{"vincent_version":"v9.9.9","schema_version":1,"created_at":"x"}`
+	for _, tc := range []struct {
+		name string
+		hdr  *tar.Header
+	}{
+		{"parent escape", &tar.Header{Typeflag: tar.TypeReg, Name: "../evil", Format: tar.FormatPAX}},
+		{"nested escape", &tar.Header{Typeflag: tar.TypeReg, Name: "transcripts/../../evil", Format: tar.FormatPAX}},
+		{"absolute", &tar.Header{Typeflag: tar.TypeReg, Name: "/etc/evil", Format: tar.FormatPAX}},
+		{"backslash", &tar.Header{Typeflag: tar.TypeReg, Name: `transcripts\..\..\evil`, Format: tar.FormatPAX}},
+		{"symlink", &tar.Header{
+			Typeflag: tar.TypeSymlink, Name: "transcripts/link", Linkname: "/etc/passwd", Format: tar.FormatPAX,
+		}},
+		{"unknown entry", &tar.Header{Typeflag: tar.TypeReg, Name: "worktrees/1/file", Format: tar.FormatPAX}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			archive := tarball(t, []*tar.Header{manifestHeader(), tc.hdr}, []string{manifest, "pwned"})
+			outside := t.TempDir()
+			into := Dirs{Data: filepath.Join(outside, "data"), Config: filepath.Join(outside, "config")}
+
+			_, err := Restore(archive, into, false)
+			if !errors.Is(err, ErrUnsafeEntry) {
+				t.Fatalf("Restore(%s) = %v, want ErrUnsafeEntry", tc.name, err)
+			}
+			var strays []string
+			_ = filepath.WalkDir(outside, func(p string, _ os.DirEntry, err error) error {
+				if err != nil {
+					return nil
+				}
+				if strings.Contains(filepath.Base(p), "evil") || strings.Contains(filepath.Base(p), "link") {
+					strays = append(strays, p)
+				}
+				return nil
+			})
+			if len(strays) > 0 {
+				t.Errorf("a rejected entry still wrote %v", strays)
+			}
+		})
+	}
+}
+
+func TestReadManifestRejectsWhatIsNotABackup(t *testing.T) {
+	t.Run("not gzip", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "plain.tar.gz")
+		write(t, p, "this is not a gzip stream")
+		if _, err := ReadManifest(p); err == nil {
+			t.Fatal("ReadManifest on a plain file = nil, want an error")
+		}
+	})
+	t.Run("no manifest", func(t *testing.T) {
+		archive := tarball(t,
+			[]*tar.Header{{Typeflag: tar.TypeReg, Name: DatabaseEntry, Format: tar.FormatPAX}},
+			[]string{"db"})
+		if _, err := ReadManifest(archive); !errors.Is(err, ErrNoManifest) {
+			t.Fatalf("ReadManifest without a manifest = %v, want ErrNoManifest", err)
+		}
+	})
+}
+
+func TestFormatTimeMatchesTheStoreFormat(t *testing.T) {
+	// Fixed-width nanoseconds, UTC: a manifest timestamp has to compare and
+	// sort the same way as one read out of the database it describes (§14).
+	got := FormatTime(time.Date(2026, 8, 25, 12, 0, 0, 0, time.FixedZone("x", 3600)))
+	if got != "2026-08-25T11:00:00.000000000Z" {
+		t.Fatalf("FormatTime = %q", got)
+	}
+}

--- a/internal/backup/doc.go
+++ b/internal/backup/doc.go
@@ -1,5 +1,5 @@
 // Package backup builds and unpacks the `.tar.gz` artifact behind
-// `vincent daemon backup` / `restore` (spec §12.1, §13.2; task 029).
+// `vincent daemon backup` / `restore` (spec §12.1, §13.2; task 030).
 //
 // It is deliberately a leaf: it imports nothing internal, because its two
 // callers sit on opposite sides of the ownership boundary. The daemon writes

--- a/internal/backup/doc.go
+++ b/internal/backup/doc.go
@@ -1,0 +1,28 @@
+// Package backup builds and unpacks the `.tar.gz` artifact behind
+// `vincent daemon backup` / `restore` (spec §12.1, §13.2; task 029).
+//
+// It is deliberately a leaf: it imports nothing internal, because its two
+// callers sit on opposite sides of the ownership boundary. The daemon writes
+// an archive (internal/api, over a database copy internal/store already made),
+// and the CLI unpacks one **client-side** — restore's whole precondition is
+// that the daemon is down, so there is no daemon to ask. Putting the layout
+// here is what keeps the writer and the reader from drifting apart.
+//
+// The layout is four things and no more:
+//
+//	manifest.json     vincent version, schema version, created_at
+//	vincent.db        the `VACUUM INTO` output — never the live file
+//	transcripts/…     {data_dir}/transcripts, verbatim
+//	config/…          {config_dir}/config.yaml and workflows/
+//
+// Excluded, and excluded on purpose: `worktrees/` (recreatable, and the
+// branches survive in the repositories), `token`, `daemon.json`,
+// `daemon.lock`, `logs/` and `tui.json` — all of which belong to one
+// installation's running identity rather than to its state.
+//
+// Entry names are relative and forward-slashed on every platform, so an
+// archive written on Windows restores on Linux. Restore refuses any entry
+// that would land outside the two destination directories, and any entry that
+// is not a regular file or a directory: an archive is untrusted input even
+// when this package wrote it.
+package backup

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -1,0 +1,310 @@
+package backup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// manifestMaxBytes bounds the manifest read. It is three short fields; an
+// entry claiming megabytes is a malformed or hostile archive, not a manifest.
+const manifestMaxBytes = 1 << 20
+
+var (
+	// ErrNoManifest means the file is not a vincent backup: it decompressed
+	// and parsed as a tar, but carries no manifest.
+	ErrNoManifest = errors.New("archive has no " + ManifestEntry)
+	// ErrOccupied means the destination already holds state a restore would
+	// overwrite. The caller decides whether --force applies.
+	ErrOccupied = errors.New("destination already holds vincent state")
+	// ErrUnsafeEntry means an entry names a path outside the destination, or
+	// something that is not a plain file or directory. An archive is
+	// untrusted input: it may have been edited, corrupted, or handed over.
+	ErrUnsafeEntry = errors.New("archive entry is not safe to extract")
+)
+
+// Dirs are the two directories a restore writes into (§12.2).
+type Dirs struct {
+	Data   string
+	Config string
+}
+
+// Report is what a restore did.
+type Report struct {
+	Manifest Manifest
+	Files    int
+	Bytes    int64
+	// Displaced are the paths --force moved aside, newest name first written.
+	// Nothing is ever deleted, so this list is the record of where the
+	// previous installation's state went (§18).
+	Displaced []Displaced
+}
+
+// Displaced is one path a --force restore renamed rather than overwrote.
+type Displaced struct {
+	From string
+	To   string
+}
+
+// ReadManifest reads just the manifest out of an archive. Create writes it
+// first, so this decompresses one block rather than the whole file — which is
+// what makes a schema check affordable before a multi-gigabyte extraction.
+func ReadManifest(archive string) (Manifest, error) {
+	f, err := os.Open(archive)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("open %s: %w", archive, err)
+	}
+	defer func() { _ = f.Close() }()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read %s: %w", archive, err)
+	}
+	defer func() { _ = zr.Close() }()
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return Manifest{}, fmt.Errorf("%s: %w", archive, ErrNoManifest)
+		}
+		if err != nil {
+			return Manifest{}, fmt.Errorf("read %s: %w", archive, err)
+		}
+		if path.Clean(hdr.Name) != ManifestEntry {
+			continue
+		}
+		body, err := io.ReadAll(io.LimitReader(tr, manifestMaxBytes))
+		if err != nil {
+			return Manifest{}, fmt.Errorf("read %s from %s: %w", ManifestEntry, archive, err)
+		}
+		var m Manifest
+		if err := json.Unmarshal(body, &m); err != nil {
+			return Manifest{}, fmt.Errorf("parse %s from %s: %w", ManifestEntry, archive, err)
+		}
+		return m, nil
+	}
+}
+
+func marshalManifest(m Manifest) ([]byte, error) {
+	body, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode %s: %w", ManifestEntry, err)
+	}
+	return append(body, '\n'), nil
+}
+
+// Occupied lists the paths under dirs that a restore would overwrite, in the
+// order a report should name them. An empty result means a clean restore.
+//
+// The write-ahead log and shared-memory files are in the set with the database
+// they belong to, and that is not tidiness: leaving a `vincent.db-wal` from
+// the old installation beside a freshly restored `vincent.db` is how a good
+// backup turns into a corrupt database at first open.
+func Occupied(dirs Dirs) []string {
+	var candidates []string
+	if dirs.Data != "" {
+		candidates = append(candidates,
+			filepath.Join(dirs.Data, DatabaseEntry),
+			filepath.Join(dirs.Data, DatabaseEntry+"-wal"),
+			filepath.Join(dirs.Data, DatabaseEntry+"-shm"),
+			filepath.Join(dirs.Data, TranscriptsPrefix))
+	}
+	if dirs.Config != "" {
+		candidates = append(candidates,
+			filepath.Join(dirs.Config, configFile),
+			filepath.Join(dirs.Config, workflowsDir))
+	}
+	var out []string
+	for _, p := range candidates {
+		if _, err := os.Lstat(p); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Restore unpacks archive into dirs.
+//
+// It refuses when the destination already holds vincent state, unless force,
+// in which case each occupied path is **moved aside** as `<name>.bak-<ts>`
+// and nothing is deleted — §18's posture, applied to the one command whose
+// whole job is to overwrite. Whether the daemon is down is the caller's
+// precondition to check: this package opens no lock file and no database.
+func Restore(archive string, dirs Dirs, force bool) (Report, error) {
+	var rep Report
+	m, err := ReadManifest(archive)
+	if err != nil {
+		return rep, err
+	}
+	rep.Manifest = m
+
+	if occupied := Occupied(dirs); len(occupied) > 0 {
+		if !force {
+			return rep, fmt.Errorf("%w: %s", ErrOccupied, strings.Join(occupied, ", "))
+		}
+		stamp := time.Now().UTC().Format("20060102T150405Z")
+		for _, p := range occupied {
+			to, err := moveAside(p, stamp)
+			if err != nil {
+				return rep, err
+			}
+			rep.Displaced = append(rep.Displaced, Displaced{From: p, To: to})
+		}
+	}
+
+	f, err := os.Open(archive)
+	if err != nil {
+		return rep, fmt.Errorf("open %s: %w", archive, err)
+	}
+	defer func() { _ = f.Close() }()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		return rep, fmt.Errorf("read %s: %w", archive, err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return rep, fmt.Errorf("read %s: %w", archive, err)
+		}
+		name := path.Clean(hdr.Name)
+		if name == ManifestEntry {
+			continue
+		}
+		dest, isDir, err := target(hdr, dirs)
+		if err != nil {
+			return rep, err
+		}
+		if isDir {
+			if err := os.MkdirAll(dest, dirMode); err != nil {
+				return rep, fmt.Errorf("create %s: %w", dest, err)
+			}
+			continue
+		}
+		n, err := extractFile(dest, tr)
+		if err != nil {
+			return rep, err
+		}
+		rep.Files++
+		rep.Bytes += n
+	}
+	return rep, nil
+}
+
+// target maps an archive entry onto a destination path, refusing anything
+// that would escape the two roots or that is not a plain file or directory.
+//
+// The check is done twice on purpose: once on the entry name, which catches a
+// hand-crafted `../evil`, and once on the joined result, which catches
+// whatever a platform's path rules make of a name the first pass thought was
+// fine.
+func target(hdr *tar.Header, dirs Dirs) (dest string, isDir bool, err error) {
+	switch hdr.Typeflag {
+	case tar.TypeReg, tar.TypeDir:
+	default:
+		// Symlinks, hard links and device nodes: vincent writes none of
+		// them, and a link is exactly how an archive reaches outside the
+		// directory it was told to write to.
+		return "", false, fmt.Errorf("%w: %s (type %q)", ErrUnsafeEntry, hdr.Name, hdr.Typeflag)
+	}
+	name := hdr.Name
+	if strings.ContainsRune(name, '\\') {
+		// tar names are forward-slashed by definition; a backslash is a
+		// Windows separator smuggled into a name, where filepath.Join on
+		// that platform would treat it as one.
+		return "", false, fmt.Errorf("%w: %s", ErrUnsafeEntry, hdr.Name)
+	}
+	name = strings.TrimSuffix(name, "/")
+	if name == "" || path.IsAbs(name) || path.Clean(name) != name {
+		return "", false, fmt.Errorf("%w: %s", ErrUnsafeEntry, hdr.Name)
+	}
+	for _, elem := range strings.Split(name, "/") {
+		if elem == ".." || elem == "." || elem == "" {
+			return "", false, fmt.Errorf("%w: %s", ErrUnsafeEntry, hdr.Name)
+		}
+	}
+
+	var root, rel string
+	switch {
+	case name == DatabaseEntry:
+		root, rel = dirs.Data, DatabaseEntry
+	case name == TranscriptsPrefix || strings.HasPrefix(name, TranscriptsPrefix+"/"):
+		root, rel = dirs.Data, name
+	case name == ConfigPrefix:
+		// The container itself; the config directory already exists.
+		root, rel = dirs.Config, "."
+	case strings.HasPrefix(name, ConfigPrefix+"/"):
+		root, rel = dirs.Config, strings.TrimPrefix(name, ConfigPrefix+"/")
+	default:
+		// Not a layout this binary knows. Refused rather than skipped: a
+		// newer vincent that adds an entry produces an archive this one
+		// cannot restore faithfully, and saying so beats restoring most of
+		// it in silence.
+		return "", false, fmt.Errorf("%w: unexpected entry %s", ErrUnsafeEntry, hdr.Name)
+	}
+	dest = filepath.Join(root, filepath.FromSlash(rel))
+	if !within(root, dest) {
+		return "", false, fmt.Errorf("%w: %s", ErrUnsafeEntry, hdr.Name)
+	}
+	return dest, hdr.Typeflag == tar.TypeDir, nil
+}
+
+// within reports whether p is root itself or sits under it.
+func within(root, p string) bool {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func extractFile(dest string, r io.Reader) (int64, error) {
+	if err := os.MkdirAll(filepath.Dir(dest), dirMode); err != nil {
+		return 0, fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, entryMode)
+	if err != nil {
+		return 0, fmt.Errorf("create %s: %w", dest, err)
+	}
+	n, copyErr := io.Copy(f, r)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return 0, fmt.Errorf("write %s: %w", dest, copyErr)
+	}
+	if closeErr != nil {
+		return 0, fmt.Errorf("write %s: %w", dest, closeErr)
+	}
+	return n, nil
+}
+
+// moveAside renames p to `<p>.bak-<stamp>`, adding a counter when that name is
+// taken. os.Rename onto an existing path replaces it, and replacing a
+// displaced file would delete state — which is the one thing restore promises
+// never to do — so two restores in the same second must not collide.
+func moveAside(p, stamp string) (string, error) {
+	base := p + ".bak-" + stamp
+	candidate := base
+	for i := 2; ; i++ {
+		if _, err := os.Lstat(candidate); errors.Is(err, fs.ErrNotExist) {
+			break
+		}
+		candidate = fmt.Sprintf("%s-%d", base, i)
+	}
+	if err := os.Rename(p, candidate); err != nil {
+		return "", fmt.Errorf("move %s aside: %w", p, err)
+	}
+	return candidate, nil
+}

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -15,7 +15,7 @@ import (
 	"github.com/lezli01/vincent/internal/store"
 )
 
-// newDaemonBackupCmd is `vincent daemon backup <path.tar.gz>` (task 029).
+// newDaemonBackupCmd is `vincent daemon backup <path.tar.gz>` (task 030).
 //
 // A thin API client like the rest of §12.1: the daemon assembles the archive,
 // this resolves the destination and prints what came back.
@@ -96,7 +96,7 @@ type displacedReport struct {
 	To   string `json:"to"`
 }
 
-// newDaemonRestoreCmd is `vincent daemon restore <path.tar.gz>` (task 029).
+// newDaemonRestoreCmd is `vincent daemon restore <path.tar.gz>` (task 030).
 //
 // This one is **not** an API client, and cannot be: the daemon whose files it
 // replaces has to be down for the restore to be safe. §4's "clients never

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/backup"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// newDaemonBackupCmd is `vincent daemon backup <path.tar.gz>` (task 029).
+//
+// A thin API client like the rest of §12.1: the daemon assembles the archive,
+// this resolves the destination and prints what came back.
+func newDaemonBackupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backup <path.tar.gz>",
+		Short: "Write a portable copy of daemon state (needs a running daemon)",
+		Long: "Write one .tar.gz containing the database, every transcript, config.yaml " +
+			"and the global workflows.\n\n" +
+			"The database copy is taken with SQLite's own VACUUM INTO, so it is consistent " +
+			"even while tasks are running — unlike copying vincent.db, which under WAL is " +
+			"missing whatever has not been checkpointed yet.\n\n" +
+			"Transcripts are included in full, so the archive is as large as your history " +
+			"is; the command prints what it wrote. The destination must not already exist.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Resolved here rather than daemon-side: the daemon's working
+			// directory is not this shell's, so a relative path would mean
+			// two different places to the two processes.
+			dst, err := filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
+			c, err := client(cmd)
+			if err != nil {
+				if errors.Is(err, errDaemonUnreachable) {
+					// Same policy as `doctor --fix`, said the same way: only
+					// the daemon opens SQLite (§4), so only the daemon can
+					// copy it. There is no cold-copy fallback in this
+					// command, and the honest alternative is in the docs.
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+						"backup needs a running daemon: only the daemon opens the database, "+
+							"and only it can copy it consistently.\n"+
+							"With the daemon stopped, copy vincent.db, vincent.db-wal and "+
+							"vincent.db-shm together instead.")
+				}
+				return err
+			}
+			res, err := c.Backup(cmd.Context(), dst)
+			if err != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+				return exitError{code: 1}
+			}
+			if wantJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), res)
+			}
+			return renderBackup(cmd.OutOrStdout(), res)
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+func renderBackup(w io.Writer, res apiclient.BackupResult) error {
+	_, err := fmt.Fprintf(w, "wrote %s (%s: database %s, transcripts %s)\n",
+		res.Path, humanBytes(res.Bytes),
+		humanBytes(res.DatabaseBytes), humanBytes(res.TranscriptBytes))
+	return err
+}
+
+// restoreReport is `daemon restore --json`. It names where everything went,
+// because a restore is the one command whose whole effect is on disk.
+type restoreReport struct {
+	Archive        string            `json:"archive"`
+	DataDir        string            `json:"data_dir"`
+	ConfigDir      string            `json:"config_dir"`
+	VincentVersion string            `json:"vincent_version"`
+	SchemaVersion  int               `json:"schema_version"`
+	CreatedAt      string            `json:"created_at"`
+	Files          int               `json:"files"`
+	Bytes          int64             `json:"bytes"`
+	Displaced      []displacedReport `json:"displaced"`
+}
+
+// displacedReport is one path --force renamed instead of overwriting.
+type displacedReport struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// newDaemonRestoreCmd is `vincent daemon restore <path.tar.gz>` (task 029).
+//
+// This one is **not** an API client, and cannot be: the daemon whose files it
+// replaces has to be down for the restore to be safe. §4's "clients never
+// touch the DB" still holds — the invariant is that only the daemon *opens*
+// SQLite, and restore opens nothing. It reads a manifest and moves files.
+func newDaemonRestoreCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "restore <path.tar.gz>",
+		Short: "Restore daemon state from a backup archive (the daemon must be stopped)",
+		Long: "Unpack an archive written by `vincent daemon backup` into the config and " +
+			"data directories in effect.\n\n" +
+			"Refused while the daemon is running, when the archive was written by a newer " +
+			"schema than this binary understands, and when the destination already holds " +
+			"state — unless --force, which moves that state aside as <name>.bak-<timestamp> " +
+			"and deletes nothing.\n\n" +
+			"Worktrees are not in a backup and are not restored; the branches they held " +
+			"live in your repositories. The daemon mints a fresh API token at next start.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, errOut := cmd.OutOrStdout(), cmd.ErrOrStderr()
+			archive, err := filepath.Abs(args[0])
+			if err != nil {
+				return err
+			}
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return err
+			}
+			running, err := daemon.ProbeRunning(dirs.Data)
+			if err != nil {
+				return err
+			}
+			if running {
+				_, _ = fmt.Fprintln(errOut,
+					"Error: the daemon is running, and restore replaces the files it has open — "+
+						"stop it first with `vincent daemon stop`")
+				return exitError{code: 1}
+			}
+
+			m, err := backup.ReadManifest(archive)
+			if err != nil {
+				_, _ = fmt.Fprintln(errOut, "Error:", err)
+				return exitError{code: 1}
+			}
+			// Migrations are up-only and append-only (§14): a database written
+			// by a newer vincent cannot be stepped back to this binary's
+			// schema, and opening it anyway is the one database state §18
+			// says needs a human.
+			if ceiling := store.NewestMigration(); m.SchemaVersion > ceiling {
+				_, _ = fmt.Fprintf(errOut,
+					"Error: %s holds schema version %d and this vincent embeds %d — "+
+						"restore it with the version that wrote it (%s)\n",
+					archive, m.SchemaVersion, ceiling, dash(m.VincentVersion))
+				return exitError{code: 1}
+			}
+
+			rep, err := backup.Restore(archive, backup.Dirs{Data: dirs.Data, Config: dirs.Config}, force)
+			if err != nil {
+				if errors.Is(err, backup.ErrOccupied) {
+					_, _ = fmt.Fprintf(errOut,
+						"Error: %v\nRe-run with --force to move it aside as <name>.bak-<timestamp>; "+
+							"nothing is deleted either way\n", err)
+					return exitError{code: 1}
+				}
+				_, _ = fmt.Fprintln(errOut, "Error:", err)
+				return exitError{code: 1}
+			}
+			if wantJSON(cmd) {
+				return emitJSON(out, toRestoreReport(archive, dirs, rep))
+			}
+			return renderRestore(out, archive, dirs, rep)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Move existing state aside as <name>.bak-<timestamp> and restore over it")
+	jsonFlag(cmd)
+	return cmd
+}
+
+func toRestoreReport(archive string, dirs config.Dirs, rep backup.Report) restoreReport {
+	displaced := make([]displacedReport, 0, len(rep.Displaced))
+	for _, d := range rep.Displaced {
+		displaced = append(displaced, displacedReport{From: d.From, To: d.To})
+	}
+	return restoreReport{
+		Archive:        archive,
+		DataDir:        dirs.Data,
+		ConfigDir:      dirs.Config,
+		VincentVersion: rep.Manifest.VincentVersion,
+		SchemaVersion:  rep.Manifest.SchemaVersion,
+		CreatedAt:      rep.Manifest.CreatedAt,
+		Files:          rep.Files,
+		Bytes:          rep.Bytes,
+		Displaced:      displaced,
+	}
+}
+
+func renderRestore(w io.Writer, archive string, dirs config.Dirs, rep backup.Report) error {
+	rows := [][2]string{
+		{"taken", fmt.Sprintf("%s by vincent %s (schema %d)",
+			dash(rep.Manifest.CreatedAt), dash(rep.Manifest.VincentVersion), rep.Manifest.SchemaVersion)},
+		{"contents", fmt.Sprintf("%d file(s), %s", rep.Files, humanBytes(rep.Bytes))},
+		{"data", dirs.Data},
+		{"config", dirs.Config},
+	}
+	if _, err := fmt.Fprintf(w, "restored %s\n", archive); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(w, "  %-9s %s\n", r[0], r[1]); err != nil {
+			return err
+		}
+	}
+	if len(rep.Displaced) > 0 {
+		if _, err := fmt.Fprintln(w, "\nmoved aside (nothing was deleted):"); err != nil {
+			return err
+		}
+		for _, d := range rep.Displaced {
+			if _, err := fmt.Fprintf(w, "  %s -> %s\n", d.From, d.To); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintln(w,
+		"\nWorktrees are not restored; the branches they held are in your repositories.\n"+
+			"A fresh API token is minted at next start, so every client re-reads it.\n"+
+			"Start the daemon with `vincent daemon start`.")
+	return err
+}

--- a/internal/cli/backup_e2e_test.go
+++ b/internal/cli/backup_e2e_test.go
@@ -28,7 +28,7 @@ type e2eTask struct {
 	OutputTokens int64    `json:"output_tokens"`
 }
 
-// TestBackupRestoreRoundTripE2E is task 029's acceptance, driven through the
+// TestBackupRestoreRoundTripE2E is task 030's acceptance, driven through the
 // real binary: a backup taken **while a task is running**, restored into a
 // clean pair of directories, and a daemon started on the result that reports
 // the same tasks, step runs and costs.

--- a/internal/cli/backup_e2e_test.go
+++ b/internal/cli/backup_e2e_test.go
@@ -1,0 +1,337 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/backup"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// e2eTask is the slice of a task row this file asserts on.
+type e2eTask struct {
+	ID           int64    `json:"id"`
+	Title        string   `json:"title"`
+	State        string   `json:"state"`
+	CostUSD      *float64 `json:"cost_usd"`
+	InputTokens  int64    `json:"input_tokens"`
+	OutputTokens int64    `json:"output_tokens"`
+}
+
+// TestBackupRestoreRoundTripE2E is task 029's acceptance, driven through the
+// real binary: a backup taken **while a task is running**, restored into a
+// clean pair of directories, and a daemon started on the result that reports
+// the same tasks, step runs and costs.
+//
+// Two daemon generations before the backup, because the fake agent's
+// behaviour comes from the environment its daemon was started with: the first
+// runs a task to completion so there are token counts to compare, the second
+// hangs so a task is genuinely mid-step when the archive is written.
+func TestBackupRestoreRoundTripE2E(t *testing.T) {
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	cfg := fmt.Sprintf("listen: \"127.0.0.1:0\"\nagents:\n  claude:\n    path: %q\n", fake)
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// A global workflow, so the config half of the archive carries both the
+	// file and the tree beneath it.
+	if err := os.MkdirAll(filepath.Join(cfgDir, "workflows"), 0o700); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "workflows", "keepme.yaml"),
+		[]byte("name: keepme\ndescription: a global workflow\nsteps:\n  - id: noop\n    type: command\n    run: \"exit 0\"\n"),
+		0o600); err != nil {
+		t.Fatalf("write global workflow: %v", err)
+	}
+	repo := testrepo.Init(t, "main")
+
+	// Generation one: a task that finishes, with usage the result event
+	// reports, so the restored database has costs to compare.
+	first := startDaemonProcess(t, dataDir, cfgDir, "big-usage")
+	c1 := waitDaemonAPI(t, dataDir)
+	if out, code := runVincent(t, dataDir, cfgDir, "project", "add", repo); code != 0 {
+		t.Fatalf("project add: code %d, out %q", code, out)
+	}
+	doneID := addTask(t, dataDir, cfgDir, "finished before the backup")
+	waitTaskState(t, dataDir, cfgDir, doneID, "done")
+	c1.post(t, "/v1/daemon/stop", nil, http.StatusAccepted, nil)
+	waitExit(t, first)
+
+	// Generation two: a task that is still running when the archive is taken.
+	second := startDaemonProcess(t, dataDir, cfgDir, "hang")
+	c2 := waitDaemonAPI(t, dataDir)
+	runningID := addTask(t, dataDir, cfgDir, "still running at backup time")
+	waitJournaledPID(t, c2, runningID)
+
+	archive := filepath.Join(t.TempDir(), "vincent-backup.tar.gz")
+	out, code := runVincent(t, dataDir, cfgDir, "daemon", "backup", archive)
+	if code != 0 {
+		t.Fatalf("daemon backup: code %d, out %q", code, out)
+	}
+	if !strings.Contains(out, archive) || !strings.Contains(out, "database") {
+		t.Errorf("daemon backup printed %q, want the path and the sizes", out)
+	}
+	// The command refuses to overwrite what it just wrote.
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "backup", archive)
+	if code != 1 || !strings.Contains(out, "already exists") {
+		t.Errorf("second backup to the same path: code %d, out %q; want 1 and a refusal", code, out)
+	}
+
+	// Restore refuses while the daemon it would overwrite is up.
+	out, code = runVincent(t, dataDir, cfgDir, "daemon", "restore", archive)
+	if code != 1 || !strings.Contains(out, "daemon is running") {
+		t.Fatalf("restore against a live daemon: code %d, out %q; want 1", code, out)
+	}
+
+	c2.post(t, "/v1/daemon/stop", nil, http.StatusAccepted, nil)
+	waitExit(t, second)
+
+	// Into a clean installation, the way a user moving machines would.
+	newData, newCfg := t.TempDir(), t.TempDir()
+	out, code = runVincent(t, newData, newCfg, "daemon", "restore", archive)
+	if code != 0 {
+		t.Fatalf("daemon restore: code %d, out %q", code, out)
+	}
+	if !strings.Contains(out, "restored") {
+		t.Errorf("daemon restore printed %q", out)
+	}
+	for _, want := range []string{
+		filepath.Join(newData, backup.DatabaseEntry),
+		filepath.Join(newData, backup.TranscriptsPrefix, strconv.FormatInt(doneID, 10)),
+		filepath.Join(newCfg, config.FileName),
+		filepath.Join(newCfg, "workflows", "keepme.yaml"),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("restore did not produce %s: %v", want, err)
+		}
+	}
+	// The running-identity files are not in a backup and must not appear.
+	for _, gone := range []string{"token", "daemon.json", backup.DatabaseEntry + "-wal"} {
+		if _, err := os.Stat(filepath.Join(newData, gone)); err == nil {
+			t.Errorf("restore produced %s, which a backup does not carry", gone)
+		}
+	}
+
+	// Generation three, on the restored installation.
+	third := startDaemonProcess(t, newData, newCfg, "success")
+	c3 := waitDaemonAPI(t, newData)
+	t.Cleanup(func() { _ = third.Process.Kill() })
+
+	var restored []e2eTask
+	c3.get(t, "/v1/tasks?archived=all", &restored)
+	byTitle := map[string]e2eTask{}
+	for _, task := range restored {
+		byTitle[task.Title] = task
+	}
+	if len(byTitle) != 2 {
+		t.Fatalf("restored tasks = %+v, want both", restored)
+	}
+	finished, ok := byTitle["finished before the backup"]
+	if !ok {
+		t.Fatalf("the finished task did not survive the round trip: %+v", restored)
+	}
+	if finished.State != "done" {
+		t.Errorf("restored state = %q, want done", finished.State)
+	}
+	if finished.InputTokens == 0 || finished.OutputTokens == 0 {
+		t.Errorf("restored task = %+v, want the token counts the original recorded", finished)
+	}
+
+	var steps []struct {
+		StepIndex int    `json:"step_index"`
+		State     string `json:"state"`
+	}
+	c3.get(t, fmt.Sprintf("/v1/tasks/%d/steps", finished.ID), &steps)
+	var succeeded bool
+	for _, s := range steps {
+		if s.State == "succeeded" {
+			succeeded = true
+		}
+	}
+	if !succeeded {
+		t.Errorf("restored step runs = %+v, want the succeeded attempt", steps)
+	}
+
+	c3.post(t, "/v1/daemon/stop", nil, http.StatusAccepted, nil)
+	waitExit(t, third)
+}
+
+// TestBackupRefusesWithoutADaemonE2E: `backup` is a write of daemon-owned
+// state, so it follows `doctor --fix`'s policy — and says so, with the
+// no-binary fallback, rather than leaving a user to guess.
+func TestBackupRefusesWithoutADaemonE2E(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+
+	out, code := runVincent(t, dataDir, cfgDir, "daemon", "backup", dst)
+	if code != 2 {
+		t.Fatalf("backup with no daemon: code %d, out %q; want 2", code, out)
+	}
+	if !strings.Contains(out, "needs a running daemon") {
+		t.Errorf("backup with no daemon printed %q, want the policy line", out)
+	}
+	if !strings.Contains(out, "vincent.db-wal") {
+		t.Errorf("backup with no daemon printed %q, want the stopped-daemon fallback", out)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		t.Error("a refused backup still wrote the destination")
+	}
+}
+
+// TestRestoreRefusalsE2E covers the refusals that need no daemon at all. The
+// archives are built here rather than taken from a running instance: a
+// manifest from the future cannot be produced by this binary.
+func TestRestoreRefusalsE2E(t *testing.T) {
+	dbCopy := filepath.Join(t.TempDir(), backup.DatabaseEntry)
+	if err := os.WriteFile(dbCopy, []byte("SQLite format 3\x00"), 0o600); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	src := backup.Dirs{Data: t.TempDir(), Config: t.TempDir()}
+	if err := os.WriteFile(filepath.Join(src.Config, config.FileName), []byte("x: 1\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	makeArchive := func(t *testing.T, schema int) string {
+		t.Helper()
+		dst := filepath.Join(t.TempDir(), "backup.tar.gz")
+		if _, err := backup.Create(dst, backup.Source{
+			Database: dbCopy, DataDir: src.Data, ConfigDir: src.Config,
+			Manifest: backup.Manifest{
+				VincentVersion: "v99.0.0",
+				SchemaVersion:  schema,
+				CreatedAt:      backup.FormatTime(time.Now()),
+			},
+		}); err != nil {
+			t.Fatalf("create archive: %v", err)
+		}
+		return dst
+	}
+
+	t.Run("schema from the future", func(t *testing.T) {
+		archive := makeArchive(t, store.NewestMigration()+1)
+		dataDir, cfgDir := t.TempDir(), t.TempDir()
+		out, code := runVincent(t, dataDir, cfgDir, "daemon", "restore", archive)
+		if code != 1 {
+			t.Fatalf("restore of a newer schema: code %d, out %q; want 1", code, out)
+		}
+		if !strings.Contains(out, "schema version") || !strings.Contains(out, "v99.0.0") {
+			t.Errorf("restore printed %q, want the schema versions and the writing binary", out)
+		}
+		if _, err := os.Stat(filepath.Join(dataDir, backup.DatabaseEntry)); err == nil {
+			t.Error("a refused restore still wrote the database")
+		}
+	})
+
+	t.Run("not a backup", func(t *testing.T) {
+		notAnArchive := filepath.Join(t.TempDir(), "notes.tar.gz")
+		if err := os.WriteFile(notAnArchive, []byte("just some text"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		out, code := runVincent(t, t.TempDir(), t.TempDir(), "daemon", "restore", notAnArchive)
+		if code != 1 {
+			t.Fatalf("restore of a non-archive: code %d, out %q; want 1", code, out)
+		}
+	})
+
+	t.Run("occupied without force", func(t *testing.T) {
+		archive := makeArchive(t, store.NewestMigration())
+		dataDir, cfgDir := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(dataDir, backup.DatabaseEntry),
+			[]byte("the database that was here"), 0o600); err != nil {
+			t.Fatalf("seed database: %v", err)
+		}
+		out, code := runVincent(t, dataDir, cfgDir, "daemon", "restore", archive)
+		if code != 1 || !strings.Contains(out, "--force") {
+			t.Fatalf("restore over existing state: code %d, out %q; want 1 and a --force pointer", code, out)
+		}
+		body, err := os.ReadFile(filepath.Join(dataDir, backup.DatabaseEntry))
+		if err != nil || string(body) != "the database that was here" {
+			t.Fatalf("a refused restore changed the database: %q (%v)", body, err)
+		}
+	})
+
+	t.Run("force displaces and deletes nothing", func(t *testing.T) {
+		archive := makeArchive(t, store.NewestMigration())
+		dataDir, cfgDir := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(dataDir, backup.DatabaseEntry),
+			[]byte("the database that was here"), 0o600); err != nil {
+			t.Fatalf("seed database: %v", err)
+		}
+		out, code := runVincent(t, dataDir, cfgDir, "daemon", "restore", archive, "--force", "--json")
+		if code != 0 {
+			t.Fatalf("restore --force: code %d, out %q", code, out)
+		}
+		var rep restoreReport
+		if err := json.Unmarshal([]byte(out), &rep); err != nil {
+			t.Fatalf("restore --json is not JSON: %v (%q)", err, out)
+		}
+		if len(rep.Displaced) != 1 {
+			t.Fatalf("displaced = %+v, want the one occupied path", rep.Displaced)
+		}
+		// The assertion is on the bytes, not on a name: a rename that
+		// clobbered the old file would pass the weaker check.
+		body, err := os.ReadFile(rep.Displaced[0].To)
+		if err != nil || string(body) != "the database that was here" {
+			t.Fatalf("displaced state at %s = %q (%v), want the pre-restore bytes",
+				rep.Displaced[0].To, body, err)
+		}
+		restored, err := os.ReadFile(filepath.Join(dataDir, backup.DatabaseEntry))
+		if err != nil || !strings.HasPrefix(string(restored), "SQLite format 3") {
+			t.Fatalf("restored database = %q (%v)", restored, err)
+		}
+	})
+}
+
+// addTask creates a task through the CLI and returns its id.
+func addTask(t *testing.T, dataDir, cfgDir, title string) int64 {
+	t.Helper()
+	out, code := runVincent(t, dataDir, cfgDir,
+		"task", "add", "--project", "1", "--title", title, "--json")
+	if code != 0 {
+		t.Fatalf("task add %q: code %d, out %q", title, code, out)
+	}
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &created); err != nil {
+		t.Fatalf("task add --json is not JSON: %v (%q)", err, out)
+	}
+	return created.ID
+}
+
+func waitTaskState(t *testing.T, dataDir, cfgDir string, id int64, want string) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		out, code := runVincent(t, dataDir, cfgDir, "task", "ls", "--json")
+		if code == 0 {
+			var tasks []e2eTask
+			if err := json.Unmarshal([]byte(out), &tasks); err == nil {
+				for _, task := range tasks {
+					if task.ID != id {
+						continue
+					}
+					if task.State == want {
+						return
+					}
+					if task.State == "blocked" || task.State == "aborted" {
+						t.Fatalf("task %d ended %s, want %s", id, task.State, want)
+					}
+				}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("task %d never reached %s", id, want)
+}

--- a/internal/cli/crash_e2e_test.go
+++ b/internal/cli/crash_e2e_test.go
@@ -121,7 +121,7 @@ func TestCrashRecoveryE2E(t *testing.T) {
 
 	// Daemon #2 goes down gracefully.
 	c2.post(t, "/v1/daemon/stop", nil, http.StatusAccepted, nil)
-	waitExit(t, second, 30*time.Second)
+	waitExit(t, second)
 }
 
 // startDaemonProcess runs `vincent daemon` (foreground) as a real child
@@ -147,15 +147,19 @@ func startDaemonProcess(t *testing.T, dataDir, cfgDir, scenario string) *exec.Cm
 	return cmd
 }
 
-func waitExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
+// daemonExitTimeout bounds a graceful shutdown in the e2e tests: §12.4's 15 s
+// process grace plus the HTTP drain has to fit inside it.
+const daemonExitTimeout = 30 * time.Second
+
+func waitExit(t *testing.T, cmd *exec.Cmd) {
 	t.Helper()
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	select {
 	case <-done:
-	case <-time.After(timeout):
+	case <-time.After(daemonExitTimeout):
 		_ = cmd.Process.Kill()
-		t.Fatalf("daemon did not exit within %s", timeout)
+		t.Fatalf("daemon did not exit within %s", daemonExitTimeout)
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -76,7 +76,8 @@ func newDaemonCmd() *cobra.Command {
 	// fails to start at logon, to fix a word.
 	cmd.Flags().BoolVar(&hideConsole, "hide-console", false,
 		"detach from the console the OS allocated for this process (Windows only; no-op elsewhere)")
-	cmd.AddCommand(newDaemonStartCmd(), newDaemonStopCmd(), newDaemonStatusCmd())
+	cmd.AddCommand(newDaemonStartCmd(), newDaemonStopCmd(), newDaemonStatusCmd(),
+		newDaemonBackupCmd(), newDaemonRestoreCmd())
 	return cmd
 }
 

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// BackupTo writes a consistent copy of the database to dst (task 029).
+// BackupTo writes a consistent copy of the database to dst (task 030).
 //
 // `VACUUM INTO` is the mechanism rather than a file copy, and the difference
 // matters: under WAL a committed row lives in `vincent.db-wal` until a

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -1,0 +1,32 @@
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// BackupTo writes a consistent copy of the database to dst (task 029).
+//
+// `VACUUM INTO` is the mechanism rather than a file copy, and the difference
+// matters: under WAL a committed row lives in `vincent.db-wal` until a
+// checkpoint, so copying `vincent.db` while the daemon runs yields a file
+// missing recent commits, and copying the three files separately yields a
+// non-atomic set. `VACUUM INTO` runs in a read transaction and emits a single
+// self-contained file with no `-wal`/`-shm` sidecar. It is also the only
+// mechanism available here: the driver is `modernc.org/sqlite`, which does not
+// expose SQLite's C online-backup API through `database/sql`.
+//
+// Unlike Vacuum this needs no quiet moment — it writes elsewhere and never
+// takes an exclusive lock on the live file, which is why a backup may be taken
+// while tasks run. The cost it does have is the store's single connection
+// (phase 1 decision): every other daemon query waits behind the copy for its
+// duration, bounded by the size of the database.
+//
+// dst must not exist: SQLite refuses to overwrite, and the caller is expected
+// to have staged a fresh name.
+func (s *Store) BackupTo(ctx context.Context, dst string) error {
+	if _, err := s.db.ExecContext(ctx, `VACUUM INTO ?`, dst); err != nil {
+		return fmt.Errorf("back up database to %s: %w", dst, err)
+	}
+	return nil
+}

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -1,0 +1,62 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBackupToProducesASelfContainedFile pins the property the whole feature
+// rests on: the copy is one file that opens on its own. A `cp vincent.db`
+// under WAL is missing everything since the last checkpoint, and the three
+// files copied separately are not a consistent set.
+func TestBackupToProducesASelfContainedFile(t *testing.T) {
+	s := openTest(t)
+	if err := s.AppendEvent(t.Context(), &Event{Type: EventDaemonShuttingDown}); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "copy.db")
+	if err := s.BackupTo(t.Context(), dst); err != nil {
+		t.Fatalf("BackupTo: %v", err)
+	}
+	for _, sidecar := range []string{dst + "-wal", dst + "-shm"} {
+		if _, err := os.Stat(sidecar); err == nil {
+			t.Errorf("VACUUM INTO left %s beside the copy", sidecar)
+		}
+	}
+
+	copied, err := Open(dst)
+	if err != nil {
+		t.Fatalf("the copy does not open: %v", err)
+	}
+	t.Cleanup(func() { _ = copied.Close() })
+	if verdict, err := copied.IntegrityCheck(t.Context()); err != nil || verdict != "ok" {
+		t.Fatalf("integrity_check = %q (%v), want ok", verdict, err)
+	}
+	if got, want := schemaVersion(t, copied), schemaVersion(t, s); got != want {
+		t.Errorf("copied schema version = %d, want %d", got, want)
+	}
+	events, err := copied.ListEvents(t.Context(), EventFilter{Limit: 10})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("copied events = %d (%v), want the one that was committed", len(events), err)
+	}
+}
+
+// TestBackupToRefusesAnExistingDestination is why the daemon stages the copy
+// under a fresh name: SQLite will not overwrite, so a caller that reused a
+// path would fail at the last moment instead of the first.
+func TestBackupToRefusesAnExistingDestination(t *testing.T) {
+	s := openTest(t)
+	dst := filepath.Join(t.TempDir(), "copy.db")
+	if err := os.WriteFile(dst, []byte("in the way"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := s.BackupTo(t.Context(), dst); err == nil {
+		t.Fatal("BackupTo over an existing file = nil, want an error")
+	}
+	body, err := os.ReadFile(dst)
+	if err != nil || string(body) != "in the way" {
+		t.Fatalf("the existing file was modified: %q (%v)", body, err)
+	}
+}


### PR DESCRIPTION
## Summary

`vincent.db` holds every project, task, step run, durable event, cost record and
transcript pointer. Nothing copied it, and the workaround a user would reach for
is actively unsafe: under WAL a committed row lives in `vincent.db-wal` until a
checkpoint, so `cp vincent.db` against a live daemon produces a file missing
recent work, and copying the three files separately produces a non-atomic set
that can restore into a torn database. §18 already promised to point at a corrupt
database and never act on it — a posture that assumes the user has something to
restore from.

This adds one endpoint, two commands and one leaf package. No scheduling, no
retention, no new config key, no migration.

**`POST /v1/daemon/backup`** — `{ path }` in, `{ path, bytes, database_bytes,
transcript_bytes, schema_version, created_at }` out. The daemon assembles the
whole `.tar.gz`: a `VACUUM INTO` copy of the database, `transcripts/`,
`config/config.yaml`, `config/workflows/` and `manifest.json`. One process walks
daemon-owned state, and the staging copy has an unambiguous owner. `VACUUM INTO`
runs in a read transaction, so a backup may be taken **while tasks are running**;
what it costs is the store's single connection for the duration of the copy,
which is named in §14 rather than left to be discovered.

**`vincent daemon backup <path.tar.gz>`** is a thin API client. It refuses
without a running daemon in `doctor --fix`'s own words — only the daemon opens
the database — and prints the "stop the daemon, then copy `vincent.db`,
`vincent.db-wal` and `vincent.db-shm` together" fallback rather than leaving a
user to guess. Transcripts are included in full and the size is *reported*, not
trimmed: the output splits the total between database and transcripts.

**`vincent daemon restore <path.tar.gz> [--force]`** runs client-side and cannot
be otherwise — the daemon it overwrites has to be down. §4's ownership invariant
holds because it opens no database: it probes the lock, reads `manifest.json` for
the schema version, and moves files. That exception is written into §12.1
explicitly. It refuses a running daemon, a schema newer than this binary's, and
an occupied destination without `--force`, which moves the old state aside as
`<name>.bak-<timestamp>` and deletes nothing.

Three things worth a reviewer's attention:

- **Stale `-wal`/`-shm` files are occupants.** Restoring a fresh `vincent.db`
  beside the old installation's write-ahead log is how a good backup becomes a
  corrupt database at first open, so they are refused and displaced with the
  database they belong to. `moveAside` also uniquifies a colliding `.bak-<ts>`,
  since `os.Rename` onto an existing path would replace it — and replacing a
  displaced file *is* a delete.
- **Two live-data hazards are handled rather than hoped about.** A transcript
  being appended to while the tar is written is copied to exactly its declared
  size and padded on a short read (`archive/tar` rejects both an overrun and an
  underrun); a directory the pruner or a project delete removes mid-walk is a
  skip, not a failure. Both have direct tests, the second with a real concurrent
  appender.
- **An archive is untrusted input even when vincent wrote it.** Entries that
  escape the destination after cleaning, that are not plain files or directories,
  or that fall outside the known layout are all refused, and the destination
  guard refuses a backup path under `{data_dir}/transcripts`, which would
  otherwise feed the archive into itself.

## Related

Closes #99
Closes 029.1, 029.2, 029.3, 029.4, 029.5, 029.6

Decisions are recorded in `docs/tasks/029-daemon-backup-and-restore.md`. One
prior decision is cited but not revisited: task 005 decision 4 skips `VACUUM`
while work is in flight because it rewrites the live file under an exclusive
lock. `VACUUM INTO` takes no such lock and writes elsewhere, so it does not
inherit that rule — said in §14 rather than left implicit.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### On the last two boxes

`docs/reference/cli.md` gains both subcommands, `docs/reference/api.md` the route
and a `### Backup` section, `docs/reference/files.md` a "Backup and restore"
section beside the delete table, and `docs/security-model.md` the arbitrary-path
write the endpoint grants — not a new privilege beside §16's full-auto agents,
but worth stating rather than discovering. No TUI key table or `Reason*` constant
changed, so those parts of that line do not apply, and no `docs/assets/tui-*.png`
is stale — nothing under `internal/tui` moved.

`docs/features.md` gains the pair too, in the "Diagnose and maintain it" section
beside `doctor` and `gc` and in the "At a glance" Operations row: that page is
where a reader finds out a capability exists, as opposed to looking one up.

Two **exclusivity claims elsewhere went stale** and are qualified rather than
rewritten. `docs/reference/cli.md` called `workflow validate` "the one command
that needs no daemon", and `docs/guides/scripting.md` called it "the only command
that works with no daemon. Everything else exits 2." `daemon restore` works with
no daemon, refuses to run with one, and exits `0` — so a script written against
that bullet would expect exit `2` from a command that succeeds. Validate is still
the one command that never wants a daemon; restore is the one that requires its
absence.

`docs/spec.md` is amended in four places, dated 2026-08-25: a §12.1 command row
plus the reasoning for backup's live-daemon requirement and restore's client-side
exception; the §13.2 route, with the consequence that `/v1/daemon/*` now holds
more than process lifecycle; §14 on why a backup is a `VACUUM INTO` copy; and two
§18 rows.

### On testing

- `internal/store` — the copy is one self-contained file, opens on its own,
  passes `integrity_check`, and refuses an existing destination.
- `internal/backup` — the archive layout and its exclusions, forward-slashed
  names, `copyExactly` in both directions, a real concurrent appender during
  `Create`, the round trip, every occupancy refusal, `--force` displacement
  asserted on the *bytes* rather than on a name existing, `moveAside`
  collisions, and six hostile archives (`../evil`, a nested escape, an absolute
  name, a backslash, a symlink, an unknown entry) each asserting nothing landed
  outside the destination.
- `internal/api` — the archive's database opens and returns `ok` from
  `PRAGMA integrity_check` with no `-wal`/`-shm` entry, including with a
  concurrent writer committing throughout; every 400; and no staging directory
  left behind.
- `internal/apiclient` — a live test against the real handler over `httptest`,
  which also asserts the manifest and the response agree.
- `internal/cli` — an e2e round trip through the real binary: a task run to
  completion for its token counts, a second daemon generation with a task
  genuinely mid-step when the archive is taken, then restore into a clean
  `VINCENT_DATA_DIR`/`VINCENT_CONFIG_DIR` and a third daemon that reports the
  same tasks, step runs and costs. Plus every CLI refusal, and `--force`
  asserting the displaced bytes are still readable.

No gate script: the acceptance is assertable end to end in Go, which is what
`scripts/*-gate.sh` exists to avoid duplicating.

`go run mage.go test` and `go run mage.go lint` are green, and lint was run
cross-built for `windows`, `darwin` and `linux` — 0 issues on each.
