### PR TITLE
Let a step report its own status message, live and on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,61 @@ list with the user-facing context a commit subject cannot carry.
   name an issue; set it to `false` to switch the whole thing off.
   ([#200](https://github.com/lezli01/vincent/issues/200))
 
+- **A step can now say what it is doing, in its own words.** A running step used
+  to be opaque: a board row that had been `running` for twenty-five minutes
+  looked identical whether the agent was scaffolding a migration or stuck
+  retrying the same failing test, and when a step failed, `check_failed` was all
+  you got — the step usually *knew* it was "3 tests red in internal/store" and
+  had no way to say so. Any `agent` or `command` step can now run
+  `vincent status "<one short line>"` from inside itself. The message shows live
+  on the board's new `STATUS` column and on the attempt line in the task detail
+  view, and the last value the step set stays on the finished attempt as its own
+  account of how it went. It is one field with two readings, not two features.
+
+  It is **opt-in per workflow**: vincent never appends a protocol instruction to
+  an agent's prompt, so an agent reports its status only because a workflow
+  author asked it to in their own prompt — see the new *Reporting status from a
+  step* section in the workflows guide. A `command` step just calls it between
+  phases of its script.
+
+  It is **not** a failure reason and nothing renders it as one. `failure_reason`
+  remains a closed set of vincent's own constants; a step killed on a timeout
+  may be carrying a line it wrote half an hour earlier, so the two are shown
+  differently and never conflated. It is also invisible to `if:` guards and
+  `.Steps` — free text an agent chose at run time is not something a workflow
+  should branch on.
+
+  The plumbing, for anything scripted:
+  `POST /v1/tasks/{id}/steps/{step_id}/status` takes `{ message }`; every
+  step-run object gains `status_message`, and so does each row of
+  `GET /v1/tasks`; and a new durable `task.status_changed` SSE event carries
+  `{ task_id, step_id, message }`, so a client that reconnects with
+  `Last-Event-ID` recovers a message it missed. Messages are bounded rather than
+  refused — flattened to one line, control characters stripped, truncated at 256
+  bytes — and two writes within a second coalesce, so a chatty step costs
+  nothing. ([#199](https://github.com/lezli01/vincent/issues/199))
+
+- **Agent steps now receive the `VINCENT_*` environment variables.** They were
+  specified for command and check steps only, which left an agent process able
+  to see its worktree but unable to name the task or step it was executing.
+  Agent steps now get the same block — `VINCENT_TASK_ID`, `VINCENT_STEP_ID`,
+  `VINCENT_BRANCH` and the rest — under the same precedence rule, so a script an
+  agent runs can address the task it belongs to. This is what makes
+  `vincent status` work from an agent's shell tool, and it is useful on its own.
+
 ### Changed
 
 - **vincent is once again released under the MIT License.** The source,
   documentation, release archives, and package-manager metadata all carry the
   same permissive license, with no separate commercial-use restriction.
+
+- **The task detail view finally shows a failed attempt's result summary.** The
+  agent's final message, or the tail of a command's output, had been recorded on
+  every attempt and served on the API since the first release, and was rendered
+  on no screen at all — so diagnosing a blocked step always meant opening the
+  transcript. It now appears as a dim line under any attempt that did not
+  succeed, which is where the question "what went wrong" is actually being
+  asked. ([#199](https://github.com/lezli01/vincent/issues/199))
 
 ## [0.6.0](https://github.com/lezli01/vincent/compare/v0.5.0...v0.6.0) (2026-08-25)
 

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -20,8 +20,20 @@
 //	                      report-env (echoes FAKEAGENT_REPORT_ENV's named
 //	                      variables as its result — the §12.3 environment
 //	                      policy) | usage-limit | unauthenticated (task 003) |
+//	                      set-status (runs the real `vincent status` command
+//	                      from inside the step — task 033) |
 //	                      sleep (internal: silent child)
 //	FAKEAGENT_REPORT_ENV  comma-separated variable names for report-env
+//	FAKEAGENT_VINCENT_BIN set-status: path to the vincent binary to invoke.
+//	                      A fake agent has no other way to find one
+//	FAKEAGENT_STATUS      set-status: the message to report while running
+//	FAKEAGENT_STATUS_HOLD_MS
+//	                      set-status: hold this long after reporting, so a
+//	                      watcher can see the message on the *running* row
+//	FAKEAGENT_STATUS_FINAL
+//	                      set-status: a second message set just before the
+//	                      step ends — the value that must survive on the
+//	                      finished row
 //	FAKEAGENT_USAGE_LIMIT_RESET
 //	                      usage-limit: seconds from now until the window
 //	                      reopens, embedded in the message as the CLI does.
@@ -251,6 +263,26 @@ func main() {
 		}
 		emitText(strings.Join(reported, " "))
 		emitSuccessResult([]byte(strings.Join(reported, " ")), 1, 1)
+	case "set-status":
+		// A step that reports on itself (task 033). It runs the real
+		// `vincent status` command rather than emitting a marker the daemon
+		// would parse, because that is what the feature *is*: an agent tells
+		// the daemon what it is doing by calling it, and nothing in any
+		// adapter is involved. Addressing comes from §8.5's VINCENT_TASK_ID
+		// and VINCENT_STEP_ID, which reach an agent step's environment — so
+		// this scenario failing is also how a regression there is caught.
+		reports := setStatus(os.Getenv("FAKEAGENT_STATUS"))
+		if ms := envMillis("FAKEAGENT_STATUS_HOLD_MS"); ms > 0 {
+			// Long enough for a watcher to see the message on the *running*
+			// row, which is the live half of the feature.
+			emitText("holding so the status is observable while running")
+			time.Sleep(ms)
+		}
+		if final := os.Getenv("FAKEAGENT_STATUS_FINAL"); final != "" {
+			reports += " " + setStatus(final)
+		}
+		emitText(reports)
+		emitSuccessResult([]byte(reports), 1, 1)
 	case "flood":
 		// An agent that will not stop talking: emits until something kills
 		// it, which is exactly what the §12.3 transcript cap must do.
@@ -554,6 +586,39 @@ func emitSuccessResult(prompt []byte, inTok, outTok int64) {
 		"total_cost_usd": 0.0123,
 		"usage":          map[string]int64{"input_tokens": inTok, "output_tokens": outTok},
 	})
+}
+
+// setStatus runs `vincent status <message>` the way a step's own process
+// would, and reports what happened in one line so the result text carries it
+// — a scenario that swallowed the error would make a broken command look like
+// a step that simply said nothing.
+//
+// The binary comes from FAKEAGENT_VINCENT_BIN because a fake agent has no
+// other way to find it: there is no install on a test machine's PATH, and
+// os.Executable() is this program.
+func setStatus(message string) string {
+	if message == "" {
+		return "status: nothing to say"
+	}
+	bin := os.Getenv("FAKEAGENT_VINCENT_BIN")
+	if bin == "" {
+		return "status: FAKEAGENT_VINCENT_BIN is unset"
+	}
+	out, err := exec.Command(bin, "status", message).CombinedOutput()
+	if err != nil {
+		return "status: failed: " + err.Error() + ": " + flatten(string(out), 200)
+	}
+	return "status: set to " + flatten(message, 200)
+}
+
+// envMillis reads a millisecond duration from the environment; 0 when unset
+// or unparseable.
+func envMillis(name string) time.Duration {
+	n, err := strconv.Atoi(os.Getenv(name))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Millisecond
 }
 
 // block sleeps forever. Not `select {}` — with no other goroutines that

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -21,7 +21,7 @@
 //	                      variables as its result — the §12.3 environment
 //	                      policy) | usage-limit | unauthenticated (task 003) |
 //	                      set-status (runs the real `vincent status` command
-//	                      from inside the step — task 033) |
+//	                      from inside the step — task 036) |
 //	                      sleep (internal: silent child)
 //	FAKEAGENT_REPORT_ENV  comma-separated variable names for report-env
 //	FAKEAGENT_VINCENT_BIN set-status: path to the vincent binary to invoke.
@@ -264,7 +264,7 @@ func main() {
 		emitText(strings.Join(reported, " "))
 		emitSuccessResult([]byte(strings.Join(reported, " ")), 1, 1)
 	case "set-status":
-		// A step that reports on itself (task 033). It runs the real
+		// A step that reports on itself (task 036). It runs the real
 		// `vincent status` command rather than emitting a marker the daemon
 		// would parse, because that is what the feature *is*: an agent tells
 		// the daemon what it is doing by calling it, and nothing in any

--- a/docs/features.md
+++ b/docs/features.md
@@ -134,6 +134,10 @@ Human oversight is part of the workflow instead of an informal terminal habit:
   in its existing worktree, as many times as it takes, before archiving it.
 - Use bulk selection to act on several eligible tasks while refusals remain
   selected for follow-up.
+- Let a long-running step say what it is doing: `vincent status "<message>"`
+  from inside an agent or command step reports a line that shows live on the
+  board and stays on the finished attempt as the step's own account of how it
+  went. It is opt-in per workflow — vincent never asks an agent for it.
 
 The daemon computes the actions valid in each state and sends that list to
 every client, so the TUI, CLI, and API agree on what can happen next. See the
@@ -143,8 +147,8 @@ every client, so the TUI, CLI, and API agree on what can happen next. See the
 
 Running `vincent` opens a Bubble Tea interface for active agent workloads:
 
-- A filterable, grouped task board shows state, current step, elapsed time, and
-  reported cost.
+- A filterable, grouped task board shows state, current step, elapsed time,
+  reported cost, and — on a wide terminal — the step's own status message.
 - Task detail keeps the attempt timeline beside live output and the git diff.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -83,6 +83,16 @@ Three behaviors matter:
 `/` filters by id, title, project or state; `tab` commits the filter, `esc`
 clears it.
 
+A wide terminal also gets a **`STATUS` column**: what the task's newest step run
+said about *itself*, if it said anything —
+`compiling internal/store`, `3 tests red`. It is set by the step, not by
+vincent, through [`vincent status`](../reference/cli.md#vincent-status), so it
+is empty until a workflow asks for it; see
+[Reporting status from a step](workflows.md#56-reporting-status-from-a-step).
+It is the first column dropped when the terminal narrows, and it needs a
+comfortably wide title to be admitted at all — so a board that has never seen it
+is a board that has the width for everything else instead.
+
 Elapsed on the board is **wall clock** from the task's start. That is
 deliberate: a task idle on a human for 35 of its 40 minutes must not read as
 "5m" on the board whose job is to flag it. The per-attempt figures in the
@@ -172,6 +182,17 @@ and the one you arrived to read is almost always the pass it stopped on.
 
 The board's and the header's step column say the same thing more briefly: a
 task inside a loop reads `3/7 green · loop 4/10`.
+
+Two things on an attempt line are worth telling apart. A red word like
+`check_failed` is vincent's **failure reason** — a fixed set of constants, and
+vincent's own verdict. A cyan `» 3 tests red in internal/store` is the step's
+own **status message**, free text it set while it was running and the last thing
+it said before it ended. It is never a cause: a step killed on a timeout may be
+carrying a line it wrote half an hour earlier.
+
+An attempt that did **not** succeed also gets a dim line beneath it with its
+**result summary** — the agent's final message, or the tail of a command's
+output. It is the sentence that decides whether to open the transcript.
 
 | Key | Does |
 |---|---|

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -52,7 +52,7 @@ requires reasoning.
 
 **Making steps talk to each other**
 
-- [5. Templates and data flow](#5-templates-and-data-flow) — [5.1 Template fields](#51-which-fields-are-templates) · [5.2 The context](#52-the-template-context) · [5.3 Step to step](#53-passing-one-steps-output-to-the-next) · [5.4 Task fields](#54-task-fields) · [5.5 Environment](#55-environment-variables)
+- [5. Templates and data flow](#5-templates-and-data-flow) — [5.1 Template fields](#51-which-fields-are-templates) · [5.2 The context](#52-the-template-context) · [5.3 Step to step](#53-passing-one-steps-output-to-the-next) · [5.4 Task fields](#54-task-fields) · [5.5 Environment](#55-environment-variables) · [5.6 Reporting status](#56-reporting-status-from-a-step)
 - [6. Control flow](#6-control-flow) — [6.1 `if:`](#61-if--skip-a-step-and-carry-on) · [6.2 `allow_failure:`](#62-allow_failure--a-failure-that-is-data) · [6.3 `condition`](#63-condition--finish-early-and-succeed) · [6.4 Loops in depth](#64-loops-in-depth) · [6.5 Guard recipes](#65-guard-recipes)
 
 **Making it reliable**
@@ -980,8 +980,10 @@ workflow *requires*, where failing loudly is what you want.
 
 ### 5.5 Environment variables
 
-Command steps and checks run with the working directory set to the worktree and
-receive these on top of the daemon's own environment:
+<a id="the-vincent-environment"></a>
+
+Agent steps, command steps and checks run with the working directory set to the
+worktree and receive these on top of the daemon's own environment:
 
 | Variable | |
 |---|---|
@@ -1007,11 +1009,65 @@ keep out of the YAML:
       SLACK_CHANNEL: "#builds"
 ```
 
-A step's `env:` is layered on top and wins. What the daemon passes down in the
-first place is itself configurable — see
+A command step's `env:` is layered on top and wins. What the daemon passes down
+in the first place is itself configurable — see
 [`environment`](../reference/configuration.md#environment) — but neither that
 policy nor a step's `env:` can remove a `VINCENT_*` variable: those are facts
 about the run, not inherited state.
+
+An **agent** step gets the same block, without the `env:` layer — `env:` is a
+command-step field. That is what lets an agent call
+[`vincent status`](#56-reporting-status-from-a-step) from its own shell tool: the
+command reads `VINCENT_TASK_ID` and `VINCENT_STEP_ID` and needs nothing else.
+
+### 5.6 Reporting status from a step
+
+A running step can say what it is doing, in a sentence, by running
+[`vincent status`](../reference/cli.md#vincent-status) from inside itself:
+
+```yaml
+  - id: suite
+    type: command
+    run: |
+      vincent status "running the store suite"
+      go test ./internal/store/...
+```
+
+The message shows up live on the board's `STATUS` column and on the attempt line
+in the [TUI](tui.md), and the last value set before the step ends stays on the
+finished attempt. It is the answer to "what is this actually doing" for a step
+that has been running for twenty-five minutes, and to "why did that fail" in
+terms a `failure_reason` like `check_failed` cannot reach.
+
+For an **agent** step, ask for it in the prompt. The daemon deliberately does
+not append any instruction of its own, so an agent reports its status only
+because you asked:
+
+```yaml
+  - id: implement
+    type: agent
+    prompt: |
+      Implement {{.Task.Title}}.
+
+      Before each significant phase of work, run:
+        vincent status "<one short line about what you are doing now>"
+      Keep it under ten words. If you get stuck or something fails, set it to
+      what is actually wrong — "3 tests red in internal/store", not "working".
+```
+
+Worth knowing when you write that instruction:
+
+- Only `agent` and `command` steps can report. `manual`, `parallel`, `fan_out`,
+  `condition`, `loop` and `break` run no process, so they have no voice and
+  their status stays empty.
+- The message is flattened to one line, stripped of control characters and
+  truncated to 256 bytes. Being wordy never fails the step.
+- Two messages inside one second coalesce to the later one, so an agent that
+  narrates in a tight loop costs nothing. The first message after a quiet
+  period is always immediate.
+- It is **not** a failure reason and nothing renders it as one. It is also not
+  visible to `.Steps` or to an `if:` guard — free text an agent chose at run
+  time is not something a workflow should branch on.
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -588,6 +588,7 @@ rather than inventing a model name.
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
 | `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based; `0` outside one) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart |
+| `POST` | `/v1/tasks/{id}/steps/{step_id}/status` | `{ message }` → `{ message }` as stored. What the **running** step is doing, in its own words. Called by that step's own process — see [Step status](#step-status) |
 
 On `POST /v1/tasks`, the daemon validates the selected root workflow's
 declared fields before inserting the task. Missing required values and invalid
@@ -738,9 +739,10 @@ Four details worth knowing:
   is given rather than switching on the two it knows.
 
 - **List rows carry the board fields** — `project_name`, `step_total`,
-  `step_name`, and `cost_usd` / `input_tokens` / `output_tokens` rolled up across
-  every attempt — so a board renders without an N+1. Those are list-only;
-  `GET /v1/tasks/{id}` serves the same numbers per attempt in `steps[]`.
+  `step_name`, `status_message`, and `cost_usd` / `input_tokens` /
+  `output_tokens` rolled up across every attempt — so a board renders without an
+  N+1. Those are list-only; `GET /v1/tasks/{id}` serves the same numbers per
+  attempt in `steps[]`.
 
 Every task shape carries `parent_task_id`, `lane_id` and `lane_order`, all null
 for a root task. `GET /v1/tasks/{id}` additionally carries `children` whenever
@@ -792,6 +794,58 @@ resolved into the snapshot, so an include that cycles, names a workflow this
 project cannot see, nests past `include.max_depth`, brings a step id already in
 use, or is restricted to another platform is a `400` here.
 
+## Step status
+
+A running step can say what it is doing, in its own words:
+
+```
+POST /v1/tasks/{id}/steps/{step_id}/status
+{ "message": "3 tests red in internal/store" }
+```
+
+The answer is `{ "message": … }` — the value **as stored**, so you can see what
+a reader will see.
+
+The caller is the step's own process. It addresses itself with two of the
+[`VINCENT_*` variables](../guides/workflows.md#the-vincent-environment) the
+daemon sets on every agent and command step, `VINCENT_TASK_ID` and
+`VINCENT_STEP_ID`, and the usual way to call it is not curl but
+[`vincent status`](cli.md#vincent-status), which reads both and needs no
+arguments beyond the message.
+
+The path names a **step id**, not a `step_runs` row id, because a step knows
+which step it is and cannot know its row. It names a step rather than only the
+task because a `parallel` group's sub-steps share one task and run at the same
+time; within one task a step id has at most one running row.
+
+What the daemon does with the message:
+
+- **Bounds it rather than validating it.** It is flattened to a single line,
+  stripped of control characters and truncated to 256 bytes. Over-long text is
+  never a `400` — a step reporting progress should not fail because it was
+  wordy. An empty message clears the status.
+- **Refuses a step that is not running**, with `409 invalid_state`. An unknown
+  task is `404`. A write is never silently dropped, so a script still narrating
+  after its step was killed finds out.
+- **Paces writes without rejecting them.** Two writes for one step run inside
+  one second coalesce to the later value, which lands when the second is up.
+  The first write after a quiet period is always immediate.
+- **Announces the change** as the durable
+  [`task.status_changed`](#state-events--durable) event — but only when the
+  stored value actually changed.
+
+Where it shows up: `status_message` on every step-run object from
+`GET /v1/tasks/{id}` and `GET /v1/tasks/{id}/steps`, and on each row of
+`GET /v1/tasks`, denormalized from the task's **newest** step run so a board
+never fetches step rows for it. It is `null` when the step said nothing, which
+is the ordinary case — only `agent` and `command` steps run a process, and one
+only speaks if its prompt or script was written to.
+
+**It is not a failure reason.** `failure_reason` is a closed set of
+daemon-authored constants and is vincent's own verdict; `status_message` is free
+text the step chose, possibly long before it died. Render it as the step's last
+status, not as the cause of anything.
+
 ## Transcripts and diffs
 
 ```
@@ -836,8 +890,9 @@ a client reconnecting with `Last-Event-ID` misses nothing.
 
 ```
 task.created            task.state_changed      task.priority_changed
-task.step_advanced      task.children_changed   project.*
-workflow.registry_changed  agent.quota_changed  daemon.shutting_down
+task.step_advanced      task.status_changed     task.children_changed
+project.*               workflow.registry_changed
+agent.quota_changed     daemon.shutting_down
 ```
 
 Payloads carry ids and the new state, not full objects — clients re-fetch what
@@ -858,6 +913,11 @@ they need.
   transitions — re-fetch the `children` rollup when you see one. It exists
   because the per-task stream filters on `task_id` alone, so a root's stream
   would otherwise never see a depth-2 transition.
+- `task.status_changed` carries `{ task_id, step_id, message }` when a running
+  step changes what it says about itself — see [Step status](#step-status). It
+  is on the durable side deliberately, so a client that blinks recovers the
+  message through `Last-Event-ID`. It is emitted only when the stored value
+  actually changed, so a step re-asserting the same line does not wake you.
 - `agent.quota_changed` carries `{ agent, spent, resets_at, source }` and no
   `task_id`: the fact is about an adapter, not about any one task. It is
   emitted when a `usage_limit` stop is observed and when a successful run

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,7 @@ localhost API.
 - [`vincent service`](#vincent-service)
 - [`vincent project`](#vincent-project)
 - [`vincent task`](#vincent-task)
+- [`vincent status`](#vincent-status)
 - [`vincent workflow`](#vincent-workflow)
 - [`vincent github`](#vincent-github)
 - [`vincent gc`](#vincent-gc)
@@ -404,6 +405,18 @@ vincent task show <id> [--json]
 Shows one task with its step runs, the actions valid right now, and any pending
 input request.
 
+The step table's last two columns are different kinds of thing and should not be
+read as one. `REASON` is vincent's own `failure_reason`, a closed set of
+constants. `STATUS` is what the step said about *itself* through
+[`vincent status`](#vincent-status) — free text, `-` when it said nothing, and
+never the cause of a failure:
+
+```
+RUN  STEP       STATE      AGENT   REASON        STATUS
+1    implement  succeeded  claude  -             wired the adapter
+2    verify     failed     -       check_failed  3 tests red in internal/store
+```
+
 ### `vincent task cancel`
 
 ```sh
@@ -456,6 +469,52 @@ done
 The remaining human actions — approve, reject, retry, repair, skip, pause,
 resume, answer, archive — are TUI and API operations; see
 [the API reference](api.md#tasks).
+
+## `vincent status`
+
+```sh
+vincent status <message> [--json]
+```
+
+Records what the current step is doing, in its own words. It runs **from inside
+a step** — an agent's shell tool, or a `command` step's script — and takes no
+task or step argument: it reads `VINCENT_TASK_ID` and `VINCENT_STEP_ID` from
+[the environment](../guides/workflows.md#the-vincent-environment) the daemon
+sets on every agent and command step.
+
+```sh
+vincent status "running the store suite"
+# … later in the same step
+vincent status "3 tests red in internal/store"
+```
+
+The message has two readings and is one value. While the step runs it is the
+live answer to "what is this doing", shown on the board's `STATUS` column and on
+the attempt line in the [TUI](../guides/tui.md); the last value set before the
+attempt ends stays on the finished attempt as the step's own account of how it
+went.
+
+Details worth knowing:
+
+- **It is bounded, not validated.** The message is flattened to one line,
+  stripped of control characters and truncated to 256 bytes. Being wordy never
+  fails the command. An empty message clears the status.
+- **It is silent on success.** Its stdout is the step's transcript, and a step
+  that reports progress ten times should not add ten lines of vincent's own
+  noise to the record it is summarizing. `--json` prints the stored value if you
+  want it.
+- **It only works while the step is running.** Afterwards the daemon answers
+  `409` and the command exits 1 saying so, rather than dropping the message.
+- **Nothing asks an agent to call it.** The daemon appends no instruction to a
+  prompt, so an agent reports its status only when the workflow author asked it
+  to — see
+  [Reporting status from a step](../guides/workflows.md#56-reporting-status-from-a-step).
+- Outside a step, with neither variable set, it exits 1 and says so. It never
+  guesses a task.
+
+The status is never a `failure_reason`: nothing renders it as the cause of a
+failure, because a step killed on a timeout can be carrying a line it wrote
+half an hour earlier.
 
 ## `vincent workflow`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -534,10 +534,10 @@ only keeps other local accounts out. Prefer naming the variable under `inherit`
 and letting the value come from the environment that starts the daemon; see
 [Security model](../security-model.md#credentials).
 
-Command and check steps layer the [`VINCENT_*` variables](../guides/workflows.md#55-environment-variables)
-and then their own `env:` on top. Neither `unset` nor `set` can touch those —
-they are facts about the run, not inherited state — and a step's `env:` still
-wins over everything.
+Agent, command and check steps layer the [`VINCENT_*` variables](../guides/workflows.md#55-environment-variables)
+on top of that, and command and check steps then layer their own `env:`. Neither
+`unset` nor `set` can touch the `VINCENT_*` block — those are facts about the
+run, not inherited state — and a step's `env:` still wins over everything.
 
 #### What it is for
 
@@ -713,7 +713,7 @@ VINCENT_CONFIG_DIR=/tmp/v-cfg VINCENT_DATA_DIR=/tmp/v-data vincent daemon start
 > or the CLI and the service will quietly use different databases. See
 > [Running at login](../guides/running-at-login.md).
 
-Command and check steps additionally receive `VINCENT_TASK_ID`,
+Agent, command and check steps additionally receive `VINCENT_TASK_ID`,
 `VINCENT_TASK_TITLE`, `VINCENT_PROJECT_NAME`, `VINCENT_PROJECT_PATH`,
 `VINCENT_WORKTREE`, `VINCENT_BRANCH`, `VINCENT_BASE_BRANCH`, `VINCENT_STEP_ID`,
 `VINCENT_STEP_ATTEMPT` and `VINCENT_WORKFLOW` — see

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -222,6 +222,25 @@ that long in `queued` — holding no slot — and the step re-runs when the wait
 over. The budget is unchanged either way: the backoff decides *when* an attempt
 happens, never *whether*.
 
+## What a step says about itself
+
+Beside the outcome, a step run carries two pieces of text that are **not**
+vincent's words:
+
+- **`status_message`** — a line the running step wrote about itself through
+  [`vincent status`](../guides/workflows.md#56-reporting-status-from-a-step).
+  While the step runs it is the live answer to "what is this doing"; the last
+  value it set stays on the finished attempt. Empty unless the workflow asked
+  for it, and empty always for the step types that run no process (`manual`,
+  `parallel`, `fan_out`, `condition`, `loop`, `break`).
+- **`result_summary`** — the agent's final result text, or the last 200 lines of
+  a command step's stdout. Recorded on every attempt, readable from a later
+  step's `{{ .Steps.<id>.Result }}`.
+
+Neither is a failure reason, and no surface renders either as one. The reasons
+below are a closed set vincent authors; these two are whatever the step
+produced, possibly long before it stopped.
+
 ## Failure reasons
 
 The reason is recorded on the step run and on the task when it blocks. The
@@ -271,7 +290,9 @@ that renames the branch and re-admits it. See
 vincent is **crash-first**: every transition is persisted before it is acted on.
 When the daemon starts, recovery:
 
-1. finalizes any step run still marked `running` as `interrupted`;
+1. finalizes any step run still marked `running` as `interrupted`, keeping
+   whatever status message that step had set — "what was it doing when the
+   machine went down" is exactly what you want off that row;
 2. kills verified orphan processes — the recorded PID must still exist **and**
    still hold the very process the run spawned, checked against a
    platform-native identity recorded at spawn (start ticks plus boot id on

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -920,8 +920,8 @@ missing value before a snapshot can run.
 
 ## Environment
 
-Command and check steps run with cwd set to the worktree, inherit the daemon's
-environment, and additionally receive:
+Agent, command and check steps run with cwd set to the worktree, inherit the
+daemon's environment, and additionally receive:
 
 ```
 VINCENT_TASK_ID        VINCENT_TASK_TITLE     VINCENT_PROJECT_NAME
@@ -930,7 +930,13 @@ VINCENT_BASE_BRANCH    VINCENT_STEP_ID        VINCENT_STEP_ATTEMPT
 VINCENT_WORKFLOW
 ```
 
-`env:` on a step is merged on top of these.
+`env:` on a step is merged on top of these — it is a command-step field, so an
+agent step has none. Nothing can remove a `VINCENT_*` variable: they are facts
+about the run, not inherited state.
+
+`VINCENT_TASK_ID` and `VINCENT_STEP_ID` are what
+[`vincent status`](cli.md#vincent-status) uses to address the step it is being
+run from, which is why every step type that runs a process gets them.
 
 ## Resolution order
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -276,7 +276,9 @@ re-runs after interruption) is a distinct StepRun row — history is append-only
 
 Records: step id/index/type, attempt number, state (`running`, `succeeded`, `failed`,
 `interrupted`, `approved`, `rejected`, `skipped`, `stopped`), timestamps, agent/model/effort used (as resolved per §8.6), exit code,
-check exit code, failure reason, skip reason, transcript file path, input/output tokens, cost (USD,
+check exit code, failure reason, skip reason, result summary, status message
+(both added to this list 2026-08-26 — see the task 036 amendment below),
+transcript file path, input/output tokens, cost (USD,
 nullable — not all agents report cost), input wait time (ms spent in `awaiting_input`,
 §7.4 — excluded from duration metrics).
 
@@ -333,6 +335,58 @@ point of a follow-up; rows from *earlier* rounds are hidden for the reason a
 `__repair` row is, because nobody wrote them into the workflow being run. Where
 a follow-up workflow reuses an id from the original workflow, the round's own
 row shadows it.
+
+*Amended 2026-08-26 (task 036).* The field list above gains two entries. The
+first, **`result_summary`**, is not new — it has been recorded, served on the
+§13.2 DTO and read by `.Steps.<id>.Result` and the repair prompt since the first
+release — and was simply never listed here. It holds the agent's final result
+text, or the last 200 lines of a command step's stdout.
+
+The second is new: the **status message**, a short piece of free text a
+*running* step writes about itself through
+`POST /v1/tasks/{id}/steps/{step_id}/status` (§13.2). It is nullable, and null
+is the ordinary case.
+
+It is one field with two readings, not two features. While the row is `running`
+it is the live answer to "what is this doing"; the last value written before the
+attempt ends stays on the finished row as the step's self-report, which is the
+half that answers "why did that fail" in terms a human wants — "3 tests red in
+internal/store" rather than `check_failed`.
+
+Four properties are normative:
+
+- **It is not a `failure_reason`, and no client may render it as one.** That
+  enum stays the closed, daemon-authored vocabulary shared with
+  `internal/worktree` (T1.5/T1.6 decision). A step killed on `timeout` after
+  forty minutes may be carrying a message it set thirty-five minutes earlier,
+  so presenting it beside the reason as though it were the daemon's verdict
+  would be a lie the daemon never told. It renders as *the step's last status*,
+  visually distinct (§15).
+- **Only `agent` and `command` steps have one.** `manual`, `parallel`,
+  `fan_out`, `condition`, `loop` and `break` write `step_run` rows but run no
+  process, so they have no voice and their status stays null; `include` never
+  reaches the engine at all (§7.9). Synthesising daemon text for the
+  process-less types was rejected: it would put daemon-authored and
+  step-authored strings in one field, which is the confusion this field exists
+  to escape. So is a workflow-authored `status:` template — it can only restate
+  what the author knew before the run, and the whole value here is what only the
+  run can know.
+- **The daemon never asks for it.** No protocol instruction is appended to a
+  rendered agent prompt; §8.4's automatic append stays reserved for
+  `<previous-attempt-failure>`. A workflow author who wants live status writes
+  the instruction into their own prompt. The cost is a low hit rate until
+  authors adopt it; the alternative charges every workflow that does not care
+  for tokens on every step.
+- **It is human-facing only.** It is not in `.Steps` (§8.4) and not in the
+  `<previous-attempt-failure>` block (§7.2). Free text an agent chose at run
+  time is not something an `if:` guard should branch on, and `.Steps.<id>.Status`
+  already means the run *state* — exposing the message there would need a
+  second, confusable key.
+
+There is no `status_updated_at` column and no rule that clears the value: the
+event announces when it changed (§13.3), the row carries what it is, and a
+second column would have to be kept true by every writer for something no
+surface renders.
 
 ## 6. Task lifecycle
 
@@ -666,6 +720,14 @@ stdout/stderr are captured to the step transcript.
 - **`condition_error` is the one reason that does not run this budget.**
   *Added 2026-08-18 (task 015).* A guard is evaluated before the step becomes
   an attempt, so there is no attempt to retry (§7.7).
+- **A step's status message is not part of the retry block.** *Added
+  2026-08-26 (task 036).* The status a step wrote about itself (§5.4) is never
+  a `failure_reason` and is deliberately **not** put in the
+  `<previous-attempt-failure>` block the daemon appends on retry. The block is
+  the daemon's account of what went wrong — reason plus output — and mixing an
+  agent's own free text into it hands the next attempt a claim it cannot tell
+  apart from a fact vincent established. The failed attempt's status is
+  displayed to humans (§15) and reaches nothing the run itself reads.
 - **`agent_unauthenticated` stays under the normal budget.** *Added 2026-08-14
   (task 003).* A CLI that refuses because it is not logged in fails the attempt
   like any other, retries as usual, and blocks when the budget is spent. Waiting
@@ -1588,7 +1650,22 @@ reason: check command failed (exit 1)
 </previous-attempt-failure>
 ```
 
-### 8.5 Environment for command/check steps
+*Recorded 2026-08-26 (task 036).* That block stays the **only** thing the
+daemon appends to a rendered prompt. In particular the step-status protocol
+(§5.4, §13.2) is documented rather than injected: a workflow author who wants
+an agent to report on itself writes the instruction into their own prompt, and
+`.Steps.<id>` deliberately does not gain the status message — it means what a
+completed step *produced*, and `Status` there already means the run state.
+
+### 8.5 Environment for command, check and agent steps
+
+*Retitled 2026-08-26 (task 036): this block now reaches `agent` steps too. It
+had always been specified for command and check steps alone, which left an
+agent process able to see the resolved environment and none of the facts about
+the run it was executing — so an agent could not name its own step even to the
+daemon that started it. `vincent status` (§12.1) addresses itself with
+`VINCENT_TASK_ID` and `VINCENT_STEP_ID`, which is what made the gap
+load-bearing.*
 
 Inherits the daemon's environment (which inherits the user's), with cwd set to the
 worktree, plus:
@@ -1598,6 +1675,12 @@ VINCENT_TASK_ID, VINCENT_TASK_TITLE, VINCENT_PROJECT_NAME, VINCENT_PROJECT_PATH,
 VINCENT_WORKTREE, VINCENT_BRANCH, VINCENT_BASE_BRANCH, VINCENT_STEP_ID,
 VINCENT_STEP_ATTEMPT, VINCENT_WORKFLOW
 ```
+
+The precedence is one rule for all three step types: the §12.3 resolved base
+environment, then this block, then a `command` step's own `env:` (which is a
+command-step field, so an agent step has none). Because the block is layered
+*after* the policy, `environment.unset` cannot reach a `VINCENT_*` variable:
+these are facts about the run, not inherited state.
 
 ### 8.6 Agent, model, and effort resolution
 
@@ -1631,6 +1714,23 @@ a workflow `agent` step, so the workflow's `defaults:` govern it and full-auto,
 `wait` and the agent timeout are the fallbacks.
 
 ## 9. Agent adapters
+
+*Recorded 2026-08-26 (task 036).* The step-status channel (§5.4) is
+**adapter-independent** and is not part of this section's surface. A step sets
+its status by calling `POST /v1/tasks/{id}/steps/{step_id}/status` from its own
+process — usually through `vincent status` (§12.1) — so nothing is parsed out
+of an adapter's stream and no `AgentAdapter` method is involved. No adapter can
+therefore lack the feature, and nothing about it is emulated for one that would
+have: the difference this section documents everywhere else does not arise
+here.
+
+That is also why the status is not a marked line in a step's output. A marker
+lifted out of the normalized `AgentEvent` stream would miss the obvious agent
+spelling — an agent running `echo '::vincent:status:: …'` through its shell
+tool produces a tool-use event, not an `Output` event — would force a
+strip-or-keep choice over the transcript and `result_summary` with no good
+answer, and would make every step's stdout a control channel, so that any
+program which happened to print the marker changed daemon state.
 
 ### 9.1 Interface
 
@@ -2474,6 +2574,7 @@ One Go binary, `vincent`:
 | `vincent workflow ls / validate [file] / init <name>` | Registry listing / YAML validation / writing a new registry file. *Amended 2026-08-26 (task 034):* `init` writes the §5.2 scope directory a `--project` flag selects — global by default, resolved from §12.2 with **no daemon**; `--project N` needs one, purely to resolve the id to a repository root. `--from <example>` writes an embedded `examples/*.yaml` with its top-level `name:` rewritten. It refuses an existing path (`O_EXCL`) or a name another file in the same scope already declares, and only warns when the name shadows a lower scope |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
 | `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2) |
+| `vincent status <message>` | *Added 2026-08-26 (task 036).* Records what the current step is doing, in its own words (§5.4). Runs **from inside a step**: it addresses itself with §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, takes no id argument, and errors naming those variables when they are unset. Silent on success — its stdout is the step's transcript |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent github issues / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub |
 | `vincent doctor` | One diagnostic report: paths, daemon, log tail, database, agents, storage, task counts (§17). `--json` for scripting and bug reports; `--fix` (`--force`) reclaims orphaned worktrees and compacts the database. Exit 0 healthy · 1 problems found · 2 no daemon answered. *Amended 2026-08-26 (task 035):* it also reports the GitHub integration — the `github.enabled` toggle, `gh`'s presence, version and login state, whether a token variable is set (its **name**, never its value), and whether issues are readable. It is a **row, not a problem**: every "no" it can report leaves task creation without an issue working exactly as before, so none of it changes the exit code |
@@ -2492,6 +2593,15 @@ retype.
 (`project add`, `task ls`) knowingly: `git gc` is the idiom users already have, and the
 scope spans two directory trees — worktrees and transcripts — so a `worktree` noun
 would have been wrong on the day it shipped.
+
+*Added 2026-08-26 (task 036).* `status` is the second command in this table
+invoked by a *program* rather than by a human at a prompt, after `follow-up`,
+and it is the reason the noun-verb pattern is broken again: there is no noun. It
+does not act on a task the caller names, it reports on the step the caller *is*,
+which is also why it takes its addressing from the environment rather than from
+flags nobody would be there to type. It is a thin client for
+`POST /v1/tasks/{id}/steps/{step_id}/status` (§13.2) and carries `--json` like
+the rest.
 
 *Added 2026-08-25 (task 027).* `follow_up` is the one §6 human action with a
 command line. `retry`, `repair`, `skip` and `approve` are deliberately
@@ -3386,6 +3496,39 @@ GET    /v1/tasks/{id}/steps             all StepRuns (every attempt)
                                         (task 015, 2026-08-18: each carries `skip_reason`
                                         — "condition" for a false `if:`, null for the human
                                         skip — and `state` may now be "stopped", §5.4/§7.7)
+                                        (task 036, 2026-08-26: each also carries
+                                        `status_message` — what the step said about itself,
+                                        null when it said nothing — and `result_summary`,
+                                        which has always been on this DTO and is now listed
+                                        in §5.4 as well. `GET /v1/tasks` carries
+                                        `status_message` too, denormalized from the task's
+                                        *newest* step run the way `step_name` and `cost_usd`
+                                        are, so a board never fetches step rows for it)
+POST   /v1/tasks/{id}/steps/{step_id}/status
+                                        { message } → { message }, the value as stored
+                                        (added 2026-08-26, task 036). Records what the
+                                        **running** step at `step_id` is doing, in its own
+                                        words (§5.4). The caller is that step's own process:
+                                        it addresses itself with §8.5's VINCENT_TASK_ID and
+                                        VINCENT_STEP_ID, which is why the path names a step
+                                        id rather than a `step_runs` row id — a step knows
+                                        which step it is and cannot know its row. It is keyed
+                                        by step id and not by task alone because a `parallel`
+                                        group's sub-steps share one task and run at the same
+                                        time (§7.5); within one task a step id has at most one
+                                        running row.
+                                        `message` is bounded rather than validated: it is
+                                        flattened to a single line, stripped of control
+                                        characters and truncated to **256 bytes**, and the
+                                        response reports what was stored. An empty message
+                                        clears the status. An unknown task is a 404; a step
+                                        that is **not running** is a **409** — never a silent
+                                        no-op, so a script still reporting progress after its
+                                        step was killed learns that.
+                                        Writes are paced, not rejected: two writes for one
+                                        step run inside **1 s** coalesce to the later value,
+                                        which lands when the floor expires (§13.3). The first
+                                        write after a quiet period is always immediate
 GET    /v1/tasks/{id}/steps/{run_id}/transcript?offset=&tail=&format=
                                         the attempt's JSONL transcript, ranged.
                                         `offset=` (bytes) and `tail=` (last N bytes) are
@@ -3439,8 +3582,23 @@ Two kinds of streams:
    emitted as SSE with `id:` set, so clients reconnect with `Last-Event-ID` and miss
    nothing. Types:
    `task.created`, `task.state_changed`, `task.priority_changed`, `task.step_advanced`,
-   `task.children_changed`, `project.*`, `workflow.registry_changed`,
-   `agent.quota_changed`, `daemon.shutting_down`.
+   `task.status_changed`, `task.children_changed`, `project.*`,
+   `workflow.registry_changed`, `agent.quota_changed`, `daemon.shutting_down`.
+   (`task.status_changed` — *added 2026-08-26, task 036* — carries
+   `{task_id, step_id, message}` and announces that a running step changed what
+   it says about itself (§5.4). It is on the **durable** side deliberately: the
+   message is state, not output, so a client that blinks must be able to recover
+   it through `Last-Event-ID`, which a live output chunk cannot offer. Three
+   bounds keep it off the events table's critical path. A write whose message is
+   byte-identical to the stored value appends **no** event — the rule
+   `agent.quota_changed` already records, so a board that refetches on it is not
+   woken by news it has. A **1 s** minimum interval per step run coalesces
+   anything faster to the latest value rather than rejecting it, and the first
+   write after a quiet period is always immediate, so the live reading is never
+   delayed. The message itself is capped at **256 bytes**, truncated rather than
+   refused, forced to a single line with control characters stripped.
+   `scheduler.WakeOn` is **false** for it: nothing about admission changes when
+   a step describes itself.)
    (`agent.quota_changed` — *added 2026-08-24, task 026* — carries
    `{agent, spent, resets_at, source}` and, like `workflow.registry_changed`,
    no `task_id` and no `project_id`: the fact is about an adapter, not about
@@ -3597,6 +3755,14 @@ CREATE TABLE step_runs (
   failure_reason      TEXT,
   skip_reason         TEXT,                   -- 'condition' for a false `if:` (§7.7); NULL for the human skip (§6)
   result_summary      TEXT,                   -- agent result text / command stdout tail
+  -- What the step said about *itself* (§5.4, task 036, migration 0014): short
+  -- free text its own process set through
+  -- POST /v1/tasks/{id}/steps/{step_id}/status while it was running. NULL is
+  -- the ordinary case — the step types that run no process never speak, and an
+  -- agent or command step only speaks when its prompt or script was written to.
+  -- Never written by the actor's own row updates, which is what makes the last
+  -- live value survive onto the finished row.
+  status_message      TEXT,                   -- NULL = the step said nothing
   prompt_override     TEXT,                   -- edit+retry: the prompt a human supplied for this attempt (§6)
   run_override        TEXT,                   -- edit+retry: the command a human supplied for this attempt (§6)
   transcript_path     TEXT,
@@ -3704,7 +3870,32 @@ stream for the live tail.
    `space` marks the row under the cursor, `V` marks everything the filter is
    showing, and while anything is marked the task-action keys act on the whole
    selection. See *Bulk selection* below.
-2. **Task detail.** Step timeline (every attempt, with durations, tokens, cost);
+   **A STATUS column (task 036, added 2026-08-26)** shows what the task's
+   newest step run said about itself (§5.4), truncated with an ellipsis. It sits
+   at the top of the shedding ladder — dropped before cost, the step name, the
+   workflow and the project — and it carries a higher bar than the others: it is
+   admitted only when the title still clears a comfortable width, so a board
+   narrow enough to lose it renders exactly as it did before the column existed,
+   and the width a grouped board frees by dropping PROJECT and WORKFLOW still
+   goes to the title. The status of the *newest* row, not the newest message: a
+   step that spoke and finished must not have its line linger beside the next
+   step, which is doing something else. The state cell is untouched — the
+   recorded reasoning that keeps a hold's reason out of it (it does not fit, and
+   widening a column for a rare state costs every board the columns that shed
+   first) stands unchanged, and this column is why the status did not go there.
+2. **Task detail.** *Amended 2026-08-26 (task 036): the attempt line gains two
+   fields.* The step's own **status message** (§5.4) renders last on the line,
+   in its own style and behind a glyph, so it reads as a quotation from the step
+   rather than as another of the daemon's fields — and specifically **not** in
+   `failure_reason`'s style, because a step killed on `timeout` can be carrying
+   a line it wrote half an hour earlier and a client must never present that as
+   the daemon's verdict. And **`result_summary`**, which had been stored and
+   served since the first release and rendered on no screen at all, appears as a
+   dim continuation line under an attempt that did **not** succeed — where a
+   reader is asking "what went wrong" and the reason answers only which
+   category. Under every attempt it would double a healthy timeline's height to
+   restate what the output pane already shows for the selected one.
+   Step timeline (every attempt, with durations, tokens, cost);
    live output tail of the running step (follow mode); scrollback into full
    transcripts of past steps. Timeline and output are **side by side, both always
    visible** — selecting an attempt *is* how scrollback is navigated, so neither

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3755,7 +3755,7 @@ CREATE TABLE step_runs (
   failure_reason      TEXT,
   skip_reason         TEXT,                   -- 'condition' for a false `if:` (§7.7); NULL for the human skip (§6)
   result_summary      TEXT,                   -- agent result text / command stdout tail
-  -- What the step said about *itself* (§5.4, task 036, migration 0014): short
+  -- What the step said about *itself* (§5.4, task 036, migration 0015): short
   -- free text its own process set through
   -- POST /v1/tasks/{id}/steps/{step_id}/status while it was running. NULL is
   -- the ordinary case — the step types that run no process never speak, and an

--- a/docs/tasks/036-step-status-message.md
+++ b/docs/tasks/036-step-status-message.md
@@ -174,7 +174,7 @@ doing something else.
 
 ## Tasks
 
-- [x] **036.1** Store: migration `0014_step_status.sql`, `StatusMessage` on
+- [x] **036.1** Store: migration `0015_step_status.sql`, `StatusMessage` on
   `store.StepRun` threaded through the typed CRUD (and deliberately *not*
   through `UpdateStepRun`), `SetStepRunStatus` /`SetStepRunStatusByRun` with the
   dedup rule and the `task.status_changed` event in one transaction,

--- a/docs/tasks/036-step-status-message.md
+++ b/docs/tasks/036-step-status-message.md
@@ -1,0 +1,216 @@
+# 036 — A step-authored status message, live and terminal
+
+**Status:** ✅ done (7/7)
+**Issue:** [#199](https://github.com/lezli01/vincent/issues/199)
+**Spec:** amends §5.4, §7.2, §8.4 (a recorded non-change), §8.5, §9, §12.1,
+§13.2, §13.3, §14, §15
+
+## Problem
+
+A step could not say anything about itself. A reader had two channels and
+neither answered "what is this doing" or "why did that fail":
+
+- `failure_reason` is a **closed enum** of daemon-authored constants
+  (`timeout`, `nonzero_exit`, `check_failed`, `merge_conflict`, …). It says
+  which *category* of thing went wrong, never which file, which test, which
+  assertion. `nonzero_exit` on a forty-minute agent step is almost no
+  information.
+- `step_runs.result_summary` holds the agent's final result text or the last
+  200 lines of command stdout. It was stored, served on the API DTO, and read
+  by `.Steps.<id>.Result` and the repair prompt — and rendered **nowhere** in
+  the TUI.
+
+So a running task told you only that it was running, and a blocked task told
+you only the category of its failure. Finding out more meant opening the
+transcript, which is the durable output copy rather than a summary.
+
+## What shipped
+
+One nullable free-text field on `step_runs`, the **status message**: a short
+line the running step writes about itself, in its own words. It has two
+readings and is one field, not two features — while the step runs it is the
+live answer to "what is this doing", and the last value written before the
+attempt ends stays on the finished row as its self-report.
+
+It does **not** replace or widen `failure_reason`. That enum stays a closed,
+shared vocabulary between `internal/worktree` and `internal/taskrun/engine.go`
+(T1.5/T1.6 decision), and the status message is never rendered as a cause of
+failure.
+
+## Decisions
+
+**1. The producer is the API, not a sentinel line in the step's output.**
+*2026-08-26.* A step sets its status by calling the daemon —
+`POST /v1/tasks/{id}/steps/{step_id}/status`, wrapped in a new
+`vincent status "<text>"` subcommand that resolves task and step from its
+environment.
+
+The sentinel design the issue proposed lost on three counts. It forces a
+strip-or-keep choice over the transcript and `result_summary` that has no good
+answer. It cannot see the obvious agent spelling, because an agent that runs
+`echo '::vincent:status:: …'` through its Bash tool produces an
+`agent.EventToolUse`/`EventToolResult`, not the `EventOutput` that
+`Runner.publishOutput` would be parsing. And it makes every step's stdout a
+control channel, so any program that happens to print the marker changes daemon
+state. The API call has none of those properties, works identically for `agent`
+and `command` steps, and reuses auth, transport and the error envelope that
+already exist.
+
+**2. Agent steps gain the §8.5 `VINCENT_*` environment.** *2026-08-26.* This is
+decision 1's prerequisite and was a real gap, not a chore:
+`internal/taskrun/steps.go` passed `Env: r.childEnv()` to `agent.RunSpec`, so an
+agent step saw the resolved base environment and none of the run facts, while
+`commandEnv` added them for command and check steps only. `vincent status` needs
+`VINCENT_TASK_ID` and `VINCENT_STEP_ID` to address itself. Agent steps now get
+the same block by the same precedence rule; `env:` stays a command-step field,
+so an agent step has no third layer.
+
+**3. Scope is `agent` and `command` steps.** *2026-08-26.* Of the issue's three
+ways out this is option 1, deliberately narrowed. `manual`, `parallel`,
+`fan_out`, `condition`, `loop` and `break` write `step_run` rows but run no
+process, so they have no voice and their status stays empty; `include` is out by
+construction (§7.9).
+
+The alternatives were rejected for one reason each. Synthesising daemon text for
+the process-less types (option 3) puts daemon-authored and step-authored strings
+in one field, which is exactly the muddle this feature exists to escape from. A
+workflow-authored `status:` template (option 2) reintroduces as a second
+mechanism the design the issue already rejected as primary, and can only restate
+what the author knew before the run. "Every step type carries a status" is
+therefore **not** met, knowingly. The field means "what the step said about
+itself"; a step with nothing to say says nothing.
+
+**4. No automatic prompt injection.** *2026-08-26.* The daemon does not append a
+protocol instruction to rendered agent prompts. §8.4's automatic append stays
+reserved for the `<previous-attempt-failure>` block. The protocol is documented
+instead — in `skills/vincent-workflows/SKILL.md`, `docs/guides/workflows.md` and
+`docs/reference/cli.md` — and a workflow author who wants live status writes the
+instruction into their own prompt. This costs nothing in tokens for the
+workflows that do not care, at the price of a low hit rate until authors adopt
+it. That price is what makes decision 8's `result_summary` rendering part of
+this task rather than a follow-up.
+
+**5. Durable, deduped, rate-capped.** *2026-08-26.* The status lands on §13.3's
+durable side, as the issue requires: a client that blinks must be able to
+recover it via `Last-Event-ID`. A new durable event type `task.status_changed`
+carries `{task_id, step_id, message}`.
+
+Two bounds keep it from flooding the `events` table. A write whose message is
+byte-identical to the stored value is dropped without an event — the rule
+`agent.quota_changed` already records. And a minimum interval per step run
+(**1 s**) coalesces anything faster to the latest value rather than rejecting
+it; the throttle is leading-edge, so the first write after a quiet period is
+always immediate and the live reading is never delayed. The message itself is
+capped at **256 bytes**, truncated rather than refused, forced to a single line,
+with control characters stripped. `scheduler.WakeOn` is **false** for the new
+type: nothing about admission changes when a step describes itself.
+
+*Amended during implementation.* A coalesced write is persisted **by row id**,
+not re-resolved as "the running step at this id". The first shape lost the last
+thing a step said whenever the step finished inside the floor — which is
+precisely the message the terminal reading exists for. The step wrote it while
+it *was* running; the floor is the daemon's choice about when to persist it, not
+a licence to drop it. `store.SetStepRunStatusByRun` is that write, and nothing
+but the throttle may call it — the endpoint's own 409 lives in
+`SetStepRunStatus`.
+
+**6. Terminal reading is neutral.** *2026-08-26.* The last value survives on the
+finished row — that is the half of the issue that answers "why did that fail" —
+but no client ever labels it as a failure cause. A step killed on `timeout`
+after forty minutes may be carrying a message it set thirty-five minutes
+earlier, and rendering that beside `failure_reason` would present a stale
+self-report as the daemon's verdict. It renders as the step's last status,
+visually distinct from the `styleBad` failure reason on the attempt line. No
+`status_updated_at` column and no clearing rule.
+
+The mechanism that makes survival free is that `UpdateStepRun` does **not**
+carry `status_message`. The actor is the sole writer of every other column of
+its rows; this is the one column written from another goroutine, so an update
+with the actor's stale struct would erase it. Leaving the column out of the SET
+list makes recovery's `terminalizeOpenStepRuns` keep it too, with no extra rule.
+
+**7. Human-facing only.** *2026-08-26.* The status reaches the TUI, the CLI and
+the API and stops there. It is not added to `.Steps` (§8.4) and not added to the
+`<previous-attempt-failure>` retry block (§7.2). Two reasons: the blast radius
+stays on display surfaces, and free text an agent chose at run time does not
+become something an `if:` guard can branch on. This also sidesteps a name
+collision — `.Steps.<id>.Status` already means the run *state*, so exposing the
+message there would need a second, confusable key.
+
+**8. Two adjacent gaps close in the same pass.** *2026-08-26.* §5.4's normative
+field list gains both the new field *and* `result_summary`, which it had never
+listed. And `result_summary` is finally rendered in the TUI detail view: it is
+stored, served, read by `.Steps.<id>.Result` and by the repair prompt, and was
+shown nowhere. Given decision 4, most steps will emit no status for a while, and
+the stored summary is what improves the blocked case for all of them meanwhile.
+It renders as a dim continuation line under an attempt that did **not** succeed
+— under every attempt it would roughly double a healthy timeline's height to
+restate what the output pane already shows for the one attempt the reader
+selected.
+
+**9. The board column is shed first, and has a gate of its own.**
+*2026-08-26.* `renderBoardState` records that a hold's *reason* is deliberately
+kept out of the state cell: "it does not fit `widthState`, and widening the
+column for a rare state would cost every board the columns that get shed first.
+The detail header, which has the width, names it." That decision is **not**
+overturned. The status gets its own column, shed *before* `cost`, `stepName`,
+`workflow` and `project` under width pressure.
+
+The shedding ladder alone turned out to be the wrong gate. `minTitle` is 16, so
+a 120-column board — the common case — would have admitted the status and taken
+its title from 50 cells to 20: legal, and useless. `minTitleWithStatus` (64) is
+the column's own bar. It is also set high enough that the column cannot eat the
+width a *grouped* board frees by dropping PROJECT and WORKFLOW, which
+`columnsFor` records as going to the title; at every width a grouped board's
+title stays strictly wider than a flat board's, and a test asserts it.
+
+**10. The list row denormalizes the *newest* row's status.** *2026-08-26.* The
+board reads `GET /v1/tasks` and never fetches step rows, so `status_message`
+rides the list DTO the way `step_name` and `cost_usd` do — one extra query for
+the whole page, never one per row. It is the status of the newest `step_runs`
+row, not a search for the newest non-empty message: a step that spoke and
+finished must not have its line linger beside the next step, which is silently
+doing something else.
+
+## Tasks
+
+- [x] **036.1** Store: migration `0014_step_status.sql`, `StatusMessage` on
+  `store.StepRun` threaded through the typed CRUD (and deliberately *not*
+  through `UpdateStepRun`), `SetStepRunStatus` /`SetStepRunStatusByRun` with the
+  dedup rule and the `task.status_changed` event in one transaction,
+  `RunningStepRunID`, `LatestStepStatuses`. ✓ 2026-08-26
+- [x] **036.2** Engine: `Runner.SetStepStatus`, `NormalizeStatusMessage`, the
+  per-run coalescing throttle, and the §8.5 environment on an agent step's
+  `RunSpec.Env`. ✓ 2026-08-26
+- [x] **036.3** API + apiclient: the route, `status_message` on the step-run DTO
+  and the list row, `Client.SetStepStatus`, and the new event type in the client
+  vocabulary. ✓ 2026-08-26
+- [x] **036.4** CLI: `vincent status`, and a `STATUS` column on
+  `vincent task show`. ✓ 2026-08-26
+- [x] **036.5** TUI: the status on the attempt line in its own style, the
+  `result_summary` continuation line, and the sheddable board column. ✓
+  2026-08-26
+- [x] **036.6** Tests: store, engine, recovery, API/apiclient live, CLI e2e and
+  TUI, plus `cmd/fakeagent`'s `set-status` scenario. ✓ 2026-08-26
+- [x] **036.7** Docs: spec amendments, `docs/reference/api.md`,
+  `docs/reference/cli.md`, `docs/reference/task-lifecycle.md`,
+  `docs/reference/workflow-schema.md`, `docs/guides/workflows.md`,
+  `docs/guides/tui.md`, `docs/features.md`,
+  `skills/vincent-workflows/SKILL.md`, and `m2-gate.sh` scenario 12. ✓
+  2026-08-26
+
+## Verification
+
+- `go test ./...` and `go test -race ./internal/taskrun ./internal/store` green.
+- `go run mage.go lint` clean, and `golangci-lint` cross-built for `windows`,
+  `darwin` and `linux` clean.
+- `./scripts/m2-gate.sh` green, all twelve scenarios. Scenario 12 asserts over
+  curl that a running step's status is visible on the step row and on
+  `GET /v1/tasks`, and that the last value the step set survives on the finished
+  row.
+- `docs/assets/tui-*.png` were **not** re-captured. The board's shape is
+  unchanged at the widths `scripts/screenshots.sh` renders — the status column
+  is not admitted below a 64-cell title — and the detail panel's new fields need
+  a task whose step actually set a status, which the seeding script does not
+  produce. Re-capturing would have produced byte-identical board shots and a
+  detail shot no more informative than the current one.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -49,6 +49,7 @@ the living engineering specification records implementation contracts.
 | [033](033-task-cost-cap.md) | `max_task_cost_usd`: a per-task cost cap enforced at attempt boundaries | ✅ done (4/4) |
 | [034](034-workflow-init.md) | `vincent workflow init`, a CLI on-ramp for authoring a workflow | ✅ done (5/5) |
 | [035](035-github-issue-selection.md) | Select a GitHub issue when creating a task | ✅ done (12/12) |
+| [036](036-step-status-message.md) | A step-authored status message, live and terminal | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -213,6 +213,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/archive", s.handleTaskArchive)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/follow_up", s.handleTaskFollowUp)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/steps", s.handleTaskSteps)
+	rt.handle(http.MethodPost, "/v1/tasks/{id}/steps/{step_id}/status", s.handleStepStatus)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/steps/{run_id}/transcript", s.handleTranscript)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/diff", s.handleTaskDiff)
 	rt.handle(http.MethodGet, "/v1/events", s.handleEvents)

--- a/internal/api/stepstatus.go
+++ b/internal/api/stepstatus.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
+)
+
+// stepStatusRequest is the body of POST /v1/tasks/{id}/steps/{step_id}/status
+// (§13.2, task 033): the one line the step wants to say about itself.
+type stepStatusRequest struct {
+	Message string `json:"message"`
+}
+
+// handleStepStatus records a running step's own status message.
+//
+// The producer is this endpoint and not a sentinel line in the step's output
+// (task 033 decision 1). A marker printed on stdout would force a
+// strip-or-keep choice over the transcript and `result_summary` with no good
+// answer, would miss the obvious agent spelling entirely — an agent running
+// `echo` through its Bash tool produces a tool-use event, not the output
+// event a parser would be watching — and would make every step's stdout a
+// control channel, so any program that happened to print the marker would
+// change daemon state. An API call has none of those properties, works
+// identically for `agent` and `command` steps, and reuses the auth,
+// transport and error envelope that already exist.
+//
+// The step addresses itself with §8.5's VINCENT_TASK_ID and VINCENT_STEP_ID,
+// which is why the path is keyed by step id and not by run id: a step's
+// process knows which step it is and has no way to learn its row's id. It is
+// keyed by step id rather than by task alone because a `parallel` group's
+// sub-steps share one task and run at the same time (§7.5).
+func (s *Server) handleStepStatus(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Runner == nil {
+		s.internalError(w, "step status", errors.New("no task runner is configured"))
+		return
+	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	stepID := r.PathValue("step_id")
+	if strings.TrimSpace(stepID) == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "step id is required")
+		return
+	}
+	var req stepStatusRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	// An empty message is a clear, not a validation failure: a step that has
+	// finished the thing it was narrating should be able to stop saying it
+	// without a second endpoint.
+	if err := s.deps.Runner.SetStepStatus(r.Context(), id, stepID, req.Message); err != nil {
+		switch {
+		case errors.Is(err, store.ErrStepNotRunning):
+			// 409 and not 404: the step exists in the workflow, it is simply
+			// past the point where it can speak. A client re-reads the task
+			// and sees why.
+			writeConflict(w, err.Error(), map[string]string{"step_id": stepID})
+		case errors.Is(err, store.ErrNotFound):
+			writeError(w, http.StatusNotFound, CodeNotFound, err.Error())
+		default:
+			s.internalError(w, "set step status", err)
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		// The normalized text, so a caller sees exactly what was stored —
+		// flattened to one line and truncated at taskrun.StatusMessageLimit.
+		"message": taskrun.NormalizeStatusMessage(req.Message),
+	})
+}

--- a/internal/api/stepstatus.go
+++ b/internal/api/stepstatus.go
@@ -10,7 +10,7 @@ import (
 )
 
 // stepStatusRequest is the body of POST /v1/tasks/{id}/steps/{step_id}/status
-// (§13.2, task 033): the one line the step wants to say about itself.
+// (§13.2, task 036): the one line the step wants to say about itself.
 type stepStatusRequest struct {
 	Message string `json:"message"`
 }
@@ -18,7 +18,7 @@ type stepStatusRequest struct {
 // handleStepStatus records a running step's own status message.
 //
 // The producer is this endpoint and not a sentinel line in the step's output
-// (task 033 decision 1). A marker printed on stdout would force a
+// (task 036 decision 1). A marker printed on stdout would force a
 // strip-or-keep choice over the transcript and `result_summary` with no good
 // answer, would miss the obvious agent spelling entirely — an agent running
 // `echo` through its Bash tool produces a tool-use event, not the output

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -239,7 +239,7 @@ type stepRunResponse struct {
 	// two share one state, so this is what tells a timeline which it is.
 	SkipReason    *string `json:"skip_reason"`
 	ResultSummary string  `json:"result_summary"`
-	// StatusMessage is what the step said about *itself* (§5.4, task 033):
+	// StatusMessage is what the step said about *itself* (§5.4, task 036):
 	// free text its own process set through
 	// POST /v1/tasks/{id}/steps/{step_id}/status. Null when it said nothing,
 	// which is every step type that runs no process and every `agent` or
@@ -281,7 +281,7 @@ type listTaskResponse struct {
 	CostUSD      *float64 `json:"cost_usd"`
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
-	// StatusMessage is the newest step run's status (§5.4, task 033),
+	// StatusMessage is the newest step run's status (§5.4, task 036),
 	// denormalized here the way step_name and cost_usd are: a board reads
 	// this endpoint and never fetches step rows. Null when the newest
 	// attempt said nothing — which is deliberate, so a finished step's line

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -237,8 +237,18 @@ type stepRunResponse struct {
 	// SkipReason says why a `skipped` attempt was skipped: "condition" for a
 	// false `if:` guard (§7.7), null for the human `skip` action (§6). The
 	// two share one state, so this is what tells a timeline which it is.
-	SkipReason     *string  `json:"skip_reason"`
-	ResultSummary  string   `json:"result_summary"`
+	SkipReason    *string `json:"skip_reason"`
+	ResultSummary string  `json:"result_summary"`
+	// StatusMessage is what the step said about *itself* (§5.4, task 033):
+	// free text its own process set through
+	// POST /v1/tasks/{id}/steps/{step_id}/status. Null when it said nothing,
+	// which is every step type that runs no process and every `agent` or
+	// `command` step that was never asked to report.
+	//
+	// It is not a failure cause and must not be rendered as one: a step
+	// killed on `timeout` can carry a message it set half an hour earlier,
+	// and `failure_reason` is the daemon's verdict.
+	StatusMessage  *string  `json:"status_message"`
 	TranscriptPath *string  `json:"transcript_path"`
 	InputTokens    *int64   `json:"input_tokens"`
 	OutputTokens   *int64   `json:"output_tokens"`
@@ -271,6 +281,12 @@ type listTaskResponse struct {
 	CostUSD      *float64 `json:"cost_usd"`
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
+	// StatusMessage is the newest step run's status (§5.4, task 033),
+	// denormalized here the way step_name and cost_usd are: a board reads
+	// this endpoint and never fetches step rows. Null when the newest
+	// attempt said nothing — which is deliberate, so a finished step's line
+	// does not linger beside the next one.
+	StatusMessage *string `json:"status_message"`
 }
 
 func toStepRunResponse(r *store.StepRun, summary snapshotSummary) stepRunResponse {
@@ -295,6 +311,7 @@ func toStepRunResponse(r *store.StepRun, summary snapshotSummary) stepRunRespons
 		FailureReason:  nilIfEmpty(r.FailureReason),
 		SkipReason:     nilIfEmpty(r.SkipReason),
 		ResultSummary:  r.ResultSummary,
+		StatusMessage:  nilIfEmpty(r.StatusMessage),
 		TranscriptPath: nilIfEmpty(r.TranscriptPath),
 		InputTokens:    r.InputTokens,
 		OutputTokens:   r.OutputTokens,
@@ -862,6 +879,10 @@ func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]list
 	if err != nil {
 		return nil, err
 	}
+	statuses, err := s.deps.Store.LatestStepStatuses(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
 	projects, err := s.deps.Store.ListProjects(ctx)
 	if err != nil {
 		return nil, err
@@ -883,6 +904,7 @@ func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]list
 		}
 		row.Loop = s.loopRollup(ctx, t, summary)
 		row.ProjectName = names[t.ProjectID]
+		row.StatusMessage = nilIfEmpty(statuses[t.ID])
 		if ru := rollups[t.ID]; ru.HasCost {
 			cost := ru.CostUSD
 			row.CostUSD = &cost

--- a/internal/apiclient/stepstatus.go
+++ b/internal/apiclient/stepstatus.go
@@ -7,7 +7,7 @@ import (
 )
 
 // EventTaskStatusChanged is the durable SSE type a running step's status
-// change arrives as (§13.3, task 033). Payload
+// change arrives as (§13.3, task 036). Payload
 // `{task_id, step_id, message}`; a client re-fetches rather than rendering
 // the payload, the way it does for every other state event.
 //
@@ -17,7 +17,7 @@ import (
 const EventTaskStatusChanged = "task.status_changed"
 
 // SetStepStatus records what a running step is doing, in its own words
-// (§13.2, task 033). taskID and stepID are §8.5's VINCENT_TASK_ID and
+// (§13.2, task 036). taskID and stepID are §8.5's VINCENT_TASK_ID and
 // VINCENT_STEP_ID: the step's process is the caller, so those are the only
 // two things it knows about itself.
 //

--- a/internal/apiclient/stepstatus.go
+++ b/internal/apiclient/stepstatus.go
@@ -1,0 +1,37 @@
+package apiclient
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// EventTaskStatusChanged is the durable SSE type a running step's status
+// change arrives as (§13.3, task 033). Payload
+// `{task_id, step_id, message}`; a client re-fetches rather than rendering
+// the payload, the way it does for every other state event.
+//
+// It is declared here for the reason the action names are: the client owns
+// its wire vocabulary and keys onto the daemon's strings rather than
+// importing them. A test pins the two together.
+const EventTaskStatusChanged = "task.status_changed"
+
+// SetStepStatus records what a running step is doing, in its own words
+// (§13.2, task 033). taskID and stepID are §8.5's VINCENT_TASK_ID and
+// VINCENT_STEP_ID: the step's process is the caller, so those are the only
+// two things it knows about itself.
+//
+// It returns the message as stored — flattened to one line and truncated to
+// the daemon's cap, so a caller can see what a reader will see. A step that
+// is no longer running is an *Error carrying 409: the write is refused
+// rather than silently dropped.
+func (c *Client) SetStepStatus(ctx context.Context, taskID int64, stepID, message string) (string, error) {
+	var out struct {
+		Message string `json:"message"`
+	}
+	path := fmt.Sprintf("/v1/tasks/%d/steps/%s/status", taskID, url.PathEscape(stepID))
+	if err := c.post(ctx, path, map[string]string{"message": message}, &out); err != nil {
+		return "", err
+	}
+	return out.Message, nil
+}

--- a/internal/apiclient/stepstatus_live_test.go
+++ b/internal/apiclient/stepstatus_live_test.go
@@ -1,0 +1,165 @@
+package apiclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// runningStep gives the harness task a `running` step run to speak for, and
+// puts the task itself in `running` — which is the only shape the endpoint
+// can be reached in.
+func runningStep(t *testing.T, h *harness, taskID int64, stepID string) *store.StepRun {
+	t.Helper()
+	h.setState(t, taskID, store.TaskRunning)
+	run := &store.StepRun{
+		TaskID: taskID, StepIndex: 0, StepID: stepID, StepType: "agent",
+		Attempt: 1, State: store.StepRunning,
+	}
+	if err := h.st.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return run
+}
+
+// The wire round trip, against the real handlers: a step sets its status, and
+// it comes back on the step-run DTO and on the list row a board reads. This
+// is where client and server types would drift apart if either side grew the
+// field alone.
+func TestStepStatusOverTheWire(t *testing.T) {
+	h := newHarness(t)
+	c := h.client()
+	run := runningStep(t, h, h.taskID, "implement")
+
+	stored, err := c.SetStepStatus(t.Context(), h.taskID, "implement", "3 tests red in internal/store")
+	if err != nil {
+		t.Fatalf("SetStepStatus: %v", err)
+	}
+	if stored != "3 tests red in internal/store" {
+		t.Errorf("stored message = %q", stored)
+	}
+
+	detail, err := c.GetTask(t.Context(), h.taskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if len(detail.Steps) != 1 || detail.Steps[0].ID != run.ID {
+		t.Fatalf("steps = %+v, want the one row", detail.Steps)
+	}
+	if got := detail.Steps[0].StatusMessage; got == nil || *got != "3 tests red in internal/store" {
+		t.Errorf("step DTO status = %v, want the message", got)
+	}
+
+	tasks, err := c.ListTasks(t.Context(), apiclient.ListTasksOptions{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	var row *apiclient.Task
+	for i := range tasks {
+		if tasks[i].ID == h.taskID {
+			row = &tasks[i]
+		}
+	}
+	if row == nil {
+		t.Fatalf("task %d missing from the list", h.taskID)
+	}
+	if row.StatusMessage == nil || *row.StatusMessage != "3 tests red in internal/store" {
+		t.Errorf("list row status = %v, want the message denormalized onto it", row.StatusMessage)
+	}
+
+	// The bounds are the daemon's, not the caller's: a multi-line message
+	// over the cap comes back flattened and truncated rather than refused.
+	long := "first line\nsecond line " + strings.Repeat("x", 400)
+	stored, err = c.SetStepStatus(t.Context(), h.taskID, "implement", long)
+	if err != nil {
+		t.Fatalf("SetStepStatus (long): %v", err)
+	}
+	if len(stored) != 256 || strings.ContainsAny(stored, "\n\r") {
+		t.Errorf("stored long message = %d bytes %q, want 256 on one line", len(stored), stored)
+	}
+}
+
+// A write against a step that is no longer running is refused with 409, not
+// applied silently and not answered 404: the task is there, the step is past
+// the point where it can speak.
+func TestStepStatusRefusedWhenNotRunning(t *testing.T) {
+	h := newHarness(t)
+	c := h.client()
+	run := runningStep(t, h, h.taskID, "implement")
+	run.State = store.StepSucceeded
+	if err := h.st.UpdateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+
+	_, err := c.SetStepStatus(t.Context(), h.taskID, "implement", "too late")
+	var apiErr *apiclient.Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusConflict {
+		t.Fatalf("SetStepStatus on a finished step = %v, want a 409", err)
+	}
+
+	if _, err = c.SetStepStatus(t.Context(), 9999, "implement", "nobody"); !errors.As(err, &apiErr) ||
+		apiErr.Status != http.StatusNotFound {
+		t.Errorf("SetStepStatus on an unknown task = %v, want a 404", err)
+	}
+}
+
+// The whole reason the status is on §13.3's durable side: a client that
+// blinks recovers it from the events table rather than losing it. A live
+// output chunk could not do this.
+func TestStepStatusReplaysWithLastEventID(t *testing.T) {
+	h := newHarness(t)
+	c := h.client()
+	runningStep(t, h, h.taskID, "implement")
+
+	// The cursor a subscriber would have held before the status was set.
+	before := h.append(t, "task.state_changed")
+	if _, err := c.SetStepStatus(t.Context(), h.taskID, "implement", "packing the artifact"); err != nil {
+		t.Fatalf("SetStepStatus: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notes := c.StreamTask(ctx, h.taskID, apiclient.StreamOptions{
+		LastEventID:    before.ID,
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+	})
+	if _, ok := nextNote(t, notes).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note was not ConnectedNote")
+	}
+	ev, ok := nextNote(t, notes).(apiclient.EventNote)
+	if !ok {
+		t.Fatalf("replay note = %T, want an EventNote", ev)
+	}
+	if ev.Event.Type != apiclient.EventTaskStatusChanged {
+		t.Fatalf("replayed event type = %q, want %q", ev.Event.Type, apiclient.EventTaskStatusChanged)
+	}
+	var payload struct {
+		TaskID  int64  `json:"task_id"`
+		StepID  string `json:"step_id"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(ev.Event.Payload, &payload); err != nil {
+		t.Fatalf("payload: %v (%s)", err, ev.Event.Payload)
+	}
+	if payload.TaskID != h.taskID || payload.StepID != "implement" ||
+		payload.Message != "packing the artifact" {
+		t.Errorf("replayed payload = %+v, want the task, step and message", payload)
+	}
+}
+
+// The client's copy of the event name has to be the daemon's; nothing else
+// pins two string literals in two packages together.
+func TestStatusEventNameMatchesTheDaemon(t *testing.T) {
+	if apiclient.EventTaskStatusChanged != store.EventTaskStatusChanged {
+		t.Errorf("client event name %q != daemon's %q",
+			apiclient.EventTaskStatusChanged, store.EventTaskStatusChanged)
+	}
+}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -44,7 +44,7 @@ type Task struct {
 	OutputTokens int64    `json:"output_tokens"`
 
 	// StatusMessage is the newest step run's status message (§5.4, task
-	// 033), served on the list row so a board never fetches step rows for
+	// 036), served on the list row so a board never fetches step rows for
 	// it. Nil when the newest attempt said nothing.
 	StatusMessage *string `json:"status_message"`
 
@@ -210,7 +210,7 @@ type StepRun struct {
 	// carry State "skipped".
 	SkipReason    *string `json:"skip_reason"`
 	ResultSummary string  `json:"result_summary"`
-	// StatusMessage is what the step said about itself (§5.4, task 033):
+	// StatusMessage is what the step said about itself (§5.4, task 036):
 	// free text its own process set while it was running, and nil when it
 	// said nothing. It is never a failure cause — `failure_reason` is the
 	// daemon's verdict, and a killed step can be carrying a message it set

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -43,6 +43,11 @@ type Task struct {
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
 
+	// StatusMessage is the newest step run's status message (§5.4, task
+	// 033), served on the list row so a board never fetches step rows for
+	// it. Nil when the newest attempt said nothing.
+	StatusMessage *string `json:"status_message"`
+
 	// ParentTaskID, LaneID and LaneOrder identify a fan-out lane (§7.6, task
 	// 014); all nil for a root task.
 	ParentTaskID *int64  `json:"parent_task_id"`
@@ -205,6 +210,13 @@ type StepRun struct {
 	// carry State "skipped".
 	SkipReason    *string `json:"skip_reason"`
 	ResultSummary string  `json:"result_summary"`
+	// StatusMessage is what the step said about itself (§5.4, task 033):
+	// free text its own process set while it was running, and nil when it
+	// said nothing. It is never a failure cause — `failure_reason` is the
+	// daemon's verdict, and a killed step can be carrying a message it set
+	// long before — so a client renders it as the step's last status, not
+	// beside the reason.
+	StatusMessage *string `json:"status_message"`
 
 	// TranscriptPath is nil for a step that produced no transcript — a manual
 	// gate or a skipped step. The output pane renders such a row's metadata

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,7 +41,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(
 		newDaemonCmd(), newVersionCmd(), newDoctorCmd(),
 		newProjectCmd(), newTaskCmd(), newWorkflowCmd(), newServiceCmd(),
-		newGCCmd(), newGitHubCmd(),
+		newGCCmd(), newGitHubCmd(), newStatusCmd(),
 	)
 	return root
 }

--- a/internal/cli/commands_e2e_test.go
+++ b/internal/cli/commands_e2e_test.go
@@ -24,7 +24,7 @@ func TestCommandsAgainstLiveDaemon(t *testing.T) {
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
 	t.Cleanup(func() {
 		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(hermeticEnv(),
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})

--- a/internal/cli/crash_e2e_test.go
+++ b/internal/cli/crash_e2e_test.go
@@ -130,7 +130,7 @@ func TestCrashRecoveryE2E(t *testing.T) {
 func startDaemonProcess(t *testing.T, dataDir, cfgDir, scenario string) *exec.Cmd {
 	t.Helper()
 	cmd := exec.Command(vincentBin, "daemon")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(hermeticEnv(),
 		config.EnvDataDir+"="+dataDir,
 		config.EnvConfigDir+"="+cfgDir,
 		"FAKEAGENT_SCENARIO="+scenario,

--- a/internal/cli/doctor_e2e_test.go
+++ b/internal/cli/doctor_e2e_test.go
@@ -154,7 +154,7 @@ func pointAgentsAtNothing(t *testing.T, cfgDir string) {
 func stopDaemon(t *testing.T, dataDir, cfgDir string) {
 	t.Helper()
 	cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(hermeticEnv(),
 		config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 	_, _ = cmd.CombinedOutput()
 }

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -39,12 +39,34 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// hermeticEnv is the test process's environment with every VINCENT_* variable
+// removed.
+//
+// This suite is itself run from inside a vincent step — that is what the
+// repository's own workflows do, and what CI's gates do — and a step's
+// environment carries §8.5's VINCENT_* block. Inheriting it makes a child
+// `vincent` believe it belongs to the *outer* task: `TestStatusOutsideAStep`
+// saw a real VINCENT_TASK_ID and reported a daemon problem instead of the
+// missing-variable error it asserts. The two dirs the callers pin are appended
+// after this, so nothing a test relies on is lost.
+func hermeticEnv() []string {
+	env := os.Environ()
+	out := env[:0:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "VINCENT_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 // runVincent runs the built binary with isolated config/data dirs and
 // returns its combined output and exit code.
 func runVincent(t *testing.T, dataDir, cfgDir string, args ...string) (string, int) {
 	t.Helper()
 	cmd := exec.Command(vincentBin, args...)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(hermeticEnv(),
 		config.EnvDataDir+"="+dataDir,
 		config.EnvConfigDir+"="+cfgDir,
 	)
@@ -64,7 +86,7 @@ func TestDaemonStartStatusStopCycle(t *testing.T) {
 	t.Cleanup(func() {
 		// Never leak a detached daemon, even when an assertion fails.
 		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(hermeticEnv(),
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})

--- a/internal/cli/gc_e2e_test.go
+++ b/internal/cli/gc_e2e_test.go
@@ -18,7 +18,7 @@ func TestGCAgainstLiveDaemon(t *testing.T) {
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
 	t.Cleanup(func() {
 		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(hermeticEnv(),
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,7 +14,7 @@ import (
 
 // Environment variables `vincent status` addresses the step with. They are
 // two of §8.5's block, which reaches `agent` steps as well as `command` ones
-// as of task 033 — the whole point of the command is that a step can say
+// as of task 036 — the whole point of the command is that a step can say
 // something without being told which row it is.
 const (
 	envTaskID = "VINCENT_TASK_ID"

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Environment variables `vincent status` addresses the step with. They are
+// two of §8.5's block, which reaches `agent` steps as well as `command` ones
+// as of task 033 — the whole point of the command is that a step can say
+// something without being told which row it is.
+const (
+	envTaskID = "VINCENT_TASK_ID"
+	envStepID = "VINCENT_STEP_ID"
+)
+
+// newStatusCmd is the second §6-adjacent command with a command line, after
+// `task follow-up` (task 027 decision 11), and it is here for the same kind
+// of reason: it is invoked by a program, not by a human at a prompt. A step's
+// own script or an agent's shell tool runs it, from inside the worktree, to
+// say what it is doing — so it takes its addressing from the environment
+// rather than from flags nobody would be there to type.
+func newStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <message>",
+		Short: "Report what the current step is doing, from inside that step",
+		Long: "Set the status message of the step run this process belongs to (§5.4). " +
+			"The task and step are read from " + envTaskID + " and " + envStepID + ", which " +
+			"the daemon sets on every agent and command step (§8.5), so this only works " +
+			"from inside a running step.\n\n" +
+			"The message is one line of free text: it is flattened, stripped of control " +
+			"characters and truncated to 256 bytes. An empty message clears the status. " +
+			"It is shown live on the board and the task detail view, and the last value " +
+			"set stays on the finished attempt — it is never treated as a failure reason.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, stepID, err := stepFromEnv()
+			if err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				stored, err := c.SetStepStatus(ctx, taskID, stepID, args[0])
+				if err != nil {
+					// A 409 is the daemon refusing because the step is no
+					// longer running — a rejected request, not a broken one.
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), map[string]any{
+						"task_id": taskID, "step_id": stepID, "message": stored,
+					})
+				}
+				// Quiet on success by default. This runs inside a step whose
+				// stdout is the transcript, and a step that reports progress
+				// ten times should not add ten lines of vincent's own noise
+				// to the record it is trying to summarize.
+				return nil
+			})
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+// stepFromEnv reads the step this process belongs to out of §8.5's variables.
+// The error names them, because the overwhelmingly likely cause of a miss is
+// that the command was run outside a step at all.
+func stepFromEnv() (int64, string, error) {
+	raw := strings.TrimSpace(os.Getenv(envTaskID))
+	stepID := strings.TrimSpace(os.Getenv(envStepID))
+	if raw == "" || stepID == "" {
+		return 0, "", fmt.Errorf(
+			"%s and %s are not set: `vincent status` runs from inside a step, not from a shell",
+			envTaskID, envStepID)
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("%s is not a task id: %q", envTaskID, raw)
+	}
+	return id, stepID, nil
+}

--- a/internal/cli/status_e2e_test.go
+++ b/internal/cli/status_e2e_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/lezli01/vincent/internal/testrepo"
 )
 
-// TestStatusFromInsideAStep is task 033's whole claim, driven end to end
+// TestStatusFromInsideAStep is task 036's whole claim, driven end to end
 // through the real binary: an agent step runs `vincent status`, and the
 // message it wrote reaches the row, `vincent task show` and `--json`.
 //

--- a/internal/cli/status_e2e_test.go
+++ b/internal/cli/status_e2e_test.go
@@ -29,7 +29,7 @@ func TestStatusFromInsideAStep(t *testing.T) {
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
 	t.Cleanup(func() {
 		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(hermeticEnv(),
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})
@@ -134,6 +134,13 @@ func TestStatusFromInsideAStep(t *testing.T) {
 // that someone typed the command at a shell.
 func TestStatusOutsideAStep(t *testing.T) {
 	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	// Pin the hostile environment rather than hoping for a clean one. This
+	// suite really is run from inside a vincent step, and inheriting §8.5's
+	// block made the child address the *outer* task and report a daemon
+	// problem instead. `runVincent` strips it; setting it here is what asserts
+	// that, and what makes the regression reproduce off a dev machine.
+	t.Setenv(envTaskID, "4242")
+	t.Setenv(envStepID, "outer-step")
 	out, code := runVincent(t, dataDir, cfgDir, "status", "hello")
 	if code != 1 {
 		t.Errorf("exit code = %d, want 1", code)

--- a/internal/cli/status_e2e_test.go
+++ b/internal/cli/status_e2e_test.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// TestStatusFromInsideAStep is task 033's whole claim, driven end to end
+// through the real binary: an agent step runs `vincent status`, and the
+// message it wrote reaches the row, `vincent task show` and `--json`.
+//
+// It goes through the fake agent rather than calling the command directly
+// because the interesting part is the addressing: §8.5's VINCENT_TASK_ID and
+// VINCENT_STEP_ID have to reach an *agent* step's environment for the command
+// to know which row it is. Calling it from the test's own shell would prove
+// the endpoint and skip the reason the endpoint is reachable at all.
+func TestStatusFromInsideAStep(t *testing.T) {
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	t.Cleanup(func() {
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = append(os.Environ(),
+			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
+		_, _ = cmd.CombinedOutput()
+	})
+
+	// The daemon reads the scenario from its own environment and hands it to
+	// the step through the §12.3 policy, so this is set before it starts.
+	t.Setenv("FAKEAGENT_SCENARIO", "set-status")
+	t.Setenv("FAKEAGENT_VINCENT_BIN", vincentBin)
+	t.Setenv("FAKEAGENT_STATUS", "scaffolding the migration")
+	// Past the daemon's one-second coalescing floor (§13.3), so the second
+	// message is a write in its own right rather than one folded into the
+	// first — which is how a real step that narrates its work behaves.
+	t.Setenv("FAKEAGENT_STATUS_HOLD_MS", "1500")
+	t.Setenv("FAKEAGENT_STATUS_FINAL", "3 tests red in internal/store")
+
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName),
+		[]byte("agents:\n  claude:\n    path: \""+filepath.ToSlash(fake)+"\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(cfgDir, "workflows"), 0o700); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "workflows", "narrate.yaml"), []byte(
+		"name: narrate\ndescription: one agent step that reports on itself.\n"+
+			"defaults:\n  agent: claude\n  max_retries: 0\nsteps:\n"+
+			"  - id: implement\n    type: agent\n    prompt: report your status\n"), 0o600); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	if out, code := runVincent(t, dataDir, cfgDir, "daemon", "start"); code != 0 {
+		t.Fatalf("daemon start: code %d, out %q", code, out)
+	}
+	repo := testrepo.Init(t, "main")
+	if out, code := runVincent(t, dataDir, cfgDir, "project", "add", repo, "--json"); code != 0 {
+		t.Fatalf("project add: code %d, out %q", code, out)
+	}
+	out, code := runVincent(t, dataDir, cfgDir, "task", "add",
+		"--project", "1", "--workflow", "narrate", "--title", "narrating task", "--json")
+	if code != 0 {
+		t.Fatalf("task add: code %d, out %q", code, out)
+	}
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &created); err != nil || created.ID == 0 {
+		t.Fatalf("task add --json: %v (%q)", err, out)
+	}
+	id := strconv.FormatInt(created.ID, 10)
+
+	// Wait for the run to settle, then read the row the step wrote to.
+	var detail struct {
+		State string `json:"state"`
+		Steps []struct {
+			StepID        string  `json:"step_id"`
+			State         string  `json:"state"`
+			StatusMessage *string `json:"status_message"`
+		} `json:"steps"`
+	}
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		out, code = runVincent(t, dataDir, cfgDir, "task", "show", id, "--json")
+		if code != 0 {
+			t.Fatalf("task show --json: code %d, out %q", code, out)
+		}
+		if err := json.Unmarshal([]byte(out), &detail); err != nil {
+			t.Fatalf("task show --json is not JSON: %v (%q)", err, out)
+		}
+		if detail.State == "done" || detail.State == "blocked" || detail.State == "aborted" {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if detail.State != "done" {
+		t.Fatalf("task state = %q, want done (steps %+v)", detail.State, detail.Steps)
+	}
+	if len(detail.Steps) != 1 {
+		t.Fatalf("step runs = %d, want 1", len(detail.Steps))
+	}
+	got := detail.Steps[0].StatusMessage
+	if got == nil {
+		t.Fatalf("status_message is null: `vincent status` never reached the row (%q)", out)
+	}
+	// The *last* value set before the attempt ended is what stays on the
+	// finished row — the terminal half of the feature.
+	if *got != "3 tests red in internal/store" {
+		t.Errorf("status_message = %q, want the last value the step set", *got)
+	}
+
+	// And the human-readable table carries it under its own column, distinct
+	// from REASON.
+	out, code = runVincent(t, dataDir, cfgDir, "task", "show", id)
+	if code != 0 {
+		t.Fatalf("task show: code %d, out %q", code, out)
+	}
+	if !strings.Contains(out, "STATUS") || !strings.Contains(out, "3 tests red in internal/store") {
+		t.Errorf("`vincent task show` does not render the status:\n%s", out)
+	}
+}
+
+// Outside a step there is nothing to address, and the error has to say so
+// rather than reporting a daemon problem: the overwhelmingly likely cause is
+// that someone typed the command at a shell.
+func TestStatusOutsideAStep(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	out, code := runVincent(t, dataDir, cfgDir, "status", "hello")
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(out, "VINCENT_TASK_ID") || !strings.Contains(out, "from inside a step") {
+		t.Errorf("error does not name the missing variables:\n%s", out)
+	}
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -290,9 +290,16 @@ func newTaskShowCmd() *cobra.Command {
 					rows = append(rows, []string{
 						strconv.FormatInt(s.ID, 10), s.StepID, s.State,
 						dash(deref(s.Agent)), dash(deref(s.FailureReason)),
+						dash(deref(s.StatusMessage)),
 					})
 				}
-				if err := table(out, []string{"RUN", "STEP", "STATE", "AGENT", "REASON"}, rows); err != nil {
+				// STATUS sits after REASON rather than beside it, and is the
+				// last column, because they are different kinds of thing: the
+				// reason is the daemon's closed verdict and the status is what
+				// the step said about itself (§5.4). A tabwriter's last column
+				// is also the one free to be long.
+				if err := table(out,
+					[]string{"RUN", "STEP", "STATE", "AGENT", "REASON", "STATUS"}, rows); err != nil {
 					return err
 				}
 				// The transcript is the complete record of what the agent did

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -343,6 +343,10 @@ func TestWakeOnFiltersEvents(t *testing.T) {
 		// near-exhausted agent is shown, never withheld. Waking the loop on
 		// it would spin it for nothing.
 		{store.EventAgentQuotaChanged, false},
+		// Task 033: a step describing itself is a display fact too. Nothing
+		// about admission changes when it does, so waking the loop on it
+		// would spin it once per status message.
+		{store.EventTaskStatusChanged, false},
 	}
 	for _, c := range cases {
 		if got := WakeOn(&store.Event{Type: c.evType}); got != c.want {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -343,7 +343,7 @@ func TestWakeOnFiltersEvents(t *testing.T) {
 		// near-exhausted agent is shown, never withheld. Waking the loop on
 		// it would spin it for nothing.
 		{store.EventAgentQuotaChanged, false},
-		// Task 033: a step describing itself is a display fact too. Nothing
+		// Task 036: a step describing itself is a display fact too. Nothing
 		// about admission changes when it does, so waking the loop on it
 		// would spin it once per status message.
 		{store.EventTaskStatusChanged, false},

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 14
+const latestSchemaVersion = 15
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0014_step_status.sql
+++ b/internal/store/migrations/0014_step_status.sql
@@ -1,4 +1,4 @@
--- 0014_step_status: the step-authored status message (task 033, issue #199).
+-- 0014_step_status: the step-authored status message (task 036, issue #199).
 --
 -- Free text a *running* step wrote about itself — "3 tests red in
 -- internal/store", "rebasing onto master" — set through

--- a/internal/store/migrations/0014_step_status.sql
+++ b/internal/store/migrations/0014_step_status.sql
@@ -1,0 +1,28 @@
+-- 0014_step_status: the step-authored status message (task 033, issue #199).
+--
+-- Free text a *running* step wrote about itself — "3 tests red in
+-- internal/store", "rebasing onto master" — set through
+-- `POST /v1/tasks/{id}/steps/{step_id}/status` (§13.2) by the step's own
+-- process, which is what makes it say something no workflow author could have
+-- written in advance.
+--
+-- One column with two readings, not two features: while the row is `running`
+-- it is the live answer to "what is this doing", and the last value written
+-- before the attempt ends stays on the finished row as its self-report.
+--
+-- NULL and empty are the same thing and mean the ordinary case: the step said
+-- nothing. Most rows carry NULL — `manual`, `parallel`, `fan_out`,
+-- `condition`, `loop` and `break` run no process and so have no voice at all
+-- (§5.4), and an `agent` or `command` step only speaks when its prompt or its
+-- script was written to.
+--
+-- It is deliberately **not** a widening of `failure_reason`, which stays the
+-- closed, daemon-authored vocabulary shared with internal/worktree
+-- (T1.5/T1.6 decision): nothing renders this as a cause of failure, because a
+-- step killed on `timeout` may be carrying a message it set half an hour
+-- earlier.
+--
+-- No `status_updated_at` companion and no clearing rule. The event carries the
+-- moment it changed (§13.3), the row carries the value, and a second column
+-- would have to be kept true by every writer for something no surface renders.
+ALTER TABLE step_runs ADD COLUMN status_message TEXT; -- NULL = the step said nothing

--- a/internal/store/migrations/0015_step_status.sql
+++ b/internal/store/migrations/0015_step_status.sql
@@ -1,4 +1,4 @@
--- 0014_step_status: the step-authored status message (task 036, issue #199).
+-- 0015_step_status: the step-authored status message (task 036, issue #199).
 --
 -- Free text a *running* step wrote about itself — "3 tests red in
 -- internal/store", "rebasing onto master" — set through

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -200,6 +200,17 @@ type StepRun struct {
 	// for a false guard, empty for the human `skip` action (§6, §7.7).
 	SkipReason    string
 	ResultSummary string
+	// StatusMessage is what the step said about *itself* (§5.4, task 033):
+	// short free text its own process wrote through
+	// `POST /v1/tasks/{id}/steps/{step_id}/status`. Empty is the ordinary
+	// case — a step with nothing to say says nothing, and the step types that
+	// run no process never say anything.
+	//
+	// It is never written by UpdateStepRun, only by SetStepRunStatus. That is
+	// what makes the last live value survive onto the finished row: the
+	// actor's own final write does not carry the column, so it cannot clobber
+	// a status the step set from another goroutine seconds earlier.
+	StatusMessage string
 	// PromptOverride and RunOverride record the text a human supplied for
 	// this attempt via edit+retry (spec §6). Empty on every other attempt,
 	// including later automatic retries of the same step: the edit happened

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -200,7 +200,7 @@ type StepRun struct {
 	// for a false guard, empty for the human `skip` action (§6, §7.7).
 	SkipReason    string
 	ResultSummary string
-	// StatusMessage is what the step said about *itself* (§5.4, task 033):
+	// StatusMessage is what the step said about *itself* (§5.4, task 036):
 	// short free text its own process wrote through
 	// `POST /v1/tasks/{id}/steps/{step_id}/status`. Empty is the ordinary
 	// case — a step with nothing to say says nothing, and the step types that

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -123,7 +123,7 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 // UpdateStepRun writes every mutable field of r (matched by ID). Returns
 // ErrNotFound when the row does not exist.
 //
-// `status_message` is deliberately **not** in the SET list (task 033). It is
+// `status_message` is deliberately **not** in the SET list (task 036). It is
 // the one column the actor is not the sole writer of: the step's own process
 // sets it through SetStepRunStatus while the actor is blocked in Wait, so an
 // UPDATE carrying the actor's stale copy of the struct would erase whatever

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -13,6 +13,7 @@ import (
 const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
 	state, agent, model, effort, pid,
 	proc_started_at, proc_identity, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
+	status_message,
 	prompt_override, run_override, transcript_path,
 	input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at`
 
@@ -96,14 +97,15 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
 			state, agent, model, effort, pid,
 			proc_started_at, proc_identity, exit_code, check_exit_code, failure_reason, skip_reason,
-			result_summary, prompt_override, run_override, transcript_path,
+			result_summary, status_message, prompt_override, run_override, transcript_path,
 			input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, r.Iteration, nullString(r.LoopItem),
 		string(r.State),
 		nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
 		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity, r.ExitCode, r.CheckExitCode,
 		nullString(r.FailureReason), nullString(r.SkipReason), nullString(r.ResultSummary),
+		nullString(r.StatusMessage),
 		nullString(r.PromptOverride), nullString(r.RunOverride), nullString(r.TranscriptPath),
 		r.InputTokens, r.OutputTokens, r.CostUSD, r.InputWaitMS,
 		formatTime(r.StartedAt), formatTimePtr(r.FinishedAt))
@@ -120,6 +122,13 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 
 // UpdateStepRun writes every mutable field of r (matched by ID). Returns
 // ErrNotFound when the row does not exist.
+//
+// `status_message` is deliberately **not** in the SET list (task 033). It is
+// the one column the actor is not the sole writer of: the step's own process
+// sets it through SetStepRunStatus while the actor is blocked in Wait, so an
+// UPDATE carrying the actor's stale copy of the struct would erase whatever
+// the step said. Leaving the column out is what makes the last live value
+// survive onto the finished row for free.
 func (s *Store) UpdateStepRun(ctx context.Context, r *StepRun) error {
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE step_runs SET state = ?, agent = ?, model = ?, effort = ?, pid = ?, proc_started_at = ?,
@@ -327,6 +336,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		r                                       StepRun
 		agent, model, effort                    sql.NullString
 		failure, skip, summary, transcript      sql.NullString
+		status                                  sql.NullString
 		loopItem                                sql.NullString
 		promptOv, runOv                         sql.NullString
 		pid, exitCode, checkExit, inTok, outTok sql.NullInt64
@@ -338,7 +348,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		&r.Iteration, &loopItem,
 		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &procIdentity,
 		&exitCode, &checkExit,
-		&failure, &skip, &summary, &promptOv, &runOv, &transcript,
+		&failure, &skip, &summary, &status, &promptOv, &runOv, &transcript,
 		&inTok, &outTok, &cost, &r.InputWaitMS, &started, &finished); err != nil {
 		return nil, err
 	}
@@ -349,6 +359,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	r.FailureReason = failure.String
 	r.SkipReason = skip.String
 	r.ResultSummary = summary.String
+	r.StatusMessage = status.String
 	r.PromptOverride = promptOv.String
 	r.RunOverride = runOv.String
 	r.TranscriptPath = transcript.String

--- a/internal/store/stepstatus.go
+++ b/internal/store/stepstatus.go
@@ -10,14 +10,14 @@ import (
 )
 
 // ErrStepNotRunning reports that no *running* step run of the task carries
-// the step id a status write was addressed at (task 033). It is deliberately
+// the step id a status write was addressed at (task 036). It is deliberately
 // distinct from ErrNotFound, which the task lookup answers with: the API
 // turns a missing task into a 404 and this into a 409, because a finished
 // step is a state the caller can see and re-check rather than a typo.
 var ErrStepNotRunning = errors.New("step run is not running")
 
 // LatestStepStatuses returns, for each of ids that has one, the status
-// message on the task's **newest** step run (task 033). Tasks whose newest
+// message on the task's **newest** step run (task 036). Tasks whose newest
 // row said nothing are absent from the map.
 //
 // The newest row rather than a search for the newest *message* is the whole
@@ -72,7 +72,7 @@ func (s *Store) LatestStepStatuses(ctx context.Context, ids []int64) (map[int64]
 // stepID, or ErrStepNotRunning when the task has none.
 //
 // It exists so a caller can answer "is this addressable at all" before
-// deciding whether to write — the engine's status throttle (task 033) refuses
+// deciding whether to write — the engine's status throttle (task 036) refuses
 // a write against a finished step whether or not it would have coalesced the
 // value. The resolution rule is SetStepRunStatus's, and the two are
 // deliberately the same query.
@@ -138,7 +138,7 @@ func (s *Store) SetStepRunStatus(
 // SetStepRunStatusByRun is SetStepRunStatus addressed at one row, whatever
 // state it is in.
 //
-// It exists for the engine's coalescing floor (§13.3, task 033). A message
+// It exists for the engine's coalescing floor (§13.3, task 036). A message
 // written inside the floor is deferred, not refused, and the step may finish
 // before the deferred write lands — so requiring `running` here would silently
 // drop the last thing a step said, which is precisely the value the terminal

--- a/internal/store/stepstatus.go
+++ b/internal/store/stepstatus.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrStepNotRunning reports that no *running* step run of the task carries
+// the step id a status write was addressed at (task 033). It is deliberately
+// distinct from ErrNotFound, which the task lookup answers with: the API
+// turns a missing task into a 404 and this into a 409, because a finished
+// step is a state the caller can see and re-check rather than a typo.
+var ErrStepNotRunning = errors.New("step run is not running")
+
+// LatestStepStatuses returns, for each of ids that has one, the status
+// message on the task's **newest** step run (task 033). Tasks whose newest
+// row said nothing are absent from the map.
+//
+// The newest row rather than a search for the newest *message* is the whole
+// definition, and it is what keeps a board honest: a step that spoke and
+// finished must not have its line linger beside the next step, which is
+// silently doing something else. A running task therefore shows its live
+// step's message, a blocked one shows the failing attempt's last words, and
+// a task whose current step has nothing to say shows nothing.
+//
+// One query regardless of task count, like TaskRollups: `GET /v1/tasks` is
+// what a board polls, and it must never fan out per row (§18).
+func (s *Store) LatestStepStatuses(ctx context.Context, ids []int64) (map[int64]string, error) {
+	out := make(map[int64]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	// The join picks each task's highest row id and reads that row's message;
+	// MAX(id) with a bare column would pair a maximum with an arbitrary row.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT r.task_id, r.status_message FROM step_runs r
+		JOIN (SELECT task_id, MAX(id) AS id FROM step_runs
+			WHERE task_id IN (`+placeholders+`) GROUP BY task_id) m
+		ON r.id = m.id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read step statuses: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			taskID  int64
+			message sql.NullString
+		)
+		if err := rows.Scan(&taskID, &message); err != nil {
+			return nil, fmt.Errorf("scan step status: %w", err)
+		}
+		if message.String != "" {
+			out[taskID] = message.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read step statuses: %w", err)
+	}
+	return out, nil
+}
+
+// RunningStepRunID resolves the running step run of task taskID at step
+// stepID, or ErrStepNotRunning when the task has none.
+//
+// It exists so a caller can answer "is this addressable at all" before
+// deciding whether to write — the engine's status throttle (task 033) refuses
+// a write against a finished step whether or not it would have coalesced the
+// value. The resolution rule is SetStepRunStatus's, and the two are
+// deliberately the same query.
+func (s *Store) RunningStepRunID(ctx context.Context, taskID int64, stepID string) (int64, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id FROM step_runs
+		WHERE task_id = ? AND step_id = ? AND state = ?
+		ORDER BY id DESC LIMIT 1`, taskID, stepID, string(StepRunning)).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("task %d step %q: %w", taskID, stepID, ErrStepNotRunning)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("resolve running step run: %w", err)
+	}
+	return id, nil
+}
+
+// SetStepRunStatus records message as what the running step run of task
+// taskID at step stepID is saying about itself (§5.4, §13.3), appending the
+// durable `task.status_changed` event in the same transaction. It returns the
+// row it wrote and whether anything actually changed.
+//
+// The row is resolved by `(task_id, step_id, state = running)` rather than by
+// run id, because the caller is the step's own process and all it knows about
+// itself is §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`. Keying on the
+// step id and not on the task alone is what makes a `parallel` group work:
+// its sub-steps share one task id and run at the same time, so a task-keyed
+// write would have two live steps overwriting each other's message. Within
+// one task a step id has at most one running row — a `loop` body runs its
+// passes in sequence, and a group's members have distinct ids — so the newest
+// match is the only match.
+//
+// A message byte-identical to the stored one writes no event and reports
+// changed=false: the `agent.quota_changed` rule, for the same reason. It
+// still returns the row, so a caller can tell "nothing changed" from "there
+// was nothing to change".
+//
+// The whole thing is one transaction so that the resolution, the write and
+// the event commit together: a status can never be visible on the row without
+// the event that announced it, which is what `Last-Event-ID` recovery rests
+// on.
+func (s *Store) SetStepRunStatus(
+	ctx context.Context, taskID int64, stepID, message string,
+) (runID int64, changed bool, err error) {
+	return s.setStepRunStatus(ctx, message, func(ctx context.Context, tx *sql.Tx) (statusTarget, error) {
+		var t statusTarget
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, task_id, step_id, status_message FROM step_runs
+			WHERE task_id = ? AND step_id = ? AND state = ?
+			ORDER BY id DESC LIMIT 1`, taskID, stepID, string(StepRunning)).
+			Scan(&t.runID, &t.taskID, &t.stepID, &t.stored)
+		if errors.Is(err, sql.ErrNoRows) {
+			return t, fmt.Errorf("task %d step %q: %w", taskID, stepID, ErrStepNotRunning)
+		}
+		if err != nil {
+			return t, fmt.Errorf("resolve running step run: %w", err)
+		}
+		return t, nil
+	})
+}
+
+// SetStepRunStatusByRun is SetStepRunStatus addressed at one row, whatever
+// state it is in.
+//
+// It exists for the engine's coalescing floor (§13.3, task 033). A message
+// written inside the floor is deferred, not refused, and the step may finish
+// before the deferred write lands — so requiring `running` here would silently
+// drop the last thing a step said, which is precisely the value the terminal
+// reading is about. The step said it while it was running; the daemon merely
+// chose when to persist it.
+//
+// Nothing else may use this. The endpoint's own refusal (409 for a step that
+// is not running) lives in SetStepRunStatus and is what a caller sees.
+func (s *Store) SetStepRunStatusByRun(
+	ctx context.Context, runID int64, message string,
+) (changed bool, err error) {
+	_, changed, err = s.setStepRunStatus(ctx, message,
+		func(ctx context.Context, tx *sql.Tx) (statusTarget, error) {
+			t := statusTarget{runID: runID}
+			err := tx.QueryRowContext(ctx,
+				`SELECT task_id, step_id, status_message FROM step_runs WHERE id = ?`, runID).
+				Scan(&t.taskID, &t.stepID, &t.stored)
+			if errors.Is(err, sql.ErrNoRows) {
+				return t, fmt.Errorf("step run %d: %w", runID, ErrNotFound)
+			}
+			if err != nil {
+				return t, fmt.Errorf("resolve step run %d: %w", runID, err)
+			}
+			return t, nil
+		})
+	return changed, err
+}
+
+// statusTarget is the row a status write landed on, as its resolver found it.
+type statusTarget struct {
+	runID  int64
+	taskID int64
+	stepID string
+	stored sql.NullString
+}
+
+// setStepRunStatus is the shared write: resolve, dedup, update, and append the
+// durable event — all in one transaction, so a status can never be visible on
+// the row without the event that announced it, which is what `Last-Event-ID`
+// recovery rests on.
+func (s *Store) setStepRunStatus(
+	ctx context.Context, message string,
+	resolve func(context.Context, *sql.Tx) (statusTarget, error),
+) (runID int64, changed bool, err error) {
+	var ev *Event
+	err = s.withTx(ctx, func(tx *sql.Tx) error {
+		target, err := resolve(ctx, tx)
+		if err != nil {
+			return err
+		}
+		runID = target.runID
+		if target.stored.String == message {
+			return nil
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE step_runs SET status_message = ? WHERE id = ?`,
+			nullString(message), target.runID); err != nil {
+			return fmt.Errorf("set step run status: %w", err)
+		}
+		changed = true
+
+		// project_id rides along so the /v1/events project filter works on
+		// this type the way it does on every other task event. It is read
+		// here rather than passed in because the caller is a step process
+		// that has no reason to know its project's row id.
+		var projectID int64
+		if err := tx.QueryRowContext(ctx,
+			`SELECT project_id FROM tasks WHERE id = ?`, target.taskID).Scan(&projectID); err != nil {
+			return fmt.Errorf("read task project: %w", err)
+		}
+		payload, err := json.Marshal(map[string]any{
+			"task_id": target.taskID, "step_id": target.stepID, "message": message,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal %s event: %w", EventTaskStatusChanged, err)
+		}
+		id, pid := target.taskID, projectID
+		ev = &Event{Type: EventTaskStatusChanged, TaskID: &id, ProjectID: &pid, Payload: payload}
+		return appendEventTx(ctx, tx, ev)
+	})
+	if err != nil {
+		return 0, false, err
+	}
+	if ev != nil {
+		s.notify(ev)
+	}
+	return runID, changed, nil
+}

--- a/internal/store/stepstatus_test.go
+++ b/internal/store/stepstatus_test.go
@@ -68,7 +68,7 @@ func TestStepRunStatusRoundTrip(t *testing.T) {
 	// its status from another process while the actor is blocked in Wait, so
 	// an UpdateStepRun with the actor's stale struct would erase it. This is
 	// the property that makes the last live value survive onto the finished
-	// row (task 033).
+	// row (task 036).
 	stale := *got
 	stale.StatusMessage = ""
 	stale.State = StepSucceeded

--- a/internal/store/stepstatus_test.go
+++ b/internal/store/stepstatus_test.go
@@ -243,7 +243,7 @@ func TestLatestStepStatuses(t *testing.T) {
 	}
 }
 
-// A database written before 0014 has rows with no status column at all. They
+// A database written before 0015 has rows with no status column at all. They
 // must survive the upgrade readable, with the status reading as "said
 // nothing" rather than as an error.
 func TestMigrateAddsStatusToPreexistingRows(t *testing.T) {
@@ -272,7 +272,7 @@ func TestMigrateAddsStatusToPreexistingRows(t *testing.T) {
 			t.Fatalf("pragma_table_info: %v", err)
 		}
 		if n != 0 {
-			t.Fatalf("status_message exists at schema 13; the fixture is not a pre-0014 database")
+			t.Fatalf("status_message exists at schema 13; the fixture is not a pre-0015 database")
 		}
 	}()
 

--- a/internal/store/stepstatus_test.go
+++ b/internal/store/stepstatus_test.go
@@ -1,0 +1,300 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// countStatusEvents is how many `task.status_changed` rows the database
+// holds — the figure that says whether the dedup rule actually held.
+func countStatusEvents(t *testing.T, s *Store) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM events WHERE type = ?`, EventTaskStatusChanged).Scan(&n); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	return n
+}
+
+func runningStepRun(t *testing.T, s *Store, taskID int64, stepID string) *StepRun {
+	t.Helper()
+	r := &StepRun{
+		TaskID: taskID, StepIndex: 0, StepID: stepID, StepType: "agent",
+		Attempt: 1, State: StepRunning,
+	}
+	if err := s.CreateStepRun(t.Context(), r); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return r
+}
+
+// The column is nothing but a value the store carries: what goes in comes
+// back, and an empty message is stored as NULL rather than as "".
+func TestStepRunStatusRoundTrip(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+
+	in := &StepRun{
+		TaskID: task.ID, StepIndex: 0, StepID: "impl", StepType: "agent",
+		Attempt: 1, State: StepRunning, StatusMessage: "rebasing onto master",
+	}
+	if err := s.CreateStepRun(ctx, in); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	got, err := s.GetStepRun(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.StatusMessage != "rebasing onto master" {
+		t.Fatalf("StatusMessage = %q, want the message the insert carried", got.StatusMessage)
+	}
+
+	var raw sql.NullString
+	if err := s.db.QueryRow(
+		`SELECT status_message FROM step_runs WHERE id = ?`, in.ID).Scan(&raw); err != nil {
+		t.Fatalf("read status_message: %v", err)
+	}
+	if !raw.Valid {
+		t.Error("a message that was set stored as NULL")
+	}
+
+	// The engine's own final write must not carry the column: the step sets
+	// its status from another process while the actor is blocked in Wait, so
+	// an UpdateStepRun with the actor's stale struct would erase it. This is
+	// the property that makes the last live value survive onto the finished
+	// row (task 033).
+	stale := *got
+	stale.StatusMessage = ""
+	stale.State = StepSucceeded
+	if err := s.UpdateStepRun(ctx, &stale); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	after, err := s.GetStepRun(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun after update: %v", err)
+	}
+	if after.StatusMessage != "rebasing onto master" {
+		t.Errorf("StatusMessage after UpdateStepRun = %q, want it untouched", after.StatusMessage)
+	}
+	if after.State != StepSucceeded {
+		t.Errorf("state = %s, want the update to have applied everything else", after.State)
+	}
+}
+
+// The dedup rule of §13.3: a changed write appends exactly one event, and a
+// re-write of the identical message appends none. A board that refetches on
+// the event must not be woken by news it already has.
+func TestSetStepRunStatusDedupesEvents(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+	run := runningStepRun(t, s, task.ID, "impl")
+
+	runID, changed, err := s.SetStepRunStatus(ctx, task.ID, "impl", "3 tests red in internal/store")
+	if err != nil {
+		t.Fatalf("SetStepRunStatus: %v", err)
+	}
+	if runID != run.ID || !changed {
+		t.Fatalf("first write = (%d, %v), want (%d, true)", runID, changed, run.ID)
+	}
+	if n := countStatusEvents(t, s); n != 1 {
+		t.Fatalf("events after the first write = %d, want exactly 1", n)
+	}
+
+	_, changed, err = s.SetStepRunStatus(ctx, task.ID, "impl", "3 tests red in internal/store")
+	if err != nil {
+		t.Fatalf("identical re-write: %v", err)
+	}
+	if changed {
+		t.Error("an identical re-write reported a change")
+	}
+	if n := countStatusEvents(t, s); n != 1 {
+		t.Errorf("events after an identical re-write = %d, want still 1", n)
+	}
+
+	if _, changed, err = s.SetStepRunStatus(ctx, task.ID, "impl", "1 test red"); err != nil {
+		t.Fatalf("changed write: %v", err)
+	}
+	if !changed {
+		t.Error("a changed write reported no change")
+	}
+	if n := countStatusEvents(t, s); n != 2 {
+		t.Errorf("events after a changed write = %d, want 2", n)
+	}
+
+	// The payload is what §13.3 promises, and it carries the project so the
+	// /v1/events project filter works on this type like every other.
+	evs, err := s.ListEvents(ctx, EventFilter{Types: []string{EventTaskStatusChanged}})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	last := evs[len(evs)-1]
+	var payload struct {
+		TaskID  int64  `json:"task_id"`
+		StepID  string `json:"step_id"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("payload: %v (%s)", err, last.Payload)
+	}
+	if payload.TaskID != task.ID || payload.StepID != "impl" || payload.Message != "1 test red" {
+		t.Errorf("payload = %+v, want the task, step and message", payload)
+	}
+	if last.ProjectID == nil || *last.ProjectID != task.ProjectID {
+		t.Errorf("event project = %v, want %d", last.ProjectID, task.ProjectID)
+	}
+}
+
+// A write addressed at a step that is not running is refused, never applied
+// silently — and the refusal is its own error, so the API can answer 409
+// rather than 404.
+func TestSetStepRunStatusRefusesAFinishedStep(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+	run := runningStepRun(t, s, task.ID, "impl")
+
+	run.State = StepSucceeded
+	if err := s.UpdateStepRun(ctx, run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	if _, _, err := s.SetStepRunStatus(ctx, task.ID, "impl", "too late"); !errors.Is(err, ErrStepNotRunning) {
+		t.Fatalf("write against a finished step = %v, want ErrStepNotRunning", err)
+	}
+	if _, err := s.RunningStepRunID(ctx, task.ID, "impl"); !errors.Is(err, ErrStepNotRunning) {
+		t.Errorf("RunningStepRunID on a finished step = %v, want ErrStepNotRunning", err)
+	}
+	if n := countStatusEvents(t, s); n != 0 {
+		t.Errorf("a refused write appended %d events, want 0", n)
+	}
+	if got, _ := s.GetStepRun(ctx, run.ID); got.StatusMessage != "" {
+		t.Errorf("a refused write reached the row: %q", got.StatusMessage)
+	}
+}
+
+// Two `parallel` sub-steps share one task id and run at once (§7.5), which is
+// the whole reason the endpoint is keyed by step id: each must address its
+// own row.
+func TestSetStepRunStatusAddressesOneSubStep(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+	left := runningStepRun(t, s, task.ID, "lint")
+	right := runningStepRun(t, s, task.ID, "test")
+
+	if _, _, err := s.SetStepRunStatus(ctx, task.ID, "lint", "checking imports"); err != nil {
+		t.Fatalf("lint status: %v", err)
+	}
+	if _, _, err := s.SetStepRunStatus(ctx, task.ID, "test", "running ./internal/..."); err != nil {
+		t.Fatalf("test status: %v", err)
+	}
+	gotLeft, _ := s.GetStepRun(ctx, left.ID)
+	gotRight, _ := s.GetStepRun(ctx, right.ID)
+	if gotLeft.StatusMessage != "checking imports" {
+		t.Errorf("lint status = %q", gotLeft.StatusMessage)
+	}
+	if gotRight.StatusMessage != "running ./internal/..." {
+		t.Errorf("test status = %q", gotRight.StatusMessage)
+	}
+}
+
+// The board reads GET /v1/tasks and never fetches step rows, so the list
+// endpoint denormalizes the newest row's status. Newest row and not newest
+// *message*: a step that spoke and finished must not have its line linger
+// beside the next step, which is doing something else.
+func TestLatestStepStatuses(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+
+	first := runningStepRun(t, s, task.ID, "build")
+	if _, _, err := s.SetStepRunStatus(ctx, task.ID, "build", "compiling"); err != nil {
+		t.Fatalf("build status: %v", err)
+	}
+	got, err := s.LatestStepStatuses(ctx, []int64{task.ID})
+	if err != nil {
+		t.Fatalf("LatestStepStatuses: %v", err)
+	}
+	if got[task.ID] != "compiling" {
+		t.Fatalf("status = %q, want the running step's", got[task.ID])
+	}
+
+	first.State = StepSucceeded
+	if err := s.UpdateStepRun(ctx, first); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	runningStepRun(t, s, task.ID, "publish") // says nothing
+	got, err = s.LatestStepStatuses(ctx, []int64{task.ID})
+	if err != nil {
+		t.Fatalf("LatestStepStatuses: %v", err)
+	}
+	if _, ok := got[task.ID]; ok {
+		t.Errorf("status = %q, want none: the newest row said nothing", got[task.ID])
+	}
+
+	if got, err := s.LatestStepStatuses(ctx, nil); err != nil || len(got) != 0 {
+		t.Errorf("LatestStepStatuses(nil) = %v, %v; want an empty map", got, err)
+	}
+}
+
+// A database written before 0014 has rows with no status column at all. They
+// must survive the upgrade readable, with the status reading as "said
+// nothing" rather than as an error.
+func TestMigrateAddsStatusToPreexistingRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vincent.db")
+	migrateTo(t, path, 13)
+
+	func() {
+		db, err := sql.Open("sqlite", dsn(path))
+		if err != nil {
+			t.Fatalf("reopen at 0013: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+		db.SetMaxOpenConns(1)
+		if _, err := db.Exec(`PRAGMA foreign_keys = OFF`); err != nil {
+			t.Fatalf("disable foreign keys: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO step_runs
+			(task_id, step_index, step_id, step_type, attempt, state, result_summary, started_at)
+			VALUES (1, 0, 'impl', 'agent', 1, 'succeeded', 'all green', ?)`,
+			formatTime(time.Now())); err != nil {
+			t.Fatalf("insert legacy row: %v", err)
+		}
+		var n int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('step_runs') WHERE name = 'status_message'`).Scan(&n); err != nil {
+			t.Fatalf("pragma_table_info: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("status_message exists at schema 13; the fixture is not a pre-0014 database")
+		}
+	}()
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrating 13 -> %d): %v", latestSchemaVersion, err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if v := schemaVersion(t, s); v != latestSchemaVersion {
+		t.Errorf("schema version = %d, want %d", v, latestSchemaVersion)
+	}
+	runs, err := s.ListStepRuns(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("step runs = %d, want the legacy row", len(runs))
+	}
+	if runs[0].StatusMessage != "" {
+		t.Errorf("legacy StatusMessage = %q, want empty", runs[0].StatusMessage)
+	}
+	if runs[0].ResultSummary != "all green" {
+		t.Errorf("the migration disturbed an existing column: %q", runs[0].ResultSummary)
+	}
+}

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -28,7 +28,7 @@ const (
 	// nothing about what may be admitted (see scheduler.WakeOn).
 	EventTaskStepAdvanced = "task.step_advanced"
 	// EventTaskStatusChanged is written when a running step changes what it
-	// says about itself (§5.4, §13.3, task 033). Payload
+	// says about itself (§5.4, §13.3, task 036). Payload
 	// `{task_id, step_id, message}`. It is durable, so a client that blinks
 	// recovers the message through `Last-Event-ID` — which is the whole
 	// reason a status is not a live output chunk.

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -27,6 +27,19 @@ const (
 	// It deliberately does not wake the scheduler: advancing a step changes
 	// nothing about what may be admitted (see scheduler.WakeOn).
 	EventTaskStepAdvanced = "task.step_advanced"
+	// EventTaskStatusChanged is written when a running step changes what it
+	// says about itself (§5.4, §13.3, task 033). Payload
+	// `{task_id, step_id, message}`. It is durable, so a client that blinks
+	// recovers the message through `Last-Event-ID` — which is the whole
+	// reason a status is not a live output chunk.
+	//
+	// Like the two above it is not a transition, and like them it does not
+	// wake the scheduler (see scheduler.WakeOn): nothing about admission
+	// changes when a step describes itself. It is appended only when the
+	// stored value actually changed — the rule agent.quota_changed already
+	// records — so a step re-asserting the line it already set does not wake
+	// every board with news it has.
+	EventTaskStatusChanged = "task.status_changed"
 )
 
 // StateConflictError reports that a task was not in the expected state when

--- a/internal/taskrun/environment_test.go
+++ b/internal/taskrun/environment_test.go
@@ -1,6 +1,7 @@
 package taskrun
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,6 +126,44 @@ func TestAgentStepGetsTheResolvedEnvironment(t *testing.T) {
 	}
 	if !strings.Contains(got, "VINCENT_T423_AMBIENT=[]") {
 		t.Errorf("environment.unset did not drop the inherited variable: %q", got)
+	}
+}
+
+// TestAgentStepGetsTheVincentVariables is task 033's prerequisite: an agent
+// step saw the resolved base environment and none of the §8.5 run facts, so
+// an agent had no way to name the step it was running — which is exactly what
+// `vincent status` needs in order to address itself.
+//
+// VINCENT_STEP_ID and VINCENT_TASK_ID are the two the command uses; the rest
+// of the block rides along, since it is one layering either way.
+func TestAgentStepGetsTheVincentVariables(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "report-env")
+	t.Setenv("FAKEAGENT_REPORT_ENV", "VINCENT_TASK_ID,VINCENT_STEP_ID,VINCENT_WORKTREE,VINCENT_BRANCH")
+
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: env\nsteps:\n  - id: implement\n    type: agent\n    prompt: report\n")
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task = %s (%s), want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) != 1 {
+		t.Fatalf("step runs = %d, want 1", len(runs))
+	}
+	got := runs[0].ResultSummary
+	for _, want := range []string{
+		"VINCENT_STEP_ID=[implement]",
+		fmt.Sprintf("VINCENT_TASK_ID=[%d]", task.ID),
+		"VINCENT_BRANCH=[" + done.BranchName + "]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("agent step environment misses %s: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "VINCENT_WORKTREE=[]") {
+		t.Errorf("VINCENT_WORKTREE did not reach the agent: %q", got)
 	}
 }
 

--- a/internal/taskrun/environment_test.go
+++ b/internal/taskrun/environment_test.go
@@ -129,7 +129,7 @@ func TestAgentStepGetsTheResolvedEnvironment(t *testing.T) {
 	}
 }
 
-// TestAgentStepGetsTheVincentVariables is task 033's prerequisite: an agent
+// TestAgentStepGetsTheVincentVariables is task 036's prerequisite: an agent
 // step saw the resolved base environment and none of the §8.5 run facts, so
 // an agent had no way to name the step it was running — which is exactly what
 // `vincent status` needs in order to address itself.

--- a/internal/taskrun/runner.go
+++ b/internal/taskrun/runner.go
@@ -88,7 +88,7 @@ type Runner struct {
 	mu   sync.Mutex
 	live map[int64]*liveRun
 
-	// status paces the step-authored status message (§13.3, task 033). It is
+	// status paces the step-authored status message (§13.3, task 036). It is
 	// on the runner rather than on a live run because a status write arrives
 	// on an API goroutine, addressed by ids the step read from its own
 	// environment — there is no actor to route it through, and the row it

--- a/internal/taskrun/runner.go
+++ b/internal/taskrun/runner.go
@@ -87,6 +87,13 @@ type Runner struct {
 
 	mu   sync.Mutex
 	live map[int64]*liveRun
+
+	// status paces the step-authored status message (§13.3, task 033). It is
+	// on the runner rather than on a live run because a status write arrives
+	// on an API goroutine, addressed by ids the step read from its own
+	// environment — there is no actor to route it through, and the row it
+	// lands on is the truth either way.
+	status *statusThrottle
 }
 
 // stopper is the part of a live process the human actions need: ask it to
@@ -124,7 +131,18 @@ func New(deps Deps) *Runner {
 	if deps.Shells == nil {
 		deps.Shells = NewShells(deps.Logger)
 	}
-	return &Runner{deps: deps, live: map[int64]*liveRun{}}
+	r := &Runner{deps: deps, live: map[int64]*liveRun{}}
+	r.status = newStatusThrottle(func(runID int64, message string) {
+		// By run id, and through persistCtx rather than a request context:
+		// the coalesced write happens up to an interval after the request
+		// that produced it returned, and the step may have finished in the
+		// meantime. The step said this while it was running — deferring when
+		// to persist it must not turn it into something the step never said.
+		if _, err := r.deps.Store.SetStepRunStatusByRun(r.persistCtx(), runID, message); err != nil {
+			r.deps.Logger.Error("persist step status", "run", runID, "error", err)
+		}
+	})
+	return r
 }
 
 // Start prepares the runner to accept admissions until ctx is canceled or

--- a/internal/taskrun/status.go
+++ b/internal/taskrun/status.go
@@ -9,7 +9,7 @@ import (
 	"unicode/utf8"
 )
 
-// StatusMessageLimit bounds a step's status message (§5.4, §13.3, task 033).
+// StatusMessageLimit bounds a step's status message (§5.4, §13.3, task 036).
 //
 // 256 bytes is a line, not a report: the message is rendered in a board cell
 // and on one attempt line, and anything longer is a transcript. Over-long
@@ -30,7 +30,7 @@ const StatusMessageLimit = 256
 const statusMinInterval = time.Second
 
 // SetStepStatus records what a running step says about itself (§5.4, task
-// 033).
+// 036).
 //
 // It is the engine's entry point for
 // `POST /v1/tasks/{id}/steps/{step_id}/status`, and it is here rather than in

--- a/internal/taskrun/status.go
+++ b/internal/taskrun/status.go
@@ -1,0 +1,212 @@
+package taskrun
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// StatusMessageLimit bounds a step's status message (§5.4, §13.3, task 033).
+//
+// 256 bytes is a line, not a report: the message is rendered in a board cell
+// and on one attempt line, and anything longer is a transcript. Over-long
+// text is truncated rather than refused — the caller is a script or an agent
+// mid-run, and failing its status write because it was wordy would turn a
+// display nicety into a step failure.
+const StatusMessageLimit = 256
+
+// statusMinInterval is the floor between two persisted status writes of one
+// step run. A write inside the floor is not rejected: it is coalesced, and
+// the latest value lands when the floor expires, so a step that narrates in a
+// tight loop costs one `events` row per second rather than thousands.
+//
+// The throttle is leading-edge on purpose. The first write after a quiet
+// period goes through immediately, which is what the live reading needs — a
+// step that says one thing and then works for ten minutes must not have that
+// one thing delayed.
+const statusMinInterval = time.Second
+
+// SetStepStatus records what a running step says about itself (§5.4, task
+// 033).
+//
+// It is the engine's entry point for
+// `POST /v1/tasks/{id}/steps/{step_id}/status`, and it is here rather than in
+// the API for the reason every other write is: the engine owns the step_run
+// rows, and this one carries policy — §13.3's bounds and the coalescing
+// floor — that has to hold whoever calls it.
+//
+// The task lookup is separate from the row resolution so the two failures
+// stay distinguishable: an unknown task is store.ErrNotFound (a 404) and a
+// step that is not running is store.ErrStepNotRunning (a 409). A write
+// addressed at a finished attempt is never a silent no-op — a script still
+// reporting progress after its step was killed should learn that.
+func (r *Runner) SetStepStatus(ctx context.Context, taskID int64, stepID, message string) error {
+	if _, err := r.deps.Store.GetTask(ctx, taskID); err != nil {
+		return err
+	}
+	// Resolved before the throttle is consulted, and unconditionally: the 409
+	// for a step that is not running must not depend on how recently
+	// something else wrote a status, and the throttle needs a row id to key
+	// on. The row can still finish between here and the write, which the
+	// write itself catches — it re-resolves inside its own transaction.
+	runID, err := r.deps.Store.RunningStepRunID(ctx, taskID, stepID)
+	if err != nil {
+		return err
+	}
+	msg := NormalizeStatusMessage(message)
+	if !r.status.admit(runID, msg) {
+		// Coalesced, not refused: the caller succeeded, and the value it
+		// wrote is the one the pending flush will persist.
+		return nil
+	}
+	if _, _, err := r.deps.Store.SetStepRunStatus(ctx, taskID, stepID, msg); err != nil {
+		return err
+	}
+	r.status.accept(runID, msg)
+	return nil
+}
+
+// NormalizeStatusMessage puts a status message into the one shape every
+// surface can render: a single line of printable text, no longer than
+// StatusMessageLimit bytes.
+//
+// Newlines become spaces rather than a truncation point — a step that writes
+// two sentences means both — and other control characters are dropped
+// outright, because this text lands in a table cell and an embedded escape
+// sequence there is a terminal-control bug wearing a status message (§16).
+// Truncation is on a rune boundary: a message cut mid-rune renders as a
+// replacement character, which reads as corruption rather than as brevity.
+func NormalizeStatusMessage(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteRune(' ')
+		case r == utf8.RuneError, unicode.IsControl(r):
+			// Dropped: the C0 and C1 ranges, and any byte that is not valid
+			// UTF-8 (which ranging over a string yields as RuneError).
+		default:
+			b.WriteRune(r)
+		}
+	}
+	// Collapse the runs of whitespace the flattening just created, so a
+	// message written as a paragraph reads as a sentence rather than as gaps.
+	out := strings.Join(strings.Fields(b.String()), " ")
+	if len(out) <= StatusMessageLimit {
+		return out
+	}
+	cut := StatusMessageLimit
+	for cut > 0 && !utf8.RuneStart(out[cut]) {
+		cut--
+	}
+	return strings.TrimRight(out[:cut], " ")
+}
+
+// statusThrottle enforces statusMinInterval per step run. It holds one slot
+// per run that has spoken recently; a slot is retired an interval after its
+// last write, so a daemon running for a week accumulates nothing.
+type statusThrottle struct {
+	// interval is a field rather than the constant so tests can drive the
+	// coalescing without spending a wall-clock second per case. It is
+	// deliberately not a config key: the floor is a property of the events
+	// table's shape (§13.3), not an operator's choice.
+	interval time.Duration
+	// write persists a coalesced value, addressed at the row it was written
+	// against. Injected so the throttle is testable without a store, and so
+	// the flush writes through the runner's shutdown-proof context rather
+	// than a request's.
+	write func(runID int64, message string)
+
+	mu    sync.Mutex
+	slots map[int64]*statusSlot
+}
+
+// statusSlot is one step run's recent status traffic.
+type statusSlot struct {
+	last    time.Time
+	pending string
+	// armed is the timer that will flush pending; nil when nothing waits.
+	armed *time.Timer
+}
+
+func newStatusThrottle(write func(runID int64, message string)) *statusThrottle {
+	return &statusThrottle{
+		interval: statusMinInterval,
+		write:    write,
+		slots:    map[int64]*statusSlot{},
+	}
+}
+
+// admit reports whether a write for runID may go straight to the database.
+// When it may not, message is remembered as the pending value and a flush is
+// armed for the remainder of the floor, so the caller still succeeds and the
+// latest value still lands — exactly once.
+func (t *statusThrottle) admit(runID int64, message string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	slot := t.slots[runID]
+	if slot == nil || time.Since(slot.last) >= t.interval {
+		return true
+	}
+	if slot.pending == message {
+		// Nothing new to say. The store would drop this as a duplicate
+		// anyway, and not arming a timer for it stops a step that repeats
+		// itself from keeping a slot alive forever.
+		return false
+	}
+	slot.pending = message
+	if slot.armed == nil {
+		slot.armed = time.AfterFunc(t.interval-time.Since(slot.last), func() { t.flush(runID) })
+	}
+	return false
+}
+
+// accept records that runID's status was just persisted, which is what makes
+// the next write inside the floor coalesce instead of reaching the database.
+func (t *statusThrottle) accept(runID int64, message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	slot := t.slots[runID]
+	if slot == nil {
+		slot = &statusSlot{}
+		t.slots[runID] = slot
+	}
+	slot.last = time.Now()
+	slot.pending = message
+}
+
+// flush persists whatever the slot ended up holding, then schedules its
+// retirement. It writes by row id and does not re-check that the attempt is
+// still running: the step wrote this while it *was*, and the floor is the
+// daemon's choice about when to persist it, not a licence to lose the last
+// thing a step said before it exited.
+func (t *statusThrottle) flush(runID int64) {
+	t.mu.Lock()
+	slot := t.slots[runID]
+	if slot == nil {
+		t.mu.Unlock()
+		return
+	}
+	message := slot.pending
+	slot.armed = nil
+	slot.last = time.Now()
+	t.mu.Unlock()
+
+	t.write(runID, message)
+	time.AfterFunc(t.interval, func() { t.retire(runID) })
+}
+
+// retire drops a slot whose step has stopped talking. A write arriving in the
+// meantime re-creates it, and a fresh slot admits immediately — which is
+// correct, because the floor has passed.
+func (t *statusThrottle) retire(runID int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if s := t.slots[runID]; s != nil && s.armed == nil && time.Since(s.last) >= t.interval {
+		delete(t.slots, runID)
+	}
+}

--- a/internal/taskrun/status_test.go
+++ b/internal/taskrun/status_test.go
@@ -1,0 +1,314 @@
+package taskrun
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+func TestNormalizeStatusMessage(t *testing.T) {
+	long := strings.Repeat("a", StatusMessageLimit+50)
+	// A run of multi-byte runes straddling the cap: the cut has to land on a
+	// boundary, or the message ends in a replacement character that reads as
+	// corruption rather than as brevity.
+	wide := strings.Repeat("é", StatusMessageLimit)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "3 tests red in internal/store", "3 tests red in internal/store"},
+		{"multiline", "rebasing\nonto master", "rebasing onto master"},
+		{"crlf", "packing\r\nthe artifact", "packing the artifact"},
+		{"tabs and runs", "  two\t\tspaces   here  ", "two spaces here"},
+		{"control characters", "clear\x1b[2Jscreen\x00", "clear[2Jscreen"},
+		{"truncated", long, strings.Repeat("a", StatusMessageLimit)},
+		{"empty", "", ""},
+		{"only whitespace", " \n\t ", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeStatusMessage(c.in); got != c.want {
+				t.Errorf("NormalizeStatusMessage(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+
+	got := NormalizeStatusMessage(wide)
+	if len(got) > StatusMessageLimit {
+		t.Errorf("truncated length = %d bytes, want at most %d", len(got), StatusMessageLimit)
+	}
+	if strings.ContainsRune(got, '�') {
+		t.Error("truncation cut a rune in half")
+	}
+	if got != strings.Repeat("é", StatusMessageLimit/2) {
+		t.Errorf("multi-byte truncation = %q, want a whole number of runes", got)
+	}
+}
+
+// Writes faster than the floor are coalesced, never rejected: the first goes
+// through, the burst behind it does not reach the database, and the latest
+// value lands once when the floor expires (§13.3).
+func TestStatusThrottleCoalesces(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		written []string
+	)
+	th := newStatusThrottle(func(_ int64, message string) {
+		mu.Lock()
+		defer mu.Unlock()
+		written = append(written, message)
+	})
+	th.interval = 60 * time.Millisecond
+
+	if !th.admit(1, "first") {
+		t.Fatal("the first write was not admitted; a quiet step must never be delayed")
+	}
+	th.accept(1, "first")
+
+	for _, msg := range []string{"second", "third", "fourth"} {
+		if th.admit(1, msg) {
+			t.Fatalf("%q was admitted inside the floor", msg)
+		}
+	}
+	// A different run is a different slot: one chatty step must not silence
+	// another.
+	if !th.admit(2, "sibling") {
+		t.Error("a second step run was throttled by the first's traffic")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(written)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(written) != 1 {
+		t.Fatalf("coalesced writes = %v, want exactly one flush", written)
+	}
+	if written[0] != "fourth" {
+		t.Errorf("flushed %q, want the latest value", written[0])
+	}
+}
+
+// After the floor has passed, a write goes straight through again.
+func TestStatusThrottleAdmitsAfterTheFloor(t *testing.T) {
+	th := newStatusThrottle(func(int64, string) {})
+	th.interval = 20 * time.Millisecond
+	th.accept(1, "first")
+	if th.admit(1, "second") {
+		t.Fatal("admitted inside the floor")
+	}
+	// Well past the floor, and past the flush that the coalesced write above
+	// armed — which restarts it. A margin rather than the floor exactly: this
+	// asserts that the throttle reopens, not how precisely a timer fires.
+	time.Sleep(250 * time.Millisecond)
+	if !th.admit(1, "third") {
+		t.Error("still throttled after the floor expired")
+	}
+}
+
+// The engine path end to end, against a real store and a real agent step: a
+// status set while the step is running is readable on the running row, and
+// the last value set survives onto the finished one.
+func TestSetStepStatusLiveAndTerminal(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: s\nsteps:\n  - id: implement\n    type: agent\n    prompt: work\n")
+	h.start(t)
+
+	run := waitForRunningRun(t, h, task.ID, "implement")
+	ctx := t.Context()
+	if err := h.runner.SetStepStatus(ctx, task.ID, "implement", "scaffolding the migration"); err != nil {
+		t.Fatalf("SetStepStatus: %v", err)
+	}
+	got, err := h.store.GetStepRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepRunning {
+		t.Fatalf("row state = %s, want the status readable while running", got.State)
+	}
+	if got.StatusMessage != "scaffolding the migration" {
+		t.Fatalf("live status = %q", got.StatusMessage)
+	}
+
+	// A cancel ends the step as `interrupted`/`canceled`, which is the §12.4
+	// shape: the terminalizing write must leave the status alone.
+	if _, err := h.runner.Cancel(ctx, task.ID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	h.waitForState(t, task.ID, store.TaskAborted)
+	// The task is aborted durably before the actor reaps the process and
+	// closes the row, so the row is what to wait on here.
+	after := waitForFinishedRun(t, h, run.ID)
+	if after.StatusMessage != "scaffolding the migration" {
+		t.Errorf("terminal status = %q, want the last live value to survive", after.StatusMessage)
+	}
+
+	// And the endpoint refuses a write against the finished attempt rather
+	// than applying it silently.
+	err = h.runner.SetStepStatus(ctx, task.ID, "implement", "too late")
+	if !errors.Is(err, store.ErrStepNotRunning) {
+		t.Errorf("write against a finished step = %v, want ErrStepNotRunning", err)
+	}
+}
+
+// The failing leg: a status set before the step fails is what stays on the
+// `failed` row, beside — never instead of — the daemon's failure_reason.
+func TestSetStepStatusSurvivesAFailure(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newEngineHarness(t)
+	task := h.createTask(t,
+		"name: s\nsteps:\n  - id: implement\n    type: agent\n    prompt: work\n    timeout: 3s\n")
+	h.start(t)
+
+	run := waitForRunningRun(t, h, task.ID, "implement")
+	if err := h.runner.SetStepStatus(t.Context(), task.ID, "implement", "stuck retrying the same test"); err != nil {
+		t.Fatalf("SetStepStatus: %v", err)
+	}
+	h.waitForState(t, task.ID, store.TaskBlocked)
+
+	got, err := h.store.GetStepRun(t.Context(), run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepFailed || got.FailureReason != ReasonTimeout {
+		t.Fatalf("row = %s/%s, want failed/timeout", got.State, got.FailureReason)
+	}
+	if got.StatusMessage != "stuck retrying the same test" {
+		t.Errorf("status on the failed row = %q, want the step's own last words", got.StatusMessage)
+	}
+}
+
+// A step that says two things in quick succession has the second coalesced —
+// and the coalesced value still lands, even though the step finished inside
+// the floor. Losing it would lose exactly the message the terminal reading is
+// about: the last thing a step said before it exited.
+func TestSetStepStatusCoalescedValueSurvivesTheStep(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newEngineHarness(t)
+	task := h.createTask(t, "name: s\nsteps:\n  - id: implement\n    type: agent\n    prompt: work\n")
+	h.start(t)
+
+	run := waitForRunningRun(t, h, task.ID, "implement")
+	// Short enough that the whole burst plus the cancel fit inside one floor,
+	// which is the case the flush has to survive.
+	h.runner.status.interval = 300 * time.Millisecond
+	ctx := t.Context()
+	for _, msg := range []string{"first", "second", "third"} {
+		if err := h.runner.SetStepStatus(ctx, task.ID, "implement", msg); err != nil {
+			t.Fatalf("SetStepStatus(%q): %v", msg, err)
+		}
+	}
+	if _, err := h.runner.Cancel(ctx, task.ID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	h.waitForState(t, task.ID, store.TaskAborted)
+	waitForFinishedRun(t, h, run.ID)
+
+	deadline := time.Now().Add(10 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		got, err := h.store.GetStepRun(ctx, run.ID)
+		if err != nil {
+			t.Fatalf("GetStepRun: %v", err)
+		}
+		last = got.StatusMessage
+		if last == "third" {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("status after the burst = %q, want the coalesced latest value", last)
+}
+
+// An unknown task is not-found, which the API answers 404 to; only a step
+// that is not running is the 409.
+func TestSetStepStatusUnknownTask(t *testing.T) {
+	h := newEngineHarness(t)
+	err := h.runner.SetStepStatus(t.Context(), 9999, "implement", "hello")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("SetStepStatus on an unknown task = %v, want ErrNotFound", err)
+	}
+}
+
+// §12.4 recovery finalizes a `running` row left by a crashed daemon as
+// `interrupted`. The step's last words are the most useful thing on that row
+// — "what was it doing when the machine went down" — so the terminalizing
+// write must not take them with it.
+func TestRecoverKeepsTheStatusMessage(t *testing.T) {
+	st, projectID := recoverStore(t)
+	ctx := context.Background()
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	run := journalRun(t, st, task.ID, nil, nil)
+
+	if _, _, err := st.SetStepRunStatus(ctx, task.ID, run.StepID, "migrating the schema"); err != nil {
+		t.Fatalf("SetStepRunStatus: %v", err)
+	}
+	if _, err := Recover(ctx, st, discardLog()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	got, err := st.GetStepRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.State != store.StepInterrupted {
+		t.Fatalf("row = %s, want interrupted", got.State)
+	}
+	if got.StatusMessage != "migrating the schema" {
+		t.Errorf("status after recovery = %q, want it kept", got.StatusMessage)
+	}
+}
+
+// waitForFinishedRun polls until a step run carries a finish stamp.
+func waitForFinishedRun(t *testing.T, h *engineHarness, runID int64) *store.StepRun {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	var last *store.StepRun
+	for time.Now().Before(deadline) {
+		run, err := h.store.GetStepRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetStepRun: %v", err)
+		}
+		last = run
+		if run.FinishedAt != nil {
+			return run
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("step run %d never finished: %+v", runID, last)
+	return nil
+}
+
+// waitForRunningRun polls until the named step has a `running` row.
+func waitForRunningRun(t *testing.T, h *engineHarness, taskID int64, stepID string) *store.StepRun {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		runs, err := h.store.ListStepRuns(context.Background(), taskID)
+		if err != nil {
+			t.Fatalf("ListStepRuns: %v", err)
+		}
+		for i := range runs {
+			if runs[i].StepID == stepID && runs[i].State == store.StepRunning {
+				return &runs[i]
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("step %q of task %d never reached running", stepID, taskID)
+	return nil
+}

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -73,7 +73,7 @@ func (r *Runner) runAgentStep(
 		// value this engine computed, not whatever the daemon was started
 		// from.
 		//
-		// It carries the §8.5 VINCENT_* block too, as of task 033: an agent
+		// It carries the §8.5 VINCENT_* block too, as of task 036: an agent
 		// step used to see the resolved base and none of the run facts, so
 		// an agent could not name the step it was running even to the daemon
 		// that started it. `vincent status` addresses itself with
@@ -743,7 +743,7 @@ func (r *Runner) childEnv() []string {
 // `environment.unset` cannot reach a VINCENT_* variable. Those are facts
 // about the run, not inherited state.
 //
-// It serves `agent` steps as well as `command` and `check` ones (task 033);
+// It serves `agent` steps as well as `command` and `check` ones (task 036);
 // only the latter pass a stepEnvVars map, since `env:` is a command-step
 // field.
 func commandEnv(base []string, rc workflow.RenderContext, stepEnvVars map[string]string) []string {

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -72,12 +72,17 @@ func (r *Runner) runAgentStep(
 		// and "decided" is the whole point: what a step runs under is now a
 		// value this engine computed, not whatever the daemon was started
 		// from.
-		Env: r.childEnv(),
-		// Always explicit, even when the policy inherits everything (T4.23).
-		// Passing nil would hand the adapter the ambient environment again,
-		// and "decided" is the whole point: what a step runs under is now a
-		// value this engine computed, not whatever the daemon was started
-		// from.
+		//
+		// It carries the §8.5 VINCENT_* block too, as of task 033: an agent
+		// step used to see the resolved base and none of the run facts, so
+		// an agent could not name the step it was running even to the daemon
+		// that started it. `vincent status` addresses itself with
+		// VINCENT_TASK_ID and VINCENT_STEP_ID, which is what made the gap
+		// load-bearing. Same precedence rule as a command step's — the
+		// variables layer over the policy, so `environment.unset` cannot
+		// reach them. There is no step-level `env:` here: `env:` is a
+		// command-step field (§8.1).
+		Env: commandEnv(r.childEnv(), rc, nil),
 	})
 	if err != nil {
 		tr.Note("error", map[string]any{"error": err.Error()})
@@ -720,9 +725,6 @@ func resultChunks(results []agent.ToolResult) []map[string]any {
 	return out
 }
 
-// commandEnv builds the environment of a command or check step: the
-// daemon's own environment, the §8.5 vincent variables, then the step's
-// declared `env` (which wins, so a workflow can override anything).
 // childEnv resolves the §12.3 environment policy against this process's own
 // environment (T4.23).
 //
@@ -735,11 +737,15 @@ func (r *Runner) childEnv() []string {
 	return r.deps.Config().Environment.ResolveProcess()
 }
 
-// commandEnv builds a command or check step's environment: the §12.3 resolved
-// base, then the §8.5 VINCENT_* variables, then the step's own `env:`. The
-// order is the precedence — Go's exec keeps the last of any duplicate name —
-// and it is why `environment.unset` cannot reach a VINCENT_* variable. Those
-// are facts about the run, not inherited state.
+// commandEnv builds a step's environment: the §12.3 resolved base, then the
+// §8.5 VINCENT_* variables, then the step's own `env:`. The order is the
+// precedence — Go's exec keeps the last of any duplicate name — and it is why
+// `environment.unset` cannot reach a VINCENT_* variable. Those are facts
+// about the run, not inherited state.
+//
+// It serves `agent` steps as well as `command` and `check` ones (task 033);
+// only the latter pass a stepEnvVars map, since `env:` is a command-step
+// field.
 func commandEnv(base []string, rc workflow.RenderContext, stepEnvVars map[string]string) []string {
 	out := append([]string(nil), base...)
 	out = append(out, workflow.Env(rc)...)

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -832,6 +832,9 @@ func (b *board) rowsFor(rows []boardRow, set columnSet) []table.Row {
 		if set.cost {
 			row = append(row, formatCost(t.CostUSD))
 		}
+		if set.status {
+			row = append(row, formatStatus(t.StatusMessage))
+		}
 		out = append(out, row)
 	}
 	return out
@@ -857,6 +860,9 @@ func groupHeaderRow(r boardRow, set columnSet) table.Row {
 	}
 	row = append(row, r.headerCell(), "", "", "")
 	if set.cost {
+		row = append(row, "")
+	}
+	if set.status {
 		row = append(row, "")
 	}
 	return row

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -20,7 +20,7 @@ const (
 	widthStepLong  = 18
 	widthElapsed   = 9
 	widthCost      = 8
-	// widthStatus holds a step's own status message (task 033) — enough for a
+	// widthStatus holds a step's own status message (task 036) — enough for a
 	// clause, with the rest truncated. It is not wider because this column is
 	// affordable only on a board with room to spare, which is the deal it is
 	// admitted on.
@@ -60,7 +60,7 @@ type columnSet struct {
 	workflow bool
 	stepName bool
 	cost     bool
-	// status is the step's own status message (§5.4, task 033). It is the
+	// status is the step's own status message (§5.4, task 036). It is the
 	// first column shed and the last admitted: it is a luxury of a wide
 	// terminal, and a board narrow enough to drop it renders exactly as it
 	// did before the column existed.
@@ -114,7 +114,7 @@ func (s columnSet) titleWidth(width int) int { return width - s.fixedWidth() }
 // than being second-guessed as constants that can silently disagree with
 // them.
 //
-// The status goes first (task 033) because it is the only column that is
+// The status goes first (task 036) because it is the only column that is
 // prose: a task is found by its project, its workflow and its title, and a
 // step's self-report is what you read once you have found it. Shedding it
 // first is also what keeps the addition free — a board too narrow for it

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -20,12 +20,31 @@ const (
 	widthStepLong  = 18
 	widthElapsed   = 9
 	widthCost      = 8
-	minTitle       = 16
+	// widthStatus holds a step's own status message (task 033) — enough for a
+	// clause, with the rest truncated. It is not wider because this column is
+	// affordable only on a board with room to spare, which is the deal it is
+	// admitted on.
+	widthStatus = 28
+	minTitle    = 16
+	// minTitleWithStatus is the title width below which the status column is
+	// not worth its cells. minTitle alone is the wrong gate for it: a
+	// 120-column board is the common case, and admitting the status there
+	// would take a 50-cell title down to 20 — still "legal", and still a
+	// board whose titles no longer identify anything.
+	//
+	// Set high enough that the column is genuinely a wide-terminal luxury,
+	// and — deliberately — high enough that it cannot eat the width a grouped
+	// board frees by dropping PROJECT and WORKFLOW. That width was recorded
+	// as going to the title (see columnsFor), and a new column quietly
+	// spending it would overturn that decision rather than add to it. At
+	// every width, a grouped board's title stays strictly wider than a flat
+	// board's.
+	minTitleWithStatus = 64
 )
 
 // maxBoardColumns is every column the widest board can carry — the size a row
 // is built at, so rowsFor and groupHeaderRow never grow their slice mid-loop.
-const maxBoardColumns = 9
+const maxBoardColumns = 10
 
 // columnSet records which optional columns survived the current width.
 type columnSet struct {
@@ -41,6 +60,11 @@ type columnSet struct {
 	workflow bool
 	stepName bool
 	cost     bool
+	// status is the step's own status message (§5.4, task 033). It is the
+	// first column shed and the last admitted: it is a luxury of a wide
+	// terminal, and a board narrow enough to drop it renders exactly as it
+	// did before the column existed.
+	status bool
 }
 
 // fixedWidth is everything a set costs except the title, padding included.
@@ -69,6 +93,10 @@ func (s columnSet) fixedWidth() int {
 		total += widthCost
 		count++
 	}
+	if s.status {
+		total += widthStatus
+		count++
+	}
 	return total + count*colPadding
 }
 
@@ -80,10 +108,17 @@ func (s columnSet) titleWidth(width int) int { return width - s.fixedWidth() }
 // §15's columns do not fit a narrow terminal, and truncating all of them
 // proportionally leaves a row of unreadable stubs — a 6-character title
 // tells you nothing. Whole columns are dropped instead, in increasing order
-// of how much you navigate by them: cost, then the step name, then the
-// workflow, then the project. Dropping continues until the title clears its
-// minimum, so the thresholds follow from the widths rather than being
-// second-guessed as constants that can silently disagree with them.
+// of how much you navigate by them: the status, then cost, then the step
+// name, then the workflow, then the project. Dropping continues until the
+// title clears its minimum, so the thresholds follow from the widths rather
+// than being second-guessed as constants that can silently disagree with
+// them.
+//
+// The status goes first (task 033) because it is the only column that is
+// prose: a task is found by its project, its workflow and its title, and a
+// step's self-report is what you read once you have found it. Shedding it
+// first is also what keeps the addition free — a board too narrow for it
+// renders byte-for-byte as it did before.
 //
 // The workflow outranks the step name: "survey" is meaningless without
 // knowing it belongs to docs-update, while the workflow alone still tells you
@@ -103,9 +138,20 @@ func columnsFor(width int, g grouping, marking bool) columnSet {
 		workflow: !g.has(groupWorkflow),
 		stepName: true,
 		cost:     true,
+		status:   true,
+	}
+	// The status has a gate of its own, stricter than the shedding ladder
+	// below, which is what makes it a luxury of a wide terminal rather than
+	// something every board pays for. Anything that clears this gate has room
+	// to spare; anything that does not renders exactly as it did before the
+	// column existed.
+	if set.titleWidth(width) < minTitleWithStatus {
+		set.status = false
 	}
 	for set.titleWidth(width) < minTitle {
 		switch {
+		case set.status:
+			set.status = false
 		case set.cost:
 			set.cost = false
 		case set.stepName:
@@ -154,6 +200,9 @@ func boardColumns(width int, g grouping, marking bool) ([]table.Column, columnSe
 	)
 	if set.cost {
 		cols = append(cols, table.Column{Title: "COST", Width: widthCost})
+	}
+	if set.status {
+		cols = append(cols, table.Column{Title: "STATUS", Width: widthStatus})
 	}
 	return cols, set
 }

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -237,7 +237,7 @@ func TestGroupedColumnsAreDropped(t *testing.T) {
 // glitch.
 func TestGroupedRowsMatchTheColumnCount(t *testing.T) {
 	b := groupedBoard(task(1, stateRunning, inProject("api"), inWorkflow("build")))
-	// 240 is wide enough for the status column (task 033), which is the
+	// 240 is wide enough for the status column (task 036), which is the
 	// widest set a row is ever built at.
 	for _, width := range []int{40, 70, 90, 120, 200, 240} {
 		for _, g := range []grouping{nil, {groupProject}, {groupProject, groupWorkflow}} {

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -237,7 +237,9 @@ func TestGroupedColumnsAreDropped(t *testing.T) {
 // glitch.
 func TestGroupedRowsMatchTheColumnCount(t *testing.T) {
 	b := groupedBoard(task(1, stateRunning, inProject("api"), inWorkflow("build")))
-	for _, width := range []int{40, 70, 90, 120, 200} {
+	// 240 is wide enough for the status column (task 033), which is the
+	// widest set a row is ever built at.
+	for _, width := range []int{40, 70, 90, 120, 200, 240} {
 		for _, g := range []grouping{nil, {groupProject}, {groupProject, groupWorkflow}} {
 			b.group = g
 			// With and without the bulk-selection marker column (task 011):

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -266,7 +266,7 @@ func formatCost(c *float64) string {
 }
 
 // formatStatus renders the newest step run's own status message in the board
-// cell (§5.4, task 033). Empty rather than a dash: a step saying nothing is
+// cell (§5.4, task 036). Empty rather than a dash: a step saying nothing is
 // the ordinary case for most step types and every workflow that has not
 // adopted the protocol, and a column of dashes reads as something missing.
 //

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -262,6 +263,22 @@ func formatCost(c *float64) string {
 		return "—"
 	}
 	return fmt.Sprintf("$%.2f", *c)
+}
+
+// formatStatus renders the newest step run's own status message in the board
+// cell (§5.4, task 033). Empty rather than a dash: a step saying nothing is
+// the ordinary case for most step types and every workflow that has not
+// adopted the protocol, and a column of dashes reads as something missing.
+//
+// Truncated with an ellipsis rather than wrapped, because the table gives
+// every row one line. The whole message is on the attempt line in the detail
+// view, which has the width — the same division of labour renderBoardState
+// makes for a hold's reason.
+func formatStatus(message *string) string {
+	if message == nil || *message == "" {
+		return ""
+	}
+	return ansi.Truncate(*message, widthStatus, "…")
 }
 
 // formatStep renders k/n plus the step name when there is room. A snapshot

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -19,6 +19,11 @@ var (
 	styleStderr     = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Faint(true)
 	styleAsk        = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true)
 	styleFocus      = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	// styleStatus renders a step's own status message (task 033). Cyan and
+	// unbold: near the running state's colour, because that is what it is
+	// usually reporting on, and nowhere near styleBad — the failure reason
+	// beside it is the daemon's verdict and this is not.
+	styleStatus = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 )
 
 // editedBadge marks an attempt whose prompt or command a human rewrote
@@ -328,6 +333,13 @@ func (d *detail) renderTimeline(height int) string {
 		}
 		lines = append(lines, line)
 		ids = append(ids, r.ID)
+		if summary := summaryLine(r, grouped || looped || repair); summary != "" {
+			// The same run id, so clicking the continuation selects the
+			// attempt it belongs to rather than falling through to a focus
+			// click on nothing.
+			lines = append(lines, summary)
+			ids = append(ids, r.ID)
+		}
 	}
 	// The windowed ids are kept for hit-testing clicks on the same lines.
 	start := windowStart(len(lines), cursorLine, height)
@@ -551,7 +563,47 @@ func (d *detail) attemptLine(r apiclient.StepRun, indented bool) string {
 	if r.Agent != nil && *r.Agent != "" {
 		fields = append(fields, styleDim.Render(agentTriple(r)))
 	}
+	// What the step said about itself (§5.4, task 033) goes last, and in its
+	// own style. It is deliberately *not* rendered beside failure_reason:
+	// the reason is the daemon's verdict, while this is free text the step
+	// chose — a step killed on `timeout` may be carrying a line it wrote
+	// thirty-five minutes earlier, and styling the two alike would present a
+	// stale self-report as a cause. Last, because it is the one field with no
+	// bound a reader can predict: when the pane is too narrow it is what the
+	// frame truncates, rather than the metrics beside it.
+	if r.StatusMessage != nil && *r.StatusMessage != "" {
+		fields = append(fields, styleStatus.Render(statusGlyph+" "+*r.StatusMessage))
+	}
 	return strings.Join(fields, " ")
+}
+
+// statusGlyph marks a step-authored status message, so it reads as a quote
+// rather than as another of the daemon's own fields — and so the distinction
+// survives a monochrome terminal, where the colour does not.
+const statusGlyph = "»"
+
+// summaryLine renders an attempt's result_summary as a dim continuation line
+// under it: the agent's final result text, or the tail of a command's stdout
+// (§5.4). It has been stored, served and read by `.Steps.<id>.Result` and the
+// repair prompt since the first release and shown on no screen at all.
+//
+// Only for an attempt that did **not** succeed. That is where it earns a
+// line: a blocked task's reader is asking "what went wrong", and
+// `failure_reason` answers only which category. Under every attempt it would
+// roughly double the height of a healthy timeline to restate what the output
+// pane is already showing for the one attempt the reader selected.
+//
+// One line, flattened. The full text is in the output pane and the
+// transcript; this is the sentence that decides whether to go there.
+func summaryLine(r apiclient.StepRun, indented bool) string {
+	if r.State == "succeeded" || strings.TrimSpace(r.ResultSummary) == "" {
+		return ""
+	}
+	indent := "       "
+	if indented {
+		indent = "         "
+	}
+	return styleDim.Render(indent + strings.Join(strings.Fields(r.ResultSummary), " "))
 }
 
 func formatTokens(r apiclient.StepRun) string {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -19,7 +19,7 @@ var (
 	styleStderr     = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Faint(true)
 	styleAsk        = lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Bold(true)
 	styleFocus      = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-	// styleStatus renders a step's own status message (task 033). Cyan and
+	// styleStatus renders a step's own status message (task 036). Cyan and
 	// unbold: near the running state's colour, because that is what it is
 	// usually reporting on, and nowhere near styleBad — the failure reason
 	// beside it is the daemon's verdict and this is not.
@@ -563,7 +563,7 @@ func (d *detail) attemptLine(r apiclient.StepRun, indented bool) string {
 	if r.Agent != nil && *r.Agent != "" {
 		fields = append(fields, styleDim.Render(agentTriple(r)))
 	}
-	// What the step said about itself (§5.4, task 033) goes last, and in its
+	// What the step said about itself (§5.4, task 036) goes last, and in its
 	// own style. It is deliberately *not* rendered beside failure_reason:
 	// the reason is the daemon's verdict, while this is free text the step
 	// chose — a step killed on `timeout` may be carrying a line it wrote

--- a/internal/tui/stepstatus_test.go
+++ b/internal/tui/stepstatus_test.go
@@ -1,0 +1,186 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The attempt line carries both readings of the status (task 033): the live
+// one on a running attempt, and the terminal one on a finished attempt beside
+// — never instead of — the daemon's failure_reason. The two are rendered in
+// different styles, because a stale self-report presented as the daemon's
+// verdict is the failure mode this feature has to avoid.
+func TestAttemptLineRendersStatusDistinctlyFromTheFailureReason(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 7
+
+	failed := attempt(1, 0, 1, "implement", "failed", false)
+	failed.FailureReason = ptr("check_failed")
+	failed.StatusMessage = ptr("3 tests red in internal/store")
+	live := attempt(2, 0, 2, "implement", "running", true)
+	live.StatusMessage = ptr("scaffolding the migration")
+	loadDetail(d, []apiclient.StepRun{failed, live})
+
+	got := d.timelinePanel(30)
+	for _, want := range []string{
+		statusGlyph + " 3 tests red in internal/store",
+		statusGlyph + " scaffolding the migration",
+		"check_failed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timeline is missing %q:\n%s", want, got)
+		}
+	}
+
+	// The styles must actually differ, or "visually distinct" is a comment
+	// rather than a property. Compared on the rendered escape sequences,
+	// since that is what a terminal sees.
+	reason := styleBad.Render("check_failed")
+	status := styleStatus.Render(statusGlyph + " 3 tests red in internal/store")
+	if !strings.Contains(got, reason) {
+		t.Errorf("the failure reason lost its styleBad rendering:\n%q", got)
+	}
+	if !strings.Contains(got, status) {
+		t.Errorf("the status lost its own rendering:\n%q", got)
+	}
+	if styleBad.Render("x") == styleStatus.Render("x") {
+		t.Error("the status and the failure reason render identically")
+	}
+}
+
+// result_summary has been stored, served and read by `.Steps.<id>.Result`
+// since the first release and shown on no screen at all. It renders under an
+// attempt that did not succeed — where a reader is asking "what went wrong"
+// and `failure_reason` answers only which category — and nowhere else.
+func TestTimelineRendersResultSummaryOnFailure(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 7
+
+	failed := attempt(1, 0, 1, "implement", "failed", false)
+	failed.FailureReason = ptr("nonzero_exit")
+	failed.ResultSummary = "FAIL\tgithub.com/lezli01/vincent/internal/store\t0.4s"
+	ok := attempt(2, 0, 2, "implement", "succeeded", false)
+	ok.ResultSummary = "all green, nothing to report"
+	loadDetail(d, []apiclient.StepRun{failed, ok})
+
+	got := d.timelinePanel(30)
+	if !strings.Contains(got, "FAIL\tgithub.com/lezli01/vincent/internal/store\t0.4s") &&
+		!strings.Contains(got, "FAIL github.com/lezli01/vincent/internal/store 0.4s") {
+		t.Errorf("the failed attempt's result summary is missing:\n%s", got)
+	}
+	if strings.Contains(got, "all green, nothing to report") {
+		t.Errorf("a succeeded attempt's summary was rendered; it belongs to the output pane:\n%s", got)
+	}
+}
+
+// A multi-line summary is flattened to one: the timeline gives every attempt
+// a fixed number of rows, and a stack trace pasted into it would push the
+// rest of the run off the pane.
+func TestSummaryLineIsOneLine(t *testing.T) {
+	r := attempt(1, 0, 1, "implement", "failed", false)
+	r.ResultSummary = "panic: boom\n\tgoroutine 1 [running]:\n\tmain.main()"
+	got := summaryLine(r, false)
+	if strings.Contains(got, "\n") {
+		t.Errorf("summaryLine returned %d lines: %q", strings.Count(got, "\n")+1, got)
+	}
+	if !strings.Contains(got, "panic: boom goroutine 1 [running]: main.main()") {
+		t.Errorf("summaryLine = %q, want the flattened summary", got)
+	}
+	if summaryLine(attempt(1, 0, 1, "implement", "succeeded", false), false) != "" {
+		t.Error("a succeeded attempt with no summary rendered a line")
+	}
+}
+
+// The board cell: present when there is something to say, empty when there is
+// not — a column of dashes would read as something missing rather than as the
+// ordinary case — and truncated with an ellipsis to the column's width.
+func TestFormatStatus(t *testing.T) {
+	if got := formatStatus(nil); got != "" {
+		t.Errorf("formatStatus(nil) = %q, want empty", got)
+	}
+	if got := formatStatus(ptr("")); got != "" {
+		t.Errorf("formatStatus(\"\") = %q, want empty", got)
+	}
+	if got := formatStatus(ptr("compiling")); got != "compiling" {
+		t.Errorf("formatStatus = %q", got)
+	}
+	long := strings.Repeat("x", widthStatus+20)
+	got := formatStatus(&long)
+	if len([]rune(got)) > widthStatus {
+		t.Errorf("formatStatus width = %d, want at most %d", len([]rune(got)), widthStatus)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("a truncated status = %q, want an ellipsis", got)
+	}
+}
+
+// The shedding ladder (task 033): the status is the last column admitted and
+// the first shed, so a board narrow enough to drop it renders exactly as it
+// did before the column existed. Asserted over every width rather than at a
+// few, because what matters is that there is no width at which the status
+// displaces a column a reader navigates by.
+func TestStatusColumnIsTheLastAdmitted(t *testing.T) {
+	groupings := []grouping{nil, {groupProject}, {groupProject, groupWorkflow}}
+	sawStatus := false
+	for width := 20; width <= 400; width++ {
+		for _, g := range groupings {
+			set := columnsFor(width, g, false)
+			if !set.status {
+				continue
+			}
+			sawStatus = true
+			if !set.cost || !set.stepName {
+				t.Fatalf("width %d %s: status displaced cost/step name: %+v",
+					width, g.label(), set)
+			}
+			if !g.has(groupWorkflow) && !set.workflow {
+				t.Fatalf("width %d %s: status displaced the workflow: %+v", width, g.label(), set)
+			}
+			if !g.has(groupProject) && !set.project {
+				t.Fatalf("width %d %s: status displaced the project: %+v", width, g.label(), set)
+			}
+		}
+	}
+	if !sawStatus {
+		t.Fatal("no width in 20..400 carries the status column at all")
+	}
+}
+
+// The one recorded decision this column could have overturned: a grouped
+// board drops PROJECT and WORKFLOW because the headers name them, and the
+// width that frees goes to the title (see columnsFor). Admitting the status
+// on exactly that freed width would reverse it — which is what
+// minTitleWithStatus is set high enough to prevent.
+//
+// Checked at the widths a grouped board actually carries the status at.
+// Below them the ladder has always spent freed width on buying back the step
+// name and cost first, which predates this column and is not its business.
+func TestStatusColumnDoesNotEatTheWidthGroupingFrees(t *testing.T) {
+	for _, width := range []int{160, 240, 400} {
+		flat := columnsFor(width, nil, false)
+		grouped := columnsFor(width, grouping{groupProject, groupWorkflow}, false)
+		if grouped.titleWidth(width) <= flat.titleWidth(width) {
+			t.Errorf("width %d: grouped title %d, flat %d — grouping must gain title space",
+				width, grouped.titleWidth(width), flat.titleWidth(width))
+		}
+	}
+}
+
+func withStatus(message string) func(*apiclient.Task) {
+	return func(t *apiclient.Task) { t.StatusMessage = &message }
+}
+
+// The cell reaches the rendered board, and only on a board wide enough to
+// carry the column.
+func TestBoardRendersTheStatusCell(t *testing.T) {
+	b := groupedBoard(task(1, stateRunning, withStatus("compiling internal/store")))
+	if out := b.render(240, 20); !strings.Contains(out, "STATUS") ||
+		!strings.Contains(out, "compiling internal/store") {
+		t.Errorf("a 240-column board rendered no status:\n%s", out)
+	}
+	if out := b.render(120, 20); strings.Contains(out, "compiling internal/store") {
+		t.Errorf("a 120-column board rendered the status it should have shed:\n%s", out)
+	}
+}

--- a/internal/tui/stepstatus_test.go
+++ b/internal/tui/stepstatus_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// The attempt line carries both readings of the status (task 033): the live
+// The attempt line carries both readings of the status (task 036): the live
 // one on a running attempt, and the terminal one on a finished attempt beside
 // — never instead of — the daemon's failure_reason. The two are rendered in
 // different styles, because a stale self-report presented as the daemon's
@@ -116,7 +116,7 @@ func TestFormatStatus(t *testing.T) {
 	}
 }
 
-// The shedding ladder (task 033): the status is the last column admitted and
+// The shedding ladder (task 036): the status is the last column admitted and
 // the first shed, so a board narrow enough to drop it renders exactly as it
 // did before the column existed. Asserted over every width rather than at a
 // few, because what matters is that there is no width at which the status

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -15,11 +15,12 @@
 # follow-up run works on a finished task's own branch before it is archived
 # (scenario 10), and that a step carrying `retry_backoff` paces its retry
 # through the same admission hold — releasing its slot and recovering
-# unattended (scenario 11).
+# unattended (scenario 11), and that a step can report its own status message
+# — visible on the running row and on the finished one (scenario 12).
 # Runs against the committed fakeagent so CI never calls a real
 # API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
 # (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1..11 runs a single scenario for debugging.
+# VINCENT_GATE_SCENARIO=1..12 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -1353,6 +1354,91 @@ YAML
   echo "=== scenario 11 PASS (task $paced retried after a paced wait)"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 12 — a step reports its own status, live and terminal (task 033,
+# §5.4, §13.3). The agent step runs the real `vincent status` command from
+# inside itself, so this also proves §8.5's VINCENT_* block reaches an agent
+# step's environment — without it the command cannot address its own row.
+# ---------------------------------------------------------------------------
+scenario12() {
+  echo "=== scenario 12: a step's own status message, live then terminal"
+  scenario_dirs s12
+
+  export FAKEAGENT_SCENARIO=set-status
+  export FAKEAGENT_VINCENT_BIN
+  FAKEAGENT_VINCENT_BIN="$(hostpath "$VINCENT")"
+  export FAKEAGENT_STATUS="scaffolding the migration"
+  # Past the daemon's 1 s coalescing floor, so the second message is a write
+  # of its own and there is a window to observe the first one live.
+  export FAKEAGENT_STATUS_HOLD_MS=4000
+  export FAKEAGENT_STATUS_FINAL="3 tests red in internal/store"
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-status.yaml" <<'YAML'
+name: m2-status
+description: M2 gate — one agent step that reports on itself.
+defaults:
+  agent: claude
+  max_retries: 0
+steps:
+  - id: narrate
+    type: agent
+    prompt: report your status
+YAML
+
+  daemon_up
+
+  local repo="$TMP/s12/repo" proj task_id
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+  task_id="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-status\",\"title\":\"Narrating task\"}" | jq -r .id)"
+
+  echo "== the running step's status is visible while it runs"
+  local live="" row=""
+  for _ in $(seq 1 60); do
+    row="$(api GET "/tasks/$task_id/steps" | jq '[.[] | select(.step_id == "narrate")][-1] // {}')"
+    if [[ "$(jq -r '.state // ""' <<<"$row")" == "running" ]]; then
+      live="$(jq -r '.status_message // ""' <<<"$row")"
+      [[ -n "$live" ]] && break
+    fi
+    sleep 1
+  done
+  [[ "$live" == "scaffolding the migration" ]] \
+    || fail "running step's status_message is '$live', want the message the step set: $row"
+
+  echo "== the board's list row carries it too, without fetching step rows"
+  local listed
+  listed="$(api GET "/tasks?limit=50" | jq -r "[.[] | select(.id == $task_id)][0].status_message // \"\"")"
+  [[ "$listed" == "scaffolding the migration" ]] \
+    || fail "GET /tasks status_message is '$listed', want the running step's"
+
+  echo "== wait for done; the last value survives on the finished row"
+  wait_for_state "$task_id" done 180
+  local final=""
+  for _ in $(seq 1 15); do
+    row="$(api GET "/tasks/$task_id/steps" | jq '[.[] | select(.step_id == "narrate")][-1]')"
+    final="$(jq -r '.status_message // ""' <<<"$row")"
+    [[ "$final" == "3 tests red in internal/store" ]] && break
+    sleep 1
+  done
+  [[ "$(jq -r .state <<<"$row")" == "succeeded" ]] || fail "narrate step not succeeded: $row"
+  [[ "$final" == "3 tests red in internal/store" ]] \
+    || fail "finished step's status_message is '$final', want the last value the step set: $row"
+  [[ "$(jq -r '.failure_reason // "null"' <<<"$row")" == "null" ]] \
+    || fail "a status is not a failure: $row"
+
+  unset FAKEAGENT_SCENARIO FAKEAGENT_VINCENT_BIN FAKEAGENT_STATUS \
+    FAKEAGENT_STATUS_HOLD_MS FAKEAGENT_STATUS_FINAL
+  "$VINCENT" daemon stop
+  echo "=== scenario 12 PASS (task $task_id narrated itself, live and terminal)"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -1370,8 +1456,9 @@ case "$WHICH" in
   9) scenario9 ;;
   10) scenario10 ;;
   11) scenario11 ;;
+  12) scenario12 ;;
   all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8
-     scenario9; scenario10; scenario11 ;;
+     scenario9; scenario10; scenario11; scenario12 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -1355,7 +1355,7 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 12 — a step reports its own status, live and terminal (task 033,
+# Scenario 12 — a step reports its own status, live and terminal (task 036,
 # §5.4, §13.3). The agent step runs the real `vincent status` command from
 # inside itself, so this also proves §8.5's VINCENT_* block reaches an agent
 # step's environment — without it the command cannot address its own row.

--- a/skills/vincent-workflows/SKILL.md
+++ b/skills/vincent-workflows/SKILL.md
@@ -117,6 +117,28 @@ Place a manual gate immediately before the effect it authorizes. Make the
 instructions name the artifact or change to inspect and the next action that
 approval permits.
 
+## Make long steps report on themselves
+
+A step that runs for many minutes is opaque to whoever is watching the board:
+the row says `running` and nothing else. Any `agent` or `command` step can fix
+that by running `vincent status "<one short line>"` from inside itself. The
+message is shown live and the last value set stays on the finished attempt, so
+it also answers "why did that fail" in words a failure reason cannot reach.
+
+Vincent never asks an agent to do this. Add the instruction yourself, and only
+where it pays for itself:
+
+- A `command` step calls it directly between phases of its script.
+- An `agent` step needs it in the prompt. Ask for a status before each
+  significant phase, under ten words, and specifically for a status naming what
+  is actually wrong when something fails — "3 tests red in internal/store", not
+  "working on it".
+
+Add it to steps that take minutes or that a human is likely to be waiting on,
+not to every step. The message is flattened to one line and truncated to 256
+bytes, two messages within a second coalesce, and it is never a failure reason
+and never readable by an `if:` guard or `.Steps` — it is for humans watching.
+
 Assume task fields, rendered prompts, instructions, command output, and agent
 transcripts are persisted or inspectable. Never put a secret in them. Use
 preconfigured environment credentials, credential stores, or authenticated


### PR DESCRIPTION
## Summary

A step can now say what it is doing, in its own words. `step_runs` gains one
nullable free-text column, `status_message`, with two readings and one field:
while the step runs it is the live answer to "what is this doing", and the last
value written before the attempt ends stays on the finished row as the step's
own account of how it went.

**The producer is the API, not a sentinel line in the step's output.** The issue
proposed a marked line on stdout; that was beaten on three counts and the
alternative was chosen deliberately (task 033 decision 1, recorded in
`docs/tasks/033-step-status-message.md` and in the handler comment):

- a marker forces a strip-or-keep choice over the transcript and
  `result_summary` that has no good answer;
- it cannot see the obvious agent spelling at all — an agent that runs
  `echo '::vincent:status:: …'` through its Bash tool produces an
  `agent.EventToolUse`/`EventToolResult`, never the `EventOutput` that
  `Runner.publishOutput` would be parsing;
- it makes every step's stdout a control channel, so any program that happens
  to print the marker changes daemon state.

So a step calls `POST /v1/tasks/{id}/steps/{step_id}/status`, wrapped in a new
`vincent status "<text>"` that addresses itself from §8.5's `VINCENT_TASK_ID`
and `VINCENT_STEP_ID`. It works identically for `agent` and `command` steps and
reuses the auth, transport and error envelope that already exist. It is keyed by
step id rather than by task because a `parallel` group's sub-steps share one task
id and run concurrently (§7.5).

That decision carried one prerequisite, which is the second user-visible change
here: **agent steps now get the §8.5 `VINCENT_*` block**. `steps.go` passed
`Env: r.childEnv()` to `agent.RunSpec`, so an agent step saw the resolved base
environment and none of the run facts; `commandEnv` added them for command and
check steps only. Agent steps now get the same block under the same precedence
rule — useful on its own, and what makes `vincent status` reachable from an
agent's shell tool. §8.5 is retitled accordingly.

**Bounds, because this is state and not output.** The message is flattened to one
line, control characters and invalid UTF-8 are stripped, and it is truncated on a
rune boundary at 256 bytes — truncated rather than refused, since failing a
status write would turn a display nicety into a step failure. A write whose text
is byte-identical to the stored value appends no event (the rule
`agent.quota_changed` already records), and a 1 s leading-edge floor per step run
coalesces a chatty step to its latest value rather than rejecting it. A write
addressed at a step that is not `running` is a 409, never a silent no-op.

**Durable, so a client that blinks can recover it.** A new
`task.status_changed` event carries `{task_id, step_id, message}` on §13.3's
durable side and replays via `Last-Event-ID`. `scheduler.WakeOn` is false for it:
nothing about admission changes when a step describes itself.

**It is not a failure reason and nothing renders it as one.** `failure_reason`
stays the closed enum shared between `internal/worktree` and
`internal/taskrun/engine.go` (T1.5/T1.6 decision). A step killed on `timeout`
after forty minutes may be carrying a line it wrote thirty-five minutes earlier,
so the status renders in its own style with its own glyph, apart from the
`styleBad` reason on the attempt line. It is also kept out of `.Steps` (§8.4) and
out of the `<previous-attempt-failure>` block (§7.2): free text an agent chose at
run time is not something an `if:` guard should branch on, and `.Steps.<id>.Status`
already means the run *state*.

**Scope is `agent` and `command` steps** — the issue's option 1, deliberately
narrowed. `manual`, `parallel`, `fan_out`, `condition`, `loop` and `break` write
`step_run` rows but run no process, so they have no voice and their status stays
empty; `include` is out by construction (§7.9). "Every step type carries a status"
is knowingly **not** met: synthesising daemon text for the process-less types
(option 3) would put daemon-authored and step-authored strings in one field, which
is the muddle this feature exists to escape, and a workflow-authored `status:`
template (option 2) reintroduces as a second mechanism the design the issue
already rejected as primary.

**No automatic prompt injection.** §8.4's automatic append stays reserved for the
`<previous-attempt-failure>` block — recorded as a decision, since the issue
raised it. The protocol is documented instead (`skills/vincent-workflows/SKILL.md`,
the workflows guide, the CLI page) and a workflow author who wants live status
writes the instruction into their own prompt. Nothing is spent on the workflows
that do not care, at the price of a low hit rate until authors adopt it — which is
why the last item below is part of this PR rather than a follow-up.

**Surfaces.** The status shows on the TUI attempt line, on a new sheddable
`STATUS` board column, in `vincent task show` (and `--json`), and on the API — on
the step-run DTO and denormalized onto each `GET /v1/tasks` row the way `StepName`
and `CostUSD` already are, since the board never fetches step rows. The board
column is shed *first*, before `project` and `workflow`, and has a stricter gate
of its own, so a board narrow enough to drop it renders exactly as it did before
the column existed. `renderBoardState`'s recorded decision to keep a hold's reason
out of the state cell is **not** overturned — the state cell and the title column
are untouched.

**Two adjacent gaps close in the same pass.** §5.4's normative field list gains
both the new field and `result_summary`, which it had never listed. And
`result_summary` is finally rendered: stored, served and read by
`.Steps.<id>.Result` and the repair prompt since the first release, shown on no
screen at all. It now appears as a dim continuation line under any attempt that
did **not** succeed — where "what went wrong" is actually being asked, and not
under every attempt, which would double a healthy timeline's height to restate
what the output pane already shows.

**One test-isolation fix falls out of the §8.5 change.** The `internal/cli` e2e
tests handed the built binary `os.Environ()` plus their two isolated dirs. That
is fine until the suite is itself run from inside a vincent step — which is
exactly what this repository's own `github-resolve-issue` workflow does when it
runs `go run mage.go test` as a step check — because the step's environment now
carries `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, and the child `vincent`
addresses the *outer* task. `TestStatusOutsideAStep` is the one that notices: it
saw a real task id, got past `stepFromEnv`, and failed on the outer daemon's
absence with exit 2 instead of the missing-variable error it asserts. It passed
on a dev machine and in CI and failed only under the daemon. The e2e files now
share one helper that strips `VINCENT_*` from the inherited environment, and the
test pins both variables so the isolation is asserted rather than assumed. No
product code changes; nothing a user can hit, so there is no `CHANGELOG` entry
for it.

### Documentation audit

A separate pass over the derived pages found one page stale beyond the ones this
PR already touched: **`docs/reference/configuration.md`** scoped the `VINCENT_*`
block to command and check steps in both places it mentions it — the
`environment` policy section's layering paragraph and the environment-variables
table — which §8.5's retitling makes false. Both now name agent steps, and the
layering paragraph no longer implies that every step which gets the block also
gets an `env:` layer (an agent step does not; `env:` is a command-step field).
Fixed in its own `docs:` commit.

One stale comment was found and **not** fixed, because that step's commits are
documentation commits: `internal/workflow/template.go:177` still describes
`Env` as "the vincent variables added to the environment of command and check
steps (spec §8.5)". The function now serves agent steps too — `commandEnv`
calls it for all three. One line, worth folding into this PR before it merges.

### Verification

- `go run mage.go test` — green, both from a plain shell and with `VINCENT_TASK_ID`
  / `VINCENT_STEP_ID` set, which is the environment that caught the isolation bug
  above; `go test -race` on every touched package.
- `go tool golangci-lint run ./...` cross-built for the host and run for
  `linux`, `darwin` and `windows` — 0 issues on all three.
- `./scripts/m2-gate.sh` — **M2 GATE PASS**, including the new scenario 12, which
  drives the real `vincent status` from inside an agent step over curl and asserts
  the message live on the running row, on the `GET /tasks` list row, and surviving
  onto the finished row with `failure_reason` still null. Since the agent step
  invokes the real binary, that scenario also proves §8.5's block reaches an agent
  step's environment — without it the command cannot address its own row.
- `docs/assets/tui-*.png` **not** re-captured, and this is deliberate rather than
  skipped. `scripts/screenshots.sh` renders at 132 columns (measured with a VHS
  tape at the script's own `Width`/`FontSize`), and the `STATUS` column is first
  admitted at 196 on a flat board and 164 on a grouped one — so every board
  capture is unchanged by construction. The two
  captures that show a timeline (`tui-board`, `tui-diff`) are of a running task
  and a `done` task, and the summary line renders only under an attempt that did
  not succeed.

## Related

Closes #199.
Implements task [033](../docs/tasks/033-step-status-message.md) (033.1–033.7).

Amends `docs/spec.md` in place with dated notes (2026-08-26), per
`docs/tasks/README.md`: §5.4 (the new field *and* the long-missing
`result_summary`), §6 (the CLI table), §7.2 (the status is never a
`failure_reason` and is deliberately not in the retry block), §8.5 (retitled —
the `VINCENT_*` block now reaches agent steps), §9 (the channel is
adapter-independent: an API call by the step's own process, so no adapter can
lack it and nothing is emulated), §12.1, §13.2 (the route), §13.3 (the durable
event, the dedup rule, the 1 s floor, the 256-byte cap, `WakeOn: false`), §14
(the DDL) and §15 (the shedding ladder and the attempt line, noting that
`renderBoardState`'s recorded reasoning stands). §8.4 is unchanged, and that
non-change is itself recorded because the issue raised it.

No decision in `docs/history/v0-tasks.md` or in an existing task document is
revisited. Two are honoured rather than overturned: T1.5/T1.6's closed
`failure_reason` vocabulary, and `renderBoardState`'s reason for keeping prose
out of the board's state cell.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
