### PR TITLE
Add idempotency keys for task creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Release Please creates release entries from Conventional Commit history. Its
 release pull request is the review point for replacing the mechanical commit
 list with the user-facing context a commit subject cannot carry.
 
+## [Unreleased]
+
+### Added
+
+- **Creating a task can now be retried safely.** If the daemon commits your task
+  but you never see the response — a timeout, a dropped connection, a script
+  that dies mid-`curl` — re-sending the request used to create a second task, a
+  second worktree and a second agent run against the same repository. Send an
+  `Idempotency-Key` header on `POST /v1/tasks` and the retry returns the task the
+  first request created instead. Same key with a *different* body is refused with
+  a `409` carrying `details.reason: "idempotency_key_reused"`, so a key
+  accidentally reused for a second operation cannot silently answer with the
+  wrong task. Two requests racing with the same key commit exactly one task. The
+  key and the task are written in one transaction, so neither can exist without
+  the other. Keys are kept for 24 hours and then pruned, they are deleted along
+  with the task they name, and `vincent doctor` counts them under
+  `database.table_rows`. Nothing changes without the header: the CLI and the TUI
+  do not send one, they do not retry a create, and two identical sends still make
+  two tasks — which is what pressing enter twice means. Documented in the
+  [API reference](docs/reference/api.md#replaying-a-create).
+
 ## [0.6.0](https://github.com/lezli01/vincent/compare/v0.5.0...v0.6.0) (2026-08-25)
 
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -185,6 +185,8 @@ localhost API.
 - Every subcommand supports `--json` for machine-readable output.
 - Stable exit codes distinguish a rejected request from an unavailable daemon.
 - REST endpoints cover projects, workflows, tasks, actions, output, and diffs.
+- Creating a task takes an optional idempotency key, so a create that loses its
+  response can be re-sent without making a second task.
 - Server-sent events provide durable state replay and live per-task output.
 - `vincent workflow validate` works without a daemon or installed agent CLI, so
   it fits pre-commit hooks and CI.

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -153,8 +153,20 @@ Creating a task:
 ```sh
 curl -s -X POST "http://127.0.0.1:$PORT/v1/tasks" \
   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -H "Idempotency-Key: $(uuidgen)" \
   -d '{"project_id":1,"workflow":"feature-pr","title":"Add a health endpoint"}' | jq
 ```
+
+`Idempotency-Key` is optional, and this is the one request worth setting it on.
+Creating a task inserts a row, claims a branch and wakes the scheduler, so a
+create that commits and then loses its response — a timeout, a dropped
+connection, a script killed mid-`curl` — makes a second task, a second worktree
+and a second agent run on the same repository when the script re-sends it. Under
+a key, re-sending the same body returns the task the first send created;
+re-sending a *different* body under that key is a `409` rather than a wrong
+answer. Keys last 24 hours, no other route needs one, and without the header
+nothing changes — two identical sends make two tasks. The rules are in
+[Replaying a create](../reference/api.md#replaying-a-create).
 
 Errors come back in a stable envelope with `snake_case` codes:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,6 +27,14 @@ The daemon serves REST + SSE on loopback. Every client — the TUI, the
 - **Discovery:** read `{data_dir}/daemon.json` for the port, then
   `GET /v1/health`.
 - **Versioning:** path-prefixed (`/v1`), additive changes only within a version.
+- **`Idempotency-Key`** (optional, `POST /v1/tasks` only) makes a create
+  replayable: if the daemon committed the task but you never saw the response,
+  re-sending the *same body* under the *same key* returns that task instead of
+  making a second one. Up to 255 bytes of printable ASCII; anything else is
+  `400 validation_failed`. Keys are scoped to the route and kept for **24
+  hours**, which is fixed rather than configurable. Every other mutating route
+  is already replay-safe and ignores the header — see
+  [`POST /v1/tasks`](#tasks) for what a replay returns.
 
 ```sh
 DATA_DIR=${VINCENT_DATA_DIR:-$HOME/.local/share/vincent}
@@ -47,6 +55,12 @@ Codes are stable `snake_case` strings; HTTP status codes are used properly.
 `details` is optional and carries values a client should branch on rather than
 parse out of prose — an invalid state transition is always `409` with
 `details.state` set to the state actually found. It is omitted when empty.
+
+Every `409` carries the code `invalid_state`; what varies is `details`. A
+conflict that is not about a task's state names itself in `details.reason` —
+`idempotency_key_reused` when an `Idempotency-Key` is re-sent with a different
+body, and the GitHub integration's reasons on the issue routes. Branch on
+`details`, not on a per-case code.
 
 ## Request bodies
 
@@ -590,11 +604,49 @@ rather than inventing a model name.
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/v1/tasks?project_id=&state=&archived=&limit=&offset=&parent_id=&include_children=` | List. Fan-out lanes are **excluded** by default — `parent_id` lists one parent's lanes in merge order, `include_children=true` the flat everything |
-| `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort?, github_issue? }` — `branch_name` is used verbatim and wins over any template |
+| `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort?, github_issue? }` — `branch_name` is used verbatim and wins over any template. Accepts an optional `Idempotency-Key` header |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
 | `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based; `0` outside one) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart |
 | `POST` | `/v1/tasks/{id}/steps/{step_id}/status` | `{ message }` → `{ message }` as stored. What the **running** step is doing, in its own words. Called by that step's own process — see [Step status](#step-status) |
+
+### Replaying a create
+
+`POST /v1/tasks` is the one route where re-sending a request does something
+twice: it inserts a task, claims a branch and wakes the scheduler. Send an
+`Idempotency-Key` header to make the retry safe.
+
+```sh
+KEY=$(uuidgen)
+curl -sS -X POST "http://127.0.0.1:$PORT/v1/tasks" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $KEY" \
+  -d '{"project_id":1,"title":"Add login page"}'
+# lost the response? send exactly that again — same key, same body.
+```
+
+- **Same key, same body** → `201` with the task the first request created. The
+  body is the task **as it is now**, not a recording of the original response,
+  so a task the scheduler has already admitted replays as `"state": "running"`
+  under a `201`. The task exists, and this is it.
+- **Same key, a different body** → `409 invalid_state` with
+  `details.reason: "idempotency_key_reused"`, and no task is created. Use a new
+  key for a new operation.
+- **No key** → exactly the behaviour vincent has always had. Two identical
+  sends make two tasks, which is what a person pressing enter twice means.
+
+The body is compared by a digest of the decoded request, so reformatting your
+JSON or reordering its keys between the two sends is not a difference. It is
+taken before the `github_issue` prefill runs, so an issue edited in between does
+not turn a genuine retry into a conflict.
+
+Keys live for 24 hours and are then pruned; they are also deleted along with the
+task they name, so a key whose task was destroyed by a forced project delete
+creates a fresh task on the next send. `vincent doctor` counts them under
+`database.table_rows.idempotency_keys`.
+
+The CLI and the TUI do not send the header: neither retries a create, so a
+failed create is reported to you and what to do next is your call.
 
 On `POST /v1/tasks`, the daemon validates the selected root workflow's
 declared fields before inserting the task. Missing required values and invalid

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -301,6 +301,11 @@ reboots rather than only on the restarts it no longer has.
 
 Task and step rows are **never** deleted — only the transcript files.
 
+That same pass also drops
+[idempotency keys](api.md#transport-and-auth) older than a fixed 24 hours. This
+setting does not govern them: `0` keeps every transcript, and expired keys still
+go.
+
 ### `transcript_max_bytes`
 
 ```yaml

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3181,6 +3181,47 @@ long-lived by contract and a server-wide write deadline would sever every one of
 them. The read deadline covers reading the *request*, so it does not shorten an
 SSE response.
 
+*Amended 2026-08-28 (task 040, issue #146).* A request may carry an optional
+**`Idempotency-Key`** header, and exactly one route acts on it:
+`POST /v1/tasks`. That route is the only one in §13.2 where a replayed request
+produces a second side effect — it inserts a row, claims a branch and wakes the
+scheduler, none of which is a compare-and-swap, so a client that times out
+*after* the commit and re-sends gets a second task, a second worktree and a
+second agent run against the same repository. Every other mutating route is
+already safe and ignores the header: the §6 actions are a compare-and-swap on
+the state the request read (amended 2026-08-24), `POST /v1/projects` refuses an
+already-registered path, and the `PATCH`es, `DELETE /v1/projects/{id}`,
+`POST /v1/maintenance/gc` and `POST /v1/doctor/fix` are desired-state
+operations that reach the same end state when re-sent.
+
+- **The key** is at most 255 bytes of printable ASCII; anything else is `400`
+  `validation_failed` naming the field and the limit, like every other §13.1
+  field bound. It is scoped `(method, path, key)`, which is the whole of what
+  exists to scope by: there is one daemon, one token and no caller identity.
+- **The digest** is taken over the *decoded* request, canonically re-marshalled
+  — not over the bytes as they arrived — so whitespace and JSON key order
+  cannot manufacture a conflict. It is taken **before** the `github_issue`
+  prefill mutates the request, so an issue edited between two identical sends
+  cannot either.
+- **Same key, same digest** replays: `201` carrying the task the first request
+  created. The stored row is a *reference*, not a recorded response body, and
+  the replay renders the task **as it is now** — so a task the scheduler has
+  since admitted replays as `state: running` under a `201`. Persisting the
+  rendered JSON instead would put a workflow snapshot under this section's
+  4 MiB bound into a table that grows with every create.
+- **Same key, a different digest** is `409` `invalid_state` with
+  `details.reason = "idempotency_key_reused"`, and no task is created. It is
+  deliberately **not** a new error code: this section fixes every `409` at
+  `invalid_state` with the specific reason in `details`, and that rule holds.
+- **Retention** is a fixed **24 hours**, pruned by the daemon's existing
+  retention pass (§17). Fixed the way this section's body bounds are fixed: a
+  key exists to cover a transport retry, which happens in seconds.
+- **No client sends it.** `internal/apiclient` has no REST retry — a create
+  that times out is reported to the person, who looks at the board and decides —
+  so there is no retry for a key to survive, and minting one per composed form
+  would fight the rule that a new explicit user action is a new operation. The
+  header is for external callers.
+
 ### 13.2 Endpoints
 
 ```
@@ -3431,6 +3472,12 @@ POST   /v1/tasks                        { project_id, workflow, title, descripti
                                         An unusable integration is the same **409** with
                                         `details.reason` the issues endpoint returns; a request
                                         without github_issue makes no GitHub call at all
+                                        *Added 2026-08-28 (task 040):* accepts an optional
+                                        `Idempotency-Key` header. Same key + same request →
+                                        `201` with the task the first send created; same key +
+                                        a different request → `409` with
+                                        `details.reason = "idempotency_key_reused"`; no header
+                                        → unchanged. §13.1 has the rules
 GET    /v1/tasks/{id}                   full task incl. step runs summary and pending_input (§7.4).
                                         Every task representation carries `available_actions`
                                         (the §6 human actions valid right now) and
@@ -3820,6 +3867,17 @@ CREATE TABLE agent_quota (
   source             TEXT NOT NULL       -- 'observed'; the seam a probe would fill
 );
 
+CREATE TABLE idempotency_keys (       -- §13.1 replay protection (task 040)
+  method       TEXT NOT NULL,
+  path         TEXT NOT NULL,
+  key          TEXT NOT NULL,
+  request_sha  TEXT NOT NULL,          -- digest of the decoded request, canonically re-marshalled
+  task_id      INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  created_at   TEXT NOT NULL,
+  PRIMARY KEY (method, path, key)
+);
+CREATE INDEX idx_idempotency_keys_created_at ON idempotency_keys(created_at);
+
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 ```
 
@@ -3860,6 +3918,23 @@ backwards. The row is written by `internal/taskrun` alongside the §11 hold and
 deleted by the next successful agent step on that adapter; the daemon remains
 the single writer and the row is agent-scoped rather than task-scoped, so no
 taskrun or scheduler ownership invariant moves.
+
+*Added 2026-08-28 (task 040, issue #146).* `idempotency_keys` stores a
+**reference**, not a response: a replay re-reads `task_id` and renders the task
+as it is now. Persisting the rendered `201` would mean storing a workflow
+snapshot per create, under §13.1's 4 MiB body bound, in the one table that grows
+with every task created — exactly the storage surface task 029 was opened to
+measure. The primary key is `(method, path, key)` rather than `key` alone so a
+later route joins the table with no migration, even though `POST /v1/tasks` is
+the only writer today. `ON DELETE CASCADE` because a key whose task has been
+destroyed has nothing left to replay: force-deleting a project deletes its
+tasks, foreign keys are enforced on every connection, and the key goes with
+them, so a send inside the remaining window creates a fresh task. That beat
+`ON DELETE SET NULL` plus a `410`, which adds a status and an error code for a
+case only a deliberate destructive act inside a 24-hour window can reach. The
+key row is written **in the same transaction as the task**, so the two commit
+together or not at all; a concurrent duplicate loses on the primary key, rolls
+its task insert back, and replays the winner's.
 
 ## 15. TUI
 
@@ -4493,7 +4568,14 @@ currently true to show (§15 view 6).
 - **Daemon log:** structured (slog), rotated; scheduler decisions at debug level.
 - **Retention:** transcripts of archived tasks pruned after
   `transcript_retention_days` (default 90); DB rows kept indefinitely (rows are small,
-  history is valuable).
+  history is valuable). *Amended 2026-08-28 (task 040):* one exception —
+  §13.1's `idempotency_keys` rows are pruned after a **fixed 24 hours** by the
+  same pass, with no config knob and independent of
+  `transcript_retention_days`' "zero keeps everything". A key is opaque,
+  small, and useless once the retry window it covers has passed, so there is no
+  operator reason to keep one. The table is counted in
+  `GET /v1/doctor`'s `database.table_rows` like every other, by enumeration
+  rather than by name.
 - **Entry point** (*added 2026-08-15, task 005*): `vincent doctor` and
   `GET /v1/doctor`. Everything above answers "what happened to this task"; the
   question that had no surface at all was "why is nothing running?", which took

--- a/docs/tasks/040-api-idempotency-keys.md
+++ b/docs/tasks/040-api-idempotency-keys.md
@@ -1,0 +1,137 @@
+# 040 — Idempotency keys for task creation
+
+**Issue:** [#146](https://github.com/lezli01/vincent/issues/146) (P2, API
+correctness). Parent review [#135](https://github.com/lezli01/vincent/issues/135).
+
+**Spec:** §13.1 (transport, amended 2026-08-28), §13.2 (`POST /v1/tasks`), §14
+(`idempotency_keys`), §17 (retention).
+
+## The problem
+
+A mutating request that commits and then loses its response leaves the client
+unable to tell "not processed" from "processed, response lost". For most of
+vincent's API that distinction does not matter, because re-sending is harmless.
+For one route it does.
+
+`POST /v1/tasks` inserts a row, claims a branch and wakes the scheduler. None of
+that is a compare-and-swap on state the request read, so a client that times out
+after the commit and re-sends gets a second task, a second worktree, and a second
+agent run against the same repository.
+
+The issue proposes covering every mutating route. Most of them do not need it:
+
+- **The §6 action routes** — `cancel`, `pause`, `resume`, `retry`, `repair`,
+  `skip`, `approve`, `reject`, `answer`, `archive`, `follow_up` — are applied as
+  a compare-and-swap on the state the request read (§6, amended 2026-08-24,
+  issue #127). A transport retry re-reads a state the action is no longer valid
+  from and gets `409` with `details.state`. `follow_up` is the one that could in
+  principle duplicate, since it is repeatable and returns the task to
+  `done`/`aborted` — but only if the whole follow-up run finished between the
+  original request and the retry, which no transport retry window reaches.
+- **`POST /v1/projects`** refuses an already-registered path with a `400` naming
+  the existing project, and `projects.name` is `UNIQUE`.
+- **The `PATCH` routes, `DELETE /v1/projects/{id}`, `POST /v1/maintenance/gc`
+  and `POST /v1/doctor/fix`** are desired-state operations: re-sending one
+  reaches the same end state.
+
+So: one route, one header, one table.
+
+## Tasks
+
+- [x] 040.1 — `idempotency_keys` migration, keyed `(method, path, key)`, with
+  the `created_at` index the prune scan needs ✓ 2026-08-28
+- [x] 040.2 — `internal/store/idempotency.go`: lookup, transactional insert,
+  prune; `CreateTaskWithKey` writes the key in the task's own transaction
+  ✓ 2026-08-28
+- [x] 040.3 — `internal/api/idempotency.go`: header validation, canonical
+  digest, replay; wired into `handleTaskCreate` ✓ 2026-08-28
+- [x] 040.4 — the 24-hour prune rides `taskrun.TranscriptPruner` ✓ 2026-08-28
+- [x] 040.5 — tests: no-header regression, sequential replay, digest
+  insensitivity to formatting, conflict, concurrent duplicates, atomicity,
+  cascade, bounds, prune, doctor ✓ 2026-08-28
+- [x] 040.6 — `scripts/m1-gate.sh` leg over curl ✓ 2026-08-28
+- [x] 040.7 — spec §13.1/§13.2/§14/§17 amendments and
+  `docs/reference/api.md` ✓ 2026-08-28
+
+## Decisions
+
+**1. Scope is `POST /v1/tasks` alone** (2026-08-28). Not the action routes, not
+the project routes, not the `PATCH`es. The action routes were the real
+candidate: their replay `409` is ambiguous between "another actor moved this
+task" and "my own retry already applied this". That ambiguity is real, but
+resolving it costs a key check in every action handler for a case a human on
+loopback settles by looking at the board. The schema is keyed by
+`(method, path, key)` so a later route joins without a migration.
+
+**2. A key row stores a reference, not a response body** (2026-08-28). The row
+records the created task's id; a replay re-reads the task and renders today's
+`201` from it. *Beat:* persisting the rendered JSON and replaying it verbatim,
+which reads the issue's "returns the original result" literally — but a task
+response carries the workflow snapshot's steps and the route's body bound is
+4 MiB (§13.1), so keys would become a storage-growth surface of exactly the kind
+issue #98 was opened about. The consequence is stated rather than hidden: a
+replay shows the task **as it is now**, so an already-admitted task replays as
+`state: running` under a `201`. That is the honest answer — the task exists, and
+this is it.
+
+**3. Server-side only; no client changes** (2026-08-28). The issue's criterion
+"CLI/TUI retries preserve the key; a new explicit user action generates a new
+one" describes machinery that does not exist. `internal/apiclient` has no REST
+retry: `client.go` sets a 10-second timeout and returns the error to the caller,
+where the TUI or CLI shows it and a human decides. Only the SSE subscription
+reconnects, and it is a `GET`. Adding an automatic retry would be a behaviour
+change in its own right — today a timeout on task creation is reported to the
+person, who can look at the board first — and minting a key per composed form
+fights the issue's own rule that a new explicit user action is a new operation:
+a human pressing enter a second time may well mean "yes, make another one".
+
+**4. Retention is a fixed 24 hours with no config knob** (2026-08-28). Pruned by
+the existing 24-hour pass (`taskrun.PruneInterval`), fixed the way §13.1's body
+bounds are fixed. A key exists to cover a transport retry, which happens in
+seconds; 24 hours is three orders of magnitude of headroom, and a knob here is
+config surface to document and defend forever for a number nobody will tune. It
+is independent of `transcript_retention_days`, including that setting's "zero
+keeps everything" escape.
+
+**5. A key conflict is `409 invalid_state` with `details.reason`, not a new
+code** (2026-08-28). The issue asks for `409 idempotency_conflict`.
+`internal/api/errors.go` records the opposite rule — the code is always
+`CodeInvalidState`, the specific reason travels in `details` — and
+`docs/reference/api.md` publishes it. The convention wins: `details.reason =
+"idempotency_key_reused"`. One 409 code stays true, clients that branch on
+`code` are unaffected, and no published rule needs amending.
+
+**6. A key row cascades away with its task** (2026-08-28). `task_id` carries
+`REFERENCES tasks(id) ON DELETE CASCADE`, and foreign keys are enforced on every
+connection. Force-deleting a project deletes its tasks, and a key whose task has
+been destroyed has nothing left to replay — so the key goes with it and a replay
+inside the remaining window creates a fresh task. *Beat:* `ON DELETE SET NULL`
+plus a `410`, which adds a status and an error code for a case only a deliberate
+destructive act inside a 24-hour window can reach.
+
+**7. The digest is taken over the request as received** (2026-08-28). Canonical
+re-marshal of the decoded `taskCreateRequest`, hashed, **before**
+`applyIssuePrefill` mutates it. Prefill reads GitHub; hashing after it would
+turn an edited issue title into a spurious `409` on a request the caller sent
+identically twice. Hashing the decoded struct rather than the raw bytes means
+whitespace and key order do not manufacture a conflict either.
+
+## Acceptance criteria from the issue that this does not build
+
+Stated rather than quietly dropped.
+
+- *"CLI/TUI retries preserve the key"* — dropped. There is no client retry to
+  preserve a key across (decision 3).
+- *"Keys are not logged as secrets"* — nothing to build. `logMiddleware` logs
+  method, path, status and duration; no header reaches the log, and a
+  client-chosen key is not a credential.
+- *"Scope keys by … authenticated vincent instance, and logical caller"* — there
+  is one daemon, one token (§13.1) and no caller identity to scope by. The
+  `(method, path, key)` scope is the whole of what exists.
+- *Coverage of the action routes and the project routes* — out of scope by
+  decision 1, on the evidence above.
+
+`internal/api/doctor.go` needed no change: `store.TableRows` enumerates the
+schema, so `idempotency_keys` appears in `database.table_rows` on
+`GET /v1/doctor` with no code — which is what the issue's "exposed through
+doctor/storage metrics" asks for.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -53,6 +53,7 @@ the living engineering specification records implementation contracts.
 | [037](037-update-workflows-builtin.md) | `update-workflows`, a built-in that maintains the ones you have | ✅ done (5/5) |
 | [038](038-release-signing-posture.md) | Release signing posture for an MIT project | ⚠ blocked on the owner (1/7) |
 | [039](039-unsigned-releases-by-default.md) | A missing certificate must not destroy a release | ⚠ verification blocked (6/7) |
+| [040](040-api-idempotency-keys.md) | Idempotency keys for `POST /v1/tasks` | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/api/idempotency.go
+++ b/internal/api/idempotency.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// Idempotency keys (§13.1, amended 2026-08-28, task 040, issue #146).
+//
+// `POST /v1/tasks` is the only route in §13.2 where a replayed request produces
+// a second side effect. Everything else is already safe: the §6 action routes
+// are a compare-and-swap on the state the request read (amended 2026-08-24),
+// `POST /v1/projects` refuses an already-registered path, and the PATCH and
+// DELETE routes are desired-state operations. So this is one header on one
+// route, even though the table is keyed to take more later.
+const (
+	// idempotencyHeader is the request header a client sets to make a create
+	// replayable. It is optional: a request without it behaves exactly as it
+	// did before this existed.
+	idempotencyHeader = "Idempotency-Key"
+	// idempotencyReasonReused is the `details.reason` of the 409 a key reused
+	// with a different body gets. It is not a new error *code*: §13.1 fixes
+	// every 409 at CodeInvalidState with the specific reason in details, and
+	// docs/reference/api.md publishes that rule, so the reason travels where
+	// every other 409 reason travels.
+	idempotencyReasonReused = "idempotency_key_reused"
+)
+
+// idempotencyRoute is the `path` half of the `(method, path, key)` scope. It is
+// the route, not r.URL.Path, so the scope cannot be widened by a client
+// appending a trailing slash or a query string.
+const idempotencyRoute = "/v1/tasks"
+
+// readIdempotencyKey returns the request's Idempotency-Key, "" when it carries
+// none, and false when it carries one that is not usable — in which case the
+// 400 has already been written.
+//
+// The key is bounded and required to be printable ASCII for the reason every
+// §13.1 field bound exists: it is persisted, and it is compared byte for byte
+// on a later request, so a control character or a truncated multi-byte rune in
+// it is a client bug that would silently never match again.
+func readIdempotencyKey(w http.ResponseWriter, r *http.Request) (string, bool) {
+	key := r.Header.Get(idempotencyHeader)
+	if key == "" {
+		return "", true
+	}
+	if msg := boundString(idempotencyHeader, key, maxIdempotencyKeyBytes); msg != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
+		return "", false
+	}
+	for i := range len(key) {
+		if key[i] < 0x20 || key[i] > 0x7e {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("%s must be printable ASCII (byte %d is 0x%02x)",
+					idempotencyHeader, i, key[i]))
+			return "", false
+		}
+	}
+	return key, true
+}
+
+// idempotencyDigest is the canonical digest of a decoded request.
+//
+// It hashes the **decoded struct re-marshalled**, not the bytes as they
+// arrived, so whitespace and JSON key order cannot manufacture a conflict out
+// of two sends of the same request. Callers take it *before* any server-side
+// mutation of the decoded value — the GitHub issue prefill in particular reads
+// a live issue (§13.2, task 035), and hashing after it would turn an edited
+// issue title into a spurious 409 on a request the caller sent identically
+// twice.
+func idempotencyDigest(v any) (string, error) {
+	// Go marshals map keys in sorted order, so the `fields` map is canonical
+	// here without any help.
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("digest request: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// replayTaskCreate answers a create whose key has already been recorded, and
+// reports whether it did. false means the key is new and the caller should do
+// the work.
+//
+// A key recorded against a *different* request digest is a 409 — the client
+// reused a key for a second operation, which is a client bug the daemon must
+// not paper over by creating a task under a key that names another one.
+//
+// A key recorded against the same digest replays the task it names. The body is
+// rendered from the task **as it is now**, not from a stored copy of the
+// original response: storing the rendered JSON would put a task's workflow
+// snapshot under a 4 MiB body bound (§13.1) into a table that grows with every
+// create. The consequence is visible and deliberate — a task the scheduler has
+// since admitted replays as `state: running` under a `201`. That is the honest
+// answer: the task exists, and this is it.
+func (s *Server) replayTaskCreate(w http.ResponseWriter, r *http.Request, key, sha string) bool {
+	rec, err := s.deps.Store.GetIdempotencyKey(r.Context(), r.Method, idempotencyRoute, key)
+	if errors.Is(err, store.ErrNotFound) {
+		return false
+	}
+	if err != nil {
+		s.internalError(w, "get idempotency key", err)
+		return true
+	}
+	if rec.RequestSHA != sha {
+		writeConflict(w,
+			fmt.Sprintf("%s %q was already used for a different request",
+				idempotencyHeader, key),
+			map[string]string{"reason": idempotencyReasonReused})
+		return true
+	}
+	task, err := s.deps.Store.GetTask(r.Context(), rec.TaskID)
+	if err != nil {
+		// Unreachable in a consistent database: the key row carries
+		// ON DELETE CASCADE, so a destroyed task takes its key with it and
+		// this lookup is never reached for a task that is gone.
+		s.internalError(w, "get task for idempotent replay", err)
+		return true
+	}
+	writeJSON(w, http.StatusCreated, toTaskResponse(task, s.snaps.get(task.ID, task.WorkflowSnapshot)))
+	return true
+}

--- a/internal/api/idempotency_test.go
+++ b/internal/api/idempotency_test.go
@@ -1,0 +1,300 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// postTaskKey is doJSON against POST /v1/tasks with an Idempotency-Key header.
+// It sets the header only when key is non-empty, so the same helper covers the
+// no-header path a request without replay protection takes.
+func (h *projectHarness) postTaskKey(t *testing.T, body any, key string) (*http.Response, []byte) {
+	t.Helper()
+	var rd io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rd = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(http.MethodPost, h.ts.URL+"/v1/tasks", rd)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	if key != "" {
+		req.Header.Set("Idempotency-Key", key)
+	}
+	resp, err := h.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("post task: %v", err)
+	}
+	out, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+// rowCount reads one table's row count straight from the schema enumeration
+// doctor uses, which is the only assertion that can say "no *second* task was
+// created" without trusting the response that claims so.
+func (h *projectHarness) rowCount(t *testing.T, table string) int64 {
+	t.Helper()
+	rows, err := h.store.TableRows(t.Context())
+	if err != nil {
+		t.Fatalf("table rows: %v", err)
+	}
+	return rows[table]
+}
+
+// decodeCreated parses a create response, failing the test on a status that is
+// not 201.
+func decodeCreated(t *testing.T, resp *http.Response, body []byte) taskResponse {
+	t.Helper()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create task: %d %s", resp.StatusCode, body)
+	}
+	var tr taskResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		t.Fatalf("task body: %v (%s)", err, body)
+	}
+	return tr
+}
+
+// createWithKey posts a create carrying key and expects a 201.
+func (h *projectHarness) createWithKey(t *testing.T, body any, key string) taskResponse {
+	t.Helper()
+	resp, out := h.postTaskKey(t, body, key)
+	return decodeCreated(t, resp, out)
+}
+
+// TestCreateWithoutKeyIsUnchanged is the regression that matters most: a
+// request carrying no Idempotency-Key behaves exactly as it did before replay
+// protection existed, so two identical sends are two tasks — which is what a
+// human pressing enter twice means (decision 3, task 040).
+func TestCreateWithoutKeyIsUnchanged(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	body := map[string]any{"project_id": h.projectID, "title": "no key here"}
+
+	first := h.createWithKey(t, body, "")
+	second := h.createWithKey(t, body, "")
+
+	if first.ID == second.ID {
+		t.Errorf("two keyless creates returned the same task %d", first.ID)
+	}
+	if n := h.rowCount(t, "tasks"); n != 2 {
+		t.Errorf("tasks = %d, want 2 from two keyless creates", n)
+	}
+	if n := h.rowCount(t, "idempotency_keys"); n != 0 {
+		t.Errorf("idempotency_keys = %d after keyless creates, want 0", n)
+	}
+}
+
+// TestSameKeySameBodyReplays covers the case the whole feature exists for: the
+// client committed a task, lost the response, and re-sent. It gets a 201
+// naming the task that already exists, not a second one.
+func TestSameKeySameBodyReplays(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	body := map[string]any{"project_id": h.projectID, "title": "replay me"}
+
+	first := h.createWithKey(t, body, "key-1")
+	second := h.createWithKey(t, body, "key-1")
+
+	if first.ID != second.ID {
+		t.Errorf("replay returned task %d, want the original %d", second.ID, first.ID)
+	}
+	if second.BranchName != first.BranchName || second.Title != first.Title {
+		t.Errorf("replay body = %+v, want the original task %+v", second, first)
+	}
+	if n := h.rowCount(t, "tasks"); n != 1 {
+		t.Errorf("tasks = %d after a replayed create, want 1", n)
+	}
+	if n := h.rowCount(t, "idempotency_keys"); n != 1 {
+		t.Errorf("idempotency_keys = %d, want the one recorded key", n)
+	}
+}
+
+// TestReplayIgnoresWhitespaceAndKeyOrder: the digest is over the *decoded*
+// request re-marshalled canonically, so a client that reserialises its own
+// body differently on the retry still replays rather than conflicting.
+func TestReplayIgnoresWhitespaceAndKeyOrder(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	post := func(raw string) (*http.Response, []byte) {
+		req, err := http.NewRequest(http.MethodPost, h.ts.URL+"/v1/tasks", strings.NewReader(raw))
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+testToken)
+		req.Header.Set("Idempotency-Key", "key-shuffled")
+		resp, err := h.ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		out, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		return resp, out
+	}
+	resp, out := post(fmt.Sprintf(
+		`{"project_id":%d,"title":"shuffled","description":"d"}`, h.projectID))
+	first := decodeCreated(t, resp, out)
+	resp, out = post(fmt.Sprintf(
+		"{\n  \"description\": \"d\",\n  \"title\": \"shuffled\",\n  \"project_id\": %d\n}\n",
+		h.projectID))
+	second := decodeCreated(t, resp, out)
+
+	if first.ID != second.ID {
+		t.Errorf("reformatted retry created task %d, want a replay of %d", second.ID, first.ID)
+	}
+	if n := h.rowCount(t, "tasks"); n != 1 {
+		t.Errorf("tasks = %d, want 1", n)
+	}
+}
+
+// TestSameKeyDifferentBodyConflicts: a key reused for a second operation is a
+// client bug the daemon refuses rather than papering over. The 409 keeps
+// §13.1's single conflict code and carries the specific reason in details
+// (decision 5).
+func TestSameKeyDifferentBodyConflicts(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	first := h.createWithKey(t,
+		map[string]any{"project_id": h.projectID, "title": "original"}, "key-2")
+
+	resp, body := h.postTaskKey(t,
+		map[string]any{"project_id": h.projectID, "title": "something else"}, "key-2")
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("reused key with a new body: %d %s, want 409", resp.StatusCode, body)
+	}
+	var env errorBody
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("error body: %v (%s)", err, body)
+	}
+	if env.Error.Code != CodeInvalidState {
+		t.Errorf("code = %q, want %q — every 409 carries one code (§13.1)",
+			env.Error.Code, CodeInvalidState)
+	}
+	if env.Error.Details["reason"] != "idempotency_key_reused" {
+		t.Errorf("details = %v, want reason=idempotency_key_reused", env.Error.Details)
+	}
+	if n := h.rowCount(t, "tasks"); n != 1 {
+		t.Errorf("tasks = %d after a conflicting create, want just task %d", n, first.ID)
+	}
+}
+
+// TestConcurrentDuplicatesCommitOne is the acceptance criterion the feature
+// exists for. The store is a single WAL writer, so the two transactions
+// serialize: the loser's key insert violates the primary key, its task insert
+// rolls back with it, and it replays the winner's task.
+func TestConcurrentDuplicatesCommitOne(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	body := map[string]any{"project_id": h.projectID, "title": "raced"}
+
+	var wg sync.WaitGroup
+	ids := make([]int64, 2)
+	codes := make([]int, 2)
+	for i := range ids {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, out := h.postTaskKey(t, body, "key-race")
+			codes[i] = resp.StatusCode
+			var tr taskResponse
+			if err := json.Unmarshal(out, &tr); err == nil {
+				ids[i] = tr.ID
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusCreated {
+			t.Errorf("request %d: %d, want 201", i, code)
+		}
+	}
+	if ids[0] != ids[1] || ids[0] == 0 {
+		t.Errorf("concurrent duplicates returned tasks %d and %d, want one id", ids[0], ids[1])
+	}
+	if n := h.rowCount(t, "tasks"); n != 1 {
+		t.Errorf("tasks = %d after two concurrent duplicates, want 1", n)
+	}
+}
+
+// TestKeyBoundsAreValidated: the key is persisted and compared byte for byte
+// later, so it gets the §13.1 field treatment — a 400 naming the field and the
+// limit, never a silent truncation.
+func TestKeyBoundsAreValidated(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	body := map[string]any{"project_id": h.projectID, "title": "bounded"}
+
+	for _, tc := range []struct{ name, key, want string }{
+		{"too long", strings.Repeat("k", maxIdempotencyKeyBytes+1), "255"},
+		// Non-ASCII rather than a control byte: Go's own client refuses to
+		// send a control character in a header value, so the byte a real
+		// caller can actually get here is a high one.
+		{"not ascii", "clé-café", "printable ASCII"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, out := h.postTaskKey(t, body, tc.key)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d %s, want 400", resp.StatusCode, out)
+			}
+			var env errorBody
+			if err := json.Unmarshal(out, &env); err != nil {
+				t.Fatalf("error body: %v (%s)", err, out)
+			}
+			if env.Error.Code != CodeValidationFailed {
+				t.Errorf("code = %q, want %q", env.Error.Code, CodeValidationFailed)
+			}
+			if !strings.Contains(env.Error.Message, "Idempotency-Key") ||
+				!strings.Contains(env.Error.Message, tc.want) {
+				t.Errorf("message = %q, want it to name the field and %q", env.Error.Message, tc.want)
+			}
+		})
+	}
+	if n := h.rowCount(t, "tasks"); n != 0 {
+		t.Errorf("tasks = %d, want none created behind a rejected key", n)
+	}
+}
+
+// TestKeyCascadesWithItsTask: a key whose task has been destroyed has nothing
+// left to replay, so the foreign key takes it away with the task (decision 6)
+// and a later send of the same key creates a fresh task rather than 500ing on
+// a dangling reference.
+func TestKeyCascadesWithItsTask(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	body := map[string]any{"project_id": h.projectID, "title": "doomed"}
+	first := h.createWithKey(t, body, "key-cascade")
+
+	resp, out := h.doJSON(t, http.MethodDelete,
+		fmt.Sprintf("/v1/projects/%d?force", h.projectID), nil)
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		t.Fatalf("force delete project: %d %s", resp.StatusCode, out)
+	}
+	if n := h.rowCount(t, "tasks"); n != 0 {
+		t.Fatalf("tasks = %d after a force delete, want 0", n)
+	}
+	if n := h.rowCount(t, "idempotency_keys"); n != 0 {
+		t.Errorf("idempotency_keys = %d after task %d was destroyed, want 0", n, first.ID)
+	}
+}
+
+// TestDoctorCountsIdempotencyKeys: the table is enumerated from the schema, so
+// it appears in `database.table_rows` with no code of its own — which is what
+// "expiry is exposed through doctor/storage metrics" asks for.
+func TestDoctorCountsIdempotencyKeys(t *testing.T) {
+	h := newDoctorHarness(t)
+	if _, ok := h.report(t).Database.TableRows["idempotency_keys"]; !ok {
+		t.Error("table_rows omits idempotency_keys")
+	}
+}

--- a/internal/api/limits.go
+++ b/internal/api/limits.go
@@ -40,6 +40,12 @@ const (
 	maxFieldValueBytes  = 64 << 10 // one fields/answers value
 	maxFieldCount       = 100      // fields/answers entries in one request
 	maxValueCount       = 100      // values in one answer
+	// maxIdempotencyKeyBytes bounds the Idempotency-Key header (task 040). A
+	// header rather than a body field, but persisted and compared byte for
+	// byte on a later request like any other, so it is bounded alongside them.
+	// 255 B is the size the header is conventionally given elsewhere and is
+	// generous for the UUID a client actually sends.
+	maxIdempotencyKeyBytes = 255
 )
 
 // The two key bounds differ because the two keys are different kinds of thing

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -378,6 +378,24 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Replay protection (§13.1, task 040). The digest is taken here, over the
+	// request as it arrived and before applyIssuePrefill mutates it below, so
+	// an issue edited between two identical sends cannot manufacture a 409.
+	idemKey, ok := readIdempotencyKey(w, r)
+	if !ok {
+		return
+	}
+	var idemSHA string
+	if idemKey != "" {
+		var derr error
+		if idemSHA, derr = idempotencyDigest(&req); derr != nil {
+			s.internalError(w, "digest task create request", derr)
+			return
+		}
+		if s.replayTaskCreate(w, r, idemKey, idemSHA) {
+			return
+		}
+	}
 	ctx := r.Context()
 	project, err := s.deps.Store.GetProject(ctx, req.ProjectID)
 	if errors.Is(err, store.ErrNotFound) {
@@ -593,15 +611,32 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		}
 		t.BranchName = preview.Name
 	}
-	if err := s.deps.Store.CreateTask(ctx, &t, resolveBranch); err != nil {
+	var key *store.IdempotencyKey
+	if idemKey != "" {
+		key = &store.IdempotencyKey{
+			Method: r.Method, Path: idempotencyRoute, Key: idemKey, RequestSHA: idemSHA,
+		}
+	}
+	if err := s.deps.Store.CreateTaskWithKey(ctx, &t, resolveBranch, key); err != nil {
 		var claimed *store.BranchClaimedError
-		if errors.As(err, &claimed) {
+		switch {
+		case errors.As(err, &claimed):
 			writeError(w, http.StatusBadRequest, CodeValidationFailed,
 				fmt.Sprintf("branch %q is already claimed by task %d",
 					claimed.Branch, claimed.TaskID))
-			return
+		case errors.Is(err, store.ErrIdempotencyKeyExists):
+			// The concurrent duplicate: another request carrying this key
+			// committed while this one was doing its work. The store's single
+			// writer serialized the two transactions, this one's task insert
+			// rolled back with the key insert that lost, and the winner's task
+			// is the answer. replayTaskCreate cannot come back false here —
+			// the row it looks for is the one that just rejected this insert.
+			if !s.replayTaskCreate(w, r, idemKey, idemSHA) {
+				s.internalError(w, "replay idempotent create", err)
+			}
+		default:
+			s.internalError(w, "create task", err)
 		}
-		s.internalError(w, "create task", err)
 		return
 	}
 	if s.deps.WakeRunner != nil {

--- a/internal/store/idempotency.go
+++ b/internal/store/idempotency.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrIdempotencyKeyExists reports that the `(method, path, key)` row a create
+// tried to write is already there — the concurrent-duplicate case, where two
+// requests carrying the same key raced and this one lost. The store's single
+// WAL connection serializes the two transactions, so the loser sees the
+// primary-key violation, rolls its task insert back, and the API re-reads by
+// key and replays the winner's task (task 040).
+//
+// It is a sentinel rather than a wrapped driver error because that is the only
+// thing the caller can act on: every other insert failure is a 500, and this
+// one is a 201.
+var ErrIdempotencyKeyExists = errors.New("idempotency key already exists")
+
+// IdempotencyKey is one recorded replay-protected request (§13.1, task 040).
+// It stores a *reference* to what the request produced, not the response body
+// it produced: TaskID names the created task, and a replay re-reads that task
+// to render the response.
+type IdempotencyKey struct {
+	Method     string
+	Path       string
+	Key        string
+	RequestSHA string
+	TaskID     int64
+	CreatedAt  time.Time
+}
+
+// GetIdempotencyKey returns the recorded key for one route, or ErrNotFound
+// when the caller has not used this key on this route inside the retention
+// window.
+func (s *Store) GetIdempotencyKey(ctx context.Context, method, path, key string) (*IdempotencyKey, error) {
+	k := IdempotencyKey{Method: method, Path: path, Key: key}
+	var created string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT request_sha, task_id, created_at FROM idempotency_keys
+		WHERE method = ? AND path = ? AND key = ?`,
+		method, path, key).Scan(&k.RequestSHA, &k.TaskID, &created)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get idempotency key: %w", err)
+	}
+	k.CreatedAt, err = parseTime(created)
+	if err != nil {
+		return nil, fmt.Errorf("parse idempotency key created_at: %w", err)
+	}
+	return &k, nil
+}
+
+// insertIdempotencyKeyTx writes the key row inside the caller's transaction —
+// the same transaction as the task insert, so the row and the key commit
+// together or not at all. That atomicity is the whole point: a key committed
+// without its task would replay a task that does not exist, and a task
+// committed without its key would be duplicated by the retry the key exists to
+// absorb.
+func insertIdempotencyKeyTx(ctx context.Context, tx *sql.Tx, k *IdempotencyKey, taskID int64, now time.Time) error {
+	if k.CreatedAt.IsZero() {
+		k.CreatedAt = now
+	}
+	k.TaskID = taskID
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO idempotency_keys (method, path, key, request_sha, task_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		k.Method, k.Path, k.Key, k.RequestSHA, k.TaskID, formatTime(k.CreatedAt))
+	if err != nil {
+		// The driver reports the primary-key violation as a constraint failure
+		// naming the table; matched on the message the way the projects.name
+		// clash already is, because modernc's error carries no typed column
+		// identity to branch on.
+		if strings.Contains(err.Error(), "constraint failed") &&
+			strings.Contains(err.Error(), "idempotency_keys") {
+			return ErrIdempotencyKeyExists
+		}
+		return fmt.Errorf("insert idempotency key: %w", err)
+	}
+	return nil
+}
+
+// PruneIdempotencyKeys deletes keys recorded before cutoff, returning how many
+// went. The window is fixed at 24 hours by the caller (§17, task 040) rather
+// than configured: a key exists to cover a transport retry, which happens in
+// seconds, so a day is three orders of magnitude of headroom and a knob here
+// would be config surface to document and defend forever for a number nobody
+// would tune.
+//
+// cutoff is a parameter so tests can age rows without sleeping.
+func (s *Store) PruneIdempotencyKeys(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM idempotency_keys WHERE created_at < ?`, formatTime(cutoff))
+	if err != nil {
+		return 0, fmt.Errorf("prune idempotency keys: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune idempotency keys: %w", err)
+	}
+	return n, nil
+}

--- a/internal/store/idempotency_test.go
+++ b/internal/store/idempotency_test.go
@@ -1,0 +1,163 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestCreateTaskWithKeyRecordsBoth: the row and the key are one write, so the
+// key names a task that exists.
+func TestCreateTaskWithKeyRecordsBoth(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	task := newTask(p.ID, "keyed", TaskQueued)
+	key := &IdempotencyKey{
+		Method: "POST", Path: "/v1/tasks", Key: "abc", RequestSHA: "sha-1",
+	}
+	if err := s.CreateTaskWithKey(ctx, task, nil, key); err != nil {
+		t.Fatalf("CreateTaskWithKey: %v", err)
+	}
+	got, err := s.GetIdempotencyKey(ctx, "POST", "/v1/tasks", "abc")
+	if err != nil {
+		t.Fatalf("GetIdempotencyKey: %v", err)
+	}
+	if got.TaskID != task.ID {
+		t.Errorf("key names task %d, want %d", got.TaskID, task.ID)
+	}
+	if got.RequestSHA != "sha-1" {
+		t.Errorf("request_sha = %q, want %q", got.RequestSHA, "sha-1")
+	}
+	if time.Since(got.CreatedAt) > time.Minute {
+		t.Errorf("created_at = %s, want roughly now", got.CreatedAt)
+	}
+	// The scope is (method, path, key): the same key on another route is a
+	// different row, which is what lets a later route join the table.
+	if _, err := s.GetIdempotencyKey(ctx, "POST", "/v1/projects", "abc"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("lookup on another route: %v, want ErrNotFound", err)
+	}
+}
+
+// TestCreateTaskWithKeyIsAtomic: a key that is already recorded fails the
+// *whole* transaction, so the task the losing request was inserting is rolled
+// back with it. Without that, a duplicate would leave an orphan task behind
+// the key that rejected it.
+func TestCreateTaskWithKeyIsAtomic(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	first := newTask(p.ID, "winner", TaskQueued)
+	if err := s.CreateTaskWithKey(ctx, first, nil,
+		&IdempotencyKey{Method: "POST", Path: "/v1/tasks", Key: "dup", RequestSHA: "sha"}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	second := newTask(p.ID, "loser", TaskQueued)
+	second.BranchName = "vincent/0-loser"
+	err := s.CreateTaskWithKey(ctx, second, nil,
+		&IdempotencyKey{Method: "POST", Path: "/v1/tasks", Key: "dup", RequestSHA: "sha"})
+	if !errors.Is(err, ErrIdempotencyKeyExists) {
+		t.Fatalf("second create: %v, want ErrIdempotencyKeyExists", err)
+	}
+	rows, err := s.TableRows(ctx)
+	if err != nil {
+		t.Fatalf("TableRows: %v", err)
+	}
+	if rows["tasks"] != 1 {
+		t.Errorf("tasks = %d after a rejected key, want only the first", rows["tasks"])
+	}
+	if rows["idempotency_keys"] != 1 {
+		t.Errorf("idempotency_keys = %d, want 1", rows["idempotency_keys"])
+	}
+}
+
+// TestCreateTasksCarriesNoKey: the fan-out path spawns lanes the engine chose,
+// not a request a client could replay, so it writes no key at all.
+func TestCreateTasksCarriesNoKey(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	lanes := []*Task{newTask(p.ID, "lane-a", TaskQueued), newTask(p.ID, "lane-b", TaskQueued)}
+	lanes[1].BranchName = "vincent/0-lane-b"
+	if err := s.CreateTasks(ctx, lanes, nil); err != nil {
+		t.Fatalf("CreateTasks: %v", err)
+	}
+	rows, err := s.TableRows(ctx)
+	if err != nil {
+		t.Fatalf("TableRows: %v", err)
+	}
+	if rows["idempotency_keys"] != 0 {
+		t.Errorf("idempotency_keys = %d after a fan-out spawn, want 0", rows["idempotency_keys"])
+	}
+}
+
+// TestPruneIdempotencyKeys: rows past the window go, rows inside it stay, and
+// a second pass removes nothing — the ticker runs this forever.
+func TestPruneIdempotencyKeys(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	now := time.Now()
+	old := newTask(p.ID, "old", TaskQueued)
+	if err := s.CreateTaskWithKey(ctx, old, nil, &IdempotencyKey{
+		Method: "POST", Path: "/v1/tasks", Key: "old", RequestSHA: "sha",
+		CreatedAt: now.Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("create the aged task: %v", err)
+	}
+	fresh := newTask(p.ID, "fresh", TaskQueued)
+	fresh.BranchName = "vincent/0-fresh"
+	if err := s.CreateTaskWithKey(ctx, fresh, nil, &IdempotencyKey{
+		Method: "POST", Path: "/v1/tasks", Key: "fresh", RequestSHA: "sha",
+		CreatedAt: now.Add(-time.Hour),
+	}); err != nil {
+		t.Fatalf("create the fresh task: %v", err)
+	}
+
+	n, err := s.PruneIdempotencyKeys(ctx, now.Add(-24*time.Hour))
+	if err != nil || n != 1 {
+		t.Fatalf("first pass: removed %d, err %v; want 1, nil", n, err)
+	}
+	if _, err := s.GetIdempotencyKey(ctx, "POST", "/v1/tasks", "old"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("the aged key survived: %v", err)
+	}
+	if _, err := s.GetIdempotencyKey(ctx, "POST", "/v1/tasks", "fresh"); err != nil {
+		t.Errorf("a key inside the window was pruned: %v", err)
+	}
+	// Pruning never touches the tasks themselves: the key expires, the work
+	// it created does not.
+	if _, err := s.GetTask(ctx, old.ID); err != nil {
+		t.Errorf("pruning a key deleted its task: %v", err)
+	}
+	n, err = s.PruneIdempotencyKeys(ctx, now.Add(-24*time.Hour))
+	if err != nil || n != 0 {
+		t.Fatalf("second pass: removed %d, err %v; want 0, nil", n, err)
+	}
+}
+
+// TestIdempotencyKeyCascades: force-deleting a project deletes its tasks, and
+// a key whose task is gone has nothing left to replay, so it goes too
+// (task 040 decision 6).
+func TestIdempotencyKeyCascades(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	task := newTask(p.ID, "doomed", TaskQueued)
+	if err := s.CreateTaskWithKey(ctx, task, nil, &IdempotencyKey{
+		Method: "POST", Path: "/v1/tasks", Key: "cascade", RequestSHA: "sha",
+	}); err != nil {
+		t.Fatalf("CreateTaskWithKey: %v", err)
+	}
+	if err := s.DeleteProjectCascade(ctx, p.ID); err != nil {
+		t.Fatalf("DeleteProjectCascade: %v", err)
+	}
+	if _, err := s.GetIdempotencyKey(ctx, "POST", "/v1/tasks", "cascade"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("the key outlived its task: %v", err)
+	}
+}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 15
+const latestSchemaVersion = 16
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0016_idempotency.sql
+++ b/internal/store/migrations/0016_idempotency.sql
@@ -1,0 +1,47 @@
+-- 0016_idempotency: replay protection for task creation (task 040, issue #146).
+--
+-- `POST /v1/tasks` is the one route in §13.2 where a replayed request produces
+-- a second side effect: it inserts a row, claims a branch and wakes the
+-- scheduler, and none of that is a compare-and-swap. A client that times out
+-- *after* the commit and re-sends gets a second task, a second worktree and a
+-- second agent run against the same repository. Every other mutating route is
+-- already safe — the §6 actions are a CAS on the state the request read
+-- (amended 2026-08-24, issue #127), `POST /v1/projects` refuses a duplicate
+-- path outright, and the PATCH/DELETE routes are desired-state operations that
+-- reach the same end state when re-sent.
+--
+-- The primary key is `(method, path, key)` rather than `key` alone so a later
+-- route joins the table without a migration, even though today only
+-- `POST /v1/tasks` writes it.
+--
+-- `request_sha` is a digest of the *decoded* request, canonically re-marshalled
+-- — not of the raw bytes, so whitespace and JSON key order cannot manufacture a
+-- conflict — and taken before the GitHub issue prefill mutates the request, so
+-- an edited issue title cannot turn two identical sends into a 409.
+--
+-- `task_id` is a reference, not a stored response body. A replay re-reads the
+-- task and renders today's 201 from it; persisting the rendered JSON would put
+-- the workflow snapshot and a 4 MiB body bound (§13.1) into a table that grows
+-- with every create. The visible consequence is stated rather than hidden: a
+-- replay shows the task as it is **now**, so an already-admitted task replays
+-- as `state: running` under a `201`.
+--
+-- ON DELETE CASCADE because a key whose task has been destroyed has nothing
+-- left to replay. Force-deleting a project deletes its tasks, and foreign keys
+-- are enforced on every connection (`_foreign_keys=1`), so the key goes with
+-- it and a replay inside the remaining window creates a fresh task. That beat
+-- ON DELETE SET NULL plus a 410, which adds a status and an error code for a
+-- case only a deliberate destructive act inside a 24-hour window can reach.
+CREATE TABLE idempotency_keys (
+    method      TEXT NOT NULL,
+    path        TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    request_sha TEXT NOT NULL,
+    task_id     INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    created_at  TEXT NOT NULL,
+    PRIMARY KEY (method, path, key)
+);
+
+-- The prune scan is a range over created_at and nothing else; without this it
+-- is a full table scan on every 24-hour pass.
+CREATE INDEX idx_idempotency_keys_created_at ON idempotency_keys(created_at);

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -71,7 +71,24 @@ func (e *BranchClaimedError) Error() string {
 // It is the one-task spelling of CreateTasks, which is where the transaction
 // lives.
 func (s *Store) CreateTask(ctx context.Context, t *Task, resolveBranch func(id int64) (string, error)) error {
-	return s.CreateTasks(ctx, []*Task{t}, resolveBranch)
+	return s.createTasks(ctx, []*Task{t}, resolveBranch, nil)
+}
+
+// CreateTaskWithKey is CreateTask with an idempotency key written in the same
+// transaction as the row (task 040, issue #146). Either the task and its key
+// both commit or neither does, which is what makes a replayed create find the
+// key exactly when the task it names exists.
+//
+// A key already recorded for this `(method, path, key)` returns
+// ErrIdempotencyKeyExists with the whole insert rolled back — the concurrent
+// duplicate — and the caller replays the winner's task instead.
+//
+// k is the only caller-supplied part; the task id and, when unset, the
+// timestamp are filled in from the insert.
+func (s *Store) CreateTaskWithKey(
+	ctx context.Context, t *Task, resolveBranch func(id int64) (string, error), k *IdempotencyKey,
+) error {
+	return s.createTasks(ctx, []*Task{t}, resolveBranch, k)
 }
 
 // CreateTasks inserts several tasks in **one** transaction, resolving each
@@ -92,6 +109,18 @@ func (s *Store) CreateTask(ctx context.Context, t *Task, resolveBranch func(id i
 // transaction, so two lanes resolving to the same name collide here exactly
 // as a lane colliding with an existing task does.
 func (s *Store) CreateTasks(ctx context.Context, tasks []*Task, resolveBranch func(id int64) (string, error)) error {
+	return s.createTasks(ctx, tasks, resolveBranch, nil)
+}
+
+// createTasks is the shared body. k, when non-nil, is the idempotency key
+// recorded for the *first* task in the batch — which in practice means the
+// single task CreateTaskWithKey passes, since the fan-out path never carries
+// one (task 040): a lane spawn is the engine's own work, not a request a
+// client could replay.
+func (s *Store) createTasks(
+	ctx context.Context, tasks []*Task,
+	resolveBranch func(id int64) (string, error), k *IdempotencyKey,
+) error {
 	if len(tasks) == 0 {
 		return nil
 	}
@@ -99,10 +128,15 @@ func (s *Store) CreateTasks(ctx context.Context, tasks []*Task, resolveBranch fu
 	events := make([]*Event, 0, len(tasks))
 	err := s.withTx(ctx, func(tx *sql.Tx) error {
 		events = events[:0]
-		for _, t := range tasks {
+		for i, t := range tasks {
 			ev, err := insertTaskTx(ctx, tx, t, now, resolveBranch)
 			if err != nil {
 				return err
+			}
+			if i == 0 && k != nil {
+				if err := insertIdempotencyKeyTx(ctx, tx, k, t.ID, now); err != nil {
+					return err
+				}
 			}
 			events = append(events, ev)
 		}

--- a/internal/taskrun/prune.go
+++ b/internal/taskrun/prune.go
@@ -19,10 +19,25 @@ import (
 // it no longer has (PR V decision).
 const PruneInterval = 24 * time.Hour
 
-// TranscriptPruner deletes transcripts of tasks archived longer ago than the
-// retention window (§17). It owns no state: each pass reads the current
-// config, so a retention change takes effect on the next tick without a
-// restart.
+// IdempotencyRetention is how long a recorded Idempotency-Key stays replayable
+// (§17, task 040). Fixed, not configurable, the way §13.1's body bounds are
+// fixed: a key exists to absorb a transport retry, which happens in seconds,
+// so a day is three orders of magnitude of headroom and a knob here would be
+// config surface to document and defend forever for a number nobody would tune.
+//
+// It is independent of TranscriptRetentionDays, including that setting's
+// "zero keeps everything" escape: keys are small, opaque and useless once the
+// retry window has passed, so there is no operator reason to keep them.
+const IdempotencyRetention = 24 * time.Hour
+
+// TranscriptPruner runs the daemon's retention pass (§17): it deletes
+// transcripts of tasks archived longer ago than the configured window, and —
+// since task 040 — idempotency keys past their fixed 24-hour window. It owns
+// no state: each pass reads the current config, so a retention change takes
+// effect on the next tick without a restart.
+//
+// It keeps its name: transcripts are the retention story, and the keys are a
+// few rows a day riding the ticker that already runs at their expiry interval.
 type TranscriptPruner struct {
 	deps Deps
 }
@@ -61,6 +76,26 @@ func (p *TranscriptPruner) once(ctx context.Context) {
 	default:
 		p.deps.Logger.Debug("prune transcripts: nothing to do")
 	}
+	// Idempotency keys ride the same pass rather than getting a ticker of
+	// their own: it already runs at exactly the interval they expire on, and a
+	// second goroutine to delete a handful of rows a day would be machinery
+	// for nothing. A failure here is logged and dropped for the same reason
+	// the transcript failure above is.
+	switch keys, err := p.PruneKeys(ctx, time.Now()); {
+	case err != nil:
+		p.deps.Logger.Error("prune idempotency keys", "error", err)
+	case keys > 0:
+		p.deps.Logger.Info("pruned idempotency keys", "keys", keys)
+	}
+}
+
+// PruneKeys deletes idempotency keys older than IdempotencyRetention,
+// returning how many went. A second pass over the same rows removes nothing
+// and is not an error — the ticker runs this forever (PR V decision).
+//
+// now is a parameter so tests can age rows without sleeping.
+func (p *TranscriptPruner) PruneKeys(ctx context.Context, now time.Time) (int64, error) {
+	return p.deps.Store.PruneIdempotencyKeys(ctx, now.Add(-IdempotencyRetention))
 }
 
 // Prune deletes the transcript directory of every task archived before

--- a/internal/taskrun/prune_test.go
+++ b/internal/taskrun/prune_test.go
@@ -175,3 +175,48 @@ func TestPruneRunHonoursContextCancel(t *testing.T) {
 		t.Fatal("Run did not return after its context was canceled")
 	}
 }
+
+// keyTask creates a task carrying an idempotency key recorded ago in the past,
+// and returns the key's identifier.
+func (h *pruneHarness) keyTask(t *testing.T, title string, ago time.Duration) string {
+	t.Helper()
+	task := &store.Task{
+		ProjectID: h.projectID, Title: title, WorkflowName: "adhoc",
+		State: store.TaskQueued, WorkflowSnapshot: "name: adhoc\nsteps: []\n",
+		BranchName: "vincent/" + title,
+	}
+	key := &store.IdempotencyKey{
+		Method: "POST", Path: "/v1/tasks", Key: title, RequestSHA: "sha",
+		CreatedAt: time.Now().Add(-ago),
+	}
+	if err := h.store.CreateTaskWithKey(t.Context(), task, nil, key); err != nil {
+		t.Fatalf("CreateTaskWithKey: %v", err)
+	}
+	return title
+}
+
+// TestPruneKeysDropsExpiredOnly: the 24-hour pass also expires idempotency
+// keys (task 040). The window is fixed rather than read from
+// TranscriptRetentionDays, so a harness configured to keep transcripts forever
+// still expires keys.
+func TestPruneKeysDropsExpiredOnly(t *testing.T) {
+	h := newPruneHarness(t, 0) // transcripts kept forever; keys are not
+	expired := h.keyTask(t, "expired", 25*time.Hour)
+	live := h.keyTask(t, "live", time.Hour)
+
+	n, err := h.pruner.PruneKeys(t.Context(), time.Now())
+	if err != nil || n != 1 {
+		t.Fatalf("first pass: removed %d, err %v; want 1, nil", n, err)
+	}
+	if _, err := h.store.GetIdempotencyKey(t.Context(), "POST", "/v1/tasks", expired); err == nil {
+		t.Error("a key past the window survived the pass")
+	}
+	if _, err := h.store.GetIdempotencyKey(t.Context(), "POST", "/v1/tasks", live); err != nil {
+		t.Errorf("a key inside the window was pruned: %v", err)
+	}
+	// The ticker runs this every 24 h forever, so a second pass over
+	// already-pruned rows must be a no-op rather than an error.
+	if n, err := h.pruner.PruneKeys(t.Context(), time.Now()); err != nil || n != 0 {
+		t.Fatalf("second pass: removed %d, err %v; want 0, nil", n, err)
+	}
+}

--- a/scripts/m1-gate.sh
+++ b/scripts/m1-gate.sh
@@ -169,6 +169,42 @@ $GC"
 git -C "$REPO" rev-parse --verify "refs/heads/$BRANCH" >/dev/null \
   || fail "gc deleted branch $BRANCH — branches are never deleted"
 
+# Idempotency keys (§13.1, task 040). It rides this gate because the two things
+# it asserts — that a replayed create does not make a second task, and that a
+# reused key with a new body is refused — are only true over the wire, against a
+# real daemon that committed the first one.
+#
+# The api() helper above is `curl -f`, which exits non-zero on the 409 this leg
+# has to read, so the conflict goes through a status-capturing variant instead.
+idem() { # idem KEY METHOD PATH JSON_BODY — a request carrying an Idempotency-Key
+  curl -sS -f -X "$2" "${auth[@]}" -H "Content-Type: application/json" \
+    -H "Idempotency-Key: $1" -d "$4" "$BASE$3"
+}
+idem_status() { # idem_status KEY METHOD PATH JSON_BODY — prints the status, body in $TMP/idem.json
+  curl -sS -o "$TMP/idem.json" -w '%{http_code}' -X "$2" "${auth[@]}" \
+    -H "Content-Type: application/json" -H "Idempotency-Key: $1" -d "$4" "$BASE$3"
+}
+
+echo "== replay a create carrying an Idempotency-Key"
+IDEM_BODY="{\"project_id\":$PROJECT_ID,\"title\":\"M1 idempotent task\",\"description\":\"Say hello.\"}"
+IDEM_FIRST="$(idem m1-gate-key POST /tasks "$IDEM_BODY" | jq -r .id | tr -d '\r')"
+[[ "$IDEM_FIRST" =~ ^[0-9]+$ ]] || fail "keyed task creation returned no id"
+IDEM_SECOND="$(idem m1-gate-key POST /tasks "$IDEM_BODY" | jq -r .id | tr -d '\r')"
+[[ "$IDEM_SECOND" == "$IDEM_FIRST" ]] \
+  || fail "the replay created task $IDEM_SECOND rather than replaying $IDEM_FIRST"
+COUNT="$(api GET /tasks | jq '[.[] | select(.title == "M1 idempotent task")] | length' | tr -d '\r')"
+[[ "$COUNT" == "1" ]] || fail "the replayed create left $COUNT tasks, want 1"
+
+echo "== the same key with a different body is a 409"
+IDEM_OTHER="{\"project_id\":$PROJECT_ID,\"title\":\"M1 different task\",\"description\":\"Say hello.\"}"
+STATUS="$(idem_status m1-gate-key POST /tasks "$IDEM_OTHER" | tr -d '\r')"
+[[ "$STATUS" == "409" ]] || fail "reusing a key with a new body returned $STATUS, want 409"
+jq -e '.error.code == "invalid_state" and .error.details.reason == "idempotency_key_reused"' \
+  "$TMP/idem.json" >/dev/null || fail "the conflict body is not the §13.1 envelope:
+$(cat "$TMP/idem.json")"
+COUNT="$(api GET /tasks | jq '[.[] | select(.title == "M1 different task")] | length' | tr -d '\r')"
+[[ "$COUNT" == "0" ]] || fail "the refused create made a task anyway"
+
 echo "== stop daemon"
 "$VINCENT" daemon stop
 


### PR DESCRIPTION
## Summary

`POST /v1/tasks` is the one route in the §13.2 table where a replayed request
produces a second side effect. It inserts a row, claims a branch and wakes the
scheduler, and none of that is a compare-and-swap on state the request read — so
a client that times out *after* the commit and re-sends gets a second task, a
second worktree and a second agent run against the same repository.

This adds an optional `Idempotency-Key` header on that route.

- **Same key, same request** → `201` with the task the first send created.
- **Same key, a different request** → `409 invalid_state` with
  `details.reason = "idempotency_key_reused"`, and no task is created.
- **No header** → byte-for-byte today's behaviour. Two identical sends make two
  tasks, which is what a human pressing enter twice means.
- **Two requests racing with the same key** → exactly one task. The store is a
  single WAL writer, so the transactions serialize; the loser's key insert
  violates the primary key, its task insert rolls back with it, and it replays
  the winner's task.

The key row is written **inside the task's own transaction**, so the two commit
together or not at all. It stores a *reference* (the task id), not a rendered
response body: a task response carries the workflow snapshot's steps under a
4 MiB body bound (§13.1), and persisting that per create would be a
storage-growth surface of exactly the kind #98 was opened about. The consequence
is documented rather than hidden — a replay renders the task **as it is now**, so
an already-admitted task replays as `state: running` under a `201`. Keys expire
after a fixed 24 hours on the daemon's existing retention pass, and cascade away
with the task they name.

Scope is deliberately this one route. The §6 action routes are already a
compare-and-swap on the state the request read (amended 2026-08-24, #127),
`POST /v1/projects` refuses an already-registered path, and the `PATCH`es,
`DELETE /v1/projects/{id}`, `POST /v1/maintenance/gc` and `POST /v1/doctor/fix`
are desired-state operations. The table is keyed `(method, path, key)` so a later
route joins without a migration.

**Acceptance criteria from the issue this does not build**, stated rather than
quietly dropped:

- *"CLI/TUI retries preserve the key"* — dropped. `internal/apiclient` has no
  REST retry at all: a create that times out is reported to the person, who looks
  at the board and decides. There is no retry for a key to survive, and minting
  one per composed form would fight the issue's own rule that a new explicit user
  action is a new operation.
- *"Keys are not logged as secrets"* — nothing to build. `logMiddleware` logs
  method, path, status and duration; no header reaches the log, and a
  client-chosen key is not a credential.
- *"Scope keys by … authenticated vincent instance, and logical caller"* — there
  is one daemon, one token and no caller identity. `(method, path, key)` is the
  whole of what exists to scope by.
- *Coverage of the action and project routes* — out of scope on the evidence
  above; the reasoning is recorded as decision 1 in the task document.

`internal/api/doctor.go` needed no change: `store.TableRows` enumerates the
schema, so `idempotency_keys` appears in `database.table_rows` on
`GET /v1/doctor` with no code — which is what the issue's "exposed through
doctor/storage metrics" asks for.

**Note on the PR title.** The step that generated this asked for a Conventional
Commits title; `CLAUDE.md` and the `PR title` workflow require the opposite for
human PRs, so the title here is plain language and the conventional prefix is on
the commit.

## Related

Closes #146
Closes 040.1–040.7 (`docs/tasks/040-api-idempotency-keys.md`).

Builds on the §6 CAS amendment from #127 and the §13.1 body bounds from #140 —
neither is revisited. Decision 5 follows the existing rule in
`internal/api/errors.go` that every `409` carries `invalid_state` and the reason
travels in `details`, rather than adding the `idempotency_conflict` code the
issue proposed.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### What was verified

- `go run mage.go test` — full suite green.
- `go test -race ./internal/api -run 'Idempoten|TestConcurrentDuplicates|…'` —
  green, including the two-goroutine duplicate test.
- `golangci-lint run ./...` built for the host and run under `GOOS=darwin`,
  `GOOS=linux` and `GOOS=windows` — 0 issues on all three.
- `./scripts/m1-gate.sh` — pass, including the new leg that replays a create over
  curl and asserts the `409` on a changed body.

New tests: `internal/api/idempotency_test.go` (no-header regression, sequential
replay, digest insensitivity to whitespace and key order, conflict envelope,
concurrent duplicates, key bounds, cascade, doctor row count),
`internal/store/idempotency_test.go` (round-trip and route scoping, transaction
atomicity, fan-out writes no key, prune, cascade),
`internal/taskrun/prune_test.go` (expired keys go, live ones stay, second pass is
a no-op).

Docs: `docs/spec.md` §13.1 (the header, the digest, replay semantics, the
409-in-details, the fixed window), §13.2's `POST /v1/tasks` entry, §14 (the
table and why it stores a reference), §17 (the key prune alongside transcript
retention); `docs/reference/api.md` (transport, errors, and a "Replaying a
create" section); `docs/tasks/040-api-idempotency-keys.md` plus its index row.

A separate documentation commit adds the three pages the header is visible
from and the first pass missed: `docs/guides/scripting.md` — the page whose
whole audience is a script creating tasks over curl, which by decision 3 is the
only caller that sends this header — now sets the key in its create example and
says what a retry under one does; `docs/features.md` gains the integration
bullet; and `docs/reference/configuration.md` no longer implies that
`transcript_retention_days: 0` means nothing is pruned, because the pass it
describes now also drops expired keys on a window that setting does not govern.

### Found while auditing the docs, not changed here

- **The `GET /v1/doctor` sample body in `docs/reference/api.md` is illustrative
  and predates this branch.** Its `schema_version` and `newest_migration` read
  `13` against 16 applied migrations, and its `table_rows` object lists a
  handful of tables, so `idempotency_keys` is absent from it. Nothing there is a
  claim this change falsified — the prose beneath already states that
  `table_rows` is enumerated from the schema rather than from a fixed list, so a
  new table appears with no client change — and refreshing sample data is not
  this PR's business.
- No TUI surface changed, so nothing under `docs/assets/tui-*.png` is stale.
- The audit found no defect in the implementation to report.
