### PR TITLE
A command line for every human action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,28 @@ list with the user-facing context a commit subject cannot carry.
   [scripting guide](docs/guides/scripting.md) and
   [troubleshooting](docs/guides/troubleshooting.md).
 
+- **Every human action on a task now has a command line.** `vincent task` grew
+  `pause`, `resume`, `skip`, `approve`, `reject`, `retry`, `repair`, `archive`
+  and `answer`, and `vincent project` grew `rm` — so a blocked task can be
+  rescued from a shell loop, a cron job or an SSH session with no usable
+  terminal, instead of only from the TUI or hand-assembled `curl`. This matters
+  most when an agent credential expires: every task that reaches an agent step
+  blocks on `agent_unauthenticated` once its retry budget is spent, waiting
+  fixes nothing, and until now that board could not be cleared from a script.
+  `vincent task ls --state blocked --json | jq -r '.[].id'` piped into
+  `vincent task retry` now does it. Each action takes one id, carries `--json`,
+  and prints the daemon's own post-action view of the task rather than a guess.
+  `retry` takes `--branch` (the `branch_exists` recovery: the task keeps its id
+  and its transcripts) and `--prompt`/`--run` for edit+retry, each with a
+  `-file` twin that reads stdin from `-`; `repair` takes a required `--prompt`
+  plus `--agent`/`--model`/`--effort`; `archive` takes `--force` and tells you
+  so when it refuses a dirty worktree; `answer` takes `--answer <n>=<value>`
+  against the questions `vincent task show` numbers, `--allow`/`--deny` for a
+  permission request, or `--body` to post a payload verbatim. `vincent task
+  show` now prints the pending input request and the actions the daemon will
+  accept right now, so a script can read what is legal instead of probing for
+  errors. Documented in the [CLI reference](docs/reference/cli.md#vincent-task)
+  and [Scripting vincent](docs/guides/scripting.md).
 - **Creating a task can now be retried safely.** If the daemon commits your task
   but you never see the response — a timeout, a dropped connection, a script
   that dies mid-`curl` — re-sending the request used to create a second task, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,19 @@ list with the user-facing context a commit subject cannot carry.
   needs its own issue, not a side effect of turning a linter on.
   ([#147](https://github.com/lezli01/vincent/issues/147))
 
+### Fixed
+
+- **`vincent doctor` no longer times out instead of answering.** The report asks
+  the daemon to probe every agent CLI, and each probe carries that adapter's own
+  deadline — up to 145 seconds in total, with cursor's model catalog being an
+  authenticated network call. The client gave up after ten, so on a machine
+  where a probe was merely slow the command printed `context deadline exceeded`
+  rather than the report that would have named the adapter holding it up. The
+  two calls whose cost is that probe walk — `vincent doctor` and a forced
+  refresh of the agent picker — now wait longer than the adapters can, so the
+  diagnosis reaches you. Every other call still gives up after ten seconds: a
+  daemon that cannot answer a cached read that fast is wedged.
+
 ## [0.6.0](https://github.com/lezli01/vincent/compare/v0.5.0...v0.6.0) (2026-08-25)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -445,14 +445,19 @@ The task appears on the board, runs in its own worktree on branch
 TUI, press `a` to approve, and the publish step pushes the branch. `q` quits
 the TUI — the daemon and any running task keep going without it.
 
-The data commands the TUI runs are subcommands too (`vincent task show 1`,
-`vincent task cancel 1`, plus `project`, `workflow` and `daemon`), and
-everything either does is the same localhost API. One human action has a command
-line of its own — `vincent task follow-up <id>`, because running one more thing
-in each of several finished tasks' worktrees is a batch. The rest — approve,
-reject, retry, repair, skip, pause, resume, answer, archive — are TUI and API
-operations for now ([#89](https://github.com/lezli01/vincent/issues/89)); the
-[CLI reference](docs/reference/cli.md) is the full tree. To keep the daemon
+Everything the TUI does is a subcommand, and everything either does is the same
+localhost API. That covers the data commands (`vincent task show 1`, plus
+`project`, `workflow` and `daemon`) and every human action on a live task —
+`approve`, `reject`, `retry`, `repair`, `skip`, `pause`, `resume`, `answer`,
+`archive`, `follow-up` — so a blocked task can be rescued from a shell loop
+rather than from a terminal:
+
+```sh
+vincent task ls --state blocked --json | jq -r '.[].id' |
+  while read -r id; do vincent task retry "$id"; done
+```
+
+The [CLI reference](docs/reference/cli.md) is the full tree. To keep the daemon
 running across reboots, `vincent service install`.
 
 **Next:** [writing your own workflows](docs/guides/workflows.md), or the

--- a/docs/features.md
+++ b/docs/features.md
@@ -98,8 +98,11 @@ stray file to drop. A **follow-up run** does that work inside vincent: give a
 workflow, and it runs on that task's own branch in that task's own worktree,
 recorded in its own ledger with a transcript and cost accounting. It is
 repeatable, and it never changes the task's verdict — a done task comes back
-`done` and an aborted one comes back `aborted`. It is the one human action with
-a command line, because "rebase these six finished branches" is a batch.
+`done` and an aborted one comes back `aborted`. It was the first human action to
+get a command line, because "rebase these six finished branches" is a batch;
+every other one — approve, reject, retry, repair, skip, pause, resume, answer,
+archive — is a subcommand now too, so a board full of blocked tasks can be
+cleared from a shell loop.
 
 Every state transition is persisted before execution. If the daemon dies
 mid-step, restart recovery finalizes the interrupted attempt, verifies and

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -178,10 +178,18 @@ vincent task show 1
 vincent task ls --state running
 ```
 
-The human actions on a running task — approve, reject, retry, skip, pause,
-resume, answer, archive — are TUI and API operations for now
-([#89](https://github.com/lezli01/vincent/issues/89)). The
-[CLI reference](../reference/cli.md) is the full tree.
+Everything the TUI does is a subcommand, including the human actions on a live
+task — approve, reject, retry, repair, skip, pause, resume, answer, archive —
+so the gate you are about to approve by hand can also be approved from a script:
+
+```sh
+vincent task approve 1
+vincent task ls --state blocked --json | jq -r '.[].id' |
+  while read -r id; do vincent task retry "$id"; done
+```
+
+The [CLI reference](../reference/cli.md) is the full tree, and
+[Scripting vincent](../guides/scripting.md) is the guide.
 
 ## 5. Approve the gate
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -1,16 +1,34 @@
 # Scripting vincent
 
-Everything the TUI does goes through the same localhost API, and its data
-commands are subcommands too — `task add/ls/show/cancel/follow-up`, `project`,
-`workflow`, `daemon`. The human actions that act on a running task (approve,
-reject, retry, repair, skip, pause, resume, answer, archive) have no subcommand
-yet ([#89](https://github.com/lezli01/vincent/issues/89)), so a script reaches
-those over the API; the [CLI reference](../reference/cli.md) is the full tree.
+Everything the TUI does is a subcommand, and everything either does is the same
+localhost API. That includes the actions that act on a *live* task — approve,
+reject, retry, repair, skip, pause, resume, answer, archive — so a blocked task
+can be rescued from a shell loop, a cron job or an SSH session with no usable
+terminal. The [CLI reference](../reference/cli.md) is the full tree.
 
-[`task follow-up`](../reference/cli.md#vincent-task-follow-up) is the exception,
-and it is one because the thing it is for is a batch — running one more agent
-prompt, shell command or workflow in each of several finished tasks' own
-worktrees, before they are archived:
+The shape is always the same: one id per invocation, `--json` if you want the
+task back as data, and the daemon's own post-action view of the task printed
+rather than a guess about where it went.
+
+```sh
+vincent task ls --state blocked --json |
+  jq -r '.[].id' |
+  while read -r id; do
+    vincent task retry "$id"
+  done
+```
+
+That loop is the answer to the failure this guide exists for. An agent
+credential expires, every task that reaches an agent step fails its retry budget
+and blocks on `agent_unauthenticated`, and no amount of waiting helps: someone
+has to fix the login and then move each task. (`usage_limit` is deliberately
+*not* this case — it is a queued reason, never a block reason, and the scheduler
+re-admits on its own.)
+
+The same loop with a different verb does the other batches — archiving a day's
+finished work, or running one more command in each of several finished tasks'
+own worktrees with
+[`task follow-up`](../reference/cli.md#vincent-task-follow-up):
 
 ```sh
 vincent task ls --state done --json |
@@ -109,6 +127,13 @@ Two guarantees make it safe to pipe into `jq`:
 ```sh
 vincent task ls --state blocked --json | jq -r '.[] | "\(.id)\t\(.title)"'
 ```
+
+`vincent task show <id> --json` carries two fields worth knowing about:
+`available_actions`, which is what the daemon will accept right now — read it
+instead of probing for `409`s, and every name in it is a `vincent task <action>`
+subcommand — and `pending_input`, the §7.4 request an `awaiting_input` task is
+parked on. The human rendering numbers those questions, and
+`vincent task answer <id> --answer <n>=<value>` takes the numbers.
 
 ## Supplying task fields
 
@@ -353,17 +378,33 @@ set -euo pipefail
 
 id=$(vincent task add --project 1 --workflow feature-pr \
        --title "$1" --json | jq -r .id)
+retried=0
 
 while :; do
   state=$(vincent task show "$id" --json | jq -r .state)
   case "$state" in
-    done)                     echo "✓ task $id done";        exit 0 ;;
-    blocked|aborted)          echo "✗ task $id $state" >&2;  exit 1 ;;
-    awaiting_gate)            echo "task $id needs approval"; exit 0 ;;
-    *)                        sleep 5 ;;
+    done)          echo "✓ task $id done";                  exit 0 ;;
+    aborted)       echo "✗ task $id aborted" >&2;           exit 1 ;;
+    awaiting_gate) vincent task approve "$id" >/dev/null ;;
+    blocked)
+      # One retry, then hand it to a human. A script that retries a
+      # blocked task forever burns tokens on the same failure.
+      if [ "$retried" -eq 0 ]; then
+        retried=1
+        vincent task retry "$id" >/dev/null
+      else
+        echo "✗ task $id blocked: $(vincent task show "$id" --json | jq -r .block_reason)" >&2
+        exit 1
+      fi
+      ;;
+    *) sleep 5 ;;
   esac
 done
 ```
+
+Approving from a script is a real decision, not a formality: a `manual` gate is
+there because someone wanted a person to look. Approve unattended only where the
+gate is a pacing device rather than a review.
 
 For anything longer-lived, replace the poll loop with the `/v1/events` stream —
 the states are the same, the latency is not.

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -130,8 +130,9 @@ vincent task ls --state blocked --json | jq -r '.[] | "\(.id)\t\(.title)"'
 
 `vincent task show <id> --json` carries two fields worth knowing about:
 `available_actions`, which is what the daemon will accept right now — read it
-instead of probing for `409`s, and every name in it is a `vincent task <action>`
-subcommand — and `pending_input`, the §7.4 request an `awaiting_input` task is
+instead of probing for `409`s, and every name in it has a `vincent task <action>`
+subcommand once `_` is replaced with `-` (the API says `follow_up`, the tree says
+`follow-up`) — and `pending_input`, the §7.4 request an `awaiting_input` task is
 parked on. The human rendering numbers those questions, and
 `vincent task answer <id> --answer <n>=<value>` takes the numbers.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -338,6 +338,26 @@ vincent project ls [--json]
 
 Lists registered projects with their ids, paths and defaults.
 
+### `vincent project rm`
+
+```sh
+vincent project rm <id> [--force] [--json]
+```
+
+Removes the project registration and its task rows. It never prompts: `--force`
+is the whole confirmation story, because this tree exists to be scripted.
+
+Two refusals reach you intact, and they want opposite things:
+
+| Refusal | What to do |
+|---|---|
+| `project has N non-archived task(s)` | Archive or cancel them, or pass `--force` to archive them on the way out |
+| `task N is running; cancel it before deleting the project` | Cancel that task. `--force` cannot help — it is refused either way |
+
+`--json` emits `{"id": N, "removed": true}`. The endpoint answers `204`, so
+there is no task to print, and an empty stdout would be a parse error in
+whatever wraps this.
+
 ## `vincent task`
 
 ### `vincent task add`
@@ -504,6 +524,25 @@ same name, so this is what tells a repository's own `adhoc.yaml` from the
 built-in `adhoc` long after the fact. It is captured once, at creation, and
 never updated.
 
+An `awaiting_input` task prints the request it is parked on, numbered. Those
+numbers are what [`vincent task answer`](#vincent-task-answer) takes — the wire
+format is keyed by question *text*, and nobody should have to retype a sentence:
+
+```
+actions   answer, cancel
+
+awaiting input: question
+  1. Which database?
+     suggested: postgres, sqlite
+  2. deploy: Which regions?  (one or more)
+     suggested: eu, us
+  answer with `vincent task answer 7 --answer 1=<value>`
+```
+
+The `actions` row is the daemon's own `available_actions`, so a script reads
+what is legal instead of probing for `409`s. Every name in it is a
+`vincent task <action>` subcommand.
+
 The step table's last two columns are different kinds of thing and should not be
 read as one. `REASON` is vincent's own `failure_reason`, a closed set of
 constants. `STATUS` is what the step said about *itself* through
@@ -591,7 +630,7 @@ anything else. When it ends the task returns to the state it came from: `done`
 to `done`, `aborted` to `aborted`, whatever the run did. A follow-up never
 changes a task's verdict, and it is repeatable.
 
-This is the one human action with a command line, and it has one because
+It was the first human action to get a command line, and it got one because
 batches want one:
 
 ```sh
@@ -600,9 +639,138 @@ for id in 41 42 43 44 45 46; do
 done
 ```
 
-The remaining human actions — approve, reject, retry, repair, skip, pause,
-resume, answer, archive — are TUI and API operations; see
-[the API reference](api.md#tasks).
+The rest followed (task 048); they are documented below.
+
+### `vincent task pause`
+
+```sh
+vincent task pause <id> [--json]
+vincent task resume <id> [--json]
+```
+
+`pause` holds the task at the **next step boundary** — a running step finishes
+first, it is not killed. Valid from `queued` and `running`. `resume` returns a
+paused task to the queue, where the scheduler admits it like any other; valid
+from `paused`.
+
+### `vincent task approve`
+
+```sh
+vincent task approve <id> [--json]
+vincent task reject <id> [--json]
+vincent task skip <id> [--json]
+```
+
+`approve` passes the manual gate the task is waiting on and the workflow
+continues. `reject` fails it, and the task blocks with reason `gate_rejected`.
+Both are valid from `awaiting_gate` only.
+
+`skip` abandons the step the task is sitting on and advances to the next one.
+It is valid from `awaiting_gate` **and** from `blocked` — skipping a step that
+failed is how a workflow gets past a check the run does not need.
+
+### `vincent task retry`
+
+```sh
+vincent task retry <id> [--branch NAME] [--prompt TEXT | --prompt-file FILE]
+                        [--run CMD | --run-file FILE] [--json]
+```
+
+Re-runs the step the task blocked on. Valid from `blocked`. With no flags it is
+a plain retry; the flags change what gets re-run, and each one is a different
+kind of recovery:
+
+| Flag | What it does |
+|---|---|
+| `--branch NAME` | Renames the task's branch **before** the retry re-admits it. This is the [`branch_exists`](task-lifecycle.md) recovery: the task, its id and its transcripts all survive, which deleting and re-creating it would not |
+| `--prompt` / `--run` | Edit+retry. The text replaces that step's prompt or command in **this task's** workflow snapshot, and in no other task's — the registry file is untouched |
+| `--prompt-file` / `--run-file` | The same, read from a file, or from stdin with `-`. A replacement prompt is usually several lines, which argv is a poor place for |
+
+`--prompt` with `--prompt-file` (or `--run` with `--run-file`) is a usage error:
+they are two spellings of one value, so it exits 1 before any request is sent.
+
+```sh
+vincent task retry 7 --prompt-file - <<'EOF'
+The check failed because the fixture path is wrong on Windows.
+Use filepath.Join rather than a slash-separated literal.
+EOF
+```
+
+### `vincent task repair`
+
+```sh
+vincent task repair <id> (--prompt TEXT | --prompt-file FILE)
+                         [--agent NAME] [--model M] [--effort E] [--json]
+```
+
+Runs one ad-hoc agent with this prompt in the blocked task's **existing**
+worktree. Valid from `blocked`. Whatever the agent does, the task returns to
+`blocked` at the same step with the same reason: a repair changes the worktree,
+and a human still decides whether to retry.
+
+A prompt is required — `--prompt` and `--prompt-file` are mutually exclusive and
+one of them must be given, and `-` reads stdin. `--agent`, `--model` and
+`--effort` apply to this run only, standing in for the step level of §8.6's
+chain; a value no catalog recognizes is a warning on stderr, not a failure.
+
+### `vincent task archive`
+
+```sh
+vincent task archive <id> [--force] [--json]
+```
+
+Archives a finished task and removes its worktree. Valid from `done` and
+`aborted`. When
+[`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)
+is on, a branch carrying no commits past its base is deleted too, and what
+happened to it is printed under the state line — and carried in `--json` as
+`branch`.
+
+A worktree with **uncommitted changes** is refused with exit 1 and
+`details.reason: "worktree_dirty"`; the command says so and names the way out.
+`--force` is the confirmation, and it discards those changes:
+
+```
+Error: worktree has uncommitted changes
+  pass --force to archive it anyway, discarding those changes
+```
+
+### `vincent task answer`
+
+```sh
+vincent task answer <id> (--answer N=VALUE... | --allow | --deny |
+                          --body FILE) [--json]
+```
+
+Answers the input request an `awaiting_input` task is parked on; the run resumes
+in place. There are two ways in, and they do not mix — the flags below are
+mutually exclusive, and one of them is required.
+
+**By number, for a person.** `N` is the position
+[`vincent task show`](#vincent-task-show) prints the question under. Repeat the
+flag for one index to give a multi-select several values; everything after the
+**first** `=` is the value, so a URL or a regex needs no escaping:
+
+```sh
+vincent task answer 7 --answer 1=postgres --answer 2=eu --answer 2=us
+```
+
+The wire format is keyed by question *text* (§13.2) and stays that way — the
+numbering is a CLI convenience that never reaches the daemon. The command reads
+the pending request first, maps the numbers onto it, and checks the answer
+locally before posting: a wrong number or a missing answer costs no round trip.
+The daemon validates it again and remains the authority.
+
+A **permission** request is decided, not answered: `--allow` or `--deny`, and
+`--answer` on one is refused.
+
+**By payload, for a script.** `--body FILE` posts a §13.2 answer payload
+verbatim, with `-` reading stdin and no per-flag reconstruction:
+
+```sh
+jq -n '{answers: {"Which database?": ["postgres"]}}' |
+  vincent task answer 7 --body -
+```
 
 ## `vincent status`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -540,8 +540,10 @@ awaiting input: question
 ```
 
 The `actions` row is the daemon's own `available_actions`, so a script reads
-what is legal instead of probing for `409`s. Every name in it is a
-`vincent task <action>` subcommand.
+what is legal instead of probing for `409`s. Every name in it has a
+`vincent task <action>` subcommand, under the tree's spelling: the API says
+`follow_up` where the command is `follow-up`, so a script turning one into the
+other replaces `_` with `-`.
 
 The step table's last two columns are different kinds of thing and should not be
 read as one. `REASON` is vincent's own `failure_reason`, a closed set of
@@ -662,8 +664,9 @@ vincent task skip <id> [--json]
 ```
 
 `approve` passes the manual gate the task is waiting on and the workflow
-continues. `reject` fails it, and the task blocks with reason `gate_rejected`.
-Both are valid from `awaiting_gate` only.
+continues. `reject` fails it, and the task blocks with reason
+[`rejected`](task-lifecycle.md#failure-reasons). Both are valid from
+`awaiting_gate` only.
 
 `skip` abandons the step the task is sitting on and advances to the next one.
 It is valid from `awaiting_gate` **and** from `blocked` — skipping a step that
@@ -731,9 +734,12 @@ A worktree with **uncommitted changes** is refused with exit 1 and
 `--force` is the confirmation, and it discards those changes:
 
 ```
-Error: worktree has uncommitted changes
+Error: worktree_dirty: worktree ~/.local/share/vincent/worktrees/7 has local changes (untracked included); confirm with force
   pass --force to archive it anyway, discarding those changes
 ```
+
+The first line is the daemon's, printed as it stands; the second is the
+command's own.
 
 ### `vincent task answer`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -600,8 +600,9 @@ vincent task cancel <id> [--json]
 
 Aborts the task, killing any running process (graceful termination, then a kill
 after 10 seconds). Valid from `queued`, `running`, `awaiting_input`,
-`awaiting_gate`, `blocked` and `paused`; anything else exits 1 with the state it
-actually found.
+`awaiting_gate`, `awaiting_children`, `blocked` and `paused`; anything else exits
+1 with the state it actually found. From `awaiting_children` it cascades to every
+unfinished lane.
 
 ### `vincent task follow-up`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -176,7 +176,9 @@ which it was not before follow-ups existed.
 
 In the TUI these are the action bar keys (`a`, `x`, `r`, `R`, `E`, `s`, `p`,
 `c`, `A`, `F`); over the API they are `POST /v1/tasks/{id}/{action}`; from the
-CLI, `vincent task cancel` and `vincent task follow-up`.
+CLI, [`vincent task <action> <id>`](cli.md#vincent-task) — one subcommand each,
+spelled in kebab-case (`follow_up` is `vincent task follow-up`). `set priority`
+is the exception: it is a `PATCH`, and has no subcommand.
 
 An action the current state does not allow returns `409` with `details.state`
 set to the state actually found — so a client branches on a value rather than

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2737,9 +2737,10 @@ One Go binary, `vincent`:
 | `vincent daemon backup <path.tar.gz> / restore <path.tar.gz>` | *Added 2026-08-25 (task 030).* One `.tar.gz` of the database (`VACUUM INTO`, §14), `transcripts/`, `config.yaml` and `workflows/`, plus a manifest. `backup` is a thin API client and needs a **running** daemon; `restore` runs client-side and needs a **stopped** one, and refuses a newer schema or an occupied destination without `--force` |
 | `vincent service install / uninstall / status` | Registers OS-native autostart, always as the invoking user: launchd agent, systemd user unit, Windows Scheduled Task |
 | `vincent workflow ls / validate [file] / render <file> / init <name>` | Registry listing / YAML validation / template dry run / writing a new registry file. *Amended 2026-08-26 (task 034):* `init` writes the §5.2 scope directory a `--project` flag selects — global by default, resolved from §12.2 with **no daemon**; `--project N` needs one, purely to resolve the id to a repository root. `--from <example>` writes an embedded `examples/*.yaml` with its top-level `name:` rewritten. It refuses an existing path (`O_EXCL`) or a name another file in the same scope already declares, and only warns when the name shadows a lower scope. *Added 2026-08-28 (task 044):* `render` executes every template the file declares — `prompt`, `run`, `check`, `instructions`, `if` and `for_each` — against a synthetic §8.4 preview context and prints what each step would send, with the §8.6 triple each agent step resolves to. Where `validate` parses a template, this **executes** it, which is the only way `missingkey=error` catches a typo'd field. It is offline for the same reason `validate` is; `--task`/`--project` reach the daemon for a real task's facts and for registry lookups. Exit 0 clean · 1 a render error · 2 no daemon answered a `--task`/`--project` |
-| `vincent project add <path> / ls` | Thin API clients for scripting |
 | `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2). *Amended 2026-08-28 (task 045):* `add` fills the §8.1.2 field map from repeatable `--field name=value` and/or `--fields-file <path\|->` |
 | `vincent task transcript <id>` | *Added 2026-08-28 (task 047).* Prints one attempt's transcript through `GET /v1/tasks/{id}/steps/{run_id}/transcript` (§13.2). `--step` takes a **step_run id**; omitted, it selects the running attempt, else the newest by run id. Default output is the normalized records rendered as text, `--json` is those records as NDJSON, `--raw` is the agent's own dialect byte for byte. `-f` opens on a tail and resumes from `X-Next-Offset`, ending when that attempt stops running |
+| `vincent project add <path> / ls / rm <id>` | Thin API clients for scripting. *Amended 2026-08-28 (task 048):* `rm` deletes the registration and its task rows, forwarding `--force` as `?force`. It never prompts — the daemon's two 409s (`N non-archived task(s)`, and one naming a `running` task) are the confirmation story, and an interactive question would be the first in a command tree whose purpose is scripting |
+| `vincent task pause / resume / skip / approve / reject / retry / repair / archive / answer <id>` | *Added 2026-08-28 (task 048).* The rest of §6's human actions, one subcommand each, one id per invocation. All carry `--json` and print the daemon's post-action view of the task; a 409 from the FSM is exit 1 with the daemon's own wording. `retry` takes `--branch` (§18's `branch_exists` recovery) and the edit+retry pair `--prompt`/`--run`; `repair` requires `--prompt` and takes the §8.6 triple; `archive` takes `--force` and surfaces `details.reason: worktree_dirty` with the way out; `answer` takes `--answer <n>=<value>` against the questions `task show` numbers, `--allow`/`--deny` for a permission request, or `--body <file\|->` to post a §13.2 payload verbatim. Each of `--prompt`, `--run` and `--body` has a `-file` twin, and `-` reads stdin |
 | `vincent status <message>` | *Added 2026-08-26 (task 036).* Records what the current step is doing, in its own words (§5.4). Runs **from inside a step**: it addresses itself with §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, takes no id argument, and errors naming those variables when they are unset. Silent on success — its stdout is the step's transcript |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent github issues / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub |
@@ -2822,6 +2823,19 @@ TUI-and-API only, and stay that way; the reason to break with them here is that
 wants a shell loop rather than six visits to a form. The unevenness that leaves
 is accepted rather than papered over — giving every human action a command line
 is separate work.
+
+*Amended 2026-08-28 (task 048).* That separate work is this one, and "stay that
+way" no longer holds: every §6 human action has a command line. The reasoning
+above is kept rather than deleted because it is what lost. What it did not
+weigh is that the actions it left out are the ones a **blocked** task needs, so
+the recovery half of the product was reachable from exactly one client — the
+heavyweight interactive one — which contradicts §2's own claim that the daemon
+owns the work and clients are disposable. An agent auth outage is the case that
+settles it: `agent_unauthenticated` blocks each task once the retry budget is
+spent (§7.2), waiting fixes nothing, and a board full of those blocks could not
+be cleared from a script. `follow-up` remains the action whose *motivation* was
+a batch; the rest are here because a client that cannot unblock work is not a
+client.
 
 *Added 2026-08-25 (task 030).* `daemon restore` is a **stated exception** to
 "clients never touch the DB" (§4), and is written down here rather than left to

--- a/docs/tasks/025-ad-hoc-repair-agent.md
+++ b/docs/tasks/025-ad-hoc-repair-agent.md
@@ -164,6 +164,14 @@ nothing binding on it.
     `ls`, `show` and `cancel`; retry, skip and approve are already TUI-and-API
     only, and repair follows them.
 
+    *Superseded 2026-08-28 by [task 048](048-cli-human-actions.md).* `vincent
+    task repair` ships, along with every other §6 human action. This decision
+    reasoned from the company repair kept — retry, skip and approve — and none
+    of them had a command line either. What it did not weigh is that those four
+    are exactly the actions a **blocked** task needs, so the recovery half of
+    the product was reachable from one client only. Task 027 decision 11 broke
+    ranks for `follow_up` and named this follow-on work by name; 048 is it.
+
 ## Work
 
 - [x] **025.1 — Store: migration `0010_repair.sql`, `RepairRequest`, the

--- a/docs/tasks/027-follow-up-runs.md
+++ b/docs/tasks/027-follow-up-runs.md
@@ -156,6 +156,12 @@ recorded; the rest are followed.
     repair not — is accepted rather than papered over; filling the gap for every
     human action is a separate piece of work and out of scope here.
 
+    *Superseded 2026-08-28 by [task 048](048-cli-human-actions.md)*, which is
+    that separate piece of work: every §6 human action now has a subcommand, so
+    the unevenness this decision accepted is gone. The reason recorded here
+    stands for `follow-up` itself — its motivation was a batch — and 048's is
+    different: a client that cannot unblock work is not a client (§2).
+
 12. **2026-08-25 — Agent, model and effort resolve request > task override >
     workflow `defaults` > adapter default**, §8.6's chain with the request
     standing in for the step level, exactly as `repair` applies it. For the

--- a/docs/tasks/048-cli-human-actions.md
+++ b/docs/tasks/048-cli-human-actions.md
@@ -1,0 +1,158 @@
+# 048 — A command line for every §6 human action
+
+**Status:** ✅ done (6/6)
+**Issue:** [#89](https://github.com/lezli01/vincent/issues/89)
+**Spec:** amends §12.1
+
+## Problem
+
+The API exposes every §6 human action. `vincent task` exposed `add`, `ls`,
+`show`, `cancel` and `follow-up` — so the entire *recovery* half of the product
+was reachable from the TUI, from `curl`, and from nothing else.
+
+That makes the daemon's headline property false in one direction. "The daemon
+owns the work and clients are disposable" (§2, `CLAUDE.md`'s ownership
+invariants) is true of creating work and untrue of unblocking it: for the
+actions a **blocked** task needs, exactly one client could perform them, and it
+was the heavyweight interactive one.
+
+The failure mode that makes this more than an inconvenience is an agent auth
+outage. `agent_unauthenticated` fails an attempt under the normal retry budget
+and blocks the task once that budget is spent (§7.2, task 003); waiting does not
+fix it, because a human has to repair the login and then move each task. A board
+full of `agent_unauthenticated` blocks was a board that could not be un-blocked
+from a script. (`usage_limit` is deliberately *not* this case: it is a
+`queued_reason`, never a `block_reason`, and the scheduler re-admits without a
+human.)
+
+Secondary gap of the same shape: `DELETE /v1/projects/{id}` has existed with
+`?force` since T1.5, and `vincent project` registered only `add` and `ls`. A
+project could be created from the CLI and deleted only from the TUI or curl.
+
+## What shipped
+
+Nine subcommands under `vincent task` — `pause`, `resume`, `skip`, `approve`,
+`reject`, `retry`, `repair`, `archive`, `answer` — and `vincent project rm`.
+`internal/apiclient` already had every typed method, so this is cobra wiring,
+flag design, output rendering and documentation: no API, store, scheduler,
+`taskstate` or engine change.
+
+All of them take one id, carry `--json`, print the daemon's *post-action* view
+of the task rather than a predicted transition, and follow `task cancel`'s error
+shape — a 409 from the FSM is exit 1 with the daemon's own wording.
+
+`task show` grew two things the numbering depends on: the pending §7.4 request,
+rendered as numbered questions with their options and a multi-select marker (or
+the tool and summary of a `permission` request), and an `actions` row carrying
+`available_actions`, so a script reads what is legal instead of probing for
+409s. `--json` needed no change — `TaskDetail` has carried `pending_input` and
+`available_actions` all along; a test pins that rather than code adding it.
+
+## Decisions
+
+1. **2026-08-28 — Nine actions, not eight: `repair` ships too.** The issue
+   omits it. §12.1 and task 025 decision 12 name repair in the same breath as
+   retry, skip and approve, and `TestDocsClaimsTUIActionsHaveSubcommands` walks
+   **every** `taskstate.HumanActionsFrom` result — so restoring the parity
+   sentence while `task repair` was absent would turn that drift check red.
+   Repair takes `--prompt` (required) with `--prompt-file`, plus the §8.6
+   triple, and prints the catalog warnings its selection raised to stderr,
+   exactly as `follow-up` does.
+
+2. **2026-08-28 — One id per invocation** (`cobra.ExactArgs(1)`), matching
+   `cancel` and `follow-up`. The motivating case — a board of
+   `agent_unauthenticated` blocks — is a shell loop over
+   `task ls --state blocked --json | jq -r '.[].id'`, the idiom
+   `scripting.md` already teaches for `follow-up`. Variadic ids were rejected:
+   they force a partial-failure exit code that the documented 0/1/2 contract has
+   no room for, and a `--json` array shape no other single-task command emits.
+
+3. **2026-08-28 — `project rm` is flags-only and never prompts.** `--force`
+   forwards `?force` and that is the whole confirmation story. The daemon
+   already guards the unsafe cases with two distinct 409s — "project has N
+   non-archived task(s)" and one naming a `running` task — and both messages
+   reach the user intact, because they ask for opposite things. An interactive
+   confirm was rejected: it would make this the first interactive subcommand in
+   a tree whose stated purpose is scripting.
+
+4. **2026-08-28 — `--answer` is indexed, and the wire format is not.**
+   `InputResponse.Answers` is keyed by question *text* (§13.2) and stays that
+   way. `--answer <n>=<value>` numbers off what `task show` prints, because a
+   question is a sentence and nobody should retype one to answer it. A repeated
+   index is a multi-select's several values; values split on the **first** `=`,
+   the rule `parseFieldFlags` already documents, so a URL or a regex needs no
+   escaping. The command GETs the task, maps the indexes, and runs
+   `InputRequest.Validate` locally before posting — a fast fail, never the
+   authority, exactly as `Validate`'s own doc comment says.
+
+5. **2026-08-28 — `--body` posts the payload as it stands**, through a new
+   `apiclient.AnswerRaw` taking a `json.RawMessage`. Decoding a script's own
+   §13.2 document through `InputResponse` and re-encoding it would put this
+   client between a caller and a document the daemon is the authority on, for no
+   gain. The CLI checks only that it is JSON at all, so prose never leaves the
+   process as an answer payload.
+
+6. **2026-08-28 — `archive` must not flatten the dirty-worktree 409.**
+   `apiMessage` returns only `Message`; the reason lives in
+   `Error.Details["reason"] == "worktree_dirty"` — the discriminator
+   `internal/tui/bulkaction.go` already reads — so the command branches on it
+   and appends the `--force` hint. Exit 1 with no way out is a riddle.
+
+7. **2026-08-28 — Task 025 decision 12 and the §12.1 note it produced are
+   superseded in full.** They made retry, repair, skip and approve TUI-and-API
+   only, and said so in the spec. This work does not relitigate that by
+   assertion: task 027 decision 11 already named its own successor, closing with
+   "filling the gap for every human action is a separate piece of work and out
+   of scope here." This is that piece of work, and the §12.1 note is amended in
+   place with a dated paragraph rather than deleted — `spec §12.1` citations
+   stay stable, and the reasoning that lost is what makes the record worth
+   keeping.
+
+8. **2026-08-28 — The drift test compares the CLI's spelling of an action.**
+   `taskstate` spells actions in snake_case (`follow_up`) and the command tree
+   in kebab-case (`follow-up`), so `TestDocsClaimsTUIActionsHaveSubcommands`
+   normalizes before comparing. Renaming the subcommand to match the API was
+   rejected: `follow-up` is the published name, and the hyphen is the CLI's
+   convention, not a drift.
+
+9. **2026-08-28 — `answer`'s coverage is a stub-daemon test, not the live
+   one.** Everything else is asserted end to end against a real daemon through
+   the real binary — including the headline, a **blocked** task taken back to
+   `running`. Reaching `awaiting_input` for real needs an agent that asks a
+   question mid-run, which would make the assertion depend on the fake agent's
+   scenario rather than on the command. So the request shapes (index mapping,
+   multi-select, first-`=` splitting, the refusals, `--body` pass-through) are
+   pinned against a hand-written daemon that records the posted body, which is
+   the thing under test. The live suite still covers `answer`'s refusal path on
+   a task that is not waiting for input.
+
+## Work
+
+- [x] **048.1 — The five bare actions** (`pause`, `resume`, `skip`, `approve`,
+  `reject`) through one shared constructor, plus `taskID` and `printTaskAction`.
+  ✓ 2026-08-28
+- [x] **048.2 — The flag-carrying actions**: `retry` (`--branch`, the
+  `--prompt`/`--run` edit+retry pair and their `-file` twins), `repair`,
+  `archive` (`--force` and the `worktree_dirty` hint), `answer`
+  (`--answer`/`--allow`/`--deny`/`--body`), and `apiclient.AnswerRaw`.
+  ✓ 2026-08-28
+- [x] **048.3 — `task show` renders the pending request and the available
+  actions.** ✓ 2026-08-28
+- [x] **048.4 — `vincent project rm`.** ✓ 2026-08-28
+- [x] **048.5 — Tests**: `internal/cli/actions_e2e_test.go` against the real
+  binary and a real daemon (blocked → running, the gate trio, the
+  `branch_exists` recovery, the dirty-archive 409 and its `--force`, both
+  `project rm` 409s, exit 2 with no daemon and no daemon started), and
+  `internal/cli/taskanswer_test.go` for `answer` and the `task show` rendering.
+  `TestDocsClaimsTUIActionsHaveSubcommands` stops skipping. ✓ 2026-08-28
+- [x] **048.6 — Documentation**: §12.1 amended, `docs/reference/cli.md`,
+  `docs/guides/scripting.md` (the parity claim restored), `README.md`,
+  `docs/features.md`, `docs/getting-started/quickstart.md`, `CHANGELOG.md`, and
+  the superseded-by pointers on tasks 025 and 027. ✓ 2026-08-28
+
+## What is still API-only
+
+Out of scope here, and named so the next reader does not mistake this for full
+parity: the `PATCH` endpoints, `resolve`, `agents`, `task diff` and
+`task transcript`. None of them strands a blocked task, which is what made this
+issue urgent and makes those their own work.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -61,6 +61,7 @@ the living engineering specification records implementation contracts.
 | [045](045-cli-task-fields-file.md) | Task fields from a file or stdin in `vincent task add` | ✅ done (4/4) |
 | [046](046-notify-hook.md) | A notify hook: letting the daemon signal a human outside the TUI | ✅ done (6/6) |
 | [047](047-cli-logs-and-transcripts.md) | `vincent daemon logs` and `vincent task transcript` | ✅ done (5/5) |
+| [048](048-cli-human-actions.md) | A command line for every §6 human action | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/apiclient/agents.go
+++ b/internal/apiclient/agents.go
@@ -203,7 +203,9 @@ func (c *Client) ListAgents(ctx context.Context, refresh bool) (Agents, error) {
 	var body struct {
 		Agents Agents `json:"agents"`
 	}
-	if err := c.get(ctx, path, &body); err != nil {
+	// refresh is the same subprocess-per-adapter walk /v1/doctor?probe=true
+	// makes, and is bounded the same way.
+	if err := c.getVia(ctx, c.probeClient(refresh), path, &body); err != nil {
 		return nil, err
 	}
 	return body.Agents, nil

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -16,13 +16,31 @@ import (
 // so a slow response means a wedged daemon, not a slow network.
 const requestTimeout = 10 * time.Second
 
+// probeTimeout bounds the two calls whose server-side work is not loopback at
+// all: GET /v1/doctor with probe=true and GET /v1/agents?refresh=true both ask
+// the daemon to spawn an agent CLI per adapter (§9.5, §9.6). The daemon walks
+// the adapters serially and each subprocess carries the adapter's own deadline
+// — 45 s for claude (--version plus --help), 40 s for codex (--version plus
+// `login status`), 60 s for cursor, whose model catalog is an authenticated
+// network call — so the honest ceiling for these two is that sum, not loopback
+// latency.
+//
+// It has to *exceed* the sum rather than merely be generous. The report is the
+// thing that names which adapter hung; a client that gives up first replaces
+// that diagnosis with "context deadline exceeded", which is the one answer
+// `vincent doctor` must never give. Every other call keeps requestTimeout: a
+// wedged daemon is still caught in ten seconds everywhere it means anything.
+const probeTimeout = 3 * time.Minute
+
 // Client talks to one vincent daemon. It is safe for concurrent use.
 type Client struct {
 	baseURL string
 	token   string
 	// rest carries request/response calls and enforces requestTimeout;
+	// probes carries the adapter-probing calls and enforces probeTimeout;
 	// stream has no timeout because SSE responses never end on their own.
 	rest   *http.Client
+	probes *http.Client
 	stream *http.Client
 }
 
@@ -33,6 +51,7 @@ func New(baseURL, token string) *Client {
 		baseURL: strings.TrimRight(baseURL, "/"),
 		token:   token,
 		rest:    &http.Client{Timeout: requestTimeout},
+		probes:  &http.Client{Timeout: probeTimeout},
 		stream:  &http.Client{},
 	}
 }
@@ -86,12 +105,19 @@ func (c *Client) Health(ctx context.Context) (Health, error) {
 // get performs an authenticated GET and decodes the JSON response into out.
 // Non-2xx responses come back as *Error.
 func (c *Client) get(ctx context.Context, path string, out any) error {
+	return c.getVia(ctx, c.rest, path, out)
+}
+
+// getVia is get over a caller-chosen http.Client, so a request whose cost is
+// the daemon's adapter probes can be held to probeTimeout instead of the
+// loopback deadline the rest of the surface is held to.
+func (c *Client) getVia(ctx context.Context, hc *http.Client, path string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("build request %s: %w", path, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	resp, err := c.rest.Do(req)
+	resp, err := hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s: %w", path, err)
 	}
@@ -132,4 +158,14 @@ func decodeError(resp *http.Response) error {
 		Code:    "unexpected_response",
 		Message: fmt.Sprintf("unexpected status %s", resp.Status),
 	}
+}
+
+// probeClient picks the deadline a request is held to: probeTimeout when the
+// daemon will spawn an agent CLI per adapter to answer it, requestTimeout when
+// it answers from its §9.6 cache and the call really is loopback-fast.
+func (c *Client) probeClient(probing bool) *http.Client {
+	if probing {
+		return c.probes
+	}
+	return c.rest
 }

--- a/internal/apiclient/doctor.go
+++ b/internal/apiclient/doctor.go
@@ -90,8 +90,10 @@ func (c *Client) Doctor(ctx context.Context, probe bool) (*DoctorReport, error) 
 	if !probe {
 		path += "?probe=false"
 	}
+	// A probing report costs one agent-CLI subprocess per adapter, so it is
+	// the adapters' own deadlines that bound it, not loopback (probeTimeout).
 	var rep DoctorReport
-	if err := c.get(ctx, path, &rep); err != nil {
+	if err := c.getVia(ctx, c.probeClient(probe), path, &rep); err != nil {
 		return nil, err
 	}
 	return &rep, nil

--- a/internal/apiclient/input.go
+++ b/internal/apiclient/input.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,6 +66,15 @@ func (r InputResponse) body() any {
 		Allow   *bool               `json:"allow,omitempty"`
 	}{Answers: r.Answers, Allow: r.Allow}
 	return out
+}
+
+// AnswerRaw delivers an answer payload the caller assembled itself, passed to
+// the daemon as it stands (§13.2). It exists for `vincent task answer --body`,
+// where a script already holds the object: decoding it through InputResponse
+// and re-encoding it would put this client between a caller and a document the
+// daemon is the authority on, for no gain.
+func (c *Client) AnswerRaw(ctx context.Context, id int64, payload json.RawMessage) (Task, error) {
+	return c.action(ctx, id, ActionAnswer, payload)
 }
 
 // Validate checks an answer against the request it answers, using §7.4's

--- a/internal/apiclient/probetimeout_test.go
+++ b/internal/apiclient/probetimeout_test.go
@@ -1,0 +1,70 @@
+package apiclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The two adapter-probing calls are not loopback calls, and holding them to
+// the loopback deadline is what made `vincent doctor` answer "context deadline
+// exceeded" on a machine whose `cursor-agent` needs a few seconds to answer:
+// GET /v1/doctor?probe=true and GET /v1/agents?refresh=true both make the
+// daemon spawn an agent CLI per adapter (§9.5, §9.6), and the adapters' own
+// deadlines already sum to more than two minutes.
+//
+// The three legs below are the whole contract: the two probing calls survive a
+// response that takes longer than requestTimeout, and the same call *without*
+// probing does not — because that one really is served from the cache, and a
+// daemon that cannot answer it in ten seconds is wedged.
+func TestProbingCallsOutliveTheLoopbackDeadline(t *testing.T) {
+	// Comfortably past requestTimeout, comfortably short of probeTimeout: the
+	// test is over in about this long, not in three minutes.
+	const slack = 2 * time.Second
+	delay := requestTimeout + slack
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(delay):
+		case <-r.Context().Done():
+			// The client gave up. Returning promptly keeps Close from
+			// waiting out the delay on a request nobody is reading.
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/agents" {
+			_, _ = io.WriteString(w, `{"agents":[]}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "test-token")
+	ctx := context.Background()
+
+	var (
+		wg                             sync.WaitGroup
+		doctorErr, agentsErr, cacheErr error
+	)
+	wg.Add(3)
+	go func() { defer wg.Done(); _, doctorErr = c.Doctor(ctx, true) }()
+	go func() { defer wg.Done(); _, agentsErr = c.ListAgents(ctx, true) }()
+	go func() { defer wg.Done(); _, cacheErr = c.Doctor(ctx, false) }()
+	wg.Wait()
+
+	if doctorErr != nil {
+		t.Errorf("Doctor(probe=true) after %s: %v, want it to wait for the probes", delay, doctorErr)
+	}
+	if agentsErr != nil {
+		t.Errorf("ListAgents(refresh=true) after %s: %v, want it to wait for the probes", delay, agentsErr)
+	}
+	if !errors.Is(cacheErr, context.DeadlineExceeded) {
+		t.Errorf("Doctor(probe=false) after %s: %v, want the loopback deadline to still apply", delay, cacheErr)
+	}
+}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -322,7 +322,7 @@ type TaskDetail struct {
 	// BaseBranch and the three overrides have always been on the wire; only
 	// this struct dropped them. `vincent workflow render --task` binds a real
 	// task's §8.4 context and its §8.6 level-2 override from exactly these
-	// four, and re-deriving either client-side is what task 044 declined to
+	// four, and re-deriving either client-side is what task 048 declined to
 	// do.
 	BaseBranch     string          `json:"base_branch"`
 	AgentOverride  *string         `json:"agent_override"`

--- a/internal/cli/actions_e2e_test.go
+++ b/internal/cli/actions_e2e_test.go
@@ -1,0 +1,450 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// TestHumanActionCommands is task 044's done-when, and issue #89's: every §6
+// human action driven through the real binary against a real daemon, with no
+// TTY and no curl — a blocked task taken back to `running`, a gate approved
+// and rejected, an archive refused and then forced, and a project removed.
+//
+// It is one test because the interesting assertions are sequential and share
+// one expensive fixture: a task can only be retried after it has blocked, and
+// only blocked after the scheduler admitted it.
+//
+// No agent runs here. Every workflow step is a `command`, so the assertions
+// depend on the daemon and the shell rather than on which agent CLI the host
+// happens to have — and the step bodies stay inside the sh ∩ pwsh
+// intersection the gate scripts are held to (`exit N`, `sleep N`, `git ...`).
+func TestHumanActionCommands(t *testing.T) {
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	t.Cleanup(func() {
+		cmd := exec.Command(vincentBin, "daemon", "stop", "--force")
+		cmd.Env = append(hermeticEnv(),
+			config.EnvDataDir+"="+dataDir, config.EnvConfigDir+"="+cfgDir)
+		_, _ = cmd.CombinedOutput()
+	})
+
+	// One slot globally, so a task that has not been admitted yet stays
+	// `queued` for as long as the test needs it to: pause is valid from
+	// `queued`, and racing the scheduler for that window would be flaky.
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(
+		"max_parallel_tasks: 1\nagents:\n  claude:\n    path: \"/nonexistent/claude\"\n"),
+		0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repo := testrepo.Init(t, "main")
+	writeActionWorkflow(t, repo, "blocky", "steps:\n  - id: fail\n    type: command\n    run: exit 1\n")
+	writeActionWorkflow(t, repo, "slow", "steps:\n  - id: wait\n    type: command\n    run: sleep 30\n")
+	writeActionWorkflow(t, repo, "gated", "steps:\n"+
+		"  - id: gate\n    type: manual\n    instructions: approve me\n"+
+		"  - id: after\n    type: command\n    run: git --version\n")
+	// `git config -f` is how a step writes a file to disk in both the POSIX
+	// and the pwsh spelling of §8.3's shell; the untracked file it leaves is
+	// what makes the worktree dirty.
+	writeActionWorkflow(t, repo, "messy", "steps:\n"+
+		"  - id: mess\n    type: command\n    run: git config -f leftover.txt dirt.left yes\n")
+	testrepo.Run(t, repo, "add", ".")
+	testrepo.Run(t, repo, "commit", "-q", "-m", "workflows")
+
+	if out, code := runVincent(t, dataDir, cfgDir, "daemon", "start"); code != 0 {
+		t.Fatalf("daemon start: code %d, out %q", code, out)
+	}
+	if out, code := runVincent(t, dataDir, cfgDir, "project", "add", repo, "--json"); code != 0 {
+		t.Fatalf("project add: code %d, out %q", code, out)
+	}
+
+	// The slot holder. Everything created after this stays queued until it is
+	// cancelled, which is what makes the `queued` assertions deterministic.
+	hog := addActionTask(t, dataDir, cfgDir, "slow", "--workflow", "slow")
+	waitForState(t, dataDir, cfgDir, hog, "running")
+
+	t.Run("pause and resume a queued task", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "pausable", "--workflow", "blocky")
+		out, code := runVincent(t, dataDir, cfgDir, "task", "pause", id)
+		if code != 0 || !strings.Contains(out, "paused") {
+			t.Fatalf("task pause: code %d, out %q; want 0 and the new state", code, out)
+		}
+		// The state printed is the daemon's, after the fact — so a second
+		// pause is refused by the FSM with the state it actually found.
+		out, code = runVincent(t, dataDir, cfgDir, "task", "pause", id)
+		if code != 1 {
+			t.Errorf("pause an already paused task: code %d, want 1 (out %q)", code, out)
+		}
+
+		out, code = runVincent(t, dataDir, cfgDir, "task", "resume", id, "--json")
+		if code != 0 {
+			t.Fatalf("task resume: code %d, out %q", code, out)
+		}
+		var resumed struct {
+			ID    int64  `json:"id"`
+			State string `json:"state"`
+		}
+		if err := json.Unmarshal([]byte(out), &resumed); err != nil {
+			t.Fatalf("task resume --json is not JSON: %v (%q)", err, out)
+		}
+		if resumed.State != "queued" {
+			t.Errorf("resumed task = %+v, want state queued", resumed)
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Errorf("cancel the paused task: code %d", code)
+		}
+	})
+
+	t.Run("approve, reject and skip a manual gate", func(t *testing.T) {
+		approved := addActionTask(t, dataDir, cfgDir, "approve me", "--workflow", "gated")
+		rejected := addActionTask(t, dataDir, cfgDir, "reject me", "--workflow", "gated")
+		skipped := addActionTask(t, dataDir, cfgDir, "skip me", "--workflow", "gated")
+		// Free the slot: all three need admitting to reach the gate.
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", hog); code != 0 {
+			t.Fatalf("cancel the slot holder: code %d", code)
+		}
+		for _, id := range []string{approved, rejected, skipped} {
+			waitForState(t, dataDir, cfgDir, id, "awaiting_gate")
+		}
+
+		if out, code := runVincent(t, dataDir, cfgDir, "task", "approve", approved); code != 0 {
+			t.Fatalf("task approve: code %d, out %q", code, out)
+		}
+		waitForState(t, dataDir, cfgDir, approved, "done")
+
+		out, code := runVincent(t, dataDir, cfgDir, "task", "reject", rejected)
+		if code != 0 || !strings.Contains(out, "blocked") {
+			t.Fatalf("task reject: code %d, out %q; want 0 and blocked", code, out)
+		}
+		if out, code := runVincent(t, dataDir, cfgDir, "task", "skip", skipped); code != 0 {
+			t.Fatalf("task skip: code %d, out %q", code, out)
+		}
+		waitForState(t, dataDir, cfgDir, skipped, "done")
+
+		// An action the FSM refuses for the state the task is in: exit 1
+		// with the daemon's own wording, not a broken command.
+		out, code = runVincent(t, dataDir, cfgDir, "task", "approve", approved)
+		if code != 1 {
+			t.Errorf("approve a done task: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "done") {
+			t.Errorf("the refusal does not name the state it found: %q", out)
+		}
+	})
+
+	// The issue's headline: a blocked task rescued from a script. `--run` is
+	// edit+retry, so the step that failed is replaced in this task's snapshot
+	// only — which is also what makes `running` observable rather than a race
+	// against a command that exits immediately.
+	t.Run("retry takes a blocked task back to running", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "retry me", "--workflow", "blocky")
+		waitForState(t, dataDir, cfgDir, id, "blocked")
+
+		// Two spellings of one value is a usage error, refused locally
+		// before any request is sent.
+		out, code := runVincent(t, dataDir, cfgDir,
+			"task", "retry", id, "--prompt", "a", "--prompt-file", "b")
+		if code != 1 {
+			t.Errorf("--prompt with --prompt-file: code %d, want 1 (out %q)", code, out)
+		}
+		if state := taskState(t, dataDir, cfgDir, id); state != "blocked" {
+			t.Errorf("the refused retry moved the task to %s; it must send no request", state)
+		}
+
+		out, code = runVincent(t, dataDir, cfgDir, "task", "retry", id, "--run", "sleep 30")
+		if code != 0 || !strings.Contains(out, "queued") {
+			t.Fatalf("task retry --run: code %d, out %q; want 0 and queued", code, out)
+		}
+		waitForState(t, dataDir, cfgDir, id, "running")
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Errorf("cancel the retried task: code %d", code)
+		}
+	})
+
+	t.Run("retry --branch clears a branch_exists block", func(t *testing.T) {
+		// The block this recovers from is a *race*, not a typo: creating the
+		// task validates the name against the repository, and the collision
+		// appears afterwards — someone else pushed that branch, or an earlier
+		// run left it behind. So the task is parked behind a full slot while
+		// the branch is created under it, which is the situation task 001
+		// gave `branch_override` for.
+		slot := addActionTask(t, dataDir, cfgDir, "slot", "--workflow", "slow")
+		waitForState(t, dataDir, cfgDir, slot, "running")
+		id := addActionTask(t, dataDir, cfgDir, "collide", "--branch", "contested")
+		testrepo.Run(t, repo, "branch", "contested")
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", slot); code != 0 {
+			t.Fatalf("cancel the slot holder: code %d", code)
+		}
+		waitForState(t, dataDir, cfgDir, id, "blocked")
+		before := taskJSON(t, dataDir, cfgDir, id)
+		if before.BlockReason != "branch_exists" {
+			t.Fatalf("block_reason = %q, want branch_exists", before.BlockReason)
+		}
+
+		if out, code := runVincent(t, dataDir, cfgDir,
+			"task", "retry", id, "--branch", "rescued"); code != 0 {
+			t.Fatalf("task retry --branch: code %d, out %q", code, out)
+		}
+		// The task is the same task: same id, its own history intact, on the
+		// branch the flag named. That is the whole point of the recovery —
+		// the alternative was deleting the task and creating it again.
+		after := taskJSON(t, dataDir, cfgDir, id)
+		if after.ID != before.ID || after.BranchName != "rescued" {
+			t.Errorf("after retry --branch: id %d branch %q; want id %d on rescued",
+				after.ID, after.BranchName, before.ID)
+		}
+		if after.State == "blocked" && after.BlockReason == "branch_exists" {
+			t.Errorf("the task is still blocked on branch_exists: %+v", after)
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Logf("cancel after branch rescue: already settled")
+		}
+	})
+
+	t.Run("repair reads its prompt from stdin", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "repair me", "--workflow", "blocky")
+		waitForState(t, dataDir, cfgDir, id, "blocked")
+
+		// A repair with no instructions never leaves the process.
+		if out, code := runVincent(t, dataDir, cfgDir, "task", "repair", id); code != 1 {
+			t.Errorf("task repair with no prompt: code %d, want 1 (out %q)", code, out)
+		}
+
+		out, code := runVincentStdin(t, dataDir, cfgDir,
+			"the check failed; fix the config\nand try again\n",
+			"task", "repair", id, "--prompt-file", "-")
+		if code != 0 || !strings.Contains(out, "queued") {
+			t.Fatalf("task repair --prompt-file -: code %d, out %q; want 0 and queued", code, out)
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Logf("cancel after repair: already settled")
+		}
+	})
+
+	t.Run("archive refuses a dirty worktree until --force", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "messy", "--workflow", "messy")
+		waitForState(t, dataDir, cfgDir, id, "done")
+
+		out, code := runVincent(t, dataDir, cfgDir, "task", "archive", id)
+		if code != 1 {
+			t.Fatalf("archive a dirty worktree: code %d, want 1 (out %q)", code, out)
+		}
+		// The reason is a discriminator in details, not prose in the message,
+		// and the way out has to be named or exit 1 is a riddle.
+		if !strings.Contains(out, "--force") {
+			t.Errorf("the refusal does not offer --force: %q", out)
+		}
+
+		if out, code := runVincent(t, dataDir, cfgDir,
+			"task", "archive", id, "--force"); code != 0 {
+			t.Fatalf("task archive --force: code %d, out %q", code, out)
+		}
+		if state := taskState(t, dataDir, cfgDir, id); state != "archived" {
+			t.Errorf("state after archive --force = %s, want archived", state)
+		}
+	})
+
+	t.Run("answer refuses a task that is not waiting for input", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "not asking", "--workflow", "blocky")
+		waitForState(t, dataDir, cfgDir, id, "blocked")
+		out, code := runVincent(t, dataDir, cfgDir, "task", "answer", id, "--allow")
+		if code != 1 {
+			t.Errorf("answer a blocked task: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "not waiting for input") {
+			t.Errorf("the refusal does not say why: %q", out)
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Errorf("cancel: code %d", code)
+		}
+	})
+
+	t.Run("project rm", func(t *testing.T) {
+		// A project still holding tasks is refused, and the count reaches the
+		// user intact — it is the thing that tells them what --force will do.
+		out, code := runVincent(t, dataDir, cfgDir, "project", "rm", "1")
+		if code != 1 {
+			t.Fatalf("project rm with live tasks: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "non-archived task") {
+			t.Errorf("the refusal does not carry the daemon's count: %q", out)
+		}
+
+		// A *running* task is refused whether or not --force is set: force
+		// cannot help, and the message names the task to cancel.
+		running := addActionTask(t, dataDir, cfgDir, "still running", "--workflow", "slow")
+		waitForState(t, dataDir, cfgDir, running, "running")
+		out, code = runVincent(t, dataDir, cfgDir, "project", "rm", "1", "--force")
+		if code != 1 {
+			t.Fatalf("project rm --force with a running task: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "is running") || !strings.Contains(out, running) {
+			t.Errorf("the refusal does not name the running task %s: %q", running, out)
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", running); code != 0 {
+			t.Errorf("cancel the running task: code %d", code)
+		}
+
+		// An empty project is removed, and --json says so rather than
+		// leaving a parser looking at an empty stdout for a 204.
+		second := testrepo.Init(t, "main")
+		out, code = runVincent(t, dataDir, cfgDir, "project", "add", second, "--json")
+		if code != 0 {
+			t.Fatalf("project add: code %d, out %q", code, out)
+		}
+		var added struct {
+			ID int64 `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(out), &added); err != nil {
+			t.Fatalf("project add --json is not JSON: %v (%q)", err, out)
+		}
+		id := strconv.FormatInt(added.ID, 10)
+		out, code = runVincent(t, dataDir, cfgDir, "project", "rm", id, "--json")
+		if code != 0 {
+			t.Fatalf("project rm: code %d, out %q", code, out)
+		}
+		var removed struct {
+			ID      int64 `json:"id"`
+			Removed bool  `json:"removed"`
+		}
+		if err := json.Unmarshal([]byte(out), &removed); err != nil {
+			t.Fatalf("project rm --json is not JSON: %v (%q)", err, out)
+		}
+		if removed.ID != added.ID || !removed.Removed {
+			t.Errorf("project rm --json = %+v, want the id and removed", removed)
+		}
+		if out, code := runVincent(t, dataDir, cfgDir, "project", "rm", id); code != 1 {
+			t.Errorf("project rm twice: code %d, want 1 (out %q)", code, out)
+		}
+	})
+
+	if out, code := runVincent(t, dataDir, cfgDir, "daemon", "stop"); code != 0 {
+		t.Fatalf("daemon stop: code %d, out %q", code, out)
+	}
+
+	// Every action is a thin client, and no thin client starts a daemon: a
+	// `task retry` inside a shell loop that silently spawned one would be a
+	// surprise in a CI job (PR U decision).
+	t.Run("no daemon exits 2 and starts nothing", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"task", "retry", "1"},
+			{"task", "approve", "1"},
+			{"task", "answer", "1", "--allow"},
+			{"task", "archive", "1"},
+			{"project", "rm", "1"},
+		} {
+			out, code := runVincent(t, dataDir, cfgDir, args...)
+			if code != 2 {
+				t.Errorf("%v with no daemon: code %d, want 2 (out %q)", args, code, out)
+			}
+			if !strings.Contains(out, "vincent daemon start") {
+				t.Errorf("%v does not point at `vincent daemon start`: %q", args, out)
+			}
+		}
+		if out, code := runVincent(t, dataDir, cfgDir, "daemon", "status"); code != 1 {
+			t.Errorf("daemon status after the actions: code %d, want 1 (out %q)", code, out)
+		}
+	})
+}
+
+// writeActionWorkflow puts a project-scope workflow in the repository, named after
+// the file so the CLI can select it with --workflow.
+func writeActionWorkflow(t *testing.T, repo, name, body string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".vincent", "workflows")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"),
+		[]byte("name: "+name+"\n"+body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// addActionTask creates a task in project 1 and returns its id as the string every
+// subcommand takes.
+func addActionTask(t *testing.T, dataDir, cfgDir, title string, extra ...string) string {
+	t.Helper()
+	args := append([]string{"task", "add", "--project", "1", "--title", title, "--json"}, extra...)
+	out, code := runVincent(t, dataDir, cfgDir, args...)
+	if code != 0 {
+		t.Fatalf("task add %q: code %d, out %q", title, code, out)
+	}
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &created); err != nil {
+		t.Fatalf("task add --json is not JSON: %v (%q)", err, out)
+	}
+	return strconv.FormatInt(created.ID, 10)
+}
+
+// taskView is the part of `task show --json` these assertions read.
+type taskView struct {
+	ID               int64    `json:"id"`
+	State            string   `json:"state"`
+	BranchName       string   `json:"branch_name"`
+	BlockReason      string   `json:"block_reason"`
+	AvailableActions []string `json:"available_actions"`
+}
+
+func taskJSON(t *testing.T, dataDir, cfgDir, id string) taskView {
+	t.Helper()
+	out, code := runVincent(t, dataDir, cfgDir, "task", "show", id, "--json")
+	if code != 0 {
+		t.Fatalf("task show %s --json: code %d, out %q", id, code, out)
+	}
+	var v taskView
+	if err := json.Unmarshal([]byte(jsonObject(out)), &v); err != nil {
+		t.Fatalf("task show --json is not JSON: %v (%q)", err, out)
+	}
+	return v
+}
+
+func taskState(t *testing.T, dataDir, cfgDir, id string) string {
+	t.Helper()
+	return taskJSON(t, dataDir, cfgDir, id).State
+}
+
+// waitForState polls until the task reaches want. The daemon owns the
+// transition — admission, the step, the block — so the test waits for it
+// rather than predicting when it happens.
+func waitForState(t *testing.T, dataDir, cfgDir, id, want string) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		last = taskState(t, dataDir, cfgDir, id)
+		if last == want {
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("task %s is %s after 90s, want %s", id, last, want)
+}
+
+// runVincentStdin is runVincent with something on stdin, for the `-` forms of
+// --prompt-file, --run-file and --body.
+func runVincentStdin(t *testing.T, dataDir, cfgDir, stdin string, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(vincentBin, args...)
+	cmd.Env = append(hermeticEnv(),
+		config.EnvDataDir+"="+dataDir,
+		config.EnvConfigDir+"="+cfgDir,
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	out, err := cmd.CombinedOutput()
+	code := cmd.ProcessState.ExitCode()
+	if err != nil && code < 0 {
+		t.Fatalf("vincent %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out), code
+}

--- a/internal/cli/actions_e2e_test.go
+++ b/internal/cli/actions_e2e_test.go
@@ -430,21 +430,3 @@ func waitForState(t *testing.T, dataDir, cfgDir, id, want string) {
 	}
 	t.Fatalf("task %s is %s after 90s, want %s", id, last, want)
 }
-
-// runVincentStdin is runVincent with something on stdin, for the `-` forms of
-// --prompt-file, --run-file and --body.
-func runVincentStdin(t *testing.T, dataDir, cfgDir, stdin string, args ...string) (string, int) {
-	t.Helper()
-	cmd := exec.Command(vincentBin, args...)
-	cmd.Env = append(hermeticEnv(),
-		config.EnvDataDir+"="+dataDir,
-		config.EnvConfigDir+"="+cfgDir,
-	)
-	cmd.Stdin = strings.NewReader(stdin)
-	out, err := cmd.CombinedOutput()
-	code := cmd.ProcessState.ExitCode()
-	if err != nil && code < 0 {
-		t.Fatalf("vincent %s: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return string(out), code
-}

--- a/internal/cli/actions_e2e_test.go
+++ b/internal/cli/actions_e2e_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/lezli01/vincent/internal/testrepo"
 )
 
-// TestHumanActionCommands is task 044's done-when, and issue #89's: every §6
+// TestHumanActionCommands is task 048's done-when, and issue #89's: every §6
 // human action driven through the real binary against a real daemon, with no
 // TTY and no curl — a blocked task taken back to `running`, a gate approved
 // and rejected, an archive refused and then forced, and a project removed.

--- a/internal/cli/docs_claims_test.go
+++ b/internal/cli/docs_claims_test.go
@@ -116,8 +116,9 @@ func TestDocsClaimsTaskListShowsBranch(t *testing.T) {
 
 // TestDocsClaimsTUIActionsHaveSubcommands: README, quickstart and the
 // scripting guide state that everything the TUI does is also a subcommand.
-// The TUI offers every §6 human action; `vincent task` exposes cancel alone
-// of the nine (#89).
+// The TUI offers every §6 human action; `vincent task` exposed cancel alone of
+// the ten until task 048 filled the gap (#89), and this is what keeps the two
+// from drifting apart again.
 func TestDocsClaimsTUIActionsHaveSubcommands(t *testing.T) {
 	parity := regexp.MustCompile(`(?i)everything the tui (?:does|can do) is (?:also )?a subcommand`)
 	collapse := regexp.MustCompile(`\s+`)
@@ -143,7 +144,10 @@ func TestDocsClaimsTUIActionsHaveSubcommands(t *testing.T) {
 				continue
 			}
 			seen[action] = true
-			if !have[string(action)] {
+			// The API spells an action in snake_case and the command tree in
+			// kebab-case — `follow_up` is `vincent task follow-up`. The same
+			// action either way, so the comparison is on the CLI's spelling.
+			if !have[strings.ReplaceAll(string(action), "_", "-")] {
 				missing = append(missing, string(action))
 			}
 		}

--- a/internal/cli/fields_e2e_test.go
+++ b/internal/cli/fields_e2e_test.go
@@ -122,7 +122,8 @@ func TestTaskFieldsReachATemplate(t *testing.T) {
 }
 
 // runVincentStdin is runVincent with a body on standard input, which is the
-// only way to exercise `--fields-file -`.
+// only way to exercise `--fields-file -` and the `-` forms of --prompt-file,
+// --run-file and --body.
 func runVincentStdin(t *testing.T, dataDir, cfgDir, stdin string, args ...string) (string, int) {
 	t.Helper()
 	cmd := exec.Command(vincentBin, args...)

--- a/internal/cli/project.go
+++ b/internal/cli/project.go
@@ -13,9 +13,9 @@ import (
 func newProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project",
-		Short: "Register and inspect projects",
+		Short: "Register, inspect and remove projects",
 	}
-	cmd.AddCommand(newProjectAddCmd(), newProjectLsCmd())
+	cmd.AddCommand(newProjectAddCmd(), newProjectLsCmd(), newProjectRmCmd())
 	return cmd
 }
 
@@ -105,6 +105,50 @@ func newProjectLsCmd() *cobra.Command {
 			})
 		},
 	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newProjectRmCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "rm <id>",
+		Short: "Remove a project registration",
+		Long: "Removes the project and its task rows. A project still holding\n" +
+			"non-archived tasks is refused until --force is passed — force is the\n" +
+			"confirmation, and it archives them on the way out. A project holding a\n" +
+			"*running* task is refused either way: cancel it first.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("project id must be a number: %q", args[0])
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				if err := c.DeleteProject(ctx, id, force); err != nil {
+					// Two different 409s reach here — "N non-archived task(s)"
+					// and one naming a running task — and they want opposite
+					// things from the caller, so the daemon's own wording is
+					// printed rather than a summary that would blur them.
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					// The endpoint answers 204, so there is no task to print.
+					// A `--json` caller still gets an object: an empty stdout
+					// is a parse error in every wrapper that pipes this.
+					return emitJSON(cmd.OutOrStdout(), struct {
+						ID      int64 `json:"id"`
+						Removed bool  `json:"removed"`
+					}{ID: id, Removed: true})
+				}
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "project %d removed\n", id)
+				return err
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Remove even when the project still holds non-archived tasks, archiving them")
 	jsonFlag(cmd)
 	return cmd
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -21,10 +21,12 @@ import (
 func newTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "task",
-		Short: "Create, inspect and cancel tasks",
+		Short: "Create, inspect and act on tasks",
 	}
 	cmd.AddCommand(newTaskAddCmd(), newTaskLsCmd(), newTaskShowCmd(), newTaskCancelCmd(),
-		newTaskFollowUpCmd(), newTaskTranscriptCmd())
+		newTaskFollowUpCmd(), newTaskTranscriptCmd(), newTaskPauseCmd(), newTaskResumeCmd(),
+		newTaskSkipCmd(), newTaskApproveCmd(), newTaskRejectCmd(), newTaskRetryCmd(),
+		newTaskRepairCmd(), newTaskArchiveCmd(), newTaskAnswerCmd())
 	return cmd
 }
 
@@ -371,9 +373,9 @@ func newTaskShowCmd() *cobra.Command {
 		Short: "Show a task and its step runs",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.ParseInt(args[0], 10, 64)
+			id, err := taskID(args[0])
 			if err != nil {
-				return fmt.Errorf("task id must be a number: %q", args[0])
+				return err
 			}
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
 				t, err := c.GetTask(ctx, id)
@@ -402,6 +404,13 @@ func newTaskShowCmd() *cobra.Command {
 				if t.BlockReason != nil && *t.BlockReason != "" {
 					fields = append(fields, [2]string{"blocked", *t.BlockReason})
 				}
+				// What may happen next, from the daemon rather than from a
+				// guess: a script reads this instead of probing for 409s, and
+				// every name in it is a `vincent task <action>` subcommand.
+				if len(t.AvailableActions) > 0 {
+					fields = append(fields,
+						[2]string{"actions", strings.Join(t.AvailableActions, ", ")})
+				}
 				if t.InputTokens > 0 || t.OutputTokens > 0 {
 					fields = append(fields, [2]string{
 						"tokens",
@@ -417,6 +426,13 @@ func newTaskShowCmd() *cobra.Command {
 					if _, err := fmt.Fprintf(out, "%-9s %s\n", f[0], f[1]); err != nil {
 						return err
 					}
+				}
+				// The pending request is printed before the description because
+				// it is the thing that needs doing: `task answer` numbers its
+				// questions off exactly this list, and indexed answers are
+				// unusable if the questions are invisible from here.
+				if err := printPendingRequest(out, t); err != nil {
+					return err
 				}
 				if t.Description != "" {
 					if _, err := fmt.Fprintf(out, "\n%s\n", strings.TrimRight(t.Description, "\n")); err != nil {
@@ -492,9 +508,9 @@ func newTaskFollowUpCmd() *cobra.Command {
 			"--workflow says what to run. The task returns to the state it came from.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.ParseInt(args[0], 10, 64)
+			id, err := taskID(args[0])
 			if err != nil {
-				return fmt.Errorf("task id must be a number: %q", args[0])
+				return err
 			}
 			in := apiclient.FollowUpInput{
 				Prompt: prompt, Run: run, Workflow: workflow,
@@ -544,9 +560,9 @@ func newTaskCancelCmd() *cobra.Command {
 		Short: "Cancel a task",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := strconv.ParseInt(args[0], 10, 64)
+			id, err := taskID(args[0])
 			if err != nil {
-				return fmt.Errorf("task id must be a number: %q", args[0])
+				return err
 			}
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
 				t, err := c.Cancel(ctx, id)
@@ -567,4 +583,485 @@ func newTaskCancelCmd() *cobra.Command {
 	}
 	jsonFlag(cmd)
 	return cmd
+}
+
+// taskID parses the single <id> argument every task subcommand takes. A
+// non-numeric id is a usage error, not a rejected request: it never reaches
+// the daemon.
+func taskID(arg string) (int64, error) {
+	id, err := strconv.ParseInt(arg, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("task id must be a number: %q", arg)
+	}
+	return id, nil
+}
+
+// printTaskAction renders the daemon's post-action view of a task. Every §6
+// action command ends here, and none of them predicts the transition: what is
+// printed is the state the daemon reported *after* it acted (task 044).
+func printTaskAction(cmd *cobra.Command, t apiclient.Task) error {
+	if wantJSON(cmd) {
+		return emitJSON(cmd.OutOrStdout(), t)
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "task %d is now %s\n", t.ID, t.State)
+	return err
+}
+
+// newTaskActionCmd builds one of the §6 human actions that takes nothing but
+// an id. The error shape is `task cancel`'s: a 409 is the FSM refusing the
+// action for the state the task is actually in, which is a rejected request
+// rather than a broken one, so it exits 1 carrying the daemon's own wording.
+func newTaskActionCmd(name, short, long string,
+	act func(context.Context, *apiclient.Client, int64) (apiclient.Task, error),
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   name + " <id>",
+		Short: short,
+		Long:  long,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := taskID(args[0])
+			if err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, err := act(ctx, c, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				return printTaskAction(cmd, t)
+			})
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newTaskPauseCmd() *cobra.Command {
+	return newTaskActionCmd("pause", "Hold a task at its next step boundary",
+		"Requests a pause. A running step finishes first — the task pauses at the next "+
+			"step boundary rather than mid-step. Valid from queued and running.",
+		func(ctx context.Context, c *apiclient.Client, id int64) (apiclient.Task, error) {
+			return c.Pause(ctx, id)
+		})
+}
+
+func newTaskResumeCmd() *cobra.Command {
+	return newTaskActionCmd("resume", "Re-queue a paused task",
+		"Returns a paused task to the queue; the scheduler admits it like any other. "+
+			"Valid from paused.",
+		func(ctx context.Context, c *apiclient.Client, id int64) (apiclient.Task, error) {
+			return c.Resume(ctx, id)
+		})
+}
+
+func newTaskSkipCmd() *cobra.Command {
+	return newTaskActionCmd("skip", "Mark the current step skipped and advance",
+		"Abandons the step the task is sitting on and advances to the next one. "+
+			"Valid from blocked and awaiting_gate.",
+		func(ctx context.Context, c *apiclient.Client, id int64) (apiclient.Task, error) {
+			return c.Skip(ctx, id)
+		})
+}
+
+func newTaskApproveCmd() *cobra.Command {
+	return newTaskActionCmd("approve", "Pass a manual gate",
+		"Passes the manual gate the task is waiting on and continues the workflow. "+
+			"Valid from awaiting_gate.",
+		func(ctx context.Context, c *apiclient.Client, id int64) (apiclient.Task, error) {
+			return c.Approve(ctx, id)
+		})
+}
+
+func newTaskRejectCmd() *cobra.Command {
+	return newTaskActionCmd("reject", "Fail a manual gate, blocking the task",
+		"Fails the manual gate the task is waiting on; the task blocks with reason "+
+			"gate_rejected. Valid from awaiting_gate.",
+		func(ctx context.Context, c *apiclient.Client, id int64) (apiclient.Task, error) {
+			return c.Reject(ctx, id)
+		})
+}
+
+func newTaskRetryCmd() *cobra.Command {
+	var branch, prompt, promptFile, run, runFile string
+	cmd := &cobra.Command{
+		Use:   "retry <id>",
+		Short: "Re-run the step a task blocked on",
+		Long: "Re-runs the step the task blocked on. With no flags this is a plain retry.\n" +
+			"--prompt and --run are edit+retry: the text replaces that step's prompt or\n" +
+			"command in this task's workflow snapshot, and in no other task's. --branch\n" +
+			"renames the task's branch before the retry re-admits it, which is how a\n" +
+			"branch_exists block is cleared without losing the task or its transcripts.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := taskID(args[0])
+			if err != nil {
+				return err
+			}
+			ov := apiclient.Override{Branch: branch}
+			if ov.Prompt, err = flagText(cmd, prompt, promptFile); err != nil {
+				return err
+			}
+			if ov.Run, err = flagText(cmd, run, runFile); err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, err := c.Retry(ctx, id, ov)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				return printTaskAction(cmd, t)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&branch, "branch", "",
+		"Rename the task's branch first — the branch_exists recovery path (§10, §18)")
+	cmd.Flags().StringVar(&prompt, "prompt", "", "Replace the failed step's prompt (edit+retry)")
+	cmd.Flags().StringVar(&promptFile, "prompt-file", "",
+		"Read the replacement prompt from this file, or from stdin with -")
+	cmd.Flags().StringVar(&run, "run", "", "Replace the failed step's command (edit+retry)")
+	cmd.Flags().StringVar(&runFile, "run-file", "",
+		"Read the replacement command from this file, or from stdin with -")
+	// The literal and the file are two spellings of one value, so cobra
+	// refuses the pair locally rather than letting one silently win.
+	cmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	cmd.MarkFlagsMutuallyExclusive("run", "run-file")
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newTaskRepairCmd() *cobra.Command {
+	var prompt, promptFile, agent, model, effort string
+	cmd := &cobra.Command{
+		Use:   "repair <id>",
+		Short: "Run a one-off agent in a blocked task's worktree",
+		Long: "Runs one ad-hoc agent with this prompt in the blocked task's existing\n" +
+			"worktree (task 025). Whatever the agent does, the task returns to blocked at\n" +
+			"the same step with the same reason: a repair changes the worktree, and a\n" +
+			"human still decides whether to retry. Valid from blocked.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := taskID(args[0])
+			if err != nil {
+				return err
+			}
+			in := apiclient.RepairInput{Agent: agent, Model: model, Effort: effort}
+			if in.Prompt, err = flagText(cmd, prompt, promptFile); err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, warnings, err := c.Repair(ctx, id, in)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if err := printTaskAction(cmd, t); err != nil {
+					return err
+				}
+				// The §8.2 catalog warnings the selection raised, on stderr for
+				// the reason `task add`'s are: the run is queued and will
+				// happen, so this is not a failure, and stdout stays pipeable.
+				for _, w := range warnings {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning:", w)
+				}
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&prompt, "prompt", "", "What the repair agent should do (required)")
+	cmd.Flags().StringVar(&promptFile, "prompt-file", "",
+		"Read the prompt from this file, or from stdin with -")
+	cmd.Flags().StringVar(&agent, "agent", "", "Agent for this run (§8.6, request level)")
+	cmd.Flags().StringVar(&model, "model", "", "Model for this run (§8.6, request level)")
+	cmd.Flags().StringVar(&effort, "effort", "", "Effort for this run (§8.6, request level)")
+	cmd.MarkFlagsMutuallyExclusive("prompt", "prompt-file")
+	// A repair with no instructions is a 400 from the daemon; saying so here
+	// costs no round trip and names the flags rather than the JSON field.
+	cmd.MarkFlagsOneRequired("prompt", "prompt-file")
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newTaskArchiveCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "archive <id>",
+		Short: "Archive a finished task and remove its worktree",
+		Long: "Archives the task and removes its worktree. When\n" +
+			"delete_empty_branch_on_archive is on, a branch carrying no commits past its\n" +
+			"base is deleted too. A worktree with uncommitted changes is refused until\n" +
+			"--force is passed — force is the confirmation. Valid from done and aborted.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := taskID(args[0])
+			if err != nil {
+				return err
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, branch, err := c.Archive(ctx, id, force)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					// The one refusal that is a question rather than a failure
+					// (§6): the reason lives in details, not in the message, so
+					// flattening the error to its prose would lose both the
+					// discriminator and the way out.
+					if isDirtyWorktreeErr(err) {
+						_, _ = fmt.Fprintln(cmd.ErrOrStderr(),
+							"  pass --force to archive it anyway, discarding those changes")
+					}
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					// The daemon's own shape: the task's fields at the top
+					// level beside `branch`, so a script reads the branch
+					// outcome here rather than only from the human line.
+					return emitJSON(cmd.OutOrStdout(), struct {
+						apiclient.Task
+						Branch *apiclient.BranchOutcome `json:"branch,omitempty"`
+					}{Task: t, Branch: branchOutcome(branch)})
+				}
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "task %d is now %s\n", t.ID, t.State); err != nil {
+					return err
+				}
+				if summary := branch.Summary(); summary != "" {
+					_, err = fmt.Fprintln(out, "  "+summary)
+				}
+				return err
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Archive even when the worktree has uncommitted changes, discarding them")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// branchOutcome renders the archive's branch result for --json. A zero value
+// means the branch step never ran — the setting is off, or the task had no
+// branch of its own — which is `null`, not an object full of empty strings.
+func branchOutcome(o apiclient.BranchOutcome) *apiclient.BranchOutcome {
+	if o == (apiclient.BranchOutcome{}) {
+		return nil
+	}
+	return &o
+}
+
+// isDirtyWorktreeErr reports the daemon refused an archive because the
+// worktree has uncommitted changes. `details.reason` is the discriminator the
+// TUI branches on too (§13.1); the message alone is prose.
+func isDirtyWorktreeErr(err error) bool {
+	var apiErr *apiclient.Error
+	return errors.As(err, &apiErr) && apiErr.Details["reason"] == "worktree_dirty"
+}
+
+func newTaskAnswerCmd() *cobra.Command {
+	var (
+		answers  []string
+		allow    bool
+		deny     bool
+		bodyFile string
+	)
+	cmd := &cobra.Command{
+		Use:   "answer <id>",
+		Short: "Answer the input request a task is waiting on",
+		Long: "Answers the §7.4 request an awaiting_input task is parked on; the run\n" +
+			"resumes in place. Questions are answered by the number `vincent task show`\n" +
+			"prints them under — repeat --answer for one index to give a multi-select\n" +
+			"several values — and a permission request takes --allow or --deny. --body\n" +
+			"passes an answer payload straight through for a script that already has one.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := taskID(args[0])
+			if err != nil {
+				return err
+			}
+			if bodyFile != "" {
+				payload, err := flagText(cmd, "", bodyFile)
+				if err != nil {
+					return err
+				}
+				if !json.Valid([]byte(payload)) {
+					return fmt.Errorf("--body %s is not valid JSON", bodyFile)
+				}
+				return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+					t, err := c.AnswerRaw(ctx, id, json.RawMessage(payload))
+					if err != nil {
+						_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+						return exitError{code: 1}
+					}
+					return printTaskAction(cmd, t)
+				})
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				// The request has to be read before it can be answered: the
+				// wire format is keyed by question *text* (§13.2), and the
+				// index exists only so nobody retypes quoted prose.
+				detail, err := c.GetTask(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				req, ok, err := detail.PendingRequest()
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("task %d is %s and is not waiting for input", id, detail.State)
+				}
+				resp, err := answerResponse(req, answers, allow, deny)
+				if err != nil {
+					return err
+				}
+				// Local validation is a convenience, never the authority: the
+				// daemon checks the same rules and its answer is the one that
+				// counts. Failing here just saves a round trip to be told the
+				// obvious.
+				if err := req.Validate(resp); err != nil {
+					return err
+				}
+				t, err := c.Answer(ctx, id, resp)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				return printTaskAction(cmd, t)
+			})
+		},
+	}
+	// No backquotes in a flag's usage string: cobra reads the first
+	// backquoted word as the argument placeholder, so "`task show`" would
+	// render the flag as `--answer task show`.
+	cmd.Flags().StringArrayVar(&answers, "answer", nil,
+		"Answer as <n>=<value>, n being the question number 'vincent task show' prints; repeat for more")
+	cmd.Flags().BoolVar(&allow, "allow", false, "Allow a permission request")
+	cmd.Flags().BoolVar(&deny, "deny", false, "Deny a permission request")
+	cmd.Flags().StringVar(&bodyFile, "body", "",
+		"Read the §13.2 answer payload from this file, or from stdin with -, and post it verbatim")
+	// One way of answering per invocation: allow and deny contradict each
+	// other, a question is not a permission, and --body is the escape hatch
+	// that reconstructs neither.
+	cmd.MarkFlagsMutuallyExclusive("answer", "allow", "deny", "body")
+	cmd.MarkFlagsOneRequired("answer", "allow", "deny", "body")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// answerResponse maps the CLI's flags onto the §13.2 answer payload.
+//
+// --answer is indexed because the wire format is keyed by question text, and
+// that text is a sentence: indexing off `task show` keeps the format intact
+// without making anyone retype it. Values split on the *first* '=', the rule
+// parseFieldFlags already documents, so a URL or a regex needs no escaping,
+// and a repeated index is a multi-select's several values.
+func answerResponse(req apiclient.InputRequest, answers []string, allow, deny bool) (apiclient.InputResponse, error) {
+	var resp apiclient.InputResponse
+	switch {
+	case allow:
+		v := true
+		resp.Allow = &v
+	case deny:
+		v := false
+		resp.Allow = &v
+	}
+	if len(answers) == 0 {
+		return resp, nil
+	}
+	if req.Kind == apiclient.InputKindPermission {
+		return apiclient.InputResponse{},
+			errors.New("this is a permission request: answer it with --allow or --deny")
+	}
+	resp.Answers = make(map[string][]string, len(answers))
+	for _, a := range answers {
+		index, value, ok := strings.Cut(a, "=")
+		n, convErr := strconv.Atoi(strings.TrimSpace(index))
+		if !ok || convErr != nil {
+			return apiclient.InputResponse{},
+				fmt.Errorf("answer must be <number>=<value>, got %q", a)
+		}
+		if n < 1 || n > len(req.Questions) {
+			return apiclient.InputResponse{},
+				fmt.Errorf("no question %d: the task is asking %d, numbered as `vincent task show` prints them",
+					n, len(req.Questions))
+		}
+		text := req.Questions[n-1].Text
+		resp.Answers[text] = append(resp.Answers[text], value)
+	}
+	return resp, nil
+}
+
+// flagText resolves a --x / --x-file flag pair to one string. Cobra has
+// already refused the combination, so at most one is set here. "-" reads
+// stdin, which is what makes a multi-line replacement prompt something a
+// pipe can carry rather than something argv has to quote.
+func flagText(cmd *cobra.Command, literal, file string) (string, error) {
+	if file == "" {
+		return literal, nil
+	}
+	if file == "-" {
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	// G304: a path the user of this CLI typed, read with that user's own
+	// privileges — the whole purpose of the flag.
+	b, err := os.ReadFile(file) //nolint:gosec // G304: see above
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// printPendingRequest renders the §7.4 request an awaiting_input task is
+// parked on. The numbering is the contract `task answer --answer <n>=<value>`
+// reads: question 1 is the first question the daemon sent, in the order it
+// sent them. A task waiting on nothing prints nothing.
+func printPendingRequest(w io.Writer, t apiclient.TaskDetail) error {
+	req, ok, err := t.PendingRequest()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "\nawaiting input: %s\n", req.Kind); err != nil {
+		return err
+	}
+	if req.Kind == apiclient.InputKindPermission {
+		if req.Permission == nil {
+			return nil
+		}
+		_, err := fmt.Fprintf(w, "  tool     %s\n  summary  %s\n"+
+			"  answer with `vincent task answer %d --allow` or `--deny`\n",
+			req.Permission.Tool, req.Permission.Summary, t.ID)
+		return err
+	}
+	for i, q := range req.Questions {
+		text := q.Text
+		if q.Header != "" {
+			text = q.Header + ": " + text
+		}
+		if q.MultiSelect {
+			text += "  (one or more)"
+		}
+		if _, err := fmt.Fprintf(w, "  %d. %s\n", i+1, text); err != nil {
+			return err
+		}
+		// Options are suggestions, never an enum — §7.4 accepts free text for
+		// any question — so they are listed as such rather than as a menu.
+		if len(q.Options) > 0 {
+			if _, err := fmt.Fprintf(w, "     suggested: %s\n", strings.Join(q.Options, ", ")); err != nil {
+				return err
+			}
+		}
+	}
+	if len(req.Questions) == 0 {
+		return nil
+	}
+	_, err = fmt.Fprintf(w, "  answer with `vincent task answer %d --answer 1=<value>`\n", t.ID)
+	return err
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -598,7 +598,7 @@ func taskID(arg string) (int64, error) {
 
 // printTaskAction renders the daemon's post-action view of a task. Every §6
 // action command ends here, and none of them predicts the transition: what is
-// printed is the state the daemon reported *after* it acted (task 044).
+// printed is the state the daemon reported *after* it acted (task 048).
 func printTaskAction(cmd *cobra.Command, t apiclient.Task) error {
 	if wantJSON(cmd) {
 		return emitJSON(cmd.OutOrStdout(), t)

--- a/internal/cli/taskanswer_test.go
+++ b/internal/cli/taskanswer_test.go
@@ -1,0 +1,354 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+// `task show` renders the §7.4 request a task is parked on, and `task answer`
+// answers it by the numbers that rendering prints. Both are exercised against
+// a hand-written daemon rather than a live one: what is asserted is the
+// rendering and the request body, and pinning a real agent to a question it
+// asks mid-run would test the agent instead.
+
+// stubDetail is GET /v1/tasks/{id} as the daemon serves it, with the pending
+// request and available actions the real detail response carries.
+func stubDetail(state, pendingInput string, actions []string) string {
+	acts, _ := json.Marshal(actions)
+	pending := ""
+	if pendingInput != "" {
+		pending = `"pending_input": ` + pendingInput + `,`
+	}
+	return `{
+  "id": 7,
+  "project_id": 1,
+  "project_name": "vincent",
+  "title": "Wire the adapter",
+  "workflow": "adhoc",
+  "state": "` + state + `",
+  "base_branch": "main",
+  "branch_name": "vincent/7-wire-the-adapter",
+  "priority": 0,
+  "current_step": 0,
+  "step_total": 2,
+  "block_reason": null,
+  "available_actions": ` + string(acts) + `,
+  ` + pending + `
+  "steps": [],
+  "created_at": "2026-08-26T10:00:00Z",
+  "updated_at": "2026-08-26T10:05:00Z"
+}`
+}
+
+const questionRequest = `{
+  "kind": "question",
+  "questions": [
+    {"text": "Which database?", "options": ["postgres", "sqlite"]},
+    {"text": "Which regions?", "header": "deploy", "options": ["eu", "us"], "multi_select": true}
+  ]
+}`
+
+const permissionRequest = `{
+  "kind": "permission",
+  "permission": {"tool": "Bash", "summary": "rm -rf build/"}
+}`
+
+func TestTaskShowRendersPendingQuestions(t *testing.T) {
+	out, code := runAgainstStub(t, stubHandler(t, stubDetail("awaiting_input", questionRequest,
+		[]string{"answer", "cancel"}), nil), "", "task", "show", "7")
+	if code != 0 {
+		t.Fatalf("task show: code %d, out %q", code, out)
+	}
+	for _, want := range []string{
+		"actions   answer, cancel",
+		"awaiting input: question",
+		"1. Which database?",
+		"suggested: postgres, sqlite",
+		"2. deploy: Which regions?",
+		"(one or more)",
+		"vincent task answer 7 --answer 1=<value>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("task show is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTaskShowRendersPermissionRequest(t *testing.T) {
+	out, code := runAgainstStub(t, stubHandler(t, stubDetail("awaiting_input", permissionRequest,
+		[]string{"answer", "cancel"}), nil), "", "task", "show", "7")
+	if code != 0 {
+		t.Fatalf("task show: code %d, out %q", code, out)
+	}
+	for _, want := range []string{
+		"awaiting input: permission", "tool     Bash", "summary  rm -rf build/", "--allow",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("task show is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A task waiting on nothing says nothing: the block exists to be acted on, and
+// an empty one would read as a rendering bug.
+func TestTaskShowWithoutPendingInput(t *testing.T) {
+	out, code := runAgainstStub(t, stubHandler(t, stubDetail("running", "", []string{"cancel", "pause"}), nil),
+		"", "task", "show", "7")
+	if code != 0 {
+		t.Fatalf("task show: code %d, out %q", code, out)
+	}
+	if strings.Contains(out, "awaiting input") {
+		t.Errorf("task show renders a request the task does not have:\n%s", out)
+	}
+	if !strings.Contains(out, "actions   cancel, pause") {
+		t.Errorf("task show does not print the available actions:\n%s", out)
+	}
+}
+
+// `--json` needed no change for either: emitJSON marshals the detail response,
+// which has carried both fields all along. This pins that, so the guide's
+// claim that a script can read them cannot quietly stop being true.
+func TestTaskShowJSONCarriesPendingInputAndActions(t *testing.T) {
+	out, code := runAgainstStub(t, stubHandler(t, stubDetail("awaiting_input", questionRequest,
+		[]string{"answer", "cancel"}), nil), "", "task", "show", "7", "--json")
+	if code != 0 {
+		t.Fatalf("task show --json: code %d, out %q", code, out)
+	}
+	var doc struct {
+		AvailableActions []string        `json:"available_actions"`
+		PendingInput     json.RawMessage `json:"pending_input"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("task show --json is not JSON: %v (%q)", err, out)
+	}
+	if len(doc.AvailableActions) != 2 || len(doc.PendingInput) == 0 {
+		t.Errorf("task show --json = %s; want available_actions and pending_input", out)
+	}
+}
+
+func TestTaskAnswerIndexedQuestions(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", questionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7",
+		"--answer", "1=postgres", "--answer", "2=eu", "--answer", "2=us")
+	if code != 0 {
+		t.Fatalf("task answer: code %d, out %q", code, out)
+	}
+	var body struct {
+		Answers map[string][]string `json:"answers"`
+		Allow   *bool               `json:"allow"`
+	}
+	if err := json.Unmarshal(posted, &body); err != nil {
+		t.Fatalf("posted body is not JSON: %v (%q)", err, posted)
+	}
+	// The wire format stays keyed by question text (§13.2); the index is a
+	// CLI convenience that never reaches the daemon.
+	if got := body.Answers["Which database?"]; len(got) != 1 || got[0] != "postgres" {
+		t.Errorf("answers[Which database?] = %v, want [postgres]", got)
+	}
+	if got := body.Answers["Which regions?"]; len(got) != 2 || got[0] != "eu" || got[1] != "us" {
+		t.Errorf("answers[Which regions?] = %v, want [eu us] — a repeated index is a multi-select", got)
+	}
+	if body.Allow != nil {
+		t.Errorf("allow = %v on a question request", *body.Allow)
+	}
+}
+
+// Everything after the first '=' is the value, the rule --field already
+// documents, so a URL or a regex needs no CLI-specific escaping.
+func TestTaskAnswerKeepsEverythingAfterTheFirstEquals(t *testing.T) {
+	var posted []byte
+	_, code := runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", questionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7",
+		"--answer", "1=https://example.test/?a=b", "--answer", "2=eu")
+	if code != 0 {
+		t.Fatalf("task answer: code %d", code)
+	}
+	var body struct {
+		Answers map[string][]string `json:"answers"`
+	}
+	if err := json.Unmarshal(posted, &body); err != nil {
+		t.Fatalf("posted body is not JSON: %v (%q)", err, posted)
+	}
+	if got := body.Answers["Which database?"]; len(got) != 1 || got[0] != "https://example.test/?a=b" {
+		t.Errorf("answers[Which database?] = %v, want the whole URL", got)
+	}
+}
+
+func TestTaskAnswerRejectsAnIndexTheTaskIsNotAsking(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", questionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7", "--answer", "5=nope")
+	if code != 1 {
+		t.Errorf("answer an index that does not exist: code %d, want 1 (out %q)", code, out)
+	}
+	if posted != nil {
+		t.Errorf("a wrong index still posted an answer: %q", posted)
+	}
+	if !strings.Contains(out, "no question 5") {
+		t.Errorf("the error does not say which index is wrong: %q", out)
+	}
+}
+
+// Local validation is a fast fail, not the authority: an unanswered question
+// costs no round trip to be told the obvious.
+func TestTaskAnswerRefusesAnIncompleteAnswer(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", questionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7", "--answer", "1=postgres")
+	if code != 1 {
+		t.Errorf("answer only the first of two questions: code %d, want 1 (out %q)", code, out)
+	}
+	if posted != nil {
+		t.Errorf("an incomplete answer was posted anyway: %q", posted)
+	}
+}
+
+func TestTaskAnswerPermission(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", permissionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7", "--allow")
+	if code != 0 {
+		t.Fatalf("task answer --allow: code %d, out %q", code, out)
+	}
+	var body struct {
+		Answers map[string][]string `json:"answers"`
+		Allow   *bool               `json:"allow"`
+	}
+	if err := json.Unmarshal(posted, &body); err != nil {
+		t.Fatalf("posted body is not JSON: %v (%q)", err, posted)
+	}
+	if body.Allow == nil || !*body.Allow || len(body.Answers) != 0 {
+		t.Errorf("posted %q, want allow true and no answers", posted)
+	}
+
+	// A permission request is decided, not answered.
+	posted = nil
+	out, code = runAgainstStub(t,
+		stubHandler(t, stubDetail("awaiting_input", permissionRequest, []string{"answer"}), &posted),
+		"", "task", "answer", "7", "--answer", "1=yes")
+	if code != 1 {
+		t.Errorf("--answer on a permission request: code %d, want 1 (out %q)", code, out)
+	}
+	if posted != nil {
+		t.Errorf("--answer on a permission request was posted anyway: %q", posted)
+	}
+}
+
+// --body is the script's entry point: the §13.2 payload goes to the daemon as
+// it stands, with no per-flag reconstruction and no request to read the
+// question first.
+func TestTaskAnswerBodyIsPassedThrough(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t, stubHandler(t, "", &posted),
+		`{"answers":{"Which database?":["postgres"],"Which regions?":["eu","us"]}}`,
+		"task", "answer", "7", "--body", "-")
+	if code != 0 {
+		t.Fatalf("task answer --body -: code %d, out %q", code, out)
+	}
+	var body map[string]map[string][]string
+	if err := json.Unmarshal(posted, &body); err != nil {
+		t.Fatalf("posted body is not JSON: %v (%q)", err, posted)
+	}
+	if len(body["answers"]) != 2 || body["answers"]["Which regions?"][1] != "us" {
+		t.Errorf("posted %q, want the payload as it was written", posted)
+	}
+}
+
+func TestTaskAnswerRefusesBodyThatIsNotJSON(t *testing.T) {
+	var posted []byte
+	out, code := runAgainstStub(t, stubHandler(t, "", &posted), "postgres, please",
+		"task", "answer", "7", "--body", "-")
+	if code != 1 {
+		t.Errorf("--body with prose: code %d, want 1 (out %q)", code, out)
+	}
+	if posted != nil {
+		t.Errorf("prose was posted as an answer payload: %q", posted)
+	}
+}
+
+// stubHandler answers the two routes these commands use: the detail GET and
+// the answer POST, whose body it records when posted is non-nil.
+func stubHandler(t *testing.T, detail string, posted *[]byte) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/v1/health":
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.URL.Path == "/v1/tasks/7" && r.Method == http.MethodGet:
+			if detail == "" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(detail))
+		case r.URL.Path == "/v1/tasks/7/answer" && r.Method == http.MethodPost:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read posted body: %v", err)
+			}
+			if posted != nil {
+				*posted = body
+			}
+			_, _ = w.Write([]byte(`{"id":7,"state":"running"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+// runAgainstStub runs the real command tree in-process against a stub daemon,
+// with stdin wired for the `-` forms of --body and --prompt-file.
+func runAgainstStub(t *testing.T, h http.HandlerFunc, stdin string, args ...string) (string, int) {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse stub URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("stub port: %v", err)
+	}
+	if _, err := daemon.EnsureToken(dataDir); err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if err := daemon.WriteRuntimeInfo(dataDir, daemon.RuntimeInfo{
+		Port: port, PID: os.Getpid(), StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("daemon.json: %v", err)
+	}
+
+	var buf bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(args)
+	code := asExitCode(root.ExecuteContext(context.Background()))
+	return buf.String(), code
+}


### PR DESCRIPTION
## Summary

`vincent task` grows a subcommand for each remaining §6 human action —
`pause`, `resume`, `skip`, `approve`, `reject`, `retry`, `repair`, `archive`,
`answer` — and `vincent project` grows `rm`. `internal/apiclient` already had
every typed method, so this is cobra wiring, flag design, output rendering and
documentation: no API, store, scheduler, `taskstate` or engine change.

The gap was not a convenience gap. The API exposes every human action and the
CLI exposed `add`, `ls`, `show`, `cancel` and `follow-up`, so the *recovery*
half of the product was reachable from the TUI, from `curl`, and from nothing
else. That makes "the daemon owns the work and clients are disposable" (§2,
`CLAUDE.md`'s ownership invariants) false in one direction, for exactly the
actions a **blocked** task needs. The case that settles it is an agent auth
outage: `agent_unauthenticated` blocks each task once its retry budget is spent
(§7.2), waiting fixes nothing, and a board full of those blocks could not be
cleared from a script. It can now:

```sh
vincent task ls --state blocked --json | jq -r '.[].id' |
  while read -r id; do vincent task retry "$id"; done
```

Every action takes one id (`ExactArgs(1)`, matching `cancel` and `follow-up`),
carries `--json`, prints the daemon's **post-action view** of the task rather
than a predicted transition, and follows `task cancel`'s error shape — a 409
from the FSM is exit 1 with the daemon's own wording. The 0/1/2 exit contract
is unchanged and nothing auto-starts a daemon.

The flags that were not free choices:

- **`retry`** takes `--branch` (§18's `branch_exists` recovery — the task keeps
  its id and its transcripts) and the edit+retry pair `--prompt`/`--run`, which
  rewrite this task's snapshot only. Each has a `-file` twin, mutually exclusive
  with its literal, and `-` reads stdin: a replacement prompt is usually several
  lines, which argv is a poor place for.
- **`archive`** branches on `details.reason == "worktree_dirty"` — the
  discriminator `internal/tui/bulkaction.go` already reads — so the `--force`
  way out is named instead of flattened into prose.
- **`answer`** maps `--answer <n>=<value>` onto the numbers `task show` prints.
  The wire format stays keyed by question *text* (§13.2); the index exists so
  nobody retypes a sentence. A repeated index is a multi-select's several
  values, values split on the first `=`, and `InputRequest.Validate` runs
  locally as a fast fail — never as the authority. `--body` posts a script's own
  payload verbatim through a new `apiclient.AnswerRaw`.
- **`repair`** ships too, which the issue omits. `TestDocsClaimsTUIActionsHaveSubcommands`
  walks **every** `HumanActionsFrom` result, so restoring the parity sentence
  without it would turn that drift check red.
- **`project rm`** is flags-only and never prompts. The daemon's two 409s ask
  for opposite things — archive them, or cancel that running task — so both
  reach the user intact.

`task show` now renders the pending §7.4 request, numbered, and an `actions`
row carrying `available_actions`, so a script reads what is legal instead of
probing for 409s. `--json` needed no change: `TaskDetail` has carried both
fields all along, and a test pins that rather than code adding it.

**PR title:** the workflow's brief asked for a Conventional Commits title;
`CLAUDE.md` and the `PR title` workflow require plain language on a PR title
and reject a conventional prefix outright. The repository's rule wins, so the
title is plain and the *commits* carry the prefixes.

## Related

Closes #89
Closes 044.1–044.6 (`docs/tasks/044-cli-human-actions.md`).

This **revisits recorded decisions**, deliberately and by citation rather than
by assertion. Task 025 decision 12 and `spec §12.1`'s 2026-08-25 note say retry,
repair, skip and approve are "deliberately TUI-and-API only, and stay that way".
Task 027 decision 11 already named its own successor — "filling the gap for
every human action is a separate piece of work and out of scope here" — and this
is that work. All three records are amended **in place** with dated
superseded-by paragraphs rather than rewritten: `spec §12.1` citations stay
stable, and the reasoning that lost is what makes the record worth keeping. What
it did not weigh is that the four actions it left out are the ones a blocked
task needs.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### What the tests prove

`internal/cli/actions_e2e_test.go` — the real binary against a real daemon,
with no agent: every step is a `command`, spelled in the sh ∩ pwsh intersection
the gates are held to, so the assertions do not depend on which agent CLI the
host has.

- The issue's headline: a **blocked** task goes `blocked → running` with no TTY
  and no `curl` (`retry --run`, which is also the edit+retry proof).
- `retry --branch` clears a `branch_exists` block — the task keeps its id and
  lands on the branch the flag named.
- `pause`/`resume` on a queued task, `approve`/`reject`/`skip` on a manual gate,
  and an action the FSM refuses for the state the task is in, exiting 1 with the
  state it found.
- `repair --prompt-file -` reads stdin; `repair` with no prompt and `retry
  --prompt --prompt-file` both exit 1 **before any request**, verified by the
  task not having moved.
- `archive` on a dirty worktree: exit 1, the `--force` hint survives, `--force`
  then archives it.
- `project rm` with live tasks (the count) and with a running task (the message
  naming it), then a successful `--json` removal.
- Exit **2** with no daemon for five of the new commands, and `daemon status`
  afterwards proving none of them started one.

`internal/cli/taskanswer_test.go` — `answer` and the `task show` rendering
against a hand-written daemon that records the posted body: index → question
text, a repeated index producing both values, everything after the first `=`
kept, a wrong index and an incomplete answer refused **with no POST**,
`--allow` on a permission request and `--answer` refused on one, `--body -`
passed through, prose refused. Plus `task show` on a question request, a
permission request and a task with neither, and a pin that `--json` already
carries `pending_input` and `available_actions`.

Reaching `awaiting_input` for real needs an agent that asks mid-run, which would
make the assertion depend on the fake agent's scenario rather than on the
command — recorded as decision 9 in the task document. The live suite still
covers `answer`'s refusal on a task that is not waiting for input.

`internal/cli/docs_claims_test.go` — `TestDocsClaimsTUIActionsHaveSubcommands`
**stops skipping** and passes, which is the mechanical proof that the restored
parity sentence is true of the tree. It now compares the CLI's spelling of an
action, since `taskstate` says `follow_up` where the tree says `follow-up`.

Full suite and `golangci-lint` green, the linter run for `windows`, `darwin` and
`linux`.

### Documentation

- `docs/spec.md` §12.1 — the nine actions, a `project rm` row, and the dated
  amendment described under **Related**.
- `docs/reference/cli.md` — a section per new subcommand, tracking the cobra
  tree as that page is required to, plus the pending-request rendering under
  `task show`.
- `docs/guides/scripting.md` — the opening is a parity claim again, the #89 link
  is gone, and the worked example acts on a task instead of only reporting on
  it. The `curl` section stays as the escape hatch it is: the PATCH endpoints,
  `resolve`, `agents`, `task diff` and `task transcript` are still API-only and
  out of scope here.
- `README.md`, `docs/features.md`, `docs/getting-started/quickstart.md` — the
  same claim, and `follow-up` is no longer "the one human action with a command
  line".
- `docs/tasks/044-cli-human-actions.md` and its index row.
- `docs/reference/task-lifecycle.md` — **the page the change had missed.** Its
  human-actions table closed by telling the reader that from the CLI these are
  `vincent task cancel` and `vincent task follow-up`, which this PR makes false.
  It now points at the tree, names the kebab-case rule, and carves out `set
  priority` as the one action with no subcommand — it is a `PATCH` on the task,
  not a `POST` to an action.

A documentation audit ran over the whole change and corrected three further
claims that were invented rather than derived (commit `docs: correct four
claims the new subcommands left false`):

- `cli.md` said `reject` blocks with reason `gate_rejected`. No such constant
  exists — `Reject` records `ReasonRejected`, which is `rejected`, and
  `task-lifecycle.md`'s reason table has always spelled it that way.
- `cli.md`'s archive-refusal example was hand-written. The real first line is
  the daemon's own error, unwrapped, so it carries the `worktree_dirty:` prefix
  and the worktree path. Replaced with output captured from a running daemon.
- `cli.md` and `scripting.md` both said every name in `available_actions` is a
  `vincent task <action>` subcommand. It is not: the API spells an action in
  snake_case and the tree in kebab-case, so `follow_up` is `vincent task
  follow-up`. `docs_claims_test.go` already compares on the CLI's spelling for
  this reason; only the prose was wrong.

A second pass re-derived each rule from the source rather than from that record
and found one more (commit `docs: cancel is valid from awaiting_children too`):
`cli.md`'s `task cancel` listed six valid-from states where `taskstate`'s table
allows seven. `awaiting_children` has been missing since fan-out (task 014)
added the state — the sentence dates from `e1ac224` — and
`task-lifecycle.md` has carried the correct list, cascade included, the whole
time. It is not a claim this work made false, but `cancel` now sits among eight
sibling sections that each state their valid-from correctly, so the omission
read as a deliberate contrast. Those other eight were checked against the FSM
table one by one and are right.

### For the reviewer: one defect left unfixed, in the code

`internal/cli/task.go:543` — `newTaskRejectCmd`'s `Long` help carries the same
invented reason the documentation did:

> `gate_rejected. Valid from awaiting_gate.`

The reason the runner actually records is `rejected`
(`ReasonRejected`, `internal/taskrun/engine.go:31`, set at
`internal/taskrun/actions.go:337`), and `gate_rejected` appears nowhere else in
the tree. So `vincent task reject --help` names a block reason that will never
appear in `task show`, in `--json`, or on the board. The documentation commit
could not fix it: that step's scope is `docs/`, `skills/`, `CHANGELOG.md`,
`README.md` and `internal/workflow/builtin.go`. It is a one-word change and
should land before merge.

No stale screenshots: this change touches no TUI panel, so nothing under
`docs/assets/tui-*.png` needs re-capturing.

### Repair pass 1: a pre-existing timeout, not a fault of this change

The `testrace` leg came back red on
`TestGitHubIssueCommandsAgainstLiveDaemon/doctor_reports_the_integration`, with

    Error: GET /v1/doctor: Get "http://127.0.0.1:.../v1/doctor": context
    deadline exceeded (Client.Timeout exceeded while awaiting headers)

at exactly 10.02 s — `apiclient`'s `requestTimeout`. The same test, run three
times against `master`'s tree on the same machine, produced `FAIL 10.02s`,
`PASS 8.98s`, `PASS 7.83s`; this branch produced `FAIL 10.02s`, `PASS 9.10s`,
`PASS 9.73s`. Identical distribution, straddling the deadline. **The fault
predates this branch** and touches no file this work changed —
`internal/cli/github_e2e_test.go`, `internal/api/doctor.go` and
`internal/doctor` are all untouched here.

It is a real bug, not a flake to wait out. `GET /v1/doctor?probe=true` asks the
daemon to spawn an agent CLI per adapter (§9.5, §9.6) and walks them serially,
and each probe carries the adapter's own deadline: claude 20 s + 25 s, codex
20 s + 20 s, cursor 20 s + 20 s + 20 s — 145 s in total, against a client that
gave up at 10 s. On any machine where the real `cursor-agent` is installed (its
model catalog is an authenticated network call) the honest report is already
close to the deadline, and past it `vincent doctor` answers "context deadline
exceeded" instead of naming the adapter that hung — which is the one answer the
diagnostic must never give.

Fixed in `internal/apiclient`: a second `http.Client` bounded by a new
`probeTimeout` of 3 minutes, chosen to *exceed* the adapters' summed budget so
the client can never preempt them, and `get` split into `getVia` so a call can
pick its deadline. `Doctor(probe=true)` and `ListAgents(refresh=true)` — the
two calls whose cost is that subprocess walk, and the only two — use it.
Everything else keeps `requestTimeout`: a wedged daemon is still caught in ten
seconds everywhere that means anything, including `Doctor(probe=false)`, the
TUI daemon panel's cached read.

`internal/apiclient/probetimeout_test.go` pins all three legs against a server
that answers slower than `requestTimeout`: both probing calls succeed, the
non-probing one still fails with the loopback deadline. No test was weakened,
skipped or deleted, no lint rule relaxed, and no `//nolint` added. The
originally failing e2e subtest now passes three runs for three
(6.81 s, 5.94 s, 5.49 s), and lint is clean under `GOOS=windows`, `darwin` and
`linux`.

This changes no documented claim — no page under `docs/` states a client
timeout — so nothing there went stale.
