### PR TITLE
Record where a task's workflow definition came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ list with the user-facing context a commit subject cannot carry.
   the version verdict), permission-compatible (`restricted_verdict`), and
   model-catalog health, which is the existing `probe_error` and is not
   duplicated. ([#148](https://github.com/lezli01/vincent/issues/148))
+- **Every task now records which workflow definition it actually ran.** A
+  project or global workflow file shadows a built-in of the same name — that is
+  by design, and it includes the `adhoc` a task falls back to when you create it
+  without naming a workflow. Until now the task recorded only the *name*, so a
+  repository's own `.vincent/workflows/adhoc.yaml` standing in for the built-in
+  was invisible on the task forever afterwards. Tasks created from here on carry
+  a `workflow_origin`: the scope that won (`builtin`, `global`, `project`, or
+  `derived` for a fan-out lane), the source file relative to that scope's root,
+  and a SHA-256 of the file's bytes as the registry loaded them. It appears as
+  the `origin` row in `vincent task show`, beside the workflow name in the TUI's
+  task-detail header, as `workflow_origin` on every task the API serves, and in
+  the `task.created` event. It is captured once, at creation, and never
+  recomputed, so editing a workflow file does not rewrite the history of tasks
+  that already ran it. Tasks created before this change report `unknown` — the
+  honest answer; vincent does not look the name up again to invent one.
 
 ### Changed
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -173,6 +173,18 @@ the right shows the live tail of the running step.
 Selecting an attempt in the timeline *is* how you read scrollback — that is why
 the two panels are side by side and both always visible.
 
+The header names the task's workflow and, in brackets, where that definition
+came from: `adhoc (built-in)`, `adhoc (project .vincent/workflows/adhoc.yaml)`,
+`release (global workflows/release.yaml)`, `api (derived from task 41)` for a
+fan-out lane, or `(unknown)` for a task created before vincent recorded it.
+A project or global file shadows a built-in of the same name, so the name on its
+own does not say which one ran.
+
+It sits at the end of the header, after the branch, so a narrow pane truncates
+it before anything that was there already —
+[`vincent task show`](../reference/cli.md#vincent-task-show) prints the same
+thing plus the source digest, and is where an audit is actually done.
+
 A structure step gets a tier of its own. A `parallel` group's sub-steps share
 the group's index, so the group is one header and each sub-step sits beneath
 it. A `loop` (§7.8) goes one further: its body's rows are grouped **by

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -176,12 +176,12 @@ the two panels are side by side and both always visible.
 The header names the task's workflow and, in brackets, where that definition
 came from: `adhoc (built-in)`, `adhoc (project .vincent/workflows/adhoc.yaml)`,
 `release (global workflows/release.yaml)`, `api (derived from task 41)` for a
-fan-out lane, or `(unknown)` for a task created before vincent recorded it.
-A project or global file shadows a built-in of the same name, so the name on its
-own does not say which one ran.
+fan-out lane, or `adhoc (unknown)` for a task created before vincent recorded
+it. A project or global file shadows a built-in of the same name, so the name on
+its own does not say which one ran.
 
-It sits at the end of the header, after the branch, so a narrow pane truncates
-it before anything that was there already —
+It sits late in the header — after the branch, before the run's cost — so a
+narrow pane truncates it early;
 [`vincent task show`](../reference/cli.md#vincent-task-show) prints the same
 thing plus the source digest, and is where an audit is actually done.
 

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -170,6 +170,24 @@ a sibling in the same scope already declaring that `name:`, is refused. Taking a
 name from a *lower* scope is the shadowing above working as intended, so it
 warns and writes.
 
+**Which definition actually ran.** Shadowing means a name is not, on its own,
+an answer — a repository's `.vincent/workflows/adhoc.yaml` wins over the
+built-in `adhoc`, including for tasks created without naming a workflow at all.
+Every task therefore records where its definition came from, and
+[`vincent task show`](../reference/cli.md#vincent-task-show) prints it as
+`origin`:
+
+```
+workflow  adhoc
+origin    project .vincent/workflows/adhoc.yaml sha256:0f4a1c1e…
+```
+
+The scope, the file relative to that scope's root, and a digest of the bytes the
+registry loaded. It is captured at creation and never updated, so editing the
+file afterwards does not rewrite the history of tasks that already ran it. The
+TUI's task-detail header carries the same thing without the digest, and the API
+serves it as `workflow_origin`.
+
 That is the offline route: instant, free, and always the same file.
 `create-workflow` above is the other one — it *designs* a workflow from a
 description, at the cost of a daemon, an agent CLI, tokens, wall-clock time and

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -160,16 +160,6 @@ Details that matter in practice:
 `vincent workflow ls` prints the merged registry with a scope badge per entry;
 `--project <id>` includes that repository's own files.
 
-**Getting a file into one of those directories.**
-[`vincent workflow init <name>`](../reference/cli.md#vincent-workflow-init)
-writes one and prints the path — the skeleton by default, or a shipped example
-with `--from`, embedded in the binary so it works from any directory. The
-default (global) scope needs no daemon; `--project <id>` does, because only the
-daemon knows where that repository is. It never overwrites: an existing path, or
-a sibling in the same scope already declaring that `name:`, is refused. Taking a
-name from a *lower* scope is the shadowing above working as intended, so it
-warns and writes.
-
 **Which definition actually ran.** Shadowing means a name is not, on its own,
 an answer — a repository's `.vincent/workflows/adhoc.yaml` wins over the
 built-in `adhoc`, including for tasks created without naming a workflow at all.
@@ -187,6 +177,16 @@ registry loaded. It is captured at creation and never updated, so editing the
 file afterwards does not rewrite the history of tasks that already ran it. The
 TUI's task-detail header carries the same thing without the digest, and the API
 serves it as `workflow_origin`.
+
+**Getting a file into one of those directories.**
+[`vincent workflow init <name>`](../reference/cli.md#vincent-workflow-init)
+writes one and prints the path — the skeleton by default, or a shipped example
+with `--from`, embedded in the binary so it works from any directory. The
+default (global) scope needs no daemon; `--project <id>` does, because only the
+daemon knows where that repository is. It never overwrites: an existing path, or
+a sibling in the same scope already declaring that `name:`, is refused. Taking a
+name from a *lower* scope is the shadowing above working as intended, so it
+warns and writes.
 
 That is the offline route: instant, free, and always the same file.
 `create-workflow` above is the other one — it *designs* a workflow from a

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -702,6 +702,36 @@ a later step renders through
 `github_issue` makes no GitHub call at all. An unusable integration is the same
 409 with `details.reason` the GitHub endpoints return.
 
+Every task representation also carries `workflow_origin`: which definition the
+`workflow` name resolved to at creation.
+
+```json
+"workflow": "adhoc",
+"workflow_origin": {
+  "scope": "project",
+  "file": ".vincent/workflows/adhoc.yaml",
+  "digest": "sha256:0f4a1c1e…"
+}
+```
+
+A project or global workflow **shadows** a built-in of the same name, including
+the `adhoc` a task created without a `workflow` falls back to. That is by
+design, and this field is how you see it happened: `scope` is `builtin`,
+`global`, `project` or `derived`, `file` is the source path relative to that
+scope's root (absent for a built-in), and `digest` is a SHA-256 of the file's
+bytes as the registry loaded them.
+
+It is frozen at creation and never recomputed, so editing the workflow file
+afterwards does not rewrite an existing task's origin — and the digest names the
+file the task came from, not the (expanded, possibly `edit + retry`-rewritten)
+`workflow_snapshot` the engine executes. A `fan_out` lane reports
+`{"scope": "derived", "parent_task_id": 41}`: its steps came from its parent's
+snapshot, not from a registry file. A task created before vincent recorded this
+has `"workflow_origin": null`, which means *not recorded* — vincent will not
+look the name up again to invent one.
+
+The `task.created` event carries the same object under `workflow_origin`.
+
 Human actions, all `POST /v1/tasks/{id}/…`:
 
 | Path | Valid from | Body |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -718,8 +718,9 @@ A project or global workflow **shadows** a built-in of the same name, including
 the `adhoc` a task created without a `workflow` falls back to. That is by
 design, and this field is how you see it happened: `scope` is `builtin`,
 `global`, `project` or `derived`, `file` is the source path relative to that
-scope's root (absent for a built-in), and `digest` is a SHA-256 of the file's
-bytes as the registry loaded them.
+scope's root (absent for a built-in), and `digest` is a SHA-256 of the source
+bytes as the registry loaded them — for a built-in, the copy compiled into the
+binary.
 
 It is frozen at creation and never recomputed, so editing the workflow file
 afterwards does not rewrite an existing task's origin — and the digest names the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -418,10 +418,12 @@ input request.
 The `origin` row says which definition the task's workflow name resolved to —
 `built-in`, `project .vincent/workflows/adhoc.yaml`, `global
 workflows/release.yaml`, `derived from task 41` for a fan-out lane, or `unknown`
-for a task created before vincent recorded it — followed by a digest of that
-file's bytes. A project or global workflow shadows a built-in of the same name,
-so this is what tells a repository's own `adhoc.yaml` from the built-in `adhoc`
-long after the fact. It is captured once, at creation, and never updated.
+for a task created before vincent recorded it. A registry-backed origin is
+followed by a `sha256:` digest of the source it was loaded from; `derived` and
+`unknown` carry none. A project or global workflow shadows a built-in of the
+same name, so this is what tells a repository's own `adhoc.yaml` from the
+built-in `adhoc` long after the fact. It is captured once, at creation, and
+never updated.
 
 The step table's last two columns are different kinds of thing and should not be
 read as one. `REASON` is vincent's own `failure_reason`, a closed set of

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -415,6 +415,14 @@ vincent task show <id> [--json]
 Shows one task with its step runs, the actions valid right now, and any pending
 input request.
 
+The `origin` row says which definition the task's workflow name resolved to —
+`built-in`, `project .vincent/workflows/adhoc.yaml`, `global
+workflows/release.yaml`, `derived from task 41` for a fan-out lane, or `unknown`
+for a task created before vincent recorded it — followed by a digest of that
+file's bytes. A project or global workflow shadows a built-in of the same name,
+so this is what tells a repository's own `adhoc.yaml` from the built-in `adhoc`
+long after the fact. It is captured once, at creation, and never updated.
+
 The step table's last two columns are different kinds of thing and should not be
 read as one. `REASON` is vincent's own `failure_reason`, a closed set of
 constants. `STATUS` is what the step said about *itself* through

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -242,6 +242,21 @@ A file rejected by either bound becomes an **invalid registry entry** naming the
 and the violated type or bound — the same treatment as a file that fails to parse, so
 its valid siblings in the scope stay available.
 
+*Amended 2026-08-28 (task 043, issue #145).* Built-in shadowing **stands**. A
+global or project file named `adhoc`, `create-workflow` or `update-workflows`
+still wins the lookup, including for a task created without naming a workflow —
+the phase 2 reasoning holds: creation is one uniform path and `workflow` stays
+optional. There is no reserved namespace, no `builtin:` selector and no
+`allow_shadow_builtin` declaration; a qualified name would be a new grammar
+four resolution sites would have to honour at once, and the current name
+pattern admits no colon.
+
+What changes is that the substitution is no longer **invisible**. Every task
+records a `workflow_origin` beside `workflow_snapshot` (§5.3) saying which
+scope won the walk, which file it was, and a digest of that file's bytes, so a
+task created six months ago can still be told apart from one created against
+the built-in of the same name.
+
 ### 5.3 Task
 
 A unit of work delivered by running a workflow against a project.
@@ -264,6 +279,7 @@ A unit of work delivered by running a workflow against a project.
 | `current_step` | index into the snapshot's step list |
 | `pending_input` | normalized InputRequest (§7.4) while state is `awaiting_input`; cleared on answer, timeout, or process exit |
 | `pending_follow_up` | *Added 2026-08-25 (task 027).* The follow-up run a human asked for from `done` or `aborted` (§6): its compiled workflow, the run form and text it came from, the optional agent/model/effort, the **origin state** the task is returned to, the 1-based **round**, and the run's own **step cursor**. NULL when no follow-up is in flight |
+| `workflow_origin` | *Added 2026-08-28 (task 043).* Where the definition behind `workflow_name` came from, captured **once at creation** beside `workflow_snapshot`. It holds the **scope** that won §5.2's shadowing walk (`builtin`, `global`, `project`, or `derived`), the source **file relative to that scope's root** (`.vincent/workflows/adhoc.yaml`, `workflows/release.yaml`; absent for a built-in, which has none), and a **digest** — `sha256:<hex>` over the registry entry's source bytes exactly as loaded, with no normalization. It is **never recomputed**, so it identifies the *file version the task was created from* rather than the bytes the engine runs: include expansion (§7.9), fan-out resolution (§7.6) and `edit + retry` all rewrite `workflow_snapshot` afterwards, and `edit + retry` is separately audited through `step_runs.prompt_override` / `run_override`. A `fan_out` lane records `derived` naming its parent task (§7.6): its steps come from the parent's snapshot, resolved at the *parent's* creation, so it never read a registry at all. NULL for a task created before this was recorded, which is reported as `unknown` — never re-derived from today's registry, which would report a substitution as though it had always been there |
 | `github_issue` | *Added 2026-08-26 (task 035).* The GitHub issue this task was created from, captured **once at creation** and NULL for every task created without one. It holds the normalized issue — repo, number, title, body, url, state, labels, author, assignee, milestone (title and number), the issue's own timestamps and the instant it was fetched — and it is **never re-fetched**: every step renders `.Issue` (§8.4) from this snapshot, so an issue edited on GitHub afterwards is deliberately not reflected. That is the reasoning `workflow_snapshot` already rests on: a run is reproducible, no network call enters the step path, and a step render still cannot fail for an external reason. A `fan_out` lane inherits its parent's copy verbatim (§7.6) |
 
 
@@ -3752,6 +3768,12 @@ Two kinds of streams:
    `task.created`, `task.state_changed`, `task.priority_changed`, `task.step_advanced`,
    `task.status_changed`, `task.children_changed`, `project.*`,
    `workflow.registry_changed`, `agent.quota_changed`, `daemon.shutting_down`.
+   (`task.created` — *amended 2026-08-28, task 043* — carries
+   `workflow_origin` beside `workflow`: the scope, scope-relative file and
+   source digest the task's workflow name resolved to (§5.3), omitted only for
+   a task whose origin was not recorded. The name alone cannot tell a project
+   `adhoc.yaml` from the built-in it shadows, and a consumer that never fetches
+   the task should not have to.)
    (`task.status_changed` — *added 2026-08-26, task 036* — carries
    `{task_id, step_id, message}` and announces that a running step changed what
    it says about itself (§5.4). It is on the **durable** side deliberately: the
@@ -3881,6 +3903,15 @@ CREATE TABLE tasks (
                                               -- index, no generated column — so a linked task costs the same
                                               -- as any other on every board query. A fan_out lane inherits
                                               -- its parent's copy verbatim (§7.6)
+  workflow_origin_json TEXT,                  -- where workflow_name's definition came from (§5.2/§5.3, task 043,
+                                              -- migration 0017); NULL = origin not recorded, reported as `unknown`.
+                                              -- {scope, file, digest} for a registry-backed task and
+                                              -- {scope:"derived", parent_task_id} for a fan_out lane. `file` is
+                                              -- relative to its scope root, because an absolute path is where a
+                                              -- checkout happens to live rather than provenance. Frozen at
+                                              -- creation and never recomputed, so it names the file version the
+                                              -- task came from, not the bytes the engine runs. Nothing queries
+                                              -- inside it — no index, no generated column
   created_at          TEXT NOT NULL,
   updated_at          TEXT NOT NULL,
   started_at          TEXT,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3599,6 +3599,15 @@ GET    /v1/tasks/{id}                   full task incl. step runs summary and pe
                                         Every task representation carries `available_actions`
                                         (the §6 human actions valid right now) and
                                         `pause_requested`, so clients never restate the FSM.
+                                        *Added 2026-08-28 (task 043):* every task
+                                        representation also carries `workflow_origin` —
+                                        the scope that won §5.2's shadowing walk, the
+                                        source file relative to that scope's root and a
+                                        digest of the bytes it was loaded from, or
+                                        `derived` naming a fan-out lane's parent (§5.3).
+                                        null for a task created before origin was
+                                        recorded, which is *not recorded* and never a
+                                        re-lookup of today's registry
                                         Detail-only: `workflow_steps[]` — the task's snapshot
                                         as { index, id, type, prompt?, run?, instructions?,
                                         resolved_from[]? }, which is what edit+retry prefills

--- a/docs/tasks/043-workflow-origin.md
+++ b/docs/tasks/043-workflow-origin.md
@@ -1,0 +1,205 @@
+# 043 — Persisting where a task's workflow definition came from
+
+**Status:** ✅ done (6/6)
+**Issue:** [#145](https://github.com/lezli01/vincent/issues/145)
+**Spec:** amends §5.2, §5.3, §13.3, §14
+
+## Problem
+
+A task records `workflow_name` and `workflow_snapshot` and **nothing about
+where that definition came from**.
+
+Registry precedence is project → global → built-in (§5.2), and a task created
+without naming a workflow resolves to `adhoc`. So a repository that versions
+`.vincent/workflows/adhoc.yaml` silently replaces the built-in for every task
+created in it — including every task created by someone who never chose a
+workflow at all. The snapshot is durable, so the *steps* that ran are
+recoverable, but the answer to "did this run the built-in, or did this
+repository substitute its own?" is not recorded anywhere and cannot be
+reconstructed afterwards: looking the name up again reports today's registry,
+not the one the task was created against.
+
+The TUI's workflow picker shows a scope badge during selection, which helps a
+human who is choosing. It does nothing for the implicit CLI/API path, and
+nothing at all six months later.
+
+## What shipped
+
+One nullable JSON column, `tasks.workflow_origin_json` (migration 0017), written
+once at creation beside `workflow_snapshot` and never recomputed:
+
+| Field | Meaning |
+|---|---|
+| `scope` | `builtin`, `global`, `project`, or `derived` |
+| `file` | the source path **relative to its scope root** — `.vincent/workflows/adhoc.yaml`, `workflows/release.yaml`; absent for a built-in |
+| `digest` | `sha256:<hex>` over the registry entry's source bytes as loaded |
+| `parent_task_id` | set only for `derived`: the fan-out parent whose snapshot the lane's steps came from |
+
+Surfaced on every task the API serves (`workflow_origin`), in the `task.created`
+event, as the `origin` row of `vincent task show`, and beside the workflow name
+in the TUI's task-detail header.
+
+## Decisions
+
+**1. Resolution is unchanged — the substitution is made *visible*, not
+prevented.** *(2026-08-28)*
+
+The issue proposed a reserved `builtin:adhoc` identifier and a rule that
+built-ins are not shadowed by name. That reverses a recorded phase 2 decision
+(`docs/history/v0-tasks.md`: "`adhoc` becomes a **built-in registry entry** at
+lowest precedence (a real file named `adhoc` in either scope shadows it), so
+creation is one uniform path, `workflow` stays optional") and the §5.2 built-in
+contract, which covers all three built-ins rather than `adhoc` alone. The author
+was asked and chose to keep shadowing.
+
+`firstNonBlank(req.Workflow, project.DefaultWorkflow, workflow.AdhocName)` and
+`Registry.Lookup`'s project → global → built-in walk are therefore untouched.
+No reserved namespace, no `allow_shadow_builtin` declaration, no `builtin:adhoc`
+selector.
+
+The qualified selector was the expensive half. It would be a new name grammar
+four resolution sites must honour at once — `POST /v1/tasks`, `default_workflow`,
+a `fan_out` lane's `workflow:` and an `include` step's `workflow:` — and the
+current name pattern `^[a-z0-9][a-z0-9._-]*$` admits no colon, so it is a schema
+change stacked on a resolution change. Issue acceptance criteria 1, 2 and 3 are
+dropped; criterion 8 is honoured as *visibility* — two same-name workflows are
+told apart on the task row — rather than as a new selector grammar.
+
+**Beat:** reserving the built-in names, which would have been a silent
+behaviour change for any repository already shipping its own `adhoc.yaml`.
+
+**2. Three fields: scope, scope-relative file, digest.** *(2026-08-28)*
+
+No repository HEAD commit: capturing one means a git call inside `POST
+/v1/tasks`, plus a defined answer for a dirty tree and for a workflow file that
+is not committed at all — cost and edge cases out of proportion to "which
+definition ran".
+
+No separate include-provenance chain: the names are already there. Expansion
+records `resolved_from` per step in the snapshot and the API already returns it
+(`internal/api/tasks.go`, asserted by `internal/api/include_test.go`). What is
+genuinely missing is a file and digest *per included workflow*, and that is not
+being added.
+
+The file is **relative to its scope root** because an audit row outlives the
+checkout it was written in: `/Users/someone/src/app/.vincent/workflows/x.yaml`
+is machine state, not provenance. `Entry.File` stays absolute, and `GET
+/v1/workflows` goes on exposing it that way — that one is a live pointer to a
+file on this machine, which is a different thing.
+
+**3. The digest is of the source, frozen at creation.** *(2026-08-28)*
+
+It hashes the registry entry's bytes as loaded and is never recomputed, so it
+identifies **the file version this task was created from**, not the bytes the
+engine executes. Those diverge immediately and by design: include expansion
+(§7.9) and fan-out tree resolution (§7.6) both re-marshal the snapshot at
+creation, and `edit + retry` rewrites a step inside it afterwards (§5.3, PR C
+decision).
+
+This deliberately contradicts the issue's criterion 5 ("snapshot digest is
+computed from the exact bytes executed"). A digest that tracks the executed
+bytes stops identifying a registry file the moment an operator edits one, which
+is the question this column exists to answer; and `edit + retry` is already
+independently audited through `step_runs.prompt_override` / `run_override`.
+Criterion 6 ("edited workflow files never rewrite existing task provenance")
+falls out for free — nothing recomputes the value, and neither `UpdateTask` nor
+`TransitionTask` writes the column.
+
+**No normalization before hashing.** Raw bytes as loaded. A canonical form (line
+endings, trailing whitespace) exists nowhere else in this codebase, and a CRLF
+checkout genuinely *is* different bytes on disk; a normalizer here would make
+the digest claim two files agree when the daemon parsed different sources. The
+consequence is stated rather than papered over: **the same committed file
+digests differently on a Windows checkout with `autocrlf` than on a POSIX one.**
+Scope and file still match, and those are what identify the *file*; the digest
+identifies the *bytes*.
+
+**4. Legacy rows report missing provenance honestly.** *(2026-08-28)*
+
+The migration adds a nullable column and backfills nothing. NULL means "created
+before origin was recorded" and renders as `unknown` with that wording — never a
+synthesized scope, and never a re-lookup of today's registry, which would report
+the very substitution this feature exists to catch as though it had always been
+so. A NULL column scans to a nil pointer rather than a zero-valued origin: "not
+recorded" and "recorded as an empty scope" are different claims.
+
+**5. Surfaces: API, `vincent task show`, TUI detail header, `task.created`.**
+*(2026-08-28)*
+
+Not transcripts — those are the agent's own JSONL output and the daemon does not
+author their content. Not "task plan": no such command or endpoint exists in
+this repository (`internal/cli/task.go` has `add`/`ls`/`show`/`follow-up`/
+`cancel`, and `internal/api/server.go` has no `/plan` route), so that bullet in
+the issue names a surface that is not there.
+
+The TUI header shows scope and file but **not** the digest: that line is a
+glance, and half a hash compares against nothing. `vincent task show` and the
+API carry the whole digest, which is where an audit is actually done.
+
+The segment goes at the **end** of the header, after the branch. The detail
+view is the home shell's bottom-left pane rather than a takeover, so its header
+is roughly half the terminal wide and already truncates on a long title — the
+`scripts/screenshots.sh` capture of `tui-diff` shows it cut mid-branch-name
+before this change. Putting the origin earlier would have bought its visibility
+by pushing the project or the branch out, and the branch has no other home in
+the TUI. Nothing that was visible stops being visible; a wide terminal shows the
+origin; and the audit answer was already `vincent task show` by this same
+decision. `docs/assets/tui-diff.png` was re-captured and is unchanged in
+content for exactly that reason, so the committed asset was left alone rather
+than churned with capture noise.
+
+**6. A fan-out lane child records `scope: derived`, naming its parent.**
+*(2026-08-28)*
+
+A lane's steps come from the parent's snapshot, resolved at the *parent's*
+creation (§7.6); the child never reads the registry. Inheriting the parent's
+file and digest would claim the child's steps came from a file they did not come
+from, and leaving it NULL would read as a legacy row (decision 4). `derived`
+with the parent id is the true statement. This is a design call made in this
+task, not something the issue addresses.
+
+## Tasks
+
+- [x] **043.1** Migration `0017_workflow_origin.sql`, `store.WorkflowOrigin`,
+  `Task.WorkflowOrigin`, the column in `insertTaskTx` and every task scan, and
+  `workflow_origin` on the `task.created` payload.
+- [x] **043.2** `internal/workflow/origin.go`: `Origin`, `Entry.Origin`,
+  `SourceDigest`, and `Registry.GlobalDir`.
+- [x] **043.3** `POST /v1/tasks` fills the origin from the resolved entry;
+  `workflow_origin` on `taskResponse`; the matching wire type and renderers in
+  `internal/apiclient`.
+- [x] **043.4** `internal/taskrun/fanout.go` sets the derived origin on a lane.
+- [x] **043.5** `vincent task show`'s `origin` row and the TUI detail header.
+- [x] **043.6** Spec amendments (§5.2, §5.3, §13.3, §14), the API/CLI reference
+  pages, the workflows and TUI guides, and the changelog entry.
+
+## What the tests prove
+
+- **Store** (`internal/store/workfloworigin_test.go`) — an origin round-trips,
+  a derived origin keeps its parent id and claims no file, a row with NULL
+  `workflow_origin_json` scans as *unrecorded*, and the value survives a §6
+  transition.
+- **Workflow** (`internal/workflow/origin_test.go`) — the built-in `adhoc` and a
+  project `adhoc.yaml` produce different scopes and different digests; a global
+  entry's file reads `workflows/x.yaml`; the digest is stable across a reload of
+  unchanged bytes and moves when the bytes do; `SourceDigest` hashes raw bytes,
+  LF and CRLF included.
+- **API — the issue's actual complaint** (`internal/api/origin_test.go`) — two
+  projects, one with `.vincent/workflows/adhoc.yaml` and one without, each
+  creating a task with `workflow` omitted. Both run; the first reports
+  `scope: project` with that file and its digest, the second `scope: builtin`.
+  That is criterion 8 satisfied as visibility.
+- **API — provenance is immutable** — rewriting the workflow file after creation
+  leaves the task's origin untouched, and so does a rewritten
+  `workflow_snapshot`.
+- **API — the digest names the file, not the snapshot** — a workflow with an
+  `include` produces a task whose snapshot is the expanded form while the digest
+  matches the caller's own source bytes.
+- **Fan-out** (`internal/taskrun/fanout_test.go`) — a lane child's origin is
+  `derived` naming the parent, not a copy of the parent's file and digest.
+- **CLI/TUI** — `apiclient`'s renderers cover all four shapes including
+  `unknown`; the TUI detail header carries each of them; and the CLI e2e run
+  asserts the `origin` row on a real `vincent task show`.
+
+No gate script changes: this adds no cross-process seam the seven existing gates
+do not already cross.

--- a/docs/tasks/043-workflow-origin.md
+++ b/docs/tasks/043-workflow-origin.md
@@ -2,7 +2,7 @@
 
 **Status:** ✅ done (6/6)
 **Issue:** [#145](https://github.com/lezli01/vincent/issues/145)
-**Spec:** amends §5.2, §5.3, §13.3, §14
+**Spec:** amends §5.2, §5.3, §13.2, §13.3, §14
 
 ## Problem
 
@@ -170,7 +170,7 @@ task, not something the issue addresses.
   `internal/apiclient`.
 - [x] **043.4** `internal/taskrun/fanout.go` sets the derived origin on a lane.
 - [x] **043.5** `vincent task show`'s `origin` row and the TUI detail header.
-- [x] **043.6** Spec amendments (§5.2, §5.3, §13.3, §14), the API/CLI reference
+- [x] **043.6** Spec amendments (§5.2, §5.3, §13.2, §13.3, §14), the API/CLI reference
   pages, the workflows and TUI guides, and the changelog entry.
 
 ## What the tests prove

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -56,6 +56,7 @@ the living engineering specification records implementation contracts.
 | [040](040-api-idempotency-keys.md) | Idempotency keys for `POST /v1/tasks` | ✅ done (7/7) |
 | [041](041-adapter-compatibility-health.md) | Adapter version compatibility and protocol health | ✅ done (5/5) |
 | [042](042-gosec-static-analysis.md) | gosec in the normal static-analysis gate, with reviewed suppressions | ✅ done (5/5) |
+| [043](043-workflow-origin.md) | Persisting where a task's workflow definition came from | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/api/origin_test.go
+++ b/internal/api/origin_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// Workflow origin over the API (task 043, issue #145). §5.2's built-in
+// shadowing is unchanged: a project or global `adhoc.yaml` still wins. What
+// these assert is that the substitution is *visible* on the task afterwards.
+
+type originBody struct {
+	Scope        string `json:"scope"`
+	File         string `json:"file"`
+	Digest       string `json:"digest"`
+	ParentTaskID *int64 `json:"parent_task_id"`
+}
+
+// originOf creates a task and returns its id and the origin the API reports.
+func originOf(t *testing.T, h *workflowHarness, req map[string]any) (int64, originBody) {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/tasks", req)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d %s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID     int64      `json:"id"`
+		Origin originBody `json:"workflow_origin"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return created.ID, created.Origin
+}
+
+// fetchOrigin re-reads a task and returns the origin on the detail response.
+func fetchOrigin(t *testing.T, h *workflowHarness, id int64) originBody {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks/"+itoa(id), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get task: %d %s", resp.StatusCode, body)
+	}
+	var got struct {
+		Origin originBody `json:"workflow_origin"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return got.Origin
+}
+
+// TestTaskOriginSeesAShadowedAdhoc is the issue's actual complaint. Two
+// projects, one versioning `.vincent/workflows/adhoc.yaml` and one not, each
+// creating a task with `workflow` omitted. Both run — resolution is unchanged
+// — and the task row says which definition each one got.
+func TestTaskOriginSeesAShadowedAdhoc(t *testing.T) {
+	h := newWorkflowHarness(t)
+	shadowingRepo := testrepo.Init(t, "main")
+	shadowSrc := manualYAML(workflow.AdhocName, "the project's own adhoc")
+	writeWorkflowFile(t, filepath.Join(shadowingRepo, workflow.ProjectDirName),
+		workflow.AdhocName, shadowSrc)
+
+	shadowing := h.mustCreate(t, map[string]any{"path": shadowingRepo})
+	plain := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+
+	_, shadowed := originOf(t, h, map[string]any{
+		"project_id": int64(shadowing["id"].(float64)), "title": "implicit adhoc",
+	})
+	if shadowed.Scope != store.WorkflowScopeProject {
+		t.Errorf("scope = %q, want %q", shadowed.Scope, store.WorkflowScopeProject)
+	}
+	if want := ".vincent/workflows/adhoc.yaml"; shadowed.File != want {
+		t.Errorf("file = %q, want %q", shadowed.File, want)
+	}
+	if want := workflow.SourceDigest(shadowSrc); shadowed.Digest != want {
+		t.Errorf("digest = %q, want %q — the bytes the registry loaded", shadowed.Digest, want)
+	}
+
+	_, builtin := originOf(t, h, map[string]any{
+		"project_id": int64(plain["id"].(float64)), "title": "implicit adhoc",
+	})
+	if builtin.Scope != store.WorkflowScopeBuiltin {
+		t.Errorf("scope = %q, want %q", builtin.Scope, store.WorkflowScopeBuiltin)
+	}
+	if builtin.File != "" {
+		t.Errorf("file = %q, want none: a built-in has no file", builtin.File)
+	}
+	if builtin.Digest == shadowed.Digest {
+		t.Error("both tasks report the same digest; the shadowed adhoc is still invisible")
+	}
+}
+
+// TestTaskOriginIsFrozenAtCreation: editing the workflow file afterwards must
+// not rewrite an existing task's provenance, and neither must a rewrite of the
+// snapshot — the digest names the file version the task was created from, not
+// the bytes the engine is executing (decision 3).
+func TestTaskOriginIsFrozenAtCreation(t *testing.T) {
+	h := newWorkflowHarness(t)
+	repo := testrepo.Init(t, "main")
+	dir := filepath.Join(repo, workflow.ProjectDirName)
+	writeWorkflowFile(t, dir, "release", manualYAML("release", "before"))
+	p := h.mustCreate(t, map[string]any{"path": repo})
+
+	id, at := originOf(t, h, map[string]any{
+		"project_id": int64(p["id"].(float64)), "title": "frozen", "workflow": "release",
+	})
+
+	writeWorkflowFile(t, dir, "release", manualYAML("release", "after"))
+	h.reg.Reload()
+	if got := fetchOrigin(t, h, id); got != at {
+		t.Errorf("an edit to the file moved an existing task's origin:\n %+v\nwas\n %+v", got, at)
+	}
+
+	// The snapshot's own bytes move under `edit + retry`; the origin does not.
+	task, err := h.store.GetTask(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	task.WorkflowSnapshot = manualYAML("release", "rewritten by edit+retry")
+	if err := h.store.UpdateTask(t.Context(), task); err != nil {
+		t.Fatalf("UpdateTask: %v", err)
+	}
+	if got := fetchOrigin(t, h, id); got != at {
+		t.Errorf("a rewritten snapshot moved the origin:\n %+v\nwas\n %+v", got, at)
+	}
+}
+
+// TestTaskOriginDigestsTheFileNotTheSnapshot: include expansion re-marshals the
+// snapshot at creation (§7.9), so the two genuinely differ. The digest is of
+// the caller's own source, which is what makes it identify a registry file.
+func TestTaskOriginDigestsTheFileNotTheSnapshot(t *testing.T) {
+	h := newWorkflowHarness(t)
+	rootSrc := "name: root\nsteps:\n" +
+		"  - {id: work, type: manual, instructions: do the thing}\n" +
+		"  - {id: verify, type: include, workflow: checks}\n"
+	writeWorkflowFile(t, h.globalDir, "checks",
+		"name: checks\nsteps:\n  - {id: gate, type: manual, instructions: check it}\n")
+	writeWorkflowFile(t, h.globalDir, "root", rootSrc)
+	h.reg.ReloadGlobal()
+	p := h.mustCreate(t, map[string]any{"path": testrepo.Init(t, "main")})
+
+	id, got := originOf(t, h, map[string]any{
+		"project_id": int64(p["id"].(float64)), "title": "included", "workflow": "root",
+	})
+	if want := workflow.SourceDigest(rootSrc); got.Digest != want {
+		t.Errorf("digest = %q, want %q — the caller's own source bytes", got.Digest, want)
+	}
+	task, err := h.store.GetTask(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.WorkflowSnapshot == rootSrc {
+		t.Fatal("the snapshot was not expanded; this test proves nothing")
+	}
+	if strings.Contains(task.WorkflowSnapshot, "type: include") {
+		t.Error("the snapshot still carries an include step")
+	}
+	if got.Digest == workflow.SourceDigest(task.WorkflowSnapshot) {
+		t.Error("the digest tracks the snapshot rather than the file it came from")
+	}
+}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -30,6 +30,16 @@ func firstNonBlank(values ...string) string {
 	return ""
 }
 
+// taskOrigin records which definition a task was created from (§5.3, task
+// 043). The entry is the one Lookup's shadowing walk just returned, so this
+// costs no second registry read, and the value is frozen here: nothing
+// recomputes it afterwards, which is what lets it still answer "did a project
+// `adhoc.yaml` stand in for the built-in" months later.
+func taskOrigin(entry workflow.Entry, projectPath, globalDir string) *store.WorkflowOrigin {
+	o := entry.Origin(projectPath, globalDir)
+	return &store.WorkflowOrigin{Scope: string(o.Scope), File: o.File, Digest: o.Digest}
+}
+
 // ptrValue dereferences an optional string field, treating nil as empty.
 func ptrValue(p *string) string {
 	if p == nil {
@@ -101,6 +111,12 @@ type taskResponse struct {
 	// captured and never refreshed — clients render it as history, not as the
 	// issue's current state.
 	GitHubIssue *github.Issue `json:"github_issue"`
+	// WorkflowOrigin is where the task's workflow definition came from (§5.3,
+	// task 043): scope, scope-relative file and source digest, or `derived`
+	// naming the parent of a fan-out lane. Null for a task created before the
+	// origin was recorded, which clients render as `unknown` — never as a
+	// synthesized scope, and never re-derived from today's registry.
+	WorkflowOrigin *store.WorkflowOrigin `json:"workflow_origin"`
 	// AvailableActions are the §6 human actions valid from the current
 	// state. Derived, never stored: clients render an action bar from this
 	// rather than restating the state machine.
@@ -186,6 +202,7 @@ func toTaskResponse(t *store.Task, summary snapshotSummary) taskResponse {
 		QueuedReason:     nilIfEmpty(t.QueuedReason),
 		PendingInput:     rawIfNotEmpty(t.PendingInputJSON),
 		GitHubIssue:      t.GitHubIssue,
+		WorkflowOrigin:   t.WorkflowOrigin,
 		PauseRequested:   t.PauseRequested,
 		AvailableActions: availableActions(t.State),
 		CreatedAt:        t.CreatedAt.UTC().Format(time.RFC3339),
@@ -550,6 +567,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		Title:            title,
 		WorkflowName:     entry.Name,
 		WorkflowSnapshot: snapshot,
+		WorkflowOrigin:   taskOrigin(entry, project.Path, s.deps.Workflows.GlobalDir()),
 		BaseBranch:       baseBranch,
 		Fields:           req.Fields,
 		AgentOverride:    agentOverride,

--- a/internal/apiclient/origin_test.go
+++ b/internal/apiclient/origin_test.go
@@ -1,0 +1,54 @@
+package apiclient
+
+import "testing"
+
+// The four shapes a task's workflow origin renders as (task 043). A client
+// never composes these itself: the nil case is a real one — a task created
+// before migration 0017 — and it must read as "not recorded", never as a
+// guessed scope.
+func TestWorkflowOriginRendering(t *testing.T) {
+	parent := int64(41)
+	digest := "sha256:0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e"
+	for _, tc := range []struct {
+		name          string
+		origin        *WorkflowOrigin
+		source, whole string
+	}{
+		{
+			name:   "unrecorded",
+			origin: nil,
+			source: "unknown", whole: "unknown",
+		},
+		{
+			name:   "builtin",
+			origin: &WorkflowOrigin{Scope: "builtin", Digest: digest},
+			source: "built-in", whole: "built-in " + digest,
+		},
+		{
+			name:   "project",
+			origin: &WorkflowOrigin{Scope: "project", File: ".vincent/workflows/adhoc.yaml", Digest: digest},
+			source: "project .vincent/workflows/adhoc.yaml",
+			whole:  "project .vincent/workflows/adhoc.yaml " + digest,
+		},
+		{
+			name:   "global",
+			origin: &WorkflowOrigin{Scope: "global", File: "workflows/release.yaml", Digest: digest},
+			source: "global workflows/release.yaml",
+			whole:  "global workflows/release.yaml " + digest,
+		},
+		{
+			name:   "derived",
+			origin: &WorkflowOrigin{Scope: "derived", ParentTaskID: &parent},
+			source: "derived from task 41", whole: "derived from task 41",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.origin.Source(); got != tc.source {
+				t.Errorf("Source() = %q, want %q", got, tc.source)
+			}
+			if got := tc.origin.Display(); got != tc.whole {
+				t.Errorf("Display() = %q, want %q", got, tc.whole)
+			}
+		})
+	}
+}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -23,6 +23,12 @@ type Task struct {
 	State       string            `json:"state"`
 	Priority    int               `json:"priority"`
 
+	// WorkflowOrigin is where the task's workflow definition came from (§5.3,
+	// task 043). Nil for a task created before origin was recorded; the
+	// renderers below say `unknown` for that rather than guessing, because a
+	// guess is exactly the silent substitution this field exists to expose.
+	WorkflowOrigin *WorkflowOrigin `json:"workflow_origin,omitempty"`
+
 	// BranchName is the task's branch (§5.3). It belongs on the list row and
 	// not on TaskDetail alone: with configurable names (task 001) a
 	// `vincent/*` glob no longer finds every branch vincent made, so the
@@ -329,6 +335,56 @@ type TaskDetail struct {
 	// WorkflowSteps is the task's snapshot: the text edit+retry opens in an
 	// editor, and a gate's instructions.
 	WorkflowSteps []WorkflowStep `json:"workflow_steps,omitempty"`
+}
+
+// WorkflowOrigin is a task's recorded workflow provenance (§5.3, task 043):
+// which scope of the registry won the shadowing walk, the source file relative
+// to that scope's root, and a digest of the bytes it was created from. A
+// fan-out lane instead carries `derived` naming its parent, whose snapshot its
+// steps came from (§7.6).
+//
+// It is frozen at creation. The digest names the file version the task was
+// created from, not the bytes the engine ran: include expansion, fan-out
+// resolution and `edit + retry` all rewrite the snapshot afterwards.
+type WorkflowOrigin struct {
+	Scope        string `json:"scope"`
+	File         string `json:"file,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	ParentTaskID *int64 `json:"parent_task_id,omitempty"`
+}
+
+// Source names where the definition came from, without the digest: `built-in`,
+// `project .vincent/workflows/adhoc.yaml`, `derived from task 41`, or `unknown`
+// for a task that predates the record. A nil receiver is the unrecorded case,
+// so a caller never has to guard.
+func (o *WorkflowOrigin) Source() string {
+	if o == nil || o.Scope == "" {
+		return "unknown"
+	}
+	switch o.Scope {
+	case "builtin":
+		return "built-in"
+	case "derived":
+		if o.ParentTaskID != nil {
+			return fmt.Sprintf("derived from task %d", *o.ParentTaskID)
+		}
+		return "derived"
+	}
+	if o.File == "" {
+		return o.Scope
+	}
+	return o.Scope + " " + o.File
+}
+
+// Display is Source plus the digest — the full audit line. The digest is
+// printed whole rather than abbreviated: it is the part a reader compares
+// against a file, and half of a hash compares against nothing.
+func (o *WorkflowOrigin) Display() string {
+	src := o.Source()
+	if o == nil || o.Digest == "" {
+		return src
+	}
+	return src + " " + o.Digest
 }
 
 // WorkflowStep is one step of the task's snapshot (§13.2).

--- a/internal/cli/commands_e2e_test.go
+++ b/internal/cli/commands_e2e_test.go
@@ -126,8 +126,13 @@ func TestCommandsAgainstLiveDaemon(t *testing.T) {
 		// The project name is included deliberately: `task show` printed a
 		// blank project row until the detail endpoint learned to carry it
 		// (T4.4 walkthrough finding).
+		// `origin` is asserted for the same reason `project` is: this task was
+		// created without naming a workflow, so it ran the built-in adhoc, and
+		// the row is what says so rather than leaving the name ambiguous
+		// (task 043).
 		for _, want := range []string{
 			"cli e2e task", "created by the CLI test", created.BranchName, filepath.Base(repo),
+			"origin", "built-in sha256:",
 		} {
 			if !strings.Contains(out, want) {
 				t.Errorf("task show is missing %q:\n%s", want, out)

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -252,6 +252,11 @@ func newTaskShowCmd() *cobra.Command {
 					{"state", t.State},
 					{"project", t.ProjectName},
 					{"workflow", t.Workflow},
+					// Which definition that name resolved to (task 043). Always
+					// printed, including `unknown` for a task created before the
+					// record: "no provenance" is the honest answer for those, and
+					// silently omitting the row would read like the built-in.
+					{"origin", t.WorkflowOrigin.Display()},
 					{"step", progress(t.Task)},
 					{"branch", t.BranchName},
 				}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 16
+const latestSchemaVersion = 17
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0017_workflow_origin.sql
+++ b/internal/store/migrations/0017_workflow_origin.sql
@@ -1,0 +1,27 @@
+-- 0017_workflow_origin: where a task's workflow definition came from (task
+-- 040, spec §5.2/§5.3/§14).
+--
+-- One nullable JSON column, the shape 0012's pending_follow_up_json and 0014's
+-- github_issue_json already set: NULL means the task was created before origin
+-- was recorded, and clients render that as `unknown` rather than synthesizing a
+-- scope. Nothing queries inside it — no index, no generated column — so a task
+-- carrying one costs the same as any other on every board query.
+--
+-- The payload is {scope, file, digest} for a task created from the registry and
+-- {scope: "derived", parent_task_id} for a fan-out lane. `scope` is builtin,
+-- global, project or derived; `file` is the source path **relative to its scope
+-- root** (`.vincent/workflows/x.yaml`, `workflows/x.yaml`), because an absolute
+-- path is where this checkout happens to live rather than provenance; `digest`
+-- is sha256 over the registry entry's source bytes as loaded.
+--
+-- It is a **snapshot**, like workflow_snapshot and github_issue_json beside it.
+-- The digest names the file version the task was created from, not the bytes the
+-- engine executes: include expansion (§7.9) and fan-out resolution (§7.6)
+-- re-marshal the snapshot at creation, and `edit + retry` rewrites a step inside
+-- it afterwards. Nothing recomputes this column, which is exactly what makes it
+-- answer "which definition did this task come from" months later.
+--
+-- No backfill. A pre-0017 task genuinely has no recorded origin, and re-looking
+-- up today's registry to invent one would report the substitution this column
+-- exists to catch as though it had always been there.
+ALTER TABLE tasks ADD COLUMN workflow_origin_json TEXT; -- NULL = origin not recorded

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -153,11 +153,59 @@ type Task struct {
 	// which is why a step render still cannot fail for an external reason
 	// (§8.4). A fan-out lane inherits its parent's copy verbatim.
 	GitHubIssue *github.Issue
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	StartedAt   *time.Time
-	FinishedAt  *time.Time
-	ArchivedAt  *time.Time
+	// WorkflowOrigin is where this task's workflow definition came from
+	// (§5.3, task 043), captured once at creation beside WorkflowSnapshot.
+	// nil means the origin was not recorded — a task created before migration
+	// 0017 — and is reported as `unknown`, never re-derived from today's
+	// registry: a re-lookup would report the shadowing this field exists to
+	// make visible as though it had always been so.
+	WorkflowOrigin *WorkflowOrigin
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	StartedAt      *time.Time
+	FinishedAt     *time.Time
+	ArchivedAt     *time.Time
+}
+
+// Workflow origin scopes (task 043). The first three mirror workflow.Scope —
+// the shadowing walk's three registry scopes — and `derived` is the one a
+// registry can never produce: a fan-out lane's steps come from its parent's
+// snapshot, resolved at the *parent's* creation (§7.6), so the lane never reads
+// a registry at all.
+const (
+	WorkflowScopeBuiltin = "builtin"
+	WorkflowScopeGlobal  = "global"
+	WorkflowScopeProject = "project"
+	WorkflowScopeDerived = "derived"
+)
+
+// WorkflowOrigin is a task's recorded workflow provenance (§5.3, task 043),
+// stored as the JSON of `workflow_origin_json`.
+//
+// It is deliberately its own type rather than workflow.Origin: that one
+// describes a registry *entry*, and this one describes a *task*, whose origin
+// may be `derived` — a scope no entry has. The registry-backed shapes are
+// converted from workflow.Origin at task creation.
+//
+// Frozen at creation and never recomputed. The digest therefore identifies the
+// file version the task was created from, not the bytes the engine executes:
+// include expansion (§7.9), fan-out resolution (§7.6) and `edit + retry` all
+// rewrite WorkflowSnapshot afterwards, and `edit + retry` is independently
+// audited through step_runs.prompt_override / run_override.
+type WorkflowOrigin struct {
+	// Scope is one of the WorkflowScope* constants above.
+	Scope string `json:"scope"`
+	// File is the source path relative to its scope root, forward-slashed —
+	// `.vincent/workflows/adhoc.yaml`, `workflows/release.yaml`. Empty for
+	// `builtin` and `derived`.
+	File string `json:"file,omitempty"`
+	// Digest is `sha256:<hex>` over the registry entry's source bytes as
+	// loaded. Empty for `derived`.
+	Digest string `json:"digest,omitempty"`
+	// ParentTaskID names the task whose fan_out step spawned this lane; set
+	// only for `derived`. Inheriting the parent's file and digest instead
+	// would claim the lane's steps came from a file they did not come from.
+	ParentTaskID *int64 `json:"parent_task_id,omitempty"`
 }
 
 // StepRun is one attempt at executing one step of one task; history is

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -17,7 +17,7 @@ const taskColumns = `id, project_id, title, description, fields_json, workflow_n
 	base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 	state, current_step, block_reason, pause_requested, retry_cursor_at, pending_override_json,
 	pending_repair_json, pending_follow_up_json, pending_input_json, admit_not_before, queued_reason,
-	parent_task_id, parent_step_index, lane_id, lane_order, github_issue_json,
+	parent_task_id, parent_step_index, lane_id, lane_order, github_issue_json, workflow_origin_json,
 	created_at, updated_at, started_at, finished_at, archived_at`
 
 // slotStates is the set of states that occupy a concurrency slot (spec §11),
@@ -172,18 +172,24 @@ func insertTaskTx(
 	if err != nil {
 		return nil, fmt.Errorf("insert task: %w", err)
 	}
+	originJSON, err := marshalWorkflowOrigin(t.WorkflowOrigin)
+	if err != nil {
+		return nil, fmt.Errorf("insert task: %w", err)
+	}
 	res, err := tx.ExecContext(ctx, `
 		INSERT INTO tasks (project_id, title, description, fields_json, workflow_name, workflow_snapshot,
 			base_branch, branch_name, worktree_path, priority, agent_override, model_override, effort_override,
 			state, current_step, block_reason,
 			parent_task_id, parent_step_index, lane_id, lane_order, github_issue_json,
+			workflow_origin_json,
 			created_at, updated_at, started_at, finished_at, archived_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		t.ProjectID, t.Title, t.Description, fields, t.WorkflowName, t.WorkflowSnapshot,
 		t.BaseBranch, t.BranchName, nullString(t.WorktreePath), t.Priority,
 		nullString(t.AgentOverride), nullString(t.ModelOverride), nullString(t.EffortOverride),
 		string(t.State), t.CurrentStep, nullString(t.BlockReason),
 		t.ParentTaskID, t.ParentStepIndex, nullString(t.LaneID), t.LaneOrder, issueJSON,
+		originJSON,
 		formatTime(t.CreatedAt), formatTime(t.UpdatedAt),
 		formatTimePtr(t.StartedAt), formatTimePtr(t.FinishedAt), formatTimePtr(t.ArchivedAt))
 	if err != nil {
@@ -210,9 +216,16 @@ func insertTaskTx(
 	if err := claimBranchTx(ctx, tx, t.ProjectID, t.BranchName, id); err != nil {
 		return nil, err
 	}
-	payload, err := json.Marshal(map[string]any{
+	// `workflow_origin` rides beside `workflow` (task 043): the name alone
+	// cannot tell a shadowed `adhoc` from the built-in, and an event consumer
+	// that never fetches the task should not have to.
+	created := map[string]any{
 		"state": string(t.State), "title": t.Title, "workflow": t.WorkflowName,
-	})
+	}
+	if t.WorkflowOrigin != nil {
+		created["workflow_origin"] = t.WorkflowOrigin
+	}
+	payload, err := json.Marshal(created)
 	if err != nil {
 		return nil, fmt.Errorf("marshal task.created event: %w", err)
 	}
@@ -870,6 +883,7 @@ func scanTask(r rowScanner) (*Task, error) {
 		laneID                         sql.NullString
 		laneOrder                      sql.NullInt64
 		githubIssue                    sql.NullString
+		workflowOrigin                 sql.NullString
 		created, updated               string
 		started, finished, archived    sql.NullString
 	)
@@ -879,7 +893,7 @@ func scanTask(r rowScanner) (*Task, error) {
 		(*string)(&t.State), &t.CurrentStep, &blockReason,
 		&t.PauseRequested, &retryCursor, &pendingOv,
 		&pendingRepair, &pendingFollowUp, &pendingInput, &admitNotBefore, &queuedWhy,
-		&parentID, &parentStep, &laneID, &laneOrder, &githubIssue,
+		&parentID, &parentStep, &laneID, &laneOrder, &githubIssue, &workflowOrigin,
 		&created, &updated, &started, &finished, &archived); err != nil {
 		return nil, err
 	}
@@ -928,6 +942,16 @@ func scanTask(r rowScanner) (*Task, error) {
 		}
 		t.GitHubIssue = &issue
 	}
+	// A NULL column stays nil rather than becoming a zero-valued origin: "not
+	// recorded" and "recorded as an empty scope" are different claims, and only
+	// the first one is true of a pre-0017 row (task 043 decision 4).
+	if workflowOrigin.Valid && workflowOrigin.String != "" {
+		var origin WorkflowOrigin
+		if err := json.Unmarshal([]byte(workflowOrigin.String), &origin); err != nil {
+			return nil, fmt.Errorf("workflow_origin_json: %w", err)
+		}
+		t.WorkflowOrigin = &origin
+	}
 	if err := json.Unmarshal([]byte(fields), &t.Fields); err != nil {
 		return nil, fmt.Errorf("fields_json: %w", err)
 	}
@@ -969,6 +993,20 @@ func marshalGitHubIssue(issue *github.Issue) (any, error) {
 	b, err := json.Marshal(issue)
 	if err != nil {
 		return nil, fmt.Errorf("marshal github issue: %w", err)
+	}
+	return string(b), nil
+}
+
+// marshalWorkflowOrigin renders a task's workflow provenance for storage; no
+// origin is SQL NULL, the same shape marshalGitHubIssue uses for its column
+// (task 043 decision 4).
+func marshalWorkflowOrigin(origin *WorkflowOrigin) (any, error) {
+	if origin == nil || origin.Scope == "" {
+		return nil, nil
+	}
+	b, err := json.Marshal(origin)
+	if err != nil {
+		return nil, fmt.Errorf("marshal workflow origin: %w", err)
 	}
 	return string(b), nil
 }

--- a/internal/store/workfloworigin_test.go
+++ b/internal/store/workfloworigin_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The `workflow_origin_json` column (migration 0017, task 043). It records
+// which definition a task's workflow name resolved to, so a project or global
+// file shadowing a built-in is visible on the task forever afterwards. Like
+// `github_issue_json` beside it, it is written once and never recomputed.
+
+func projectOrigin() *WorkflowOrigin {
+	return &WorkflowOrigin{
+		Scope:  WorkflowScopeProject,
+		File:   ".vincent/workflows/adhoc.yaml",
+		Digest: "sha256:0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e0f4a1c1e",
+	}
+}
+
+func TestTaskWorkflowOriginRoundTrip(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "provenance")
+
+	in := newTask(p.ID, "shadowed-adhoc", TaskQueued)
+	in.WorkflowOrigin = projectOrigin()
+	if err := s.CreateTask(ctx, in, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	out, err := s.GetTask(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if out.WorkflowOrigin == nil {
+		t.Fatal("the stored task carries no workflow origin")
+	}
+	if !reflect.DeepEqual(*out.WorkflowOrigin, *projectOrigin()) {
+		t.Errorf("origin round-tripped as\n %+v\nwant\n %+v", *out.WorkflowOrigin, *projectOrigin())
+	}
+}
+
+// TestTaskDerivedWorkflowOriginRoundTrip: a fan-out lane carries `derived`
+// naming its parent instead of a file and digest (decision 6), so the parent id
+// has to survive the column too.
+func TestTaskDerivedWorkflowOriginRoundTrip(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "lanes")
+
+	parent := newTask(p.ID, "root", TaskQueued)
+	if err := s.CreateTask(ctx, parent, nil); err != nil {
+		t.Fatalf("CreateTask parent: %v", err)
+	}
+	in := newTask(p.ID, "lane", TaskQueued)
+	in.WorkflowOrigin = &WorkflowOrigin{Scope: WorkflowScopeDerived, ParentTaskID: &parent.ID}
+	if err := s.CreateTask(ctx, in, nil); err != nil {
+		t.Fatalf("CreateTask lane: %v", err)
+	}
+	out, err := s.GetTask(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if out.WorkflowOrigin == nil || out.WorkflowOrigin.Scope != WorkflowScopeDerived {
+		t.Fatalf("lane origin = %+v, want scope %q", out.WorkflowOrigin, WorkflowScopeDerived)
+	}
+	if out.WorkflowOrigin.ParentTaskID == nil || *out.WorkflowOrigin.ParentTaskID != parent.ID {
+		t.Errorf("lane origin parent = %v, want %d", out.WorkflowOrigin.ParentTaskID, parent.ID)
+	}
+	if out.WorkflowOrigin.File != "" || out.WorkflowOrigin.Digest != "" {
+		t.Errorf("lane origin claims a file or digest it does not have: %+v", out.WorkflowOrigin)
+	}
+}
+
+// TestTaskWithoutAnOriginStoresNull: a row created before migration 0017 has
+// no provenance, and reads back as *unrecorded* rather than as a zero-valued
+// origin — "created before origin was recorded" and "created from an empty
+// scope" are different claims and only one of them is true (decision 4).
+func TestTaskWithoutAnOriginStoresNull(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "legacy")
+
+	in := newTask(p.ID, "pre-0017", TaskQueued)
+	if err := s.CreateTask(ctx, in, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	out, err := s.GetTask(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if out.WorkflowOrigin != nil {
+		t.Errorf("a task with no recorded origin read back with one: %+v", out.WorkflowOrigin)
+	}
+	var raw any
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT workflow_origin_json FROM tasks WHERE id = ?`, in.ID).Scan(&raw); err != nil {
+		t.Fatalf("read column: %v", err)
+	}
+	if raw != nil {
+		t.Errorf("workflow_origin_json = %v, want SQL NULL", raw)
+	}
+}
+
+// TestTaskOriginSurvivesATransition: the origin is not part of any
+// transition's write set, so walking the §6 lifecycle must not drop it.
+func TestTaskOriginSurvivesATransition(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "transitions-origin")
+
+	in := newTask(p.ID, "shadowed", TaskQueued)
+	in.WorkflowOrigin = projectOrigin()
+	if err := s.CreateTask(ctx, in, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	out, _, err := s.TransitionTask(ctx, in.ID, TaskQueued, TaskRunning, TaskChange{})
+	if err != nil {
+		t.Fatalf("TransitionTask: %v", err)
+	}
+	if out.WorkflowOrigin == nil || out.WorkflowOrigin.File != projectOrigin().File {
+		t.Errorf("the origin did not survive a transition: %+v", out.WorkflowOrigin)
+	}
+}

--- a/internal/taskrun/fanout.go
+++ b/internal/taskrun/fanout.go
@@ -294,6 +294,16 @@ func (r *Runner) laneTask(env *stepEnv, lane workflow.Lane, order int) (*store.T
 		ParentStepIndex: &index,
 		LaneID:          lane.ID,
 		LaneOrder:       order,
+		// A lane's steps come from the parent's snapshot, resolved at the
+		// *parent's* creation (§7.6) — the child never reads a registry. So
+		// its origin is `derived` naming the parent, not a copy of the
+		// parent's file and digest, which would claim these steps came from a
+		// file they did not come from. Leaving it NULL is not an option
+		// either: that reads as a pre-0017 row (task 043 decision 6).
+		WorkflowOrigin: &store.WorkflowOrigin{
+			Scope:        store.WorkflowScopeDerived,
+			ParentTaskID: &env.task.ID,
+		},
 	}
 	// A lane spec overrides the inheritance for its own subtree.
 	if lane.Agent != "" {

--- a/internal/taskrun/fanout_test.go
+++ b/internal/taskrun/fanout_test.go
@@ -95,6 +95,22 @@ func TestFanOutSpawnsLanesAndMerges(t *testing.T) {
 		if !strings.Contains(lane.Title, lane.LaneID) {
 			t.Errorf("lane title %q does not name the lane", lane.Title)
 		}
+		// Provenance (task 043 decision 6): a lane's steps came from the
+		// parent's snapshot, not from a registry file, so it records `derived`
+		// naming the parent. Copying the parent's file and digest would claim
+		// a source these steps never had; leaving it NULL would read as a task
+		// created before origins were recorded.
+		origin := lane.WorkflowOrigin
+		if origin == nil || origin.Scope != store.WorkflowScopeDerived {
+			t.Errorf("lane %q origin = %+v, want scope %q", lane.LaneID, origin, store.WorkflowScopeDerived)
+			continue
+		}
+		if origin.ParentTaskID == nil || *origin.ParentTaskID != task.ID {
+			t.Errorf("lane %q origin parent = %v, want %d", lane.LaneID, origin.ParentTaskID, task.ID)
+		}
+		if origin.File != "" || origin.Digest != "" {
+			t.Errorf("lane %q origin claims a file or digest: %+v", lane.LaneID, origin)
+		}
 	}
 
 	done := h.waitForStateWithin(t, task.ID, fanOutBudget, store.TaskDone, store.TaskBlocked)

--- a/internal/tui/detailorigin_test.go
+++ b/internal/tui/detailorigin_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The detail header names the workflow *and* where its definition came from
+// (task 043). A name on its own cannot tell a project `adhoc.yaml` from the
+// built-in it shadows, which is the whole reason the origin is recorded.
+func TestDetailHeaderNamesTheWorkflowOrigin(t *testing.T) {
+	parent := int64(41)
+	for _, tc := range []struct {
+		name   string
+		origin *apiclient.WorkflowOrigin
+		want   string
+	}{
+		{"unrecorded", nil, "adhoc (unknown)"},
+		{"builtin", &apiclient.WorkflowOrigin{Scope: "builtin", Digest: "sha256:beef"}, "adhoc (built-in)"},
+		{
+			"shadowed",
+			&apiclient.WorkflowOrigin{Scope: "project", File: ".vincent/workflows/adhoc.yaml"},
+			"adhoc (project .vincent/workflows/adhoc.yaml)",
+		},
+		{
+			"lane",
+			&apiclient.WorkflowOrigin{Scope: "derived", ParentTaskID: &parent},
+			"adhoc (derived from task 41)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDetail(t)
+			d.taskID = 42
+			d.applyLoaded(detailLoadedMsg{
+				id: d.taskID,
+				task: apiclient.TaskDetail{Task: apiclient.Task{
+					ID: d.taskID, Title: "detail task", State: stateRunning,
+					Workflow: "adhoc", WorkflowOrigin: tc.origin,
+				}},
+			})
+			got := d.headerLine()
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("header = %q, want it to carry %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -230,6 +230,14 @@ func (d *detail) headerLine() string {
 	if t.BranchName != "" {
 		parts = append(parts, styleDim.Render(t.BranchName))
 	}
+	// The workflow and where its definition came from (task 043). A name on
+	// its own cannot tell a project `adhoc.yaml` from the built-in it shadows,
+	// which is the whole point of recording an origin. The digest is left to
+	// `vincent task show` and the API: this line is a glance, and half a hash
+	// compares against nothing anyway.
+	if t.Workflow != "" {
+		parts = append(parts, styleDim.Render(t.Workflow+" ("+t.WorkflowOrigin.Source()+")"))
+	}
 	parts = append(parts, formatCost(t.CostUSD))
 	return strings.Join(parts, styleDim.Render(" · "))
 }

--- a/internal/workflow/origin.go
+++ b/internal/workflow/origin.go
@@ -1,0 +1,93 @@
+package workflow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+)
+
+// Origin is where one registry entry's definition came from (§5.2, task 043):
+// the scope that won the shadowing walk, the source file **relative to that
+// scope's root**, and a digest of the source bytes as loaded.
+//
+// It exists because `workflow_name` alone cannot tell two definitions apart. A
+// project or global file named `adhoc` shadows the built-in — a phase 2
+// decision that stands (§5.2) — so a task recording only the name leaves the
+// substitution invisible forever afterwards. This is how it is seen.
+//
+// The path is scope-relative rather than absolute: a task row outlives the
+// checkout it was created in, and `/Users/someone/src/app/.vincent/...` is
+// machine state, not provenance. It is spelled with forward slashes on every
+// platform for the same reason — the same committed file must read the same in
+// a task created on Windows and one created on Linux.
+type Origin struct {
+	Scope Scope `json:"scope"`
+	// File is empty for ScopeBuiltin: a built-in has no file.
+	File string `json:"file,omitempty"`
+	// Digest is `sha256:<hex>` over Source, hashed exactly as loaded.
+	Digest string `json:"digest,omitempty"`
+}
+
+// Origin describes where this entry came from. projectRoot is the repo root of
+// the entry's project scope and globalDir is `{config_dir}/workflows`; either
+// may be empty, in which case a path under it degrades to its base name rather
+// than leaking an absolute one.
+//
+// It lives here because this package is the only one that holds both halves:
+// the absolute path the loader recorded and the scope root it was found under.
+func (e Entry) Origin(projectRoot, globalDir string) Origin {
+	o := Origin{Scope: e.Scope, Digest: SourceDigest(e.Source)}
+	switch e.Scope {
+	case ScopeBuiltin:
+		// No file, by construction: builtins() sets Source and leaves File
+		// empty. The digest still identifies which binary's copy ran.
+	case ScopeProject:
+		o.File = scopeRelative(e.File, projectRoot, "")
+	case ScopeGlobal:
+		// Relative to the *config directory*, not to globalDir itself, so the
+		// value reads `workflows/x.yaml` and names the scope it came from.
+		o.File = scopeRelative(e.File, globalDir, GlobalDirName)
+	}
+	return o
+}
+
+// SourceDigest hashes a workflow source as `sha256:<hex>`.
+//
+// Raw bytes, with no normalization: this codebase has no canonical form for a
+// workflow file, and a CRLF checkout genuinely is different bytes on disk. A
+// normalizer here would make the digest claim two files agree when the daemon
+// would parse them from different sources. The consequence — the same committed
+// file digesting differently on a Windows checkout with `autocrlf` — is stated
+// in docs/tasks/043-workflow-origin.md rather than papered over.
+func SourceDigest(src string) string {
+	sum := sha256.Sum256([]byte(src))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// scopeRelative renders path relative to root, under an optional prefix. A path
+// that is not under root — or a root nobody supplied — degrades to the base
+// name: a relative path is the point, so an absolute fallback would defeat it.
+func scopeRelative(path, root, prefix string) string {
+	if path == "" {
+		return ""
+	}
+	rel := ""
+	if root != "" {
+		if r, err := filepath.Rel(root, path); err == nil && !strings.HasPrefix(r, "..") {
+			rel = r
+		}
+	}
+	if rel == "" {
+		rel = filepath.Base(path)
+	}
+	if prefix != "" {
+		rel = filepath.Join(prefix, rel)
+	}
+	return filepath.ToSlash(rel)
+}
+
+// GlobalDir is `{config_dir}/workflows`, the root of the global scope. It is
+// exposed so a caller building an Origin can name that scope's root without
+// having to re-derive the config directory the registry was constructed with.
+func (r *Registry) GlobalDir() string { return r.globalDir }

--- a/internal/workflow/origin_test.go
+++ b/internal/workflow/origin_test.go
@@ -1,0 +1,143 @@
+package workflow
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Origin is what tells two definitions of the same name apart (task 043). The
+// shadowing contract itself is unchanged — §5.2's built-in precedence stands —
+// so these assert that the substitution is *visible*, not prevented.
+
+func TestOriginTellsAShadowedAdhocFromTheBuiltin(t *testing.T) {
+	reg, globalDir := newTestRegistry(t)
+	repo := t.TempDir()
+	writeWorkflow(t, filepath.Join(repo, ProjectDirName), AdhocName,
+		manualWorkflow(AdhocName, "project override"))
+	reg.ReloadGlobal()
+	reg.SetProjects(map[int64]string{7: repo})
+
+	shadowed, ok := reg.Lookup(7, AdhocName)
+	if !ok {
+		t.Fatal("the project's adhoc.yaml did not resolve")
+	}
+	builtin, ok := reg.Lookup(0, AdhocName)
+	if !ok {
+		t.Fatal("the built-in adhoc did not resolve")
+	}
+
+	got := shadowed.Origin(repo, globalDir)
+	if got.Scope != ScopeProject {
+		t.Errorf("shadowing entry scope = %q, want %q", got.Scope, ScopeProject)
+	}
+	if want := ".vincent/workflows/adhoc.yaml"; got.File != want {
+		t.Errorf("shadowing entry file = %q, want %q", got.File, want)
+	}
+	base := builtin.Origin(repo, globalDir)
+	if base.Scope != ScopeBuiltin {
+		t.Errorf("built-in scope = %q, want %q", base.Scope, ScopeBuiltin)
+	}
+	if base.File != "" {
+		t.Errorf("built-in file = %q, want none: a built-in has no file", base.File)
+	}
+	// The point of the whole feature: same name, different definition, and the
+	// two are distinguishable on the task row afterwards.
+	if got.Digest == base.Digest {
+		t.Errorf("both digests are %q; a shadowed adhoc must not look like the built-in", got.Digest)
+	}
+	for _, d := range []string{got.Digest, base.Digest} {
+		if !strings.HasPrefix(d, "sha256:") || len(d) != len("sha256:")+64 {
+			t.Errorf("digest = %q, want sha256:<64 hex>", d)
+		}
+	}
+}
+
+// TestOriginGlobalFileIsNamedFromTheConfigDir: a global entry reads
+// `workflows/x.yaml`, which names the scope it came from — not the bare file
+// name, and not the absolute path of whichever machine created the task.
+func TestOriginGlobalFileIsNamedFromTheConfigDir(t *testing.T) {
+	reg, globalDir := newTestRegistry(t)
+	writeWorkflow(t, globalDir, "release", manualWorkflow("release", "global"))
+	reg.ReloadGlobal()
+
+	e, ok := reg.Lookup(0, "release")
+	if !ok {
+		t.Fatal("the global release.yaml did not resolve")
+	}
+	got := e.Origin("", reg.GlobalDir())
+	if got.Scope != ScopeGlobal {
+		t.Errorf("scope = %q, want %q", got.Scope, ScopeGlobal)
+	}
+	if want := "workflows/release.yaml"; got.File != want {
+		t.Errorf("file = %q, want %q", got.File, want)
+	}
+	if filepath.IsAbs(got.File) {
+		t.Errorf("file = %q, want a scope-relative path", got.File)
+	}
+}
+
+// TestOriginDigestIsStableAcrossAReload: nothing about re-reading unchanged
+// bytes may move the digest, or a task created before a reload would look like
+// it came from a different file than one created after it.
+func TestOriginDigestIsStableAcrossAReload(t *testing.T) {
+	reg, globalDir := newTestRegistry(t)
+	repo := t.TempDir()
+	writeWorkflow(t, filepath.Join(repo, ProjectDirName), "feature",
+		manualWorkflow("feature", "project"))
+	reg.ReloadGlobal()
+	reg.SetProjects(map[int64]string{7: repo})
+
+	first, ok := reg.Lookup(7, "feature")
+	if !ok {
+		t.Fatal("feature did not resolve")
+	}
+	reg.Reload()
+	second, ok := reg.Lookup(7, "feature")
+	if !ok {
+		t.Fatal("feature did not resolve after a reload")
+	}
+	a, b := first.Origin(repo, globalDir), second.Origin(repo, globalDir)
+	if a != b {
+		t.Errorf("origin changed across a reload of unchanged bytes:\n %+v\nthen\n %+v", a, b)
+	}
+}
+
+// TestOriginDigestFollowsTheBytes: a rewritten file is a different definition,
+// and the digest is the only field that says so — the scope and the path are
+// unchanged.
+func TestOriginDigestFollowsTheBytes(t *testing.T) {
+	reg, globalDir := newTestRegistry(t)
+	repo := t.TempDir()
+	dir := filepath.Join(repo, ProjectDirName)
+	writeWorkflow(t, dir, "feature", manualWorkflow("feature", "before"))
+	reg.ReloadGlobal()
+	reg.SetProjects(map[int64]string{7: repo})
+	before, _ := reg.Lookup(7, "feature")
+
+	writeWorkflow(t, dir, "feature", manualWorkflow("feature", "after"))
+	reg.Reload()
+	after, _ := reg.Lookup(7, "feature")
+
+	a, b := before.Origin(repo, globalDir), after.Origin(repo, globalDir)
+	if a.File != b.File || a.Scope != b.Scope {
+		t.Fatalf("scope/file moved unexpectedly: %+v then %+v", a, b)
+	}
+	if a.Digest == b.Digest {
+		t.Errorf("digest = %q for both revisions of the file", a.Digest)
+	}
+}
+
+// TestSourceDigestHashesRawBytes: no normalization. A CRLF checkout genuinely
+// is different bytes on disk, and inventing a canonical form here would make
+// the digest claim two files agree when the daemon parsed different sources.
+func TestSourceDigestHashesRawBytes(t *testing.T) {
+	lf := "name: x\nsteps: []\n"
+	crlf := strings.ReplaceAll(lf, "\n", "\r\n")
+	if SourceDigest(lf) == SourceDigest(crlf) {
+		t.Error("LF and CRLF sources digest the same; the digest is not over raw bytes")
+	}
+	if got, want := SourceDigest(lf), SourceDigest("name: x\nsteps: []\n"); got != want {
+		t.Errorf("SourceDigest is not deterministic: %q then %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary

A project or global workflow file shadows a built-in of the same name — that is
by design (spec §5.2, phase 2 decision), and it includes the `adhoc` a task
falls back to when it is created without naming a workflow. Until now the task
recorded only the resolved *name*, so a repository's own
`.vincent/workflows/adhoc.yaml` standing in for the built-in was invisible on
the task forever afterwards. Looking the name up again answers about today's
registry, not the one the task was created against.

This adds `tasks.workflow_origin_json` (migration 0016), written once at task
creation beside `workflow_snapshot`:

| Field | Meaning |
|---|---|
| `scope` | `builtin`, `global`, `project`, or `derived` |
| `file` | source path relative to its scope root — `.vincent/workflows/adhoc.yaml`, `workflows/release.yaml`; absent for a built-in |
| `digest` | `sha256:<hex>` over the registry entry's source bytes as loaded |
| `parent_task_id` | `derived` only: the fan-out parent whose snapshot the lane's steps came from |

Surfaced as `workflow_origin` on every task the API serves and on the
`task.created` event, as the `origin` row of `vincent task show`, and beside the
workflow name in the TUI's task-detail header.

**Resolution is unchanged.** `firstNonBlank(req.Workflow,
project.DefaultWorkflow, workflow.AdhocName)` and `Registry.Lookup`'s project →
global → built-in walk are untouched. No reserved namespace, no `builtin:adhoc`
selector, no `allow_shadow_builtin`. The issue proposed reversing the recorded
phase 2 decision ("`adhoc` becomes a **built-in registry entry** at lowest
precedence … so creation is one uniform path, `workflow` stays optional"); the
author was asked and chose to keep shadowing and make the substitution
**visible** rather than prevented. Issue acceptance criteria 1, 2 and 3 are
therefore dropped, and criterion 8 is honoured as visibility — two same-name
workflows are told apart on the task row — rather than as a new selector
grammar. A qualified name would be a new grammar four resolution sites must
honour at once (`POST /v1/tasks`, `default_workflow`, a `fan_out` lane's
`workflow:`, an `include` step's `workflow:`), and the name pattern
`^[a-z0-9][a-z0-9._-]*$` admits no colon.

Two more deliberate departures from the issue, both recorded in the task
document:

- **The digest is of the source, frozen at creation** — not "the exact bytes
  executed" (criterion 5). Include expansion (§7.9), fan-out resolution (§7.6)
  and `edit + retry` all rewrite `workflow_snapshot`; a digest that tracked it
  would stop identifying a registry file the moment an operator edits one, and
  `edit + retry` is already audited through `step_runs.prompt_override` /
  `run_override`. Criterion 6 falls out for free — nothing recomputes the value.
- **No repository HEAD commit and no separate include chain.** The commit means
  a git call inside `POST /v1/tasks` plus defined answers for a dirty tree and
  an uncommitted workflow file. The include names are already there:
  `resolved_from` per step in the snapshot, already served.

Legacy rows are not backfilled. NULL means "created before origin was recorded"
and renders as `unknown` — never a synthesized scope, and never a re-lookup of
today's registry, which is exactly the substitution this exists to catch.

## Related

Closes #145
Closes 040.1 through 040.6 (`docs/tasks/040-workflow-origin.md`).

Revisits, and **upholds**, the phase 2 decision in `docs/history/v0-tasks.md`
that makes `adhoc` a shadowable built-in registry entry, and the §5.2 built-in
contract that covers all three built-ins. The issue asked to reverse both; the
author declined, so §5.2 now carries a dated note saying shadowing stands and
that origin is how a shadow is seen — so the next reader does not re-open it.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Notes on the last two boxes:

- `CHANGELOG.md` had no `## [Unreleased]` section (Release Please generates the
  release entries); one was added above `0.6.0`.
- Docs touched: `docs/spec.md` (a dated note in §5.2 recording that built-in
  shadowing stands, the `workflow_origin` row in §5.3's task table, a line on
  the task representation under §13.2's `GET /v1/tasks/{id}`, the column in
  §14's `tasks` DDL, and the `task.created` payload note in §13.3),
  `docs/reference/api.md`, `docs/reference/cli.md`, `docs/guides/workflows.md`,
  `docs/guides/tui.md`, and the new `docs/tasks/040-workflow-origin.md` with its
  index row.
- A separate documentation-audit commit (`docs: correct the workflow-origin
  pages the change left inaccurate`) fixes five things the first pass got wrong,
  each checked against the source it is derived from:
  - **`docs/guides/workflows.md`** — the origin block landed between the
    `vincent workflow init` paragraph and the sentence that closes it, so "That
    is the offline route" read as pointing at `vincent task show`. Moved up
    beside the shadowing it is about, after `workflow ls`.
  - **`docs/guides/tui.md`** — the segment is not "at the end of the header":
    `formatCost` is appended after it in `detailrender.go:headerLine`, so it is
    not the last thing a narrow pane keeps. And the workflow name is printed for
    every shape, so a task with no recorded origin reads `adhoc (unknown)`, not
    a bare `(unknown)`.
  - **`docs/reference/cli.md`** — `derived from task 41` and `unknown` are
    printed with no digest (`WorkflowOrigin.Display` appends one only when
    `Digest != ""`), so "followed by a digest" was false for two of the four
    shapes.
  - **`docs/reference/api.md`** — a built-in has no `file` but does carry a
    `digest`; it is over the source bytes as loaded, which for a built-in is the
    copy compiled into the binary.
  - **`docs/spec.md` §13.2** — `workflow_origin` is served on every task
    representation and had no line in the endpoint spec, where
    `available_actions`, `admit_not_before` (task 003) and `github_issue`
    (task 035) each have one. Added, and recorded in 040's `**Spec:** amends`
    list in the same edit.

## Verification

- `go run mage.go test` — green (one flaky `internal/cli`
  `TestGitHubUnusableLeavesTaskCreationAlone` timeout on the first run, a
  `/v1/doctor` client deadline under load; green on re-run and unrelated to this
  change).
- `go run mage.go lint` — 0 issues, and cross-built for `windows`, `darwin` and
  `linux` per `CLAUDE.md` — 0 issues on each.
- No gate script changes: this adds no cross-process seam the seven existing
  gates do not already cross.

## Screenshots

`scripts/screenshots.sh` was re-run for `tui-diff`, the only capture that shows
the task-detail header. The rendered panel is unchanged: the detail view is the
home shell's bottom-left pane rather than a takeover, so its header is about
half the terminal wide and already truncates mid-branch-name at that width, and
the new segment sits after the branch. The committed PNG was therefore left
alone rather than churned with capture noise (elapsed times, cost). The
documentation audit re-checked the committed `docs/assets/tui-diff.png` against
the new header code and agrees it is not stale: that capture's detail header
already ends `· web · f…`, truncated mid-branch-name, so the new segment is out
of frame either way. The
reasoning for the placement — putting the origin earlier would buy its
visibility by pushing the branch out, and the branch has no other home in the
TUI — is recorded in the task document under decision 5.

## Known limitation

The digest hashes raw bytes with no normalization, so the same committed file
digests differently on a Windows checkout with `autocrlf` than on a POSIX one.
That is deliberate: this codebase has no canonical form for a workflow file, and
a normalizer would make the digest claim two files agree when the daemon parsed
different sources. Scope and file still identify the *file*; the digest
identifies the *bytes*. Stated in the task document rather than papered over.
