### PR TITLE
Fix the GitHub Pages build for the template-carrying reference pages

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # HTTP API
 
 The daemon serves REST + SSE on loopback. Every client — the TUI, the
@@ -802,3 +804,5 @@ store publishes after the database has recorded the event.
 - [Scripting vincent](../guides/scripting.md) — worked examples.
 - [Task lifecycle](task-lifecycle.md) — what the action endpoints do.
 - Spec [§13](../spec.md) — the normative definition.
+
+{% endraw %}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Configuration
 
 The daemon reads one file, `{config_dir}/config.yaml`. It is written with
@@ -649,3 +651,5 @@ the log tail.
 - [Workflow schema](workflow-schema.md) — the per-step overrides for these
   defaults.
 - [Agent CLIs](../guides/agents.md).
+
+{% endraw %}


### PR DESCRIPTION
## What

`docs/reference/api.md` and `docs/reference/configuration.md` get the `{% raw %}` / `{% endraw %}` wrapper that the other template-heavy pages (`concepts.md`, `troubleshooting.md`, `workflows.md`, `workflow-schema.md`) already carry.

## Why

GitHub Pages builds this repository with Jekyll 3.10, which runs Liquid over every included file before Markdown — backticks do not protect anything.

- **`api.md` breaks the build.** The `/follow_up` section says a `` `{{` `` you type is two characters, and an unterminated Liquid variable is an exception, not a warning: `Liquid syntax error (line 572): Variable '{{ ...' was not properly terminated with regexp: /\}\}/`. Every `pages-build-deployment` run since that page landed in `5a86315` has failed, so master has been red for the release preflight even with CI green on all three platforms.
- **`configuration.md` fails silently.** Its `branch_template` table lists `{{.ID}}`, `{{.Title}}`, `{{.Slug}}`, `{{.BaseBranch}}` and friends; Liquid parses each, warns, and substitutes an empty string, so the published table has been rendering with blank cells.

Jekyll 3 has no `render_with_liquid: false`, so the raw wrapper is the mechanism available, and it is already this repository's convention.

## Not fixed here

`CHANGELOG.md` carries the same expressions and the same warnings. It is generated by Release Please and would lose any wrapper on the next release, so it is left alone. It is a latent risk: a future release note quoting an unbalanced `{{` would break the Pages build the same way.

## Test plan

- Verified against the failing run's log (`32878645837`) that `api.md` line 572 is the fatal Liquid exception.
- `pages-build-deployment` on master after merge is the real check.