### PR TITLE
Unblock releases and fix a flaky gate assertion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 # Tag-driven packaging (T4.5). Normally Release Please creates the tag and the
-# GitHub release; this workflow then uploads the signed artifacts to that
-# release, attaches native Linux packages, and publishes the stable Homebrew,
-# Scoop, and WinGet metadata. The build runs once on macOS
+# GitHub release; this workflow then uploads the artifacts to that release,
+# attaches native Linux packages, and publishes the stable Homebrew, Scoop, and
+# WinGet metadata. The build runs once on macOS
 # — the binaries are pure Go, so a build matrix would produce identical
 # artifacts three times — and the per-OS jobs afterwards smoke-test what it
 # produced, which is the part a single runner genuinely cannot do.
@@ -14,6 +14,11 @@ name: Release
 # GoReleaser's own `notarize:` block is Pro-only, and signing from Linux with a
 # third-party reimplementation was rejected in favour of Apple's toolchain. The
 # deb/rpm inspection that a macOS runner cannot do moved to `verify-packages`.
+#
+# That signing is **best-effort**: Apple's Developer Program is a ~$99/yr
+# purchase this project has not made (task 039), so every signing step below
+# degrades to a warning when the certificates are absent and the release ships
+# unsigned. The runner stays macOS regardless — it is where the .pkg is built.
 on:
   push:
     tags: ["v*"]
@@ -44,13 +49,25 @@ jobs:
       id-token: write # keyless cosign + build attestations
       attestations: write
     env:
-      # A v* tag must not be able to publish an unsigned macOS artifact; a dry
-      # run and a fork must not need a secret to work. This one variable is
-      # where that split lives — every signing step reads it, and nothing else
-      # decides it.
-      MACOS_SIGN_REQUIRED: ${{ github.event_name == 'push' && '1' || '0' }}
+      # Signing is mandatory exactly where it is possible. With the Developer ID
+      # certificates configured, a v* tag must not publish an unsigned macOS
+      # artifact; without them — a fork, a dry run, or this repository until
+      # 032.7's Apple enrolment happens — every signing step degrades to a
+      # warning and the release still ships, unsigned.
+      #
+      # Keying this on the *tag* instead is what destroyed v0.7.0: the build
+      # died at the first signing step, so that release produced no archives, no
+      # packages and no manager metadata at all. An unsigned release is a worse
+      # release; no release is not a release (task 039).
+      #
+      # This one variable is still where the split lives — every signing step
+      # reads it, and nothing else decides it.
+      MACOS_SIGN_REQUIRED: ${{ secrets.MACOS_CERT_APPLICATION_P12 != '' && '1' || '0' }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
+      # Whether this run's darwin artifacts carry a signature at all, so the
+      # smoke job assesses Gatekeeper only when there is something to assess.
+      macos_signed: ${{ steps.meta.outputs.macos_signed }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -65,7 +82,10 @@ jobs:
 
       - id: meta
         shell: bash
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "macos_signed=$MACOS_SIGN_REQUIRED" >> "$GITHUB_OUTPUT"
 
       # Both identities land in a throwaway keychain created for this job: the
       # runner's login keychain is never touched, and the keychain dies with the
@@ -81,8 +101,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${MACOS_CERT_APPLICATION_P12:-}" ] || [ -z "${MACOS_CERT_INSTALLER_P12:-}" ]; then
+            # MACOS_SIGN_REQUIRED is derived from the Application certificate
+            # alone, so reaching here with it set means the pair is half
+            # configured — a misconfiguration, not the unenrolled path.
             if [ "$MACOS_SIGN_REQUIRED" = "1" ]; then
-              echo "::error::a v* tag needs the Developer ID certificates; see RELEASING.md"
+              echo "::error::MACOS_CERT_APPLICATION_P12 is set but MACOS_CERT_INSTALLER_P12 is not; see RELEASING.md"
               exit 1
             fi
             echo "::warning::no Developer ID certificates configured — this run produces unsigned macOS artifacts"
@@ -143,8 +166,12 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${MACOS_NOTARY_KEY_P8:-}" ] || [ -z "${MACOS_KEYCHAIN:-}" ]; then
+            # A Developer ID signature Apple has not notarized is worse than no
+            # signature: Gatekeeper reports source=Unnotarized Developer ID and
+            # still refuses. Certificates without a notary key is therefore a
+            # hard error, never the unsigned path.
             if [ "$MACOS_SIGN_REQUIRED" = "1" ]; then
-              echo "::error::a v* tag needs the App Store Connect notary key; see RELEASING.md"
+              echo "::error::the Developer ID certificates are configured but MACOS_NOTARY_KEY_P8 is not; see RELEASING.md"
               exit 1
             fi
             echo "::warning::no notary credentials configured — this run produces un-notarized macOS artifacts"
@@ -408,8 +435,13 @@ jobs:
       # would have set is written back by hand: that makes this a strong proxy
       # for the first-launch dialog, not a proof of it. The proof is a human
       # walkthrough — docs/gates/032-macos-notarization.md.
+      #
+      # Skipped entirely on an unsigned release: with no certificates there is
+      # no signature to assess, and `codesign --verify` on an ad-hoc binary
+      # would fail the smoke job over the documented state of the release
+      # (task 039).
       - name: Assess the macOS signature
-        if: runner.os == 'macOS' && github.event_name == 'push'
+        if: runner.os == 'macOS' && github.event_name == 'push' && needs.release.outputs.macos_signed == '1'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ name: Release
 # third-party reimplementation was rejected in favour of Apple's toolchain. The
 # deb/rpm inspection that a macOS runner cannot do moved to `verify-packages`.
 #
-# That signing is **best-effort**: Apple's Developer Program is a ~$99/yr
-# purchase this project has not made (task 039), so every signing step below
-# degrades to a warning when the certificates are absent and the release ships
-# unsigned. The runner stays macOS regardless — it is where the .pkg is built.
+# That signing is **best-effort, and currently inert**: Apple's Developer Program
+# is a ~$99/yr purchase this project declined (task 039, dropping 032.7), so
+# every signing step below degrades to a warning and the release ships unsigned.
+# The steps are kept because installing the six MACOS_* secrets is then the whole
+# of the switch. The runner stays macOS regardless — it is where the .pkg is
+# built.
 on:
   push:
     tags: ["v*"]
@@ -51,8 +53,8 @@ jobs:
     env:
       # Signing is mandatory exactly where it is possible. With the Developer ID
       # certificates configured, a v* tag must not publish an unsigned macOS
-      # artifact; without them — a fork, a dry run, or this repository until
-      # 032.7's Apple enrolment happens — every signing step degrades to a
+      # artifact; without them — a fork, a dry run, or this repository, whose
+      # 032.7 Apple enrolment was dropped — every signing step degrades to a
       # warning and the release still ships, unsigned.
       #
       # Keying this on the *tag* instead is what destroyed v0.7.0: the build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,8 @@ builds:
     # hook is the only point that comes early enough (task 032). A build hook
     # has no per-GOOS filter, so the script takes {{ .Os }} and no-ops for
     # linux and windows. It also no-ops, loudly, when no identity is present
-    # and MACOS_SIGN_REQUIRED is unset — that is the fork/dry-run path.
+    # and MACOS_SIGN_REQUIRED is unset — the fork, dry-run, and (task 039,
+    # until 032.7's Apple enrolment) stable-release path.
     hooks:
       post:
         - cmd: ./scripts/macos-sign.sh "{{ .Path }}" "{{ .Os }}"
@@ -126,13 +127,19 @@ homebrew_casks:
       name: goreleaser
       email: goreleaser@users.noreply.github.com
     commit_msg_template: "chore: vincent {{ .Tag }}"
-    # There is deliberately no `hooks.post.install` here. Until task 032 this
-    # cask ran `xattr -dr com.apple.quarantine`, which existed only because the
-    # X decision descoped notarization: brew installs from the same archive, and
-    # an unsigned quarantined binary will not start. The binaries in that
-    # archive are now Developer ID signed and notarized, so Gatekeeper clears
-    # them on its own. Stripping the attribute after paying for notarization
-    # would go on bypassing exactly the protection that was bought.
+    # brew installs from the same archive GitHub Releases serves, and Homebrew
+    # quarantines what it downloads: an unsigned quarantined binary does not
+    # start. Task 032 deleted this hook because notarization made it a bypass of
+    # protection that had been paid for — but the Apple Developer Program was
+    # never bought (task 039), so the archive is unsigned again and the hook is
+    # load-bearing again. Delete it in the same change that closes 032.7: with a
+    # notarized binary it goes back to bypassing a real check.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/vincent"]
+          end
     # `vincent service install` writes a LaunchAgent (internal/service:
     # LaunchdName). Without this, `brew uninstall` would delete the binary out
     # from under a still-loaded launchd job that holds the SQLite file open.
@@ -221,11 +228,13 @@ winget:
 
 # Keyless cosign: an OIDC identity from the workflow itself, verifiable
 # without vincent publishing or rotating a key. This is the supply-chain
-# signature and it is unchanged by task 032: Apple's Developer ID signature says
-# who built the binary to *macOS*, cosign and the build attestation say which
-# workflow and commit produced the file to *anyone*. Windows Authenticode
-# remains descoped — §19 †'s 2026-08-26 amendment reverses the Apple half only,
-# and the README still documents the SmartScreen prompt a user will meet.
+# signature, and it is the *only* signature a released artifact is guaranteed to
+# carry: OS code signing on both macOS and Windows is a recurring purchase this
+# project has not made (task 039). Apple's Developer ID signature, when the
+# certificates are configured, says who built the binary to *macOS*; cosign and
+# the build attestation say which workflow and commit produced the file to
+# *anyone*, always. The README documents the Gatekeeper and SmartScreen prompts
+# a user meets on an unsigned release.
 signs:
   - cmd: cosign
     certificate: "${artifact}.pem"
@@ -288,22 +297,31 @@ release:
     sha256sum -c checksums.txt --ignore-missing
     ```
 
-    The macOS binaries are Developer ID signed and notarized, so Gatekeeper
-    clears them without a prompt and without clearing any attribute by hand:
+    First launch prompts on macOS and on Windows: these releases carry cosign
+    signatures and build attestations, not OS code signing. Apple's Developer
+    Program and an Authenticode certificate are both recurring purchases this
+    project has not made.
+
+    On macOS, clear the quarantine attribute the browser set, once per download:
 
     ```sh
-    codesign --verify --strict --verbose=2 vincent
-    spctl --assess --type execute -vv vincent
+    xattr -d com.apple.quarantine vincent
     ```
 
-    `vincent_*_darwin_universal.pkg` is the stapled installer — signed,
-    notarized and verifiable with no network — and is covered by its Apple
-    signature and a build attestation rather than by `checksums.txt`:
+    `vincent_*_darwin_universal.pkg` installs the same binary, universal for
+    both architectures, to `/usr/local/bin`. It is unsigned, so open it with
+    right-click → *Open* rather than a double-click, or install it without
+    Finder:
 
     ```sh
-    pkgutil --check-signature vincent_*_darwin_universal.pkg
-    spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+    sudo installer -pkg vincent_*_darwin_universal.pkg -target /
     ```
 
-    Windows still prompts (SmartScreen): these releases are not
-    Authenticode-signed. *More info → Run anyway*, once per binary.
+    The `.pkg` is not in `checksums.txt` — it is built after the checksums are
+    computed — so verify it with its build attestation:
+
+    ```sh
+    gh attestation verify vincent_*_darwin_universal.pkg --repo lezli01/vincent
+    ```
+
+    On Windows, SmartScreen offers *More info → Run anyway*, once per binary.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,7 +39,7 @@ builds:
     # has no per-GOOS filter, so the script takes {{ .Os }} and no-ops for
     # linux and windows. It also no-ops, loudly, when no identity is present
     # and MACOS_SIGN_REQUIRED is unset — the fork, dry-run, and (task 039,
-    # until 032.7's Apple enrolment) stable-release path.
+    # 032.7 having been dropped) stable-release path.
     hooks:
       post:
         - cmd: ./scripts/macos-sign.sh "{{ .Path }}" "{{ .Os }}"
@@ -131,9 +131,10 @@ homebrew_casks:
     # quarantines what it downloads: an unsigned quarantined binary does not
     # start. Task 032 deleted this hook because notarization made it a bypass of
     # protection that had been paid for — but the Apple Developer Program was
-    # never bought (task 039), so the archive is unsigned again and the hook is
-    # load-bearing again. Delete it in the same change that closes 032.7: with a
-    # notarized binary it goes back to bypassing a real check.
+    # never bought and 032.7 is dropped (task 039), so the archive is unsigned
+    # again and the hook is load-bearing again. Delete it in the same change that
+    # ever installs the certificates: with a notarized binary it goes straight
+    # back to bypassing a real check.
     hooks:
       post:
         install: |

--- a/.vincent/workflows/prepare-release.yaml
+++ b/.vincent/workflows/prepare-release.yaml
@@ -1310,8 +1310,11 @@ steps:
       echo "  * read $url one more time, the changelogs especially;"
       echo "  * merge it. That merge is the release: Release Please creates"
       echo "    tag v$version and the GitHub release, and that tag triggers"
-      echo "    the Release workflow, which builds, signs, notarizes,"
-      echo "    attests, uploads and updates Homebrew, Scoop and WinGet."
+      echo "    the Release workflow, which builds, checksums, signs with"
+      echo "    cosign, attests, uploads and updates Homebrew, Scoop and"
+      echo "    WinGet. Apple code signing runs only if the MACOS_* secrets"
+      echo "    exist; without them the macOS artifacts ship unsigned"
+      echo "    (task 039) rather than failing the release."
       echo "  * a published tag is never re-pointed — RELEASING.md § If a"
       echo "    release goes wrong."
       echo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,18 @@ trailing one, and the interior CRs then fail an exact comparison against a
 `$'a\nb'` literal. Single-line captures are unaffected, which is how this hid
 until `m8` compared a list.
 
+**Never pipe into `grep -q`.** Capture first and match a here-string:
+`out="$(git log --format=%s "$b")"; grep -qx thing <<<"$out"`. `grep -q` exits
+at its first match and closes the pipe; the producer then dies of SIGPIPE
+writing whatever came next, and `set -o pipefail` reports 141 — so the
+assertion fails *because it matched*. It is a race, not a certainty: it fires
+only when the producer still had output to write, which made `m7` scenario 4
+fail ~20% of runs on a three-line `git log` whose match was the second line,
+red on CI and green on a rerun. `m2`'s follow-up assertion had carried the
+here-string fix and its explanation since it was written; eight other sites
+across `m2`, `m5`, `m6` and `m7` had not. The same applies to any early-exiting
+consumer — `head`, `read`, a `jq` that `exit`s mid-stream.
+
 Requires bash, go, git, curl, jq.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -243,16 +243,19 @@ then `vincent service install` needs no elevation again.
 brew install lezli01/tap/vincent
 ```
 
-The binary it installs is Developer ID signed and notarized, like every other
-macOS artifact here, so Gatekeeper opens it without a prompt. Upgrades are `brew
-upgrade vincent`; `brew uninstall --zap vincent` also removes the LaunchAgent and
-`~/Library/Application Support/vincent` (config, database, transcripts).
+The cask clears the quarantine attribute on install, so the binary runs
+straight away — the macOS artifacts are not Developer ID signed (see **First
+launch** below). Upgrades are `brew upgrade vincent`; `brew uninstall --zap
+vincent` also removes the LaunchAgent and `~/Library/Application
+Support/vincent` (config, database, transcripts).
 
 Homebrew casks are macOS-only — on Linuxbrew, use the archive below.
 
 Or install `vincent_*_darwin_universal.pkg` from the
 [latest release](https://github.com/lezli01/vincent/releases/latest) — one
-universal, stapled installer for both architectures, which works offline.
+universal installer for both architectures. It is unsigned, so open it with
+right-click → *Open*, or run `sudo installer -pkg vincent_*_darwin_universal.pkg
+-target /`.
 
 ### WinGet or Scoop (Windows)
 
@@ -320,14 +323,16 @@ go install github.com/lezli01/vincent/cmd/vincent@latest
 ```
 
 **First launch.** Releases carry cosign signatures, checksums and GitHub build
-attestations everywhere; macOS artifacts additionally carry Apple code signing,
-Windows ones do not. So:
+attestations everywhere, and no OS code signing on either macOS or Windows: an
+Apple Developer Program membership and an Authenticode certificate are both
+recurring purchases this project does not take on. So:
 
-- **macOS** — nothing to do. The binaries and the `.pkg` are Developer ID
-  signed under the hardened runtime and notarized, so Gatekeeper opens them.
-  Do not run `xattr -d com.apple.quarantine`; it is no longer needed, and it
-  only disables the check that would catch a tampered file. Confirm with
-  `codesign --verify --strict --verbose=2` and `spctl --assess --type execute`.
+- **macOS** shows *"cannot be opened because the developer cannot be verified"*
+  on a downloaded archive. Clear the attribute the browser set, once per
+  download: `xattr -d com.apple.quarantine vincent`. The `.pkg` is unsigned
+  too — open it with right-click → *Open* rather than a double-click, or run
+  `sudo installer -pkg vincent_*_darwin_universal.pkg -target /`. Homebrew
+  needs neither: the cask clears the attribute itself.
 - **Windows** shows a SmartScreen prompt: *More info → Run anyway*. Releases are
   not Authenticode-signed — an OV certificate on a hardware token is a recurring
   purchase this project does not take on.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,18 +4,25 @@ Releases are **Release Please-driven**. Conventional Commits on `master` keep a
 release pull request current. Merging that pull request makes Release Please
 create the `vMAJOR.MINOR.PATCH` tag and GitHub release; that tag triggers
 [`.github/workflows/release.yml`](.github/workflows/release.yml), which uses
-[`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, codesign and notarize
-the macOS binaries, checksum, sign, attest, upload, smoke-test on all three
-OSes, build deb/rpm packages and the macOS installer package, update the stable
-Homebrew and Scoop metadata, and submit the stable WinGet manifest. There
-is no manual tag or upload step, and no artifact is built on a maintainer's
-machine.
+[`.goreleaser.yaml`](.goreleaser.yaml) to cross-compile, checksum, sign, attest,
+upload, smoke-test on all three OSes, build deb/rpm packages and the macOS
+installer package, update the stable Homebrew and Scoop metadata, and submit the
+stable WinGet manifest. There is no manual tag or upload step, and no artifact
+is built on a maintainer's machine.
+
+**Apple code signing is configured but not currently active.** Every step of it
+is wired and runs the moment the six `MACOS_*` secrets exist; they do not,
+because the Apple Developer Program membership they need has not been bought
+(032.7). A tag therefore ships **unsigned** macOS artifacts rather than failing —
+that split is task 039's decision, taken after `v0.7.0` died at the first
+signing step and produced nothing at all. Everything below that describes
+signing describes what happens once the certificates are installed.
 
 The build job runs on **macOS**, not Linux: Apple's signature lives inside the
 Mach-O and has to be applied before the archives and `checksums.txt` exist, and
 `codesign`, `notarytool`, `stapler` and `pkgbuild` ship nowhere else (task 032).
-The deb/rpm and manifest inspection therefore runs in its own `verify-packages`
-job on ubuntu.
+`pkgbuild` alone keeps it there while signing is dormant. The deb/rpm and
+manifest inspection therefore runs in its own `verify-packages` job on ubuntu.
 
 Only a maintainer with push access can cut a release.
 
@@ -56,7 +63,9 @@ does not mean editing the workflow.
 
 Prerequisite: an **Apple Developer Program** membership (~$99/yr). §19 †'s
 2026-08-26 amendment records accepting that cost for macOS and declining the
-Windows equivalent.
+Windows equivalent; its 2026-08-27 amendment records that the membership was
+never actually bought, so releases ship unsigned until these six secrets exist.
+Installing them is the whole of the switch — no workflow edit follows.
 
 1. In Xcode or on the developer portal, create two certificates for the team:
    **Developer ID Application** and **Developer ID Installer**.
@@ -152,7 +161,8 @@ The normal Release Please path creates stable releases. If a maintainer cuts an
 exceptional `vX.Y.Z-rcN` tag, GoReleaser marks it as a prerelease and
 `skip_upload: auto` prevents it from moving the Homebrew, Scoop, or WinGet
 metadata. The prerelease still carries its deb, rpm and macOS `.pkg` assets
-on GitHub, signed and notarized like any other tag.
+on GitHub, signed exactly as much as any other tag — which today is not at
+all.
 
 ## Cutting a release
 
@@ -202,13 +212,14 @@ on GitHub, signed and notarized like any other tag.
    job inspects the deb/rpm payloads and the generated Scoop and WinGet metadata
    from the uploaded `dist` artifact, which is also there for a manual look.
 
-   A dry run run **from this repository** does sign and notarize, which is the
-   point: it proves the certificates and the notary key still work before a tag
-   commits you to them. A dry run run **from a fork**, where every secret
-   resolves to empty, instead warns and produces unsigned macOS binaries and an
-   unsigned `.pkg` — and must still finish green. That is the contributor path
-   and the regression test for the required/skip split; if a dry run ever needs
-   a secret to complete, the split has broken.
+   A dry run run **from this repository** signs and notarizes once the
+   certificates exist, which is the point: it proves they and the notary key
+   still work before a tag commits you to them. Without them — a fork, or this
+   repository today — every signing step warns and produces unsigned macOS
+   binaries and an unsigned `.pkg`, and must still finish green. That is both
+   the contributor path and the current release path, and it is the regression
+   test for the required/skip split; if a run ever needs a secret to complete,
+   the split has broken.
 
 5. **Merge the Release Please PR.** This is the release action. Release Please
    creates the tag and GitHub release; do not create or push the tag by hand.
@@ -216,13 +227,16 @@ on GitHub, signed and notarized like any other tag.
 6. **Watch both workflows.** `gh run watch`, or the Actions tab.
    - `Release Please` creates the tag and GitHub release from the merged release
      PR. The dedicated PAT makes that tag start the next workflow.
-   - `Release` runs on macOS: it codesigns each darwin binary before archiving,
-     runs GoReleaser, preserves Release Please's notes, builds and signs the
-     checksum, notarizes the darwin binaries, builds/signs/notarizes/staples
-     `vincent_*_darwin_universal.pkg` and uploads it, attests every archive,
-     native package and the `.pkg`, uploads the artifacts to the existing GitHub
-     release, and updates Homebrew, Scoop, and the WinGet submission for a
-     stable tag. A prerelease skips all three manager publishers automatically.
+   - `Release` runs on macOS: it codesigns each darwin binary before archiving
+     *if the certificates are installed*, runs GoReleaser, preserves Release
+     Please's notes, builds and signs the checksum, notarizes the darwin
+     binaries, builds `vincent_*_darwin_universal.pkg` — signing, notarizing and
+     stapling it under the same condition — and uploads it, attests every
+     archive, native package and the `.pkg`, uploads the artifacts to the
+     existing GitHub release, and updates Homebrew, Scoop, and the WinGet
+     submission for a stable tag. Without the certificates every signing step
+     logs a `::warning::` and the release ships unsigned. A prerelease skips all
+     three manager publishers automatically.
    - `verify-packages` (ubuntu) inspects the deb and rpm payloads and the
      generated Scoop and WinGet metadata with the native tools.
    - `smoke` (one job per OS) downloads the **real published archive**, unpacks
@@ -252,9 +266,15 @@ on GitHub, signed and notarized like any other tag.
    gh attestation verify vincent_X.Y.Z_amd64.deb --repo lezli01/vincent
    ```
 
-   On a Mac, also check what Gatekeeper will check. The `.pkg` is the only
-   asset outside `checksums.txt`, so it is verified from Apple's signature and
-   its attestation instead:
+   The `.pkg` is the only asset outside `checksums.txt`, so its attestation is
+   the whole of its verification:
+
+   ```sh
+   gh attestation verify vincent_X.Y.Z_darwin_universal.pkg --repo lezli01/vincent
+   ```
+
+   On a Mac, once the Apple certificates are installed, also check what
+   Gatekeeper will check — and expect all four to *fail* while they are not:
 
    ```sh
    tar -xzf vincent_X.Y.Z_darwin_arm64.tar.gz
@@ -264,7 +284,6 @@ on GitHub, signed and notarized like any other tag.
    pkgutil --check-signature vincent_X.Y.Z_darwin_universal.pkg
    spctl --assess --type install -vv vincent_X.Y.Z_darwin_universal.pkg
    xcrun stapler validate vincent_X.Y.Z_darwin_universal.pkg
-   gh attestation verify vincent_X.Y.Z_darwin_universal.pkg --repo lezli01/vincent
    ```
 
 8. **Check the Homebrew cask** (skip for a pre-release, which does not publish
@@ -275,14 +294,15 @@ on GitHub, signed and notarized like any other tag.
    brew info lezli01/tap/vincent               # version must be the tag
    brew reinstall lezli01/tap/vincent
    vincent version
-   spctl --assess --type execute -vv "$(readlink -f "$(brew --prefix)/bin/vincent")"
+   xattr -l "$(readlink -f "$(brew --prefix)/bin/vincent")"   # no com.apple.quarantine
    ```
 
-   The cask no longer carries a quarantine-stripping `postflight` hook — task
-   032 removed it — so what proves the install is Gatekeeper accepting the
-   binary, not the absence of an attribute. `com.apple.quarantine` being present
-   is fine and expected now; `spctl` reporting anything but `accepted` with
-   `source=Notarized Developer ID` is the failure.
+   The cask carries a quarantine-stripping `postflight` hook again (task 039):
+   the binary is unsigned, so without it `brew install` would produce something
+   that will not start. What proves the install is `vincent version` running at
+   all, plus the absence of the attribute. When 032.7 lands the certificates,
+   that hook is deleted and this step becomes `spctl --assess --type execute`
+   reporting `accepted`, `source=Notarized Developer ID`.
 
 9. **Check the Windows and Linux channels** (skip for a pre-release).
 
@@ -340,16 +360,19 @@ on GitHub, signed and notarized like any other tag.
   binary needs both darwin slices, which do not both exist until the build is
   over, so `scripts/macos-pkg.sh` builds it afterwards and `gh release upload`
   attaches it. That is also why it is absent from `checksums.txt` — its
-  integrity comes from Apple's installer signature and a build attestation.
-- **OS code signing is macOS-only, deliberately.** Apple Developer ID signing
-  and notarization are paid for and applied to every darwin artifact, including
-  a stapled universal `.pkg` — §19 †'s 2026-08-26 amendment records reversing
-  the Apple half of the original descope, and task 032 carries the reasoning.
-  **Windows Authenticode stays descoped**: an OV certificate on a hardware token
-  is a recurring purchase with no equivalent to Apple's single notary service,
-  so the README and `docs/platforms/windows.md` continue to document the
-  SmartScreen prompt users will meet. cosign signatures and build provenance are
-  unchanged on every platform and are not a substitute for either.
+  integrity comes from a build attestation, plus Apple's installer signature
+  when there is one.
+- **OS code signing is wired for macOS and dormant.** The Apple Developer ID
+  path is fully implemented — §19 †'s 2026-08-26 amendment records reversing the
+  Apple half of the original descope, and task 032 carries the reasoning — but
+  the membership was never bought, so §19's 2026-08-27 amendment (task 039)
+  makes a missing certificate produce an *unsigned release* rather than a failed
+  one. **Windows Authenticode stays descoped**: an OV certificate on a hardware
+  token is a recurring purchase with no equivalent to Apple's single notary
+  service, so the README and `docs/platforms/windows.md` continue to document
+  the SmartScreen prompt users will meet. cosign signatures and build provenance
+  are unchanged on every platform, always present, and are not a substitute for
+  either.
 - **External catalogs remain external.** Scoop updates a repository the
   maintainer controls. WinGet is a pull request into Microsoft's catalog and
   can remain pending after the GitHub release succeeds. The accepted

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,13 +10,15 @@ installer package, update the stable Homebrew and Scoop metadata, and submit the
 stable WinGet manifest. There is no manual tag or upload step, and no artifact
 is built on a maintainer's machine.
 
-**Apple code signing is configured but not currently active.** Every step of it
-is wired and runs the moment the six `MACOS_*` secrets exist; they do not,
-because the Apple Developer Program membership they need has not been bought
-(032.7). A tag therefore ships **unsigned** macOS artifacts rather than failing —
-that split is task 039's decision, taken after `v0.7.0` died at the first
-signing step and produced nothing at all. Everything below that describes
-signing describes what happens once the certificates are installed.
+**Apple code signing is configured and not used.** Every step of it is wired and
+runs the moment the six `MACOS_*` secrets exist. They do not: the Apple Developer
+Program membership they need was never bought, and **032.7, the enrolment, was
+dropped on 2026-08-27** (task 039). A tag therefore ships **unsigned** macOS
+artifacts rather than failing — a split taken after `v0.7.0` died at the first
+signing step and produced nothing at all. The machinery below is kept because
+installing those six secrets is then the entire cost of reversing that decision;
+everything in this document that describes signing describes what would happen
+once they are installed, not what happens today.
 
 The build job runs on **macOS**, not Linux: Apple's signature lives inside the
 Mach-O and has to be applied before the archives and `checksums.txt` exist, and
@@ -61,11 +63,13 @@ does not mean editing the workflow.
 
 ### Bootstrapping the Apple credentials
 
-Prerequisite: an **Apple Developer Program** membership (~$99/yr). §19 †'s
-2026-08-26 amendment records accepting that cost for macOS and declining the
-Windows equivalent; its 2026-08-27 amendment records that the membership was
-never actually bought, so releases ship unsigned until these six secrets exist.
-Installing them is the whole of the switch — no workflow edit follows.
+**This section is dormant.** §19 †'s 2026-08-26 amendment records accepting the
+~$99/yr **Apple Developer Program** cost for macOS; its two 2026-08-27
+amendments record that the membership was never bought and that the enrolment is
+dropped. It is kept, complete, because installing these six secrets is the whole
+of the switch — no workflow edit follows, and nothing else has to be rediscovered
+if the decision is ever revisited. Prerequisite for all of it: that
+membership.
 
 1. In Xcode or on the developer portal, create two certificates for the team:
    **Developer ID Application** and **Developer ID Installer**.
@@ -300,9 +304,10 @@ all.
    The cask carries a quarantine-stripping `postflight` hook again (task 039):
    the binary is unsigned, so without it `brew install` would produce something
    that will not start. What proves the install is `vincent version` running at
-   all, plus the absence of the attribute. When 032.7 lands the certificates,
-   that hook is deleted and this step becomes `spctl --assess --type execute`
-   reporting `accepted`, `source=Notarized Developer ID`.
+   all, plus the absence of the attribute. If the certificates are ever
+   installed, that hook is deleted in the same change and this step becomes
+   `spctl --assess --type execute` reporting `accepted`, `source=Notarized
+   Developer ID`.
 
 9. **Check the Windows and Linux channels** (skip for a pre-release).
 
@@ -362,17 +367,19 @@ all.
   attaches it. That is also why it is absent from `checksums.txt` — its
   integrity comes from a build attestation, plus Apple's installer signature
   when there is one.
-- **OS code signing is wired for macOS and dormant.** The Apple Developer ID
-  path is fully implemented — §19 †'s 2026-08-26 amendment records reversing the
-  Apple half of the original descope, and task 032 carries the reasoning — but
-  the membership was never bought, so §19's 2026-08-27 amendment (task 039)
-  makes a missing certificate produce an *unsigned release* rather than a failed
-  one. **Windows Authenticode stays descoped**: an OV certificate on a hardware
-  token is a recurring purchase with no equivalent to Apple's single notary
-  service, so the README and `docs/platforms/windows.md` continue to document
-  the SmartScreen prompt users will meet. cosign signatures and build provenance
-  are unchanged on every platform, always present, and are not a substitute for
-  either.
+- **OS code signing is descoped on both desktop platforms, and the macOS path is
+  built but dormant.** The Apple Developer ID implementation is complete — task
+  032 carries its reasoning, and §19 †'s 2026-08-26 amendment records accepting
+  the cost — but the membership was never bought; §19's two 2026-08-27
+  amendments (task 039) make a missing certificate produce an *unsigned release*
+  rather than a failed one, and drop the enrolment. **Windows Authenticode stays
+  descoped** for its own reasons: an OV certificate on a hardware token is a
+  recurring purchase with no equivalent to Apple's single notary service, and
+  task 038 is surveying the free-for-OSS routes. So both platforms prompt on
+  first launch, and the README, `docs/platforms/macos.md` and
+  `docs/platforms/windows.md` document what a user does about it. cosign
+  signatures and build provenance are unchanged on every platform, always
+  present, and are not a substitute for either.
 - **External catalogs remain external.** Scoop updates a repository the
   maintainer controls. WinGet is a pull request into Microsoft's catalog and
   can remain pending after the GitHub release succeeds. The accepted

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@ that is *not* true are stated rather than smoothed over.
 | Page | What it covers |
 |---|---|
 | [Windows](platforms/windows.md) | SmartScreen, `%APPDATA%`/`%LOCALAPPDATA%`, PowerShell command steps, the Scheduled Task, the one restricted-mode gap |
-| [macOS](platforms/macos.md) | Gatekeeper, the Developer ID signature and the stapled `.pkg`, `~/Library/Application Support`, the LaunchAgent, `PATH` capture |
+| [macOS](platforms/macos.md) | Gatekeeper, the quarantine attribute, the universal `.pkg`, `~/Library/Application Support`, the LaunchAgent, `PATH` capture |
 | [Linux](platforms/linux.md) | XDG directories, the systemd user unit, `loginctl enable-linger` |
 
 ## Reference

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,7 +18,7 @@ state stay on your machine; vincent provides the control plane around them.
 | GitHub | Create a task from an issue, prefilled and editable; issue details in templates; read-only, no stored credential |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
 | Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks, backup and restore |
-| Platforms | Windows, macOS, and Linux; Homebrew, a signed and notarized macOS `.pkg`, WinGet, Scoop, mise, deb/rpm, and archives |
+| Platforms | Windows, macOS, and Linux; Homebrew, a universal macOS `.pkg`, WinGet, Scoop, mise, deb/rpm, and archives |
 
 ## Orchestrate work instead of terminals
 
@@ -267,10 +267,11 @@ as archives plus platform-friendly packages:
 - mise or release archives on all platforms
 
 Release archives are checksummed, the checksum manifest is signed with cosign,
-and builds carry GitHub attestations. Every macOS artifact is additionally
-signed with an Apple Developer ID identity under the hardened runtime and
-notarized, and the `.pkg` is stapled, so Gatekeeper opens a downloaded release
-without a prompt and without a quarantine attribute to strip. Platform-specific
+and builds carry GitHub attestations. There is no OS code signing on either
+macOS or Windows — both are recurring certificate purchases this project has not
+made — so a downloaded release meets Gatekeeper or SmartScreen once, and
+[Installation](getting-started/installation.md) documents the one command that
+clears it. Platform-specific
 installation, service, shell, and restricted-mode differences are documented in
 [Installation](getting-started/installation.md) and the
 [platform guides](README.md#platforms).

--- a/docs/gates/032-macos-notarization.md
+++ b/docs/gates/032-macos-notarization.md
@@ -1,13 +1,14 @@
 # Task 032 gate — macOS signing and notarization
 
-> **Not walkable as of 2026-08-27.** No release is signed: the Apple Developer
-> Program membership 032.7 needs was never bought, and
-> [task 039](../tasks/039-unsigned-releases-by-default.md) makes a missing
-> certificate produce an unsigned release rather than a failed one. Every check
-> below will fail on a current artifact, correctly. This walkthrough describes
-> the release that exists once the six `MACOS_*` secrets are installed; until
-> then the documented macOS path is `xattr -d com.apple.quarantine`, and the
-> Homebrew cask strips the attribute itself again.
+> **Not walkable, and no longer waiting to be.** 032.7 — the Apple Developer
+> Program enrolment — was **dropped** on 2026-08-27; no release is signed, and
+> none is expected to be. Every check below will fail on a current artifact,
+> correctly. This walkthrough is retained as the acceptance procedure for the
+> day someone installs the six `MACOS_*` secrets, which is the whole of what
+> reviving macOS signing takes. Until then the documented macOS path is
+> `xattr -d com.apple.quarantine` once per download, and the Homebrew cask
+> strips the attribute itself again. Reasoning in
+> [task 039](../tasks/039-unsigned-releases-by-default.md).
 
 **Acceptance (task 032.7):** a real user downloading a real release on a real
 Mac sees **no** Gatekeeper dialog, and the `.pkg` installs with the network off.
@@ -135,4 +136,4 @@ something unintended happened, not an improvement.
 
 | Date | Version | macOS | Walked by | Result |
 |---|---|---|---|---|
-| — | — | — | — | not yet walked; blocked on 032.7 (Apple Developer Program enrolment and the six repository secrets). Releases ship unsigned in the meantime — see task 039. |
+| — | — | — | — | never walked. 032.7 dropped 2026-08-27; releases ship unsigned — see task 039. Retained as the procedure if the six `MACOS_*` secrets are ever installed. |

--- a/docs/gates/032-macos-notarization.md
+++ b/docs/gates/032-macos-notarization.md
@@ -1,5 +1,14 @@
 # Task 032 gate — macOS signing and notarization
 
+> **Not walkable as of 2026-08-27.** No release is signed: the Apple Developer
+> Program membership 032.7 needs was never bought, and
+> [task 039](../tasks/039-unsigned-releases-by-default.md) makes a missing
+> certificate produce an unsigned release rather than a failed one. Every check
+> below will fail on a current artifact, correctly. This walkthrough describes
+> the release that exists once the six `MACOS_*` secrets are installed; until
+> then the documented macOS path is `xattr -d com.apple.quarantine`, and the
+> Homebrew cask strips the attribute itself again.
+
 **Acceptance (task 032.7):** a real user downloading a real release on a real
 Mac sees **no** Gatekeeper dialog, and the `.pkg` installs with the network off.
 
@@ -92,6 +101,9 @@ validate` succeeding offline is the whole claim.
 
 ## 3. The cask, with its quarantine hook gone
 
+**Task 039 put that hook back** for as long as releases are unsigned, so this
+leg is walked only after the certificates land and the hook is deleted again.
+
 Task 032 removed `hooks.post.install`'s `xattr -dr com.apple.quarantine` from
 the cask. That hook was load-bearing before notarization, so this leg exists to
 prove it no longer is.
@@ -123,4 +135,4 @@ something unintended happened, not an improvement.
 
 | Date | Version | macOS | Walked by | Result |
 |---|---|---|---|---|
-| — | — | — | — | not yet walked; blocked on 032.7 (Apple Developer Program enrolment and the six repository secrets) |
+| — | — | — | — | not yet walked; blocked on 032.7 (Apple Developer Program enrolment and the six repository secrets). Releases ship unsigned in the meantime — see task 039. |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -41,9 +41,10 @@ Go is *not* required to run vincent — only to
 brew install lezli01/tap/vincent
 ```
 
-This is the shortest path on macOS. The binary it installs is Developer ID
-signed and notarized like every other macOS artifact, so nothing has to clear a
-quarantine attribute — the cask used to, and deliberately no longer does.
+This is the shortest path on macOS, and the only one with nothing to clear by
+hand: the macOS artifacts are not Apple code signed (see [First
+launch](#first-launch)), so the cask strips the quarantine attribute as part of
+the install.
 
 Homebrew casks are macOS-only. On Linuxbrew, use the archive below.
 
@@ -62,27 +63,26 @@ but leaves `~/Library/Application Support/vincent` intact.
 Stable releases attach `vincent_{version}_darwin_universal.pkg`: one universal
 installer covering Apple silicon and Intel, which puts the binary at
 `/usr/local/bin/vincent`. Download it from the
-[latest release](https://github.com/lezli01/vincent/releases/latest) and
-double-click it, or:
+[latest release](https://github.com/lezli01/vincent/releases/latest), then:
 
 ```sh
 sudo installer -pkg vincent_*_darwin_universal.pkg -target /
 vincent version
 ```
 
-The package is signed with an Apple Developer ID Installer identity, notarized,
-and **stapled** — its notarization ticket travels inside the file, so it
-installs on a machine with no network. That is the one thing it does that the
-archive cannot; everything else here is equivalent. Verify it before installing:
+The package is **not signed** with an Apple Developer ID Installer identity, so
+a double-click in Finder is refused. The terminal command above does not consult
+Gatekeeper and works as-is; from the Finder, use **right-click → *Open***, then
+*Open* in the dialog.
 
-```sh
-pkgutil --check-signature vincent_*_darwin_universal.pkg
-spctl --assess --type install -vv vincent_*_darwin_universal.pkg
-```
+What the `.pkg` buys over the archive is one file covering both architectures
+and a fixed install path, not a Gatekeeper-clean install — that would need the
+Apple Developer Program membership described under [First
+launch](#first-launch).
 
 The `.pkg` is deliberately absent from `checksums.txt` — it is built after the
-checksummed artifacts, from both of them — and carries Apple's installer
-signature plus a [build attestation](#verify-a-download) instead.
+checksummed artifacts, from both of them — and carries a [build
+attestation](#verify-a-download) instead.
 
 To remove it, delete `/usr/local/bin/vincent` (after `vincent service
 uninstall`, if you registered the background service) and, if you also want the
@@ -220,25 +220,29 @@ Platform-specific detail lives in [Windows](../platforms/windows.md),
 ## First launch
 
 Every release carries cosign signatures, SHA-256 checksums and GitHub build
-attestations. On top of those, macOS artifacts carry **Apple code signing**;
-Windows ones do not.
+attestations. None carries **OS code signing** — neither Apple's nor
+Authenticode — because both are recurring certificate purchases this project has
+not made. So each desktop OS asks once:
 
-- **macOS** — nothing to do. The binaries and the `.pkg` are signed with an
-  Apple Developer ID identity under the hardened runtime and notarized, so
-  Gatekeeper clears them without a prompt. Do not run `xattr -d
-  com.apple.quarantine`: it is no longer needed, and it only turns off the check
-  that would tell you the file had been tampered with. Confirm the signature
-  yourself with:
+- **macOS** — Gatekeeper refuses a downloaded binary: *"vincent cannot be opened
+  because the developer cannot be verified."* Clear the quarantine attribute the
+  browser set, once per download:
 
   ```sh
-  codesign --verify --strict --verbose=2 /usr/local/bin/vincent
-  spctl --assess --type execute -vv /usr/local/bin/vincent
+  xattr -d com.apple.quarantine /usr/local/bin/vincent
+  vincent version
   ```
 
-  Only the [`.pkg`](#installer-package-macos) is *stapled*, so it is the one
-  artifact whose first launch also works with no network — a bare binary has
-  nowhere to hold a notarization ticket, and Gatekeeper fetches its verdict from
-  Apple instead.
+  Do that on a download you have [verified](#verify-a-download): stripping
+  quarantine also turns off the check that would flag a tampered file.
+  [Homebrew](#homebrew-macos) does it for you. The
+  [`.pkg`](#installer-package-macos) is unsigned as well — open it with
+  right-click → *Open*, or install it with `sudo installer`, which does not
+  consult Gatekeeper.
+
+  Apple's Developer Program is ~$99/yr, and its fee waiver reaches only
+  nonprofit, educational and government *organizations*, which a
+  single-maintainer project cannot be.
 
 - **Windows** — SmartScreen shows *"Windows protected your PC"*. Choose
   **More info → Run anyway**. It appears once per binary. Releases are not
@@ -275,22 +279,20 @@ attestation. For example:
 gh attestation verify vincent_*_linux_amd64.tar.gz --repo lezli01/vincent
 ```
 
-The macOS `.pkg` is the one asset outside `checksums.txt`, so it is verified
-from its own two signatures — Apple's, and the attestation:
+The macOS `.pkg` is the one asset outside `checksums.txt`, so its attestation is
+the whole of its verification:
 
 ```sh
-pkgutil --check-signature vincent_*_darwin_universal.pkg
 gh attestation verify vincent_*_darwin_universal.pkg --repo lezli01/vincent
 ```
 
-The three signatures answer different questions, which is why all three exist.
-**cosign** says which GitHub Actions workflow, at which commit, produced the
-file — to anyone, with no vincent key to trust or rotate. The **build
+The two signatures answer the same question in two formats, which is why both
+exist. **cosign** says which GitHub Actions workflow, at which commit, produced
+the file — to anyone, with no vincent key to trust or rotate. The **build
 attestation** says the same thing in the format `gh` and `mise` check
-automatically. **Apple's Developer ID signature plus notarization** says to
-*macOS itself* that a known developer built this and Apple scanned it, which is
-what makes Gatekeeper open it. None of them substitutes for another, and no
-Windows equivalent of the third exists here.
+automatically, and it is the only one that covers the `.pkg`. Neither is an OS
+code signature: they tell *you* where the file came from, and tell Gatekeeper
+and SmartScreen nothing, which is why those still prompt.
 
 ## Install an agent CLI
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -17,9 +17,14 @@ Apple silicon and Intel are both released and both exercised in CI.
 brew install lezli01/tap/vincent
 ```
 
-Or double-click `vincent_*_darwin_universal.pkg` from the release page — one
+Or install `vincent_*_darwin_universal.pkg` from the release page — one
 universal installer for both architectures, putting the binary at
-`/usr/local/bin/vincent`.
+`/usr/local/bin/vincent`. It is unsigned, so open it with **right-click →
+*Open*** rather than a double-click, which a double-click will not offer:
+
+```sh
+sudo installer -pkg vincent_*_darwin_universal.pkg -target /   # or from the terminal
+```
 
 Or unpack the release archive by hand:
 
@@ -35,35 +40,43 @@ detail, including signature verification:
 
 ## Gatekeeper
 
-**There is nothing to do.** Every macOS artifact — the binaries inside both
-archives, and the `.pkg` — is signed with an Apple Developer ID identity under
-the hardened runtime, and notarized by Apple. Gatekeeper clears a downloaded
-release on its own, so there is no *"cannot be opened because it is from an
-unidentified developer"* dialog and no quarantine attribute to strip.
+**The macOS artifacts are not Apple code signed.** Developer ID signing and
+notarization require an Apple Developer Program membership — a ~$99/yr recurring
+purchase this project has not made — so a downloaded binary is quarantined by
+the browser and Gatekeeper refuses it: *"vincent cannot be opened because the
+developer cannot be verified."*
 
-If you have older instructions that say to run `xattr -d com.apple.quarantine`,
-delete them. Stripping the attribute now only turns off the check that would
-have told you the file had been tampered with.
-
-Check for yourself, on the binary you are about to run:
+Clear the attribute the browser set, once per download:
 
 ```sh
-codesign --verify --strict --verbose=2 /usr/local/bin/vincent
-spctl --assess --type execute -vv /usr/local/bin/vincent
+xattr -d com.apple.quarantine /usr/local/bin/vincent
+vincent version
 ```
 
-`spctl` should report `accepted` with `source=Notarized Developer ID`. That
-check reaches Apple over the network: the ticket for a bare binary is served by
-Apple rather than carried inside it, because a Mach-O has nowhere to staple one.
+`brew install` needs none of this — the cask strips the attribute itself as part
+of the install.
 
-The **`.pkg` is stapled**, which is the one thing it does that the archive
-cannot: its ticket travels inside the file, so a first launch works on a machine
-that is offline or behind a filtered network. Verify it before installing with:
+For the `.pkg`, the equivalent is opening it from the Finder's context menu
+(**right-click → *Open*** → *Open* in the dialog), or installing it from the
+terminal with `sudo installer -pkg … -target /`, which does not consult
+Gatekeeper at all.
+
+Stripping quarantine turns off the check that would otherwise flag a tampered
+file, so do it on a download you have verified. Both the archives and the `.pkg`
+carry proof of where they came from that does not depend on Apple:
 
 ```sh
-pkgutil --check-signature vincent_*_darwin_universal.pkg
-spctl --assess --type install -vv vincent_*_darwin_universal.pkg
+cosign verify-blob checksums.txt \
+  --certificate checksums.txt.pem --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/lezli01/vincent/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+shasum -a 256 -c checksums.txt --ignore-missing
+gh attestation verify vincent_*_darwin_universal.pkg --repo lezli01/vincent
 ```
+
+The full verification story, including why the `.pkg` is outside
+`checksums.txt`, is in
+[Installation](../getting-started/installation.md#verify-a-download).
 
 `com.apple.provenance` is unrelated — macOS adds it to everything and it does
 not block execution.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4770,6 +4770,27 @@ fee waiver reaches nonprofit, educational and government *organizations* only,
 which task 038 already recorded as unavailable here. Reasoning in
 `docs/tasks/039-unsigned-releases-by-default.md`.
 
+**Amended 2026-08-27 (later the same day) — macOS OS code signing is descoped
+again; the machinery is retained.** The amendment immediately above deliberately
+left the enrolment open. It is now closed: the ~$99/yr Apple Developer Program
+membership is **not being bought**, 032.7 is dropped, and the 2026-08-26
+amendment's reversal of the Apple half of † is itself reversed. **Neither
+desktop platform carries an OS code signature**, which returns §19 to the shape
+the X decision gave it — macOS Gatekeeper and Windows SmartScreen both prompt on
+first launch, and the documented macOS path is `xattr -d com.apple.quarantine`
+once per download, with the Homebrew cask stripping the attribute itself. What
+does **not** revert: the `.pkg`, which stands on being one universal binary at a
+fixed install path rather than on a stapled ticket; cosign over `checksums.txt`
+and the GitHub build attestations, which were never conditional; and the signing
+implementation itself, which is complete, verified and kept dormant so that
+installing six repository secrets is the entire cost of reversing this — the
+decision was made on price, and is meant to stay cheap to unmake.
+`docs/tasks/032-macos-notarization.md` is retained as that design and is no
+longer a description of what ships. Windows is untouched here: task 038's
+free-for-OSS Authenticode survey continues, and a free route accepted there would
+sign Windows while macOS stays unsigned. Reasoning in
+`docs/tasks/039-unsigned-releases-by-default.md`.
+
 **M4's acceptance is met, 2026-08-11.** The T4.6 walkthrough ran on a clean VM
 per OS with no Go toolchain, against the `v0.1.0-rc1` artifacts: **5:00** on
 Windows 11, **4:30** on macOS, **3:35** on Linux — every run under half the

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4743,6 +4743,33 @@ by this amendment and remains descoped**: the free-for-OSS signing route is bein
 surveyed under task 038, and §19 will not describe a Windows signature before one
 exists.
 
+**Amended 2026-08-27 — the macOS signature is conditional, and today absent.**
+The 2026-08-26 amendment above says the ~$99/yr Apple Developer Program cost
+"is now paid". **It was not**, and the pipeline it describes was written as
+though it had been: `MACOS_SIGN_REQUIRED` was keyed on the *tag*, so a `v*` tag
+without the certificates was a hard error. `v0.7.0` proved what that costs —
+the tag build died at its first signing step and produced no archives, no deb or
+rpm, no attestations and no Homebrew, Scoop or WinGet metadata, and the release
+was unwound. Signing is therefore keyed on the *certificates* instead: with them
+configured a tag must not publish an unsigned macOS artifact, and without them
+every signing step warns and the release ships **unsigned**. An unsigned release
+is worse than a signed one; no release is not a release. The macOS install path
+consequently meets Gatekeeper again — the direct-download path documents `xattr
+-d com.apple.quarantine` once per download, the `.pkg` is installed with
+right-click → *Open* or `sudo installer`, and the Homebrew cask's
+quarantine-stripping `postflight` hook is **restored**, because brew installs the
+same unsigned archive and would otherwise deliver a binary that will not start.
+The rest of the 2026-08-26 amendment stands unchanged and is not relitigated:
+every mechanism it describes is implemented and dormant, and installing the six
+`MACOS_*` secrets is the whole of the switch — the `.pkg` is still built, still
+universal, still outside `checksums.txt`, still covered by a build attestation,
+and the release job still runs on `macos-latest`, now for `pkgbuild` alone. The
+enrolment blocker stays 032.7's; **this amendment is not a decision to abandon
+signing**, only to stop a missing certificate from destroying a release. Apple's
+fee waiver reaches nonprofit, educational and government *organizations* only,
+which task 038 already recorded as unavailable here. Reasoning in
+`docs/tasks/039-unsigned-releases-by-default.md`.
+
 **M4's acceptance is met, 2026-08-11.** The T4.6 walkthrough ran on a clean VM
 per OS with no Go toolchain, against the `v0.1.0-rc1` artifacts: **5:00** on
 Windows 11, **4:30** on macOS, **3:35** on Linux — every run under half the

--- a/docs/tasks/002-homebrew-tap.md
+++ b/docs/tasks/002-homebrew-tap.md
@@ -31,8 +31,9 @@ it beat.
   **Reinstated 2026-08-27 by [task 039](039-unsigned-releases-by-default.md).**
   The Apple Developer Program membership task 032 assumed was never bought, so
   the archive is unsigned again and the `postflight` hook is back in the cask,
-  for exactly the reason recorded below. The 032 supersession that follows
-  applies again once 032.7 closes.
+  for exactly the reason recorded below. 032.7 was dropped the same day, so this
+  is the state for the foreseeable future; the 032 supersession that follows
+  applies again only if the Developer ID certificates are ever installed.
 
   **Partly superseded 2026-08-26 by [task 032](032-macos-notarization.md).** The
   tap itself stands; what no longer holds is the *reason* recorded above. Apple

--- a/docs/tasks/002-homebrew-tap.md
+++ b/docs/tasks/002-homebrew-tap.md
@@ -28,6 +28,12 @@ it beat.
   "download, unzip, clear the quarantine attribute, run", and that is the step
   worth deleting.
 
+  **Reinstated 2026-08-27 by [task 039](039-unsigned-releases-by-default.md).**
+  The Apple Developer Program membership task 032 assumed was never bought, so
+  the archive is unsigned again and the `postflight` hook is back in the cask,
+  for exactly the reason recorded below. The 032 supersession that follows
+  applies again once 032.7 closes.
+
   **Partly superseded 2026-08-26 by [task 032](032-macos-notarization.md).** The
   tap itself stands; what no longer holds is the *reason* recorded above. Apple
   notarization is no longer descoped, so the archive path does not make anyone

--- a/docs/tasks/032-macos-notarization.md
+++ b/docs/tasks/032-macos-notarization.md
@@ -1,6 +1,18 @@
 # 032 — macOS Developer ID signing and notarization
 
-**Status:** ⚠ verification blocked (5/7) · **Opened:** 2026-08-26
+**Status:** ✅ built, never activated (6/6, 032.7 dropped) · **Opened:**
+2026-08-26 · **Closed:** 2026-08-27
+
+> **2026-08-27 — the signature this task describes has never existed, and now
+> will not.** Every mechanism below was built and works; the Apple Developer
+> Program membership it needs was never bought, and 032.7 — the enrolment — is
+> **dropped**, with the reasoning in
+> [task 039](039-unsigned-releases-by-default.md). Releases ship unsigned; the
+> cask's quarantine hook is back; §19's 2026-08-26 amendment is superseded by its
+> two 2026-08-27 successors. **This document is retained as the design, not as a
+> description of what ships.** Read every sentence below in the future tense: it
+> is what happens if the six `MACOS_*` secrets are ever installed, which is the
+> whole of the switch.
 
 macOS artifacts are signed with an Apple Developer ID identity, notarized, and —
 for a new universal `.pkg` — stapled, so a downloaded release clears Gatekeeper
@@ -117,26 +129,28 @@ configuration and user documentation.
   README, `docs/README.md`'s macOS row, and `RELEASING.md`'s secrets, keychain
   bootstrap and certificate rotation/revocation guidance. Windows wording
   untouched throughout. ✓ 2026-08-26
-- [!] **032.6 — Run repository verification and review the final diff.** —
-  `goreleaser`, `actionlint` and `shellcheck` are all absent from this
-  environment and cannot be installed here, so the two new shell scripts and the
-  rewritten workflow have not been linted locally. `packaging-config` in
-  `ci.yml` runs `goreleaser check` on every PR, which covers the config schema;
-  the workflow's own syntax is proven by it running. Done when those three have
-  actually run, plus the repository's required code checks.
-- [!] **032.7 — Enrol with Apple and prove a signed release.** — *2026-08-27:
-  still open, and [task 039](039-unsigned-releases-by-default.md) has removed its
-  ability to break a release. Until it closes, every macOS artifact ships
-  unsigned, the cask's quarantine hook is back, and §19's 2026-08-26 amendment is
-  read through its 2026-08-27 successor. Closing this task means deleting that
-  hook in the same change.* — requires the
-  owner's Apple Developer Program enrolment, the two Developer ID identities,
-  an App Store Connect API key, and the six repository secrets; all are
-  owner-only account mutations. Done when a **stable tag** produces artifacts
-  that a human verifies through [the gate](../gates/032-macos-notarization.md).
-  **A green dry run does not close this** — a dry run with no secrets is
-  designed to produce unsigned artifacts, so it cannot evidence a working
-  signature.
+- [x] **032.6 — Run repository verification and review the final diff.** All
+  three tools were absent from the environment 032 was written in; they are
+  present now and have run against the task 039 diff, which touches every file
+  032 added. `goreleaser check` validates, `actionlint` reports nothing in
+  `release.yml` (its two findings are pre-existing and deliberate — `ci.yml`'s
+  `./bin/vincent*` glob and a `go-toolchain.yml` SC2016), `shellcheck` is clean
+  on both `scripts/macos-sign.sh` and `scripts/macos-pkg.sh`, and `go run mage.go
+  test` and `lint` are green. ✓ 2026-08-27
+- ~~**032.7 — Enrol with Apple and prove a signed release.**~~ **Dropped
+  2026-08-27** by the owner: the ~$99/yr Apple Developer Program membership is
+  not being bought, so the enrolment this task waited on will not happen and
+  there is nothing left to unblock. Reasoning in
+  [task 039](039-unsigned-releases-by-default.md)'s 2026-08-27 decisions; the
+  pipeline it would have activated is retained and dormant, and installing the
+  six `MACOS_*` secrets is still the whole of the switch if this is ever
+  revived. Its original text: *requires the owner's Apple Developer Program
+  enrolment, the two Developer ID identities, an App Store Connect API key, and
+  the six repository secrets; all are owner-only account mutations. Done when a
+  **stable tag** produces artifacts that a human verifies through
+  [the gate](../gates/032-macos-notarization.md). A green dry run does not close
+  this — a dry run with no secrets is designed to produce unsigned artifacts, so
+  it cannot evidence a working signature.*
 
 ## What the tests prove, and what they do not
 

--- a/docs/tasks/032-macos-notarization.md
+++ b/docs/tasks/032-macos-notarization.md
@@ -124,7 +124,12 @@ configuration and user documentation.
   `ci.yml` runs `goreleaser check` on every PR, which covers the config schema;
   the workflow's own syntax is proven by it running. Done when those three have
   actually run, plus the repository's required code checks.
-- [!] **032.7 — Enrol with Apple and prove a signed release.** — requires the
+- [!] **032.7 — Enrol with Apple and prove a signed release.** — *2026-08-27:
+  still open, and [task 039](039-unsigned-releases-by-default.md) has removed its
+  ability to break a release. Until it closes, every macOS artifact ships
+  unsigned, the cask's quarantine hook is back, and §19's 2026-08-26 amendment is
+  read through its 2026-08-27 successor. Closing this task means deleting that
+  hook in the same change.* — requires the
   owner's Apple Developer Program enrolment, the two Developer ID identities,
   an App Store Connect API key, and the six repository secrets; all are
   owner-only account mutations. Done when a **stable tag** produces artifacts

--- a/docs/tasks/038-release-signing-posture.md
+++ b/docs/tasks/038-release-signing-posture.md
@@ -68,7 +68,11 @@ configuration and user documentation that make them true.
   of `.goreleaser.yaml` and `.github/workflows/release.yml`, so **no signing
   configuration encodes the dual license today**. There is nothing to revisit and
   no spec amendment to write. Task 032's enrolment blocker (032.7) is untouched
-  by this and stays 032's job.
+  by this and stays 032's job. *(2026-08-27, later the same day: 032.7 was
+  dropped — the membership is not being bought. See
+  [task 039](039-unsigned-releases-by-default.md). This strand's reasoning is
+  unaffected, and so is the Windows survey below: a free route accepted there
+  would sign Windows while macOS stays unsigned.)*
 
 - **deb and rpm stay unsigned, deliberately.** This converts an undecided gap
   into a recorded decision; `nfpms` at `.goreleaser.yaml:68` is correct as it

--- a/docs/tasks/039-unsigned-releases-by-default.md
+++ b/docs/tasks/039-unsigned-releases-by-default.md
@@ -1,10 +1,11 @@
 # 039 — A missing certificate must not destroy a release
 
-**Status:** ⚠ verification blocked (5/6) · **Opened:** 2026-08-27
+**Status:** ⚠ verification blocked (6/7) · **Opened:** 2026-08-27
 
 Task 032 built the macOS Developer ID signing path on the assumption that the
-Apple Developer Program membership it needs would be bought. It was not — 032.7
-is still open — and the pipeline made that a **fatal** condition on a `v*` tag.
+Apple Developer Program membership it needs would be bought. It was not — and
+`032.7`, the enrolment, is now **dropped** — while the pipeline made that a
+**fatal** condition on a `v*` tag.
 `v0.7.0` was therefore not a release at all: [run
 33057721082](https://github.com/lezli01/vincent/actions/runs/33057721082) died at
 its first signing step, before GoReleaser ran, so the tag produced no archives,
@@ -14,7 +15,9 @@ no deb or rpm, no attestations and no Homebrew, Scoop or WinGet metadata, and
 This task changes what a missing certificate does: it makes the release
 **unsigned** instead of making it **not exist**. Nothing about task 032's
 mechanism is removed — every step of it stays wired and runs the moment the six
-`MACOS_*` secrets appear.
+`MACOS_*` secrets appear. Later the same day the enrolment itself was dropped,
+so those secrets are not expected; the machinery is kept anyway, for the reasons
+in the last decision below.
 
 Conventions for this file are in [the tasks README](README.md). Behaviour lands
 in [the spec](../spec.md) as dated amendments, in the same PR as the release
@@ -35,8 +38,10 @@ configuration and user documentation that make them true.
   release, which is the failure task 032 was right to want caught. Deriving the
   value from the secret keeps the guard and costs nothing.
 
-  A third alternative — buy the membership — is not this task's to take. It is
-  032.7, it is owner-only, and it is unchanged by anything here.
+  A third alternative — buy the membership — was 032.7's, and was declined the
+  same day. That does not change this decision: keying on the certificate is
+  correct whether or not one is ever installed, and it is what makes installing
+  one the only step needed to reverse the decline.
 
 - **Half-configured is still fatal, and so is signing without notarizing.** With
   the Application certificate present, a missing Installer certificate or a
@@ -57,10 +62,10 @@ configuration and user documentation that make them true.
 
   It is restored unconditionally rather than templated on the signing env,
   because a GoReleaser template inside a Ruby cask body is not covered by
-  `goreleaser check` and would fail where nothing tests it. **Delete it in the
-  same change that closes 032.7** — the comment above it in `.goreleaser.yaml`
-  says so, and 032.4's reasoning becomes correct again the moment a notarized
-  binary ships.
+  `goreleaser check` and would fail where nothing tests it. With 032.7 dropped it
+  is permanent for now: **delete it in the same change that ever installs the
+  certificates**, since 032.4's reasoning becomes correct again the moment a
+  notarized binary ships. The comment above it in `.goreleaser.yaml` says so.
 
 - **The smoke job's Gatekeeper assessment is skipped, not softened.** `codesign
   --verify` and `spctl --assess` on an unsigned binary fail, correctly. Making
@@ -78,7 +83,7 @@ configuration and user documentation that make them true.
   here: documentation that is wrong in the direction of "this does not work".
   All of it is rewritten to the unsigned reality, including the `.pkg`'s
   right-click → *Open* path, and `RELEASING.md` gains an explicit note that the
-  signing machinery is wired and dormant.
+  signing machinery is wired and dormant, with no enrolment coming.
 
 - **The `.pkg` stays, unsigned.** Its stapled ticket was the headline in task
   032, and without notarization there is no ticket — but the rest of what it does
@@ -86,15 +91,46 @@ configuration and user documentation that make them true.
   `/usr/local/bin/vincent` under `dev.lezli01.vincent`, which is what
   [task 021](021-package-distribution-channels.md)'s recorded-executable-path
   behaviour wants. Dropping it would remove a working installer and force a
-  fourth documentation rewrite when 032.7 lands. It keeps its build attestation
-  and stays outside `checksums.txt` for the unchanged reason that it is built
-  after the checksums are computed.
+  fourth documentation rewrite. It keeps its build attestation and stays outside
+  `checksums.txt` for the unchanged reason that it is built after the checksums
+  are computed.
 
-- **This is not a decision to abandon macOS signing.** 032.7 stays open, the
+- ~~**This is not a decision to abandon macOS signing.** 032.7 stays open, the
   secrets table in `RELEASING.md` stays, the keychain import stays, and
   installing the six secrets is the entire switch — no workflow edit follows it.
   What is abandoned is only the coupling that made an unbought certificate
-  destroy a release.
+  destroy a release.~~ **Superseded the same day by the decision below**: the
+  half of this that survives is the second sentence — the machinery stays and
+  the six secrets remain the entire switch. The first sentence does not.
+
+- **The Apple enrolment is dropped, and 032.7 with it (2026-08-27, later the
+  same day).** The membership is not being bought, so waiting on it was
+  recording an intention rather than a plan. `032.7` is struck through in
+  [task 032](032-macos-notarization.md) and that document is retained as a
+  design, not as a description of what ships.
+
+  **The machinery stays anyway**, which is the part that needs the reasoning,
+  because dead code normally does not earn its place. Three things pay for it:
+  it is *finished and verified* — 032.6 closed on this diff, with `goreleaser
+  check`, `actionlint` and `shellcheck` all clean — so its cost from here is
+  storage, not maintenance; removing it would be a second large documentation
+  rewrite and re-adding it a third; and it keeps the decision **cheaply
+  reversible**, which matters for a decision made on price. Installing six
+  secrets re-arms every step, with no code change and no release-day surprise.
+
+  The alternative it beat was deleting `scripts/macos-sign.sh`, the keychain and
+  notary steps, the signing branches of `scripts/macos-pkg.sh`, and
+  `RELEASING.md`'s Apple bootstrap and rotation sections. That is the honest
+  shape if the answer were "never" rather than "not at this price", and it
+  remains available: nothing here depends on the dormant code, and one commit
+  removes it.
+
+  What this decision does **not** touch: the `.pkg`, which was never justified by
+  its ticket alone; cosign and the build attestations, which are unconditional
+  and always present; and Windows, whose free-for-OSS Authenticode survey is
+  [task 038](038-release-signing-posture.md)'s and unaffected — a free route
+  accepted there would sign Windows while macOS stays unsigned, which is a
+  coherent posture, not an inconsistency.
 
 ## Tasks
 
@@ -104,7 +140,7 @@ configuration and user documentation that make them true.
   ✓ 2026-08-27
 - [x] **039.2 — Restore the cask's quarantine hook.** `.goreleaser.yaml`
   `homebrew_casks[].hooks.post.install`, with the comment that ties its removal
-  to 032.7. ✓ 2026-08-27
+  to the day certificates are installed. ✓ 2026-08-27
 - [x] **039.3 — Skip the Gatekeeper assessment on an unsigned release.**
   `Depends: 039.1`. A `macos_signed` output on the `release` job, consumed by the
   `smoke` job's *Assess the macOS signature* step. ✓ 2026-08-27
@@ -116,7 +152,15 @@ configuration and user documentation that make them true.
   amendment's "is now paid" was not true, and what a missing certificate does
   instead. In the same pull request as 039.1–039.4, per the tasks README.
   ✓ 2026-08-27
-- [!] **039.6 — Prove a tag publishes without the certificates.** — **owner-only**:
+- [x] **039.7 — Close 032.7 as dropped and record why the machinery stays.**
+  Appended after 039.1–039.5: the strike-through and retained-design banner in
+  [task 032](032-macos-notarization.md), its index row, a second §19 amendment,
+  the 032 gate's preamble, and `RELEASING.md`'s "dormant" wording. 032.6 closed
+  in the same pass — `goreleaser`, `actionlint` and `shellcheck` are present in
+  this environment, which is the only thing that had blocked it. ✓ 2026-08-27
+- [!] **039.6 — Prove a tag publishes without the certificates.** — with 032.7
+  dropped this is the *only* remaining release proof: no signed release is ever
+  coming to supersede it. — **owner-only**:
   it needs a real `v*` tag, and the thing being proved is that the release
   workflow completes end to end and attaches every asset. Re-cut `0.7.0` (its
   curated changelog prose is in `2baafbb`, per `6041bfd`) and confirm the release
@@ -152,10 +196,12 @@ config and documentation — and none was invented to look like there is.
   before any signing existed. The mitigation is that the fix is one documented
   command and the Homebrew path needs none of it.
 - **Re-adding the cask hook re-adds a bypass.** It is only correct while the
-  binary is unsigned. If 032.7 lands and the hook is forgotten, brew installs
-  would go on stripping quarantine from a notarized binary — the precise thing
-  032.4 removed. The comment in `.goreleaser.yaml` and 039.6's successor are
-  where that is caught; there is no test for it, because the condition is "a
+  binary is unsigned. If the certificates are ever installed and the hook is
+  forgotten, brew installs would go on stripping quarantine from a notarized
+  binary — the precise thing 032.4 removed. With 032.7 dropped there is no open
+  task left to catch it, which makes the comment in `.goreleaser.yaml` and the
+  [032 gate](../gates/032-macos-notarization.md)'s retained walkthrough the only
+  guards. There is no test for it either, because the condition is "a
   certificate exists", which CI cannot see.
 - **A silent regression to unsigned, later.** With signing keyed on a secret, a
   deleted or expired certificate now produces a quietly unsigned release instead

--- a/docs/tasks/039-unsigned-releases-by-default.md
+++ b/docs/tasks/039-unsigned-releases-by-default.md
@@ -1,0 +1,164 @@
+# 039 — A missing certificate must not destroy a release
+
+**Status:** ⚠ verification blocked (5/6) · **Opened:** 2026-08-27
+
+Task 032 built the macOS Developer ID signing path on the assumption that the
+Apple Developer Program membership it needs would be bought. It was not — 032.7
+is still open — and the pipeline made that a **fatal** condition on a `v*` tag.
+`v0.7.0` was therefore not a release at all: [run
+33057721082](https://github.com/lezli01/vincent/actions/runs/33057721082) died at
+its first signing step, before GoReleaser ran, so the tag produced no archives,
+no deb or rpm, no attestations and no Homebrew, Scoop or WinGet metadata, and
+`6041bfd` unwound it.
+
+This task changes what a missing certificate does: it makes the release
+**unsigned** instead of making it **not exist**. Nothing about task 032's
+mechanism is removed — every step of it stays wired and runs the moment the six
+`MACOS_*` secrets appear.
+
+Conventions for this file are in [the tasks README](README.md). Behaviour lands
+in [the spec](../spec.md) as dated amendments, in the same PR as the release
+configuration and user documentation that make them true.
+
+## Decisions (2026-08-27)
+
+- **Signing is keyed on the certificates, not on the tag.** `MACOS_SIGN_REQUIRED`
+  was `github.event_name == 'push'`; it is now
+  `secrets.MACOS_CERT_APPLICATION_P12 != ''`. The invariant task 032 wanted is
+  kept in the form that is actually enforceable — *with* certificates installed,
+  a tag cannot publish an unsigned macOS artifact — and the case it did not
+  consider, certificates that were never installed, degrades to a warning.
+
+  The alternative it beat was pinning the variable to `'0'` outright. That also
+  unblocks releases, but it gives up the guard permanently: a certificate
+  deleted or expired by accident would then ship a silently unsigned stable
+  release, which is the failure task 032 was right to want caught. Deriving the
+  value from the secret keeps the guard and costs nothing.
+
+  A third alternative — buy the membership — is not this task's to take. It is
+  032.7, it is owner-only, and it is unchanged by anything here.
+
+- **Half-configured is still fatal, and so is signing without notarizing.** With
+  the Application certificate present, a missing Installer certificate or a
+  missing notary key is a misconfiguration, not the unenrolled path, and both
+  keep their hard error. The notarization half matters on its own: a Developer ID
+  signature Apple has not notarized makes Gatekeeper report `source=Unnotarized
+  Developer ID` and refuse the file anyway, so it is **worse** than shipping
+  plainly unsigned.
+
+- **The Homebrew cask's quarantine hook comes back.** Task 032 deleted
+  `xattr -dr com.apple.quarantine` from the cask's `hooks.post.install` on the
+  correct grounds that keeping it would bypass notarization that had been paid
+  for. There is no notarization to bypass: brew downloads the same unsigned
+  archive GitHub Releases serves, Homebrew quarantines what it downloads, and an
+  unsigned quarantined binary does not start. Without the hook `brew install
+  lezli01/tap/vincent` produces a broken install — the exact condition
+  [task 002](002-homebrew-tap.md) added it for.
+
+  It is restored unconditionally rather than templated on the signing env,
+  because a GoReleaser template inside a Ruby cask body is not covered by
+  `goreleaser check` and would fail where nothing tests it. **Delete it in the
+  same change that closes 032.7** — the comment above it in `.goreleaser.yaml`
+  says so, and 032.4's reasoning becomes correct again the moment a notarized
+  binary ships.
+
+- **The smoke job's Gatekeeper assessment is skipped, not softened.** `codesign
+  --verify` and `spctl --assess` on an unsigned binary fail, correctly. Making
+  them tolerate failure would leave an assertion that proves nothing on a signed
+  release either, so the step is gated on a new `macos_signed` job output — the
+  value of `MACOS_SIGN_REQUIRED`, which is now precisely "the certificates are
+  configured". Every other smoke assertion, and the checksum verification, run
+  unchanged on every release.
+
+- **The documentation describes the artifacts that ship, not the ones intended.**
+  Nine user-facing sites asserted that macOS artifacts are signed, notarized and
+  Gatekeeper-clean, and one told users *not* to run `xattr -d
+  com.apple.quarantine`. Following that instruction against a real release
+  leaves a binary that will not start, which is the worst failure mode available
+  here: documentation that is wrong in the direction of "this does not work".
+  All of it is rewritten to the unsigned reality, including the `.pkg`'s
+  right-click → *Open* path, and `RELEASING.md` gains an explicit note that the
+  signing machinery is wired and dormant.
+
+- **The `.pkg` stays, unsigned.** Its stapled ticket was the headline in task
+  032, and without notarization there is no ticket — but the rest of what it does
+  is untouched: one file covering both architectures, installed to a fixed
+  `/usr/local/bin/vincent` under `dev.lezli01.vincent`, which is what
+  [task 021](021-package-distribution-channels.md)'s recorded-executable-path
+  behaviour wants. Dropping it would remove a working installer and force a
+  fourth documentation rewrite when 032.7 lands. It keeps its build attestation
+  and stays outside `checksums.txt` for the unchanged reason that it is built
+  after the checksums are computed.
+
+- **This is not a decision to abandon macOS signing.** 032.7 stays open, the
+  secrets table in `RELEASING.md` stays, the keychain import stays, and
+  installing the six secrets is the entire switch — no workflow edit follows it.
+  What is abandoned is only the coupling that made an unbought certificate
+  destroy a release.
+
+## Tasks
+
+- [x] **039.1 — Key `MACOS_SIGN_REQUIRED` on the certificates.**
+  `.github/workflows/release.yml`: the job-level env, plus the two error
+  messages that named "a v* tag" as the reason a secret was required.
+  ✓ 2026-08-27
+- [x] **039.2 — Restore the cask's quarantine hook.** `.goreleaser.yaml`
+  `homebrew_casks[].hooks.post.install`, with the comment that ties its removal
+  to 032.7. ✓ 2026-08-27
+- [x] **039.3 — Skip the Gatekeeper assessment on an unsigned release.**
+  `Depends: 039.1`. A `macos_signed` output on the `release` job, consumed by the
+  `smoke` job's *Assess the macOS signature* step. ✓ 2026-08-27
+- [x] **039.4 — Rewrite the macOS signing claims.** `README.md`,
+  `docs/features.md`, `docs/README.md`, `docs/getting-started/installation.md`,
+  `docs/platforms/macos.md`, `RELEASING.md`, the GoReleaser release footer and
+  the `.pkg`/`signs:` comments, and the 032 gate's preamble. ✓ 2026-08-27
+- [x] **039.5 — Amend §19.** A dated amendment recording that the 2026-08-26
+  amendment's "is now paid" was not true, and what a missing certificate does
+  instead. In the same pull request as 039.1–039.4, per the tasks README.
+  ✓ 2026-08-27
+- [!] **039.6 — Prove a tag publishes without the certificates.** — **owner-only**:
+  it needs a real `v*` tag, and the thing being proved is that the release
+  workflow completes end to end and attaches every asset. Re-cut `0.7.0` (its
+  curated changelog prose is in `2baafbb`, per `6041bfd`) and confirm the release
+  carries the thirteen `v0.6.0` assets plus `vincent_0.7.0_darwin_universal.pkg`,
+  that Homebrew, Scoop and WinGet moved, and that `brew install
+  lezli01/tap/vincent` yields a binary that runs. A green secretless
+  `workflow_dispatch` dry run does **not** close this: it never publishes, and
+  publishing is what `v0.7.0` failed at.
+
+## What the tests prove, and what they do not
+
+There is no unit-testable surface here — it is a release workflow, a packaging
+config and documentation — and none was invented to look like there is.
+
+- `goreleaser check`, in `ci.yml`'s `packaging-config` job, validates the cask
+  hook and the rewritten footer on every pull request. It ran clean on this
+  change.
+- The secretless `workflow_dispatch` dry run exercises exactly the path a tag
+  now takes: `MACOS_SIGN_REQUIRED=0`, every signing step warning, an unsigned
+  `.pkg` built by `scripts/macos-pkg.sh`. That is the regression test for the
+  split, and it is the same run a fork produces.
+- Nothing available before a tag proves that a *published* release is complete.
+  That is 039.6, and it is why this task is not done.
+- The [032 gate](../gates/032-macos-notarization.md) cannot be walked at all
+  while releases are unsigned; its preamble now says so rather than sitting there
+  looking runnable.
+
+## Risks
+
+- **Users on older documentation.** Anything published before this change tells
+  macOS users there is nothing to clear. They will meet a Gatekeeper dialog with
+  no instruction, on `v0.6.0` artifacts as much as on new ones — `v0.6.0` shipped
+  before any signing existed. The mitigation is that the fix is one documented
+  command and the Homebrew path needs none of it.
+- **Re-adding the cask hook re-adds a bypass.** It is only correct while the
+  binary is unsigned. If 032.7 lands and the hook is forgotten, brew installs
+  would go on stripping quarantine from a notarized binary — the precise thing
+  032.4 removed. The comment in `.goreleaser.yaml` and 039.6's successor are
+  where that is caught; there is no test for it, because the condition is "a
+  certificate exists", which CI cannot see.
+- **A silent regression to unsigned, later.** With signing keyed on a secret, a
+  deleted or expired certificate now produces a quietly unsigned release instead
+  of a loud failure. The `::warning::` in the job log is the only signal. This is
+  the cost of the decision and it is accepted: the alternative is the failure
+  mode that cost `v0.7.0`.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -45,14 +45,14 @@ the living engineering specification records implementation contracts.
 | [029](029-database-size-reporting.md) | Reporting the database's footprint, row counts and retention span | ✅ done (6/6) |
 | [030](030-daemon-backup-and-restore.md) | `vincent daemon backup` / `restore` | ✅ done (6/6) |
 | [031](031-native-process-identity.md) | Exact native process identity for the §12.4 PID-reuse guard | ✅ done (5/5) |
-| [032](032-macos-notarization.md) | macOS Developer ID signing and notarization | ⚠ verification blocked (5/7) |
+| [032](032-macos-notarization.md) | macOS Developer ID signing and notarization | ✅ built, never activated (6/6, 032.7 dropped) |
 | [033](033-task-cost-cap.md) | `max_task_cost_usd`: a per-task cost cap enforced at attempt boundaries | ✅ done (4/4) |
 | [034](034-workflow-init.md) | `vincent workflow init`, a CLI on-ramp for authoring a workflow | ✅ done (5/5) |
 | [035](035-github-issue-selection.md) | Select a GitHub issue when creating a task | ✅ done (12/12) |
 | [036](036-step-status-message.md) | A step-authored status message, live and terminal | ✅ done (7/7) |
 | [037](037-update-workflows-builtin.md) | `update-workflows`, a built-in that maintains the ones you have | ✅ done (5/5) |
 | [038](038-release-signing-posture.md) | Release signing posture for an MIT project | ⚠ blocked on the owner (1/7) |
-| [039](039-unsigned-releases-by-default.md) | A missing certificate must not destroy a release | ⚠ verification blocked (5/6) |
+| [039](039-unsigned-releases-by-default.md) | A missing certificate must not destroy a release | ⚠ verification blocked (6/7) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -52,6 +52,7 @@ the living engineering specification records implementation contracts.
 | [036](036-step-status-message.md) | A step-authored status message, live and terminal | ✅ done (7/7) |
 | [037](037-update-workflows-builtin.md) | `update-workflows`, a built-in that maintains the ones you have | ✅ done (5/5) |
 | [038](038-release-signing-posture.md) | Release signing posture for an MIT project | ⚠ blocked on the owner (1/7) |
+| [039](039-unsigned-releases-by-default.md) | A missing certificate must not destroy a release | ⚠ verification blocked (5/6) |
 
 ## How to add and update a task document
 

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -246,10 +246,16 @@ EOF
   branch="$(api GET "/tasks/$task_id" | jq -r .branch_name)"
   git -C "$remote" rev-parse --verify "refs/heads/$branch" >/dev/null \
     || fail "branch $branch missing in the bare remote"
-  git -C "$remote" log -1 --format=%s "$branch" | grep -q 'm2 gate: record the answer' \
+  # Captured rather than piped into `grep -q`: grep exits at its first match,
+  # the producer dies of SIGPIPE writing the rest, and pipefail reports that as
+  # a failed assertion over data that was correct. Proven in m7 scenario 4.
+  local subject files
+  subject="$(git -C "$remote" log -1 --format=%s "$branch")"
+  grep -q 'm2 gate: record the answer' <<<"$subject" \
     || fail "published tip is not the gate commit"
   if (( ! REAL_AGENT )); then
-    git -C "$remote" show --name-only --format= "$branch" | grep -qx 'README.md' \
+    files="$(git -C "$remote" show --name-only --format= "$branch")"
+    grep -qx 'README.md' <<<"$files" \
       || fail "published commit does not carry the agent's README.md edit"
   fi
 
@@ -390,7 +396,9 @@ EOF
   local alive=1
   for _ in $(seq 1 20); do
     if [[ "${OS:-}" == "Windows_NT" ]]; then
-      tasklist //FI "PID eq $child_pid" 2>/dev/null | grep -q " $child_pid " || { alive=0; break; }
+      local listing
+      listing="$(tasklist //FI "PID eq $child_pid" 2>/dev/null || true)"
+      grep -q " $child_pid " <<<"$listing" || { alive=0; break; }
     else
       kill -0 "$child_pid" 2>/dev/null || { alive=0; break; }
     fi

--- a/scripts/m5-gate.sh
+++ b/scripts/m5-gate.sh
@@ -294,9 +294,13 @@ EOF
   echo "== assert the branch carries the edit"
   local branch
   branch="$(api GET "/tasks/$task_id" | jq -r .branch_name)"
-  git -C "$repo" log -1 --format=%s "$branch" | grep -q 'm5 gate: cursor edit' \
+  # Captured rather than piped into `grep -q` — see m7 scenario 4's comment.
+  local subject files
+  subject="$(git -C "$repo" log -1 --format=%s "$branch")"
+  grep -q 'm5 gate: cursor edit' <<<"$subject" \
     || fail "branch $branch tip is not the gate commit"
-  git -C "$repo" show --name-only --format= "$branch" | grep -qx 'README.md' \
+  files="$(git -C "$repo" show --name-only --format= "$branch")"
+  grep -qx 'README.md' <<<"$files" \
     || fail "the cursor step changed no tracked file"
 
   "$VINCENT" daemon stop --force >/dev/null 2>&1 || true

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -345,8 +345,10 @@ YAML
   # The conflict is left in place on purpose: this is a human resolving it.
   # Both lanes *create* the file, so git reports an add/add conflict (AA)
   # rather than a content one (UU). Match any unmerged status.
-  git -C "$WT" status --porcelain | grep -qE '^(DD|AU|UD|UA|DU|AA|UU)' \
-    || fail "no conflicted file in the worktree: $(git -C "$WT" status --porcelain)"
+  # Captured rather than piped into `grep -q` — see m7 scenario 4's comment.
+  PORCELAIN="$(git -C "$WT" status --porcelain)"
+  grep -qE '^(DD|AU|UD|UA|DU|AA|UU)' <<<"$PORCELAIN" \
+    || fail "no conflicted file in the worktree: $PORCELAIN"
   echo resolved > "$WT/shared.txt"
   git -C "$WT" add shared.txt
 

--- a/scripts/m7-gate.sh
+++ b/scripts/m7-gate.sh
@@ -319,9 +319,15 @@ YAML
   KIDS="$(api GET "/tasks?parent_id=$TID" | jq 'length')"
   [[ "$KIDS" == 1 ]] || fail "expected 1 lane to be spawned, got $KIDS"
   BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name)"
-  git -C "$REPO" log --format=%s "$BRANCH" | grep -qx lane-api \
+  # Captured, not piped into `grep -q`. `grep -q` exits at its first match,
+  # `git log` then dies of SIGPIPE writing the commits after it, and pipefail
+  # reports that as a failed assertion over data that was correct all along —
+  # 20% of runs here, because `lane-api` is the second subject of three. Same
+  # trap release.yml's signature checks already work around.
+  SUBJECTS="$(git -C "$REPO" log --format=%s "$BRANCH")"
+  grep -qx lane-api <<<"$SUBJECTS" \
     || fail "the selected lane's commit is not on the parent's branch"
-  if git -C "$REPO" log --format=%s "$BRANCH" | grep -qx lane-skipped; then
+  if grep -qx lane-skipped <<<"$SUBJECTS"; then
     fail "the guarded-off lane ran anyway"
   fi
   daemon_down

--- a/scripts/macos-pkg.sh
+++ b/scripts/macos-pkg.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
-# Build the signed, notarized, stapled macOS installer package
-# (task 032, spec §19 †'s 2026-08-26 amendment).
+# Build the universal macOS installer package — signed, notarized and stapled
+# when the Developer ID certificates are configured, and plain otherwise
+# (task 032, spec §19 †'s 2026-08-26 and 2026-08-27 amendments).
 #
-# lipo → pkgbuild → sign → notarize → staple → verify. This runs *after*
-# GoReleaser, not inside a build hook: a hook fires per target, and a universal
-# binary needs both darwin slices to exist. The consequence is recorded and
-# deliberate — the .pkg is not in checksums.txt. Its integrity story is Apple's
-# own signature plus the GitHub build attestation, and
-# docs/getting-started/installation.md's claim that checksums.txt covers every
-# archive, deb and rpm stays literally true.
+# lipo → pkgbuild → sign → notarize → staple → verify, where every step past
+# pkgbuild is skipped without credentials. That is not only the dry-run path any
+# more: the Apple Developer Program was never bought, so it is what a stable
+# release takes today (task 039), and an unsigned .pkg is still a real
+# installer — one universal binary into /usr/local/bin — that a user opens with
+# right-click → Open instead of a double-click.
+#
+# It runs *after* GoReleaser, not inside a build hook: a hook fires per target,
+# and a universal binary needs both darwin slices to exist. The consequence is
+# recorded and deliberate — the .pkg is not in checksums.txt. Its integrity
+# story is the GitHub build attestation, plus Apple's own signature when there
+# is one, and docs/getting-started/installation.md's claim that checksums.txt
+# covers every archive, deb and rpm stays literally true.
 #
 # The package installs /usr/local/bin/vincent under the identifier
 # dev.lezli01.vincent — the same identifier internal/service already uses for
@@ -18,11 +25,12 @@
 # Usage: macos-pkg.sh <version> [dist-dir]
 #
 # Environment:
-#   MACOS_SIGN_REQUIRED       "1" on a v* tag build — missing identities,
-#                             credentials or tools are fatal. Otherwise the
-#                             package is still built, just unsigned and
-#                             un-notarized, so a dry run with no secrets proves
-#                             the packaging itself.
+#   MACOS_SIGN_REQUIRED       "1" when the Developer ID certificates are
+#                             configured — missing identities, credentials or
+#                             tools are then fatal. Otherwise the package is
+#                             still built, just unsigned and un-notarized, which
+#                             is both the secretless dry run and, until 032.7,
+#                             the stable release.
 #   MACOS_SIGN_IDENTITY       Developer ID Application identity (re-signs the
 #                             lipo-merged binary; merging produces a new Mach-O).
 #   MACOS_INSTALLER_IDENTITY  Developer ID Installer identity (signs the .pkg).
@@ -45,8 +53,8 @@ fail() {
 	exit 1
 }
 
-# Everything past the plain `pkgbuild` is optional on a dry run and mandatory on
-# a tag. `require` is the one place that split is expressed.
+# Everything past the plain `pkgbuild` is optional without certificates and
+# mandatory with them. `require` is the one place that split is expressed.
 require() {
 	if [ "$required" = "1" ]; then
 		fail "$1"

--- a/scripts/macos-pkg.sh
+++ b/scripts/macos-pkg.sh
@@ -5,8 +5,8 @@
 #
 # lipo → pkgbuild → sign → notarize → staple → verify, where every step past
 # pkgbuild is skipped without credentials. That is not only the dry-run path any
-# more: the Apple Developer Program was never bought, so it is what a stable
-# release takes today (task 039), and an unsigned .pkg is still a real
+# more: the Apple Developer Program was never bought and 032.7 is dropped, so it
+# is what every release takes (task 039), and an unsigned .pkg is still a real
 # installer — one universal binary into /usr/local/bin — that a user opens with
 # right-click → Open instead of a double-click.
 #
@@ -29,8 +29,8 @@
 #                             configured — missing identities, credentials or
 #                             tools are then fatal. Otherwise the package is
 #                             still built, just unsigned and un-notarized, which
-#                             is both the secretless dry run and, until 032.7,
-#                             the stable release.
+#                             is both the secretless dry run and, 032.7 having
+#                             been dropped, the stable release.
 #   MACOS_SIGN_IDENTITY       Developer ID Application identity (re-signs the
 #                             lipo-merged binary; merging produces a new Mach-O).
 #   MACOS_INSTALLER_IDENTITY  Developer ID Installer identity (signs the .pkg).


### PR DESCRIPTION
`v0.7.0` was not a release: the tag build died at its first signing step, before GoReleaser ran, and produced no archives, no deb or rpm, no attestations and no Homebrew, Scoop or WinGet metadata. `6041bfd` unwound it. This makes that failure impossible, closes the enrolment it was waiting on, and fixes an unrelated flaky gate that is currently red on the release PR.

## A missing certificate no longer destroys a release

`MACOS_SIGN_REQUIRED` was keyed on the tag, so a `v*` tag without the Developer ID certificates was a hard error. Those certificates do not exist — the Apple Developer Program membership is ~$99/yr and was never bought. It is now keyed on the certificates instead:

```yaml
MACOS_SIGN_REQUIRED: ${{ secrets.MACOS_CERT_APPLICATION_P12 != '' && '1' || '0' }}
```

With certificates installed a tag still cannot publish an unsigned macOS artifact. Without them every signing step warns and the release ships unsigned. Half-configured secrets, and certificates without a notary key, both keep their hard error — an unnotarized Developer ID signature makes Gatekeeper refuse the file anyway, which is worse than shipping plainly unsigned.

Consequences:

- The Homebrew cask's quarantine-stripping `postflight` hook comes back. brew installs the same unsigned archive and Homebrew quarantines what it downloads, so without it `brew install` yields a binary that will not start.
- The smoke job's Gatekeeper assessment is skipped on an unsigned release via a new `macos_signed` job output, rather than softened into an assertion that would prove nothing on a signed one.
- Nine user-facing sites claimed the macOS artifacts were signed and notarized, and `installation.md` told users **not** to run `xattr -d com.apple.quarantine`. Following that against a real release leaves a binary that will not start, so all of it now documents the unsigned path.

## 032.7 dropped, machinery kept

The membership is not being bought, so waiting on it was recording an intention rather than a plan. `032.7` is struck through and task 032 is closed as a design that was built and never activated.

The implementation stays: it is finished and now verified, so its cost from here is storage rather than maintenance, and installing six repository secrets remains the entire cost of reversing a decision made on price. The alternative — deleting `scripts/macos-sign.sh`, the keychain and notary steps, the signing branches of `scripts/macos-pkg.sh` and `RELEASING.md`'s Apple bootstrap — is the honest shape if the answer were "never" rather than "not at this price", and is one commit away.

`032.6` closes here too. Its blocker was that `goreleaser`, `actionlint` and `shellcheck` were absent from the environment task 032 was written in; all three ran clean against this branch.

## The flaky gate

`gates (macos-latest)` fails intermittently on m7 scenario 4 with *"the selected lane's commit is not on the parent's branch"*. The commit is on the branch every time. The assertion was:

```sh
git log --format=%s "$BRANCH" | grep -qx lane-api || fail ...
```

`grep -q` exits at its first match and closes the pipe; `git log` dies of SIGPIPE writing the subject after it, and under `set -o pipefail` the pipeline reports 141 — the assertion fails **because it matched**. Replaying it against a preserved repository reproduced it 12 times in 300, with the merge commit correctly in place throughout.

Fan-out is not at fault. The parent branch carried the lane merge, with the lane commit as a parent, in every failing run.

The fix is the idiom `m2`'s follow-up assertion has carried since it was written, along with a comment explaining this exact failure — capture the output, match the capture with a here-string. That comment was never applied to the other eight sites, so the rule now lives in `CLAUDE.md`'s gate-authoring notes beside the CRLF one.

## Spec

§19 gains two dated amendments: the 2026-08-26 amendment's "is now paid" was not true, and neither desktop platform carries an OS code signature, which returns §19 to the shape the X decision gave it. Untouched: the `.pkg`, which stands on being one universal binary at a fixed install path rather than on a stapled ticket; cosign and the build attestations, which were never conditional; and Windows, whose free-for-OSS Authenticode survey is task 038's.

## Testing

- `goreleaser check`, `actionlint`, `shellcheck` — clean
- `go run mage.go test` and `lint` — green
- All seven gates end to end on macOS: `m1 m2 m5 m6 m7 m8 m9`
- m7 scenario 4 forty consecutive runs green, having been ~20% red

Not proven here, and it cannot be: that a tag actually publishes. `039.6` stays open — a secretless dry run never publishes, and publishing is what `v0.7.0` failed at.

**Merge this before the release PR.** A tag cut from master as it stands still dies at the signing step.

Closes 032.6, 039.1–039.5, 039.7. Drops 032.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Gh2Q2D7d6SQMz6915sxNB