### PR TITLE
Enable gosec in the lint gate with reviewed suppressions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - copyloopvar
     - errorlint
     - gocritic
+    - gosec
     - intrange
     - misspell
     - nolintlint
@@ -16,6 +17,38 @@ linters:
     - sqlclosecheck
     - unconvert
     - unparam
+  exclusions:
+    rules:
+      # Tests, the fake CLIs and the test helpers are out of gosec's scope by
+      # configuration rather than by ~74 inline directives (task 042). These
+      # paths deliberately mirror real-world permissions, deliberately exec
+      # `go build`, `git` and their own compiled fixtures, and ship in no
+      # binary; annotating each site would be noise every new test file has to
+      # re-earn.
+      - linters: [gosec]
+        path: (_test\.go|^cmd/fakeagent/|^cmd/fakegh/|^internal/testrepo/|^internal/agent/agenttest/|^internal/github/githubtest/)
+
+      # gosec analyses one GOOS at a time, so a suppression can be required on
+      # one platform and stale on another — and nolintlint (deliberately kept
+      # strict, so that stale directives stay visible for every other linter)
+      # would then fail the platform where it is stale. A platform-divergent
+      # finding is therefore excluded here instead of //nolint-ed at the site,
+      # which keeps its reason in the code as an ordinary comment. See
+      # docs/tasks/042-gosec-static-analysis.md.
+      #
+      # disk_unix.go: Statfs_t.Bsize is int64 on Linux (G115 on the uint64
+      # conversion) and uint32 on Darwin (no finding). A block size is never
+      # negative.
+      - linters: [gosec]
+        path: ^internal/doctor/disk_unix\.go$
+        text: "G115"
+
+issues:
+  # gosec is a per-platform gate (task 042): a truncated report is worse than
+  # none, because *which* findings survive the default max-issues-per-linter:
+  # 50 / max-same-issues: 3 caps varies between runs of the identical command.
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 formatters:
   enable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ list with the user-facing context a commit subject cannot carry.
   workflow edited after the task was queued. Retries are not gated; that
   backstop is what catches them.
   ([#148](https://github.com/lezli01/vincent/issues/148))
+- **gosec now runs on every build, as part of the existing lint gate.** The
+  security linter is enabled inside the golangci-lint the `go.mod` tool directive
+  already pins, so `go run mage.go lint` is still one command and still the
+  byte-identical one CI runs on Linux, macOS and Windows — a new unsuppressed
+  finding now fails the build. Every one of the 39 current findings in production
+  code was read individually and either fixed or suppressed with a reason at the
+  site; the reasoning is recorded in
+  [task 042](docs/tasks/042-gosec-static-analysis.md), and
+  [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md) explain how
+  gosec and govulncheck divide the work. No runtime behaviour changed and no file
+  or directory permission moved: tightening one is a user-visible change that
+  needs its own issue, not a side effect of turning a linter on.
+  ([#147](https://github.com/lezli01/vincent/issues/147))
 
 ## [0.6.0](https://github.com/lezli01/vincent/compare/v0.5.0...v0.6.0) (2026-08-25)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,26 @@ go run mage.go lint      # golangci-lint (pinned via go.mod tool directive)
 go run mage.go vuln      # govulncheck across linux, darwin and windows
 ```
 
+`lint` and `vuln` are two different questions and neither substitutes for the
+other. **gosec**, which runs inside `lint`, reads *this repository's* source for
+insecure patterns — subprocess construction, file paths, permissions, SQL
+building, integer conversions — and runs on every pull request, on all three
+platforms, as part of the same command you run locally. **govulncheck**, which is
+`vuln`, reads the *dependency graph* for published advisories that actually reach
+code you call; it sweeps the three target platforms weekly in
+[`vuln.yml`](.github/workflows/vuln.yml) and can go red without a line of vincent
+changing.
+
+A gosec finding is evidence, not a verdict: read the site, and either fix it or
+suppress it with a `//nolint:gosec // ...` whose comment says *why it is safe
+here*. `nolintlint` is strict, so a suppression that stops applying is reported
+rather than left to rot — and a reason that merely asserts a path is
+daemon-owned, when repository or request input reaches it, is worse than no
+suppression at all. Tests, the fake CLIs and the test helpers are already out of
+scope by configuration in `.golangci.yml`; do not re-annotate them. The
+per-finding rationale for the existing baseline is in
+[task 042](docs/tasks/042-gosec-static-analysis.md).
+
 To use the tree you are working on as your everyday `vincent` — the binary on
 PATH, with the same release build flags and version symbols, so `vincent
 version` names your checkout:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,19 @@ Known vulnerabilities in the dependency graph are swept weekly by
 [`.github/workflows/vuln.yml`](https://github.com/lezli01/vincent/blob/master/.github/workflows/vuln.yml) (govulncheck across
 all three target platforms), and on every change to `go.mod`/`go.sum`.
 
+Vincent's own source is swept separately, by
+[gosec](https://github.com/securego/gosec) inside the pinned golangci-lint
+configuration. The two look at different things and neither replaces the other:
+govulncheck reads the **dependency graph** for published advisories that reach
+code vincent actually calls, and can go red without a line of vincent changing;
+gosec reads **this repository's code** for insecure patterns — subprocess
+construction, file paths, file and directory permissions, SQL building, integer
+conversions — and runs on every pull request, on Linux, macOS and Windows, as
+part of the ordinary `go run mage.go lint` gate. A new unsuppressed gosec finding
+fails CI. Existing findings are suppressed one site at a time with a stated
+reason; the adjudication is recorded in
+[task 042](https://github.com/lezli01/vincent/blob/master/docs/tasks/042-gosec-static-analysis.md).
+
 ## Reporting a vulnerability
 
 Please **do not** open a public issue for security vulnerabilities.

--- a/docs/tasks/042-gosec-static-analysis.md
+++ b/docs/tasks/042-gosec-static-analysis.md
@@ -1,0 +1,186 @@
+# 042 — gosec in the normal static-analysis gate, with reviewed suppressions
+
+**Status:** ✅ done (5/5) · **Opened:** 2026-08-28
+
+`.golangci.yml` enabled a strong quality set and no security linter, while the
+tree already carried 24 `//nolint:gosec` directives written in anticipation of
+one. This task turns gosec on inside the golangci-lint the `go.mod` tool
+directive already pins, adjudicates every current finding one site at a time,
+and records the adjudication here so a future contributor reads a reason rather
+than a bare `//nolint`.
+
+A standalone review run against
+[7b621865](https://github.com/lezli01/vincent/commit/7b6218658b040d03aeece9dc4bba78a5369d6a2b)
+produced 42 raw findings ([#147](https://github.com/lezli01/vincent/issues/147)).
+The two that mattered — workflow file loading and config modes — were promoted to
+their own issues and closed as [#136](https://github.com/lezli01/vincent/issues/136)
+and [#141](https://github.com/lezli01/vincent/issues/141). What remained, and
+what this task is, is the baseline and the gate.
+
+Conventions for this file are in [the tasks README](README.md). Behaviour lands
+in [the spec](../spec.md); nothing here changes runtime behaviour, so the spec is
+untouched — see the last decision.
+
+## Tasks
+
+- [x] **042.1** Enable gosec in `.golangci.yml`, with the output limits removed
+      and the test/fixture scope configured. ✓ 2026-08-28
+- [x] **042.2** Replace the five hand-rolled SQL `IN`-list constructions in
+      `internal/store` with one `placeholders(n)` helper, so the six G202
+      suppressions cite something checkable. ✓ 2026-08-28
+- [x] **042.3** Rewrite `grouping.has`/`grouping.equal` on `slices.Contains` /
+      `slices.Equal`, which deletes the G602 finding along with the loops, behind
+      a test that pins the predicates first. ✓ 2026-08-28
+- [x] **042.4** Adjudicate the remaining 32 production sites: an inline
+      suppression naming the reason, or an exclusion rule where the finding is
+      platform-divergent. ✓ 2026-08-28
+- [x] **042.5** Document gosec versus govulncheck in `CONTRIBUTING.md` and
+      `SECURITY.md`. ✓ 2026-08-28
+
+## What the numbers are
+
+Measured through the pinned golangci-lint (v2.13.1) with its output limits
+removed, before any suppression was added:
+
+| GOOS | findings |
+|---|---|
+| darwin | 103 |
+| linux | 102 |
+| windows | 102 |
+
+113 distinct sites across the three platforms: 74 in tests, the fake CLIs and the
+test helpers, 39 in production code. By rule: G304 ×45, G301 ×18, G204 ×17,
+G306 ×10, G202 ×6, G302 ×5, G115 ×5, G101 ×3, G103 ×2, G703 ×1, G602 ×1.
+
+The 39 production sites are the ones adjudicated below. Nothing in them was a
+vulnerability; one — the `slices.Equal` rewrite — was worth changing anyway.
+
+## Decisions
+
+- **gosec runs inside golangci-lint, not as a separately pinned tool
+  (2026-08-28).** It then inherits the existing `go.mod` pin, the existing
+  three-platform CI matrix and the existing local command, so nothing new has to
+  be kept in step and `go run mage.go lint` stays byte-identical between a
+  developer's machine and `ci.yml`. The alternative — a pinned standalone gosec
+  with its own mage target and its own CI step — buys the newest upstream rule
+  set and a SARIF feed into GitHub code scanning, and costs a second pin, a
+  second command and a second thing to keep on three platforms. The cost accepted
+  here is that the rule set is whatever golangci-lint v2.13.1 vendors. Code
+  scanning, CodeQL, secret scanning and SBOM stay out of scope, as
+  [#147](https://github.com/lezli01/vincent/issues/147) itself proposes.
+
+- **`issues.max-issues-per-linter` and `issues.max-same-issues` are both `0`
+  (2026-08-28).** This is not tidiness. golangci-lint defaults them to 50 and 3,
+  and this repository set neither, so a naive `enable: gosec` reports about 25
+  findings per platform instead of ~102 — and *which* 25 varies between runs of
+  the identical command, because the truncation happens after parallel package
+  analysis. Two consecutive runs here listed different G301 sites. A gate that
+  hides three quarters of its findings nondeterministically is not a gate, and a
+  reviewer should not believe a "only 25 findings" claim about this change.
+
+- **Test, fixture and fake-CLI scope is configured, not annotated (2026-08-28).**
+  A single `linters.exclusions.rules` entry names gosec against `_test\.go`,
+  `cmd/fakeagent`, `cmd/fakegh`, `internal/testrepo`, `internal/agent/agenttest`
+  and `internal/github/githubtest`, carrying the rationale once: those paths
+  deliberately mirror real-world permissions, deliberately exec `go build` and
+  `git`, and ship in no binary. 74 inline comments would be noise that every new
+  test file has to re-earn. Three now-redundant `//nolint:gosec` directives in
+  test files were deleted rather than kept, since nolintlint correctly calls them
+  unused once the exclusion covers them.
+
+- **Platform-divergent suppressions live in exclusion rules; stable ones stay
+  inline (2026-08-28).** gosec analyses one GOOS at a time, so a suppression can
+  be required on one platform and stale on another. `internal/doctor/disk_unix.go`
+  is exactly that: `Statfs_t.Bsize` is `int64` on Linux (G115 on the `uint64`
+  conversion) and `uint32` on Darwin (no finding), so a `//nolint` there fails
+  Darwin's nolintlint and its absence fails Linux's gosec. Loosening
+  `nolintlint.allow-unused` was rejected: it would blind the repository to stale
+  directives for every linter forever, to fix one site. An exclusion rule is
+  never "unused", so nolintlint stays strict, and the reason stays at the site as
+  an ordinary comment pointing here.
+
+- **Suppression is not a route to relitigating spec §16 or #141 (2026-08-28).**
+  G301/G302/G306 demand `0750` directories and `0600` files across the tree.
+  §16's 2026-08-25 amendment already settled which files are owner-only and why —
+  `config.yaml`, its directory, transcripts — and the code already states where
+  world-readable is deliberate: a launchd plist, a systemd unit, a scaffolded
+  workflow that gets committed to the user's repository. Tightening any of those
+  is a user-visible behaviour change that needs its own spec amendment and its
+  own issue. The disposition for those rules here is a suppression whose reason
+  names the design decision, never a mode change smuggled in under a lint PR.
+
+- **`internal/store/store.go`'s `0o755` data dir is recorded as follow-up, not
+  fixed here (2026-08-28).** It is the one directory mode in the tree that is
+  inconsistent with its neighbours: `internal/tui/firstrun.go` creates the *same*
+  data directory with `0o700`, and worktrees, logs and transcripts are all
+  `0o700`. Whichever is right, changing it alters an existing installation's
+  on-disk permissions, which is the previous decision's definition of out of
+  scope. It carries a suppression saying so, and this paragraph is the follow-up
+  record.
+
+- **The G202 suppressions were made checkable before they were written
+  (2026-08-28).** Five sites in `internal/store` built an `IN (?, ?, ?)` list by
+  hand, in two different spellings (`strings.Repeat("?,", n-1) + "?"` and
+  `"(?" + strings.Repeat(", ?", n-1) + ")"`). They now all call one
+  `placeholders(n)` in `store.go`, whose doc comment states the property the
+  suppressions rely on: the result is punctuation and bind markers derived from a
+  count, never from a value. This is the issue's "prefer a small wrapper that
+  proves safety over a blanket disable" applied where the call sites allowed it.
+  gosec still reports the six sites, because a function call is not a constant
+  operand — but a reviewer can now check all six against one helper. The sixth,
+  `transitions.go`, is a `SET` clause joined from literals assigned three lines
+  above and is left as-is.
+
+- **The backup suppressions name the real provenance (2026-08-28).** This is the
+  issue's criterion about misleading trusted-path assertions, and the backup
+  package is where it bites. `archive.go`'s `Create` opens the destination the
+  API *caller* named in `POST /v1/backup` — not a daemon-owned path — and its
+  reason says so, resting on §16's trust boundary and on `O_EXCL` rather than on
+  a provenance claim that is false. `restore.go`'s `extractFile` opens a path
+  derived from a **tar header**, which an attacker-supplied archive controls; its
+  reason cites the `target()` guard above it, which refuses any entry that does
+  not resolve inside the two roots, checking the entry name and the joined path
+  separately. Only `writeRegular` and the data-root walk get a daemon-owned
+  claim, and only because it is true of them.
+
+- **No spec amendment, and no gate script (2026-08-28).** Nothing in §16 or §19
+  describes the lint configuration, and no runtime behaviour changed: every
+  production edit is a comment, a suppression, or the two refactors above, both
+  covered by existing tests plus the one added here. The acceptance gates drive a
+  running daemon over the API and have nothing to assert about a linter.
+
+## What was proved
+
+- `go run mage.go lint` exits 0 on the host, and the CLAUDE.md cross-platform
+  loop (`for os in windows darwin linux; do GOOS=$os "$LINT" run ./...; done`)
+  exits 0 for all three. That loop is load-bearing rather than advisory here:
+  39 of the 113 sites exist under one GOOS only.
+- The gate fails on a new unsuppressed finding. A temporary
+  `os.WriteFile(..., 0o644)` in `internal/version` — a package no exclusion
+  covers — produced `G306: Expect WriteFile permissions to be 0600 or less` and a
+  non-zero exit; deleting it returned the package to `0 issues`. Run during
+  development, deliberately not committed.
+- `TestGroupingEqualAndHas` was added and passing against the hand-written
+  `equal` **before** the `slices.Equal` rewrite, so the rewrite is covered by a
+  test that distinguishes equal, different-length, different-element and
+  reordered groupings. Everywhere else in `boardgroup_test.go`, `equal` is the
+  assertion rather than the subject.
+- `go run mage.go test` and `go run mage.go testrace` both green, which is what
+  says the suppressions changed no behaviour.
+
+## Cost
+
+Measured on the maintainer's machine, host GOOS only, best of the runs taken:
+
+| | with gosec | without |
+|---|---|---|
+| warm cache | 1.45 s | 1.69 s |
+| cold cache (`golangci-lint cache clean`) | 10.7 s | 14.4 s |
+
+gosec came out *faster* in both pairs, which is the honest read: the difference
+is run-to-run variance, not a speedup. gosec is an AST pass over packages the run
+already loads and type-checks, so its marginal cost is below what this machine can
+measure. CI pays a cold Go build cache too and should be trusted over these
+numbers. If it ever threatens the 20-minute `ci` budget on Windows, the fallback
+is a separate step running gosec alone rather than a slower shared one — nothing
+measured suggests that is needed.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -55,6 +55,7 @@ the living engineering specification records implementation contracts.
 | [039](039-unsigned-releases-by-default.md) | A missing certificate must not destroy a release | ⚠ verification blocked (6/7) |
 | [040](040-api-idempotency-keys.md) | Idempotency keys for `POST /v1/tasks` | ✅ done (7/7) |
 | [041](041-adapter-compatibility-health.md) | Adapter version compatibility and protocol health | ✅ done (5/5) |
+| [042](042-gosec-static-analysis.md) | gosec in the normal static-analysis gate, with reviewed suppressions | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/agent/catalog_test.go
+++ b/internal/agent/catalog_test.go
@@ -108,7 +108,7 @@ func (s *stubAdapter) Start(context.Context, RunSpec) (RunHandle, error) {
 func fakeBinary(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "agent-bin")
-	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil { //nolint:gosec // test binary stand-in
+	if err := os.WriteFile(path, []byte("v1"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return path

--- a/internal/backup/archive.go
+++ b/internal/backup/archive.go
@@ -101,7 +101,11 @@ type Result struct {
 // be restored is worse than no archive, because it is the one a user reaches
 // for on the day they need it.
 func Create(dst string, src Source) (Result, error) {
-	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, entryMode)
+	// G304: dst is the path the API caller asked for (`POST /v1/backup`), not a
+	// daemon-owned one. That is by design — the trust boundary is the OS user
+	// (§16), and a backup is only useful if the user picks where it lands.
+	// O_EXCL is what keeps it from clobbering something that is already there.
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, entryMode) //nolint:gosec // G304: see above
 	if err != nil {
 		if errors.Is(err, fs.ErrExist) {
 			return Result{}, fmt.Errorf("%s: %w", dst, ErrDestinationExists)
@@ -194,7 +198,9 @@ func writeManifest(tw *tar.Writer, m Manifest) error {
 // fs.ErrNotExist from a missing source is returned unwrapped enough for
 // errors.Is, so a caller can decide whether absence is a failure.
 func writeRegular(tw *tar.Writer, name, src string) (int64, error) {
-	f, err := os.Open(src)
+	// G304: writeRegular is called only with paths the daemon resolved itself —
+	// the staged database copy and the config file under its own config dir.
+	f, err := os.Open(src) //nolint:gosec // G304: see above
 	if err != nil {
 		return 0, fmt.Errorf("open %s: %w", src, err)
 	}
@@ -248,7 +254,8 @@ func writeTree(tw *tar.Writer, root, prefix string) (int64, error) {
 			// is not restorable state.
 			return nil
 		}
-		f, err := os.Open(p)
+		// G304: p is a WalkDir result under one of the daemon's own data roots.
+		f, err := os.Open(p) //nolint:gosec // G304: see above
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				return nil

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -59,7 +59,9 @@ type Displaced struct {
 // first, so this decompresses one block rather than the whole file — which is
 // what makes a schema check affordable before a multi-gigabyte extraction.
 func ReadManifest(archive string) (Manifest, error) {
-	f, err := os.Open(archive)
+	// G304: the archive the user named on the command line. Reading a file the
+	// invoking user can already read crosses no boundary (§16).
+	f, err := os.Open(archive) //nolint:gosec // G304: see above
 	if err != nil {
 		return Manifest{}, fmt.Errorf("open %s: %w", archive, err)
 	}
@@ -160,7 +162,7 @@ func Restore(archive string, dirs Dirs, force bool) (Report, error) {
 		}
 	}
 
-	f, err := os.Open(archive)
+	f, err := os.Open(archive) //nolint:gosec // G304: the archive the user named, as in ReadManifest
 	if err != nil {
 		return rep, fmt.Errorf("open %s: %w", archive, err)
 	}
@@ -275,7 +277,11 @@ func extractFile(dest string, r io.Reader) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(dest), dirMode); err != nil {
 		return 0, fmt.Errorf("create %s: %w", filepath.Dir(dest), err)
 	}
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, entryMode)
+	// G304: dest is *not* trusted input — it is derived from a tar header, which
+	// an attacker-supplied archive controls. It is safe because target() above
+	// has already refused any entry that does not resolve inside one of the two
+	// roots, checking the entry name and the joined path separately.
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, entryMode) //nolint:gosec // G304: see above
 	if err != nil {
 		return 0, fmt.Errorf("create %s: %w", dest, err)
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -486,6 +486,9 @@ func doctorStorageRows(s apiclient.DoctorStorage) [][]string {
 		free = s.DiskError
 	} else if s.DiskTotalBytes > 0 {
 		free = fmt.Sprintf("%s free of %s",
+			// G115: a filesystem large enough to overflow int64 bytes (8 EiB) does not
+			// exist, and this is a line of human-readable text either way.
+			//nolint:gosec // G115: see above
 			humanBytes(int64(s.DiskFreeBytes)), humanBytes(int64(s.DiskTotalBytes)))
 	}
 	rows := [][]string{

--- a/internal/cli/workflow_init.go
+++ b/internal/cli/workflow_init.go
@@ -173,12 +173,17 @@ func writeWorkflowFile(cmd *cobra.Command, t initTarget) error {
 	}
 	shadows := shadowedBy(t)
 
-	if err := os.MkdirAll(t.dir, 0o755); err != nil {
+	// G301/G302: a scaffolded workflow is a repository file. `.vincent/workflows`
+	// is committed and read by everyone who clones the project, so it takes the
+	// ordinary repository modes rather than owner-only ones. In the global scope
+	// the parent is the 0700 config dir (§16), which is what actually bounds it.
+	if err := os.MkdirAll(t.dir, 0o755); err != nil { //nolint:gosec // G301: see above
 		return fmt.Errorf("create %s: %w", t.dir, err)
 	}
 	// O_EXCL makes "never clobber" a syscall guarantee rather than a
 	// stat-then-write race: nothing this command does can overwrite a file a
 	// user wrote by hand.
+	//nolint:gosec // G302/G304: repository file modes, path built from the scope dir above
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {
@@ -236,7 +241,8 @@ func nameTakenIn(dir, name string, except ...string) (string, bool) {
 		if slices.Contains(except, path) {
 			continue
 		}
-		src, err := os.ReadFile(path)
+		// G304: a directory entry of the workflow dir this command just scanned.
+		src, err := os.ReadFile(path) //nolint:gosec // G304: see above
 		if err != nil {
 			continue
 		}

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -152,6 +152,7 @@ func EnsureDefaultFile(dir string) (created bool, err error) {
 	if err := os.MkdirAll(dir, DirPerm); err != nil {
 		return false, fmt.Errorf("create config dir: %w", err)
 	}
+	//nolint:gosec // G304: path is ConfigPath() under the dir resolved above, never caller input
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, FilePerm)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -454,7 +454,10 @@ func Default() Config {
 // default values; unknown keys are rejected (strict decoding).
 func Load(path string) (Config, error) {
 	cfg := Default()
-	raw, err := os.ReadFile(path)
+	// G304: Load is called with ConfigPath(), or with a path a test chose. The
+	// config file belongs to the invoking user, so reading it crosses no
+	// boundary (§16); the file is what says who the user is, not the reverse.
+	raw, err := os.ReadFile(path) //nolint:gosec // G304: see above
 	if errors.Is(err, os.ErrNotExist) {
 		return cfg, nil
 	}

--- a/internal/daemon/console_windows.go
+++ b/internal/daemon/console_windows.go
@@ -106,6 +106,9 @@ func ownsConsole() bool {
 	// too small — so a two-element buffer distinguishes "just us" from "more
 	// than us" without asking how many more.
 	var pids [2]uint32
+	// G103: unsafe.Pointer is how a Win32 out-parameter is passed. pids is a
+	// stack array whose length is handed over in the same call.
+	//nolint:gosec // G103: see above
 	n, _, _ := procGetConsoleProcessList.Call(
 		uintptr(unsafe.Pointer(&pids[0])), uintptr(len(pids)))
 	return n == 1

--- a/internal/daemon/logtail.go
+++ b/internal/daemon/logtail.go
@@ -30,7 +30,9 @@ func LogPath(dataDir string) string {
 // different fact from a log with nothing in it — an empty file returns no
 // lines and no error.
 func TailFile(path string, n int) ([]string, error) {
-	f, err := os.Open(path)
+	// G304: LogPath() under the daemon's own data dir; the API exposes the tail,
+	// never the path to tail.
+	f, err := os.Open(path) //nolint:gosec // G304: see above
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -15,7 +15,9 @@ func StartDetached() (pid int, err error) {
 	if err != nil {
 		return 0, fmt.Errorf("resolve own executable: %w", err)
 	}
-	cmd := exec.Command(exe, "daemon")
+	// G204: exe is os.Executable() — this binary re-executing itself with a
+	// fixed argument. No shell is involved.
+	cmd := exec.Command(exe, "daemon") //nolint:gosec // G204: see above
 	cmd.SysProcAttr = detachSysProcAttr()
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("spawn detached daemon: %w", err)

--- a/internal/daemon/token.go
+++ b/internal/daemon/token.go
@@ -35,7 +35,7 @@ func ReadToken(dataDir string) (string, error) {
 // its permissions are re-tightened to 0600.
 func EnsureToken(dataDir string) (string, error) {
 	path := TokenPath(dataDir)
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(path) //nolint:gosec // G304: TokenPath() under the daemon's own data dir
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("read token: %w", err)
 	}

--- a/internal/doctor/disk_unix.go
+++ b/internal/doctor/disk_unix.go
@@ -20,7 +20,10 @@ func diskUsage(path string) (free, total uint64, err error) {
 		return 0, 0, fmt.Errorf("statfs %s: %w", path, err)
 	}
 	// Bsize is int64 on Linux and uint32 on Darwin; the conversion is what
-	// keeps one implementation for every unix.
-	bsize := uint64(st.Bsize) //nolint:gosec // a block size is never negative
+	// keeps one implementation for every unix. A block size is never negative,
+	// so gosec's G115 here is a false positive — and it fires on Linux only,
+	// which is why the suppression is an exclusion rule in .golangci.yml rather
+	// than a //nolint that nolintlint would call stale on Darwin (task 042).
+	bsize := uint64(st.Bsize)
 	return st.Bavail * bsize, st.Blocks * bsize, nil
 }

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -137,7 +137,9 @@ func parseGHIssue(out []byte, repo Repo, now time.Time) (Issue, error) {
 // carrying a named reason plus the stderr as *detail* — which reaches the
 // daemon log and nothing else (decision 1).
 func (c *Client) runGH(ctx context.Context, path string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, path, args...)
+	// G204: path is the configured or PATH-resolved `gh`, args are an argument
+	// slice built by this package. Never a shell string.
+	cmd := exec.CommandContext(ctx, path, args...) //nolint:gosec // G204: see above
 	hideConsole(cmd)
 	// GH_PAGER and NO_COLOR are not set here: `--json` output is neither
 	// paged nor colored by gh, and inheriting the user's environment is the

--- a/internal/github/reason.go
+++ b/internal/github/reason.go
@@ -21,7 +21,7 @@ const (
 	// ReasonNoCredential: neither `gh` nor a GITHUB_TOKEN/GH_TOKEN in the
 	// daemon's environment can authenticate. This is the row `vincent doctor`
 	// exists to explain.
-	ReasonNoCredential = "no_credential"
+	ReasonNoCredential = "no_credential" //nolint:gosec // G101: a block reason, not a credential
 	// ReasonUnauthorized: the credential was rejected (HTTP 401, `gh` reports
 	// a bad token).
 	ReasonUnauthorized = "unauthorized"
@@ -50,7 +50,7 @@ const (
 // reasonMessages are the one-line explanations clients render. Keeping them
 // here rather than at each call site is what makes "no leg leaks its own
 // error text" enforceable: the API has nothing else to print.
-var reasonMessages = map[string]string{
+var reasonMessages = map[string]string{ //nolint:gosec // G101: these are the reasons' own explanations, not credentials
 	ReasonDisabled:     "the GitHub integration is disabled in config.yaml",
 	ReasonNotGitHub:    "this project's origin remote is not a github.com repository",
 	ReasonNoCredential: "no GitHub credential: gh is not installed or not authenticated, and neither GITHUB_TOKEN nor GH_TOKEN is set",

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -70,7 +70,10 @@ func New() *Git { return &Git{path: "git"} }
 // Run executes git with args in dir and returns trimmed stdout. Failures are
 // returned as *Error with stderr captured.
 func (g *Git) Run(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, g.path, args...)
+	// G204: g.path is "git" (or a test's stand-in) and args is an argument
+	// slice assembled by callers in this repository — no shell, so no quoting
+	// or metacharacter question arises for the branch and path values in it.
+	cmd := exec.CommandContext(ctx, g.path, args...) //nolint:gosec // G204: see above
 	hideConsole(cmd)
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer

--- a/internal/procx/procx_windows.go
+++ b/internal/procx/procx_windows.go
@@ -35,12 +35,19 @@ func attach(cmd *exec.Cmd) (platformProc, error) {
 			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 		},
 	}
+	// G103/G115: the Win32 calling convention — a pointer to the struct plus its
+	// size. unsafe.Sizeof of a fixed struct is a compile-time constant far below
+	// uint32, and info outlives the call.
+	//nolint:gosec // G103/G115: see above
 	if _, err := windows.SetInformationJobObject(job,
 		windows.JobObjectExtendedLimitInformation,
 		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
 		_ = windows.CloseHandle(job)
 		return nil, fmt.Errorf("configure job object: %w", err)
 	}
+	// G115: a Windows PID is a DWORD that os/exec widened to int; narrowing it
+	// back is what the syscall takes.
+	//nolint:gosec // G115: see above
 	proc, err := windows.OpenProcess(
 		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(cmd.Process.Pid))
 	if err != nil {
@@ -84,6 +91,7 @@ func (j *jobKill) release() {
 // the belt-and-braces path for a root process found still alive. A PID that
 // is already gone is success.
 func KillPID(pid int) error {
+	//nolint:gosec // G115: a Windows PID is a DWORD widened to int; this narrows it back
 	h, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
 	if err != nil {
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {

--- a/internal/procx/starttime_windows.go
+++ b/internal/procx/starttime_windows.go
@@ -27,6 +27,7 @@ func StartTime(pid int) (time.Time, error) {
 // raw 100 ns unit.
 func creationTime(pid int) (windows.Filetime, error) {
 	var creation, exit, kernel, user windows.Filetime
+	//nolint:gosec // G115: a Windows PID is a DWORD widened to int; this narrows it back
 	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {

--- a/internal/service/exec_darwin.go
+++ b/internal/service/exec_darwin.go
@@ -11,7 +11,8 @@ import (
 // launchctl runs the one tool the macOS backend drives.
 func launchctl(ctx context.Context, args ...string) (string, error) {
 	return combined(
-		exec.CommandContext(ctx, "launchctl", args...),
+		// G204: fixed tool name, arguments built by this package. No shell.
+		exec.CommandContext(ctx, "launchctl", args...), //nolint:gosec // G204: see above
 		"launchctl "+strings.Join(args, " "),
 	)
 }

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -76,7 +76,10 @@ func install(ctx context.Context, o Options) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// G301: ~/Library/LaunchAgents is a directory launchd itself expects to find
+	// with the conventional mode; the plist in it is world-readable by design
+	// (see the WriteFile below).
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // G301: see above
 		return fmt.Errorf("create LaunchAgents dir: %w", err)
 	}
 	if err := os.WriteFile(path, []byte(renderPlist(o)), 0o644); err != nil { //nolint:gosec // a plist is world-readable by design

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -78,7 +78,9 @@ func install(ctx context.Context, o Options) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// G301: ~/.config/systemd/user takes the conventional mode; the unit file in
+	// it is world-readable by design (see the WriteFile below).
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // G301: see above
 		return fmt.Errorf("create systemd user dir: %w", err)
 	}
 	if err := os.WriteFile(path, []byte(renderUnit(o)), 0o644); err != nil { //nolint:gosec // a unit file is world-readable by design

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -304,7 +304,9 @@ func taskWriteDenied() bool {
 	if root == "" {
 		return false
 	}
-	f, err := os.OpenFile(filepath.Join(root, "System32", "Tasks", Label), os.O_WRONLY, 0)
+	// G304: %SystemRoot%\System32\Tasks joined with this package's own Label
+	// constant — a probe for write permission, not a user-named path.
+	f, err := os.OpenFile(filepath.Join(root, "System32", "Tasks", Label), os.O_WRONLY, 0) //nolint:gosec // G304: see above
 	if err == nil {
 		_ = f.Close()
 		return false
@@ -415,7 +417,9 @@ func utf16LE(s string) []byte {
 	b := make([]byte, 0, 2+len(units)*2)
 	b = append(b, 0xFF, 0xFE) // BOM
 	for _, u := range units {
-		b = append(b, byte(u), byte(u>>8))
+		// G115: splitting a UTF-16 code unit into its two little-endian bytes is
+		// the point; both halves are kept, so nothing is lost.
+		b = append(b, byte(u), byte(u>>8)) //nolint:gosec // G115: see above
 	}
 	return b
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -101,7 +100,8 @@ func (s *Store) ListEvents(ctx context.Context, f EventFilter) ([]Event, error) 
 	q := `SELECT id, ts, type, task_id, project_id, payload_json FROM events WHERE id > ?`
 	args := []any{f.AfterID}
 	if len(f.Types) > 0 {
-		q += ` AND type IN (` + strings.Repeat("?,", len(f.Types)-1) + `?)`
+		//nolint:gosec // G202: placeholders() emits bind markers; the types bind below
+		q += ` AND type IN ` + placeholders(len(f.Types))
 		for _, t := range f.Types {
 			args = append(args, t)
 		}

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -425,14 +424,15 @@ func (s *Store) TaskRollups(ctx context.Context, ids []int64) (map[int64]TaskRol
 	if len(ids) == 0 {
 		return out, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
+	inList := placeholders(len(ids))
 	args := make([]any, 0, len(ids))
 	for _, id := range ids {
 		args = append(args, id)
 	}
+	//nolint:gosec // G202: inList is placeholders(); the ids bind as arguments
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT task_id, SUM(cost_usd), SUM(input_tokens), SUM(output_tokens)
-		FROM step_runs WHERE task_id IN (`+placeholders+`) GROUP BY task_id`, args...)
+		FROM step_runs WHERE task_id IN `+inList+` GROUP BY task_id`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("roll up task metrics: %w", err)
 	}

--- a/internal/store/stepstatus.go
+++ b/internal/store/stepstatus.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // ErrStepNotRunning reports that no *running* step run of the task carries
@@ -34,17 +33,18 @@ func (s *Store) LatestStepStatuses(ctx context.Context, ids []int64) (map[int64]
 	if len(ids) == 0 {
 		return out, nil
 	}
-	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
+	inList := placeholders(len(ids))
 	args := make([]any, 0, len(ids))
 	for _, id := range ids {
 		args = append(args, id)
 	}
 	// The join picks each task's highest row id and reads that row's message;
 	// MAX(id) with a bare column would pair a maximum with an arbitrary row.
+	//nolint:gosec // G202: inList is placeholders(); the ids bind as arguments
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT r.task_id, r.status_message FROM step_runs r
 		JOIN (SELECT task_id, MAX(id) AS id FROM step_runs
-			WHERE task_id IN (`+placeholders+`) GROUP BY task_id) m
+			WHERE task_id IN `+inList+` GROUP BY task_id) m
 		ON r.id = m.id`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("read step statuses: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -39,7 +39,10 @@ type Store struct {
 // connection pragmas (WAL, busy timeout, foreign keys), and runs any pending
 // embedded migrations. The parent directory is created if missing.
 func Open(path string) (*Store, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	// G301: the data dir keeps the platform-default mode. Tightening it is a
+	// user-visible change to an existing installation and needs its own spec
+	// amendment; task 040 records it as follow-up rather than smuggling it in.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:gosec // G301: see above
 		return nil, fmt.Errorf("create data dir: %w", err)
 	}
 	db, err := sql.Open("sqlite", dsn(path))
@@ -175,4 +178,16 @@ func nullString(s string) any {
 // rowScanner is satisfied by both *sql.Row and *sql.Rows.
 type rowScanner interface {
 	Scan(dest ...any) error
+}
+
+// placeholders renders the parenthesised bind-marker list for an n-value SQL
+// `IN` clause: `(?)`, `(?, ?)`, and so on. n must be positive; callers return
+// early on an empty set, since `IN ()` is not valid SQLite.
+//
+// Every `IN` list in this package goes through here, which is what makes the
+// gosec G202 suppressions at the query sites checkable: the result is
+// punctuation and bind markers only, derived from a count and never from a
+// value, so the values themselves still travel as query arguments.
+func placeholders(n int) string {
+	return "(?" + strings.Repeat(", ?", n-1) + ")"
 }

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -31,7 +31,7 @@ var slotStates, slotPlaceholders = func() ([]any, string) {
 			args = append(args, string(s))
 		}
 	}
-	return args, "(?" + strings.Repeat(", ?", len(args)-1) + ")"
+	return args, placeholders(len(args))
 }()
 
 // BranchClaimedError reports that another unarchived task in the same project
@@ -460,6 +460,10 @@ func (s *Store) CountSlotHoldersByProject(ctx context.Context, projectID int64) 
 // admitting a task changes the tallies, and a single statement cannot see
 // its own in-flight admissions.
 func (s *Store) ListAdmissible(ctx context.Context) ([]Candidate, error) {
+	// G202: both interpolations are package-internal and value-free —
+	// prefixed() alias-qualifies the taskColumns constant, slotPlaceholders is
+	// placeholders(). The states themselves bind as arguments.
+	//nolint:gosec // G202: see above; no caller value reaches the query text
 	q := `SELECT ` + prefixed("t", taskColumns) + `,
 			(SELECT COUNT(*) FROM tasks o
 			  WHERE o.project_id = t.project_id AND o.state IN ` + slotPlaceholders + `),
@@ -511,7 +515,7 @@ var unreconcilableStates, unreconcilablePlaceholders = func() ([]any, string) {
 	args := []any{
 		string(TaskQueued), string(TaskDone), string(TaskAborted), string(TaskArchived),
 	}
-	return args, "(?" + strings.Repeat(", ?", len(args)-1) + ")"
+	return args, placeholders(len(args))
 }()
 
 // UnreconciledTasks returns every task whose state and step runs contradict
@@ -520,6 +524,7 @@ var unreconcilableStates, unreconcilablePlaceholders = func() ([]any, string) {
 // task was never reconciled and the scheduler is refusing to admit it.
 func (s *Store) UnreconciledTasks(ctx context.Context) ([]Unreconciled, error) {
 	args := append([]any{string(StepRunning)}, unreconcilableStates...)
+	//nolint:gosec // G202: unreconcilablePlaceholders is placeholders(); states bind
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT t.id, t.state, COUNT(r.id)
 		FROM tasks t JOIN step_runs r ON r.task_id = t.id AND r.state = ?

--- a/internal/store/transitions.go
+++ b/internal/store/transitions.go
@@ -355,6 +355,7 @@ func (s *Store) SetTaskProgress(ctx context.Context, id int64, currentStep *int,
 		}
 		args = append(args, id)
 		res, err := tx.ExecContext(ctx,
+			//nolint:gosec // G202: sets holds only the literals assigned above; values bind
 			`UPDATE tasks SET `+strings.Join(sets, ", ")+` WHERE id = ?`, args...)
 		if err != nil {
 			return fmt.Errorf("set task %d progress: %w", id, err)

--- a/internal/taskrun/repair_test.go
+++ b/internal/taskrun/repair_test.go
@@ -332,7 +332,7 @@ func TestRepairPromptReachesTheAgentLiterally(t *testing.T) {
 		t.Fatalf("repair row = %s/%q, want a prompt that rendered as prose",
 			row.State, row.FailureReason)
 	}
-	body, err := os.ReadFile(row.TranscriptPath) //nolint:gosec // this test's own transcript
+	body, err := os.ReadFile(row.TranscriptPath)
 	if err != nil {
 		t.Fatalf("read repair transcript: %v", err)
 	}

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -69,6 +69,7 @@ func openTranscript(dataDir string, taskID int64, stepIndex, iteration, attempt 
 		name = fmt.Sprintf("%d-%s-%d.jsonl", stepIndex, subStepID, attempt)
 	}
 	path := filepath.Join(dir, name)
+	//nolint:gosec // G304: path is built here from the daemon's transcript dir and the step's own indices
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("create transcript: %w", err)

--- a/internal/tui/boardgroup.go
+++ b/internal/tui/boardgroup.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -68,26 +69,11 @@ func (g grouping) next() grouping {
 	return cycle[0]
 }
 
-func (g grouping) has(k groupKey) bool {
-	for _, level := range g {
-		if level == k {
-			return true
-		}
-	}
-	return false
-}
+func (g grouping) has(k groupKey) bool { return slices.Contains(g, k) }
 
-func (g grouping) equal(other grouping) bool {
-	if len(g) != len(other) {
-		return false
-	}
-	for i := range g {
-		if g[i] != other[i] {
-			return false
-		}
-	}
-	return true
-}
+// equal compares levels in order: two groupings with the same levels in a
+// different order are different views, not the same one.
+func (g grouping) equal(other grouping) bool { return slices.Equal(g, other) }
 
 // label names the grouping for the panel title.
 func (g grouping) label() string {

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -361,3 +361,41 @@ func TestGroupSummaryReadsAsASetting(t *testing.T) {
 		t.Errorf("summary of no grouping = %q, want it to say the list is flat", got)
 	}
 }
+
+// TestGroupingEqualAndHas pins the two set predicates directly. Everywhere
+// else in this file `equal` is the assertion rather than the subject, so a
+// rewrite of it could silently take the assertions with it — which is exactly
+// what task 042's `slices.Equal` change does.
+func TestGroupingEqualAndHas(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b grouping
+		want bool
+	}{
+		{"identical", grouping{groupProject, groupWorkflow}, grouping{groupProject, groupWorkflow}, true},
+		{"both empty", grouping{}, grouping{}, true},
+		{"empty and nil", grouping{}, nil, true},
+		{"shorter prefix", grouping{groupProject}, grouping{groupProject, groupWorkflow}, false},
+		{"longer", grouping{groupProject, groupWorkflow}, grouping{groupProject}, false},
+		{"same length, different element", grouping{groupProject}, grouping{groupWorkflow}, false},
+		{"same set, reversed", grouping{groupProject, groupWorkflow}, grouping{groupWorkflow, groupProject}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.equal(tc.b); got != tc.want {
+				t.Errorf("%v.equal(%v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+
+	g := grouping{groupProject}
+	if !g.has(groupProject) {
+		t.Error("has(groupProject) = false on a grouping that holds it")
+	}
+	if g.has(groupWorkflow) {
+		t.Error("has(groupWorkflow) = true on a grouping that does not hold it")
+	}
+	if (grouping{}).has(groupProject) {
+		t.Error("has = true on a flat grouping")
+	}
+}

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -922,7 +922,7 @@ func TestNewTaskEditorSeedsTheFileWithWhatIsTyped(t *testing.T) {
 	n := loadedForm(t)
 	var seen string
 	n.exec = fakeExec(t, func(path string) error {
-		b, err := os.ReadFile(path) //nolint:gosec // the test's own temp file
+		b, err := os.ReadFile(path)
 		seen = string(b)
 		return err
 	}, nil)


### PR DESCRIPTION
## Summary

Turns gosec on inside the golangci-lint that the `go.mod` tool directive already
pins, adjudicates every current finding one site at a time, and records the
adjudication where a future contributor will find it.

No new binary, no new CI job, no new mage target. `go run mage.go lint` is still
one command and still the byte-identical one `ci.yml` runs on Linux, macOS and
Windows — so "new unsuppressed findings fail CI" comes for free with enabling the
linter, and the local command matches CI exactly.

**The one number a reviewer should not take on trust.** golangci-lint defaults
`max-issues-per-linter` to 50 and `max-same-issues` to 3, and this repository set
neither. With those defaults a naive `enable: gosec` reports about **25** findings
per platform instead of the real **~102** — and *which* 25 varies between runs of
the identical command, because the truncation happens after parallel package
analysis. Two consecutive runs here listed different G301 sites. Both limits are
now `0`. If you see a claim that this change had 25 findings, it was measured
through the trap.

The real baseline, measured through the pinned linter with the limits removed:

| GOOS | findings |
|---|---|
| darwin | 103 |
| linux | 102 |
| windows | 102 |

113 distinct sites: 74 in tests, the fake CLIs and the test helpers, **39 in
production code**. By rule: G304 ×45, G301 ×18, G204 ×17, G306 ×10, G202 ×6,
G302 ×5, G115 ×5, G101 ×3, G103 ×2, G703 ×1, G602 ×1. None was a vulnerability;
one was worth changing anyway.

### Two findings fixed rather than suppressed

- **`internal/store` gains one `placeholders(n)` helper.** Five sites built an
  `IN (?, ?, ?)` list by hand, in two different spellings. They now share one
  helper whose doc comment states the property the suppressions rest on: the
  result is punctuation and bind markers derived from a count, never from a
  value. gosec still reports the six G202 sites — a function call is not a
  constant operand — but a reviewer can now check all six against one place
  instead of six independent claims. This is the issue's "prefer a small wrapper
  that proves safety" applied where the call sites allowed it.
- **`grouping.has` / `grouping.equal` become `slices.Contains` / `slices.Equal`,**
  which deletes the G602 finding along with the loops. `TestGroupingEqualAndHas`
  was added and passing against the hand-written `equal` **before** the rewrite;
  everywhere else in `boardgroup_test.go`, `equal` is the assertion rather than
  the subject, so a rewrite of it could have taken the assertions with it.

### Scope, and what a suppression is not allowed to do

Tests, `cmd/fakeagent`, `cmd/fakegh`, `internal/testrepo`,
`internal/agent/agenttest` and `internal/github/githubtest` are excluded by one
configured rule carrying the rationale once, rather than by 74 inline comments
every new test file would have to re-earn. Three now-redundant `//nolint:gosec`
directives in test files are deleted.

`internal/doctor/disk_unix.go`'s G115 is excluded **by rule** rather than
annotated: `Statfs_t.Bsize` is `int64` on Linux and `uint32` on Darwin, so a
`//nolint` fails Darwin's nolintlint and its absence fails Linux's gosec.
Loosening `nolintlint.allow-unused` was rejected — that would blind the repo to
stale directives for every linter forever, to fix one site.

**No file or directory permission moved.** G301/G302/G306 demand `0750`/`0600`
across the tree; spec §16's 2026-08-25 amendment already settled which files are
owner-only, and the code already says where world-readable is deliberate (a
launchd plist, a systemd unit, a scaffolded workflow that gets committed).
Tightening any of them is a user-visible change needing its own issue, not a side
effect of turning a linter on. `internal/store/store.go`'s `0o755` data dir is
the one inconsistency found — `internal/tui/firstrun.go` creates the *same*
directory with `0o700` — and it is recorded as follow-up in the task document
rather than changed here.

**The backup suppressions name real provenance.** This is the issue's criterion
about misleading trusted-path assertions, and it is where it bites. `Create`
opens the destination the API *caller* named in `POST /v1/backup`, so its reason
rests on §16's trust boundary and on `O_EXCL`, not on a false daemon-owned claim.
`extractFile` opens a path derived from a **tar header**, which an
attacker-supplied archive controls; its reason cites the `target()` guard that
refuses any entry not resolving inside the two roots. Only `writeRegular` and the
data-root walk get a daemon-owned claim, because it is true of them.

### Verification

- `go run mage.go lint` exits 0 on the host, and the CLAUDE.md cross-platform
  loop exits 0 for `GOOS=linux`, `darwin` and `windows`. Load-bearing here, not
  advisory: 39 of the 113 sites exist under one GOOS only.
- **The gate was proved to fail.** A temporary `os.WriteFile(..., 0o644)` in
  `internal/version` (no exclusion covers it) produced `G306: Expect WriteFile
  permissions to be 0600 or less` and a non-zero exit; removing it returned the
  package to `0 issues`. Deliberately not committed.
- `go run mage.go test` and `go run mage.go testrace` both green — which is what
  says the suppressions changed no behaviour.
- **Cost:** on the maintainer's machine, warm 1.45 s with gosec vs 1.69 s
  without, cold 10.7 s vs 14.4 s. gosec came out *faster* in both pairs, which is
  the honest read — the delta is run-to-run variance, not a speedup. It is an AST
  pass over packages the run already type-checks. Trust the runner's numbers over
  these.

### Found, not fixed here

**`CLAUDE.md`'s enabled-linter list is now one linter short.** Lines 304–306 read
"golangci-lint v2 standard set plus errorlint, gocritic, revive, copyloopvar,
intrange, misspell, unconvert, unparam, nolintlint, sqlclosecheck" — gosec now
belongs in that list, and `CLAUDE.md` is the file an agent reads before it writes
a line of this repository. It is the one sentence this change made false. The
documentation pass that found it is scoped to `docs/`, `skills/`, `CHANGELOG.md`
and `README.md`, so it is reported rather than edited; the fix is adding `gosec`
to that enumeration. `docs/history/v0-tasks.md:38` carries the same list and is
correct as it stands — it is the frozen record of what v0 enabled.

Nothing else was found: `docs/spec.md` describes no lint configuration and no
runtime behaviour moved, so no sentence in it became false; no `docs/assets/tui-*.png`
is stale, since `internal/tui/boardgroup.go`'s `has`/`equal` rewrite is
behaviour-preserving and no panel, label or binding changed.

## Related

Closes #147

Adjudication and decisions: [task
040](docs/tasks/040-gosec-static-analysis.md) (closes 040.1–040.5).

The two findings that mattered from the original review run were promoted and
already closed as #136 (workflow loading) and #141 (config modes); this is the
baseline and the gate that remained. Parent review: #135.

No task-document or v0-ledger decision is revisited. Spec §16's 2026-08-25
amendment is *upheld* rather than reopened — see the permissions paragraph above.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — `TestGroupingEqualAndHas` covers
      the `slices.Equal` rewrite (equal, different-length, different-element and
      reordered groupings), written against the old implementation first
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — **audited, none needed.** Every derivation `CLAUDE.md` names was
      checked against the diff: `internal/config` (comments only, no key and no
      mode moved) against `docs/reference/configuration.md`; the cobra tree
      (`doctor.go` and `workflow_init.go` gained comments, no command, flag or
      output text) against `docs/reference/cli.md`; `internal/api/server.go`
      (untouched) against `docs/reference/api.md`; `internal/tui/bindings.go`
      (untouched) against the key tables in `docs/guides/tui.md`; the `Reason*`
      constants in `internal/worktree`, `internal/taskrun/engine.go` and
      `internal/github/reason.go` (`no_credential` and its siblings keep their
      exact values — the diff appends a `//nolint`, it does not rename) against
      the block-reason tables in `docs/reference/api.md`; `internal/workflow` and
      `internal/taskrun`'s step types (no type, field, validation rule, template
      variable or human-interaction mechanism changed) against
      `docs/reference/workflow-schema.md` and `docs/reference/task-lifecycle.md`
      — which is also why `skills/vincent-workflows/SKILL.md`,
      `internal/workflow/builtin.go` and this repository's own
      `.vincent/workflows/*.yaml` are untouched; and `internal/agent/*` (one test
      file) against `docs/guides/agents.md` and spec §9.x, no adapter capability
      gained or lost. `docs/gates/` walks no behaviour that moved, and
      `docs/reference/files.md` states no mode for the data directory, so
      `internal/store/store.go`'s unchanged `0o755` leaves no claim stale.
      `docs/security-model.md` is the runtime model for users and never mentioned
      build-time scanning; the gosec-versus-govulncheck paragraph the issue asked
      for went where govulncheck already lived, in `CONTRIBUTING.md` and
      `SECURITY.md`. See "Found, not fixed here" above for the one stale sentence
      this audit did turn up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
