### PR TITLE
Add `vincent daemon logs` and `vincent task transcript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,28 @@ list with the user-facing context a commit subject cannot carry.
   and its argv can hold a webhook secret, which is why it is not readable back
   through the API.
 
+- **The daemon log and step transcripts now have command lines.** Both were
+  reachable only from the TUI, or by knowing where the files live and reaching
+  for `tail` — which is no help over SSH, and none at all when the daemon is what
+  is broken. `vincent daemon logs [-n N] [-f]` prints the tail of
+  `{data_dir}/logs/daemon.log`, 500 lines by default, `-f` following it. It reads
+  the file **from disk and never contacts the daemon**, so it answers when no
+  daemon does; that also means it never exits 2, a missing file is an error
+  naming the path, and an empty log prints nothing and succeeds. Following is
+  safe for the daemon's own rotation: every poll opens, reads and closes the
+  file. `vincent task transcript <id> [--step RUN] [-f]` prints one attempt's
+  transcript — the complete record `vincent task show` only names the file of.
+  `--step` takes the `RUN` column's step_run id, which is unambiguous across
+  retries; omitted, it picks the running attempt, else the newest. Output is
+  rendered as text for a human, `--json` gives the normalized records as NDJSON
+  for `jq`, and `--raw` gives the agent's own JSONL byte for byte. `-f` opens on
+  the tail and resumes from the record boundary, ending when that attempt stops
+  running. A manual gate, which records nothing, says so and exits 0; a
+  transcript whose file was pruned exits 1. Documented in the
+  [CLI reference](docs/reference/cli.md), the
+  [scripting guide](docs/guides/scripting.md) and
+  [troubleshooting](docs/guides/troubleshooting.md).
+
 - **Creating a task can now be retried safely.** If the daemon commits your task
   but you never see the response — a timeout, a dropped connection, a script
   that dies mid-`curl` — re-sending the request used to create a second task, a

--- a/docs/features.md
+++ b/docs/features.md
@@ -251,6 +251,15 @@ and task counts. It supports JSON output for bug
 reports and automation, while `--fix` can reclaim orphans and compact the
 database when it is safe to do so.
 
+`vincent daemon logs` and `vincent task transcript` put the two artifacts a
+failure is diagnosed from on the command line, so neither needs the TUI. The log
+command reads `{data_dir}/logs/daemon.log` **from disk and never contacts the
+daemon**, so it still answers when the daemon is the thing that is broken; `-f`
+follows it. The transcript command prints one attempt's complete record — the
+file `vincent task show` only names — rendered as text for a person, as NDJSON
+for `jq`, or as the agent's own dialect byte for byte, with `-f` following an
+attempt while it is still running.
+
 `vincent gc` focuses on orphaned worktrees and transcripts. It supports a dry
 run, refuses to remove dirty or unknown work without an explicit force, and
 never deletes a branch or anything outside vincent's data roots. The daemon

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -171,6 +171,36 @@ task 62 created: Release OPS-42 (release, branch vincent/62-release-ops-42)
 That line is safe to leave in a CI log, and it still catches the mistake worth
 catching — a name typed wrong, which a count alone would hide.
 
+## Reading transcripts and the daemon log
+
+`vincent task transcript <id>` prints one attempt's transcript. Its `--json` is
+**NDJSON in vincent's own vocabulary** — one normalized record per line,
+including vincent's `vincent.*` annotations — so `jq` reads it a line at a time:
+
+```sh
+# every tool the last attempt ran
+vincent task transcript 7 --json | jq -r 'select(.type == "agent.tool_use") | .tools[].name'
+
+# what a specific attempt's step said on stderr
+vincent task transcript 7 --step 12 --json |
+  jq -r 'select(.stream == "stderr") | .text'
+```
+
+`--raw` is the other machine route: the agent's own JSONL, byte for byte, for
+when you want the dialect rather than vincent's reading of it. Without either
+flag the records are rendered as text for a human, with a command step's stderr
+tagged `[stderr]` on stdout — stdout carries the transcript, stderr carries the
+command's own diagnostics.
+
+The daemon log has a command too, and it is the one that still works when the
+daemon does not — it reads `{data_dir}/logs/daemon.log` off disk and never calls
+the API:
+
+```sh
+vincent daemon logs -n 200
+vincent daemon logs -f | grep -i error
+```
+
 ## Validating workflows in CI
 
 `vincent workflow validate` runs **entirely locally**: no daemon, no network, no

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -112,7 +112,8 @@ write one.
 
 ### The daemon starts and immediately exits
 
-Read `{data_dir}/logs/daemon.log`. An invalid `config.yaml` at startup is fatal
+Read the log — `vincent daemon logs`, which reads `{data_dir}/logs/daemon.log`
+from disk and so still answers here. An invalid `config.yaml` at startup is fatal
 and says which key and line. (An invalid config on *hot reload* is not fatal —
 the last good config keeps running and the rejection is logged.)
 
@@ -685,12 +686,19 @@ to show state and step columns.
 
 ## Reading the log
 
+```sh
+vincent daemon logs          # the last 500 lines
+vincent daemon logs -n 50    # fewer
+vincent daemon logs -f       # keep printing as it is written
+```
+
 ```
 {data_dir}/logs/daemon.log
 ```
 
-Rotated and size-capped. The TUI's daemon view tails it — and reads it **from
-disk**, so it still works when the daemon is the thing that died.
+Rotated and size-capped. `vincent daemon logs` and the TUI's daemon view both
+read it **from disk** rather than through the API, so both still work when the
+daemon is the thing that died — which is when you want the log.
 
 Turn up detail in [`config.yaml`](../reference/configuration.md):
 
@@ -713,10 +721,11 @@ Include:
   directory paths and the tail of the daemon log
 - `vincent version` output, for the build details doctor does not carry
 - your OS and terminal
-- the relevant slice of `{data_dir}/logs/daemon.log`
+- the relevant slice of the daemon log (`vincent daemon logs -n 200`, or
+  `{data_dir}/logs/daemon.log`)
 - the workflow YAML, if a step misbehaved
-- the step's transcript if you can share it — **read it first**, it contains the
-  prompt and everything the agent did
+- the step's transcript if you can share it (`vincent task transcript <id> --step
+  RUN`) — **read it first**, it contains the prompt and everything the agent did
 
 [Open an issue](https://github.com/lezli01/vincent/issues/new/choose). Security
 issues go through

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -214,6 +214,33 @@ vincent daemon status [--json]
 Reports whether the daemon is running, its identity, and which agent CLIs it
 resolved. Exit `0` healthy, `1` not running, `2` unresponsive.
 
+### `vincent daemon logs`
+
+```sh
+vincent daemon logs [-n N] [-f]
+```
+
+Prints the tail of `{data_dir}/logs/daemon.log` — 500 lines by default, the same
+window the TUI's daemon view shows. `-f` keeps printing lines as they are
+appended, on a two-second cadence, until Ctrl-C.
+
+It reads the file **from disk and never contacts the daemon**, which is the
+point rather than a shortcut: the log is worth reading exactly when the daemon
+is not there to serve it. So this is one of the few subcommands that can never
+exit `2` — no daemon is needed and none is started. A log file that is not there
+is an error naming the path, exit `1`; a log with nothing in it prints nothing
+and exits `0`.
+
+The data directory is resolved the way every subcommand resolves it —
+`VINCENT_DATA_DIR`, else the platform default. There is no `--data-dir` flag
+here; the one on `vincent daemon` itself exists for the Windows Scheduled Task,
+whose action carries no environment.
+
+Following is rotation-safe: each poll opens, reads and closes the file, because
+the daemon rotates by renaming it and a follower holding a handle would break
+that rotation on Windows. A rotation mid-follow is waited out and the fresh file
+picked up.
+
 ### `vincent daemon backup`
 
 ```sh
@@ -488,6 +515,41 @@ RUN  STEP       STATE      AGENT   REASON        STATUS
 1    implement  succeeded  claude  -             wired the adapter
 2    verify     failed     -       check_failed  3 tests red in internal/store
 ```
+
+### `vincent task transcript`
+
+```sh
+vincent task transcript <id> [--step RUN] [-f] [--json | --raw]
+```
+
+Prints one attempt's transcript — the complete record of what it did, which
+`task show` only names the file of.
+
+`--step` takes a **step_run id**: the `RUN` column `task show` prints, which is
+unambiguous across retries where every attempt is its own run. Omitted, it
+selects the running attempt if there is one, and otherwise the newest attempt by
+run id (creation order — which, unlike the step order, stays chronological when a
+task has parallel steps or fan-out lanes).
+
+| Output | What it is |
+|---|---|
+| default | The records rendered as text, the vocabulary the TUI's output pane renders: assistant output, tool calls and their outcomes, command output, vincent's own annotations. Token usage is dropped — `task show` carries it |
+| `--json` | The normalized records as NDJSON, one JSON object per line, in vincent's vocabulary including its `vincent.*` annotations. This is the `jq` route |
+| `--raw` | The agent's own JSONL, byte for byte, exactly as it was recorded |
+
+Everything a reader reads goes to **stdout**, including a command step's stderr,
+which is tagged `[stderr]` rather than split onto the other file descriptor: a
+transcript is one interleaved stream and two descriptors would scramble the
+ordering that makes it readable. The command's own diagnostics go to stderr, so
+stdout stays pipeable.
+
+`-f` opens on the tail and then resumes from the record boundary the daemon
+reports, printing records as the attempt writes them. It ends when that attempt
+stops running — it does not wait for a later retry, which is a different run.
+
+A step run that never had a transcript — a manual gate — prints a line saying so
+on stderr and exits `0`; nothing failed. A transcript whose file is gone (pruned
+by `transcript_retention_days`, or deleted) exits `1`.
 
 ### `vincent task cancel`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -546,8 +546,8 @@ log_level: info
 ```
 
 One of `debug`, `info`, `warn`, `error`. The log lives at
-`{data_dir}/logs/daemon.log`, is size-capped and rotated, and is tailed by the
-TUI's daemon view.
+`{data_dir}/logs/daemon.log`, is size-capped and rotated, and is read by
+[`vincent daemon logs`](cli.md#vincent-daemon-logs) and the TUI's daemon view.
 
 ### `debug`
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -76,7 +76,7 @@ Project-scoped workflows live in the repository instead, at
 | `daemon.json` | How clients find the daemon: port, pid, start time. Written atomically, removed on graceful shutdown |
 | `daemon.lock` | Single-instance enforcement; releases automatically when the process dies |
 | `tui.json` | TUI-local state, including the first-run full-auto acknowledgment |
-| `logs/daemon.log` | The daemon log, rotated and size-capped. Tailed by the TUI's daemon view — read from disk, so it still works when the daemon is what died |
+| `logs/daemon.log` | The daemon log, rotated and size-capped. Read by `vincent daemon logs` and the TUI's daemon view — from disk in both cases, so it still works when the daemon is what died |
 
 ## Worktrees and branches
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2733,11 +2733,13 @@ One Go binary, `vincent`:
 | `vincent` | Launches the TUI; auto-starts the daemon in the background if unreachable |
 | `vincent daemon` | Runs the daemon in the foreground (logs to stderr; for debugging/service managers). `--config-dir`/`--data-dir` pin the §12.2 directories for a manager with no per-process environment |
 | `vincent daemon start / stop / status` | Background daemon management (start detaches; stop = graceful shutdown) |
+| `vincent daemon logs [-n N] [-f]` | *Added 2026-08-28 (task 047).* Prints the tail of `{data_dir}/logs/daemon.log` (§17), 500 lines by default, `-f` following it on a two-second cadence. It reads the file **from disk and never calls the API**, so it needs no daemon and starts none — it cannot exit 2. A missing file is an error naming the path; an empty one prints nothing and succeeds |
 | `vincent daemon backup <path.tar.gz> / restore <path.tar.gz>` | *Added 2026-08-25 (task 030).* One `.tar.gz` of the database (`VACUUM INTO`, §14), `transcripts/`, `config.yaml` and `workflows/`, plus a manifest. `backup` is a thin API client and needs a **running** daemon; `restore` runs client-side and needs a **stopped** one, and refuses a newer schema or an occupied destination without `--force` |
 | `vincent service install / uninstall / status` | Registers OS-native autostart, always as the invoking user: launchd agent, systemd user unit, Windows Scheduled Task |
 | `vincent workflow ls / validate [file] / render <file> / init <name>` | Registry listing / YAML validation / template dry run / writing a new registry file. *Amended 2026-08-26 (task 034):* `init` writes the §5.2 scope directory a `--project` flag selects — global by default, resolved from §12.2 with **no daemon**; `--project N` needs one, purely to resolve the id to a repository root. `--from <example>` writes an embedded `examples/*.yaml` with its top-level `name:` rewritten. It refuses an existing path (`O_EXCL`) or a name another file in the same scope already declares, and only warns when the name shadows a lower scope. *Added 2026-08-28 (task 044):* `render` executes every template the file declares — `prompt`, `run`, `check`, `instructions`, `if` and `for_each` — against a synthetic §8.4 preview context and prints what each step would send, with the §8.6 triple each agent step resolves to. Where `validate` parses a template, this **executes** it, which is the only way `missingkey=error` catches a typo'd field. It is offline for the same reason `validate` is; `--task`/`--project` reach the daemon for a real task's facts and for registry lookups. Exit 0 clean · 1 a render error · 2 no daemon answered a `--task`/`--project` |
 | `vincent project add <path> / ls` | Thin API clients for scripting |
 | `vincent task add / ls / show <id> / cancel <id> / follow-up <id>` | Thin API clients for scripting. *Amended 2026-08-25 (task 027):* `follow-up` takes exactly one of `--prompt`, `--run` and `--workflow`, plus optional `--agent`/`--model`/`--effort` (§13.2). *Amended 2026-08-28 (task 045):* `add` fills the §8.1.2 field map from repeatable `--field name=value` and/or `--fields-file <path\|->` |
+| `vincent task transcript <id>` | *Added 2026-08-28 (task 047).* Prints one attempt's transcript through `GET /v1/tasks/{id}/steps/{run_id}/transcript` (§13.2). `--step` takes a **step_run id**; omitted, it selects the running attempt, else the newest by run id. Default output is the normalized records rendered as text, `--json` is those records as NDJSON, `--raw` is the agent's own dialect byte for byte. `-f` opens on a tail and resumes from `X-Next-Offset`, ending when that attempt stops running |
 | `vincent status <message>` | *Added 2026-08-26 (task 036).* Records what the current step is doing, in its own words (§5.4). Runs **from inside a step**: it addresses itself with §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, takes no id argument, and errors naming those variables when they are unset. Silent on success — its stdout is the step's transcript |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent github issues / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub |
@@ -2771,6 +2773,33 @@ per-field bounds are the API's, and declaring `fields:` still does **not** close
 the map (§8.1.2). Without `--json`, creation confirms the recorded fields by
 **name and count, never value**, read off the response so a field prefilled from
 `--github-issue` is confirmed with the rest.
+
+*Added 2026-08-28 (task 047).* The two artifacts a failure is diagnosed from —
+the daemon log and a step's transcript — had no command line at all: both were
+reachable only from the TUI, or by knowing where the files live. `daemon logs`
+and `task transcript` close that, and they close it on opposite sides of the
+API boundary, deliberately.
+
+`daemon logs` reads the log off disk rather than through an endpoint, because
+an endpoint cannot serve the log in the failure mode that most often sends a
+reader to it — a daemon that will not start, or one that is wedged. That is the
+same reasoning `LogPath` already carries for clients deriving the path
+themselves. `GET /v1/daemon/logs` is **left unbuilt on purpose**: it becomes
+right for the first client that is not on the daemon's machine, at which point
+the CLI can prefer it and keep the disk read as the fallback. Adding it now
+would mean the one client that exists reads the log through the process that
+may be what is broken.
+
+`task transcript` is a thin API client like the rest, and needs no daemon-side
+change: the endpoint already serves `format=raw|normalized`, `offset`/`tail`
+and a record-boundary `X-Next-Offset`. It follows by **polling that endpoint**
+rather than subscribing to §13.3's live output stream, and the reason is an
+ownership invariant rather than simplicity: live chunks are dropped for a slow
+subscriber because the transcript file is the durable copy, and a CLI writing
+into a slow pipe is exactly that subscriber — the stream would silently lose
+output in the case the command exists for. Reading a transcript is also not a
+§6 human action, so task 025's decision that `retry`, `repair`, `skip` and
+`approve` stay TUI-and-API only is untouched: that decision is about writes.
 
 *Amended 2026-08-15 (task 005).* `gc` breaks this table's noun-verb pattern
 (`project add`, `task ls`) knowingly: `git gc` is the idiom users already have, and the

--- a/docs/tasks/047-cli-logs-and-transcripts.md
+++ b/docs/tasks/047-cli-logs-and-transcripts.md
@@ -1,0 +1,148 @@
+# 047 — `vincent daemon logs` and `vincent task transcript`
+
+**Status:** ✅ done (5/5)
+**Issue:** [#92](https://github.com/lezli01/vincent/issues/92)
+**Spec:** amends §12.1
+
+## Problem
+
+The two artifacts a failure is diagnosed from — the daemon log and a step's
+transcript — were reachable only from the TUI, or by knowing where the files
+live and reaching for `tail` yourself.
+
+- **The daemon log had no CLI surface.** `internal/tui/daemon.go` tails it off
+  disk on a 2 s timer (500 lines); `vincent daemon start` prints a 20-line tail
+  only when startup fails; `vincent doctor` carries a fixed 20-line tail inside a
+  larger report. There was no way to ask for the log itself, at a length you
+  choose, or to follow it.
+- **The transcript gap was the CLI's alone.** `GET /v1/tasks/{id}/steps/{run_id}/transcript`
+  already served `format=raw|normalized`, `offset`/`tail` and a record-boundary
+  `X-Next-Offset`, and `apiclient.Client.Transcript` already consumed it. Only
+  the TUI called it; `vincent task show` printed the file paths and stopped.
+
+Both bite hardest in the case they exist for: a task blocked overnight on a box
+you are on over SSH, or a daemon that will not start — where launching a
+full-screen Bubble Tea client is either impossible or the wrong tool.
+
+`vincent doctor` is not the missing command, and this does not relitigate §17's
+"Entry point" note. That note records doctor replacing five surfaces for the
+question "why is nothing running?", one of which was the TUI's daemon view.
+Doctor answers that question in one pass with a fixed 20-line tail; it is not a
+pager and cannot follow. `daemon logs` serves the other question — "what is the
+daemon doing right now" — and doctor's row is unchanged.
+
+## Decisions
+
+**Decision 1 (2026-08-28) — `--json` keeps its meaning; `--raw` is the new
+flag.** `vincent task transcript --json` emits the *normalized* records as
+NDJSON, in vincent's own vocabulary including its `vincent.*` annotations.
+`--raw` passes `format=raw` and streams the agent's untouched dialect.
+
+Beat: the issue's spelling, where `--json` meant `format=raw`. `--json` means
+"vincent's typed JSON" on every other subcommand, and one command redefining it
+is a trap for exactly the reader who learned the convention elsewhere.
+
+**Decision 2 (2026-08-28) — follow polls the transcript endpoint.** `-f` opens
+on `apiclient.DefaultTailBytes` and re-fetches from `offset=NextOffset` every
+2 s.
+
+Beat: subscribing to §13.3's live output stream. The deciding reason is an
+ownership invariant rather than simplicity: live output chunks are *dropped*
+for slow subscribers because the transcript file is the durable copy, and a CLI
+writing into a slow pipe is exactly that subscriber — so the SSE route would
+silently lose output in the case the command exists for. Polling also gives one
+code path for a live attempt and an already-finished one.
+
+**Decision 3 (2026-08-28) — with `--step` omitted, the running attempt if there
+is one, else the newest by `step_run` id.** `t.Steps` arrives ordered
+`step_index, iteration, attempt, id`, which stops being chronological the moment
+a task has parallel steps or fan-out lanes; `id` is creation order and does not.
+A step run's state is `running` until it settles, so "the running attempt" is a
+single unambiguous row in practice, and ties fall through to the newest id.
+
+Beat: "the last row of the list", which is the same thing only for a linear
+workflow, and silently wrong for the shapes this project has had since §7.5.
+
+**Decision 4 (2026-08-28) — `vincent daemon logs` takes no `--data-dir`.** It
+resolves directories through `config.ResolveDirs` — `VINCENT_DATA_DIR`, else the
+§12.2 platform default — exactly as `daemon start`, `stop`, `status`, `doctor`
+and every other subcommand do.
+
+Beat: mirroring the flag on `vincent daemon` itself. That flag exists for the
+Windows Scheduled Task, whose `Exec` action has no environment (§12.1); it is
+not a CLI-wide convention, and adding it to one subcommand of five would be a
+new unevenness for no case the environment variable does not already serve.
+
+**Decision 5 (2026-08-28) — everything a reader reads goes to stdout, including
+a command step's `stream: stderr` output.** A transcript is one interleaved
+record stream; splitting it across two file descriptors scrambles the ordering
+that makes it readable. Stderr records are tagged `[stderr]` in the rendered
+text instead, and `--raw`/`--json` are byte-faithful either way. The CLI's own
+diagnostics — a step with no transcript, a follow that ended — go to stderr, so
+stdout stays pipeable per `docs/reference/cli.md`'s global-behavior rules.
+
+**Decision 6 (2026-08-28) — "no transcript" is decided client-side, before the
+request.** The endpoint returns 404 with `CodeNotFound` for two different facts:
+"step run has no transcript" (a manual gate) and "transcript file is gone
+(pruned or removed)". The CLI already holds the step rows from `GetTask` — it
+needs them for decision 3 — and `TranscriptPath` is empty for the first case, so
+it reports "step run N has no transcript" on stderr and exits **0** without
+calling the endpoint. A 404 that still comes back therefore means the file was
+pruned or removed, which is exit **1** naming `transcript_retention_days`.
+
+Beat: matching on the endpoint's message strings, which couples the CLI to
+wording the API is free to change.
+
+**Decision 7 (2026-08-28) — the CLI's renderer is new code, not a reuse of the
+TUI's.** `detail.renderRecord` returns `paneLine`s of lipgloss segments and
+branches on the pane's detail level; it is a Bubble Tea layout primitive, not a
+text formatter. Extracting a shared one would mean lifting `paneLine`, `segment`
+and the style table into a package `internal/cli` can import — a larger and
+worse change than one small renderer over the same public `apiclient` records.
+What holds the two together is the record vocabulary, which is where the
+contract already lives. The markers differ deliberately: the CLI's are ASCII,
+because its output is piped and a Windows console under an OEM code page renders
+`✓` as noise.
+
+**Decision 8 (2026-08-28) — `GET /v1/daemon/logs` is left unbuilt.** The one
+client that exists would then read the log through the daemon that may be what
+is broken. It becomes right when a client that is not on the daemon's machine is
+real — a web UI — at which point the CLI can prefer it and keep the disk read as
+the fallback. Recorded in §12.1 rather than left to be rediscovered.
+
+**Decision 9 (2026-08-28) — giving a read-only view a command line breaks no
+rule.** Task 027's decision that `retry`, `repair`, `skip` and `approve` stay
+TUI-and-API only is about §6 *human actions* — writes. Reading a transcript is
+neither, so that decision is untouched and stays binding.
+
+## Tasks
+
+- [x] **047.1** `internal/apiclient`: `TranscriptOptions.query` takes the
+  format, `Client.TranscriptRaw` returns the endpoint's bytes and
+  `X-Next-Offset` unparsed — never through `decodeTranscript`, which tolerantly
+  drops lines a renderer is right to skip and a byte-faithful flag is not.
+  ✓ 2026-08-28
+- [x] **047.2** `vincent daemon logs [-n N] [-f]` in `internal/cli/daemon.go`,
+  reading disk through `daemon.LogPath` + `daemon.TailFile`, with a follow that
+  opens/reads/closes per poll so log rotation is not broken by watching it.
+  ✓ 2026-08-28
+- [x] **047.3** `vincent task transcript <id> [--step RUN] [-f] [--json|--raw]`
+  in a new `internal/cli/transcript.go`, with the plain-text renderer beside it.
+  ✓ 2026-08-28
+- [x] **047.4** Tests: `internal/cli/logs_test.go` for the log command including
+  the rotation case, and `internal/cli/transcript_live_test.go` against the
+  **real** API handlers over `httptest` for selection, rendering, `--json`,
+  `--raw`, the two 404s and the follow seam. ✓ 2026-08-28
+- [x] **047.5** Spec §12.1 amendment, `docs/reference/cli.md`,
+  `docs/reference/files.md`, `docs/guides/troubleshooting.md`,
+  `docs/guides/scripting.md`, the `CHANGELOG.md` entry, and a drift check
+  holding every command in the tree to a mention on the CLI page. ✓ 2026-08-28
+
+## Out of scope
+
+`GET /v1/daemon/logs` (decision 8) — a follow-up issue when a remote client is
+actually on the table, not before.
+
+No gate script. Neither command changes daemon behavior, and both are covered by
+in-process tests against the real handlers; the acceptance gates exist for
+end-to-end daemon behavior over curl.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -60,6 +60,7 @@ the living engineering specification records implementation contracts.
 | [044](044-workflow-render-preview.md) | `vincent workflow render` — a template dry run | ✅ done (6/6) |
 | [045](045-cli-task-fields-file.md) | Task fields from a file or stdin in `vincent task add` | ✅ done (4/4) |
 | [046](046-notify-hook.md) | A notify hook: letting the daemon signal a human outside the TUI | ✅ done (6/6) |
+| [047](047-cli-logs-and-transcripts.md) | `vincent daemon logs` and `vincent task transcript` | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/apiclient/transcript.go
+++ b/internal/apiclient/transcript.go
@@ -87,8 +87,8 @@ type TranscriptOptions struct {
 	Tail int64
 }
 
-func (o TranscriptOptions) query() string {
-	q := url.Values{"format": {"normalized"}}
+func (o TranscriptOptions) query(format string) string {
+	q := url.Values{"format": {format}}
 	switch {
 	case o.Tail > 0:
 		q.Set("tail", strconv.FormatInt(o.Tail, 10))
@@ -105,25 +105,63 @@ func (o TranscriptOptions) query() string {
 func (c *Client) Transcript(
 	ctx context.Context, taskID, runID int64, opts TranscriptOptions,
 ) (records []TranscriptRecord, nextOffset int64, err error) {
-	path := fmt.Sprintf("/v1/tasks/%d/steps/%d/transcript%s", taskID, runID, opts.query())
+	resp, nextOffset, err := c.transcript(ctx, taskID, runID, opts, "normalized")
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	records, err = decodeTranscript(resp.Body)
+	return records, nextOffset, err
+}
+
+// TranscriptRaw fetches the same byte range in the agent's own dialect,
+// returning the file's bytes unaltered plus the offset to resume from.
+//
+// It deliberately does not go through decodeTranscript, which *drops* a line
+// it cannot parse: tolerating a bad record is right for a renderer and wrong
+// here, where the caller asked for what the file says.
+func (c *Client) TranscriptRaw(
+	ctx context.Context, taskID, runID int64, opts TranscriptOptions,
+) (data []byte, nextOffset int64, err error) {
+	resp, nextOffset, err := c.transcript(ctx, taskID, runID, opts, "raw")
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read transcript: %w", err)
+	}
+	return data, nextOffset, nil
+}
+
+// transcript performs the request both forms share and hands back the open
+// body; the caller closes it.
+func (c *Client) transcript(
+	ctx context.Context, taskID, runID int64, opts TranscriptOptions, format string,
+) (resp *http.Response, nextOffset int64, err error) {
+	path := fmt.Sprintf("/v1/tasks/%d/steps/%d/transcript%s", taskID, runID, opts.query(format))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("build transcript request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	resp, err := c.rest.Do(req)
+	resp, err = c.rest.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("GET transcript: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, 0, decodeError(resp)
+		// Closed here rather than deferred: this function's success path
+		// hands the open body to its caller, so a deferred close would run
+		// against the nil response this path returns.
+		apiErr := decodeError(resp)
+		_ = resp.Body.Close()
+		return nil, 0, apiErr
 	}
 	if v := resp.Header.Get("X-Next-Offset"); v != "" {
 		nextOffset, _ = strconv.ParseInt(v, 10, 64)
 	}
-	records, err = decodeTranscript(resp.Body)
-	return records, nextOffset, err
+	return resp, nextOffset, nil
 }
 
 // decodeTranscript reads NDJSON records, tolerating a record it cannot parse

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"time"
 
@@ -77,7 +79,7 @@ func newDaemonCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&hideConsole, "hide-console", false,
 		"detach from the console the OS allocated for this process (Windows only; no-op elsewhere)")
 	cmd.AddCommand(newDaemonStartCmd(), newDaemonStopCmd(), newDaemonStatusCmd(),
-		newDaemonBackupCmd(), newDaemonRestoreCmd())
+		newDaemonLogsCmd(), newDaemonBackupCmd(), newDaemonRestoreCmd())
 	return cmd
 }
 
@@ -249,6 +251,136 @@ func newDaemonStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// logTailDefault matches the TUI daemon view's window (tui.logTailLines): the
+// two surfaces answer the same question and disagreeing about how much of the
+// log that takes would be a difference with no reason behind it.
+const logTailDefault = 500
+
+// logFollowInterval paces `--follow`, on the TUI's cadence.
+const logFollowInterval = 2 * time.Second
+
+// newDaemonLogsCmd prints the daemon log **from disk**, not over the API, and
+// needs no daemon at all — which is the point rather than a shortcut, and the
+// reason daemon.LogPath is exported for clients to derive: the log is worth
+// reading exactly when the daemon is not there to serve it. It is one of the
+// few subcommands that can never exit 2 (task 047 decision).
+func newDaemonLogsCmd() *cobra.Command {
+	var (
+		lines  int
+		follow bool
+	)
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Print the daemon log from disk",
+		Long: "Print the tail of {data_dir}/logs/daemon.log (§17). It reads the file " +
+			"directly and never contacts the daemon, so it still answers when the " +
+			"daemon is the thing that is broken. The directory is resolved the way " +
+			"every other subcommand resolves it: $VINCENT_DATA_DIR, else the platform " +
+			"default (§12.2).",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			dirs, err := config.ResolveDirs()
+			if err != nil {
+				return err
+			}
+			path := daemon.LogPath(dirs.Data)
+			out := cmd.OutOrStdout()
+			// An absent or unreadable file is an error naming the path; an
+			// empty log prints nothing and succeeds. TailFile already draws
+			// that distinction, and the two facts are not the same.
+			tail, err := daemon.TailFile(path, lines)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", path, err)
+			}
+			if err := writeLines(out, tail); err != nil {
+				return err
+			}
+			if !follow {
+				return nil
+			}
+			return followLog(cmd.Context(), out, path, lastLine(tail), logFollowInterval)
+		},
+	}
+	cmd.Flags().IntVarP(&lines, "lines", "n", logTailDefault, "Number of trailing lines to print")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false,
+		"Keep printing lines as they are appended (Ctrl-C to stop)")
+	return cmd
+}
+
+// followLog re-reads the file on a timer and prints only what was appended
+// since the previous read — never the window again.
+//
+// Every read opens, reads and closes, because lumberjack rotates by renaming
+// the live file and on Windows renaming a file another process holds open
+// fails: a follower that kept a handle would break the daemon's own log
+// rotation for as long as it was watching. A rotation between two reads is
+// therefore ordinary here — the file may be briefly absent, which is waited
+// out rather than reported, and the fresh file's lines are all new.
+// The poll interval is a parameter so a test can drive the loop faster than a
+// human would wait; the command always passes logFollowInterval.
+func followLog(ctx context.Context, out io.Writer, path, seen string, every time.Duration) error {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		// n=0 is the whole tail window: -n bounds the opening print, not how
+		// much a single poll may pick up, or a busy daemon's lines would be
+		// dropped between polls.
+		cur, err := daemon.TailFile(path, 0)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		fresh := appendedAfter(cur, seen)
+		if len(fresh) == 0 {
+			continue
+		}
+		if err := writeLines(out, fresh); err != nil {
+			return err
+		}
+		seen = lastLine(fresh)
+	}
+}
+
+// appendedAfter returns the lines of a fresh read that follow the last line
+// already printed. The seam is found by matching that line's *last*
+// occurrence: log records carry a timestamp, so an identical line later in
+// the same window is the newer one. A window that no longer contains it at
+// all is a rotated or truncated file, whose lines are all new.
+func appendedAfter(lines []string, seen string) []string {
+	if seen == "" {
+		return lines
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		if lines[i] == seen {
+			return lines[i+1:]
+		}
+	}
+	return lines
+}
+
+func lastLine(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	return lines[len(lines)-1]
+}
+
+func writeLines(w io.Writer, lines []string) error {
+	for _, l := range lines {
+		if _, err := fmt.Fprintln(w, l); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // exitError carries a specific process exit code out of a RunE without

--- a/internal/cli/docs_claims_test.go
+++ b/internal/cli/docs_claims_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/daemon"
 	"github.com/lezli01/vincent/internal/taskstate"
@@ -241,4 +243,33 @@ func runTaskLs(t *testing.T, args ...string) string {
 		t.Fatalf("task ls: %v (%s)", err, buf.String())
 	}
 	return buf.String()
+}
+
+// TestDocsClaimsEveryCommandIsOnTheCLIPage: `docs/reference/cli.md` tracks the
+// cobra tree (CLAUDE.md's documentation model). A command the tree grows and
+// the page never mentions is the drift this file exists to catch — task 047
+// added two, and this is what keeps the next two from arriving unannounced.
+//
+// It asks only that the page names the command, not how: `vincent service
+// install` earns its mention inside a shell block rather than a heading, and
+// that is a legitimate way to document three sibling commands at once.
+func TestDocsClaimsEveryCommandIsOnTheCLIPage(t *testing.T) {
+	page, ok := docPages(t)["docs/reference/cli.md"]
+	if !ok {
+		t.Fatal("docs/reference/cli.md is missing")
+	}
+	var missing []string
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.CommandPath() != "vincent" && !strings.Contains(page, c.CommandPath()) {
+			missing = append(missing, c.CommandPath())
+		}
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+	}
+	walk(newRootCmd())
+	if len(missing) > 0 {
+		t.Errorf("the CLI reference never mentions %v", missing)
+	}
 }

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+)
+
+// `vincent daemon logs` is the one data command that needs no daemon: it
+// reads the log off disk, which is the point rather than a shortcut, so
+// everything here runs against a data dir and nothing else.
+
+// followPoll paces the follow loop in tests. The command polls every two
+// seconds, which is right for a human and pointless to wait for here.
+const followPoll = 20 * time.Millisecond
+
+// runCLI executes the real command tree in-process, returning what each
+// stream got and the exit code Execute would have returned.
+func runCLI(t *testing.T, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs(args)
+	err := root.ExecuteContext(t.Context())
+	if err != nil {
+		// Execute prints a plain error itself; a command returning exitError
+		// has already written its own report.
+		var ee exitError
+		if !errors.As(err, &ee) {
+			errOut.WriteString("Error: " + err.Error() + "\n")
+		}
+	}
+	return out.String(), errOut.String(), asExitCode(err)
+}
+
+// seedLog writes a data dir holding a daemon log with the given lines, and
+// points the CLI's directory resolution at it.
+func seedLog(t *testing.T, lines ...string) string {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+	path := daemon.LogPath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	var body string
+	if len(lines) > 0 {
+		body = strings.Join(lines, "\n") + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+func appendLog(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+		t.Fatalf("append log: %v", err)
+	}
+}
+
+func TestDaemonLogsPrintsTheTail(t *testing.T) {
+	var lines []string
+	for i := range 10 {
+		lines = append(lines, "line "+string(rune('0'+i)))
+	}
+	seedLog(t, lines...)
+
+	out, _, code := runCLI(t, "daemon", "logs")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if got := strings.Join(lines, "\n") + "\n"; out != got {
+		t.Errorf("output = %q, want the whole log %q", out, got)
+	}
+
+	out, _, code = runCLI(t, "daemon", "logs", "-n", "3")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if want := strings.Join(lines[7:], "\n") + "\n"; out != want {
+		t.Errorf("-n 3 output = %q, want %q", out, want)
+	}
+}
+
+// A log that is not there and a log with nothing in it are different facts,
+// and the command reports them differently: the first names the path and
+// fails, the second succeeds silently.
+func TestDaemonLogsMissingAndEmpty(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+
+	out, errOut, code := runCLI(t, "daemon", "logs")
+	if code != 1 {
+		t.Errorf("exit on a missing log = %d, want 1", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want nothing", out)
+	}
+	if !strings.Contains(errOut, daemon.LogPath(dataDir)) {
+		t.Errorf("error %q does not name the log path %q", errOut, daemon.LogPath(dataDir))
+	}
+
+	seedLog(t)
+	out, _, code = runCLI(t, "daemon", "logs")
+	if code != 0 || out != "" {
+		t.Errorf("empty log: exit %d, stdout %q; want 0 and nothing", code, out)
+	}
+}
+
+// Following prints what was appended and only what was appended: the window
+// it opened on is never printed a second time, and no line arrives twice.
+func TestDaemonLogsFollowPrintsOnlyNewLines(t *testing.T) {
+	path := seedLog(t, "old one", "old two")
+	var buf lockedBuffer
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- followLog(ctx, &buf, path, "old two", followPoll) }()
+
+	appendLog(t, path, "fresh one")
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "fresh one") },
+		"the first appended line")
+	appendLog(t, path, "fresh two")
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "fresh two") },
+		"the second appended line")
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("followLog: %v", err)
+	}
+	if got := buf.String(); got != "fresh one\nfresh two\n" {
+		t.Errorf("followed output = %q, want the two appended lines exactly once each", got)
+	}
+}
+
+// Rotation is what the open-read-close contract exists for: lumberjack
+// rotates by renaming the live file, and on Windows renaming a file another
+// process holds open fails. A follower must survive it — including the moment
+// where no daemon.log exists at all — and pick the new file up.
+func TestDaemonLogsFollowSurvivesRotation(t *testing.T) {
+	path := seedLog(t, "before rotation")
+	var buf lockedBuffer
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- followLog(ctx, &buf, path, "before rotation", followPoll) }()
+
+	appendLog(t, path, "still the old file")
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "still the old file") },
+		"a line from the pre-rotation file")
+
+	if err := os.Rename(path, path+".1"); err != nil {
+		t.Fatalf("rotate (a held handle is exactly what this proves absent): %v", err)
+	}
+	// Give the follower a poll or two with no log there at all: that gap is
+	// waited out, not reported as the missing-file error a first read is.
+	time.Sleep(3 * followPoll)
+	if err := os.WriteFile(path, []byte("after rotation\n"), 0o600); err != nil {
+		t.Fatalf("write rotated log: %v", err)
+	}
+	waitFor(t, func() bool { return strings.Contains(buf.String(), "after rotation") },
+		"a line from the fresh file")
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("followLog did not survive rotation: %v", err)
+	}
+	if strings.Count(buf.String(), "after rotation") != 1 {
+		t.Errorf("output = %q, want the fresh file's line exactly once", buf.String())
+	}
+}
+
+// waitFor polls a condition rather than sleeping for a fixed span, so a slow
+// CI runner costs nothing when the condition is already true.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(followPoll / 2)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// lockedBuffer is a buffer a follow goroutine writes while the test reads it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -24,7 +24,7 @@ func newTaskCmd() *cobra.Command {
 		Short: "Create, inspect and cancel tasks",
 	}
 	cmd.AddCommand(newTaskAddCmd(), newTaskLsCmd(), newTaskShowCmd(), newTaskCancelCmd(),
-		newTaskFollowUpCmd())
+		newTaskFollowUpCmd(), newTaskTranscriptCmd())
 	return cmd
 }
 
@@ -447,8 +447,10 @@ func newTaskShowCmd() *cobra.Command {
 					return err
 				}
 				// The transcript is the complete record of what the agent did
-				// (§17); the TUI shows only its tail. Naming the file is what
-				// lets someone diagnose a failed step at all right now.
+				// (§17). `vincent task transcript <id> --step RUN` prints it
+				// as of task 047; the paths stay because a file is still the
+				// thing you grep, copy or attach to a bug report, and the RUN
+				// column above is the id that command takes.
 				var paths []string
 				for _, s := range t.Steps {
 					if p := deref(s.TranscriptPath); p != "" {

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -1,0 +1,391 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// transcriptPollInterval paces `--follow`, on the TUI's cadence.
+//
+// Following polls the transcript endpoint rather than subscribing to §13.3's
+// live output stream, and the reason is an ownership invariant rather than
+// simplicity: live chunks are *dropped* for a slow subscriber because the
+// transcript file is the durable copy, and a CLI writing into a slow pipe is
+// exactly that subscriber. The stream would silently lose output in the case
+// this command exists for. Polling also gives one code path for a live
+// attempt and a finished one (task 047 decision 2).
+const transcriptPollInterval = 2 * time.Second
+
+// newTaskTranscriptCmd prints one attempt's transcript. Reading a transcript
+// is not a §6 human action, so task 025 decision 12 — retry, repair, skip and
+// approve stay TUI-and-API only — does not reach it: that decision is about
+// writes.
+func newTaskTranscriptCmd() *cobra.Command {
+	var (
+		stepRun int64
+		follow  bool
+		raw     bool
+	)
+	cmd := &cobra.Command{
+		Use:   "transcript <id>",
+		Short: "Print a step run's transcript",
+		Long: "Print the complete record of what one attempt did (§17), rendered as text. " +
+			"--step takes a step_run id — the RUN column `vincent task show` prints — " +
+			"which is unambiguous across retries, where every attempt is its own run. " +
+			"Omitted, it selects the running attempt if there is one and the newest " +
+			"attempt otherwise.\n\n" +
+			"--json emits the normalized records as NDJSON, in vincent's own vocabulary " +
+			"including its `vincent.*` annotations; --raw streams the agent's untouched " +
+			"dialect, byte for byte. Everything a human reads goes to stdout, including " +
+			"a command step's stderr, which is tagged rather than split off: a " +
+			"transcript is one interleaved stream and two file descriptors would " +
+			"scramble the ordering that makes it readable.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("task id must be a number: %q", args[0])
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				t, err := c.GetTask(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				run, err := selectStepRun(t.Steps, id, stepRun)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
+					return exitError{code: 1}
+				}
+				// Decided here rather than from the endpoint's answer: it
+				// returns 404 for two different facts — a run that never had
+				// a transcript, and a file that is gone — and the step rows
+				// this command already holds tell the two apart without
+				// matching on a message string (task 047 decision 6). A run
+				// with no transcript is not an error: a manual gate records
+				// nothing, and saying so is the whole answer.
+				if deref(run.TranscriptPath) == "" {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"step run %d (%s, %s) has no transcript\n", run.ID, run.StepID, run.StepType)
+					return nil
+				}
+				p := &transcriptPrinter{
+					out:    cmd.OutOrStdout(),
+					errOut: cmd.ErrOrStderr(),
+					raw:    raw,
+					json:   wantJSON(cmd),
+				}
+				opts := apiclient.TranscriptOptions{}
+				if follow {
+					// A follow opens on a tail: the point is what happens
+					// next, and a long-running agent's file can be enormous.
+					opts.Tail = apiclient.DefaultTailBytes
+				}
+				next, err := p.print(ctx, c, id, run.ID, opts)
+				if err != nil {
+					return transcriptError(p.errOut, err)
+				}
+				if !follow {
+					return nil
+				}
+				return p.follow(ctx, c, id, run.ID, next, transcriptPollInterval)
+			})
+		},
+	}
+	cmd.Flags().Int64Var(&stepRun, "step", 0,
+		"step_run id to print (default: the running attempt, else the newest)")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false,
+		"Keep printing as the attempt writes, until it is no longer running")
+	cmd.Flags().BoolVar(&raw, "raw", false,
+		"Emit the agent's own JSONL, byte for byte, instead of rendering it")
+	jsonFlag(cmd)
+	// --json is vincent's typed JSON on every other subcommand; a transcript
+	// does not get to redefine it (task 047 decision 1).
+	cmd.MarkFlagsMutuallyExclusive("json", "raw")
+	return cmd
+}
+
+// selectStepRun resolves which attempt to print (task 047 decision 3).
+//
+// With no --step, the running attempt wins, because that is the one a person
+// asking about a live task means. Otherwise the newest by step_run id: the
+// rows arrive ordered by step_index, iteration, attempt, id, which stops
+// being chronological the moment a task has parallel steps or fan-out lanes,
+// while id is creation order and does not.
+func selectStepRun(steps []apiclient.StepRun, taskID, want int64) (*apiclient.StepRun, error) {
+	if want > 0 {
+		for i := range steps {
+			if steps[i].ID == want {
+				return &steps[i], nil
+			}
+		}
+		return nil, fmt.Errorf("step run %d not found on task %d", want, taskID)
+	}
+	var newest, running *apiclient.StepRun
+	for i := range steps {
+		s := &steps[i]
+		if newest == nil || s.ID > newest.ID {
+			newest = s
+		}
+		if s.State == "running" && (running == nil || s.ID > running.ID) {
+			running = s
+		}
+	}
+	switch {
+	case running != nil:
+		return running, nil
+	case newest != nil:
+		return newest, nil
+	}
+	return nil, fmt.Errorf("task %d has no step runs yet", taskID)
+}
+
+// transcriptError maps a failed fetch to an exit code. The 404 that can still
+// arrive after the step row said there is a transcript means the file itself
+// is gone — pruned by §10's retention or removed by hand — which is a real
+// failure, unlike a run that never wrote one.
+func transcriptError(errOut io.Writer, err error) error {
+	var apiErr *apiclient.Error
+	if errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound {
+		_, _ = fmt.Fprintln(errOut, "Error:", apiMessage(err)+
+			" — it was pruned (config transcript_retention_days) or removed")
+		return exitError{code: 1}
+	}
+	_, _ = fmt.Fprintln(errOut, "Error:", apiMessage(err))
+	return exitError{code: 1}
+}
+
+// transcriptPrinter renders one attempt in whichever of the three forms was
+// asked for, carrying the little state the rendering needs across fetches so
+// a followed transcript reads the same as one printed in a single pass.
+type transcriptPrinter struct {
+	out    io.Writer
+	errOut io.Writer
+	raw    bool
+	json   bool
+	// sawOutput reports whether the agent has said anything yet, which is
+	// what decides whether the terminal result record repeats it.
+	sawOutput bool
+}
+
+// print fetches one range and writes it, returning the offset to resume from.
+func (p *transcriptPrinter) print(
+	ctx context.Context, c *apiclient.Client, taskID, runID int64, opts apiclient.TranscriptOptions,
+) (int64, error) {
+	if p.raw {
+		data, next, err := c.TranscriptRaw(ctx, taskID, runID, opts)
+		if err != nil {
+			return 0, err
+		}
+		_, err = p.out.Write(data)
+		return next, err
+	}
+	records, next, err := c.Transcript(ctx, taskID, runID, opts)
+	if err != nil {
+		return 0, err
+	}
+	for _, rec := range records {
+		if err := p.write(rec); err != nil {
+			return next, err
+		}
+	}
+	return next, nil
+}
+
+// write emits one record.
+func (p *transcriptPrinter) write(rec apiclient.TranscriptRecord) error {
+	if p.json {
+		// The record's own line, not a re-encoding of the struct: the
+		// annotations vincent writes carry fields TranscriptRecord does not
+		// name, and re-encoding would drop exactly those.
+		line := strings.TrimRight(string(rec.Raw), "\r\n")
+		if line == "" {
+			return nil
+		}
+		_, err := fmt.Fprintln(p.out, line)
+		return err
+	}
+	text, ok := renderTranscriptRecord(rec, p.sawOutput)
+	if rec.Type == "agent.output" && rec.Text != "" {
+		p.sawOutput = true
+	}
+	if !ok {
+		return nil
+	}
+	_, err := fmt.Fprintln(p.out, text)
+	return err
+}
+
+// follow re-fetches from the resume offset until the attempt stops running.
+// The state is read *before* each fetch so the last fetch happens after the
+// run settled: reading it after would leave whatever the step wrote between
+// the two calls unprinted.
+// The poll interval is a parameter so a test can drive the loop faster than a
+// human would wait; the command always passes transcriptPollInterval.
+func (p *transcriptPrinter) follow(
+	ctx context.Context, c *apiclient.Client, taskID, runID, offset int64, every time.Duration,
+) error {
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		state, err := stepRunState(ctx, c, taskID, runID)
+		if err != nil {
+			return transcriptError(p.errOut, err)
+		}
+		next, err := p.print(ctx, c, taskID, runID, apiclient.TranscriptOptions{Offset: offset})
+		if err != nil {
+			return transcriptError(p.errOut, err)
+		}
+		offset = next
+		// Only this attempt: a later retry is a different step run, and
+		// sitting here waiting for one would make the command hang on a task
+		// that is finished as far as the printed run is concerned.
+		if state != "running" {
+			_, _ = fmt.Fprintf(p.errOut, "step run %d is %s\n", runID, state)
+			return nil
+		}
+	}
+}
+
+func stepRunState(ctx context.Context, c *apiclient.Client, taskID, runID int64) (string, error) {
+	t, err := c.GetTask(ctx, taskID)
+	if err != nil {
+		return "", err
+	}
+	for i := range t.Steps {
+		if t.Steps[i].ID == runID {
+			return t.Steps[i].State, nil
+		}
+	}
+	return "", fmt.Errorf("step run %d is no longer on task %d", runID, taskID)
+}
+
+// renderTranscriptRecord maps one normalized record to a line of text,
+// covering the vocabulary the TUI's output pane covers. It is deliberately
+// not a reuse of that renderer: `detail.renderRecord` returns styled pane
+// segments for a Bubble Tea layout, and sharing it would mean lifting the
+// layout primitives into a package the CLI can import — a larger and worse
+// change than one small renderer over the same public records. What holds
+// the two together is the record vocabulary, which is where the contract
+// already lives.
+//
+// The markers are ASCII, unlike the pane's glyphs: this output is piped, and
+// a Windows console under an OEM code page renders `✓` as noise.
+//
+// A record with nothing a reader wants reports false. agent.usage is the
+// point of that rule — `vincent task show` already carries those numbers.
+func renderTranscriptRecord(rec apiclient.TranscriptRecord, sawOutput bool) (string, bool) {
+	switch rec.Type {
+	case "agent.output":
+		return rec.Text, rec.Text != ""
+	case "agent.tool_use":
+		if len(rec.Tools) == 0 {
+			return "", false
+		}
+		parts := make([]string, 0, len(rec.Tools))
+		for _, tool := range rec.Tools {
+			parts = append(parts, strings.TrimSpace(tool.Name+" "+tool.Summary))
+		}
+		return "> " + strings.Join(parts, ", "), true
+	case "agent.tool_result":
+		if len(rec.Results) == 0 {
+			return "", false
+		}
+		// One record can report several outcomes; the first owns the line,
+		// as it does in the pane.
+		res := rec.Results[0]
+		mark := "< "
+		if res.IsError {
+			mark = "! "
+		}
+		return mark + strings.TrimSpace(res.Name+" "+res.Summary), true
+	case "agent.error":
+		return "! " + firstNonEmpty(rec.Message, "agent error"), true
+	case "agent.result":
+		return renderTranscriptResult(rec, sawOutput), true
+	case "command.output", "vincent.output":
+		// Both streams land on stdout, tagged (task 047 decision 5): a
+		// transcript is one interleaved record stream, and splitting it
+		// across two file descriptors scrambles the ordering.
+		if rec.Stream == "stderr" {
+			return "[stderr] " + rec.Text, true
+		}
+		return rec.Text, true
+	case "vincent.command_started":
+		return "$ " + rawField(rec.Raw, "command"), true
+	case "vincent.input_request":
+		return "? " + firstNonEmpty(rec.Summary, rec.Kind, "input requested"), true
+	case "vincent.input_response":
+		return "? answered", true
+	case "vincent.input_timeout", "vincent.input_protocol_error", "vincent.error":
+		return "! " + firstNonEmpty(rec.Message, rawField(rec.Raw, "error"), rec.Type), true
+	default:
+		// An annotation this binary does not name still says that something
+		// happened, and a transcript that silently omitted it would be
+		// missing an event rather than a detail.
+		if strings.HasPrefix(rec.Type, "vincent.") {
+			return "* " + strings.TrimPrefix(rec.Type, "vincent."), true
+		}
+		return "", false
+	}
+}
+
+// renderTranscriptResult renders the terminal record. On success it says the
+// outcome and nothing else: every dialect's result text repeats assistant
+// messages already printed — cursor's is the whole turn concatenated — so
+// printing it again is the same words twice. The text is kept when nothing
+// else rendered, which is what a codex turn with no agent_message looks like,
+// and always on error, where it may be the only content there is.
+func renderTranscriptResult(rec apiclient.TranscriptRecord, sawOutput bool) string {
+	if rec.IsError {
+		return "! " + firstNonEmpty(rec.Message, rec.ResultText, "run failed")
+	}
+	if !sawOutput {
+		return "= " + firstNonEmpty(rec.ResultText, "run finished")
+	}
+	if rec.CostUSD != nil {
+		return fmt.Sprintf("= done ($%.4f)", *rec.CostUSD)
+	}
+	return "= done"
+}
+
+// rawField reads one string field of a record this struct does not name.
+func rawField(raw json.RawMessage, key string) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(raw, &fields) != nil {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(fields[key], &s) != nil {
+		return ""
+	}
+	return s
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/cli/transcript_live_test.go
+++ b/internal/cli/transcript_live_test.go
@@ -1,0 +1,446 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// `vincent task transcript` runs against the **real** API handlers over
+// httptest, not a stub: the command's whole job is to render what the
+// endpoint normalizes, and a hand-written stub would be the one place client
+// and server wire types could drift apart unnoticed.
+
+// The claude dialect, which the endpoint normalizes with the same parser that
+// read it live. Assertions name the rendered result, not these lines.
+const (
+	lineOutput = `{"type":"assistant","message":{"content":[{"type":"text","text":"looking at the failing test"}]}}`
+	lineTool   = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1",` +
+		`"name":"Bash","input":{"command":"go test ./internal/store"}}]}}`
+	lineToolResult = `{"type":"user","message":{"content":[{"type":"tool_result",` +
+		`"tool_use_id":"t1","content":"ok"}]}}`
+	lineUsage  = `{"type":"system","subtype":"usage","usage":{"input_tokens":10,"output_tokens":2}}`
+	lineResult = `{"type":"result","subtype":"success","is_error":false,"result":"all green",` +
+		`"usage":{"input_tokens":10,"output_tokens":2},"total_cost_usd":0.0125}`
+	// vincent's own annotations pass through the normalizer untouched.
+	lineCommandStarted = `{"type":"vincent.command_started","phase":"run","command":"go build ./..."}`
+	lineStderr         = `{"type":"vincent.output","phase":"run","stream":"stderr","text":"vet: no files"}`
+	lineInputRequest   = `{"type":"vincent.input_request","kind":"question","summary":"which branch?"}`
+	// An annotation this binary does not name: it still says something
+	// happened, and dropping it would lose an event rather than a detail.
+	lineUnknownAnnotation = `{"type":"vincent.parked","reason":"quota"}`
+	// Not JSON at all. The normalizer keeps it as agent.raw and the client's
+	// decoder drops it — which is why --raw must not go through that decoder.
+	lineGarbage = `not json at all`
+)
+
+// liveHarness is the daemon's own API server, its store, and a data dir the
+// CLI's discovery finds — everything `vincent task transcript` talks to.
+type liveHarness struct {
+	st        *store.Store
+	dataDir   string
+	taskID    int64
+	projectID int64
+	// transcriptCalls counts requests to the transcript endpoint, which is
+	// how "no transcript is decided client-side, before the request" is
+	// asserted rather than assumed.
+	transcriptCalls atomic.Int64
+}
+
+func newLiveHarness(t *testing.T) *liveHarness {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+
+	st, err := store.Open(filepath.Join(dataDir, "vincent.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	broker := events.New()
+	t.Cleanup(broker.Close)
+	st.SetEventHook(broker.Publish)
+
+	ctx := t.Context()
+	p := &store.Project{Name: "vincent", Path: "/nowhere", DefaultBranch: "main"}
+	if err := st.CreateProject(ctx, p); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	task := &store.Task{
+		ProjectID: p.ID, Title: "read the transcript", WorkflowName: "adhoc",
+		WorkflowSnapshot: "x", BaseBranch: "main", BranchName: "b", State: store.TaskRunning,
+	}
+	if err := st.CreateTask(ctx, task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	h := &liveHarness{st: st, dataDir: dataDir, taskID: task.ID, projectID: p.ID}
+	token, err := daemon.EnsureToken(dataDir)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	git := gitx.New()
+	agents := agent.NewRegistry(claude.New(func() string { return "" }))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// The runner is never started: nothing here admits a task, and the rows
+	// under test are written directly.
+	runner := taskrun.New(taskrun.Deps{
+		Store: st, Config: config.Default,
+		Worktrees: worktree.NewManager(git, dataDir),
+		Agents:    agents, DataDir: dataDir, Logger: logger,
+	})
+	s := api.New(api.Deps{
+		Token: token, Config: config.Default, StartedAt: time.Now(),
+		ListenAddr: "127.0.0.1:0", RequestStop: func() {}, Logger: logger,
+		Store: st, Broker: broker, Git: git, Runner: runner, WakeRunner: func() {},
+		// The registry is what lets the endpoint normalize a recorded run
+		// with the parser that read it live.
+		Agents: agents,
+	})
+	handler := s.Handler()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/transcript") {
+			h.transcriptCalls.Add(1)
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("server port: %v", err)
+	}
+	if err := daemon.WriteRuntimeInfo(dataDir, daemon.RuntimeInfo{
+		Port: port, PID: os.Getpid(), StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("daemon.json: %v", err)
+	}
+	return h
+}
+
+// addRun creates one step run, writing its transcript file when lines are
+// given. A run with no lines has no transcript at all — a manual gate.
+func (h *liveHarness) addRun(
+	t *testing.T, taskID int64, stepID string, state store.StepRunState, lines ...string,
+) *store.StepRun {
+	t.Helper()
+	run := &store.StepRun{
+		TaskID: taskID, StepIndex: 0, StepID: stepID, StepType: "agent",
+		Attempt: 1, State: state, Agent: "claude",
+	}
+	if len(lines) > 0 {
+		dir := filepath.Join(h.dataDir, "transcripts")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir transcripts: %v", err)
+		}
+		run.TranscriptPath = filepath.Join(dir, stepID+"-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".jsonl")
+		if err := os.WriteFile(run.TranscriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
+	} else {
+		run.StepType = "manual"
+	}
+	if err := h.st.CreateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return run
+}
+
+func (h *liveHarness) appendTranscript(t *testing.T, run *store.StepRun, lines ...string) {
+	t.Helper()
+	f, err := os.OpenFile(run.TranscriptPath, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+		t.Fatalf("append transcript: %v", err)
+	}
+}
+
+func (h *liveHarness) setRunState(t *testing.T, run *store.StepRun, state store.StepRunState) {
+	t.Helper()
+	run.State = state
+	if err := h.st.UpdateStepRun(t.Context(), run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+}
+
+// The default rendering covers every record type the renderer branches on,
+// including a `vincent.*` annotation it does not name — and drops the one it
+// deliberately drops.
+func TestTranscriptRendersTheRecordVocabulary(t *testing.T) {
+	h := newLiveHarness(t)
+	run := h.addRun(t, h.taskID, "implement", store.StepSucceeded,
+		lineCommandStarted, lineOutput, lineTool, lineToolResult, lineStderr,
+		lineInputRequest, lineUnknownAnnotation, lineUsage, lineResult)
+
+	out, _, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(run.ID, 10))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (%s)", code, out)
+	}
+	for _, want := range []string{
+		"$ go build ./...",
+		"looking at the failing test",
+		"> Bash go test ./internal/store",
+		"[stderr] vet: no files",
+		"? which branch?",
+		"* parked",
+		"= done ($0.0125)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output is missing %q:\n%s", want, out)
+		}
+	}
+	// agent.usage is dropped: `vincent task show` already carries those
+	// numbers, and repeating them mid-transcript is noise.
+	if strings.Contains(out, "input_tokens") {
+		t.Errorf("output rendered the usage record:\n%s", out)
+	}
+}
+
+// --raw is the file's own bytes, including a line the normalizer's client-side
+// decoder drops. Anything less would make the flag's promise false.
+func TestTranscriptRawIsByteIdentical(t *testing.T) {
+	h := newLiveHarness(t)
+	run := h.addRun(t, h.taskID, "implement", store.StepSucceeded,
+		lineOutput, lineGarbage, lineResult)
+
+	out, _, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(run.ID, 10), "--raw")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	want, err := os.ReadFile(run.TranscriptPath)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if out != string(want) {
+		t.Errorf("--raw output = %q, want the file verbatim %q", out, want)
+	}
+}
+
+// --json is vincent's own vocabulary as NDJSON — one record per line,
+// decodable back into the client's type, annotations and all.
+func TestTranscriptJSONIsNDJSON(t *testing.T) {
+	h := newLiveHarness(t)
+	run := h.addRun(t, h.taskID, "implement", store.StepSucceeded,
+		lineOutput, lineStderr, lineUnknownAnnotation, lineResult)
+
+	out, _, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(run.ID, 10), "--json")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want one per record:\n%s", len(lines), out)
+	}
+	var types []string
+	for _, line := range lines {
+		var rec apiclient.TranscriptRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("line %q is not a TranscriptRecord: %v", line, err)
+		}
+		types = append(types, rec.Type)
+	}
+	want := []string{"agent.output", "vincent.output", "vincent.parked", "agent.result"}
+	if strings.Join(types, ",") != strings.Join(want, ",") {
+		t.Errorf("types = %v, want %v", types, want)
+	}
+	// The annotation's own fields survive: the records are the endpoint's
+	// lines, not a re-encoding of the struct that would drop what it does
+	// not name.
+	if !strings.Contains(out, `"reason":"quota"`) {
+		t.Errorf("output dropped an annotation field:\n%s", out)
+	}
+}
+
+// With --step omitted: the running attempt if there is one, else the newest
+// by step_run id — asserted on a task whose step_index order disagrees with
+// its id order, which is the case that decision is for (parallel steps and
+// fan-out lanes).
+func TestTranscriptDefaultsToRunningThenNewest(t *testing.T) {
+	h := newLiveHarness(t)
+	// Created first, so the lower id, but the later lane by step_index.
+	later := h.addRun(t, h.taskID, "lane-b", store.StepRunning, lineOutput)
+	later.StepIndex = 7
+	if err := h.st.UpdateStepRun(t.Context(), later); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	earlier := h.addRun(t, h.taskID, "lane-a", store.StepSucceeded,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"lane a spoke"}]}}`)
+	if earlier.ID <= later.ID {
+		t.Fatalf("ids are not creation-ordered: %d, %d", earlier.ID, later.ID)
+	}
+
+	out, _, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out, "looking at the failing test") {
+		t.Errorf("default selection did not pick the running attempt:\n%s", out)
+	}
+
+	h.setRunState(t, later, store.StepSucceeded)
+	out, _, code = runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10))
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out, "lane a spoke") {
+		t.Errorf("with nothing running, selection did not pick the newest id:\n%s", out)
+	}
+}
+
+// A step run id belonging to another task is refused, as the endpoint refuses
+// it — the CLI holds the rows already, so it says so without asking.
+func TestTranscriptRejectsAForeignStepRun(t *testing.T) {
+	h := newLiveHarness(t)
+	h.addRun(t, h.taskID, "implement", store.StepSucceeded, lineOutput)
+	other := &store.Task{
+		ProjectID: h.projectID, Title: "other", WorkflowName: "adhoc", WorkflowSnapshot: "x",
+		BaseBranch: "main", BranchName: "b2", State: store.TaskRunning,
+	}
+	if err := h.st.CreateTask(t.Context(), other, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	foreign := h.addRun(t, other.ID, "elsewhere", store.StepSucceeded, lineOutput)
+
+	out, errOut, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(foreign.ID, 10))
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want nothing", out)
+	}
+	if !strings.Contains(errOut, "not found on task") {
+		t.Errorf("stderr = %q, want it to name the task", errOut)
+	}
+}
+
+// Two different 404s, told apart from the step rows rather than from the
+// message: a run that never had a transcript is not a failure, a file that is
+// gone is.
+func TestTranscriptNoTranscriptVersusPrunedFile(t *testing.T) {
+	h := newLiveHarness(t)
+	gate := h.addRun(t, h.taskID, "approve", store.StepSucceeded)
+
+	out, errOut, code := runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(gate.ID, 10))
+	if code != 0 {
+		t.Errorf("exit on a manual gate = %d, want 0", code)
+	}
+	if out != "" {
+		t.Errorf("stdout = %q, want nothing", out)
+	}
+	if !strings.Contains(errOut, "has no transcript") {
+		t.Errorf("stderr = %q, want it to say there is no transcript", errOut)
+	}
+	if n := h.transcriptCalls.Load(); n != 0 {
+		t.Errorf("%d transcript requests; the answer was in the step rows already", n)
+	}
+
+	pruned := h.addRun(t, h.taskID, "implement", store.StepSucceeded, lineOutput)
+	if err := os.Remove(pruned.TranscriptPath); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	_, errOut, code = runCLI(t, "task", "transcript", strconv.FormatInt(h.taskID, 10),
+		"--step", strconv.FormatInt(pruned.ID, 10))
+	if code != 1 {
+		t.Errorf("exit on a pruned transcript = %d, want 1", code)
+	}
+	if !strings.Contains(errOut, "transcript_retention_days") {
+		t.Errorf("stderr = %q, want it to name the retention setting", errOut)
+	}
+}
+
+// Following resumes from X-Next-Offset: no record is printed twice across the
+// seam, none is missed, and the follow ends when the attempt it is printing
+// stops running rather than waiting for a later retry.
+func TestTranscriptFollowResumesWithoutGapOrDuplicate(t *testing.T) {
+	h := newLiveHarness(t)
+	run := h.addRun(t, h.taskID, "implement", store.StepRunning, lineCommandStarted)
+	c, err := apiclient.Discover(h.dataDir)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+
+	var out, errOut lockedBuffer
+	p := &transcriptPrinter{out: &out, errOut: &errOut}
+	next, err := p.print(t.Context(), c, h.taskID, run.ID,
+		apiclient.TranscriptOptions{Tail: apiclient.DefaultTailBytes})
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- p.follow(ctx, c, h.taskID, run.ID, next, followPoll) }()
+
+	h.appendTranscript(t, run, lineOutput)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "looking at the failing test") },
+		"the first appended record")
+	h.appendTranscript(t, run, lineTool)
+	waitFor(t, func() bool { return strings.Contains(out.String(), "> Bash") },
+		"the second appended record")
+
+	// The attempt settles: the follow prints what it wrote on the way out and
+	// then returns, rather than sitting on a task that is finished as far as
+	// this run is concerned.
+	h.appendTranscript(t, run, lineResult)
+	h.setRunState(t, run, store.StepSucceeded)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("follow: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("follow did not end when the run left running")
+	}
+
+	want := []string{
+		"$ go build ./...",
+		"looking at the failing test",
+		"> Bash go test ./internal/store",
+		"= done ($0.0125)",
+	}
+	if got := strings.Split(strings.TrimRight(out.String(), "\n"), "\n"); strings.Join(got, "\n") !=
+		strings.Join(want, "\n") {
+		t.Errorf("followed output =\n%s\nwant each record exactly once, in order:\n%s",
+			strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+	if !strings.Contains(errOut.String(), "is succeeded") {
+		t.Errorf("follow ended without saying why: %q", errOut.String())
+	}
+}


### PR DESCRIPTION
## Summary

The two artifacts a failure is diagnosed from — the daemon log and a step's
transcript — had no command line. Both were reachable only from the TUI, or by
knowing where the files live and reaching for `tail`. That is no help over SSH,
and no help at all when the daemon is the thing that is broken.

**`vincent daemon logs [-n N] [-f]`** prints the tail of
`{data_dir}/logs/daemon.log` — 500 lines by default, the window the TUI's daemon
view shows. It reads the file **from disk and never contacts the daemon**, which
is the point rather than a shortcut: the log is worth reading exactly when the
daemon is not there to serve it. So it needs no daemon, starts none, and can
never exit `2`. A missing file is an error naming the path (`1`); an empty log
prints nothing and succeeds. `-f` re-reads every 2 s and prints only what was
appended, opening and closing the file on each poll — the daemon rotates by
renaming, and a follower holding a handle would break that rotation on Windows.
There is no `--data-dir`: directories resolve through `config.ResolveDirs` like
every other subcommand (the flag on `vincent daemon` itself exists for the
Windows Scheduled Task, which has no environment).

**`vincent task transcript <id> [--step RUN] [-f] [--json|--raw]`** prints one
attempt's transcript — the record `task show` only names the file of. It is a
thin API client; no daemon-side change was needed, since the endpoint already
served `format=raw|normalized`, `offset`/`tail` and a record-boundary
`X-Next-Offset`.

- `--step` takes a **step_run id** (the `RUN` column), unambiguous across
  retries. Omitted: the running attempt, else the newest by run id — creation
  order, which stays chronological when a task has parallel steps or fan-out
  lanes and the step order does not.
- `--json` keeps its meaning everywhere else in the tree — vincent's typed JSON,
  here the normalized records as NDJSON including `vincent.*` annotations.
  `--raw` is the new flag for the agent's own dialect, byte for byte; it
  deliberately bypasses `decodeTranscript`, which tolerantly drops lines it
  cannot parse (right for a renderer, wrong for a flag promising the file's
  bytes).
- `-f` polls the endpoint rather than subscribing to §13.3's live stream: live
  chunks are *dropped* for slow subscribers because the transcript file is the
  durable copy, and a CLI writing into a slow pipe is exactly that subscriber.
  Follow ends when that attempt stops running — a later retry is a different run.
- A manual gate has no transcript, which is decided from the step rows the
  command already holds and reported on stderr with exit **0**, without calling
  the endpoint. A 404 that does come back therefore means the file was pruned or
  removed: exit **1**, naming `transcript_retention_days`. No message-string
  matching.
- Everything a reader reads goes to stdout, including a command step's
  `stream: stderr` output, tagged `[stderr]`: a transcript is one interleaved
  stream and two file descriptors would scramble the ordering. The command's own
  diagnostics go to stderr, so stdout stays pipeable.

One bug was caught by the new tests and fixed in `internal/apiclient`: the shared
request helper deferred a body close against a named response it sets to `nil` on
the error path, which panicked on any non-2xx. It is closed explicitly now.

## Related

Closes #92
Closes 044.1–044.5 (`docs/tasks/044-cli-logs-and-transcripts.md`), the record of
the nine decisions behind this and the alternatives they beat.

Spec §12.1 amended in place with a dated note (*Added 2026-08-28 (task 044)*):
two rows in the command table, why `daemon logs` reads disk rather than the API,
and why `GET /v1/daemon/logs` is left for the first client that is not on the
daemon's machine.

Task 025 decision 12 (`retry`, `repair`, `skip`, `approve` stay TUI-and-API only)
is **not** revisited: it is about §6 human actions — writes — and reading a
transcript is neither. §17's "Entry point" note about `vincent doctor` is not
revisited either; doctor answers "why is nothing running?" in one pass with a
fixed 20-line tail, and `daemon logs` answers "what is the daemon doing right
now". Doctor's row is unchanged.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

**Tests.** `internal/cli/logs_test.go`: the tail and `-n`, a missing file
(errors naming the path, exit 1) against an empty one (silent, exit 0), a follow
that prints each appended line exactly once and never the opening window again,
and a **rotation mid-follow** — the file is renamed while `-f` runs, which is the
Windows fault the open/read/close contract exists to prevent, and the fresh file
is picked up after the gap where no log exists. `internal/cli/transcript_live_test.go`
runs against the **real API handlers** over `httptest` (the convention that keeps
client and server wire types from drifting): the whole record vocabulary
including a `vincent.*` annotation the renderer does not name and the
`agent.usage` it drops, `--raw` byte-identical to the file including a line the
normalizer's decoder would have dropped, `--json` as one decodable record per
line with its annotation fields intact, default selection on a task whose
`step_index` order disagrees with its id order (running first, then newest id), a
`--step` naming another task's run, the two different 404s — with the manual-gate
case asserted to make **no** endpoint request — and a follow across the
`NextOffset` seam with no duplicate and no gap, ending when the run leaves
`running`. `docs_claims_test.go` gains a drift check holding every command in the
cobra tree to a mention on `docs/reference/cli.md`.

**Docs.** `docs/reference/cli.md` (both commands), `docs/reference/files.md`
(`logs/daemon.log` is no longer TUI-only), `docs/guides/troubleshooting.md` (the
three places that sent a reader to the file by hand), `docs/guides/scripting.md`
(the `transcript --json | jq` and `daemon logs` recipes), `docs/spec.md` §12.1,
`docs/tasks/044-*` plus its index row, and `CHANGELOG.md`.

A documentation audit over every derivation afterwards found two more pages
carrying the same claims, fixed in a separate `docs:` commit:
`docs/features.md`'s "Diagnose and maintain it" section enumerates the
diagnostic command surface and listed only `doctor`, `gc` and `daemon
backup`/`restore`; and `docs/reference/configuration.md`'s `log_level` entry
names who reads `daemon.log` and said "the TUI's daemon view" — the same
sentence `docs/reference/files.md` was corrected for. Nothing else was stale:
`internal/config`, the `internal/api` route table, `internal/tui/bindings.go`,
the `Reason*` constants, `internal/workflow`/`internal/taskrun`'s step types and
`internal/agent/*` are all untouched by this change, so the pages derived from
them — configuration (beyond that one sentence), API, TUI keys, block reasons,
workflow schema, task lifecycle and agents — were already true, and
`skills/vincent-workflows/SKILL.md` needs no edit because the workflow schema
did not move. No gate walks either command; no TUI panel changed, so the
screenshots under `docs/assets/` are current.

**Verification.** `go run mage.go test` green on macOS, `go run mage.go lint`
0 issues, and `golangci-lint` cross-run for `windows`, `darwin` and `linux`
0 issues each. `go test -race ./internal/cli ./internal/apiclient` green. Two
earlier full-suite runs each hit one *pre-existing* GitHub e2e test
(`TestGitHubIssueCommandsAgainstLiveDaemon`, `TestGitHubUnusableLeavesTaskCreationAlone`)
timing out on a 10 s HTTP client deadline against a real daemon under full-suite
load; both pass in isolation, they are unrelated to this change, and the suite
was green on the following run.

A repair pass has since proved that finding rather than assumed it. Under a
reproduced load (five sibling worktrees verifying at once, load average ~36 on
10 cores, plus `go test -race ./internal/api ./internal/taskrun ./internal/store
./internal/worktree ./internal/doctor`), **`master` fails the same two tests
with the same `GET /v1/doctor: context deadline exceeded` at the same 10.0 s**,
from a worktree checked out at `master` with none of this branch's code in it.
The mechanism is environmental and structural, not a race: `doctor.Compose`
probes the agent CLIs actually on PATH, and this machine has real `claude`,
`codex` and `cursor-agent` installed — `cursor-agent status` alone costs ~2.3 s
idle because it is an authenticated network call, and `github.ProbeTimeout` is
10 s on its own — against `apiclient`'s flat `requestTimeout = 10 * time.Second`
(`internal/apiclient/client.go:17`). CI passes because no agent CLI is installed
there. Nothing on this branch touches `internal/doctor`, `internal/github`,
`internal/agent` or `internal/apiclient/client.go`; the branch's own additions
to `internal/cli` are in files that sort *after* `github_e2e_test.go` and so run
after it. Giving the doctor call a budget of its own is a real follow-up, but it
is a change to shared client behavior that this brief did not agree, so it is
left alone here. No gate script: neither command changes daemon
behavior, and both are covered in-process against the real handlers.
