### PR TITLE
Sign and notarize the macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,17 @@ name: Release
 # Tag-driven packaging (T4.5). Normally Release Please creates the tag and the
 # GitHub release; this workflow then uploads the signed artifacts to that
 # release, attaches native Linux packages, and publishes the stable Homebrew,
-# Scoop, and WinGet metadata. The build runs once on ubuntu
+# Scoop, and WinGet metadata. The build runs once on macOS
 # — the binaries are pure Go, so a build matrix would produce identical
 # artifacts three times — and the per-OS jobs afterwards smoke-test what it
 # produced, which is the part a single runner genuinely cannot do.
+#
+# macOS is the build runner because Apple's signature lives *inside* the Mach-O
+# and must be applied before the archives and checksums exist, and `codesign`,
+# `notarytool`, `stapler` and `pkgbuild` ship nowhere else (task 031).
+# GoReleaser's own `notarize:` block is Pro-only, and signing from Linux with a
+# third-party reimplementation was rejected in favour of Apple's toolchain. The
+# deb/rpm inspection that a macOS runner cannot do moved to `verify-packages`.
 on:
   push:
     tags: ["v*"]
@@ -28,12 +35,20 @@ permissions:
 # Dependabot updates pinned SHAs and their `# vX.Y.Z` comments together.
 jobs:
   release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    runs-on: macos-latest
+    # Notarization is a round trip to Apple's service, which usually answers in
+    # a few minutes and is entitled to take considerably longer.
+    timeout-minutes: 60
     permissions:
       contents: write # upload archives/packages and publish repository metadata
       id-token: write # keyless cosign + build attestations
       attestations: write
+    env:
+      # A v* tag must not be able to publish an unsigned macOS artifact; a dry
+      # run and a fork must not need a secret to work. This one variable is
+      # where that split lives — every signing step reads it, and nothing else
+      # decides it.
+      MACOS_SIGN_REQUIRED: ${{ github.event_name == 'push' && '1' || '0' }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
@@ -51,6 +66,100 @@ jobs:
       - id: meta
         shell: bash
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # Both identities land in a throwaway keychain created for this job: the
+      # runner's login keychain is never touched, and the keychain dies with the
+      # runner. The identity names are read back from the imported certificates
+      # rather than carried as secrets of their own, so rotating a certificate
+      # does not mean editing a workflow.
+      - name: Import the Developer ID identities
+        shell: bash
+        env:
+          MACOS_CERT_APPLICATION_P12: ${{ secrets.MACOS_CERT_APPLICATION_P12 }}
+          MACOS_CERT_INSTALLER_P12: ${{ secrets.MACOS_CERT_INSTALLER_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MACOS_CERT_APPLICATION_P12:-}" ] || [ -z "${MACOS_CERT_INSTALLER_P12:-}" ]; then
+            if [ "$MACOS_SIGN_REQUIRED" = "1" ]; then
+              echo "::error::a v* tag needs the Developer ID certificates; see RELEASING.md"
+              exit 1
+            fi
+            echo "::warning::no Developer ID certificates configured — this run produces unsigned macOS artifacts"
+            exit 0
+          fi
+
+          keychain="$RUNNER_TEMP/vincent-signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          # Prepend rather than replace: dropping the login keychain from the
+          # search list breaks unrelated tooling on the runner.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+
+          import_p12() {
+            p12="$RUNNER_TEMP/$1.p12"
+            printf '%s' "$2" | base64 --decode > "$p12"
+            security import "$p12" -k "$keychain" -P "${MACOS_CERT_PASSWORD:-}" \
+              -T /usr/bin/codesign -T /usr/bin/pkgbuild -T /usr/bin/productsign
+            rm -f "$p12"
+          }
+          import_p12 application "$MACOS_CERT_APPLICATION_P12"
+          import_p12 installer "$MACOS_CERT_INSTALLER_P12"
+          # Without this, codesign and pkgbuild block on a GUI keychain prompt
+          # that a headless runner can never answer.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_password" "$keychain" >/dev/null
+
+          # awk deliberately reads to EOF and bash takes the first line: an awk
+          # that `exit`s mid-pipe would SIGPIPE `security`, and pipefail would
+          # then fail the step over a success.
+          application="$(security find-identity -v -p codesigning "$keychain" |
+            awk -F'"' '/Developer ID Application/ {print $2}')"
+          installer="$(security find-identity -v "$keychain" |
+            awk -F'"' '/Developer ID Installer/ {print $2}')"
+          application="${application%%$'\n'*}"
+          installer="${installer%%$'\n'*}"
+          [ -n "$application" ] || { echo "::error::no Developer ID Application identity in the imported certificate"; exit 1; }
+          [ -n "$installer" ] || { echo "::error::no Developer ID Installer identity in the imported certificate"; exit 1; }
+
+          {
+            echo "MACOS_KEYCHAIN=$keychain"
+            echo "MACOS_SIGN_IDENTITY=$application"
+            echo "MACOS_INSTALLER_IDENTITY=$installer"
+          } >> "$GITHUB_ENV"
+
+      # notarytool authenticates with an App Store Connect API key, not an Apple
+      # ID and app-specific password: the key is revocable on its own and needs
+      # no interactive two-factor step.
+      - name: Store the notarization credentials
+        shell: bash
+        env:
+          MACOS_NOTARY_KEY_P8: ${{ secrets.MACOS_NOTARY_KEY_P8 }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MACOS_NOTARY_KEY_P8:-}" ] || [ -z "${MACOS_KEYCHAIN:-}" ]; then
+            if [ "$MACOS_SIGN_REQUIRED" = "1" ]; then
+              echo "::error::a v* tag needs the App Store Connect notary key; see RELEASING.md"
+              exit 1
+            fi
+            echo "::warning::no notary credentials configured — this run produces un-notarized macOS artifacts"
+            exit 0
+          fi
+
+          key="$RUNNER_TEMP/notary-key.p8"
+          printf '%s' "$MACOS_NOTARY_KEY_P8" | base64 --decode > "$key"
+          xcrun notarytool store-credentials vincent-notary \
+            --key "$key" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER_ID" \
+            --keychain "$MACOS_KEYCHAIN"
+          rm -f "$key"
+          echo "MACOS_NOTARY_PROFILE=vincent-notary" >> "$GITHUB_ENV"
 
       - name: Release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
@@ -73,6 +182,106 @@ jobs:
           # snapshot mode renders manifests but never uses the credentials.
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN || 'unset' }}
           WINGET_TOKEN: ${{ secrets.WINGET_TOKEN || 'unset' }}
+          # MACOS_SIGN_IDENTITY and MACOS_KEYCHAIN reach the darwin build hook
+          # through $GITHUB_ENV; MACOS_SIGN_REQUIRED is the job-level split.
+
+      # The archives were assembled around these binaries, so verifying the
+      # binary verifies what shipped.
+      - name: Verify the darwin signatures
+        if: env.MACOS_SIGN_IDENTITY != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          signed=0
+          while IFS= read -r binary; do
+            codesign --verify --strict --verbose=2 "$binary"
+            # bash's own regex, not a pipe into `grep -q`: grep exits at the
+            # first match, codesign takes SIGPIPE, and pipefail then reports a
+            # failure that never happened.
+            signature="$(codesign --display --verbose=2 "$binary" 2>&1)"
+            [[ "$signature" =~ flags=[^[:space:]]*runtime ]] ||
+              { echo "$binary is signed without the hardened runtime"; exit 1; }
+            signed=$((signed + 1))
+          done < <(find dist -type f -name vincent -path '*_darwin_*')
+          [ "$signed" -eq 2 ] || { echo "expected 2 signed darwin binaries, found $signed"; exit 1; }
+
+      # Notarization does not modify the artifact — the ticket is issued against
+      # the binary's code directory hash and served by Apple — so this runs
+      # after archiving, and only its success gates publication. A bare Mach-O
+      # cannot be submitted directly; notarytool takes a zip, a .pkg or a .dmg.
+      - name: Notarize the darwin binaries
+        if: env.MACOS_NOTARY_PROFILE != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging="$RUNNER_TEMP/notarize"
+          rm -rf -- "$staging"
+          while IFS= read -r binary; do
+            target="$(basename "$(dirname "$binary")")"
+            mkdir -p "$staging/$target"
+            cp "$binary" "$staging/$target/vincent"
+          done < <(find dist -type f -name vincent -path '*_darwin_*')
+          ditto -c -k --keepParent "$staging" "$RUNNER_TEMP/vincent-darwin.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/vincent-darwin.zip" \
+            --keychain-profile "$MACOS_NOTARY_PROFILE" \
+            --keychain "$MACOS_KEYCHAIN" \
+            --wait
+
+      # The universal .pkg: the one artifact that can carry a stapled ticket and
+      # therefore clear Gatekeeper with no network. Built after GoReleaser
+      # because lipo needs both darwin slices, which is also why it is not in
+      # checksums.txt — see the script's own header.
+      - name: Build the macOS installer package
+        shell: bash
+        run: ./scripts/macos-pkg.sh "$(jq -r .version dist/metadata.json)" dist
+
+      - name: Publish the macOS installer package
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/*.pkg --clobber
+
+      # Provenance for every archive, native Linux package and the macOS
+      # installer, so a downloader can prove which workflow and commit produced
+      # the file they hold. For the .pkg this is half of its integrity story —
+      # Apple's installer signature is the other half — because it is
+      # deliberately absent from checksums.txt.
+      - name: Attest build provenance
+        if: github.event_name == 'push'
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: "dist/*.tar.gz,dist/*.zip,dist/*.deb,dist/*.rpm,dist/*.pkg"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          # verify-packages inspects the generated manager metadata from a Linux
+          # runner, so the manifests travel in the artifact too.
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.deb
+            dist/*.rpm
+            dist/*.pkg
+            dist/checksums.txt
+            dist/winget/**/*.yaml
+            dist/scoop/vincent.json
+          retention-days: 7
+
+  # deb, rpm and the generated manager manifests, inspected with the native
+  # tools — `apt-get`, `dpkg-deb`, `rpm` and `rpm2archive`, none of which the
+  # macOS runner that now builds them has. Ordering is unchanged in any way that
+  # matters: this verification already ran after GoReleaser had published.
+  verify-packages:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
 
       - name: Install Linux package inspection tools
         run: |
@@ -138,25 +347,6 @@ jobs:
           grep -q '^    - PackageIdentifier: Git.Git$' "$winget_installer"
           grep -q '^License: PolyForm-Noncommercial-1.0.0$' "$winget_locale"
 
-      # Provenance for every archive and native Linux package, so a downloader
-      # can prove which workflow and commit produced the file they hold.
-      - name: Attest build provenance
-        if: github.event_name == 'push'
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
-        with:
-          subject-path: "dist/*.tar.gz,dist/*.zip,dist/*.deb,dist/*.rpm"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: |
-            dist/*.tar.gz
-            dist/*.zip
-            dist/*.deb
-            dist/*.rpm
-            dist/checksums.txt
-          retention-days: 7
-
   # The done-when: the produced artifact runs on each OS. Unpacking the real
   # archive and running the real binary is the only thing that catches a
   # broken archive layout, a missing execute bit, or a binary that will not
@@ -214,6 +404,25 @@ jobs:
           code=$?
           set -e
           [ "$code" -eq 2 ] || { echo "task ls with no daemon exited $code, want 2"; exit 1; }
+
+      # Gatekeeper's own verdict on the binary a user downloads. `download-artifact`
+      # does not carry extended attributes, so the quarantine flag a browser
+      # would have set is written back by hand: that makes this a strong proxy
+      # for the first-launch dialog, not a proof of it. The proof is a human
+      # walkthrough — docs/gates/031-macos-notarization.md.
+      - name: Assess the macOS signature
+        if: runner.os == 'macOS' && github.event_name == 'push'
+        shell: bash
+        run: |
+          set -euo pipefail
+          xattr -w com.apple.quarantine "0081;00000000;vincent-smoke;" out/vincent
+          codesign --verify --strict --verbose=2 out/vincent
+          signature="$(codesign --display --verbose=2 out/vincent 2>&1)"
+          [[ "$signature" =~ flags=[^[:space:]]*runtime ]] \
+            || { echo "the released binary lacks the hardened runtime"; exit 1; }
+          # Notarized but not stapled — a Mach-O has nowhere to hold a ticket —
+          # so this is the online check Gatekeeper performs on first launch.
+          spctl --assess --type execute -vv out/vincent
 
       - name: Verify checksum
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ name: Release
 #
 # macOS is the build runner because Apple's signature lives *inside* the Mach-O
 # and must be applied before the archives and checksums exist, and `codesign`,
-# `notarytool`, `stapler` and `pkgbuild` ship nowhere else (task 031).
+# `notarytool`, `stapler` and `pkgbuild` ship nowhere else (task 032).
 # GoReleaser's own `notarize:` block is Pro-only, and signing from Linux with a
 # third-party reimplementation was rejected in favour of Apple's toolchain. The
 # deb/rpm inspection that a macOS runner cannot do moved to `verify-packages`.
@@ -409,7 +409,7 @@ jobs:
       # does not carry extended attributes, so the quarantine flag a browser
       # would have set is written back by hand: that makes this a strong proxy
       # for the first-launch dialog, not a proof of it. The proof is a human
-      # walkthrough — docs/gates/031-macos-notarization.md.
+      # walkthrough — docs/gates/032-macos-notarization.md.
       - name: Assess the macOS signature
         if: runner.os == 'macOS' && github.event_name == 'push'
         shell: bash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@
 # CGO_ENABLED appears in the magefile or CI, so a three-OS *build* matrix would
 # buy nothing; the per-OS runners in release.yml exist only to smoke-test the
 # artifacts this produces (X decision). That runner is macos-latest as of task
-# 031 — `codesign` must run before the archives are built, and it exists
+# 032 — `codesign` must run before the archives are built, and it exists
 # nowhere else — but the single-runner shape the X decision chose is unchanged.
 version: 2
 
@@ -35,7 +35,7 @@ builds:
     # Developer ID signing has to happen here rather than in `signs:`, because
     # the signature lives *inside* the Mach-O: it must be applied before the
     # archive is assembled and before checksums.txt is computed, and a build
-    # hook is the only point that comes early enough (task 031). A build hook
+    # hook is the only point that comes early enough (task 032). A build hook
     # has no per-GOOS filter, so the script takes {{ .Os }} and no-ops for
     # linux and windows. It also no-ops, loudly, when no identity is present
     # and MACOS_SIGN_REQUIRED is unset — that is the fork/dry-run path.
@@ -134,7 +134,7 @@ homebrew_casks:
       name: goreleaser
       email: goreleaser@users.noreply.github.com
     commit_msg_template: "chore: vincent {{ .Tag }}"
-    # There is deliberately no `hooks.post.install` here. Until task 031 this
+    # There is deliberately no `hooks.post.install` here. Until task 032 this
     # cask ran `xattr -dr com.apple.quarantine`, which existed only because the
     # X decision descoped notarization: brew installs from the same archive, and
     # an unsigned quarantined binary will not start. The binaries in that
@@ -229,7 +229,7 @@ winget:
 
 # Keyless cosign: an OIDC identity from the workflow itself, verifiable
 # without vincent publishing or rotating a key. This is the supply-chain
-# signature and it is unchanged by task 031: Apple's Developer ID signature says
+# signature and it is unchanged by task 032: Apple's Developer ID signature says
 # who built the binary to *macOS*, cosign and the build attestation say which
 # workflow and commit produced the file to *anyone*. Windows Authenticode
 # remains descoped — §19 †'s 2026-08-26 amendment reverses the Apple half only,

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,11 @@
 # Release packaging (T4.5, spec §19 M4).
 #
-# Cross-compiled from a single ubuntu runner. modernc.org/sqlite is pure Go
-# and no CGO_ENABLED appears in the magefile or CI, so a three-OS *build*
-# matrix would buy nothing; the per-OS runners in release.yml exist only to
-# smoke-test the artifacts this produces (X decision).
+# Cross-compiled from a single runner. modernc.org/sqlite is pure Go and no
+# CGO_ENABLED appears in the magefile or CI, so a three-OS *build* matrix would
+# buy nothing; the per-OS runners in release.yml exist only to smoke-test the
+# artifacts this produces (X decision). That runner is macos-latest as of task
+# 031 — `codesign` must run before the archives are built, and it exists
+# nowhere else — but the single-runner shape the X decision chose is unchanged.
 version: 2
 
 project_name: vincent
@@ -30,6 +32,17 @@ builds:
       - -X github.com/lezli01/vincent/internal/version.commit={{.ShortCommit}}
       - -X github.com/lezli01/vincent/internal/version.date={{.CommitDate}}
     mod_timestamp: "{{ .CommitTimestamp }}"
+    # Developer ID signing has to happen here rather than in `signs:`, because
+    # the signature lives *inside* the Mach-O: it must be applied before the
+    # archive is assembled and before checksums.txt is computed, and a build
+    # hook is the only point that comes early enough (task 031). A build hook
+    # has no per-GOOS filter, so the script takes {{ .Os }} and no-ops for
+    # linux and windows. It also no-ops, loudly, when no identity is present
+    # and MACOS_SIGN_REQUIRED is unset — that is the fork/dry-run path.
+    hooks:
+      post:
+        - cmd: ./scripts/macos-sign.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
 
 # cmd/fakeagent is deliberately absent: it is test scaffolding compiled by
 # ./... and must never ship in a release archive.
@@ -121,16 +134,13 @@ homebrew_casks:
       name: goreleaser
       email: goreleaser@users.noreply.github.com
     commit_msg_template: "chore: vincent {{ .Tag }}"
-    # The X decision descoped Apple notarization, so a downloaded binary is
-    # quarantined and Gatekeeper refuses it. brew installs from the same
-    # unsigned archive, so the cask must strip the attribute itself or
-    # `brew install` would produce a binary that will not run.
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/vincent"]
-          end
+    # There is deliberately no `hooks.post.install` here. Until task 031 this
+    # cask ran `xattr -dr com.apple.quarantine`, which existed only because the
+    # X decision descoped notarization: brew installs from the same archive, and
+    # an unsigned quarantined binary will not start. The binaries in that
+    # archive are now Developer ID signed and notarized, so Gatekeeper clears
+    # them on its own. Stripping the attribute after paying for notarization
+    # would go on bypassing exactly the protection that was bought.
     # `vincent service install` writes a LaunchAgent (internal/service:
     # LaunchdName). Without this, `brew uninstall` would delete the binary out
     # from under a still-loaded launchd job that holds the SQLite file open.
@@ -218,10 +228,12 @@ winget:
     commit_msg_template: "{{ .PackageIdentifier }}: {{ .Tag }}"
 
 # Keyless cosign: an OIDC identity from the workflow itself, verifiable
-# without vincent publishing or rotating a key. Authenticode and Apple
-# notarization are recurring certificate costs v1 does not take on — §19's ‡
-# note records that descope, and the README documents the SmartScreen and
-# Gatekeeper prompts a user will therefore meet.
+# without vincent publishing or rotating a key. This is the supply-chain
+# signature and it is unchanged by task 031: Apple's Developer ID signature says
+# who built the binary to *macOS*, cosign and the build attestation say which
+# workflow and commit produced the file to *anyone*. Windows Authenticode
+# remains descoped — §19 †'s 2026-08-26 amendment reverses the Apple half only,
+# and the README still documents the SmartScreen prompt a user will meet.
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"
@@ -284,7 +296,22 @@ release:
     sha256sum -c checksums.txt --ignore-missing
     ```
 
-    First launch prompts on macOS (Gatekeeper) and Windows (SmartScreen):
-    the binaries carry cosign signatures and build attestations, not OS code
-    signing. See the README for the exact steps, including
-    `xattr -d com.apple.quarantine`.
+    The macOS binaries are Developer ID signed and notarized, so Gatekeeper
+    clears them without a prompt and without clearing any attribute by hand:
+
+    ```sh
+    codesign --verify --strict --verbose=2 vincent
+    spctl --assess --type execute -vv vincent
+    ```
+
+    `vincent_*_darwin_universal.pkg` is the stapled installer — signed,
+    notarized and verifiable with no network — and is covered by its Apple
+    signature and a build attestation rather than by `checksums.txt`:
+
+    ```sh
+    pkgutil --check-signature vincent_*_darwin_universal.pkg
+    spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+    ```
+
+    Windows still prompts (SmartScreen): these releases are not
+    Authenticode-signed. *More info → Run anyway*, once per binary.

--- a/README.md
+++ b/README.md
@@ -242,12 +242,16 @@ then `vincent service install` needs no elevation again.
 brew install lezli01/tap/vincent
 ```
 
-The cask clears the quarantine attribute for you, so the Gatekeeper prompt
-described below does not apply to this path. Upgrades are `brew upgrade
-vincent`; `brew uninstall --zap vincent` also removes the LaunchAgent and
+The binary it installs is Developer ID signed and notarized, like every other
+macOS artifact here, so Gatekeeper opens it without a prompt. Upgrades are `brew
+upgrade vincent`; `brew uninstall --zap vincent` also removes the LaunchAgent and
 `~/Library/Application Support/vincent` (config, database, transcripts).
 
 Homebrew casks are macOS-only — on Linuxbrew, use the archive below.
+
+Or install `vincent_*_darwin_universal.pkg` from the
+[latest release](https://github.com/lezli01/vincent/releases/latest) — one
+universal, stapled installer for both architectures, which works offline.
 
 ### WinGet or Scoop (Windows)
 
@@ -314,18 +318,18 @@ reproducible against a published checksum:
 go install github.com/lezli01/vincent/cmd/vincent@latest
 ```
 
-**First launch will be flagged.** Releases carry cosign signatures, checksums
-and GitHub build attestations, but not OS code signing — Authenticode and
-Apple notarization are recurring certificate costs this project does not take
-on. So:
+**First launch.** Releases carry cosign signatures, checksums and GitHub build
+attestations everywhere; macOS artifacts additionally carry Apple code signing,
+Windows ones do not. So:
 
-- **macOS** shows "cannot be opened because it is from an unidentified
-  developer" — for a downloaded archive, not for `brew install`. Clear the
-  quarantine attribute once:
-  ```sh
-  xattr -d com.apple.quarantine /usr/local/bin/vincent
-  ```
-- **Windows** shows a SmartScreen prompt: *More info → Run anyway*.
+- **macOS** — nothing to do. The binaries and the `.pkg` are Developer ID
+  signed under the hardened runtime and notarized, so Gatekeeper opens them.
+  Do not run `xattr -d com.apple.quarantine`; it is no longer needed, and it
+  only disables the check that would catch a tampered file. Confirm with
+  `codesign --verify --strict --verbose=2` and `spctl --assess --type execute`.
+- **Windows** shows a SmartScreen prompt: *More info → Run anyway*. Releases are
+  not Authenticode-signed — an OV certificate on a hardware token is a recurring
+  purchase this project does not take on.
 
 To verify a download instead of trusting it:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,11 +4,18 @@ Releases are **Release Please-driven**. Conventional Commits on `master` keep a
 release pull request current. Merging that pull request makes Release Please
 create the `vMAJOR.MINOR.PATCH` tag and GitHub release; that tag triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which uses
-[`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, checksum, sign, attest,
-upload, smoke-test on all three OSes, build deb/rpm packages, update the stable
+[`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, codesign and notarize
+the macOS binaries, checksum, sign, attest, upload, smoke-test on all three
+OSes, build deb/rpm packages and the macOS installer package, update the stable
 Homebrew and Scoop metadata, and submit the stable WinGet manifest. There
 is no manual tag or upload step, and no artifact is built on a maintainer's
 machine.
+
+The build job runs on **macOS**, not Linux: Apple's signature lives inside the
+Mach-O and has to be applied before the archives and `checksums.txt` exist, and
+`codesign`, `notarytool`, `stapler` and `pkgbuild` ship nowhere else (task 032).
+The deb/rpm and manifest inspection therefore runs in its own `verify-packages`
+job on ubuntu.
 
 Only a maintainer with push access can cut a release.
 
@@ -24,7 +31,8 @@ destinations. That proves the content, not publication. Do not merge a release
 change that names a missing destination: the next stable tag would discover it
 after the GitHub release already exists.
 
-Four secrets are required.
+Ten secrets are required: four publishing credentials, and six for Apple code
+signing.
 
 | Secret | Scope and permissions | Why it exists |
 |---|---|---|
@@ -32,16 +40,82 @@ Four secrets are required.
 | `HOMEBREW_TAP_TOKEN` | Fine-grained PAT selecting only [`lezli01/homebrew-tap`](https://github.com/lezli01/homebrew-tap), with **Contents: read and write** | `GITHUB_TOKEN` and the Release Please PAT are scoped to this repository; pushing the cask is a cross-repo write. |
 | `SCOOP_BUCKET_TOKEN` | Fine-grained PAT selecting only `lezli01/scoop-bucket`, with **Contents: read and write** | Push the stable `vincent.json` manifest to the bucket root. |
 | `WINGET_TOKEN` | Dedicated classic PAT with **`public_repo`** | Push a version branch to `lezli01/winget-pkgs` and open its pull request against `microsoft/winget-pkgs`. GitHub cannot express that cross-owner PR as a fine-grained token scoped only to the fork. |
+| `MACOS_CERT_APPLICATION_P12` | base64 of a `.p12` holding the **Developer ID Application** certificate and its private key | Signs each darwin binary in a GoReleaser build hook, before the archive and the checksum exist. |
+| `MACOS_CERT_INSTALLER_P12` | base64 of a `.p12` holding the **Developer ID Installer** certificate and its private key | Signs `vincent_*_darwin_universal.pkg`. A different certificate type: an Application identity cannot sign an installer, and vice versa. |
+| `MACOS_CERT_PASSWORD` | The export password used for **both** `.p12` files | Keychain Access requires one when exporting; export both with the same password so one secret covers them. |
+| `MACOS_NOTARY_ISSUER_ID` | App Store Connect API **Issuer ID** (a UUID) | `notarytool` authenticates with an API key rather than an Apple ID and app-specific password, so no interactive two-factor step is involved and the key is revocable on its own. |
+| `MACOS_NOTARY_KEY_ID` | App Store Connect API **Key ID** | The identifier of the key below. |
+| `MACOS_NOTARY_KEY_P8` | base64 of the App Store Connect API `.p8` private key | Apple lets you download this file exactly once. Keep an offline copy or you will be generating a new key. |
 
 Nothing else needs a secret: cosign signs keylessly with the packaging
-workflow's OIDC identity.
+workflow's OIDC identity, and the two signing *identity names* are read back
+from the imported certificates rather than stored, so rotating a certificate
+does not mean editing the workflow.
+
+### Bootstrapping the Apple credentials
+
+Prerequisite: an **Apple Developer Program** membership (~$99/yr). §19 †'s
+2026-08-26 amendment records accepting that cost for macOS and declining the
+Windows equivalent.
+
+1. In Xcode or on the developer portal, create two certificates for the team:
+   **Developer ID Application** and **Developer ID Installer**.
+2. In *Keychain Access → My Certificates*, export each one — the certificate
+   **with** its private key — as a `.p12`, using the same password for both.
+3. In App Store Connect → *Users and Access → Integrations → Keys*, create an
+   API key with the **Developer** role and download its `.p8`. Note the Key ID
+   and the Issuer ID shown on that page.
+4. Install the six secrets:
+
+   ```sh
+   base64 < DeveloperIDApplication.p12 |
+     gh secret set MACOS_CERT_APPLICATION_P12 --repo lezli01/vincent
+   base64 < DeveloperIDInstaller.p12 |
+     gh secret set MACOS_CERT_INSTALLER_P12 --repo lezli01/vincent
+   gh secret set MACOS_CERT_PASSWORD --repo lezli01/vincent
+   base64 < AuthKey_XXXXXXXXXX.p8 |
+     gh secret set MACOS_NOTARY_KEY_P8 --repo lezli01/vincent
+   gh secret set MACOS_NOTARY_KEY_ID --repo lezli01/vincent
+   gh secret set MACOS_NOTARY_ISSUER_ID --repo lezli01/vincent
+   ```
+
+The release job imports both `.p12` files into a **throwaway keychain** created
+for that run under `$RUNNER_TEMP` and never touches the runner's login keychain;
+`notarytool store-credentials` writes its profile into the same keychain. The
+keychain dies with the runner.
+
+### Certificate rotation, expiry and revocation
+
+Developer ID certificates are valid for **five years**, and Apple issues a
+limited number per team — you cannot simply mint a fresh one each time.
+
+- **Rotation is the same four commands as the bootstrap.** Create the new
+  certificate, export it, and overwrite the two `.p12` secrets. Nothing else
+  changes: the workflow reads the identity name out of whatever certificate it
+  imports.
+- **Expiry does not invalidate what already shipped.** Every signature is made
+  with `--timestamp`, so Apple's timestamp server attests that the signature
+  predates the expiry, and already-notarized artifacts keep verifying forever.
+  What expiry breaks is the *next* release.
+- **Revoke a compromised identity at the developer portal, immediately**, and
+  revoke the App Store Connect key in *Users and Access → Integrations*.
+  Revocation is retroactive in a way expiry is not: macOS will refuse binaries
+  signed with a revoked certificate, including ones already released. That
+  means a revocation is a re-release, not just a secret rotation — cut a new
+  patch version signed with the replacement identity, and say so in its notes.
+- **Nothing prompts any of this.** Diary the certificate expiry dates the same
+  way the GitHub tokens below are diaried, i.e. not at all by the software.
 
 **Narrow scope is the default, not a claim that WinGet has one.** Release Please,
 Homebrew, and Scoop each have a single-repository token.
 `WINGET_TOKEN` is the exception: `public_repo` can change any public repository
 the account can write. Prefer a publisher bot account if that blast radius is
-not acceptable. Every credential is passed to the pinned GoReleaser action only
-for the tag-driven release job; none is available to pull-request workflows.
+not acceptable. Every credential is read only by the release workflow, which
+runs on a `v*` tag or a manual dispatch; none is available to pull-request
+workflows or to a fork. A dry run works with none of them present — the Apple
+steps warn and produce unsigned artifacts — while a `v*` tag with a missing
+certificate or notary key **fails**, which is what makes an unsigned stable
+release impossible rather than merely unlikely.
 
 Credentials created without expiration trade a silent standing secret for
 never failing a release on a surprise expiry. Nothing will prompt their
@@ -77,7 +151,8 @@ binary.
 The normal Release Please path creates stable releases. If a maintainer cuts an
 exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
 `skip_upload: auto` prevents it from moving the Homebrew, Scoop, or WinGet
-metadata. The prerelease still carries its deb and rpm assets on GitHub.
+metadata. The prerelease still carries its deb, rpm and macOS `.pkg` assets
+on GitHub, signed and notarized like any other tag.
 
 ## Cutting a release
 
@@ -123,9 +198,17 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    the archive contents changed since the last release. Actions → **Release** →
    *Run workflow*, leaving `dry_run` checked. That runs
    `release --snapshot --clean --skip=publish,sign` — real cross-compilation and
-   real archives/packages/manifests, published nowhere. The job inspects the
-   deb/rpm payloads and generated Scoop and WinGet metadata before it
-   uploads the `dist` artifact for a manual look.
+   real archives/packages/manifests, published nowhere. The `verify-packages`
+   job inspects the deb/rpm payloads and the generated Scoop and WinGet metadata
+   from the uploaded `dist` artifact, which is also there for a manual look.
+
+   A dry run run **from this repository** does sign and notarize, which is the
+   point: it proves the certificates and the notary key still work before a tag
+   commits you to them. A dry run run **from a fork**, where every secret
+   resolves to empty, instead warns and produces unsigned macOS binaries and an
+   unsigned `.pkg` — and must still finish green. That is the contributor path
+   and the regression test for the required/skip split; if a dry run ever needs
+   a secret to complete, the split has broken.
 
 5. **Merge the Release Please PR.** This is the release action. Release Please
    creates the tag and GitHub release; do not create or push the tag by hand.
@@ -133,15 +216,22 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
 6. **Watch both workflows.** `gh run watch`, or the Actions tab.
    - `Release Please` creates the tag and GitHub release from the merged release
      PR. The dedicated PAT makes that tag start the next workflow.
-   - `Release` runs GoReleaser, preserves Release Please's notes, builds and
-     signs the checksum, inspects deb/rpm payloads, attests every archive and
-     native package, uploads the artifacts to the existing GitHub release, and
-     updates Homebrew, Scoop, and the WinGet submission for a stable tag.
-     A prerelease skips all three manager publishers automatically.
+   - `Release` runs on macOS: it codesigns each darwin binary before archiving,
+     runs GoReleaser, preserves Release Please's notes, builds and signs the
+     checksum, notarizes the darwin binaries, builds/signs/notarizes/staples
+     `vincent_*_darwin_universal.pkg` and uploads it, attests every archive,
+     native package and the `.pkg`, uploads the artifacts to the existing GitHub
+     release, and updates Homebrew, Scoop, and the WinGet submission for a
+     stable tag. A prerelease skips all three manager publishers automatically.
+   - `verify-packages` (ubuntu) inspects the deb and rpm payloads and the
+     generated Scoop and WinGet metadata with the native tools.
    - `smoke` (one job per OS) downloads the **real published archive**, unpacks
      it, asserts `vincent version` reports the tag rather than `dev`, runs
      `vincent workflow validate` and checks that `vincent task ls` exits 2 with
-     no daemon running, then verifies the archive against `checksums.txt`.
+     no daemon running, then verifies the archive against `checksums.txt`. The
+     macOS leg additionally writes a synthetic `com.apple.quarantine` attribute
+     and asserts the binary still passes `codesign --verify` and
+     `spctl --assess`.
 
    A red `smoke` job means the release is published but the artifact is
    defective — treat it as an incident, not a flake, and go to
@@ -162,6 +252,21 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    gh attestation verify vincent_X.Y.Z_amd64.deb --repo lezli01/vincent
    ```
 
+   On a Mac, also check what Gatekeeper will check. The `.pkg` is the only
+   asset outside `checksums.txt`, so it is verified from Apple's signature and
+   its attestation instead:
+
+   ```sh
+   tar -xzf vincent_X.Y.Z_darwin_arm64.tar.gz
+   codesign --verify --strict --verbose=2 vincent
+   spctl --assess --type execute -vv vincent            # accepted, Notarized Developer ID
+
+   pkgutil --check-signature vincent_X.Y.Z_darwin_universal.pkg
+   spctl --assess --type install -vv vincent_X.Y.Z_darwin_universal.pkg
+   xcrun stapler validate vincent_X.Y.Z_darwin_universal.pkg
+   gh attestation verify vincent_X.Y.Z_darwin_universal.pkg --repo lezli01/vincent
+   ```
+
 8. **Check the Homebrew cask** (skip for a pre-release, which does not publish
    one). Confirm the tap got the new version and that it installs:
 
@@ -170,11 +275,14 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
    brew info lezli01/tap/vincent               # version must be the tag
    brew reinstall lezli01/tap/vincent
    vincent version
-   xattr -l "$(readlink -f "$(brew --prefix)/bin/vincent")"   # no com.apple.quarantine
+   spctl --assess --type execute -vv "$(readlink -f "$(brew --prefix)/bin/vincent")"
    ```
 
-   `com.apple.provenance` is expected and harmless; `com.apple.quarantine` is
-   not, and means the cask's `postflight` hook did not run.
+   The cask no longer carries a quarantine-stripping `postflight` hook — task
+   032 removed it — so what proves the install is Gatekeeper accepting the
+   binary, not the absence of an attribute. `com.apple.quarantine` being present
+   is fine and expected now; `spctl` reporting anything but `accepted` with
+   `source=Notarized Developer ID` is the failure.
 
 9. **Check the Windows and Linux channels** (skip for a pre-release).
 
@@ -227,12 +335,21 @@ metadata. The prerelease still carries its deb and rpm assets on GitHub.
   GitHub release, then updates Homebrew and Scoop and prepares the WinGet
   catalog PR for stable releases. mise consumes the GitHub archives directly
   and needs no publisher. Keeping artifact and manifest generation in one run
-  prevents channel checksums from drifting from the release they name.
-- **OS code signing.** Authenticode and Apple notarization are recurring
-  certificate costs the project does not currently take on — recorded as a
-  descope in spec §19.
-  Releases carry cosign signatures and build provenance instead, and the README
-  documents the SmartScreen and Gatekeeper prompts users will meet.
+  prevents channel checksums from drifting from the release they name. The one
+  asset it does **not** produce is `vincent_*_darwin_universal.pkg`: a universal
+  binary needs both darwin slices, which do not both exist until the build is
+  over, so `scripts/macos-pkg.sh` builds it afterwards and `gh release upload`
+  attaches it. That is also why it is absent from `checksums.txt` — its
+  integrity comes from Apple's installer signature and a build attestation.
+- **OS code signing is macOS-only, deliberately.** Apple Developer ID signing
+  and notarization are paid for and applied to every darwin artifact, including
+  a stapled universal `.pkg` — §19 †'s 2026-08-26 amendment records reversing
+  the Apple half of the original descope, and task 032 carries the reasoning.
+  **Windows Authenticode stays descoped**: an OV certificate on a hardware token
+  is a recurring purchase with no equivalent to Apple's single notary service,
+  so the README and `docs/platforms/windows.md` continue to document the
+  SmartScreen prompt users will meet. cosign signatures and build provenance are
+  unchanged on every platform and are not a substitute for either.
 - **External catalogs remain external.** Scoop updates a repository the
   maintainer controls. WinGet is a pull request into Microsoft's catalog and
   can remain pending after the GitHub release succeeds. The accepted

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ that is *not* true are stated rather than smoothed over.
 | Page | What it covers |
 |---|---|
 | [Windows](platforms/windows.md) | SmartScreen, `%APPDATA%`/`%LOCALAPPDATA%`, PowerShell command steps, the Scheduled Task, the one restricted-mode gap |
-| [macOS](platforms/macos.md) | Gatekeeper and quarantine, `~/Library/Application Support`, the LaunchAgent, `PATH` capture |
+| [macOS](platforms/macos.md) | Gatekeeper, the Developer ID signature and the stapled `.pkg`, `~/Library/Application Support`, the LaunchAgent, `PATH` capture |
 | [Linux](platforms/linux.md) | XDG directories, the systemd user unit, `loginctl enable-linger` |
 
 ## Reference

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
 | Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks, backup and restore |
-| Platforms | Windows, macOS, and Linux; Homebrew, WinGet, Scoop, mise, deb/rpm, and archives |
+| Platforms | Windows, macOS, and Linux; Homebrew, a signed and notarized macOS `.pkg`, WinGet, Scoop, mise, deb/rpm, and archives |
 
 ## Orchestrate work instead of terminals
 
@@ -215,14 +215,17 @@ vincent is one self-contained Go binary with no runtime, CGO dependency, or
 external database. Releases cover Windows, macOS, and Linux, and are published
 as archives plus platform-friendly packages:
 
-- Homebrew on macOS
+- Homebrew or a universal installer package on macOS
 - WinGet or Scoop on Windows
 - deb and rpm packages on Linux
 - mise or release archives on all platforms
 
 Release archives are checksummed, the checksum manifest is signed with cosign,
-and builds carry GitHub attestations. Platform-specific installation, service,
-shell, and restricted-mode differences are documented in
+and builds carry GitHub attestations. Every macOS artifact is additionally
+signed with an Apple Developer ID identity under the hardened runtime and
+notarized, and the `.pkg` is stapled, so Gatekeeper opens a downloaded release
+without a prompt and without a quarantine attribute to strip. Platform-specific
+installation, service, shell, and restricted-mode differences are documented in
 [Installation](getting-started/installation.md) and the
 [platform guides](README.md#platforms).
 

--- a/docs/gates/032-macos-notarization.md
+++ b/docs/gates/032-macos-notarization.md
@@ -1,0 +1,126 @@
+# Task 032 gate — macOS signing and notarization
+
+**Acceptance (task 032.7):** a real user downloading a real release on a real
+Mac sees **no** Gatekeeper dialog, and the `.pkg` installs with the network off.
+
+This gate has **no script**, deliberately, for the same reason
+`scripts/m3-gate.sh` seeds instead of asserting and
+[`017`](017-workflow-graph.md) has no script at all: what is being judged is
+what *macOS* does with a file that arrived over the network, and CI cannot
+produce that file. The release job already asserts everything a machine can —
+`codesign --verify --strict`, the hardened-runtime flag, `notarytool` exiting
+non-zero on rejection, `stapler validate`, `pkgutil --check-signature`, `spctl
+--assess --type install` — and the macOS smoke leg writes a *synthetic*
+`com.apple.quarantine` attribute because `actions/download-artifact` does not
+carry extended attributes. A synthetic attribute is a strong proxy for the
+first-launch dialog. It is not the dialog.
+
+Three things only a human on a clean machine can settle, and they are the three
+below.
+
+## Prerequisites
+
+- A Mac the release has **never** been installed on and that has never had
+  vincent's Developer ID certificate in a keychain. A machine that has built
+  vincent locally is not clean: a locally built binary is ad-hoc signed and is
+  never quarantined, so it proves nothing about the released one.
+- A published stable tag whose `Release` workflow went green **with the six
+  Apple secrets configured**. A dry run cannot be used here: it is designed to
+  produce unsigned artifacts when secrets are absent, so a green dry run is not
+  evidence of a working signature.
+- A browser. `curl` and `gh release download` do **not** set
+  `com.apple.quarantine`; Safari and Chrome do, and the quarantine attribute is
+  what makes Gatekeeper assess the file at all. Downloading any other way
+  silently tests nothing.
+
+## 1. The archive
+
+Download `vincent_X.Y.Z_darwin_arm64.tar.gz` (or `_amd64` on Intel) **in the
+browser**, from the release page. Then, in Terminal:
+
+```sh
+cd ~/Downloads
+xattr -p com.apple.quarantine vincent_*_darwin_arm64.tar.gz   # must print a value
+tar -xzf vincent_*_darwin_arm64.tar.gz
+xattr -p com.apple.quarantine vincent                          # inherited by the payload
+./vincent version
+```
+
+**Look for:** the version prints. **No dialog appears** — not "cannot be opened
+because it is from an unidentified developer", not "Apple could not verify…",
+and nothing that has to be dismissed in *System Settings → Privacy & Security*.
+
+If a dialog does appear, the gate has failed; do not clear the attribute to make
+it go away. Then confirm what Gatekeeper decided:
+
+```sh
+codesign --verify --strict --verbose=2 ./vincent
+spctl --assess --type execute -vv ./vincent
+```
+
+`spctl` must print `accepted` and `source=Notarized Developer ID`. `source=No
+Rules` or `source=Unnotarized Developer ID` is a failure even if the binary ran.
+
+## 2. The `.pkg`, offline
+
+This is the only leg that distinguishes the `.pkg` from the archive: its
+notarization ticket is **stapled** into the file, so it needs no network. Verify
+that by removing the network.
+
+Download `vincent_X.Y.Z_darwin_universal.pkg` in the browser, then:
+
+```sh
+pkgutil --check-signature vincent_*_darwin_universal.pkg
+spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+xcrun stapler validate vincent_*_darwin_universal.pkg
+```
+
+Now **turn Wi-Fi off and unplug Ethernet**, and only then:
+
+```sh
+sudo installer -pkg vincent_*_darwin_universal.pkg -target /
+/usr/local/bin/vincent version
+lipo -info /usr/local/bin/vincent        # x86_64 arm64
+```
+
+**Look for:** the install completes and the binary runs with no network and no
+dialog. Double-clicking the `.pkg` in Finder must open Installer's normal
+sheet — the one naming the developer — not a refusal.
+
+Repeat the *first* command of this section with the network still off; `stapler
+validate` succeeding offline is the whole claim.
+
+## 3. The cask, with its quarantine hook gone
+
+Task 032 removed `hooks.post.install`'s `xattr -dr com.apple.quarantine` from
+the cask. That hook was load-bearing before notarization, so this leg exists to
+prove it no longer is.
+
+```sh
+brew install lezli01/tap/vincent
+vincent version
+binary="$(readlink -f "$(brew --prefix)/bin/vincent")"
+spctl --assess --type execute -vv "$binary"
+```
+
+**Look for:** `brew install` completes and `vincent version` runs. `spctl`
+reports `accepted`, `source=Notarized Developer ID`.
+
+**Do not look for** the absence of `com.apple.quarantine` — that was the old
+criterion and it is now the wrong one. The attribute may well be present; what
+matters is that Gatekeeper accepts the file anyway, which is the difference
+between clearing the check and passing it.
+
+## Also confirm nothing moved on Windows
+
+Task 032 is macOS-only by decision, so the gate's last question is that nothing
+quietly changed elsewhere: on Windows, the SmartScreen prompt should still
+appear on first launch of a downloaded `vincent.exe`, and the documentation
+should still say so. A release that silently stopped prompting would mean
+something unintended happened, not an improvement.
+
+## Runs
+
+| Date | Version | macOS | Walked by | Result |
+|---|---|---|---|---|
+| — | — | — | — | not yet walked; blocked on 032.7 (Apple Developer Program enrolment and the six repository secrets) |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,12 +5,13 @@ and no database server — the store is an embedded SQLite file.
 
 - [What you need](#what-you-need)
 - [Homebrew (macOS)](#homebrew-macos)
+- [Installer package (macOS)](#installer-package-macos)
 - [WinGet (Windows)](#winget-windows)
 - [Scoop (Windows)](#scoop-windows)
 - [mise (all platforms)](#mise-all-platforms)
 - [deb and rpm (Linux)](#deb-and-rpm-linux)
 - [Download a release](#download-a-release)
-- [First launch is flagged](#first-launch-is-flagged)
+- [First launch](#first-launch)
 - [Verify a download](#verify-a-download)
 - [Install an agent CLI](#install-an-agent-cli)
 - [Confirm the install](#confirm-the-install)
@@ -40,9 +41,9 @@ Go is *not* required to run vincent — only to
 brew install lezli01/tap/vincent
 ```
 
-This is the shortest path on macOS, and the only one that does not make you
-clear the quarantine attribute by hand — the cask does it during install, so
-[First launch is flagged](#first-launch-is-flagged) does not apply here.
+This is the shortest path on macOS. The binary it installs is Developer ID
+signed and notarized like every other macOS artifact, so nothing has to clear a
+quarantine attribute — the cask used to, and deliberately no longer does.
 
 Homebrew casks are macOS-only. On Linuxbrew, use the archive below.
 
@@ -55,6 +56,37 @@ brew uninstall --zap vincent
 
 Plain `brew uninstall vincent` removes the binary and unloads the LaunchAgent
 but leaves `~/Library/Application Support/vincent` intact.
+
+## Installer package (macOS)
+
+Stable releases attach `vincent_{version}_darwin_universal.pkg`: one universal
+installer covering Apple silicon and Intel, which puts the binary at
+`/usr/local/bin/vincent`. Download it from the
+[latest release](https://github.com/lezli01/vincent/releases/latest) and
+double-click it, or:
+
+```sh
+sudo installer -pkg vincent_*_darwin_universal.pkg -target /
+vincent version
+```
+
+The package is signed with an Apple Developer ID Installer identity, notarized,
+and **stapled** — its notarization ticket travels inside the file, so it
+installs on a machine with no network. That is the one thing it does that the
+archive cannot; everything else here is equivalent. Verify it before installing:
+
+```sh
+pkgutil --check-signature vincent_*_darwin_universal.pkg
+spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+```
+
+The `.pkg` is deliberately absent from `checksums.txt` — it is built after the
+checksummed artifacts, from both of them — and carries Apple's installer
+signature plus a [build attestation](#verify-a-download) instead.
+
+To remove it, delete `/usr/local/bin/vincent` (after `vincent service
+uninstall`, if you registered the background service) and, if you also want the
+config, database and transcripts, `~/Library/Application Support/vincent`.
 
 ## WinGet (Windows)
 
@@ -188,24 +220,34 @@ vincent version
 Platform-specific detail lives in [Windows](../platforms/windows.md),
 [macOS](../platforms/macos.md) and [Linux](../platforms/linux.md).
 
-## First launch is flagged
+## First launch
 
-Releases carry cosign signatures, SHA-256 checksums and GitHub build
-attestations — but **not OS code signing**. Authenticode certificates and Apple
-notarization are recurring costs this project does not take on, so the first
-launch of a **downloaded archive** prompts. (Installing with
-[Homebrew](#homebrew-macos) avoids this — the cask clears the attribute for
-you.)
+Every release carries cosign signatures, SHA-256 checksums and GitHub build
+attestations. On top of those, macOS artifacts carry **Apple code signing**;
+Windows ones do not.
 
-- **macOS** — *"cannot be opened because it is from an unidentified developer"*.
-  Clear the quarantine attribute once:
+- **macOS** — nothing to do. The binaries and the `.pkg` are signed with an
+  Apple Developer ID identity under the hardened runtime and notarized, so
+  Gatekeeper clears them without a prompt. Do not run `xattr -d
+  com.apple.quarantine`: it is no longer needed, and it only turns off the check
+  that would tell you the file had been tampered with. Confirm the signature
+  yourself with:
 
   ```sh
-  xattr -d com.apple.quarantine /usr/local/bin/vincent
+  codesign --verify --strict --verbose=2 /usr/local/bin/vincent
+  spctl --assess --type execute -vv /usr/local/bin/vincent
   ```
 
+  Only the [`.pkg`](#installer-package-macos) is *stapled*, so it is the one
+  artifact whose first launch also works with no network — a bare binary has
+  nowhere to hold a notarization ticket, and Gatekeeper fetches its verdict from
+  Apple instead.
+
 - **Windows** — SmartScreen shows *"Windows protected your PC"*. Choose
-  **More info → Run anyway**. It appears once per binary.
+  **More info → Run anyway**. It appears once per binary. Releases are not
+  Authenticode-signed: an OV certificate on a hardware token is a recurring
+  purchase with no equivalent to Apple's single notary service, and this project
+  does not take it on.
 
 - **Linux** — nothing to clear. Make sure the file is executable
   (`chmod +x vincent`) if your extraction tool dropped the bit.
@@ -235,6 +277,23 @@ attestation. For example:
 ```sh
 gh attestation verify vincent_*_linux_amd64.tar.gz --repo lezli01/vincent
 ```
+
+The macOS `.pkg` is the one asset outside `checksums.txt`, so it is verified
+from its own two signatures — Apple's, and the attestation:
+
+```sh
+pkgutil --check-signature vincent_*_darwin_universal.pkg
+gh attestation verify vincent_*_darwin_universal.pkg --repo lezli01/vincent
+```
+
+The three signatures answer different questions, which is why all three exist.
+**cosign** says which GitHub Actions workflow, at which commit, produced the
+file — to anyone, with no vincent key to trust or rotate. The **build
+attestation** says the same thing in the format `gh` and `mise` check
+automatically. **Apple's Developer ID signature plus notarization** says to
+*macOS itself* that a known developer built this and Apple scanned it, which is
+what makes Gatekeeper open it. None of them substitutes for another, and no
+Windows equivalent of the third exists here.
 
 ## Install an agent CLI
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -17,6 +17,10 @@ Apple silicon and Intel are both released and both exercised in CI.
 brew install lezli01/tap/vincent
 ```
 
+Or double-click `vincent_*_darwin_universal.pkg` from the release page — one
+universal installer for both architectures, putting the binary at
+`/usr/local/bin/vincent`.
+
 Or unpack the release archive by hand:
 
 ```sh
@@ -31,23 +35,38 @@ detail, including signature verification:
 
 ## Gatekeeper
 
-**This applies to the archive, not to `brew install`** — the cask clears the
-quarantine attribute during install, which is the main reason to prefer it here.
+**There is nothing to do.** Every macOS artifact — the binaries inside both
+archives, and the `.pkg` — is signed with an Apple Developer ID identity under
+the hardened runtime, and notarized by Apple. Gatekeeper clears a downloaded
+release on its own, so there is no *"cannot be opened because it is from an
+unidentified developer"* dialog and no quarantine attribute to strip.
 
-First launch of a downloaded binary shows *"vincent cannot be opened because it
-is from an unidentified developer"*. Releases carry cosign signatures, SHA-256
-checksums and GitHub build attestations, but not **Apple notarization**, which is
-a recurring cost this project does not take on.
+If you have older instructions that say to run `xattr -d com.apple.quarantine`,
+delete them. Stripping the attribute now only turns off the check that would
+have told you the file had been tampered with.
 
-Clear the quarantine attribute once:
+Check for yourself, on the binary you are about to run:
 
 ```sh
-xattr -d com.apple.quarantine /usr/local/bin/vincent
+codesign --verify --strict --verbose=2 /usr/local/bin/vincent
+spctl --assess --type execute -vv /usr/local/bin/vincent
 ```
 
-If `xattr` reports the attribute is absent, the file was never quarantined and
-there is nothing to do. `com.apple.provenance` is unrelated — macOS adds it to
-everything and it does not block execution.
+`spctl` should report `accepted` with `source=Notarized Developer ID`. That
+check reaches Apple over the network: the ticket for a bare binary is served by
+Apple rather than carried inside it, because a Mach-O has nowhere to staple one.
+
+The **`.pkg` is stapled**, which is the one thing it does that the archive
+cannot: its ticket travels inside the file, so a first launch works on a machine
+that is offline or behind a filtered network. Verify it before installing with:
+
+```sh
+pkgutil --check-signature vincent_*_darwin_universal.pkg
+spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+```
+
+`com.apple.provenance` is unrelated — macOS adds it to everything and it does
+not block execution.
 
 ## Directories
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4324,6 +4324,37 @@ per-user service. External bootstrap and first-release proof are tracked in
 `docs/tasks/021-package-distribution-channels.md`; documentation must not infer
 catalog availability from a successful local manifest render.
 
+**Amended 2026-08-26 — macOS OS code signing is accepted; Windows Authenticode
+is not.** This reverses the **Apple half** of the † descope above, and it
+supersedes the 2026-08-14 amendment's "the binaries are still not notarized …
+so the `xattr` instructions stay". The ~$99/yr Apple Developer Program cost that
+the descope priced correctly is now paid, in exchange for a macOS install path
+that clears Gatekeeper on its own rather than by stripping the quarantine
+attribute — which the cask had been doing, and no longer does. Darwin binaries
+are `codesign`ed with a Developer ID Application identity under the hardened
+runtime and a secure timestamp, inside a build hook so the signature is in the
+Mach-O before archiving and before `checksums.txt`; those binaries are notarized;
+and a new universal `vincent_*_darwin_universal.pkg`, signed with a Developer ID
+Installer identity, is notarized and **stapled**, which is the only artifact here
+that can carry a ticket and therefore the only one that clears Gatekeeper
+offline. **The direct-download macOS path now meets Gatekeeper**: neither
+`xattr -d com.apple.quarantine` nor `brew`'s former `postflight` hook is part of
+any documented install, and re-adding either would bypass the protection just
+bought. Windows Authenticode remains descoped for exactly the reasons the X
+decision gave — an OV certificate on a hardware token is a recurring purchase
+with no equivalent to Apple's single notary service — so §19's SmartScreen
+wording, `docs/platforms/windows.md` and the WinGet installation notes are
+unchanged. A Microsoft Store MSIX was weighed as a way to obtain a
+Microsoft-applied signature without buying a certificate, and rejected in the
+same session. The release job consequently builds on `macos-latest`
+(`codesign`/`notarytool`/`stapler`/`pkgbuild` exist nowhere else, and
+GoReleaser's own `notarize:` block is Pro-only); the single-runner shape the X
+decision chose survives. The `.pkg` is deliberately **not** in `checksums.txt` —
+it is built after the GoReleaser run, because a universal binary needs both
+darwin slices — and is covered by Apple's installer signature plus a GitHub
+build attestation instead. Reasoning and the external enrolment blocker are in
+`docs/tasks/032-macos-notarization.md`.
+
 **M4's acceptance is met, 2026-08-11.** The T4.6 walkthrough ran on a clean VM
 per OS with no Go toolchain, against the `v0.1.0-rc1` artifacts: **5:00** on
 Windows 11, **4:30** on macOS, **3:35** on Linux — every run under half the

--- a/docs/tasks/002-homebrew-tap.md
+++ b/docs/tasks/002-homebrew-tap.md
@@ -28,6 +28,15 @@ it beat.
   "download, unzip, clear the quarantine attribute, run", and that is the step
   worth deleting.
 
+  **Partly superseded 2026-08-26 by [task 032](032-macos-notarization.md).** The
+  tap itself stands; what no longer holds is the *reason* recorded above. Apple
+  notarization is no longer descoped, so the archive path does not make anyone
+  run `xattr -d com.apple.quarantine` and the cask's `postflight` hook has been
+  removed rather than left harmless — keeping it would go on stripping the
+  attribute that the signature now makes meaningful. The quickstart really is
+  "download, unzip, run" again on macOS; the cask earns its keep on upgrades and
+  one-command install, which is the argument the X decision originally weighed.
+
 - **Scoop and winget stay rejected.** The argument above does not carry over: no
   Windows packager erases SmartScreen the way a cask erases Gatekeeper's prompt,
   so Windows would pay the X decision's cost and get only a shorter command. The

--- a/docs/tasks/032-macos-notarization.md
+++ b/docs/tasks/032-macos-notarization.md
@@ -1,0 +1,176 @@
+# 032 — macOS Developer ID signing and notarization
+
+**Status:** ⚠ verification blocked (5/7) · **Opened:** 2026-08-26
+
+macOS artifacts are signed with an Apple Developer ID identity, notarized, and —
+for a new universal `.pkg` — stapled, so a downloaded release clears Gatekeeper
+on its own. The Homebrew cask's quarantine-stripping hook goes away, because it
+existed only to work around not having done this.
+
+[Issue #150](https://github.com/lezli01/vincent/issues/150) asked for this *and*
+for Windows Authenticode. **Windows is dropped from this task's scope by the
+owner**, 2026-08-26, and §19 †'s Authenticode descope stays in force unamended.
+
+Conventions for this file are in [the tasks README](README.md). Behaviour lands
+in [the spec](../spec.md) as dated amendments, in the same PR as the release
+configuration and user documentation.
+
+## Decisions (2026-08-26)
+
+- **This explicitly reverses the Apple half of the v0 X packaging decision**
+  ([`docs/history/v0-tasks.md`](../history/v0-tasks.md), *Packaging (X)*,
+  2026-08-10: "**Signing is descoped** … Authenticode and Apple notarization are
+  recurring cert purchases (~$99/yr Apple Developer ID, hardware-token OV for
+  Windows) that v1 does not make"), and the 2026-08-14 amendment to §19 † that
+  kept the `xattr` instructions on the grounds that "the binaries are still not
+  notarized". X priced the cost correctly and it is not being argued away: the
+  ~$99/yr Apple Developer Program membership is now **paid**, in exchange for a
+  macOS install path that clears Gatekeeper rather than one that bypasses it.
+  The alternative it beat is the status quo — telling every macOS user to run
+  `xattr -d com.apple.quarantine`, which is instructing them to disable the
+  check that would catch a tampered download.
+
+- **Windows Authenticode is dropped, not deferred to the end of this task.** The
+  same session weighed it and declined: an OV certificate lives on a hardware
+  token, is a recurring purchase, and has no equivalent to Apple's single notary
+  service that would let one CI job produce a signature. A **Microsoft Store
+  MSIX** was weighed as a way to obtain a Microsoft-applied signature without
+  buying a certificate, and rejected too. Consequently *no* Windows file changes
+  in this task: `docs/platforms/windows.md`, the WinGet `installation_notes`,
+  the README's SmartScreen sentence and the release footer's Windows wording all
+  keep their current text, and the issue's Authenticode acceptance criterion is
+  recorded as dropped rather than as met.
+
+- **The release job moves to `macos-latest`.** Signing must happen *before*
+  archiving — the signature lives inside the Mach-O, so a hook that ran later
+  would sign a binary the archive and `checksums.txt` no longer describe — and
+  `codesign`, `notarytool`, `stapler` and `pkgbuild` exist only on macOS.
+  GoReleaser's native `notarize:` block is Pro-only (its own CI examples specify
+  `distribution: goreleaser-pro`). Signing from Linux with `rcodesign` or
+  `quill` was rejected in favour of Apple's own toolchain: a third-party
+  reimplementation of the format Gatekeeper checks is the wrong place to save a
+  runner. The X decision's single-runner shape survives — it is still **one**
+  build runner, and the per-OS runners still only smoke-test what it produced.
+
+- **The deb/rpm inspection moves to its own ubuntu `verify-packages` job.** The
+  step used `apt-get`, `dpkg-deb`, `rpm` and `rpm2archive`, none of which a
+  macOS runner has. It now consumes the uploaded `dist` artifact, which
+  therefore had to start carrying `dist/winget/*.yaml` and
+  `dist/scoop/vincent.json` too. Nothing that matters about ordering changed:
+  that verification already ran after GoReleaser had published.
+
+- **The `.pkg` is built after the GoReleaser run and is not in
+  `checksums.txt`.** Getting it into the checksum file would mean producing it
+  inside a build hook, before both architectures are guaranteed built, or adding
+  a `darwin_all` archive via `universal_binaries` — a seventh release archive
+  that would perturb the cask and every install document. Instead
+  `scripts/macos-pkg.sh` runs in the same macOS job afterwards, `gh release
+  upload` attaches it, and it is added to `actions/attest-build-provenance`'s
+  `subject-path`. Its integrity story is Apple's own installer signature plus
+  the build attestation, which is *stronger* than a line in a checksum file, and
+  `docs/getting-started/installation.md`'s claim that `checksums.txt` covers
+  "every archive, deb, and rpm" stays literally true.
+
+- **A missing identity fails a tag build and no-ops a dry run.** Both scripts
+  require the identity when the workflow passes `MACOS_SIGN_REQUIRED=1` — set on
+  `push` to a `v*` tag — and skip with a warning otherwise. This is what keeps
+  `workflow_dispatch` dry runs and fork runs working with no secrets at all, the
+  same property the existing placeholder-token fallbacks give the publishers,
+  while making an unsigned stable release **impossible** rather than merely
+  unlikely.
+
+- **The `.pkg` installs `/usr/local/bin/vincent` under `dev.lezli01.vincent`** —
+  the identifier `internal/service` already uses for the LaunchAgent, and a path
+  that is stable across upgrades, so task 021's recorded-executable-path
+  decision needs nothing from this task. There are **no Go source changes** in
+  it at all.
+
+- **The cask's quarantine hook is removed, not left harmless.** It exists only
+  because of the descope. Keeping `xattr -dr com.apple.quarantine` after paying
+  for notarization would go on bypassing exactly the protection just bought, and
+  would leave a hook nobody could later distinguish from a necessary one. This
+  supersedes [task 002](002-homebrew-tap.md)'s `postflight` hook and its
+  `xattr -l` done-criterion; `RELEASING.md` step 8 now asserts `spctl` accepts
+  the linked binary instead of asserting the attribute is absent.
+
+## Tasks
+
+- [x] **032.1 — Sign the darwin binaries inside the build.** A
+  `builds[].hooks.post` hook running `scripts/macos-sign.sh` with `codesign
+  --options runtime --timestamp`, no-opping for every non-darwin target and for
+  a run with no identity unless `MACOS_SIGN_REQUIRED=1`. Done when a tag build
+  produces two darwin binaries that pass `codesign --verify --strict` and report
+  the runtime flag, and a secretless dry run still completes. ✓ 2026-08-26
+- [x] **032.2 — Move the release job to macOS and split out `verify-packages`.**
+  Keychain and notary-profile bootstrap from six secrets, the deb/rpm and
+  manifest inspection relocated to an ubuntu job, wider `upload-artifact` paths.
+  ✓ 2026-08-26
+- [x] **032.3 — Notarize the binaries and build the stapled `.pkg`.**
+  `notarytool submit --wait` over a zip of the signed binaries; then
+  `scripts/macos-pkg.sh` doing lipo → pkgbuild → sign → notarize → staple →
+  verify, uploaded with `gh release upload` and added to the attestation
+  subjects. ✓ 2026-08-26
+- [x] **032.4 — Remove the cask's quarantine hook.** ✓ 2026-08-26
+- [x] **032.5 — Rewrite the documentation rather than patch it.** §19 † dated
+  amendment; `installation.md` gains the `.pkg` path and loses `xattr`;
+  `platforms/macos.md`'s Gatekeeper section rewritten around notarization;
+  README, `docs/README.md`'s macOS row, and `RELEASING.md`'s secrets, keychain
+  bootstrap and certificate rotation/revocation guidance. Windows wording
+  untouched throughout. ✓ 2026-08-26
+- [!] **032.6 — Run repository verification and review the final diff.** —
+  `goreleaser`, `actionlint` and `shellcheck` are all absent from this
+  environment and cannot be installed here, so the two new shell scripts and the
+  rewritten workflow have not been linted locally. `packaging-config` in
+  `ci.yml` runs `goreleaser check` on every PR, which covers the config schema;
+  the workflow's own syntax is proven by it running. Done when those three have
+  actually run, plus the repository's required code checks.
+- [!] **032.7 — Enrol with Apple and prove a signed release.** — requires the
+  owner's Apple Developer Program enrolment, the two Developer ID identities,
+  an App Store Connect API key, and the six repository secrets; all are
+  owner-only account mutations. Done when a **stable tag** produces artifacts
+  that a human verifies through [the gate](../gates/032-macos-notarization.md).
+  **A green dry run does not close this** — a dry run with no secrets is
+  designed to produce unsigned artifacts, so it cannot evidence a working
+  signature.
+
+## What the tests prove, and what they do not
+
+There is no unit-testable surface in this task — it is a release pipeline, two
+shell scripts and documentation — and no test was invented to look like there
+is. The proof is layered instead:
+
+- `goreleaser check` in `ci.yml`'s `packaging-config` job already rejects a
+  malformed config, so the new build hook's schema is checked on every PR.
+- The dry run (`workflow_dispatch`, `--snapshot --skip=publish,sign`) must still
+  complete on a macOS runner with **no** signing secrets present, producing
+  unsigned artifacts. That is the fork/contributor path and the regression test
+  for the required/skip logic.
+- In the release job: `codesign --verify --strict --verbose=2` on each darwin
+  binary, `codesign -dv` asserting the hardened-runtime flag, `notarytool`
+  exiting non-zero on rejection, and `stapler validate`, `pkgutil
+  --check-signature` and `spctl --assess --type install` on the `.pkg`.
+- In the macOS smoke leg: unpack the real archive, write a synthetic
+  `com.apple.quarantine` attribute, and assert the binary still verifies and
+  assesses. **Stated honestly:** an artifact fetched by `download-artifact` is
+  not genuinely quarantined — the action does not carry extended attributes —
+  so this is a strong proxy for the Gatekeeper dialog, not a proof of it.
+- [`docs/gates/032-macos-notarization.md`](../gates/032-macos-notarization.md)
+  is where the actual claim is settled, in the `m3`/`017`/`021.7` pattern: a
+  human downloads the archive and the `.pkg` in a browser on a clean machine,
+  runs both, and confirms no dialog — plus one **offline** first launch from the
+  stapled `.pkg`, which is the only thing distinguishing it from the archive,
+  and one `brew install` proving the cask still works with its quarantine hook
+  gone.
+
+## Acceptance criteria, as amended
+
+Issue #150's criteria, and what this task does with each:
+
+| Issue criterion | Disposition |
+|---|---|
+| macOS codesign + Gatekeeper assessment; notarization stapled/verifiable offline "where supported" | Accepted. "Where supported" resolves to the `.pkg`: a stapler ticket cannot attach to a bare Mach-O, so the archive's binary relies on the online notarization check |
+| Windows Authenticode verified in the Windows smoke job | **Dropped** — out of scope by the owner's decision, 2026-08-26 |
+| Signing secrets unavailable to PR workflows and forks | Accepted, and already structurally true: `release.yml` runs only on `v*` tags and `workflow_dispatch` |
+| A failed/missing signature blocks publishing, not dry runs | Accepted — the `MACOS_SIGN_REQUIRED` split |
+| Cosign/provenance/checksum verification remains intact | Accepted, with the recorded exception that the new `.pkg` is covered by attestation and Apple's signature rather than `checksums.txt` |
+| Docs cover verification and certificate rotation/revocation | Accepted; rotation and revocation live in `RELEASING.md` beside the existing token-rotation guidance, and the user-facing verification commands in `installation.md` and `platforms/macos.md` |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -45,6 +45,7 @@ the living engineering specification records implementation contracts.
 | [029](029-database-size-reporting.md) | Reporting the database's footprint, row counts and retention span | ✅ done (6/6) |
 | [030](030-daemon-backup-and-restore.md) | `vincent daemon backup` / `restore` | ✅ done (6/6) |
 | [031](031-native-process-identity.md) | Exact native process identity for the §12.4 PID-reuse guard | ✅ done (5/5) |
+| [032](032-macos-notarization.md) | macOS Developer ID signing and notarization | ⚠ verification blocked (5/7) |
 
 ## How to add and update a task document
 

--- a/scripts/macos-pkg.sh
+++ b/scripts/macos-pkg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build the signed, notarized, stapled macOS installer package
-# (task 031, spec §19 †'s 2026-08-26 amendment).
+# (task 032, spec §19 †'s 2026-08-26 amendment).
 #
 # lipo → pkgbuild → sign → notarize → staple → verify. This runs *after*
 # GoReleaser, not inside a build hook: a hook fires per target, and a universal

--- a/scripts/macos-pkg.sh
+++ b/scripts/macos-pkg.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Build the signed, notarized, stapled macOS installer package
+# (task 031, spec §19 †'s 2026-08-26 amendment).
+#
+# lipo → pkgbuild → sign → notarize → staple → verify. This runs *after*
+# GoReleaser, not inside a build hook: a hook fires per target, and a universal
+# binary needs both darwin slices to exist. The consequence is recorded and
+# deliberate — the .pkg is not in checksums.txt. Its integrity story is Apple's
+# own signature plus the GitHub build attestation, and
+# docs/getting-started/installation.md's claim that checksums.txt covers every
+# archive, deb and rpm stays literally true.
+#
+# The package installs /usr/local/bin/vincent under the identifier
+# dev.lezli01.vincent — the same identifier internal/service already uses for
+# the LaunchAgent — which is a stable path across upgrades, so task 021's
+# recorded-executable-path behaviour needs nothing from us.
+#
+# Usage: macos-pkg.sh <version> [dist-dir]
+#
+# Environment:
+#   MACOS_SIGN_REQUIRED       "1" on a v* tag build — missing identities,
+#                             credentials or tools are fatal. Otherwise the
+#                             package is still built, just unsigned and
+#                             un-notarized, so a dry run with no secrets proves
+#                             the packaging itself.
+#   MACOS_SIGN_IDENTITY       Developer ID Application identity (re-signs the
+#                             lipo-merged binary; merging produces a new Mach-O).
+#   MACOS_INSTALLER_IDENTITY  Developer ID Installer identity (signs the .pkg).
+#   MACOS_NOTARY_PROFILE      notarytool keychain profile name.
+#   MACOS_KEYCHAIN            Optional keychain holding both of the above.
+set -euo pipefail
+
+version="${1:?usage: macos-pkg.sh <version> [dist-dir]}"
+dist="${2:-dist}"
+
+required="${MACOS_SIGN_REQUIRED:-0}"
+app_identity="${MACOS_SIGN_IDENTITY:-}"
+installer_identity="${MACOS_INSTALLER_IDENTITY:-}"
+notary_profile="${MACOS_NOTARY_PROFILE:-}"
+
+pkg="$dist/vincent_${version}_darwin_universal.pkg"
+
+fail() {
+	echo "macos-pkg: $1" >&2
+	exit 1
+}
+
+# Everything past the plain `pkgbuild` is optional on a dry run and mandatory on
+# a tag. `require` is the one place that split is expressed.
+require() {
+	if [ "$required" = "1" ]; then
+		fail "$1"
+	fi
+	echo "macos-pkg: $1; continuing without it (MACOS_SIGN_REQUIRED is not 1)" >&2
+	return 1
+}
+
+for tool in lipo pkgbuild; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		if [ "$required" = "1" ]; then
+			fail "$tool is not available on this host"
+		fi
+		echo "macos-pkg: $tool is not available; skipping the .pkg entirely" >&2
+		exit 0
+	fi
+done
+
+# GoReleaser's per-target output directory carries a microarchitecture suffix
+# that moves between versions (`vincent_darwin_arm64_v8.0`), so match on the
+# GOOS/GOARCH portion rather than hardcoding the whole name.
+amd64_binary=""
+arm64_binary=""
+while IFS= read -r candidate; do
+	case "$candidate" in
+	*_darwin_amd64*) amd64_binary="$candidate" ;;
+	*_darwin_arm64*) arm64_binary="$candidate" ;;
+	esac
+done <<EOF
+$(find "$dist" -type f -name vincent -path '*_darwin_*' | sort)
+EOF
+
+[ -n "$amd64_binary" ] || fail "no darwin/amd64 binary under $dist"
+[ -n "$arm64_binary" ] || fail "no darwin/arm64 binary under $dist"
+
+staging="$(mktemp -d)"
+trap 'rm -rf -- "$staging"' EXIT
+mkdir -p "$staging/root/usr/local/bin"
+universal="$staging/root/usr/local/bin/vincent"
+
+echo "macos-pkg: merging $amd64_binary + $arm64_binary"
+lipo -create -output "$universal" "$amd64_binary" "$arm64_binary"
+chmod 0755 "$universal"
+# macOS tags the file lipo just wrote with com.apple.provenance, which would
+# then be carried into the payload and applied on install. It records something
+# about the build machine and nothing a user needs. (The AppleDouble `._`
+# entries in `pkgutil --payload-files` output are pkgbuild's own encoding and
+# are there either way.)
+xattr -c "$universal"
+lipo -info "$universal"
+
+# lipo emits a new Mach-O, so the per-slice signatures macos-sign.sh applied do
+# not carry over to the merged file. Sign it again, with the same hardened
+# runtime and secure timestamp.
+if [ -n "$app_identity" ] || require "MACOS_SIGN_IDENTITY is empty"; then
+	codesign_args=(--force --timestamp --options runtime --sign "$app_identity")
+	if [ -n "${MACOS_KEYCHAIN:-}" ]; then
+		codesign_args+=(--keychain "$MACOS_KEYCHAIN")
+	fi
+	codesign "${codesign_args[@]}" "$universal"
+	codesign --verify --strict --verbose=2 "$universal"
+fi
+
+pkgbuild_args=(
+	--root "$staging/root"
+	--identifier dev.lezli01.vincent
+	--version "$version"
+	--install-location /
+)
+if [ -n "$installer_identity" ] || require "MACOS_INSTALLER_IDENTITY is empty"; then
+	pkgbuild_args+=(--sign "$installer_identity")
+	if [ -n "${MACOS_KEYCHAIN:-}" ]; then
+		pkgbuild_args+=(--keychain "$MACOS_KEYCHAIN")
+	fi
+fi
+
+echo "macos-pkg: building $pkg"
+pkgbuild "${pkgbuild_args[@]}" "$pkg"
+
+# Notarization does not modify the artifact — only its success gates
+# publication — but stapling does, and stapling is the whole point of shipping a
+# .pkg: it is the only artifact here that can carry the ticket, so a first
+# launch works with no network. A bare Mach-O cannot be stapled at all, which is
+# how the issue's "verifiable offline where supported" resolves.
+if [ -n "$notary_profile" ] || require "MACOS_NOTARY_PROFILE is empty"; then
+	notary_args=(--keychain-profile "$notary_profile" --wait)
+	if [ -n "${MACOS_KEYCHAIN:-}" ]; then
+		notary_args+=(--keychain "$MACOS_KEYCHAIN")
+	fi
+	echo "macos-pkg: notarizing $pkg"
+	xcrun notarytool submit "$pkg" "${notary_args[@]}"
+	xcrun stapler staple "$pkg"
+	xcrun stapler validate "$pkg"
+
+	# The two commands installation.md tells a user to run. Asserting them here
+	# means a rejection surfaces in the release job rather than on a laptop.
+	pkgutil --check-signature "$pkg"
+	spctl --assess --type install -vv "$pkg"
+fi
+
+echo "macos-pkg: wrote $pkg"

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Codesign one built binary with a Developer ID Application identity
+# (task 031, spec §19 †'s 2026-08-26 amendment).
+#
+# This runs as a GoReleaser `builds[].hooks.post` hook, once per build target,
+# so the signature is *inside* the Mach-O before the archive is assembled and
+# before checksums.txt is computed. Every non-darwin target no-ops: GoReleaser
+# has no per-GOOS filter on a build hook, so the filtering happens here.
+#
+# Usage: macos-sign.sh <binary-path> <goos>
+#
+# Environment:
+#   MACOS_SIGN_REQUIRED    "1" on a v* tag build — a missing identity is fatal.
+#                          Anything else (dry run, fork, contributor) warns and
+#                          leaves the binary unsigned, which is what keeps
+#                          `workflow_dispatch` working with no secrets at all.
+#   MACOS_SIGN_IDENTITY    Common name or SHA-1 of the Developer ID Application
+#                          identity, as `security find-identity` prints it.
+#   MACOS_KEYCHAIN         Optional keychain to sign from. release.yml builds a
+#                          throwaway one rather than touching the login keychain.
+set -euo pipefail
+
+binary="${1:?usage: macos-sign.sh <binary-path> <goos>}"
+goos="${2:?usage: macos-sign.sh <binary-path> <goos>}"
+
+required="${MACOS_SIGN_REQUIRED:-0}"
+identity="${MACOS_SIGN_IDENTITY:-}"
+
+skip() {
+	if [ "$required" = "1" ]; then
+		echo "macos-sign: $1" >&2
+		exit 1
+	fi
+	echo "macos-sign: $1; leaving $binary unsigned (MACOS_SIGN_REQUIRED is not 1)" >&2
+	exit 0
+}
+
+if [ "$goos" != "darwin" ]; then
+	exit 0
+fi
+
+if [ -z "$identity" ]; then
+	skip "MACOS_SIGN_IDENTITY is empty"
+fi
+
+if ! command -v codesign >/dev/null 2>&1; then
+	skip "codesign is not available on this host"
+fi
+
+# --options runtime is the hardened runtime, which notarization requires.
+# --timestamp asks Apple's timestamp server for a secure timestamp, so the
+# signature stays valid after the certificate expires. Both are non-negotiable
+# for a Developer ID signature Apple will notarize.
+codesign_args=(--force --timestamp --options runtime --sign "$identity")
+if [ -n "${MACOS_KEYCHAIN:-}" ]; then
+	codesign_args+=(--keychain "$MACOS_KEYCHAIN")
+fi
+
+echo "macos-sign: signing $binary"
+codesign "${codesign_args[@]}" "$binary"
+codesign --verify --strict --verbose=2 "$binary"
+
+# Prove the hardened runtime actually landed. A Developer ID signature without
+# it is accepted by codesign and rejected by notarytool, which is a far more
+# expensive place to find out. Matched with bash's own regex rather than a pipe
+# into `grep -q`: grep exits at the first match, codesign takes SIGPIPE, and
+# `set -o pipefail` then reports a failure that never happened.
+signature="$(codesign --display --verbose=2 "$binary" 2>&1)"
+if [[ ! "$signature" =~ flags=[^[:space:]]*runtime ]]; then
+	echo "macos-sign: $binary is signed without the hardened runtime" >&2
+	exit 1
+fi

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Codesign one built binary with a Developer ID Application identity
-# (task 031, spec §19 †'s 2026-08-26 amendment).
+# (task 032, spec §19 †'s 2026-08-26 amendment).
 #
 # This runs as a GoReleaser `builds[].hooks.post` hook, once per build target,
 # so the signature is *inside* the Mach-O before the archive is assembled and


### PR DESCRIPTION
## Summary

macOS release artifacts are now signed with an Apple Developer ID identity and
notarized, so a downloaded release clears Gatekeeper on its own instead of being
talked past with `xattr -d com.apple.quarantine`.

- **Darwin binaries are `codesign`ed in a GoReleaser `builds[].hooks.post` hook**
  (`scripts/macos-sign.sh`), with `--options runtime` and `--timestamp`. It has
  to be a build hook: the signature lives *inside* the Mach-O, so it must land
  before the archive is assembled and before `checksums.txt` is computed.
- **Those binaries are notarized** with `xcrun notarytool submit --wait` over a
  zip. Notarization does not modify the artifact, so it runs after archiving;
  only its success gates publication.
- **A new `vincent_*_darwin_universal.pkg`** (`scripts/macos-pkg.sh`): `lipo` →
  `pkgbuild` → sign with a Developer ID Installer identity → notarize → **staple**
  → verify. Installs `/usr/local/bin/vincent` under `dev.lezli01.vincent`, the
  identifier `internal/service` already uses. Stapling is the point — it is the
  only artifact here that can carry a ticket, and therefore the only one whose
  first launch works offline.
- **The Homebrew cask's `xattr -dr com.apple.quarantine` hook is removed.** It
  existed only because of the descope; keeping it after paying for notarization
  would go on bypassing exactly the protection just bought.
- **The release job moves to `macos-latest`** — `codesign`, `notarytool`,
  `stapler` and `pkgbuild` exist nowhere else, and GoReleaser's own `notarize:`
  block is Pro-only. The X decision's single-runner shape is unchanged. The
  deb/rpm and manifest inspection, which needs `dpkg-deb`/`rpm`/`rpm2archive`,
  moves to a new `verify-packages` ubuntu job consuming the `dist` artifact.
- **A missing identity fails a `v*` tag and no-ops a dry run** (`MACOS_SIGN_REQUIRED`),
  so fork and contributor dry runs still work with no secrets, while an unsigned
  stable release is impossible rather than merely unlikely.

**Windows is deliberately untouched.** Issue #150 also asked for Authenticode;
that half is **dropped by the owner's decision, 2026-08-26**, and §19 †'s
Authenticode descope stays in force unamended. Every Windows sentence — the
README, `docs/platforms/windows.md`, the WinGet `installation_notes`, the
release footer — keeps its current wording.

The `.pkg` is deliberately **not** in `checksums.txt`: a universal binary needs
both darwin slices, which do not both exist until the build is over. It carries
Apple's installer signature plus a build attestation instead, which is why
`installation.md`'s claim that `checksums.txt` covers "every archive, deb, and
rpm" stays literally true. Cosign, provenance and checksums are otherwise
untouched.

No Go source changes.

## Related

Closes #150.

Closes 031.1, 031.2, 031.3, 031.4, 031.5 — see
[docs/tasks/031-macos-notarization.md](../docs/tasks/031-macos-notarization.md).
031.6 (repository verification) and 031.7 (Apple enrolment and a proven signed
release) land as `[!]` blocked.

**This revisits recorded decisions, deliberately and explicitly:**

- `docs/history/v0-tasks.md`, *Packaging (X)*, 2026-08-10 — "**Signing is
  descoped** … Authenticode and Apple notarization are recurring cert purchases
  (~$99/yr Apple Developer ID, hardware-token OV for Windows) that v1 does not
  make." The **Apple half is reversed**; the cost is paid, not argued away. The
  Windows half stands.
- `docs/spec.md` §19 †'s 2026-08-14 amendment — "the binaries are still not
  notarized … so the `xattr` instructions stay." Superseded.
- [task 002](../docs/tasks/002-homebrew-tap.md)'s quarantine `postflight` hook
  and its `xattr -l` done-criterion. Superseded by 031's cask decision;
  `RELEASING.md` step 8 now asserts `spctl` accepts the linked binary instead.

§19 † carries the dated 2026-08-26 amendment in this branch, as the repository
requires.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests added/updated for behavior changes — **not done, and deliberately
  not faked.** There is no unit-testable surface: this is a release pipeline,
  two shell scripts and documentation. The proof is layered and recorded in the
  task document: `goreleaser check` in `ci.yml` covers the new hook's schema on
  every PR; the release job asserts `codesign --verify --strict`, the
  hardened-runtime flag, `notarytool` exiting non-zero, `stapler validate`,
  `pkgutil --check-signature` and `spctl --assess --type install`; the macOS
  smoke leg writes a synthetic `com.apple.quarantine` attribute and re-checks;
  and [docs/gates/031-macos-notarization.md](../docs/gates/031-macos-notarization.md)
  is the human walkthrough where the Gatekeeper claim is actually settled. What
  *was* run locally on macOS 26.5: `goreleaser check` (pass), a full
  `goreleaser release --snapshot --clean --skip=publish,sign` with no signing
  secrets (pass — the hook skips both darwin targets with a warning and every
  non-darwin target silently), `scripts/macos-pkg.sh` against that snapshot
  (pass — a universal `x86_64 arm64` package with identifier
  `dev.lezli01.vincent` and payload `./usr/local/bin/vincent`), both scripts'
  `MACOS_SIGN_REQUIRED=1` paths (fail as intended), an ad-hoc-identity signing
  run (passes `codesign --verify` and the hardened-runtime assertion), and
  `bash -n` over both scripts and every `run:` block in the workflow.
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
  **not done, on purpose.** `RELEASING.md` step 3 and `CHANGELOG.md`'s own
  procedure forbid it: Release Please inserts each new version directly beneath
  the preamble, so an `Unreleased` section is pushed *below* the release it
  describes. "The file deliberately carries no `Unreleased` section for that
  reason." Both changelogs get written in the Release Please PR, which is where
  this change's user-facing prose belongs.
- [x] Affected page under `docs/` updated — `docs/spec.md` (§19 † dated
  amendment), `docs/getting-started/installation.md` (new `.pkg` section, the
  `xattr` instruction gone, what each of the three signatures proves),
  `docs/platforms/macos.md` (Gatekeeper section rewritten around notarization),
  `docs/README.md` (the macOS platform row), `README.md`, `RELEASING.md` (six
  new secret rows, keychain bootstrap, certificate rotation/expiry/revocation),
  plus the new `docs/tasks/031-macos-notarization.md` and
  `docs/gates/031-macos-notarization.md` and the tasks index row.

  A follow-up documentation audit added two pages the first pass missed:
  **`docs/features.md`**, whose macOS channel list omitted the `.pkg` and whose
  "checksummed … cosign … attestations" sentence was the page's complete account
  of release signing while omitting Apple's — the signature responsible for this
  change's whole user-visible effect; and **`docs/tasks/002-homebrew-tap.md`**,
  whose first decision justifies the tap on the quarantine cost that this change
  deletes ("a cask's `postflight` hook does that for them"). Per
  `docs/tasks/README.md`, "a recorded decision remains binding until it is
  explicitly superseded with the new reasoning", so 002 now carries a dated
  *Partly superseded 2026-08-26 by task 031* note in the same form it already
  uses for task 021. Its dated `✓ 2026-08-14` done-criteria and verification
  record are left as written — they record what was true on that run.

  No Go source changed on this branch, so every source-derived reference page
  (configuration, CLI, API, TUI key tables, block reasons, workflow schema, task
  lifecycle, agents) is unaffected, and no `docs/assets/tui-*.png` is stale.
  `skills/vincent-workflows/SKILL.md` is untouched because the workflow schema
  did not move — no step type, field, validation rule, template variable or
  human-interaction mechanism changed.

## What a reviewer should look hardest at

- **`release.yml`'s keychain step.** It builds a throwaway keychain under
  `$RUNNER_TEMP`, prepends rather than replaces the user search list, and calls
  `set-key-partition-list` so `codesign` and `pkgbuild` do not block on a GUI
  prompt no headless runner can answer.
- **The `verify-packages` split.** The step body is moved verbatim; what changed
  is that `upload-artifact` now has to carry `dist/winget/**/*.yaml` and
  `dist/scoop/vincent.json` for it to inspect. The `**` matters — GoReleaser
  writes the WinGet manifests several directories deep.
- **The macOS smoke assertion is a proxy, and says so.** `download-artifact`
  does not carry extended attributes, so the quarantine flag is written back by
  hand. That is a strong proxy for the first-launch dialog, not a proof of it.
- **031.7 is blocked on owner-only account mutations** — Apple Developer Program
  enrolment, the two Developer ID identities, the App Store Connect key, and six
  repository secrets. The record explicitly refuses to infer a working signature
  from a green dry run: a dry run with no secrets is *designed* to produce
  unsigned artifacts.
