### PR TITLE
Read task fields from a file or stdin in `task add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ list with the user-facing context a commit subject cannot carry.
   execute, `2` no daemon answered a `--task`/`--project`. See
   [the CLI reference](docs/reference/cli.md#vincent-workflow-render).
 
+- **`vincent task add` can take its task fields from a JSON file or from
+  stdin.** `--fields-file ./inputs.json` — or `--fields-file -` to read the
+  document a `jq` pipeline just produced — fills the same
+  [task field map](docs/guides/workflows.md#54-task-fields) that repeatable
+  `--field name=value` fills, without every newline, quote and space having to
+  survive the shell first. The two combine and `--field` wins the names it
+  names, so one generated document can be reused across runs that vary a single
+  input. The values must all be JSON strings; a number, boolean, `null`, array
+  or object is refused with a message naming the **key** and never the value, as
+  are an empty name, anything after the first JSON object, and a read over the
+  API's own 4 MiB body bound. Everything else stays the daemon's call —
+  required fields, `type`, `pattern` and the per-field limits — and names the
+  workflow never declared are still accepted, exactly as before. Creating a task
+  without `--json` now also confirms what it carries by **name and count and
+  never by value** (`fields: notes, ticket (2)`), which catches a mistyped name
+  while staying safe to leave in a CI log. See
+  [Scripting vincent](docs/guides/scripting.md#supplying-task-fields).
+
 - **Creating a task can now be retried safely.** If the daemon commits your task
   but you never see the response — a timeout, a dropped connection, a script
   that dies mid-`curl` — re-sending the request used to create a second task, a

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -26,6 +26,7 @@ needs to react rather than poll.
 
 - [Exit codes](#exit-codes)
 - [JSON output](#json-output)
+- [Supplying task fields](#supplying-task-fields)
 - [Validating workflows in CI](#validating-workflows-in-ci)
 - [Talking to the API directly](#talking-to-the-api-directly)
 - [Reacting to events](#reacting-to-events)
@@ -41,7 +42,7 @@ Every subcommand uses the same three:
 | Code | Meaning | What a script should do |
 |---|---|---|
 | `0` | Success | Continue |
-| `1` | The daemon answered and rejected the request | Fix the request — a bad id, an action the task's state does not allow |
+| `1` | The request was rejected — by the daemon, or by the client before it sent one | Fix the request — a bad id, an action the task's state does not allow, a `--fields-file` that is not one JSON object of strings |
 | `2` | No daemon answered | Start one (`vincent daemon start`) and retry |
 
 That split is the point: a script can tell "start the daemon" from "fix your

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -109,6 +109,67 @@ Two guarantees make it safe to pipe into `jq`:
 vincent task ls --state blocked --json | jq -r '.[] | "\(.id)\t\(.title)"'
 ```
 
+## Supplying task fields
+
+A workflow reads its inputs from `.Task.Fields`, an open `map[string]string`
+supplied when the task is created (see
+[task fields](workflows.md#54-task-fields)). Two flags fill it.
+
+For a handful of short values, repeat `--field`:
+
+```sh
+vincent task add --project 1 --workflow release --title "Release 2.0" \
+  --field ticket=OPS-42 --field owner=ana
+```
+
+Everything after the **first** `=` is the value, so URLs and regexes need no
+escaping, and a repeated name takes its last value.
+
+For generated input — or anything with newlines, quotes or spaces — pass a JSON
+object of strings instead. `--fields-file -` reads it from stdin, which is what
+makes `jq` the natural producer:
+
+```sh
+jq -n --arg ticket "$TICKET" --arg notes "$(cat release-notes.md)" \
+     '{ticket: $ticket, notes: $notes}' |
+  vincent task add --project 1 --workflow release --title "Release 2.0" \
+    --fields-file - --json
+```
+
+The two combine, and **`--field` wins the names it names**. That is what lets a
+script keep one generated document and vary a single input per run:
+
+```sh
+for ticket in OPS-42 OPS-43; do
+  vincent task add --project 1 --workflow release --title "Release $ticket" \
+    --fields-file ./base-inputs.json --field "ticket=$ticket" --json
+done
+```
+
+Everything checked locally is checked before the daemon is called, and exits
+`1` like any other rejected request: a value that is not a JSON string (the
+message names the key, never the value), an empty name, anything after the
+first JSON object, and a document over 4 MiB — the API's own body bound,
+applied to the read so a pipe cannot be unbounded.
+
+Everything else stays **daemon-authoritative**, because the CLI is not the only
+client: required fields, `type`, `pattern`, and the per-field size bounds are
+checked by `POST /v1/tasks` and reported through the same exit `1`. Names the
+workflow never declared are still accepted — declaring `fields:` does not close
+the map — so a script may attach its own metadata to a task without touching
+the workflow.
+
+Without `--json`, the created task is confirmed with the field **names and a
+count and no values**:
+
+```
+task 62 created: Release OPS-42 (release, branch vincent/62-release-ops-42)
+  fields: notes, ticket (2)
+```
+
+That line is safe to leave in a CI log, and it still catches the mistake worth
+catching — a name typed wrong, which a count alone would hide.
+
 ## Validating workflows in CI
 
 `vincent workflow validate` runs **entirely locally**: no daemon, no network, no

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1002,6 +1002,11 @@ vincent task add --project 1 --workflow feature-pr --title "Ship it" \
 Here `ticket` may be declared and validated while `owner` is additional
 metadata; both are stored as strings in `.Task.Fields`.
 
+Generated input, or a value with newlines in it, goes in as a JSON object
+instead — `--fields-file PATH`, or `-` for stdin. A `--field` of the same name
+still wins, so one document can be reused across runs that vary one input; see
+[Supplying task fields](scripting.md#supplying-task-fields).
+
 Because rendering is strict, an **optional** field must be read defensively or
 the step fails:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -25,7 +25,7 @@ localhost API.
 | Code | Meaning |
 |---|---|
 | `0` | Success |
-| `1` | The request was rejected — either the daemon answered no (bad id, invalid state transition), or one of the daemon-free commands refused it (`workflow validate` on an invalid file, `workflow render` on a template that does not execute, `workflow init` on a name already taken) |
+| `1` | The request was rejected — the daemon answered no (bad id, invalid state transition), a daemon-free command refused it (`workflow validate` on an invalid file, `workflow render` on a template that does not execute, `workflow init` on a name already taken), or the client refused the input before sending anything (a `--fields-file` that is not one JSON object of strings) |
 | `2` | No daemon answered |
 
 `vincent daemon status` overloads them usefully: `0` healthy, `1` not running,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -319,7 +319,8 @@ Lists registered projects with their ids, paths and defaults.
 vincent task add --project ID (--title TITLE | --github-issue N)
                  [--workflow NAME] [--description TEXT] [--base-branch BRANCH]
                  [--branch NAME] [--priority N] [--agent NAME] [--model M]
-                 [--effort E] [--field NAME=VALUE]... [--json]
+                 [--effort E] [--field NAME=VALUE]... [--fields-file PATH]
+                 [--json]
 ```
 
 Creates a task. It is `queued` immediately — there is no draft state.
@@ -333,6 +334,7 @@ Creates a task. It is `queued` immediately — there is no draft state.
 | `--branch` | What the task's branch is **called**. Used verbatim and wins over any template; defaults to the project's or the global [`branch_template`](configuration.md#branch_template) |
 | `--priority` | Higher runs first; default 0 |
 | `--field name=value` | Task field; repeat for more. Everything after the first `=` is the value, and a repeated name uses the last value |
+| `--fields-file PATH` | Read fields from a JSON object of string values; `-` reads it from stdin. Combines with `--field`, which wins for a name both supply |
 | `--agent` / `--model` / `--effort` | The task-level override. It replaces workflow `defaults`, never an explicit step field |
 | `--github-issue N` | Create the task from GitHub issue `N`. See below |
 
@@ -343,6 +345,56 @@ remain valid and are recorded on the same open field map:
 vincent task add --project 1 --workflow release --title "Release 2.0" \
   --field ticket=OPS-42 --field owner=ana
 ```
+
+```
+task 62 created: Release 2.0 (release, branch vincent/62-release-2-0)
+  fields: owner, ticket (2)
+```
+
+The confirmation line lists **names and a count, never values** — a field can
+carry a ticket key or a customer name, and this line ends up in scrollback and
+CI logs. It is read off the created task, so a field the daemon filled in from
+`--github-issue` is listed too. `--json` prints the task instead, values and
+all.
+
+#### Fields from a file or stdin
+
+`--fields-file` takes one JSON object whose values are all strings — the form a
+generator produces, and the one that carries spaces, newlines and quotes
+without shell escaping:
+
+```sh
+vincent task add --project 1 --workflow release --title "Release 2.0" \
+  --fields-file ./release-inputs.json
+
+jq -n '{ticket: $t, notes: $n}' --arg t OPS-42 --arg n "$(cat notes.md)" |
+  vincent task add --project 1 --workflow release --title "Release 2.0" \
+    --fields-file -
+```
+
+The two flags **combine**: the file is the base map and each `--field`
+overrides its own name, which is the same last-wins rule `--field` already
+follows, one level out.
+
+```sh
+vincent task add --project 1 --workflow release --title "Release 2.0" \
+  --fields-file ./release-inputs.json --field ticket=OPS-43   # ticket is OPS-43
+```
+
+Rejected locally with exit 1, before the daemon is called:
+
+| | |
+|---|---|
+| A value that is not a JSON string | A number, boolean, `null`, array or object. The message names the **key** and never the value |
+| An empty or all-whitespace name | The same rule `--field` applies |
+| Anything after the first JSON object | One document per file; a second is never silently discarded |
+| More than 4 MiB | The API's own body bound (§13.1), applied to the read so a pipe cannot be unbounded |
+
+A name repeated *inside* the JSON object takes its last value, which is what a
+JSON decoder does. Names the workflow never declared stay valid either way —
+declaring `fields:` does not close the map — and everything the daemon
+validates (required, `type`, `pattern`, per-field size) is still checked by the
+daemon.
 
 Model and effort **only inherit from a level whose agent matches**, so switching
 agent without setting them resets them to the new adapter's default rather than

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2729,7 +2729,7 @@ One Go binary, `vincent`:
 | `vincent service install / uninstall / status` | Registers OS-native autostart, always as the invoking user: launchd agent, systemd user unit, Windows Scheduled Task |
 | `vincent workflow ls / validate [file] / render <file> / init <name>` | Registry listing / YAML validation / template dry run / writing a new registry file. *Amended 2026-08-26 (task 034):* `init` writes the §5.2 scope directory a `--project` flag selects — global by default, resolved from §12.2 with **no daemon**; `--project N` needs one, purely to resolve the id to a repository root. `--from <example>` writes an embedded `examples/*.yaml` with its top-level `name:` rewritten. It refuses an existing path (`O_EXCL`) or a name another file in the same scope already declares, and only warns when the name shadows a lower scope. *Added 2026-08-28 (task 044):* `render` executes every template the file declares — `prompt`, `run`, `check`, `instructions`, `if` and `for_each` — against a synthetic §8.4 preview context and prints what each step would send, with the §8.6 triple each agent step resolves to. Where `validate` parses a template, this **executes** it, which is the only way `missingkey=error` catches a typo'd field. It is offline for the same reason `validate` is; `--task`/`--project` reach the daemon for a real task's facts and for registry lookups. Exit 0 clean · 1 a render error · 2 no daemon answered a `--task`/`--project` |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
-| `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2) |
+| `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2). *Amended 2026-08-28 (task 045):* `add` fills the §8.1.2 field map from repeatable `--field name=value` and/or `--fields-file <path\|->` |
 | `vincent status <message>` | *Added 2026-08-26 (task 036).* Records what the current step is doing, in its own words (§5.4). Runs **from inside a step**: it addresses itself with §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, takes no id argument, and errors naming those variables when they are unset. Silent on success — its stdout is the step's transcript |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent github issues / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub |
@@ -2744,6 +2744,25 @@ different tasks from the same issue. Every other flag still wins over what the
 issue would have filled in, and `--title` becomes optional when it is given —
 requiring both would make the flag a decoration on a title the user had to
 retype.
+
+*Added 2026-08-28 (task 045).* `vincent task add --fields-file <path>` reads the
+§8.1.2 field map from one JSON object of **string** values, and `-` reads it from
+standard input. It combines with `--field`, which wins name by name: the file is
+the base map and the flag typed on the same command line is the more specific of
+the two, which is the last-wins rule `--field` already follows extended one level
+out. Making them mutually exclusive was rejected — it forces a script that varies
+one input to regenerate the whole document.
+
+The client rejects, with exit 1 and before any request is made, a value that is
+not a JSON string (naming the **key** and never the value), an empty name,
+anything after the first JSON object, and a read over §13.1's 4 MiB large-body
+bound — the read is bounded because standard input can be an unbounded pipe, and
+answering locally gives the caller the answer the daemon would have given them.
+Everything else stays daemon-authoritative: required, `type`, `pattern` and the
+per-field bounds are the API's, and declaring `fields:` still does **not** close
+the map (§8.1.2). Without `--json`, creation confirms the recorded fields by
+**name and count, never value**, read off the response so a field prefilled from
+`--github-issue` is confirmed with the rest.
 
 *Amended 2026-08-15 (task 005).* `gc` breaks this table's noun-verb pattern
 (`project add`, `task ls`) knowingly: `git gc` is the idiom users already have, and the

--- a/docs/tasks/045-cli-task-fields-file.md
+++ b/docs/tasks/045-cli-task-fields-file.md
@@ -1,0 +1,159 @@
+# 045 — Task fields from a file or stdin in `vincent task add`
+
+**Status:** ✅ done (4/4)
+**Issue:** [#144](https://github.com/lezli01/vincent/issues/144)
+**Spec:** amends §12.1
+
+## Problem
+
+Issue #144 was filed on 2026-08-19 against baseline `7b621865`, when `vincent
+task add` had no way to supply `.Task.Fields` at all: a workflow that takes
+inputs could be launched from the TUI or from raw `curl`, but not from the
+supported scripting interface.
+
+Most of it was answered two days later. Task 022 landed on 2026-08-21 and
+022.4 shipped repeatable `--field name=value`, daemon-authoritative validation
+of the declared field contract, the §13.1 bounds that report a limit without
+echoing a value, and the flag's row in the CLI reference. Acceptance criteria
+1, 2 and 4 were met on that day, and 3 and 5 were met for the value-safety
+half.
+
+What was left, and what this task is:
+
+- no file/stdin form, so a value carrying newlines or quotes still has to be
+  survived by the shell, and a generated document has to be exploded into flags;
+- no human confirmation of what the created task actually carries;
+- no test anywhere proving a supplied field reaches a step **template** —
+  `TestCommandsAgainstLiveDaemon` points every adapter at `/nonexistent/claude`
+  and never runs a step, so it proves storage and nothing past it;
+- nothing in the scripting guide, which is the page a person writing the
+  `jq | vincent task add` pipeline reads.
+
+## What shipped
+
+`--fields-file PATH` on `vincent task add`, `-` for standard input. It decodes
+one JSON object whose values are all JSON strings, merges under `--field`, and
+is bounded client-side at the API's own 4 MiB large-body limit.
+
+Creation without `--json` now confirms the recorded fields on an indented line
+under `task N created:` — `fields: owner, ticket (2)` — sorted names and a
+count, never a value.
+
+| Path | Change |
+|---|---|
+| `internal/cli/task.go` | The flag, `readFieldsFile`, `mergeFields`, `fieldsSummary` |
+| `internal/cli/task_fields_test.go` | The parser, the merge precedence, every rejection, the summary |
+| `internal/cli/fields_e2e_test.go` | Real binary, real daemon: a command step's template renders a field supplied on stdin |
+| `docs/reference/cli.md`, `docs/guides/scripting.md`, `docs/guides/workflows.md` | The flag, the pipeline, the precedence rule |
+| `docs/spec.md` §12.1 | Dated amendment |
+
+## Decisions
+
+**1. The scope is the gaps, not the issue as filed.** *(2026-08-28)*
+
+`--field` is not re-derived, and `parseFieldFlags` is not touched. The issue's
+"repeatable `--field key=value`, split on the first equals sign" bullet
+describes code that already exists and is already tested; rebuilding it would
+have been churn with a regression risk and no user-visible result.
+
+**Beat:** implementing the issue front to back as written.
+
+**2. `--fields-file` combines with `--field`, and `--field` wins per name.**
+*(2026-08-28)*
+
+The file supplies the base map; each `--field` overrides its own name. This is
+the same last-wins rule `--field` already documents, extended one level out.
+
+**Beat:** mutual exclusion, which the issue offered as the simpler option. It
+forces a script that wants to vary one input to regenerate the whole JSON
+document, and the precedence rule it saves is one sentence.
+
+**Beat:** file-wins, which inverts the usual expectation that the more specific
+flag on the same command line is the one that takes effect.
+
+**3. Undeclared fields stay accepted; no strict mode is added.**
+*(2026-08-28)*
+
+The issue asks to "reject fields not accepted by the resolved workflow". That
+contradicts **task 022 decision 3** (2026-08-21): declaring `fields:` does not
+close the map, because closing it turns "add form guidance to a workflow" into
+a breaking change for every existing script and metadata convention. That
+decision stands and is not relitigated here.
+
+`internal/workflow/fields.go` and `Workflow.ValidateTaskFields` are untouched,
+there is no `--strict` flag, and no warning is printed for a name the workflow
+never declared. The bullet is recorded as beaten so the next reader does not
+re-open it.
+
+**4. The confirmation line carries names and a count, never values.**
+*(2026-08-28)*
+
+A field can hold a ticket key, a customer name or a token, and the line lands
+in scrollback, screenshots and CI logs. It is suppressed under `--json` — where
+the caller asked for the task, values and all — and omitted entirely when the
+map is empty.
+
+It is read off the **response**, not off what was sent, so a field the daemon
+prefilled from `--github-issue` (task 035) is confirmed alongside the typed
+ones.
+
+**Beat:** a bare count. It cannot catch a mistyped name, which is the whole
+reason to confirm; `fields: (2)` looks identical whether the workflow got
+`ticket` or `tikcet`.
+
+**5. A local input error exits 1, not a new code.** *(2026-08-28)*
+
+A malformed `--fields-file` is the same class of thing as today's malformed
+`--field`: a plain `error` returned from `RunE`, which `asExitCode` maps to 1.
+Exit 2 keeps its single meaning — no daemon answered — so a script can still
+tell "start the daemon" from "fix your request" without parsing stderr (PR U
+decision).
+
+**6. The read is bounded client-side at the API's 4 MiB body limit.**
+*(2026-08-28)*
+
+Standard input can be an unbounded pipe. Reading through an `io.LimitReader`
+and failing with a message naming the limit gives the caller the answer the
+daemon would have given them, sooner, and without buffering an arbitrary file
+into memory first. It is the only bound the client applies: per-field key and
+value sizes, the 100-entry cap and the declared field contract stay
+daemon-authoritative, because the CLI is not the only client.
+
+**7. Values must be JSON strings; a duplicate name inside the object is
+documented, not detected.** *(2026-08-28)*
+
+`.Task.Fields` is a `map[string]string` (§8.1.2). Stringifying a number or a
+boolean would make `{"retries": 3}` and `{"retries": "3"}` the same document
+while a workflow declaring `type: integer` can tell them apart, so a non-string
+value is an error — naming the **key only**, for the same reason the
+confirmation line names no values. A JSON `null` is rejected explicitly rather
+than being allowed to unmarshal into `""`.
+
+A name repeated inside the object resolves last-wins, which is what
+`encoding/json` does and what `--field` already promises; it is written down
+rather than detected. Keys are used **verbatim** — only an empty or
+all-whitespace name is refused — because trimming them would make
+`{"ticket": …, " ticket": …}` collide, and which of the two survived would then
+depend on Go's map iteration order.
+
+**8. The end-to-end proof is a Go test, not a gate script.** *(2026-08-28)*
+
+The E2E test creates a project carrying a project-scoped workflow with a
+`command` step that renders `{{ index .Task.Fields "ticket" }}`, runs it to
+completion, and reads the effect out of the task's worktree. Its step body is
+`git config -f fields.ini …`, spelled in the intersection of `/bin/sh` and
+`pwsh` (§8.3, CLAUDE.md) so it runs unchanged on all three platforms.
+
+`go test ./...` already runs on Linux, macOS and Windows, so this is the
+cheaper home than an eighth gate script; no gate covers fields today either
+way.
+
+## Tasks
+
+- [x] **045.1** `--fields-file PATH` / `-`: bounded read, one JSON object of
+  strings, merge under `--field`.
+- [x] **045.2** The field confirmation line on human output, from the response.
+- [x] **045.3** Unit tests for the parser, the precedence, every rejection and
+  the summary; a real-binary E2E test proving template consumption.
+- [x] **045.4** `docs/reference/cli.md`, `docs/guides/scripting.md`,
+  `docs/guides/workflows.md`, and the §12.1 amendment.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -58,6 +58,7 @@ the living engineering specification records implementation contracts.
 | [042](042-gosec-static-analysis.md) | gosec in the normal static-analysis gate, with reviewed suppressions | ✅ done (5/5) |
 | [043](043-workflow-origin.md) | Persisting where a task's workflow definition came from | ✅ done (6/6) |
 | [044](044-workflow-render-preview.md) | `vincent workflow render` — a template dry run | ✅ done (6/6) |
+| [045](045-cli-task-fields-file.md) | Task fields from a file or stdin in `vincent task add` | ✅ done (4/4) |
 
 ## How to add and update a task document
 

--- a/internal/cli/fields_e2e_test.go
+++ b/internal/cli/fields_e2e_test.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// fieldConsumerWorkflow is a project-scoped workflow whose one command step
+// renders a task field into its body. `git config -f` is used rather than
+// `touch`/`echo` because a step body runs under the *daemon's* shell — /bin/sh
+// on POSIX, pwsh on Windows (§8.3) — so it has to be spelled in the
+// intersection of the two (CLAUDE.md), and git is in it.
+const fieldConsumerWorkflow = `name: field-consumer
+steps:
+  - id: record
+    type: command
+    max_retries: 0
+    run: git config -f fields.ini task.ticket {{ index .Task.Fields "ticket" }}
+`
+
+// TestTaskFieldsReachATemplate is task 045's done-when: fields supplied on the
+// command line reach a step template through the real binary and a real
+// daemon, and the effect is visible on disk in the task's worktree.
+//
+// TestCommandsAgainstLiveDaemon cannot prove this. It points every adapter at
+// /nonexistent/claude and never runs a step, so it shows only that the daemon
+// stored what was sent. What is asserted here is the whole path: --fields-file
+// on stdin, a --field overriding one of its keys, the daemon's validation, the
+// snapshot, and `{{ index .Task.Fields … }}` rendering into a command step.
+func TestTaskFieldsReachATemplate(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	t.Cleanup(func() {
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = append(hermeticEnv(),
+			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
+		_, _ = cmd.CombinedOutput()
+	})
+
+	// No step here runs an agent, and a machine that happens to have one
+	// installed must not change the outcome.
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(
+		"agents:\n  claude:\n    path: \"/nonexistent/claude\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repo := testrepo.Init(t, "main")
+	testrepo.WriteFile(t, repo,
+		filepath.Join(workflow.ProjectDirName, "field-consumer.yaml"), fieldConsumerWorkflow)
+	testrepo.Run(t, repo, "add", ".")
+	testrepo.Run(t, repo, "commit", "-q", "-m", "add the field-consumer workflow")
+
+	if out, code := runVincent(t, dataDir, cfgDir, "daemon", "start"); code != 0 {
+		t.Fatalf("daemon start: code %d, out %q", code, out)
+	}
+	out, code := runVincent(t, dataDir, cfgDir, "project", "add", repo, "--json")
+	if code != 0 {
+		t.Fatalf("project add: code %d, out %q", code, out)
+	}
+	var project struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &project); err != nil {
+		t.Fatalf("project add --json is not JSON: %v (%q)", err, out)
+	}
+
+	// The file supplies three fields; --field overrides one of them. That is
+	// the documented precedence (task 045 decision 2) and it is what the step
+	// body ends up rendering.
+	const doc = `{"ticket":"OPS-000","owner":"ana","note":"two words"}`
+	out, code = runVincentStdin(t, dataDir, cfgDir, doc,
+		"task", "add", "--project", strconv.FormatInt(project.ID, 10),
+		"--workflow", "field-consumer", "--title", "fields reach the template",
+		"--fields-file", "-", "--field", "ticket=OPS-42")
+	if code != 0 {
+		t.Fatalf("task add: code %d, out %q", code, out)
+	}
+
+	// The human confirmation line: names sorted, a count, and no value — not
+	// even the one that is a plain word (task 045 decision 4).
+	if !strings.Contains(out, "fields: note, owner, ticket (3)") {
+		t.Errorf("task add does not confirm the field names:\n%s", out)
+	}
+	for _, value := range []string{"OPS-42", "OPS-000", "ana", "two words"} {
+		if strings.Contains(out, value) {
+			t.Errorf("task add echoes the field value %q:\n%s", value, out)
+		}
+	}
+
+	taskID := taskIDFromCreated(t, out)
+
+	// The task runs to completion: one command step, no agent, no gate.
+	detail := waitForTaskState(t, dataDir, cfgDir, taskID, "done")
+	if detail.WorktreePath == "" {
+		t.Fatalf("task %s has no worktree path", taskID)
+	}
+	if detail.Fields["ticket"] != "OPS-42" {
+		t.Errorf("stored ticket = %q, want the --field value OPS-42 (it beats the file's)",
+			detail.Fields["ticket"])
+	}
+	if detail.Fields["owner"] != "ana" || detail.Fields["note"] != "two words" {
+		t.Errorf("stored fields = %v, want the file's owner and note alongside", detail.Fields)
+	}
+
+	// The proof: the step body rendered the field and the run left it on disk.
+	written, err := os.ReadFile(filepath.Join(detail.WorktreePath, "fields.ini"))
+	if err != nil {
+		t.Fatalf("read the file the step wrote: %v", err)
+	}
+	if !strings.Contains(string(written), "OPS-42") {
+		t.Errorf("the step wrote %q, want the rendered field value OPS-42", written)
+	}
+}
+
+// runVincentStdin is runVincent with a body on standard input, which is the
+// only way to exercise `--fields-file -`.
+func runVincentStdin(t *testing.T, dataDir, cfgDir, stdin string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(vincentBin, args...)
+	cmd.Env = append(hermeticEnv(),
+		config.EnvDataDir+"="+dataDir,
+		config.EnvConfigDir+"="+cfgDir,
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	code := cmd.ProcessState.ExitCode()
+	if err != nil && code < 0 {
+		t.Fatalf("vincent %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), code
+}
+
+// taskIDFromCreated reads the id out of `task N created: …`, which is the
+// human line the --json-free form prints.
+func taskIDFromCreated(t *testing.T, out string) string {
+	t.Helper()
+	_, rest, ok := strings.Cut(out, "task ")
+	if !ok {
+		t.Fatalf("no `task N created` line in:\n%s", out)
+	}
+	id, _, ok := strings.Cut(rest, " ")
+	if !ok {
+		t.Fatalf("no `task N created` line in:\n%s", out)
+	}
+	if _, err := strconv.ParseInt(id, 10, 64); err != nil {
+		t.Fatalf("task id %q is not a number, from:\n%s", id, out)
+	}
+	return id
+}
+
+// taskDetail is the slice of `vincent task show --json` this test reads.
+type taskDetail struct {
+	State        string            `json:"state"`
+	BlockReason  *string           `json:"block_reason"`
+	WorktreePath string            `json:"worktree_path"`
+	Fields       map[string]string `json:"fields"`
+}
+
+// waitForTaskState polls `task show --json` until the task reaches want, and
+// fails fast on a terminal state that is not it.
+func waitForTaskState(t *testing.T, dataDir, cfgDir, id, want string) taskDetail {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		out, code := runVincent(t, dataDir, cfgDir, "task", "show", id, "--json")
+		if code != 0 {
+			t.Fatalf("task show: code %d, out %q", code, out)
+		}
+		var got taskDetail
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("task show --json is not JSON: %v (%q)", err, out)
+		}
+		if got.State == want {
+			return got
+		}
+		if got.State == "blocked" || got.State == "aborted" {
+			t.Fatalf("task %s ended %s (%s), want %s", id, got.State, deref(got.BlockReason), want)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s stuck in %s, want %s", id, got.State, want)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/internal/cli/github_e2e_test.go
+++ b/internal/cli/github_e2e_test.go
@@ -112,11 +112,12 @@ func TestGitHubIssueCommandsAgainstLiveDaemon(t *testing.T) {
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})
-	// No adapter: this test never runs a step.
-	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(
-		"agents:\n  claude:\n    path: \"/nonexistent/claude\"\n"), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	// No adapter: this test never runs a step. All three are pointed at
+	// nothing, not just claude, because the doctor subtest below probes every
+	// adapter — and cursor's probe is an authenticated network call (§9.7), so
+	// a machine with cursor-agent installed would make the request that the
+	// report is composed from take longer than the client's 10s budget.
+	pointAgentsAtNothing(t, cfgDir)
 	if out, code := runVincentGH(t, dataDir, cfgDir, ghDir, "success", "daemon", "start"); code != 0 {
 		t.Fatalf("daemon start: code %d, out %q", code, out)
 	}
@@ -285,10 +286,9 @@ func TestGitHubUnusableLeavesTaskCreationAlone(t *testing.T) {
 			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
 		_, _ = cmd.CombinedOutput()
 	})
-	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(
-		"agents:\n  claude:\n    path: \"/nonexistent/claude\"\n"), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+	// Every adapter, for the reason given in the test above: this one reads
+	// doctor too.
+	pointAgentsAtNothing(t, cfgDir)
 	if out, code := runVincentGH(t, dataDir, cfgDir, ghDir, "logged-out",
 		"daemon", "start"); code != 0 {
 		t.Fatalf("daemon start: code %d, out %q", code, out)

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -1,8 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"maps"
+	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -34,6 +41,7 @@ func newTaskAddCmd() *cobra.Command {
 		model       string
 		effort      string
 		fields      []string
+		fieldsFile  string
 		githubIssue int
 	)
 	cmd := &cobra.Command{
@@ -41,10 +49,17 @@ func newTaskAddCmd() *cobra.Command {
 		Short: "Create a task",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			fieldMap, err := parseFieldFlags(fields)
+			flagFields, err := parseFieldFlags(fields)
 			if err != nil {
 				return err
 			}
+			var fileFields map[string]string
+			if cmd.Flags().Changed("fields-file") {
+				if fileFields, err = readFieldsFile(fieldsFile, cmd.InOrStdin()); err != nil {
+					return err
+				}
+			}
+			fieldMap := mergeTaskFields(fileFields, flagFields)
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
 				req := apiclient.CreateTaskRequest{ProjectID: projectID, Title: title, Fields: fieldMap}
 				for _, f := range []struct {
@@ -100,6 +115,15 @@ func newTaskAddCmd() *cobra.Command {
 						return err
 					}
 				}
+				// Which fields the task actually carries, confirmed by name.
+				// Read off the *response*, not off what was sent, so a field
+				// the daemon prefilled from --github-issue (task 035) is
+				// confirmed here too.
+				if summary := fieldsSummary(t.Fields); summary != "" {
+					if _, err := fmt.Fprintln(out, "  "+summary); err != nil {
+						return err
+					}
+				}
 				// Warnings are advisory — a catalog-unknown model, say. The
 				// task exists and will run, so this is not an error exit; but
 				// it goes to stderr so `--json` piping stays clean and a human
@@ -124,6 +148,9 @@ func newTaskAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&effort, "effort", "", "Effort override (§8.6 level 2)")
 	cmd.Flags().StringArrayVar(&fields, "field", nil,
 		"Task field as name=value; repeat for additional fields")
+	cmd.Flags().StringVar(&fieldsFile, "fields-file", "",
+		"Read task fields from a JSON object of strings in this file, or `-` for stdin; "+
+			"a --field of the same name wins")
 	cmd.Flags().IntVar(&githubIssue, "github-issue", 0,
 		"Create the task from this GitHub issue; explicit flags win over what it would fill in")
 	_ = cmd.MarkFlagRequired("project")
@@ -152,6 +179,118 @@ func parseFieldFlags(values []string) (map[string]string, error) {
 		fields[name] = fieldValue
 	}
 	return fields, nil
+}
+
+// maxFieldsFileBytes bounds what --fields-file reads, at the same 4 MiB the
+// API bounds a large request body at (§13.1). Stdin can be an unbounded pipe,
+// so the read is capped rather than slurped: refusing here gives the caller
+// the answer the daemon would have given them, sooner, and without buffering
+// an arbitrary file first. Nothing is re-checked client-side beyond this —
+// the per-field bounds and the workflow's declared field contract stay
+// daemon-authoritative (§8.1.2), because the CLI is not the only client.
+const maxFieldsFileBytes = 4 << 20
+
+// readFieldsFile reads one JSON object of string values from path, or from in
+// when path is "-".
+//
+// Values must be JSON strings: `.Task.Fields` is a map[string]string (§8.1.2),
+// and quietly stringifying a number or a boolean would make `{"retries": 3}`
+// and `{"retries": "3"}` the same document while a workflow declaring
+// `type: integer` can tell them apart. A rejection names the **key only** —
+// never the value — for the same reason the human confirmation line does: a
+// field can carry a token, and an error message is scrollback and CI logs.
+//
+// A key repeated inside the object resolves last-wins, which is what
+// encoding/json does; it is documented rather than detected, matching the
+// rule --field already follows.
+func readFieldsFile(path string, in io.Reader) (map[string]string, error) {
+	src := "--fields-file " + path
+	r := in
+	if path != "-" {
+		// G304: the path this command's own operator typed after --fields-file.
+		f, err := os.Open(path) //nolint:gosec // G304: see above
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", src, err)
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	// One byte past the bound, so a document that exactly fills it still
+	// parses and one byte more is caught rather than silently truncated.
+	data, err := io.ReadAll(io.LimitReader(r, maxFieldsFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", src, err)
+	}
+	if len(data) > maxFieldsFileBytes {
+		return nil, fmt.Errorf("%s must be at most %d bytes", src, maxFieldsFileBytes)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var raw map[string]json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("%s must be one JSON object of string values: %w", src, err)
+	}
+	// A second document is never silently discarded, the rule §5.5 applies at
+	// the API: a caller who concatenated two objects meant something by both.
+	var trailing json.RawMessage
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%s must contain one JSON object and nothing after it", src)
+	}
+	if raw == nil { // a literal `null`, which decodes without error
+		return nil, fmt.Errorf("%s must be one JSON object of string values, got null", src)
+	}
+
+	fields := make(map[string]string, len(raw))
+	for name, value := range raw {
+		if strings.TrimSpace(name) == "" {
+			return nil, fmt.Errorf("%s has an empty field name", src)
+		}
+		// The leading quote is checked before unmarshalling because a JSON
+		// `null` unmarshals into a string without error, and silently
+		// recording an absent value as "" is exactly the confusion this
+		// rejects everywhere else.
+		text := bytes.TrimSpace(value)
+		if len(text) == 0 || text[0] != '"' {
+			return nil, fmt.Errorf("%s: field %q must be a JSON string", src, name)
+		}
+		var s string
+		if err := json.Unmarshal(text, &s); err != nil {
+			return nil, fmt.Errorf("%s: field %q must be a JSON string", src, name)
+		}
+		fields[name] = s
+	}
+	return fields, nil
+}
+
+// mergeTaskFields lays the --field values over the --fields-file ones, key by
+// key. The two combine rather than excluding each other (task 045 decision 2):
+// a script that wants to change one key should not have to regenerate the
+// whole document, and the flag typed on the same command line is the more specific
+// of the two — the same last-wins rule --field already documents, one level
+// out. Both nil stays nil, so a task created with neither flag sends exactly
+// what it sent before.
+func mergeTaskFields(file, flags map[string]string) map[string]string {
+	if file == nil {
+		return flags
+	}
+	merged := make(map[string]string, len(file)+len(flags))
+	maps.Copy(merged, file)
+	maps.Copy(merged, flags)
+	return merged
+}
+
+// fieldsSummary confirms what a created task carries by field **name and
+// count, never value** (task 045 decision 4): a field can hold a ticket key or
+// a customer name, and this line lands in scrollback, screenshots and CI logs.
+// A count on its own was not enough — the mistake worth catching is the
+// mistyped key, and only the names catch that. Empty renders as "" so a task
+// with no fields prints nothing extra.
+func fieldsSummary(fields map[string]string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	names := slices.Sorted(maps.Keys(fields))
+	return fmt.Sprintf("fields: %s (%d)", strings.Join(names, ", "), len(names))
 }
 
 func newTaskLsCmd() *cobra.Command {

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -230,7 +230,7 @@ func readFieldsFile(path string, in io.Reader) (map[string]string, error) {
 	if err := dec.Decode(&raw); err != nil {
 		return nil, fmt.Errorf("%s must be one JSON object of string values: %w", src, err)
 	}
-	// A second document is never silently discarded, the rule §5.5 applies at
+	// A second document is never silently discarded, the rule §13.1 applies at
 	// the API: a caller who concatenated two objects meant something by both.
 	var trailing json.RawMessage
 	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {

--- a/internal/cli/task_fields_test.go
+++ b/internal/cli/task_fields_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -25,6 +29,191 @@ func TestParseFieldFlags(t *testing.T) {
 	for _, value := range []string{"ticket", "=value", "  =value"} {
 		if _, err := parseFieldFlags([]string{value}); err == nil {
 			t.Errorf("parseFieldFlags(%q) succeeded", value)
+		}
+	}
+}
+
+// TestReadFieldsFileAcceptsAnObjectOfStrings covers the shape --fields-file
+// exists for: a generated JSON document, from a file and from stdin, whose
+// values may carry the spaces, newlines, Unicode and `=` a command line makes
+// awkward.
+func TestReadFieldsFileAcceptsAnObjectOfStrings(t *testing.T) {
+	const doc = `{
+	  "ticket": "OPS-42",
+	  "url": "https://example.test/?a=b",
+	  "note": "two words\nand a second line",
+	  "who": "안나",
+	  "empty": ""
+	}`
+	want := map[string]string{
+		"ticket": "OPS-42",
+		"url":    "https://example.test/?a=b",
+		"note":   "two words\nand a second line",
+		"who":    "안나",
+		"empty":  "",
+	}
+
+	path := filepath.Join(t.TempDir(), "fields.json")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatalf("write fields file: %v", err)
+	}
+	got, err := readFieldsFile(path, nil)
+	if err != nil {
+		t.Fatalf("readFieldsFile(file): %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("from file = %v, want %v", got, want)
+	}
+
+	// `-` reads the same document from stdin, which is the piped-from-jq form.
+	got, err = readFieldsFile("-", strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("readFieldsFile(-): %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("from stdin = %v, want %v", got, want)
+	}
+
+	// An object with a key repeated inside it is last-wins, matching --field.
+	got, err = readFieldsFile("-", strings.NewReader(`{"ticket":"OPS-1","ticket":"OPS-2"}`))
+	if err != nil {
+		t.Fatalf("readFieldsFile(duplicate key): %v", err)
+	}
+	if got["ticket"] != "OPS-2" {
+		t.Errorf("duplicate key = %q, want the later value OPS-2", got["ticket"])
+	}
+}
+
+// TestReadFieldsFileRejections: every rejection names the offending key at
+// most, and never the value behind it (task 045 decision 4) — an error message
+// is scrollback and CI logs.
+func TestReadFieldsFileRejections(t *testing.T) {
+	secret := "hunter2-do-not-print"
+	cases := []struct {
+		name string
+		doc  string
+		key  string // named in the message when the key is what is wrong
+	}{
+		{"number value", `{"retries": 3}`, "retries"},
+		{"boolean value", `{"dry-run": true}`, "dry-run"},
+		{"null value", `{"owner": null}`, "owner"},
+		{"array value", `{"labels": ["` + secret + `"]}`, "labels"},
+		{"object value", `{"meta": {"token": "` + secret + `"}}`, "meta"},
+		{"empty key", `{"": "` + secret + `"}`, ""},
+		{"blank key", `{"   ": "` + secret + `"}`, ""},
+		{"not an object", `["` + secret + `"]`, ""},
+		{"null document", `null`, ""},
+		{"trailing content", `{"ticket":"OPS-42"} {"ticket":"OPS-43"}`, ""},
+		{"trailing junk", `{"ticket":"OPS-42"} nonsense`, ""},
+		{"empty document", ``, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := readFieldsFile("-", strings.NewReader(tc.doc))
+			if err == nil {
+				t.Fatalf("readFieldsFile(%s) succeeded with %v", tc.doc, got)
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Errorf("error echoes a field value: %v", err)
+			}
+			if tc.key != "" && !strings.Contains(err.Error(), tc.key) {
+				t.Errorf("error does not name the key %q: %v", tc.key, err)
+			}
+		})
+	}
+}
+
+// TestReadFieldsFileBound: stdin can be an unbounded pipe, so the read is
+// capped at the API's own large-body bound and the message says which.
+func TestReadFieldsFileBound(t *testing.T) {
+	// One byte past the bound: an object whose single value fills the rest.
+	value := strings.Repeat("x", maxFieldsFileBytes)
+	_, err := readFieldsFile("-", strings.NewReader(`{"big":"`+value+`"}`))
+	if err == nil {
+		t.Fatal("an over-bound document was accepted")
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(maxFieldsFileBytes)) {
+		t.Errorf("error does not name the limit: %v", err)
+	}
+	if strings.Contains(err.Error(), "xxxx") {
+		t.Errorf("error echoes the body: %v", err)
+	}
+
+	// Exactly at the bound still parses: the cap is inclusive.
+	fit := `{"big":"` + strings.Repeat("x", maxFieldsFileBytes-10) + `"}`
+	if len(fit) != maxFieldsFileBytes {
+		t.Fatalf("fixture is %d bytes, want exactly %d", len(fit), maxFieldsFileBytes)
+	}
+	if _, err := readFieldsFile("-", strings.NewReader(fit)); err != nil {
+		t.Errorf("a document exactly at the bound was rejected: %v", err)
+	}
+}
+
+func TestReadFieldsFileMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-file.json")
+	if _, err := readFieldsFile(missing, nil); err == nil {
+		t.Fatal("a missing --fields-file was accepted")
+	}
+}
+
+// TestMergeFields: the file supplies the base map and each --field overrides
+// its own key (task 045 decision 2), and neither flag leaves the request's
+// field map nil so an unchanged command line sends what it always sent.
+func TestMergeTaskFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		file, flags map[string]string
+		want        map[string]string
+	}{
+		{"neither", nil, nil, nil},
+		{"flags only", nil, map[string]string{"a": "1"}, map[string]string{"a": "1"}},
+		{"file only", map[string]string{"a": "1"}, nil, map[string]string{"a": "1"}},
+		{
+			"disjoint keys union",
+			map[string]string{"a": "1"},
+			map[string]string{"b": "2"},
+			map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			"--field wins the shared key",
+			map[string]string{"a": "file", "b": "2"},
+			map[string]string{"a": "flag"},
+			map[string]string{"a": "flag", "b": "2"},
+		},
+		{"empty file object", map[string]string{}, nil, map[string]string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeTaskFields(tc.file, tc.flags)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeTaskFields = %v, want %v", got, tc.want)
+			}
+			// nil is not the same as empty here: it is what keeps a task
+			// created with neither flag byte for byte unchanged on the wire.
+			if (got == nil) != (tc.want == nil) {
+				t.Errorf("mergeTaskFields nil-ness = %v, want %v", got == nil, tc.want == nil)
+			}
+		})
+	}
+}
+
+// TestFieldsSummary: names and a count, sorted, never a value.
+func TestFieldsSummary(t *testing.T) {
+	if got := fieldsSummary(nil); got != "" {
+		t.Errorf("fieldsSummary(nil) = %q, want empty", got)
+	}
+	if got := fieldsSummary(map[string]string{}); got != "" {
+		t.Errorf("fieldsSummary(empty) = %q, want empty", got)
+	}
+	got := fieldsSummary(map[string]string{
+		"ticket": "OPS-42", "owner": "ana", "api-key": "hunter2",
+	})
+	if want := "fields: api-key, owner, ticket (3)"; got != want {
+		t.Errorf("fieldsSummary = %q, want %q", got, want)
+	}
+	for _, value := range []string{"OPS-42", "ana", "hunter2"} {
+		if strings.Contains(got, value) {
+			t.Errorf("fieldsSummary echoes the value %q: %q", value, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds `--fields-file PATH` to `vincent task add`, with `-` reading standard
input. It fills the same [task field map](docs/guides/workflows.md#54-task-fields)
that repeatable `--field name=value` fills, from one JSON object of string
values — the form a generator produces, and the one that carries newlines,
quotes and spaces without the shell having to survive them first.

```sh
jq -n --arg t "$TICKET" --arg n "$(cat notes.md)" '{ticket: $t, notes: $n}' |
  vincent task add --project 1 --workflow release --title "Release 2.0" \
    --fields-file - --field ticket=OPS-43
```

The two flags **combine, and `--field` wins name by name**: the file is the base
map and the more specific flag on the same command line takes effect. That is
the last-wins rule `--field` already documents, extended one level out, and it
is what lets a script keep one generated document and vary a single input per
run. Mutual exclusion — offered by the issue as the simpler option — was
rejected for exactly that reason.

Rejected locally, exit 1, before any request is made:

- a value that is not a JSON string (number, boolean, `null`, array, object) —
  the message names the **key** and never the value;
- an empty or all-whitespace name;
- anything after the first JSON object;
- a read past §13.1's 4 MiB body bound, applied through an `io.LimitReader`
  because standard input can be an unbounded pipe.

Everything else stays **daemon-authoritative** — required, `type`, `pattern`,
the per-field size limits — and declaring `fields:` still does not close the
map.

Creating a task without `--json` now also confirms what it carries by **name and
count, never value**:

```
task 62 created: Release 2.0 (release, branch vincent/62-release-2-0)
  fields: notes, ticket (2)
```

Safe to leave in a CI log, and it still catches the mistake worth catching — a
name typed wrong, which a bare count would hide. It is read off the *response*,
so a field the daemon prefilled from `--github-issue` is confirmed alongside the
typed ones.

### Scope

The issue was filed on 2026-08-19; task 022 landed on 2026-08-21 and 022.4
already shipped `--field`, daemon-authoritative validation and the §13.1 bounds.
Acceptance criteria 1, 2 and 4 were met that day. This PR builds the remaining
gaps and deliberately does not re-derive `--field`.

One issue bullet is **not built**: "reject fields not accepted by the resolved
workflow". It contradicts **task 022 decision 3** (2026-08-21) — declaring
`fields:` does not close the map, because closing it turns "add form guidance to
a workflow" into a breaking change for every existing script and metadata
convention. That decision stands; `internal/workflow/fields.go` and
`ValidateTaskFields` are untouched and no strict flag is added. It is recorded
as beaten in `docs/tasks/044-cli-task-fields-file.md` so it is not re-opened.

### Testing

`internal/cli/fields_e2e_test.go` is the first test anywhere to prove a supplied
field reaches a step **template**. `TestCommandsAgainstLiveDaemon` cannot:
it points claude at `/nonexistent/claude` and never runs a step, so it
proves storage and nothing past it. The new test creates a project carrying a
project-scoped workflow whose `command` step renders
`{{ index .Task.Fields "ticket" }}`, runs it to completion through the real
binary and a real daemon, and reads the effect out of the task's worktree. Its
step body is `git config -f fields.ini …`, spelled in the intersection of
`/bin/sh` and `pwsh` (§8.3) so it runs unchanged on all three platforms.

Unit tests cover the parser (file and stdin, Unicode, newlines, `=`, empty
values), every rejection above — asserting no error echoes a value — the 4 MiB
bound at and one byte past the limit, the merge precedence, that neither flag present
still leaves the request's field map nil, and the summary line.

`go run mage.go test` and `go run mage.go testrace` pass, and `golangci-lint` is
clean for `GOOS=linux`, `darwin` and `windows`.

### Documentation

The CLI page, the scripting guide, `workflows.md` §5.4, the §12.1 spec
amendment, `docs/tasks/044-cli-task-fields-file.md` and its index row ship with
the implementation commit. A follow-up `docs:` commit fixes two things the audit
turned up:

- **Both exit-code tables listed the wrong sources for exit `1`.** The scripting
  guide defined it as "the daemon answered and rejected the request", which the
  page's own new section — "checked locally … before the daemon is called, and
  exits `1`" — contradicts; the CLI page named only the daemon-free commands as
  the local half. Both now name client-side input rejection too.
- **`Supplying task fields` was missing from the scripting guide's contents**,
  which lists every other section of that page.

Nothing else moved. `internal/config`, the route table, `internal/tui/bindings.go`,
the `Reason*` constants, the step types and `internal/agent/*` are all untouched
by this change, so `configuration.md`, `api.md`, `tui.md`, the block-reason
tables, `workflow-schema.md`, `task-lifecycle.md` and `agents.md` are unchanged
and still true. The workflow schema did not change, so
`skills/vincent-workflows/SKILL.md` and its `references/` are not part of this
PR, and this repo's own `.vincent/workflows/*.yaml` need no edit. No gate script
or gate walkthrough drives `vincent task add` — the gates create tasks over
curl — so `docs/gates/` is unaffected, and the TUI is untouched so the
`docs/assets/tui-*.png` captures still match.

A third `docs:` commit fixes the citation the audit found and left: the comment
on `--fields-file`'s trailing-content check cited **`§5.5`**, and `docs/spec.md`
section 5 ends at **§5.4 StepRun** — there is no §5.5. It now cites **§13.1**,
where the one-document rule and the 4 MiB bound this read mirrors actually live,
which is what the API's own single-decode path (`internal/api/projects.go:581`)
cites for the same rule and what every page in this PR already cites. Comment
only; no behaviour changed.

### A pre-existing non-hermetic test in `internal/cli`, fixed here

`go test -race ./internal/cli` failed in the **GitHub** e2e tests, always the
same way: the `vincent doctor` call exceeded `internal/apiclient`'s 10 s
request timeout —

```
Error: GET /v1/doctor: Get "http://127.0.0.1:61187/v1/doctor":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

**It is not this branch's.** `internal/cli/github_e2e_test.go` is untouched by
the feature (last changed by `d963a2c`, task 035), nothing in the diff goes near
`internal/doctor`, `internal/agent`, `internal/github`, `internal/api` or
`internal/apiclient`, and a scratch worktree at `master` reproduces both
failures byte-for-byte under the same command.

The cause is a hermeticity hole, not a flake or a tight timeout. `/v1/doctor`
probes all three adapters, and cursor's `Detect` is an **authenticated network
call** (§9.7, and `CLAUDE.md`) rather than a `--help` parse. Both tests pinned
only `claude` at `/nonexistent/claude` and left `codex` and `cursor` at their
defaults, so on any machine with `cursor-agent` installed the daemon made a real
network round-trip while composing the report. Measured against a hand-started
daemon on this host, with the config those tests write:

| agent config | `/v1/doctor` |
|---|---|
| claude pinned only (what the tests had) | 3.5 s – 9.4 s |
| claude + cursor pinned | 0.51 s |
| all three pinned | 0.43 s |

Race instrumentation and a loaded box push the first row past 10 s. CI never saw
it because the runners have no agent CLI installed, so every probe fails fast.

The fix is one the package had already made for exactly this: `doctor_e2e_test.go`
carries `pointAgentsAtNothing`, whose comment reads "keeps these tests
independent of whichever agent CLIs happen to be installed on the machine
running them", and pins all three. The two GitHub tests — the only other tests
in the package that read `doctor` — now call that same helper. No assertion was
relaxed, skipped or removed: neither test asserts anything about an agent row,
and both already accepted `doctor`'s exit code 0 or 1. `internal/cli` under
`-race` goes from failing in 24.8 s to passing in 6.4 s.

The **product-side** question this exposes is left alone deliberately, being
well outside the scope this PR agreed: `doctor` puts no bound of its own on an
adapter probe, so a hanging network makes `vincent doctor` fail on the client's
timeout rather than report "cursor: probe timed out". That belongs in
`internal/doctor` or the cursor adapter, with its own task.

## Related

Closes #144
Closes 044.1, 044.2, 044.3, 044.4 (`docs/tasks/044-cli-task-fields-file.md`).

Revisits **task 022 decision 3** only to confirm it: the issue asked for a
closed field map and this PR declines, for the reason recorded there.

Amends `docs/spec.md` §12.1 with a dated note (2026-08-28) for the new flag and
its precedence.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
