### PR TITLE
Answer a question longer than 256 bytes

### DIFF
--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -67,6 +67,11 @@
 //	                      as {"type":"fakeagent.child","pid":N} — lets tests
 //	                      verify tree-kill reaps grandchildren
 //	FAKEAGENT_ASK_MULTI   ask-question: add a second, multi-select question
+//	FAKEAGENT_ASK_LONG    ask-question: "1" asks the question as prose well
+//	                      past 256 bytes, the length Claude routinely writes.
+//	                      The answer is keyed by that text verbatim (§7.4), so
+//	                      this drives the whole round trip against the API's
+//	                      key bound (issue #197)
 //	FAKEAGENT_DELAY_MS    success (both dialects): stretch the run over this
 //	                      many milliseconds, emitting one assistant line per
 //	                      second — the M3 gate needs tasks that are still
@@ -437,11 +442,27 @@ func awaitControlResponse(rd *bufio.Reader, requestID string) (controlResponse, 
 	}
 }
 
+// longQuestionText is what the ask-question scenario asks under
+// FAKEAGENT_ASK_LONG: one question of agent-authored prose comfortably past
+// 256 bytes, which is the length Claude routinely writes. A test answering it
+// keys off the text the daemon parked on rather than repeating this literal,
+// because that is what a human answering the form does (§7.4).
+const longQuestionText = "Two colors would both work for the header, and the " +
+	"choice changes more than it looks like it does: red reads as an alert " +
+	"everywhere else in this interface, so using it here would blunt that " +
+	"signal, while blue matches the rest of the chrome but is much easier to " +
+	"miss on a dim screen. Which would you rather I use, and should I apply " +
+	"it to the footer at the same time?"
+
 // askQuestion emits an AskUserQuestion control_request in the captured shape
 // and blocks until answered; the answers round-trip into the result text.
 func askQuestion(prompt []byte, rd *bufio.Reader) {
+	question := "Which color do you prefer?"
+	if os.Getenv("FAKEAGENT_ASK_LONG") == "1" {
+		question = longQuestionText
+	}
 	questions := []any{map[string]any{
-		"question": "Which color do you prefer?",
+		"question": question,
 		"header":   "Color",
 		"options": []any{
 			map[string]any{"label": "Red", "description": "The color red"},

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -77,9 +77,15 @@ the field and the limit:
 | project `name`, `branch_name`, `base_branch`, `branch_override` | 512 B |
 | `prompt`, `prompt_override` | 1 MiB |
 | `run_override` | 16 KiB |
-| one `fields` / `answers` key | 256 B |
+| one `fields` key | 256 B |
+| one `answers` key | 64 KiB |
 | one `fields` / `answers` value | 64 KiB |
 | `fields` / `answers` entries, values per answer | 100 |
+
+The two keys differ because they are different kinds of thing. A `fields` key is
+a short identifier you choose. An `answers` key is not yours to choose at all: it
+is the agent's question text, which the answer is keyed by and which the daemon
+hands back to the CLI unchanged, so it is bounded like the prose it is.
 
 These are fixed constants, not configuration: a body larger than one of them is
 a buggy client rather than a workload to tune for.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2964,6 +2964,21 @@ in §13.2 sees the body:
   `answers` keys, values and entry counts, prompt and run overrides, names and
   branch names); over a field bound is `400` `validation_failed` naming the field
   and the limit.
+
+  *Amended 2026-08-26 (issue #197).* A `fields` key and an `answers` key are
+  bounded **separately**, because they are not the same kind of thing. A `fields`
+  key is a caller-chosen identifier a human or a workflow author types (§8.1.2),
+  and its bound is sized for one. An `answers` key is not chosen by the caller:
+  it is the agent's verbatim question text, which §7.4 makes the lookup key and
+  §9.2 writes back to the CLI unchanged, so no layer between the agent and the
+  answer route may shorten it. It is therefore bounded as agent-authored text —
+  the size an answer *value* gets — not as an identifier. Bounding the two alike
+  made any question past the identifier bound unanswerable: the daemon parked on,
+  persisted and rendered a question it then refused every answer to, leaving the
+  task holding its slot in `awaiting_input` until it was cancelled or timed out.
+  The count bounds and the route's body bound are unchanged, so nothing about the
+  key is unbounded. This section still fixes no numbers; `docs/reference/api.md`
+  publishes them.
 - **Labelled JSON, leniently.** A body with no `Content-Type`, or any `*/json` or
   `*+json` type with any parameters, is accepted. A non-empty body labelled a
   clearly non-JSON type — `text/html`, or the `application/x-www-form-urlencoded`

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -565,13 +565,15 @@ func (v *answerValues) UnmarshalJSON(b []byte) error {
 // boundAnswers bounds an answer map: §13.1's entry count on the map itself,
 // on the values of any one answer, and on each question and answer string. The
 // values are templated into a resumed step's prompt, so they are bounded like
-// any other prompt input.
+// any other prompt input. The key is the agent's question text rather than a
+// caller-chosen identifier (§7.4), so it takes maxAnswersKeyBytes and not the
+// `fields` key bound — see the note on that constant.
 func boundAnswers(answers map[string]answerValues) string {
 	if msg := boundCount("answers", len(answers), maxFieldCount); msg != "" {
 		return msg
 	}
 	for text, vals := range answers {
-		if msg := boundString("answers key", text, maxFieldKeyBytes); msg != "" {
+		if msg := boundString("answers key", text, maxAnswersKeyBytes); msg != "" {
 			return msg
 		}
 		field := fmt.Sprintf("answers[%s]", truncKey(text))

--- a/internal/api/actions_test.go
+++ b/internal/api/actions_test.go
@@ -573,3 +573,71 @@ func hasAction(actions []string, want string) bool {
 	}
 	return false
 }
+
+// longQuestionText is a question the size Claude routinely writes: prose the
+// agent authored, well past maxFieldKeyBytes. §7.4 keys an answer by the
+// question's exact text (taskrun.validateAnswer matches it verbatim, and the
+// claude adapter writes it back to the CLI under that same text, §9.2), so
+// nothing between the agent and this route may shorten it.
+func longQuestionText() string {
+	q := "Which of these two migration strategies should I take for the store " +
+		"package, given that the events table is already several million rows " +
+		"and the daemon holds a single SQLite connection: " +
+		strings.Repeat("a rolling backfill behind a feature flag, or one offline pass? ", 4)
+	if len(q) <= maxFieldKeyBytes {
+		panic("longQuestionText must exceed maxFieldKeyBytes to exercise the bound")
+	}
+	return q
+}
+
+// TestAnswerLongQuestion pins the §13.1 field bound against §7.4: a question
+// the daemon was willing to park on and display is one a human can answer. An
+// `answers` key is not a caller-chosen identifier like a `fields` key — it is
+// the agent's question text — so the 256 B key bound must not apply to it.
+func TestAnswerLongQuestion(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+
+	text := longQuestionText()
+	pending, err := json.Marshal(map[string]any{
+		"kind": "question",
+		"questions": []any{map[string]any{
+			"text": text, "header": "Migration", "options": []string{"Rolling", "Offline"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal pending: %v", err)
+	}
+	setAwaitingInput(t, h, task.ID, string(pending))
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/answer", task.ID),
+		map[string]any{"answers": map[string]any{text: "Rolling"}})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("answer a %d-byte question: %d %s, want 200", len(text), resp.StatusCode, body)
+	}
+	out := decodeTask(t, body)
+	if out.State != string(store.TaskRunning) {
+		t.Errorf("state after answer = %s, want running", out.State)
+	}
+	if len(out.PendingInput) != 0 {
+		t.Errorf("pending_input survived the answer: %s", out.PendingInput)
+	}
+}
+
+// TestFieldsKeyBoundUnchanged is TestAnswerLongQuestion's guard rail: the
+// `fields` key really is a caller-chosen identifier (§8.1.2) and keeps its
+// 256 B bound, so relaxing the answers key must not relax this one.
+func TestFieldsKeyBoundUnchanged(t *testing.T) {
+	h := newActionHarness(t)
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+		"project_id": h.projectID,
+		"title":      "long fields key",
+		"fields":     map[string]any{strings.Repeat("k", maxFieldKeyBytes+1): "v"},
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("create with an oversized fields key: %d %s, want 400", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), CodeValidationFailed) {
+		t.Errorf("error body %s does not carry %s", body, CodeValidationFailed)
+	}
+}

--- a/internal/api/limits.go
+++ b/internal/api/limits.go
@@ -35,11 +35,23 @@ const (
 	maxDescriptionBytes = 64 << 10 // task description
 	maxPromptBytes      = 1 << 20  // repair prompt, retry prompt override
 	maxCommandBytes     = 16 << 10 // retry run override — one shell command
-	maxFieldKeyBytes    = 256      // one fields/answers key
+	maxFieldKeyBytes    = 256      // one fields key
+	maxAnswersKeyBytes  = 64 << 10 // one answers key — the agent's question text
 	maxFieldValueBytes  = 64 << 10 // one fields/answers value
 	maxFieldCount       = 100      // fields/answers entries in one request
 	maxValueCount       = 100      // values in one answer
 )
+
+// The two key bounds differ because the two keys are different kinds of thing
+// (amended 2026-08-26, issue #197). A `fields` key is a caller-chosen
+// identifier a human or a workflow author types (§8.1.2), and 256 B is generous
+// for one. An `answers` key is not chosen by the caller at all: it is the
+// agent's verbatim question text, which §7.4 makes the lookup key and §9.2
+// writes back to the CLI unchanged, so nothing between the agent and the
+// answer route may shorten it. Bounding it like an identifier made any question
+// longer than 256 B unanswerable — the daemon parked on, persisted and rendered
+// a question it then refused every answer to. It is bounded like the prose it
+// is, at the same size as the answer value it arrives beside.
 
 // boundString reports the §13.1 validation message for a field longer than
 // limit, and "" when it fits. The bound is in bytes rather than runes: what it exists

--- a/internal/taskrun/input_test.go
+++ b/internal/taskrun/input_test.go
@@ -132,6 +132,58 @@ func TestEngineInputRequestRoundTrip(t *testing.T) {
 	}
 }
 
+// TestEngineLongQuestionRoundTrip is the engine leg of issue #197: a question
+// longer than the API's 256 B `fields`-key bound, asked by the agent and
+// answered under its own verbatim text. The answer is keyed off what the
+// daemon parked on rather than off a literal, because that is what a human
+// answering the form does — validateAnswer matches the key exactly (§7.4) and
+// the adapter writes it back to the CLI unchanged (§9.2), so no layer on this
+// path may shorten it.
+func TestEngineLongQuestionRoundTrip(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "ask-question")
+	t.Setenv("FAKEAGENT_ASK_LONG", "1")
+	h := newEngineHarness(t)
+	h.start(t)
+	task := h.createTask(t, askSnapshot())
+
+	waiting := h.waitForState(t, task.ID, store.TaskAwaitingInput, store.TaskBlocked, store.TaskDone)
+	if waiting.State != store.TaskAwaitingInput {
+		t.Fatalf("task reached %s (block_reason %q), want awaiting_input", waiting.State, waiting.BlockReason)
+	}
+	var pending PendingInput
+	if err := json.Unmarshal([]byte(waiting.PendingInputJSON), &pending); err != nil {
+		t.Fatalf("pending_input_json %q: %v", waiting.PendingInputJSON, err)
+	}
+	if len(pending.Questions) != 1 {
+		t.Fatalf("pending = %+v, want one question", pending)
+	}
+	text := pending.Questions[0].Text
+	if len(text) <= 256 {
+		t.Fatalf("question is %d bytes; FAKEAGENT_ASK_LONG must ask past the 256 B bound", len(text))
+	}
+
+	if _, err := h.runner.Answer(t.Context(), task.ID,
+		AnswerInput{Answers: map[string][]string{text: {"Red"}}}); err != nil {
+		t.Fatalf("Answer a %d-byte question: %v", len(text), err)
+	}
+	final := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if final.State != store.TaskDone {
+		t.Fatalf("task reached %s (block_reason %q), want done", final.State, final.BlockReason)
+	}
+	if final.PendingInputJSON != "" {
+		t.Errorf("pending_input_json survived the answer: %s", final.PendingInputJSON)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 || runs[0].State != store.StepSucceeded {
+		t.Fatalf("step runs = %+v, want one succeeded attempt", runs)
+	}
+	// The agent echoes updatedInput.answers, so this proves the key survived
+	// the trip out to the CLI and back rather than only reaching the engine.
+	if !containsAll(runs[0].ResultSummary, text, `"Red"`) {
+		t.Errorf("result %q does not echo the long question and its answer", runs[0].ResultSummary)
+	}
+}
+
 func TestEngineInputPermissionAnswer(t *testing.T) {
 	t.Setenv("FAKEAGENT_SCENARIO", "ask-permission")
 	h := newEngineHarness(t)


### PR DESCRIPTION
## Summary

A task parked in `awaiting_input` on a question longer than 256 bytes could not
be answered. `POST /v1/tasks/{id}/answer` refused every body with `400
validation_failed: answers key must be at most 256 bytes (got 438)`, so the task
sat holding its concurrency slot until it was cancelled or `input_timeout` (24 h
by default) expired and failed the step. The daemon parked on, persisted and
rendered a question it would then refuse every answer to.

**Root cause: one constant serving two unrelated kinds of key.**
`maxFieldKeyBytes = 256` (`internal/api/limits.go`) was applied both by
`boundTaskFields` to a `fields` key and by `boundAnswers` to an `answers` key.
Those are not the same kind of thing. A `fields` key is a caller-chosen
identifier a human or a workflow author types (§8.1.2), and 256 B is generous
for one. An `answers` key is not chosen by the caller at all: it is the agent's
verbatim question text. §7.4 makes that text the lookup key —
`taskrun.validateAnswer` matches `in.Answers[q.Text]` exactly and rejects any key
that matches no pending question — and §9.2 has the claude adapter write the
answer back to the CLI under the same text in `updatedInput.answers`. So no
layer between the agent and the answer route is permitted to shorten it, and
bounding it like an identifier made the question unanswerable rather than
truncating it.

The asymmetry in the report is the tell: `maxFieldValueBytes` is 64 KiB, so a
438-byte *answer* was fine while a 438-byte *question* was not.

Nothing caught it earlier. `apiclient.InputRequest.Validate` checks structure
only (every question answered, one value for a single-select), so the TUI answer
form passed its own validation and then failed on the round trip. There is no
`vincent answer` subcommand, so the TUI and raw HTTP are the only two ways in and
both hit the same bound. Mid-run input exists only on the claude adapter
(`SupportsInput` is permanently false for codex and cursor), which is exactly
where questions over 256 bytes are routine.

**The fix** splits the constant. `answers` keys take a new `maxAnswersKeyBytes`,
sized like the answer value they arrive beside rather than like an identifier;
`boundTaskFields`/`boundMap` keep `maxFieldKeyBytes = 256` for `fields`. This is
a change to the broken function, not a guard at the call site.

Nothing becomes unbounded: the route still reads at `maxLargeRequestBytes`
(4 MiB), and `boundAnswers` still applies `maxFieldCount` (100) and
`maxValueCount` (100) per answer. The error message still names the field and the
limit without echoing the key — `boundString` never echoes, and `truncKey` guards
the value-side field name.

Introduced by 2b969f5 (`fix(api): require one JSON document per request and bound
the body`, #140), which added both `maxFieldKeyBytes` and `boundAnswers`; nothing
has touched either since.

## Related

Closes #197

Amends `docs/spec.md` §13.1 in place with a dated note (2026-08-26, issue #197).
The spec was not wrong — its #140 amendment names the bounded fields without
fixing numbers for them — but it did not say the two keys are bounded
*separately*, and after this change that distinction is load-bearing, so it is
recorded there. No decision in `docs/tasks/` or the closed v0 ledger covers the
shared constant.

## How the regression test would catch this coming back

`TestAnswerLongQuestion` (`internal/api/actions_test.go`) is the red test. It
parks a task in `awaiting_input` on a 438-byte question and answers it through
the real `POST /v1/tasks/{id}/answer` handler, asserting 200, the task back in
`running`, and `pending_input` cleared. It was run against the unfixed code and
failed exactly as reported:

```
--- FAIL: TestAnswerLongQuestion (0.35s)
    actions_test.go:616: answer a 438-byte question: 400 {"error":{"code":"validation_failed",
        "message":"answers key must be at most 256 bytes (got 438)"}}, want 200
```

Any future change that puts an identifier-sized bound back on the `answers` key
turns that 200 back into a 400 and the test fails on the same line with the same
message. It builds its question by asserting `len(q) > maxFieldKeyBytes`, so it
cannot quietly stop testing the bound if that constant is retuned.

`TestFieldsKeyBoundUnchanged` is its guard rail, and the reason the fix cannot be
"relax the bound". It passed before this change and still passes: a `fields` key
of 257 bytes on `POST /v1/tasks` is still `400 validation_failed`. Widening
`maxFieldKeyBytes` instead of splitting it would make the red test pass and this
one fail.

`TestEngineLongQuestionRoundTrip` (`internal/taskrun/input_test.go`) is the
end-to-end leg the issue asked for, driven by a new `FAKEAGENT_ASK_LONG=1` knob
on fakeagent's `ask-question` scenario (`askQuestion` previously hard-coded a
short question). The agent asks a 367-byte question, the engine parks the task,
and the test answers it keyed off the text the daemon actually parked on — not
off a literal — which is what a human answering the form does. It then asserts
the result summary echoes both the question and the answer, proving the key
survived the trip out to the CLI and back.

To be straight about what that third test is worth: it passes on the unfixed
code too, because `runner.Answer` does not go through the API's `boundAnswers`.
It is not a second red test. What it pins is the premise the fix rests on — that
the key round-trips verbatim through the agent, the engine and back — so a future
change that starts truncating or normalising the question text anywhere on that
path fails here rather than silently reintroducing an unanswerable question by
another route.

No assertion was weakened anywhere. The two tests in `internal/api` are committed
as they were written and run; the fix commit does not touch them.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `test(api):` for the red test, `fix(api):` for the fix
- [x] Tests added/updated for behavior changes
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — **deliberately not done.** `RELEASING.md` (lines 105-114) states that `CHANGELOG.md` carries no `Unreleased` section on purpose: Release Please inserts each new version directly beneath the preamble, so prose parked under `Unreleased` ends up *below* the release it describes. The changelog is written once, on the Release Please PR, and the `fix(api):` commit here is what feeds it. This is a user-visible bug fix and it does belong in the changelog — via that route, not this one.
- [x] Affected page under `docs/` updated — `docs/reference/api.md` splits the "one `fields` / `answers` key" row into two rows with their own limits and says why they differ; `docs/spec.md` §13.1 carries the dated amendment

## Documentation audit

A separate pass checked every derivation `CLAUDE.md` names, and found nothing
further to change — no documentation commit is on this branch, because the two
pages that needed amending were amended in the fix commit itself.

`docs/reference/api.md` is the only page that publishes these bounds (a tree-wide
grep for `256` turns up nothing else but SHA-256 and the TUI's 256 KB transcript
tail), and spec §13.1 is the only record that describes them without fixing
numbers. Everything else was already true and was left alone: no route, CLI
command, config key, TUI binding, `Reason*` constant, step type or adapter
capability changed, so `configuration.md`, `cli.md`, the `tui.md` key tables, the
block-reason tables, `workflow-schema.md`, `task-lifecycle.md` and `agents.md`
are all untouched by design. `troubleshooting.md`'s "A task is stuck in
`awaiting_input`" entry never claimed the daemon might refuse a valid answer, so
it gets no paragraph about a bug it never described.

Three specific negatives worth a reviewer's eye:

- **No gate walkthrough changed.** `scripts/m2-gate.sh` builds its answer body
  from `pending_input` with jq rather than from a literal, and fakeagent's
  default question is still the short one — `FAKEAGENT_ASK_LONG` is off unless a
  test sets it — so the gate exercises exactly what it did before.
- **`skills/vincent-workflows/SKILL.md` is not out of date.** It is runtime text
  spliced into the `create-workflow` prompt, so it would be part of this PR if
  the schema had moved. It did not: no step type, field, validation rule,
  template variable or human-interaction mechanism changed, and the skill tree
  publishes no byte bounds at all.
- **No screenshot is stale.** No TUI code is in the change set, so no captured
  panel can have drifted; `scripts/screenshots.sh` was not run and did not need
  to be.

## Second bug noticed, not fixed here

Not a bug, but worth a reviewer's eye and out of scope for a bug fix:
`apiclient.InputRequest.Validate` validates answer *structure* client-side while
the length rule lives only server-side, which is why the TUI form accepted a
submission the daemon then rejected. That split is fine now that the bound is
sized correctly, but it is the reason this failed at the round trip rather than
in the form, and any future field bound on this path will behave the same way.
