### PR TITLE
Notify hook: let the daemon signal a human outside the TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ list with the user-facing context a commit subject cannot carry.
   while staying safe to leave in a CI log. See
   [Scripting vincent](docs/guides/scripting.md#supplying-task-fields).
 
+- **vincent can now tell you it needs you, with nothing open.** Point
+  `notify.command` in `config.yaml` at a program and the daemon runs it whenever
+  a task enters one of the states you list in `notify.on` — `blocked`,
+  `awaiting_gate`, `awaiting_input`, `done`, or any other state from the task
+  lifecycle. It writes a JSON envelope to the command's standard input: task id
+  and title, the transition, `block_reason`, the project, the workflow, the step
+  cursor, the branch and worktree path, and on `awaiting_input` the agent's
+  question — enough for a one-line script to write a message without calling
+  back into the API. Until now the only alert in the whole system was the TUI's
+  terminal bell, which rings on `awaiting_input` and only while a board is open,
+  so a task could wait a full day for an answer, fail on the timeout, and the
+  first you knew was the next time you looked. `command` is argv, not a shell
+  line, so it composes with `terminal-notifier`, `notify-send`, `msg`, a Slack
+  `curl` or a file drop without vincent picking a notification stack. It is
+  **off unless you configure it**, it hot-reloads like everything else in the
+  file, and an unknown state name fails the load naming the value rather than
+  silently never firing. Delivery is deliberately modest: root tasks only (a
+  fan-out lane does not send its own message), at most four notifiers at once
+  drained from a bounded queue, a fixed 10-second budget after which the
+  command's process tree is killed, failures logged and never retried, and
+  nothing replayed for events that happened while the daemon was down. A
+  notifier that hangs or fails changes nothing about the task it was about.
+  Documented in the
+  [configuration reference](docs/reference/configuration.md#notify) and the
+  [security model](docs/security-model.md) — it is code the daemon runs as you,
+  and its argv can hold a webhook secret, which is why it is not readable back
+  through the API.
+
 - **Creating a task can now be retried safely.** If the daemon commits your task
   but you never see the response — a timeout, a dropped connection, a script
   that dies mid-`curl` — re-sending the request used to create a second task, a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,12 @@ Requires bash, go, git, curl, jq.
 ## Architecture
 
 Dependency direction is one-way: `cli` → `tui`/`daemon`; `daemon` wires
-`store` + `workflow` + `scheduler` + `taskrun` + `events` + `api`; leaf packages
-(`taskstate`, `gitx`, `procx`, `version`, `config`) depend on nothing internal.
+`store` + `workflow` + `scheduler` + `taskrun` + `events` + `notify` + `api`;
+leaf packages (`taskstate`, `gitx`, `procx`, `version`, `config`) depend on
+nothing internal — with one deliberate exception: `config` imports `taskstate`,
+and only `taskstate`, to validate `notify.on` against §6's state vocabulary
+rather than keeping a second copy of it (task 046 decision 4). `taskstate` is
+itself a leaf, so the direction stays one-way.
 `internal/daemon/daemon.go:Run` is the single wiring point — read it first to see
 how the pieces connect.
 
@@ -234,6 +238,7 @@ is a correctness bug, not a style issue:
 | `internal/taskrun` | Step executors — agent, command and manual are the ones that run something; `parallel`, `fan_out`, `condition`, `loop` and `break` are structure, `check` is a *field* agent and command steps may carry, never a type, and `include` never arrives at all — it is spliced away at task creation (§7.9) — plus guards (`if:`, §7.7), loop iteration (§7.8), retries, timeouts, human actions, recovery, transcripts |
 | `internal/agent` | `AgentAdapter` interface + option catalog; `agent/claude`, `agent/codex`, `agent/cursor` implement it |
 | `internal/worktree` | Per-task git worktrees, `vincent/{id}-{slug}` branches, dirty detection |
+| `internal/notify` | The outward signal (§12.3, task 046): a broker subscriber that spawns `notify.command` when a task enters a state in `notify.on`, with an enriched JSON envelope on the child's stdin. Bounded queue, four workers, fixed 10 s per child, no replay |
 | `internal/tui` | Bubble Tea client: six views (board, detail, new-task, projects, workflows, daemon) routed by `viewID` |
 
 Adapters differ in what they *can* do, and the differences are documented, never

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,7 +13,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Workflows | Validated YAML, templates, declared task fields, checks, retries, timeouts, platform restrictions |
 | Control flow | Parallel groups, isolated fan-out and merge, conditions, loops, breaks, reusable workflow includes |
 | Agents | Claude Code, Codex, and Cursor; per-workflow, per-step, and per-task selection |
-| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents, follow-up runs on finished tasks |
+| Human oversight | Approval gates, mid-run answers where supported, blocked-step recovery, edit-and-retry, ad-hoc repair agents, follow-up runs on finished tasks, a notify hook that reaches you with no client open |
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | GitHub | Create a task from an issue, prefilled and editable; issue details in templates; read-only, no stored credential |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
@@ -138,6 +138,16 @@ Human oversight is part of the workflow instead of an informal terminal habit:
   from inside an agent or command step reports a line that shows live on the
   board and stays on the finished attempt as the step's own account of how it
   went. It is opt-in per workflow — vincent never asks an agent for it.
+
+- **Be told when you are needed, with nothing open.** Point `notify.command` at
+  a script and the daemon runs it whenever a task enters a state you listed —
+  `blocked`, `awaiting_gate`, `awaiting_input`, `done` — writing a JSON envelope
+  with the task, the transition, the reason and the agent's question to its
+  standard input. It composes with whatever you already use:
+  `terminal-notifier`, `notify-send`, `msg`, a Slack `curl`, a file drop. That
+  is the point of walking away: the daemon is designed to run with no client
+  attached, and this is how it says it needs you. See
+  [`notify`](reference/configuration.md#notify).
 
 The daemon computes the actions valid in each state and sends that list to
 every client, so the TUI, CLI, and API agree on what can happen next. See the

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -281,6 +281,38 @@ scrollback. Omit it for the raw file, byte for byte. `X-Next-Offset` on the
 response is where a follow-up fetch resumes — always on a record boundary, never
 mid-line.
 
+### Being told without holding a connection open
+
+A long-lived SSE reader is the right tool for a dashboard and the wrong one for
+"text me when something blocks". For that, let the daemon spawn your script:
+
+```yaml
+# config.yaml
+notify:
+  on: [blocked, awaiting_gate, awaiting_input]
+  command: ["/usr/local/bin/vincent-notify"]
+```
+
+The daemon runs that command on every matching transition and writes a JSON
+envelope — task id and title, `from`/`to`, `block_reason`, project, workflow,
+step cursor, branch, worktree path, and the agent's question on
+`awaiting_input` — to its standard input. No token, no cursor, no reconnect
+loop, and nothing to keep alive: the daemon is already the process with the
+supervised lifetime.
+
+```sh
+#!/bin/sh
+# /usr/local/bin/vincent-notify
+jq -r '"vincent: #\(.task_id) \(.title) → \(.to) \(.block_reason)"' \
+  | xargs -I{} curl -fsS -XPOST -d "text={}" "$SLACK_WEBHOOK"
+```
+
+`command` is argv, not a shell line, and there is a fixed 10-second budget per
+run. See [`notify`](../reference/configuration.md#notify) for the full envelope
+and the delivery guarantees, and the
+[security model](../security-model.md) for what it means that the daemon runs
+it as you.
+
 ## A worked example
 
 Create a task, wait for it to leave `running`, and report what happened:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -632,6 +632,101 @@ your own host, enterprise and SSO configuration — and otherwise reads
 described under [environment variables](#environment-variables), and
 `vincent doctor` reports which one is in play.
 
+### `notify`
+
+```yaml
+notify:
+  on: [blocked, awaiting_gate, awaiting_input, done]
+  command: ["/usr/local/bin/notify-me"]
+```
+
+Run a command when a task enters one of these states. **Off by default** — both
+keys are empty, and nothing is spawned.
+
+It exists because vincent's premise is that you start work and walk away, and
+the daemon is designed to run with no client attached. Without this, the only
+alert in the whole system is the TUI's terminal bell, which rings on
+`awaiting_input` and only while a board is open: a task could wait a full day
+for an answer, fail on the timeout, and the first you knew was the next time you
+looked.
+
+**`on`** is a list of [task states](task-lifecycle.md). Any of the ten is
+accepted; the four above are the ones worth waking up for. A name that is not a
+state **fails the load** and names the value, so the daemon keeps its last good
+configuration rather than silently never firing.
+
+**`command`** is **argv, not a shell line**. The first element is the program;
+the rest are passed through unchanged. Nothing is expanded, split, quoted or
+interpreted, and there is no shell on any platform — `command: ["notify.sh
+--urgent"]` looks for a program with a space in its name. Both keys are needed:
+either one alone loads, warns in the log, and never fires.
+
+#### The envelope
+
+The daemon writes one JSON object to the command's standard input and closes it.
+It is enriched on purpose: a notifier told only `{task_id, to}` would have to
+call back into the API with a bearer token to say anything useful, which defeats
+a one-line script.
+
+```json
+{
+  "event_id": 1841,
+  "ts": "2026-08-28T09:30:00Z",
+  "type": "task.state_changed",
+  "task_id": 42,
+  "title": "Fix the flaky gate",
+  "from": "running",
+  "to": "blocked",
+  "block_reason": "step_failed",
+  "queued_reason": "",
+  "current_step": 2,
+  "steps_total": 5,
+  "worktree_path": "/Users/you/.local/share/vincent/worktrees/42",
+  "branch": "vincent/42-fix-the-flaky-gate",
+  "project_id": 7,
+  "project": "vincent",
+  "workflow": "review"
+}
+```
+
+`block_reason` is empty unless `to` is `blocked`. A transition into
+`awaiting_input` additionally carries the agent's question:
+
+```json
+  "input": { "kind": "question", "summary": "Which migration should I keep?" }
+```
+
+`steps_total` comes from the task's own workflow snapshot, so it is the count
+for *that run* even if the workflow file has been edited since.
+
+A one-liner that turns it into a desktop notification on macOS:
+
+```sh
+#!/bin/sh
+jq -r '"\(.title) → \(.to)"' | xargs -0 terminal-notifier -title vincent -message
+```
+
+#### What it does and does not promise
+
+| | |
+|---|---|
+| **Root tasks only** | A `fan_out` lane is a task of its own, so a twenty-lane tree would send twenty-one messages. Lanes are skipped; the parent's own transitions fire. |
+| **At most 4 at once** | Drained from a 64-entry queue. Five tasks blocking together all notify; only a genuinely full queue drops, and a drop is logged. |
+| **10 s per command** | Fixed, not configurable. Past it the command's whole process tree is killed and the failure is logged. |
+| **Never retried** | A failure is logged with the exit code and the tail of its stderr, and dropped. |
+| **Never replayed** | Only transitions the running daemon observes fire. A weekend of downtime does not produce a storm on the next start. |
+| **Never blocks a task** | A notifier that hangs, fails or is missing changes nothing about the task it was about. |
+
+The environment the command inherits is the one
+[`environment`](#environment) resolves, like every other process the daemon
+spawns. It gets **no** `VINCENT_*` variables — those belong to command steps —
+because the envelope on stdin is this hook's whole contract.
+
+Read per event, so a [reload](#reload-semantics) governs the next transition. It
+is not served on `GET /v1/config`: no client needs it, and `command` can
+reasonably hold a webhook URL with a token in it. See the
+[security model](../security-model.md) for what running it means.
+
 ### `tui`
 
 ```yaml

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,6 +32,12 @@ Omitted keys keep their built-in defaults, so a partial file is fine.
 This is what first start writes, verbatim:
 
 ```yaml
+# vincent daemon configuration (spec §12.3).
+# Generated with defaults on first start. Edit freely: the daemon watches this
+# file and hot-reloads valid changes. Invalid edits are logged and rejected,
+# and the last good configuration stays active. Changes to "listen" take
+# effect on the next daemon restart.
+
 # Address the HTTP API binds to. Loopback only. Port 0 picks an ephemeral
 # port, published for clients in {data_dir}/daemon.json.
 listen: 127.0.0.1:0
@@ -41,6 +47,8 @@ listen: 127.0.0.1:0
 max_parallel_tasks: 3
 
 # Fallback step timeouts, used when a workflow step declares none.
+# input_timeout bounds each wait for an answer to an agent's input request
+# (awaiting_input, §7.4); on expiry the attempt fails under the retry policy.
 defaults:
   agent_timeout: 60m
   command_timeout: 15m
@@ -61,33 +69,53 @@ delete_remote_branch_on_archive: false
 # Transcripts of archived tasks older than this many days are pruned.
 transcript_retention_days: 90
 
-# Per-attempt transcript cap.
+# Per-attempt transcript cap. A step whose transcript passes this fails with
+# transcript_limit rather than filling the disk.
 transcript_max_bytes: 512MB
 
-# Ceiling on what one task may spend, in US dollars. 0 disables it.
+# Ceiling on what one task may spend, in US dollars, summed over every attempt
+# of every step it runs. Past it the task blocks with cost_limit at the next
+# attempt boundary, so expect to overshoot by at most one attempt; raise this
+# and retry to carry on. 0 disables it, which is the default.
+#
+# It counts one task. Each fan_out lane is its own task and gets its own
+# budget, so a tree of twenty lanes may spend twenty times this. Only agents
+# that report cost are counted — codex and cursor report none, so the cap is
+# inert on them.
 max_task_cost_usd: 0
 
-# How long a quota-stopped task waits when the agent CLI named no reset time.
+# How long a task waits before trying again after its agent reported that the
+# usage quota for the window is spent, when the CLI named no reset time. When
+# it does name one, that wins and this is unused. The task keeps its place in
+# the queue and holds no slot while it waits.
 usage_limit_recheck_interval: 15m
-
-# Sub-steps of one `parallel` step group running at once.
-parallel:
-  max_parallel: 4
-
-# Bounds on a `type: fan_out` tree, checked at task creation.
-fan_out:
-  max_depth: 3
-  max_tasks: 64
-
-# Ceiling on a `type: loop` step's iterations.
-loop:
-  max_iterations: 10
 
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
-# Record how every step was actually invoked in its transcript.
+# Record how every step was actually invoked in its transcript: resolved
+# agent/model/effort, permission mode, working directory, and the full argv.
+# Turn this on when a run does something you cannot explain, then paste the
+# transcript. Off by default because argv includes the rendered prompt.
 debug: false
+
+# What child processes — agent steps, command steps and their checks —
+# inherit from the daemon (T4.23). Resolved in one order: inherit, then
+# unset, then set. Command steps layer the VINCENT_* variables and their own
+# "env:" on top, so those are never affected.
+#
+# The default inherits everything, which is what the daemon always did
+# implicitly. Pin it when a run has to be reproducible, or drop a single
+# variable that breaks a CLI — on Windows, a daemon started from Git Bash
+# carries MSYSTEM, which blocks every cursor tool call.
+#
+# Values under "set" are literal: "$" is not special and nothing is expanded.
+environment:
+  inherit: all          # all | none | a list of names, e.g. [PATH, HOME]
+  # unset:
+  #   - MSYSTEM
+  # set:
+  #   LANG: C.UTF-8
 
 # Agent CLI locations. An empty path resolves the binary from PATH.
 agents:
@@ -95,6 +123,8 @@ agents:
     path: ""
   codex:
     path: ""
+  # cursor resolves the "cursor-agent" binary — not "cursor", which is the
+  # editor launcher (§9.7).
   cursor:
     path: ""
 
@@ -110,7 +140,41 @@ agents:
 github:
   enabled: true
 
-# What clients render, not what the daemon does.
+# Tell someone when a task needs them, without a client attached (task 046).
+# The daemon runs "command" whenever a task enters one of the states in "on",
+# and writes a JSON envelope describing the transition to the command's stdin
+# — task id and title, from/to, block_reason, project, workflow, step cursor,
+# branch and worktree path — so a one-line script can write a message without
+# calling back into the API.
+#
+# "command" is argv, not a shell line: nothing is expanded, quoted or split,
+# and there is no shell on any platform. Both keys are needed; either alone
+# loads and warns. Off by default.
+#
+# The states are the ones from §6, most usefully: blocked, awaiting_gate,
+# awaiting_input, done. Only root tasks notify — a fan_out lane is a task row,
+# and a twenty-lane tree would otherwise send twenty-one messages.
+#
+# It is fire-and-forget: at most 4 notifiers run at once, a child is killed
+# after 10 seconds, failures are logged and never retried, and nothing is
+# replayed for events that happened while the daemon was down.
+#
+# WARNING: this is arbitrary code the daemon runs as you, and its argv can
+# carry a secret (a webhook URL), which is part of why this file is
+# owner-only.
+#
+# notify:
+#   on: [blocked, awaiting_gate, awaiting_input]
+#   command: ["/usr/local/bin/notify-me"]
+
+# What clients render, not what the daemon does. The daemon validates these,
+# hot-reloads them and serves them on GET /v1/config; the TUI reads them from
+# there.
+#
+# group_by nests the task table under headers, outermost level first. Accepted
+# levels: project, workflow. Use [] for one flat list of tasks. A grouped
+# level drops its own column — the header already names it — and "g" cycles
+# the grouping for the session without touching this file.
 tui:
   board:
     group_by: [project, workflow]
@@ -681,7 +745,7 @@ a one-line script.
   "queued_reason": "",
   "current_step": 2,
   "steps_total": 5,
-  "worktree_path": "/Users/you/.local/share/vincent/worktrees/42",
+  "worktree_path": "/home/you/.local/share/vincent/worktrees/42",
   "branch": "vincent/42-fix-the-flaky-gate",
   "project_id": 7,
   "project": "vincent",

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -213,6 +213,27 @@ every rendered prompt and everything the agents did, plus your `config.yaml`.
 It does *not* carry the API token. Treat the file the way you would treat the
 data directory it came from.
 
+## The notify hook runs your code
+
+`notify.command` in `config.yaml` is a program the **daemon** runs, as you,
+whenever a task enters a state you listed. It is the same trust level as
+everything else on this page — an agent step already runs arbitrary commands as
+you — but it is worth stating rather than leaving implicit:
+
+- Nothing from a task, an agent or the API reaches its argv. It is exactly what
+  the owner of `config.yaml` wrote, and it is **argv, never a shell string** on
+  every platform, so a task title cannot be interpreted as a command.
+- **Its argv can hold a secret.** A webhook URL with a token in it is the
+  obvious case. That is a second reason `config.yaml` and its directory are
+  owner-only, and the reason `notify` is not served on `GET /v1/config` — a
+  client with a valid token still cannot read it back.
+- Whatever your notifier does with the envelope is outside vincent. The envelope
+  carries the task title and the agent's question summary, so a hook that posts
+  to a shared channel publishes both.
+
+It is off unless you configure it. See
+[`notify`](reference/configuration.md#notify).
+
 ## Tightening it
 
 In rough order of value:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -70,7 +70,15 @@ amendments in this specification record superseded boundaries, while
 
 - Web UI (the API is designed for it; it is not built in v1).
 - Multi-user / remote access / multi-host orchestration.
-- OS desktop notifications.
+- OS desktop notifications. *Amended 2026-08-28 (task 046, issue #90): the
+  **platform-native notification stack** is still deferred — three backends and
+  a packaging story for one hard-coded delivery channel. What was never decided
+  here is that the daemon may not signal outward at all, and that is what
+  `notify:` (§12.3) now does: it runs a command of the user's choosing when a
+  task enters a state they named, which reaches `terminal-notifier`,
+  `notify-send` and `msg` as easily as it reaches Slack, mail or a file drop.
+  The exec hook is the reason the native stack is now cheap to leave deferred
+  rather than the reason to build it.*
 - LLM-as-judge step verification.
 - Workflow branching or conditionals within one task. *Amended 2026-08-17
   (task 014): parallel steps and step fan-out are no longer deferred —
@@ -105,7 +113,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 19 | Name | `vincent` |
 | 20 | v1 scope | Everything above, both agent adapters |
 | 21 | Agent/model/effort selection | Adapter-native values; per-step resolution `step > task override > workflow defaults > adapter default` with agent-scoped inheritance; options probed ad hoc from the installed CLIs, merged with a curated catalog, free text always allowed (§8.6, §9.6) |
-| 22 | Agent input requests | Structured requests only (`question`/`permission`); new `awaiting_input` state that keeps its slot; step clock pauses, bounded by `input_timeout` (default 24h); normalized schema + raw passthrough; `POST /v1/tasks/{id}/answer`; per-adapter capability (claude yes, codex no); `on_input: wait\|deny` opt-out; TUI-level alerts only (§6, §7.4, §13.2, §15) |
+| 22 | Agent input requests | Structured requests only (`question`/`permission`); new `awaiting_input` state that keeps its slot; step clock pauses, bounded by `input_timeout` (default 24h); normalized schema + raw passthrough; `POST /v1/tasks/{id}/answer`; per-adapter capability (claude yes, codex no); `on_input: wait\|deny` opt-out; TUI-level alerts only (§6, §7.4, §13.2, §15). *Narrowed 2026-08-28 (task 046, issue #90): "TUI-level alerts only" decided how one agent question is normalized, surfaced and answered **inside a client** — it did not decide that the daemon may never signal outward, and it never spoke to `blocked` or `awaiting_gate` at all. The daemon-side `notify:` hook (§12.3) signals on any §6 state and leaves the TUI bell exactly as it was.* |
 
 | 23 | Parallel steps | `type: parallel` runs sub-steps concurrently in the task's one worktree: one step, one index, one slot, no branch and no merge. `manual`, nested groups and `on_input: require` are refused inside one; `max_parallel` (default 4) is a second concurrency dimension the §11 caps do not govern (§7.5, task 014) |
 | 24 | Workflow fan-out | `type: fan_out` makes each lane a real child task with its own worktree and branch, merged back `--no-ff` in declared order at the end of the same step. The parent parks in `awaiting_children` holding no slot, so no depth deadlocks; a conflict blocks by default, a lane that did not finish blocks the join, and the tree's bounds are checked at creation (§7.6, task 014) |
@@ -3048,6 +3056,9 @@ agents:
   cursor: { path: "" }         # resolves `cursor-agent`, never `cursor` (§9.7)
 github:
   enabled: true                # read GitHub issues, so a task can be created from one (§13.2)
+notify:                        # run a command when a task enters one of these states (task 046)
+  on: []                       # §6 state names; [] (the default) fires nothing
+  command: []                  # argv, never a shell string; the envelope arrives on stdin
 tui:                           # view preference; the daemon validates and relays it (§15)
   board:
     group_by: [project, workflow]  # task-table grouping, outermost first; [] = flat
@@ -3115,6 +3126,74 @@ costs nothing unasked for. Setting it to `false` stops the daemon reading
 GitHub entirely: the TUI's issue row disappears, `GET
 /v1/projects/{id}/github` answers `disabled`, and `github_issue` on `POST
 /v1/tasks` is refused.
+
+**`notify` (task 046, added 2026-08-28; issue #90).** The daemon's outward
+signal. When a task enters one of the states in `on`, the daemon runs `command`
+and writes a JSON envelope describing the transition to the child's stdin.
+
+It exists because §2's third goal is a daemon that runs with **zero clients
+attached**, and the one thing it could not do with zero clients attached was say
+it needed a human: the only alert in the tree is the TUI's terminal bell (§15),
+which rings on a transition into `awaiting_input` and only while a board is
+open. A task could sit in `awaiting_input` for the whole 24-hour `input_timeout`
+(§7.4), fail on expiry, and the first anyone knew was the next time they opened
+the board. `blocked` and `awaiting_gate` had no alert at all.
+
+*The selector is target **states**, not event types.* `on` lists §6 state names,
+matched against the `to` field of `task.state_changed` — exactly what the TUI
+bell keys off. No event type is introduced for this (§13.3). A name outside §6's
+vocabulary **fails the load**, naming the offending value, so a typo is refused
+whole and the watcher keeps the last good configuration.
+
+*The payload is an enriched envelope, assembled by the daemon*, not the raw
+`events` row: a notifier handed `{task_id, to}` cannot write a message without
+calling back into the API with a bearer token, which defeats the point of a
+one-line script. One JSON object, on stdin: `event_id`, `ts`, `type` (always
+`task.state_changed`); `task_id`, `title`, `from`, `to`, `block_reason` (empty
+unless `to` is `blocked` — §14's rule that a block reason means "set while
+blocked"), `queued_reason`, `current_step`, `steps_total`, `worktree_path`,
+`branch`; `project_id`, `project`, `workflow`; and `input` (`{kind, summary}`)
+on a transition into `awaiting_input`, taken from what that §7.4 transition
+already carries. `steps_total` comes from the task's own workflow snapshot,
+which is the honest *n* for that run.
+
+*Global, not per-project, and hot-reloading.* Projects are database rows, not
+YAML, so a per-project override would need a column and API surface for a case
+nobody has asked for. The hook reads the current configuration per event, so an
+edit takes effect on the next transition with no restart.
+
+*Only **root** tasks notify.* A `fan_out` lane is an ordinary task row (§7.6),
+so a twenty-lane tree reaching `done` would otherwise produce twenty child
+notifications on top of the parent's. A task whose `parent_task_id` is non-null
+is skipped: the parent's own `awaiting_children` → `running` → `done` is the
+human-meaningful signal, a lane that blocks blocks its parent's join, and a lane
+finishing is machinery. There is deliberately no `include_children` key.
+
+*Delivery is fire-and-forget, bounded, and does not replay.* At most **4**
+notifier processes run at once, drained from a bounded **64**-entry FIFO;
+`command` is argv and never a shell string, because there is no portable shell
+to assume; a child gets a **fixed 10 s** and then its whole process tree is
+killed. The timeout is not configurable, and that is the same posture as
+transcript pruning: a daemon that stops serving because a notifier hung has its
+priorities backwards. Only a full *queue* drops — the ordinary burst of five
+tasks blocking at once, which is exactly when the feature earns its keep, is
+lossless. Failures are logged and never retried, nothing is persisted, and
+**nothing is replayed on restart**: a weekend of downtime must not produce a
+notification storm on the next start.
+
+Children inherit the `environment` policy above like every other process the
+daemon spawns, and get **no** `VINCENT_*` variables — those are §8.5's contract
+for command steps, and the envelope on stdin is this hook's.
+
+Both keys are needed. `command` with an empty `on`, and `on` with no `command`,
+both load, take effect and can never fire; each is a startup/reload **warning**
+rather than a load failure, for the reason
+`delete_remote_branch_on_archive`'s is: commenting `command` out for an
+afternoon should not revert every unrelated edit in the same save.
+
+`notify` is deliberately **not** exposed on `GET /v1/config`: that response is a
+curated DTO for clients (§13.2), no client needs this, and `command` can
+reasonably carry a webhook URL with a token in its argv (§16).
 
 There is deliberately **no token key here**. Vincent stores no credential of
 its own: it drives `gh` when that is installed and authenticated, and otherwise
@@ -3834,6 +3913,12 @@ Two kinds of streams:
    `task.created`, `task.state_changed`, `task.priority_changed`, `task.step_advanced`,
    `task.status_changed`, `task.children_changed`, `project.*`,
    `workflow.registry_changed`, `agent.quota_changed`, `daemon.shutting_down`.
+   *Amended 2026-08-28 (task 046, issue #90): the `notify:` hook (§12.3)
+   introduces **no new event type**. Its selector reads the `to` field of
+   `task.state_changed`, the way the TUI bell does; `task.blocked` and
+   `task.gate_pending` do not exist and were not invented for it. The hook is a
+   daemon-side subscriber on this same post-commit fan-out, one hop downstream
+   of the store's event hook, and it never blocks the publishing goroutine.*
    (`task.created` — *amended 2026-08-28, task 043* — carries
    `workflow_origin` beside `workflow`: the scope, scope-relative file and
    source digest the task's workflow name resolved to (§5.3), omitted only for
@@ -4154,7 +4239,11 @@ stream for the live tail.
    a human (`awaiting_input`, `awaiting_gate`, `blocked`) are pinned to the top
    with a distinct badge, and the TUI rings the terminal bell when a task enters
    `awaiting_input` — most terminals flash/badge the window even unfocused
-   (§7.4). OS desktop notifications remain out of v1 (§20).
+   (§7.4). OS desktop notifications remain out of v1 (§20). *Amended 2026-08-28
+   (task 046): the bell is **unchanged** — it is still the in-client alert and
+   still rings only on `awaiting_input`. Signalling outside a client is the
+   daemon's `notify:` hook (§12.3), which is independent of it in both
+   directions.*
    **Grouped by default (task 009, added 2026-08-16):** the rows nest under group
    headers — projects, and the workflows of a project inside it — configured by
    `tui.board.group_by` (§12.3) and cycled for the session with `g`. See
@@ -4751,6 +4840,18 @@ currently true to show (§15 view 6).
   `--dangerously-skip-permissions` (claude),
   `--dangerously-bypass-approvals-and-sandbox` (codex), `--force` (cursor).
   Cursor's reads mildest and is not; the first-run notice covers all three.
+- **`notify.command` is arbitrary code the daemon runs as the invoking user.**
+  *Added 2026-08-28 (task 046, issue #90).* It is spawned by the daemon, not by
+  an agent or a task, and nothing from a task, an agent or the API reaches its
+  argv — it is exactly what the owner of `config.yaml` wrote. That is consistent
+  with the posture above rather than a new risk: an agent step already runs
+  arbitrary commands as this user. Two consequences are worth stating rather
+  than leaving implicit. Its argv can carry a **secret** — a webhook URL with a
+  token in it is the obvious use — which is a second reason `config.yaml` and
+  its directory are owner-only (§12.2, the 2026-08-25 amendment above), and it
+  is why `notify` is not served on `GET /v1/config`. And it is argv, never a
+  shell string, on every platform: nothing is expanded, split or quoted, so a
+  task title cannot reach a shell through it.
 - **Vincent writes to one CLI's own config**: a cursor step passes `--model`,
   which cursor persists to `~/.cursor/cli-config.json` (§9.7). It is not a
   secret and not an escalation, but it is the one place vincent mutates state
@@ -4844,6 +4945,20 @@ currently true to show (§15 view 6).
   scans and ride the deliberately cold one (§13.2). Every figure is the daemon's —
   only it opens SQLite (§4), so a client with no daemon reports them **unknown**
   rather than opening the file itself, exactly as the existing database rows do.
+
+**What the notify hook logs (task 046, added 2026-08-28).** The `notify:` hook
+(§12.3) is invisible by construction — it runs a process that reports to
+somewhere else — so the daemon log is the only place its behaviour surfaces. A
+fire is logged at **debug**, with the task, the target state, the event id and
+`command[0]`; the command's arguments are not logged, because argv can carry a
+webhook secret (§16). Four things are logged at **warn**, each once and never
+retried: a non-zero exit, with the exit code and a truncated tail of the
+child's stderr; a child killed at the 10 s timeout; an event dropped because
+the queue was full, with the capacity; and a task the notification could not be
+read for. A skipped `fan_out` lane is debug, not warn — it is the designed
+behaviour, not a fault. Nothing here touches task state, a step run or the exit
+code of anything: a notifier that fails loses one notification and nothing
+else.
 
 ## 18. Edge cases and errors
 
@@ -5088,7 +5203,13 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
 ## 20. Future work (explicitly out of v1)
 
 - Web UI on the same API; auth story for non-loopback exposure.
-- OS desktop notifications (blocked / gate / awaiting input / done) — natural M4+1.
+- ~~OS desktop notifications (blocked / gate / awaiting input / done)~~ —
+  **the outward-signalling half is done, 2026-08-28** (§12.3 `notify:`, task
+  046, issue #90): the daemon runs a command of the user's choosing on any §6
+  state, with an enriched envelope on stdin. The **platform-native** stack —
+  three OS backends and the packaging that comes with them — stays deferred,
+  and the exec hook is why that is now cheap: `terminal-notifier`,
+  `notify-send` and `msg` are all one `command:` line away.
 - ~~More adapters~~ — **Cursor promoted out of future work to M5, 2026-08-11**
   (§9.7). Gemini CLI, opencode, and adapter capability flags remain here.
 - ~~parallel steps and step fan-out~~ — **promoted out of future work,

--- a/docs/tasks/046-notify-hook.md
+++ b/docs/tasks/046-notify-hook.md
@@ -1,0 +1,231 @@
+# 046 — A notify hook: letting the daemon signal a human outside the TUI
+
+**Status:** ✅ done (6/6)
+**Issue:** [#90](https://github.com/lezli01/vincent/issues/90)
+**Spec:** amends §2, §3 row 22, §12.3, §13.3, §15, §16, §17, §20
+
+## Problem
+
+vincent's premise is that you start work and walk away. `awaiting_gate`,
+`awaiting_input` and `blocked` are first-class states (§6, §7.4) precisely
+because the system stops and waits for a person. It stopped and waited
+**silently** unless someone had a TUI open.
+
+The only alert in the tree was the terminal bell in the TUI board
+(`internal/tui/board.go`, `ringsFor`), which rings on a transition **into
+`awaiting_input`** and nothing else. Nothing rang for `blocked`, nothing for
+`awaiting_gate`, nothing for `done`. There was no webhook, no exec hook, no file
+drop — no mechanism of any kind that survived the TUI being closed. A task could
+sit in `awaiting_input` for the full 24-hour `input_timeout`, fail on expiry, and
+the first anyone knew was the next time they opened the board.
+
+That is a hole in the core loop rather than a missing nicety: §2's third goal is
+a daemon that runs with **zero clients attached**, and the one thing it could not
+do with zero clients attached was say it needed a human.
+
+## What shipped
+
+One new top-level `config.yaml` block, global and hot-reloading, and one new
+package that subscribes to the existing post-commit event fan-out:
+
+```yaml
+notify:
+  on: [blocked, awaiting_gate, awaiting_input, done]
+  command: ["/usr/local/bin/notify-me"]   # the envelope arrives on stdin
+```
+
+`internal/notify` is a broker subscriber (`broker.OnEvent`) that reads the `to`
+field of `task.state_changed`, and — when it names a listed state and a command
+is configured — enqueues. Workers do the database reads, assemble an enriched
+JSON envelope and spawn the command through `procx.Start`, feeding the envelope
+to its stdin. Off by default; the generated `config.yaml` documents it commented
+out.
+
+## Tasks
+
+- [x] **046.1** `config.Notify` — the block, its validation against §6's state
+  vocabulary, and the two `Warnings()` entries. ✓ 2026-08-28
+- [x] **046.2** `internal/notify` — the subscriber, the bounded queue, the worker
+  pool, envelope assembly and the child spawn. ✓ 2026-08-28
+- [x] **046.3** Daemon wiring: construct, register on the broker, stop before
+  `broker.Close()`. ✓ 2026-08-28
+- [x] **046.4** Tests: config validation and warnings; the notify package against
+  a real child process (a re-exec of the test binary); a live test over a real
+  store, a real broker and the daemon's own wiring. ✓ 2026-08-28
+- [x] **046.5** Gate: a notify leg on `scripts/m1-gate.sh`, asserting one fire
+  per matching transition against a daemon with **no client attached**, and that
+  editing `notify.on` changes what fires with no restart. ✓ 2026-08-28
+- [x] **046.6** Spec amendments and the derived documentation pages. ✓ 2026-08-28
+
+## Decisions
+
+**1 (2026-08-28). Decision record row 22 and the §2/§20 deferral are amended,
+not worked around.** Row 22 fixed agent input requests as "TUI-level alerts only
+(§6, §7.4, §13.2, §15)"; §2 lists OS desktop notifications as a non-goal and §20
+calls them "natural M4+1".
+
+M4's acceptance was met 2026-08-11 and v1 shipped as `v0.1.0`, so the §20 line is
+a **spent scope boundary rather than a decision against** — the same reading task
+035 applied when it promoted GitHub issue reading out of §20. Row 22 stays true
+about what it actually decided: how one agent question is normalized, surfaced
+and answered *inside a client*. It is narrowed in place to say it does not bind
+the daemon against signalling outward, and it never spoke to `blocked` or
+`awaiting_gate` at all — both of which have the same problem and were never
+covered by it.
+
+*Beaten:* leaving the deferral untouched and shipping nothing. That leaves the
+walk-away premise unbacked for two states no recorded decision ever considered.
+
+The **platform-native** notification stack stays deferred in §2 and §20, with the
+exec hook recorded as the reason it is now cheaper to leave deferred:
+`terminal-notifier`, `notify-send` and `msg` are all reachable through `command`.
+
+**2 (2026-08-28). Only root tasks notify.** A `fan_out` lane is an ordinary task
+row (§7.6, task 014 decision 1), so a twenty-lane tree reaching `done` produces
+twenty child transitions on top of the parent's. A task whose `parent_task_id`
+is non-null is skipped.
+
+The parent's own `awaiting_children` → `running` → `done` is the human-meaningful
+signal, a lane that blocks blocks its parent's join, and a lane finishing is
+machinery.
+
+*Beaten:* an `include_children` key. That is the same "new key for a case nobody
+has hit" the issue itself rejects for per-project routing. The trigger for
+revisiting is a user who wants per-lane signalling.
+
+**3 (2026-08-28). Bounded queue and four workers — not four-in-flight-then-drop.**
+The issue proposed "at most 4 in flight, everything else dropped". That loses a
+notification whenever five tasks block at once, which is precisely when the
+feature is supposed to earn its keep.
+
+What shipped is a fixed-size FIFO (64) drained by at most 4 concurrent children.
+Drop-and-log happens only when the **queue** is full. This keeps every property
+the issue asked for — the publishing goroutine never blocks, the backlog is
+bounded, nothing is persisted or replayed — and makes the ordinary burst
+lossless. It also absorbs the fan-out case cleanly: lanes are enqueued and
+discarded by a worker after one indexed read each.
+
+**4 (2026-08-28). `internal/config` imports `internal/taskstate` to validate
+`on:`.** This is the one internal import `config` has, and it is a deliberate
+narrowing of CLAUDE.md's "leaf packages depend on nothing internal".
+
+`taskstate` is itself a leaf — it imports only the standard library — so there is
+no cycle, and it already exposes `All` and `Valid`. It gives the acceptance the
+issue asked for literally: an unknown state name fails `config.Load`, so a bad
+edit is rejected whole and the last good configuration stays active
+(`internal/config/watch.go`).
+
+*Beaten:* the `branch_template` precedent of validating in `internal/daemon`.
+That exists because the branch-template *context* lives in `internal/worktree`, a
+package with real dependencies, and that reason does not apply to a ten-element
+string set. The alternative was a second copy of §6's vocabulary in `config`,
+free to drift from the first.
+
+**5 (2026-08-28). The payload is an enriched envelope, assembled by the daemon.**
+A notifier handed `{task_id, to}` cannot write a message without calling back
+into the API with a bearer token, which defeats a one-line shell script. One JSON
+object on the child's stdin: `event_id`, `ts`, `type`; `task_id`, `title`,
+`from`, `to`, `block_reason`, `queued_reason`, `current_step`, `steps_total`,
+`worktree_path`, `branch`; `project_id`, `project`, `workflow`; and `input`
+(`{kind, summary}`) on a transition into `awaiting_input`, taken from what that
+§7.4 transition already carries in its event payload.
+
+`steps_total` comes from the task's own `workflow_snapshot`, which is the honest
+*n* for that run — more honest than the registry-derived count the TUI shows.
+`internal/notify` does not import `internal/workflow` for it; the daemon injects
+a `func(snapshot string) int` the way `taskrun.Deps` injects its functions.
+
+**6 (2026-08-28). Filtering is split across the two goroutines by cost.** The
+`OnEvent` callback runs on the store's writing goroutine and must not block
+(`internal/events/broker.go`, `store.SetEventHook`). It does only in-memory
+checks — the event type, `to` against `on:`, a configured command — and enqueues.
+Every database read (task, project, snapshot) and the root-task check happen on
+a worker.
+
+**7 (2026-08-28). Delivery posture, as the issue specified it.** Fire-and-forget.
+A fixed **10 s** timeout per child, not configurable — this is the pruner's
+posture (`internal/taskrun/prune.go`), and a daemon that stops serving because a
+notifier hung has its priorities backwards. On expiry the process **tree** is
+killed via `procx.Start` / `Proc.Kill`, not just the direct child, because that
+is how every other process the daemon spawns is handled; `procx.Start` also
+applies `NoWindow` on Windows, for the reason `internal/agent/probe.go` applies
+it — the daemon is normally console-less, and a console-subsystem child of a
+console-less parent is handed a window unless its creator says otherwise.
+`command` is argv, never a shell string: there is no portable shell to assume. No
+replay on restart and no persisted cursor — a weekend of downtime must not
+produce a notification storm.
+
+The constant is a `Notifier` field initialised from `perChildTimeout` so tests
+can watch the kill happen without spending ten real seconds; nothing outside the
+package can reach it, which is what keeps it un-configurable.
+
+**8 (2026-08-28). Children inherit the §12.3 `environment` policy.** A notifier
+is a process the daemon spawns, and §12.3 governs every one of them. It gets no
+`VINCENT_*` variables — those are §8.5's contract for command steps and their
+checks, and the envelope on stdin is this hook's contract.
+
+**9 (2026-08-28). `notify` is not exposed on `GET /v1/config`.**
+`configResponse` (`internal/api/server.go`) is a curated DTO, no client needs
+this, and `command` can reasonably carry a webhook URL with a token in its argv.
+Adding a read path for that buys nothing.
+
+**10 (2026-08-28). Two `Warnings()` entries, not validation errors.** A `command`
+with an empty `on:`, and a non-empty `on:` with no `command`, both load and take
+effect and both can never fire — exactly the shape `Warnings()` exists for
+(`delete_remote_branch_on_archive` is its sibling). Neither refuses the file: a
+user commenting `command` out for an afternoon should not have the same save
+revert an unrelated `log_level` edit.
+
+**11 (2026-08-28). The TUI bell is untouched.** It keeps its current
+`awaiting_input`-only behaviour as the in-client alert. No coupling in either
+direction, as the issue scoped it.
+
+## Testing
+
+`internal/config` covers the validation the issue asked for by name: an unknown
+state fails `Load` with an error naming the offending value, every §6 state is
+accepted, a duplicate and an empty argv element are refused, an absent block is
+inert and moves no other default, both warnings fire on exactly their conditions,
+and the generated `config.yaml` still loads to a disabled hook with no warnings.
+
+`internal/notify`'s child is a **re-exec of the test binary**, selected with
+`-test.run` and told what to do by the argv after a `--` sentinel. That is why
+every case runs identically on Windows, macOS and Linux with no shell involved
+and no environment variable that has to survive the environment policy: the
+guard is the sentinel, which a normal `go test` invocation never carries.
+
+Covered: argv byte-identical to the configured list and the stdin JSON decoding
+to the documented envelope; an unlisted state, a foreign event type, a missing
+task id and a configured `on:` with no command all spawning nothing; a
+`parent_task_id` task skipped while its root parent still fires; a hung child
+killed and logged; a non-zero exit logged with its code and a truncated stderr
+tail and never retried; the concurrency cap and the queue drop, with `OnEvent`
+staying prompt across a burst well past both.
+
+`notify_live_test.go` drives a real SQLite store, the real broker and the
+daemon's own hook wiring through a real `TransitionTask`, with no client
+attached — the acceptance sentence the issue wrote.
+
+The gate leg rides `scripts/m1-gate.sh` rather than a new script: that gate
+already has a daemon, a project and tasks that finish, and every one of its legs
+is already "a daemon with no client attached". The notifier is `git config -f
+"$out" --add vincent.notify.fired yes` — argv only, no shell, identical on all
+three platforms, and the same trick `m6`/`m7` use to write a file from a step
+body. `notify.on` starts on a state nothing in the script reaches, so the legs
+above must fire nothing; the leg then rewrites `config.yaml` and gets exactly one
+fire for the next task's `done`, which is the hot-reload half. The timeout-kill
+and queue-drop legs stay in Go, where a portable "hang forever" child is
+available and `sleep` is not.
+
+## Deliberately not included
+
+- **A native HTTP webhook.** `command: ["curl", "-fsS", "-XPOST", ...]` reaches
+  it with no request builder, retry policy, TLS trust decision or secret handling
+  in the daemon. The exec hook does not block one later.
+- **Per-project routing.** Projects are database rows, not YAML; it would need a
+  column and API surface for a case nobody has asked for.
+- **Replay of events missed while the daemon was down.** No cursor is persisted,
+  by design.
+- **A `vincent doctor` check that `notify.command[0]` resolves.** Genuinely
+  useful and genuinely not this issue. The trigger is the first report of a
+  notifier that silently never ran because the path was wrong.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -59,6 +59,7 @@ the living engineering specification records implementation contracts.
 | [043](043-workflow-origin.md) | Persisting where a task's workflow definition came from | ✅ done (6/6) |
 | [044](044-workflow-render-preview.md) | `vincent workflow render` — a template dry run | ✅ done (6/6) |
 | [045](045-cli-task-fields-file.md) | Task fields from a file or stdin in `vincent task add` | ✅ done (4/4) |
+| [046](046-notify-hook.md) | A notify hook: letting the daemon signal a human outside the TUI | ✅ done (6/6) |
 
 ## How to add and update a task document
 

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -118,6 +118,33 @@ agents:
 github:
   enabled: true
 
+# Tell someone when a task needs them, without a client attached (task 046).
+# The daemon runs "command" whenever a task enters one of the states in "on",
+# and writes a JSON envelope describing the transition to the command's stdin
+# — task id and title, from/to, block_reason, project, workflow, step cursor,
+# branch and worktree path — so a one-line script can write a message without
+# calling back into the API.
+#
+# "command" is argv, not a shell line: nothing is expanded, quoted or split,
+# and there is no shell on any platform. Both keys are needed; either alone
+# loads and warns. Off by default.
+#
+# The states are the ones from §6, most usefully: blocked, awaiting_gate,
+# awaiting_input, done. Only root tasks notify — a fan_out lane is a task row,
+# and a twenty-lane tree would otherwise send twenty-one messages.
+#
+# It is fire-and-forget: at most 4 notifiers run at once, a child is killed
+# after 10 seconds, failures are logged and never retried, and nothing is
+# replayed for events that happened while the daemon was down.
+#
+# WARNING: this is arbitrary code the daemon runs as you, and its argv can
+# carry a secret (a webhook URL), which is part of why this file is
+# owner-only.
+#
+# notify:
+#   on: [blocked, awaiting_gate, awaiting_input]
+#   command: ["/usr/local/bin/notify-me"]
+
 # What clients render, not what the daemon does. The daemon validates these,
 # hot-reloads them and serves them on GET /v1/config; the TUI reads them from
 # there.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/goccy/go-yaml"
+
+	"github.com/lezli01/vincent/internal/taskstate"
 )
 
 // FileName is the name of the daemon configuration file inside the config
@@ -243,6 +245,10 @@ type Config struct {
 	// It is read per use, so a hot reload reaches the next call rather than
 	// requiring a restart — the same rule the rest of §12.3 follows.
 	GitHub GitHub `yaml:"github"`
+	// Notify is the outward signal: a command the daemon spawns when a task
+	// enters one of the listed states (§12.3, task 046). Its zero value is
+	// off, so a daemon nobody configured spawns nothing.
+	Notify Notify `yaml:"notify"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -273,6 +279,88 @@ type GitHub struct {
 	// parse error the strict decoder already refuses — which is why
 	// validate() has no clause for this block.
 	Enabled bool `yaml:"enabled"`
+}
+
+// Notify configures the daemon's outward signal (spec §12.3 — task 046): a
+// command spawned when a task enters one of the listed states, with a JSON
+// envelope on its stdin.
+//
+// It exists because the daemon is designed to run with zero clients attached
+// (§2), and the one thing it could not do with zero clients attached was say
+// it needed a human: the only alert in the tree is the TUI's terminal bell,
+// which rings on `awaiting_input` and only while a board is open.
+//
+// The selector is target *states*, not event types: §13.3's durable
+// vocabulary has one transition event, `task.state_changed`, and this reads
+// its `to` field — exactly what the TUI bell keys off. No event type is
+// introduced for this.
+//
+// Global rather than per-project: projects are database rows, not YAML, so a
+// per-project override would need a column and API surface for a case nobody
+// has asked for.
+type Notify struct {
+	// On lists the states whose arrival fires Command. Empty — the default —
+	// fires nothing.
+	On []taskstate.State `yaml:"on"`
+	// Command is argv, never a shell string: there is no portable shell to
+	// assume, and a string would invite quoting bugs that differ per platform.
+	// Empty means the hook is off.
+	Command []string `yaml:"command"`
+}
+
+// Enabled reports whether the hook can fire at all.
+func (n Notify) Enabled() bool { return len(n.On) > 0 && len(n.Command) > 0 }
+
+// Fires reports whether a transition into s should spawn the command.
+func (n Notify) Fires(s taskstate.State) bool {
+	if len(n.Command) == 0 {
+		return false
+	}
+	for _, want := range n.On {
+		if want == s {
+			return true
+		}
+	}
+	return false
+}
+
+// validate rejects a state name that is not in §6's vocabulary, so a typo is
+// refused at load and the last good configuration stays active (§12.3).
+//
+// This is why internal/config imports internal/taskstate — the one internal
+// import this package has (task 046 decision 4). taskstate is itself a leaf
+// (it imports only `sort`), so there is no cycle, and the alternative is a
+// second copy of §6's ten state names drifting from the first. The
+// branch_template precedent of validating in internal/daemon does not apply:
+// that one exists because the branch-template context lives in
+// internal/worktree, a package with real dependencies.
+func (n Notify) validate() error {
+	seen := make(map[taskstate.State]bool, len(n.On))
+	for _, s := range n.On {
+		if !taskstate.Valid(s) {
+			return fmt.Errorf("notify.on: unknown task state %q; want one of %s",
+				s, strings.Join(stateNames(), ", "))
+		}
+		if seen[s] {
+			return fmt.Errorf("notify.on: %q listed twice", s)
+		}
+		seen[s] = true
+	}
+	for i, arg := range n.Command {
+		if strings.TrimSpace(arg) == "" {
+			return fmt.Errorf("notify.command: element %d is empty; argv elements must be non-empty", i)
+		}
+	}
+	return nil
+}
+
+// stateNames renders §6's vocabulary for an error message.
+func stateNames() []string {
+	out := make([]string, 0, len(taskstate.All))
+	for _, s := range taskstate.All {
+		out = append(out, string(s))
+	}
+	return out
 }
 
 // TUI holds the settings clients read for themselves (§15).
@@ -534,6 +622,9 @@ func (c Config) validate() error {
 	if err := c.TUI.Board.validate(); err != nil {
 		return err
 	}
+	if err := c.Notify.validate(); err != nil {
+		return err
+	}
 	return c.Environment.validate()
 }
 
@@ -553,6 +644,19 @@ func (c Config) Warnings() []string {
 		out = append(out, "delete_remote_branch_on_archive is true while "+
 			"delete_empty_branch_on_archive is false: the remote counterpart is only "+
 			"deleted after the local branch, so no remote branch will ever be deleted")
+	}
+	// Both halves of `notify:` are required for it to fire, and a half-written
+	// block looks exactly like a working one until a task blocks at 3am and
+	// nothing happens (task 046 decision 10). Neither refuses the file: a user
+	// commenting `command` out for an afternoon should not have the same save
+	// revert an unrelated log_level edit.
+	if len(c.Notify.Command) > 0 && len(c.Notify.On) == 0 {
+		out = append(out, "notify.command is set while notify.on is empty: "+
+			"no state fires the hook, so the command will never run")
+	}
+	if len(c.Notify.On) > 0 && len(c.Notify.Command) == 0 {
+		out = append(out, "notify.on lists states while notify.command is empty: "+
+			"there is nothing to run, so no notification will be delivered")
 	}
 	return out
 }

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,3 +1,8 @@
 // Package config resolves platform-native config/data directories and
 // loads, validates, and hot-reloads config.yaml (spec §12.2–12.3; T1.1).
+//
+// It imports exactly one internal package, internal/taskstate, to validate
+// `notify.on` against §6's state vocabulary rather than keeping a second copy
+// of it (task 046 decision 4). taskstate is itself a leaf — it imports only
+// the standard library — so the dependency direction stays one-way.
 package config

--- a/internal/config/notify_test.go
+++ b/internal/config/notify_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// TestNotifyAbsentIsInert is the property that makes this feature safe to
+// ship on by default: a config that never mentions `notify` gets the zero
+// value, which fires nothing, and changes no other default.
+func TestNotifyAbsentIsInert(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "log_level: warn\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Notify.Enabled() {
+		t.Errorf("absent notify block is enabled: %+v", cfg.Notify)
+	}
+	if len(cfg.Notify.On) != 0 || len(cfg.Notify.Command) != 0 {
+		t.Errorf("absent notify block is not zero: %+v", cfg.Notify)
+	}
+	want := Default()
+	want.LogLevel = "warn"
+	if cfg.MaxParallelTasks != want.MaxParallelTasks || cfg.TranscriptMaxBytes != want.TranscriptMaxBytes {
+		t.Errorf("unrelated defaults moved: %+v", cfg)
+	}
+	if Default().Notify.Enabled() {
+		t.Error("Default() ships notify enabled; it must be off until configured")
+	}
+}
+
+// TestNotifyLoads checks the block round-trips as written, argv included.
+func TestNotifyLoads(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `
+notify:
+  on: [blocked, awaiting_gate, awaiting_input, done]
+  command: ["/usr/local/bin/notify-me", "--tag", "vincent"]
+`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Notify.Enabled() {
+		t.Fatal("configured notify block reports disabled")
+	}
+	wantArgv := []string{"/usr/local/bin/notify-me", "--tag", "vincent"}
+	if len(cfg.Notify.Command) != len(wantArgv) {
+		t.Fatalf("command = %q, want %q", cfg.Notify.Command, wantArgv)
+	}
+	for i, arg := range wantArgv {
+		if cfg.Notify.Command[i] != arg {
+			t.Errorf("command[%d] = %q, want %q", i, cfg.Notify.Command[i], arg)
+		}
+	}
+	for _, s := range []taskstate.State{
+		taskstate.Blocked, taskstate.AwaitingGate, taskstate.AwaitingInput, taskstate.Done,
+	} {
+		if !cfg.Notify.Fires(s) {
+			t.Errorf("Fires(%s) = false, want true", s)
+		}
+	}
+	if cfg.Notify.Fires(taskstate.Running) {
+		t.Error("Fires(running) = true for a state not listed")
+	}
+}
+
+// TestNotifyAcceptsEveryState holds the validator to §6's vocabulary rather
+// than to the four states the feature was designed around: a state that is
+// legal for a task is legal to notify on.
+func TestNotifyAcceptsEveryState(t *testing.T) {
+	for _, s := range taskstate.All {
+		cfg, err := Load(writeConfig(t, "notify:\n  on: ["+string(s)+"]\n  command: [\"true\"]\n"))
+		if err != nil {
+			t.Errorf("state %s rejected: %v", s, err)
+			continue
+		}
+		if !cfg.Notify.Fires(s) {
+			t.Errorf("state %s loaded but does not fire", s)
+		}
+	}
+}
+
+// TestNotifyUnknownStateRejected is the acceptance the issue asked for
+// literally: a typo fails Load with an error naming the offending value, so
+// the watcher keeps the last good configuration (§12.3).
+func TestNotifyUnknownStateRejected(t *testing.T) {
+	_, err := Load(writeConfig(t, "notify:\n  on: [blocked, awating_input]\n  command: [\"true\"]\n"))
+	if err == nil {
+		t.Fatal("unknown state accepted")
+	}
+	if !strings.Contains(err.Error(), "awating_input") {
+		t.Errorf("error does not name the offending value: %v", err)
+	}
+}
+
+func TestNotifyDuplicateStateRejected(t *testing.T) {
+	_, err := Load(writeConfig(t, "notify:\n  on: [blocked, blocked]\n  command: [\"true\"]\n"))
+	if err == nil {
+		t.Fatal("duplicate state accepted")
+	}
+	if !strings.Contains(err.Error(), "twice") {
+		t.Errorf("error does not explain the duplicate: %v", err)
+	}
+}
+
+// TestNotifyEmptyArgvElementRejected: an empty argv element is a mistake no
+// exec can act on, and it would reach exec.Command as a real, empty argument.
+func TestNotifyEmptyArgvElementRejected(t *testing.T) {
+	_, err := Load(writeConfig(t, "notify:\n  on: [blocked]\n  command: [\"notify-me\", \"\"]\n"))
+	if err == nil {
+		t.Fatal("empty argv element accepted")
+	}
+	if !strings.Contains(err.Error(), "notify.command") {
+		t.Errorf("error does not name the key: %v", err)
+	}
+}
+
+// TestNotifyWarnings pins both half-written spellings to warnings rather than
+// load failures (task 046 decision 10), and checks nothing warns when the
+// block is whole or absent.
+func TestNotifyWarnings(t *testing.T) {
+	notifyWarnings := func(c Config) []string {
+		var out []string
+		for _, w := range c.Warnings() {
+			if strings.Contains(w, "notify") {
+				out = append(out, w)
+			}
+		}
+		return out
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"command without on", "notify:\n  command: [\"true\"]\n", "notify.command is set"},
+		{"on without command", "notify:\n  on: [blocked]\n", "notify.on lists states"},
+		{"whole block", "notify:\n  on: [blocked]\n  command: [\"true\"]\n", ""},
+		{"absent", "log_level: info\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Load(writeConfig(t, tc.body))
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			got := notifyWarnings(cfg)
+			if tc.want == "" {
+				if len(got) > 0 {
+					t.Errorf("unexpected warnings: %q", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("warnings = %q, want exactly one", got)
+			}
+			if !strings.Contains(got[0], tc.want) {
+				t.Errorf("warning = %q, want it to contain %q", got[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestNotifyFiresNeedsBothHalves: a state list with no command must not fire,
+// which is what keeps the warned-about configuration inert rather than
+// spawning an empty argv.
+func TestNotifyFiresNeedsBothHalves(t *testing.T) {
+	n := Notify{On: []taskstate.State{taskstate.Blocked}}
+	if n.Fires(taskstate.Blocked) {
+		t.Error("Fires = true with no command configured")
+	}
+	if n.Enabled() {
+		t.Error("Enabled = true with no command configured")
+	}
+	n = Notify{Command: []string{"true"}}
+	if n.Fires(taskstate.Blocked) {
+		t.Error("Fires = true with an empty on: list")
+	}
+	if n.Enabled() {
+		t.Error("Enabled = true with an empty on: list")
+	}
+}
+
+// TestDefaultConfigFileDocumentsNotify keeps the generated file honest: the
+// block is present, commented out, and the shipped defaults stay inert.
+func TestDefaultConfigFileDocumentsNotify(t *testing.T) {
+	if !strings.Contains(defaultConfigYAML, "# notify:") {
+		t.Error("the default config.yaml does not document the notify block")
+	}
+	path := writeConfig(t, defaultConfigYAML)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("default config.yaml does not load: %v", err)
+	}
+	if cfg.Notify.Enabled() {
+		t.Error("the default config.yaml enables notify; it must ship off")
+	}
+	if len(cfg.Warnings()) != 0 {
+		t.Errorf("the default config.yaml warns: %q", cfg.Warnings())
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/lezli01/vincent/internal/events"
 	"github.com/lezli01/vincent/internal/github"
 	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/notify"
 	"github.com/lezli01/vincent/internal/scheduler"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskrun"
@@ -316,6 +317,27 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 			sched.Wake()
 		}
 	})
+	// The outward signal (§12.3, task 046): a third internal subscriber that
+	// spawns `notify.command` when a task enters a state listed in
+	// `notify.on`. It reads currentConfig() per event, so a hot reload
+	// governs the next transition with no extra wiring here, and it does no
+	// database work on this goroutine — the hook only enqueues.
+	notifier := notify.New(notify.Deps{
+		Store:  st,
+		Config: currentConfig,
+		Logger: logger,
+		// The honest `n` for this run: the task's own snapshot, not the
+		// registry, which may have been edited since the task was created.
+		StepCount: func(snapshot string) int {
+			wf, _, err := workflow.Parse([]byte(snapshot), workflow.Options{})
+			if err != nil {
+				return 0
+			}
+			return len(wf.Steps)
+		},
+	})
+	notifier.Start(ctx)
+	broker.OnEvent(notifier.OnEvent)
 	// Registry reloads become durable workflow.registry_changed events
 	// (§13.3). Registered after the initial loads so boot churn stays out of
 	// the event log.
@@ -438,6 +460,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		logger.Error("http server failed", "error", err)
 		sched.Stop()
 		runner.Stop()
+		notifier.Stop()
 		broker.Close()
 		return fmt.Errorf("http server: %w", err)
 	}
@@ -452,6 +475,9 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	}
 	sched.Stop()
 	runner.StopGraceful(processGrace)
+	// Before broker.Close(): the broker is what feeds the notifier's hook, and
+	// a notification for a shutdown-time transition is one a person wants.
+	notifier.Stop()
 	broker.Close()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()

--- a/internal/notify/doc.go
+++ b/internal/notify/doc.go
@@ -1,0 +1,38 @@
+// Package notify is the daemon's outward signal (spec §12.3, §13.3, §16 —
+// task 046): a subscriber on the post-commit event fan-out that spawns a
+// user-supplied command when a task enters one of the states named in
+// `notify.on`.
+//
+// It exists because the daemon is designed to run with zero clients attached
+// (§2, goal 3), and the one thing it could not do with zero clients attached
+// was say it needed a human. The only alert in the tree is the TUI's terminal
+// bell, which rings on a transition into `awaiting_input` and only while a
+// board is open, so a task could sit in `awaiting_input` for the whole
+// 24-hour `input_timeout`, fail on expiry, and the first anyone knew was the
+// next time they opened the board.
+//
+// It introduces **no new event type** (§13.3). The selector reads the `to`
+// field of `task.state_changed`, which is what the TUI bell already does;
+// `task.blocked` and `task.gate_pending` do not exist and are not invented.
+//
+// Two goroutine kinds, split by cost:
+//
+//   - The hook (OnEvent) runs on the store's writing goroutine, one hop
+//     downstream of store.SetEventHook, and must not block. It does only
+//     in-memory checks — the event type, the `to` state against `notify.on`,
+//     a configured command — and enqueues.
+//   - The workers do every database read (task, project, workflow snapshot),
+//     the root-task check, envelope assembly and the child spawn.
+//
+// Delivery is fire-and-forget and bounded: a fixed-size queue drained by at
+// most maxWorkers concurrent children, a fixed perChildTimeout after which
+// the child's whole process tree is killed, failures logged and never
+// retried, and no replay of events the daemon did not observe — a weekend of
+// downtime must not produce a notification storm on the next start.
+//
+// Security (§16): `notify.command` is arbitrary code the daemon runs as the
+// invoking user, and its argv can carry a secret such as a webhook URL. That
+// is consistent with §16's posture — agents already run full-auto as the
+// invoking user — and is part of why config.yaml is owner-only. The command
+// is argv, never a shell string: there is no portable shell to assume.
+package notify

--- a/internal/notify/helper_test.go
+++ b/internal/notify/helper_test.go
@@ -1,0 +1,102 @@
+package notify
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The notifier's child is a re-exec of the test binary rather than a script:
+// there is no shell to assume on Windows, `sleep` and `cat` are not portable,
+// and a Go helper runs identically on all three platforms. The guard is the
+// `--` sentinel in argv — a normal `go test` invocation never carries one —
+// so no environment variable has to survive the environment policy the
+// notifier applies to its children.
+const helperSentinel = "--"
+
+// helperArgv builds the argv for one helper mode. dir is where the helper
+// writes; each invocation writes its own file, so concurrent children never
+// race over one path.
+func helperArgv(t *testing.T, mode, dir string, extra ...string) []string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	argv := []string{self, "-test.run=TestNotifyHelperProcess", helperSentinel, mode, dir}
+	return append(argv, extra...)
+}
+
+// helperFiles returns the contents of every file the helper wrote in dir.
+func helperFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read helper dir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		b, rerr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if rerr != nil {
+			t.Fatalf("read %s: %v", e.Name(), rerr)
+		}
+		out = append(out, string(b))
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestNotifyHelperProcess is not a test: it is the notifier's child process,
+// selected by -test.run and told what to do by the argv after `--`.
+func TestNotifyHelperProcess(t *testing.T) {
+	args := os.Args
+	i := slices.Index(args, helperSentinel)
+	if i < 0 {
+		t.Skip("not running as the notifier's helper child")
+	}
+	args = args[i+1:]
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "helper: want a mode and a directory")
+		os.Exit(2)
+	}
+	mode, dir := args[0], args[1]
+	body, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "helper: read stdin: %v\n", err)
+		os.Exit(2)
+	}
+	write := func(name string, content []byte) {
+		if werr := os.WriteFile(filepath.Join(dir, name), content, 0o600); werr != nil {
+			fmt.Fprintf(os.Stderr, "helper: write: %v\n", werr)
+			os.Exit(2)
+		}
+	}
+	unique := strconv.Itoa(os.Getpid()) + "-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	switch mode {
+	case "capture":
+		// The remaining argv is echoed back beside the envelope so the test can
+		// assert the child was spawned with byte-identical arguments.
+		write(unique+".json", body)
+		write(unique+".argv", []byte(fmt.Sprint(args[2:])))
+	case "fail":
+		write(unique+".json", body)
+		fmt.Fprintln(os.Stderr, "helper: deliberate failure")
+		os.Exit(3)
+	case "hang":
+		write(unique+".json", body)
+		// A long sleep, not `select {}`: an empty select parks every goroutine
+		// and the runtime's deadlock detector would exit the process, which is
+		// the opposite of hanging. The notifier's timeout is what ends this.
+		time.Sleep(10 * time.Minute)
+	default:
+		fmt.Fprintf(os.Stderr, "helper: unknown mode %q\n", mode)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,412 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/procx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+const (
+	// EnvelopeType is the `type` every envelope carries. It is the durable
+	// event type the selector reads, not a new one (§13.3).
+	EnvelopeType = store.EventTaskStateChanged
+
+	// perChildTimeout bounds one notifier process. Fixed, not configurable:
+	// this is the pruner's posture (internal/taskrun/prune.go), and a daemon
+	// that stops serving because a notifier hung has its priorities backwards.
+	// Ten seconds is generous for `curl` to a webhook and short enough that a
+	// wedged notifier cannot occupy a worker while real notifications queue.
+	perChildTimeout = 10 * time.Second
+
+	// maxWorkers is how many notifier processes may run at once.
+	maxWorkers = 4
+
+	// queueCapacity is the bounded backlog. The issue proposed dropping
+	// everything past four in flight; that loses a notification whenever five
+	// tasks block at once, which is precisely when the feature earns its keep
+	// (task 046 decision 3). A FIFO in front of the workers makes the ordinary
+	// burst lossless while keeping the backlog bounded, and absorbs a fan-out
+	// tree cleanly — lanes are enqueued and discarded by a worker after one
+	// indexed read each.
+	queueCapacity = 64
+
+	// stderrTail is how much of a failed child's stderr rides the log line.
+	// Enough to carry "command not found" or a curl error, short enough that
+	// a chatty notifier cannot flood daemon.log.
+	stderrTail = 512
+)
+
+// Store is the slice of the store a notifier reads. Both calls happen on a
+// worker, never on the publishing goroutine.
+type Store interface {
+	GetTask(ctx context.Context, id int64) (*store.Task, error)
+	GetProject(ctx context.Context, id int64) (*store.Project, error)
+}
+
+// Deps are the notifier's dependencies.
+type Deps struct {
+	Store  Store
+	Config func() config.Config
+	Logger *slog.Logger
+	// StepCount reports how many steps a task's workflow snapshot holds. It
+	// is injected the way taskrun.Deps injects its functions, so this package
+	// does not import internal/workflow for one integer. The snapshot is the
+	// honest `n` for that run, unlike a registry-derived count, because the
+	// registry may have been edited since the task was created.
+	StepCount func(snapshot string) int
+}
+
+// Input is the agent's question, carried only on a transition into
+// awaiting_input (§7.4). It is lifted from the fields that transition already
+// puts in its event payload.
+type Input struct {
+	Kind    string `json:"kind"`
+	Summary string `json:"summary"`
+}
+
+// Envelope is the JSON object written to the child's stdin.
+//
+// It is enriched rather than the raw events-table row: a notifier handed
+// `{task_id, to}` cannot write a message without calling back into the API
+// with a bearer token, which defeats the point of a one-line shell script
+// (task 046 decision 5).
+type Envelope struct {
+	EventID int64  `json:"event_id"`
+	TS      string `json:"ts"`
+	Type    string `json:"type"`
+
+	TaskID       int64  `json:"task_id"`
+	Title        string `json:"title"`
+	From         string `json:"from"`
+	To           string `json:"to"`
+	BlockReason  string `json:"block_reason"`
+	QueuedReason string `json:"queued_reason"`
+	CurrentStep  int    `json:"current_step"`
+	StepsTotal   int    `json:"steps_total"`
+	WorktreePath string `json:"worktree_path"`
+	Branch       string `json:"branch"`
+
+	ProjectID int64  `json:"project_id"`
+	Project   string `json:"project"`
+	Workflow  string `json:"workflow"`
+
+	Input *Input `json:"input,omitempty"`
+}
+
+// job is one enqueued transition. The argv and the environment policy are
+// captured at enqueue time so a config edit mid-burst cannot half-apply: the
+// event that matched the old `on:` is delivered by the old `command`.
+type job struct {
+	eventID int64
+	ts      time.Time
+	taskID  int64
+	from    string
+	to      string
+	input   *Input
+	argv    []string
+	env     []string
+}
+
+// Notifier spawns the configured command for matching transitions. The zero
+// value is not usable; call New.
+type Notifier struct {
+	deps  Deps
+	queue chan job
+	wg    sync.WaitGroup
+
+	stopOnce sync.Once
+	stopped  chan struct{}
+
+	// timeout is perChildTimeout. It is a field rather than a constant read
+	// directly so a test can watch the kill happen without spending ten real
+	// seconds; nothing outside this package can reach it, which is what keeps
+	// it un-configurable (task 046 decision 7).
+	timeout time.Duration
+
+	// spawn is the child-process launcher, replaced in tests that need to
+	// observe concurrency without counting real processes.
+	spawn func(context.Context, job, []byte) error
+}
+
+// New returns a stopped notifier. Call Start before registering OnEvent.
+func New(deps Deps) *Notifier {
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	if deps.StepCount == nil {
+		deps.StepCount = func(string) int { return 0 }
+	}
+	n := &Notifier{
+		deps:    deps,
+		queue:   make(chan job, queueCapacity),
+		stopped: make(chan struct{}),
+		timeout: perChildTimeout,
+	}
+	n.spawn = n.run
+	return n
+}
+
+// Start launches the worker pool. It returns immediately.
+func (n *Notifier) Start(ctx context.Context) {
+	for range maxWorkers {
+		n.wg.Add(1)
+		go func() {
+			defer n.wg.Done()
+			n.worker(ctx)
+		}()
+	}
+}
+
+// Stop closes the queue and waits for in-flight children. Idempotent, and
+// safe to call without Start. It belongs before broker.Close() in the
+// shutdown order: the broker is what feeds OnEvent.
+func (n *Notifier) Stop() {
+	n.stopOnce.Do(func() { close(n.stopped) })
+	n.wg.Wait()
+}
+
+// OnEvent is the broker subscriber. It runs on the publishing goroutine and
+// must not block (internal/events, store.SetEventHook), so it does only
+// in-memory work and a non-blocking enqueue.
+func (n *Notifier) OnEvent(e *store.Event) {
+	if e == nil || e.TaskID == nil || e.Type != store.EventTaskStateChanged {
+		return
+	}
+	var payload struct {
+		From    string `json:"from"`
+		To      string `json:"to"`
+		Kind    string `json:"kind"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(e.Payload, &payload); err != nil {
+		return
+	}
+	to := taskstate.State(payload.To)
+	cfg := n.deps.Config()
+	if !cfg.Notify.Fires(to) {
+		return
+	}
+	j := job{
+		eventID: e.ID,
+		ts:      e.TS,
+		taskID:  *e.TaskID,
+		from:    payload.From,
+		to:      payload.To,
+		argv:    append([]string(nil), cfg.Notify.Command...),
+		env:     cfg.Environment.ResolveProcess(),
+	}
+	// The §7.4 transition already carries the normalized request's kind and
+	// summary in its event payload; nothing else does, so this is the only
+	// state that gets an `input` object.
+	if to == taskstate.AwaitingInput && (payload.Kind != "" || payload.Summary != "") {
+		j.input = &Input{Kind: payload.Kind, Summary: payload.Summary}
+	}
+	select {
+	case <-n.stopped:
+		return
+	default:
+	}
+	select {
+	case n.queue <- j:
+	default:
+		// Only a full *queue* drops, never a busy worker (decision 3).
+		n.deps.Logger.Warn("notification dropped: notifier queue full",
+			"task", j.taskID, "to", j.to, "event", j.eventID, "capacity", queueCapacity)
+	}
+}
+
+func (n *Notifier) worker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-n.stopped:
+			return
+		case j := <-n.queue:
+			n.handle(ctx, j)
+		}
+	}
+}
+
+// handle does the expensive half: the reads, the root-task check, the
+// envelope and the spawn.
+func (n *Notifier) handle(ctx context.Context, j job) {
+	log := n.deps.Logger.With("task", j.taskID, "to", j.to, "event", j.eventID)
+	env, ok := n.envelope(ctx, j, log)
+	if !ok {
+		return
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		log.Warn("notification not sent: envelope could not be encoded", "error", err)
+		return
+	}
+	body = append(body, '\n')
+	log.Debug("notification firing", "command", j.argv[0])
+	if err := n.spawn(ctx, j, body); err != nil {
+		log.Warn("notification command failed", "command", j.argv[0], "error", err)
+	}
+}
+
+// envelope assembles the payload, or reports that this transition should not
+// notify at all.
+func (n *Notifier) envelope(ctx context.Context, j job, log *slog.Logger) (Envelope, bool) {
+	task, err := n.deps.Store.GetTask(ctx, j.taskID)
+	if err != nil {
+		log.Warn("notification skipped: task could not be read", "error", err)
+		return Envelope{}, false
+	}
+	if task == nil {
+		return Envelope{}, false
+	}
+	// Only root tasks notify (task 046 decision 2). A `fan_out` lane is an
+	// ordinary task row (§7.6, task 014 decision 1), so a twenty-lane tree
+	// reaching `done` would produce twenty child transitions on top of the
+	// parent's. The parent's own awaiting_children → running → done is the
+	// human-meaningful signal; a lane finishing is machinery.
+	if task.ParentTaskID != nil {
+		log.Debug("notification skipped: fan-out lane, not a root task",
+			"parent", *task.ParentTaskID)
+		return Envelope{}, false
+	}
+	env := Envelope{
+		EventID:      j.eventID,
+		TS:           j.ts.UTC().Format(time.RFC3339),
+		Type:         EnvelopeType,
+		TaskID:       task.ID,
+		Title:        task.Title,
+		From:         j.from,
+		To:           j.to,
+		QueuedReason: task.QueuedReason,
+		CurrentStep:  task.CurrentStep,
+		StepsTotal:   n.deps.StepCount(task.WorkflowSnapshot),
+		WorktreePath: task.WorktreePath,
+		Branch:       task.BranchName,
+		ProjectID:    task.ProjectID,
+		Workflow:     task.WorkflowName,
+		Input:        j.input,
+	}
+	// block_reason means "set while blocked" (§14); carrying one on any other
+	// state would lie to whoever reads it.
+	if j.to == string(taskstate.Blocked) {
+		env.BlockReason = task.BlockReason
+	}
+	// A project that vanished between the transition and this read is not
+	// worth losing the notification over: the task fields still say what
+	// happened.
+	if p, perr := n.deps.Store.GetProject(ctx, task.ProjectID); perr != nil {
+		log.Debug("notification project name unavailable", "error", perr)
+	} else if p != nil {
+		env.Project = p.Name
+	}
+	return env, true
+}
+
+// run spawns one notifier child, feeds it the envelope and waits out the
+// timeout.
+//
+// procx.Start is what gives this NoWindow on Windows and a killable process
+// *tree* on both — the daemon is normally console-less (a detached `daemon
+// start`, or the Scheduled Task), and a console-subsystem child of a
+// console-less parent is handed a window unless its creator says otherwise.
+func (n *Notifier) run(ctx context.Context, j job, body []byte) error {
+	// G204: the argv is config.yaml's, which belongs to the invoking user, and
+	// running it is the entire point of the feature (§16). Nothing from a task,
+	// an agent or the API reaches it.
+	cmd := exec.Command(j.argv[0], j.argv[1:]...) //nolint:gosec // G204: see above
+	cmd.Stdin = bytes.NewReader(body)
+	// §12.3's environment policy governs every process the daemon spawns, this
+	// one included. It gets no VINCENT_* variables: those are §8.5's contract
+	// for command steps, and the envelope on stdin is this hook's.
+	cmd.Env = j.env
+	var stderr tailBuffer
+	cmd.Stderr = &stderr
+
+	proc, err := procx.Start(cmd)
+	if err != nil {
+		return err
+	}
+	defer proc.Release()
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	timer := time.NewTimer(n.timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				return &ExitError{Code: exitErr.ExitCode(), Stderr: stderr.String()}
+			}
+			return err
+		}
+		return nil
+	case <-timer.C:
+		_ = proc.Kill()
+		<-done
+		return &TimeoutError{After: n.timeout}
+	case <-ctx.Done():
+		_ = proc.Kill()
+		<-done
+		return ctx.Err()
+	}
+}
+
+// ExitError is a notifier that ran and failed. It is never retried: a
+// notification is only interesting while it is fresh, and a retry policy here
+// is a queue with a persistence story attached.
+type ExitError struct {
+	Code   int
+	Stderr string
+}
+
+func (e *ExitError) Error() string {
+	if e.Stderr == "" {
+		return "exit status " + strconv.Itoa(e.Code)
+	}
+	return "exit status " + strconv.Itoa(e.Code) + ": " + e.Stderr
+}
+
+// TimeoutError is a notifier killed at perChildTimeout, process tree and all.
+type TimeoutError struct{ After time.Duration }
+
+func (e *TimeoutError) Error() string {
+	return "killed after " + e.After.String() + ": notification command did not exit"
+}
+
+// tailBuffer keeps the last stderrTail bytes a child wrote. The tail, not the
+// head: a script that logs before it fails puts the reason last.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > stderrTail {
+		b.buf = b.buf[len(b.buf)-stderrTail:]
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.buf))
+}

--- a/internal/notify/notify_live_test.go
+++ b/internal/notify/notify_live_test.go
@@ -1,0 +1,121 @@
+package notify
+
+import (
+	"encoding/json"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// TestLiveNotificationFromRealTransition is the acceptance sentence the issue
+// wrote, assembled from the real parts: a real SQLite store, the real
+// post-commit broker, the daemon's own hook wiring, and a real child process
+// — with no client attached to anything.
+//
+// It is a *live_test.go for the same reason the TUI's are: the pieces this
+// feature spans (the store's event hook, the broker's fan-out contract, the
+// state-change payload's field names) are exactly the ones a unit test with a
+// hand-built event cannot keep honest.
+func TestLiveNotificationFromRealTransition(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(t.TempDir(), "live.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	project := &store.Project{Name: "vincent", Path: t.TempDir(), DefaultBranch: "main"}
+	if err := st.CreateProject(t.Context(), project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	snapshot := "name: review\nsteps:\n" +
+		"  - {id: plan, type: manual, instructions: plan it}\n" +
+		"  - {id: ship, type: manual, instructions: ship it}\n"
+	task := &store.Task{
+		ProjectID: project.ID, Title: "Ship the notify hook",
+		WorkflowName: "review", WorkflowSnapshot: snapshot,
+		BranchName: "vincent/1-ship", State: store.TaskRunning,
+	}
+	if err := st.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.Notify = config.Notify{
+		On:      []taskstate.State{taskstate.Blocked},
+		Command: helperArgv(t, "capture", dir),
+	}
+	logs := &logCapture{}
+
+	// The daemon's wiring, verbatim in shape: the store's single event hook
+	// publishes to the broker, and the notifier is one of the broker's
+	// internal subscribers (internal/daemon/daemon.go).
+	broker := events.New()
+	notifier := New(Deps{
+		Store:  st,
+		Config: func() config.Config { return cfg },
+		Logger: slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		StepCount: func(s string) int {
+			wf, _, perr := workflow.Parse([]byte(s), workflow.Options{})
+			if perr != nil {
+				return 0
+			}
+			return len(wf.Steps)
+		},
+	})
+	notifier.Start(t.Context())
+	t.Cleanup(notifier.Stop)
+	broker.OnEvent(notifier.OnEvent)
+	st.SetEventHook(broker.Publish)
+	t.Cleanup(broker.Close)
+
+	reason := "step_failed"
+	if _, _, err := st.TransitionTask(t.Context(), task.ID,
+		store.TaskRunning, store.TaskBlocked,
+		store.TaskChange{BlockReason: &reason},
+	); err != nil {
+		t.Fatalf("block: %v", err)
+	}
+
+	waitFor(t, "the notifier child to run off a real transition", func() bool {
+		return len(helperFiles(t, dir)) == 2
+	})
+
+	var env Envelope
+	for _, body := range helperFiles(t, dir) {
+		if strings.HasPrefix(strings.TrimSpace(body), "{") {
+			if uerr := json.Unmarshal([]byte(body), &env); uerr != nil {
+				t.Fatalf("stdin is not the documented envelope: %v (%q)", uerr, body)
+			}
+		}
+	}
+	if env.TaskID != task.ID || env.Title != "Ship the notify hook" {
+		t.Errorf("envelope names the wrong task: %+v", env)
+	}
+	if env.From != "running" || env.To != "blocked" {
+		t.Errorf("from/to = %q/%q, want running/blocked", env.From, env.To)
+	}
+	if env.BlockReason != reason {
+		t.Errorf("block_reason = %q, want %q", env.BlockReason, reason)
+	}
+	if env.Project != "vincent" || env.Workflow != "review" {
+		t.Errorf("project/workflow = %q/%q, want vincent/review", env.Project, env.Workflow)
+	}
+	// The honest n for this run comes from the task's own snapshot.
+	if env.StepsTotal != 2 {
+		t.Errorf("steps_total = %d, want 2 from the workflow snapshot", env.StepsTotal)
+	}
+	if env.EventID == 0 || env.TS == "" {
+		t.Errorf("envelope carries no event cursor: %+v", env)
+	}
+	if env.Type != store.EventTaskStateChanged {
+		t.Errorf("type = %q; no event type is introduced for this (§13.3)", env.Type)
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,476 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// fakeStore is the two reads a worker makes. It is a fake rather than a real
+// SQLite store because these cases are about the notifier's own behaviour;
+// the real store, the real broker and the daemon's own wiring are exercised
+// in notify_live_test.go.
+type fakeStore struct {
+	tasks    map[int64]*store.Task
+	projects map[int64]*store.Project
+	taskErr  error
+}
+
+func (f *fakeStore) GetTask(_ context.Context, id int64) (*store.Task, error) {
+	if f.taskErr != nil {
+		return nil, f.taskErr
+	}
+	return f.tasks[id], nil
+}
+
+func (f *fakeStore) GetProject(_ context.Context, id int64) (*store.Project, error) {
+	return f.projects[id], nil
+}
+
+// harness wires a notifier over a fake store with a fixed configuration.
+type harness struct {
+	notifier *Notifier
+	store    *fakeStore
+	cfg      config.Config
+	logs     *logCapture
+	mu       sync.Mutex
+}
+
+// logCapture keeps the daemon log lines a case wants to assert on.
+type logCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *logCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, string(p))
+	return len(p), nil
+}
+
+func (c *logCapture) contains(sub string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, l := range c.lines {
+		if strings.Contains(l, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func newHarness(t *testing.T, on []taskstate.State, argv []string) *harness {
+	t.Helper()
+	h := &harness{
+		store: &fakeStore{
+			tasks: map[int64]*store.Task{
+				1: {
+					ID: 1, ProjectID: 7, Title: "Fix the flaky gate",
+					WorkflowName: "review", WorkflowSnapshot: "name: review\n",
+					BranchName: "vincent/1-fix", WorktreePath: filepath.Join("/tmp", "wt", "1"),
+					CurrentStep: 2, BlockReason: "step_failed",
+				},
+			},
+			projects: map[int64]*store.Project{7: {ID: 7, Name: "vincent"}},
+		},
+		logs: &logCapture{},
+	}
+	h.cfg = config.Default()
+	h.cfg.Notify = config.Notify{On: on, Command: argv}
+	h.notifier = New(Deps{
+		Store: h.store,
+		Config: func() config.Config {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			return h.cfg
+		},
+		Logger:    slog.New(slog.NewTextHandler(h.logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		StepCount: func(string) int { return 5 },
+	})
+	h.notifier.timeout = 3 * time.Second
+	h.notifier.Start(t.Context())
+	t.Cleanup(h.notifier.Stop)
+	return h
+}
+
+// setConfig replaces the configuration the hook reads, the way a hot reload
+// does.
+func (h *harness) setConfig(f func(c *config.Config)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	f(&h.cfg)
+}
+
+// stateEvent builds a task.state_changed event the way store.statePayload
+// does.
+func stateEvent(id int64, taskID int64, from, to taskstate.State, extra map[string]any) *store.Event {
+	payload := map[string]any{"from": string(from), "to": string(to)}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	b, _ := json.Marshal(payload)
+	tid := taskID
+	return &store.Event{
+		ID: id, TS: time.Date(2026, 8, 28, 9, 30, 0, 0, time.UTC),
+		Type: store.EventTaskStateChanged, TaskID: &tid, Payload: b,
+	}
+}
+
+// waitFor polls until cond holds or the deadline passes. Spawning a real
+// process is asynchronous by construction, so there is nothing to synchronize
+// on but the effect.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestFiresAndDeliversEnvelope is the feature: a matching transition spawns
+// the configured command with byte-identical argv, and the JSON on its stdin
+// carries what a notifier needs to write a message without calling back into
+// the API.
+func TestFiresAndDeliversEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	argv := helperArgv(t, "capture", dir, "--tag", "vincent")
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, argv)
+
+	h.notifier.OnEvent(stateEvent(42, 1, taskstate.Running, taskstate.Blocked, nil))
+	waitFor(t, "the notifier child to write its capture", func() bool {
+		return len(helperFiles(t, dir)) == 2
+	})
+
+	var env Envelope
+	var gotArgv string
+	for _, body := range helperFiles(t, dir) {
+		if strings.HasPrefix(strings.TrimSpace(body), "{") {
+			if err := json.Unmarshal([]byte(body), &env); err != nil {
+				t.Fatalf("stdin is not the documented envelope: %v (%q)", err, body)
+			}
+			continue
+		}
+		gotArgv = strings.TrimSpace(body)
+	}
+	if gotArgv != "[--tag vincent]" {
+		t.Errorf("child argv tail = %q, want [--tag vincent]", gotArgv)
+	}
+
+	want := Envelope{
+		EventID: 42, TS: "2026-08-28T09:30:00Z", Type: "task.state_changed",
+		TaskID: 1, Title: "Fix the flaky gate", From: "running", To: "blocked",
+		BlockReason: "step_failed", CurrentStep: 2, StepsTotal: 5,
+		WorktreePath: filepath.Join("/tmp", "wt", "1"), Branch: "vincent/1-fix",
+		ProjectID: 7, Project: "vincent", Workflow: "review",
+	}
+	if env != want {
+		t.Errorf("envelope =\n  %+v\nwant\n  %+v", env, want)
+	}
+}
+
+// TestAwaitingInputCarriesTheQuestion: the §7.4 transition already puts the
+// normalized request's kind and summary in its event payload, and this is the
+// only state that gets an `input` object.
+func TestAwaitingInputCarriesTheQuestion(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.AwaitingInput}, helperArgv(t, "capture", dir))
+
+	h.notifier.OnEvent(stateEvent(9, 1, taskstate.Running, taskstate.AwaitingInput,
+		map[string]any{"kind": "choice", "summary": "Overwrite the migration?"}))
+	waitFor(t, "the notifier child to write its capture", func() bool {
+		return len(helperFiles(t, dir)) == 2
+	})
+
+	var env Envelope
+	for _, body := range helperFiles(t, dir) {
+		if strings.HasPrefix(strings.TrimSpace(body), "{") {
+			if err := json.Unmarshal([]byte(body), &env); err != nil {
+				t.Fatalf("decode envelope: %v", err)
+			}
+		}
+	}
+	if env.Input == nil {
+		t.Fatal("no input object on an awaiting_input transition")
+	}
+	if env.Input.Kind != "choice" || env.Input.Summary != "Overwrite the migration?" {
+		t.Errorf("input = %+v, want the kind and summary from the event", env.Input)
+	}
+	// block_reason means "set while blocked" (§14) and must not ride along on
+	// any other state, even though the task row carries one.
+	if env.BlockReason != "" {
+		t.Errorf("block_reason = %q on an awaiting_input transition", env.BlockReason)
+	}
+}
+
+// TestSpawnsNothing covers every way a transition must be ignored.
+func TestSpawnsNothing(t *testing.T) {
+	cases := []struct {
+		name  string
+		on    []taskstate.State
+		argv  func(dir string) []string
+		event func(t *testing.T) *store.Event
+	}{
+		{
+			name:  "unlisted state",
+			on:    []taskstate.State{taskstate.Blocked},
+			event: func(*testing.T) *store.Event { return stateEvent(1, 1, taskstate.Queued, taskstate.Running, nil) },
+		},
+		{
+			name: "another event type",
+			on:   []taskstate.State{taskstate.Blocked},
+			event: func(*testing.T) *store.Event {
+				e := stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil)
+				e.Type = store.EventTaskCreated
+				return e
+			},
+		},
+		{
+			name: "no task id",
+			on:   []taskstate.State{taskstate.Blocked},
+			event: func(*testing.T) *store.Event {
+				e := stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil)
+				e.TaskID = nil
+				return e
+			},
+		},
+		{
+			name:  "states configured with no command",
+			on:    []taskstate.State{taskstate.Blocked},
+			argv:  func(string) []string { return nil },
+			event: func(*testing.T) *store.Event { return stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil) },
+		},
+		{
+			name:  "no states configured",
+			on:    nil,
+			event: func(*testing.T) *store.Event { return stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil) },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argv := helperArgv(t, "capture", dir)
+			if tc.argv != nil {
+				argv = tc.argv(dir)
+			}
+			h := newHarness(t, tc.on, argv)
+			h.notifier.OnEvent(tc.event(t))
+			// Give a spawn that should not happen time to happen anyway.
+			time.Sleep(200 * time.Millisecond)
+			if got := helperFiles(t, dir); len(got) != 0 {
+				t.Errorf("spawned a notifier: %q", got)
+			}
+		})
+	}
+}
+
+// TestFanOutLaneIsSkipped: a lane is an ordinary task row (§7.6), so a
+// twenty-lane tree reaching done would otherwise send twenty-one messages.
+// The root parent's own transition still fires (task 046 decision 2).
+func TestFanOutLaneIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.Done}, helperArgv(t, "capture", dir))
+	parent := int64(1)
+	h.store.tasks[2] = &store.Task{
+		ID: 2, ProjectID: 7, Title: "lane 0", ParentTaskID: &parent,
+		WorkflowName: "lane", BranchName: "vincent/2-lane",
+	}
+
+	h.notifier.OnEvent(stateEvent(1, 2, taskstate.Running, taskstate.Done, nil))
+	time.Sleep(200 * time.Millisecond)
+	if got := helperFiles(t, dir); len(got) != 0 {
+		t.Fatalf("a fan-out lane notified: %q", got)
+	}
+
+	h.notifier.OnEvent(stateEvent(2, 1, taskstate.Running, taskstate.Done, nil))
+	waitFor(t, "the root task's own notification", func() bool {
+		return len(helperFiles(t, dir)) == 2
+	})
+}
+
+// TestHungChildIsKilled: the child never exits, the notifier kills its
+// process tree at the timeout and logs it, and the worker is free again.
+func TestHungChildIsKilled(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, helperArgv(t, "hang", dir))
+	h.notifier.timeout = 500 * time.Millisecond
+
+	start := time.Now()
+	h.notifier.OnEvent(stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil))
+	waitFor(t, "the hung notifier to be killed and logged", func() bool {
+		return h.logs.contains("notification command failed") && h.logs.contains("killed after")
+	})
+	if elapsed := time.Since(start); elapsed > 20*time.Second {
+		t.Errorf("kill took %s; the timeout is meant to bound it", elapsed)
+	}
+	if !h.logs.contains("level=WARN") {
+		t.Error("a killed notifier was not logged at warn")
+	}
+}
+
+// TestPerChildTimeoutIsTenSeconds pins the documented, un-configurable value
+// the tests above lower for speed.
+func TestPerChildTimeoutIsTenSeconds(t *testing.T) {
+	if perChildTimeout != 10*time.Second {
+		t.Errorf("perChildTimeout = %s, want 10s (§12.3, task 046 decision 7)", perChildTimeout)
+	}
+	if New(Deps{Store: &fakeStore{}, Config: config.Default}).timeout != perChildTimeout {
+		t.Error("New did not take the documented timeout")
+	}
+}
+
+// TestNonZeroExitIsLoggedWithStderr: a notifier that ran and failed is
+// reported with its exit code and a stderr tail, and is never retried.
+func TestNonZeroExitIsLoggedWithStderr(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, helperArgv(t, "fail", dir))
+
+	h.notifier.OnEvent(stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil))
+	waitFor(t, "the failed notifier to be logged", func() bool {
+		return h.logs.contains("notification command failed")
+	})
+	if !h.logs.contains("exit status 3") {
+		t.Error("the log line does not carry the exit code")
+	}
+	if !h.logs.contains("deliberate failure") {
+		t.Error("the log line does not carry the stderr tail")
+	}
+	// No retry: exactly one run happened.
+	time.Sleep(300 * time.Millisecond)
+	if got := helperFiles(t, dir); len(got) != 1 {
+		t.Errorf("the failed notifier ran %d times; it must not be retried", len(got))
+	}
+}
+
+// TestStderrTailIsTruncated keeps a chatty notifier from flooding daemon.log.
+func TestStderrTailIsTruncated(t *testing.T) {
+	var b tailBuffer
+	if _, err := b.Write([]byte(strings.Repeat("a", stderrTail*3))); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := b.Write([]byte("the reason it failed")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := b.String()
+	if len(got) > stderrTail {
+		t.Errorf("kept %d bytes, want at most %d", len(got), stderrTail)
+	}
+	if !strings.HasSuffix(got, "the reason it failed") {
+		t.Error("the tail was dropped; a script that logs before it fails puts the reason last")
+	}
+}
+
+// TestConcurrencyCapAndQueueDrop is asserted against the spawn hook rather
+// than real processes: what is under test is the pool and the queue, and
+// counting four concurrent children is the same assertion either way.
+func TestConcurrencyCapAndQueueDrop(t *testing.T) {
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, []string{"unused"})
+
+	var inFlight, peak, ran atomic.Int64
+	release := make(chan struct{})
+	h.notifier.spawn = func(context.Context, job, []byte) error {
+		n := inFlight.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		ran.Add(1)
+		<-release
+		inFlight.Add(-1)
+		return nil
+	}
+
+	// Fill the workers and the queue, then push well past both. Publish must
+	// stay prompt with every worker busy: this hook runs on the store's
+	// writing goroutine.
+	const burst = maxWorkers + queueCapacity + 32
+	start := time.Now()
+	for i := range burst {
+		h.notifier.OnEvent(stateEvent(int64(i+1), 1, taskstate.Running, taskstate.Blocked, nil))
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("OnEvent blocked for %s across %d events; it must never block the publisher",
+			elapsed, burst)
+	}
+	waitFor(t, "every worker to be busy", func() bool { return inFlight.Load() == maxWorkers })
+	if !h.logs.contains("notifier queue full") {
+		t.Error("the excess was not logged as a drop")
+	}
+	close(release)
+
+	waitFor(t, "the queue to drain", func() bool { return ran.Load() >= maxWorkers+queueCapacity })
+	// Nothing past the workers plus the queue may have run: the rest was
+	// dropped, not backed up.
+	time.Sleep(200 * time.Millisecond)
+	if got := ran.Load(); got > maxWorkers+queueCapacity {
+		t.Errorf("%d notifications ran; at most %d were admitted", got, maxWorkers+queueCapacity)
+	}
+	if peak.Load() > maxWorkers {
+		t.Errorf("%d children ran at once, cap is %d", peak.Load(), maxWorkers)
+	}
+}
+
+// TestUnreadableTaskIsSkipped: a task that cannot be read loses its
+// notification and nothing else. The daemon keeps serving.
+func TestUnreadableTaskIsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, helperArgv(t, "capture", dir))
+	h.store.taskErr = errors.New("database is locked")
+
+	h.notifier.OnEvent(stateEvent(1, 1, taskstate.Running, taskstate.Blocked, nil))
+	waitFor(t, "the skip to be logged", func() bool {
+		return h.logs.contains("task could not be read")
+	})
+	if got := helperFiles(t, dir); len(got) != 0 {
+		t.Errorf("spawned a notifier without a task: %q", got)
+	}
+}
+
+// TestHotReloadChangesWhatFires: the hook reads the configuration per event,
+// so an edit to notify.on takes effect on the next transition with no
+// restart and no re-registration.
+func TestHotReloadChangesWhatFires(t *testing.T) {
+	dir := t.TempDir()
+	h := newHarness(t, []taskstate.State{taskstate.Blocked}, helperArgv(t, "capture", dir))
+
+	h.notifier.OnEvent(stateEvent(1, 1, taskstate.Running, taskstate.Done, nil))
+	time.Sleep(200 * time.Millisecond)
+	if got := helperFiles(t, dir); len(got) != 0 {
+		t.Fatalf("done fired before it was configured: %q", got)
+	}
+
+	h.setConfig(func(c *config.Config) { c.Notify.On = []taskstate.State{taskstate.Done} })
+	h.notifier.OnEvent(stateEvent(2, 1, taskstate.Running, taskstate.Done, nil))
+	waitFor(t, "the reloaded state to fire", func() bool { return len(helperFiles(t, dir)) == 2 })
+}
+
+// TestStopIsIdempotentWithoutStart guards the shutdown path: Stop runs before
+// broker.Close(), and a daemon that failed early may never have started the
+// pool.
+func TestStopIsIdempotentWithoutStart(_ *testing.T) {
+	n := New(Deps{
+		Store:  &fakeStore{},
+		Config: config.Default,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	n.Stop()
+	n.Stop()
+}

--- a/scripts/m1-gate.sh
+++ b/scripts/m1-gate.sh
@@ -55,11 +55,25 @@ if [[ "${VINCENT_GATE_AGENT:-fake}" == "claude" ]]; then
 else
   export FAKEAGENT_EDIT_FILE=README.md # give the diff something to show
 fi
-cat > "$CONFIG_DIR/config.yaml" <<EOF
+# The notify hook (task 046, §12.3). It is configured before the daemon starts
+# and set to a state nothing here reaches, so the legs above run untouched; the
+# leg at the bottom flips it and proves the reload.
+#
+# The notifier is argv only — there is no shell on any platform — and `git
+# config -f` is the same trick m6/m7 use to write a file from a step body: it
+# creates the file, appends one entry per call, and counts them back.
+NOTIFY_OUT="$(hostpath "$TMP/notify.ini")"
+write_config() { # write_config STATE
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
 agents:
   claude:
     path: "$AGENT_PATH"
+notify:
+  on: [$1]
+  command: ["git", "config", "-f", "$NOTIFY_OUT", "--add", "vincent.notify.fired", "yes"]
 EOF
+}
+write_config blocked
 
 echo "== start daemon"
 "$VINCENT" daemon start
@@ -204,6 +218,52 @@ jq -e '.error.code == "invalid_state" and .error.details.reason == "idempotency_
 $(cat "$TMP/idem.json")"
 COUNT="$(api GET /tasks | jq '[.[] | select(.title == "M1 different task")] | length' | tr -d '\r')"
 [[ "$COUNT" == "0" ]] || fail "the refused create made a task anyway"
+
+# The notify hook (task 046, §12.3, issue #90). It rides this gate because the
+# claim is about a daemon with **no client attached**, which is what every leg
+# above already is: curl makes a request and goes away.
+#
+# `notify.on` is `blocked` up to here and nothing in this script blocks, so the
+# tasks above must have fired nothing. Flipping it to `done` in config.yaml and
+# getting a notification for the next task — with no daemon restart — is the
+# hot-reload half.
+notify_count() { # prints how many times the hook has fired
+  local out="$TMP/notify.ini"
+  [[ -f "$out" ]] || { printf '0\n'; return; }
+  git config -f "$out" --get-all vincent.notify.fired | wc -l | tr -d ' \r'
+}
+
+echo "== nothing fired while notify.on listed a state no task reached"
+# Every task has to be settled before the selector changes, or one still
+# running would fire under the new one and be counted here.
+for _ in $(seq 1 120); do
+  BUSY="$(api GET /tasks | jq '[.[] | select(.state == "queued" or .state == "running")] | length' | tr -d '\r')"
+  [[ "$BUSY" == "0" ]] && break
+  sleep 1
+done
+[[ "$BUSY" == "0" ]] || fail "tasks still running; the notify leg cannot count fires"
+[[ "$(notify_count)" == "0" ]] || fail "the hook fired for a state it was not configured for"
+
+echo "== hot-reload notify.on to done"
+write_config done
+sleep 2  # the config watcher debounces a save for 100ms
+
+echo "== a finished task notifies with no client attached"
+NOTIFY_TASK="$(api POST /tasks "{\"project_id\":$PROJECT_ID,\"title\":\"M1 notify task\",\"description\":\"Say hello.\"}" | jq -r .id | tr -d '\r')"
+[[ "$NOTIFY_TASK" =~ ^[0-9]+$ ]] || fail "notify task creation returned no id"
+for _ in $(seq 1 120); do
+  STATE="$(api GET "/tasks/$NOTIFY_TASK" | jq -r .state | tr -d '\r')"
+  [[ "$STATE" == "done" ]] && break
+  [[ "$STATE" == "blocked" ]] && fail "notify task blocked"
+  sleep 1
+done
+[[ "$STATE" == "done" ]] || fail "notify task did not finish (state $STATE)"
+for _ in $(seq 1 30); do
+  [[ "$(notify_count)" == "0" ]] || break
+  sleep 1
+done
+FIRED="$(notify_count)"
+[[ "$FIRED" == "1" ]] || fail "the hook fired $FIRED times for one done transition, want 1"
 
 echo "== stop daemon"
 "$VINCENT" daemon stop


### PR DESCRIPTION
## Summary

vincent's premise is that you start work and walk away, and the daemon is
designed to run with **zero clients attached** (§2, goal 3). The one thing it
could not do with zero clients attached was say it needed a human.

The only alert in the whole tree was the TUI's terminal bell
(`internal/tui/board.go`, `ringsFor`), which rings on a transition **into
`awaiting_input`** and only while a board is open. Nothing rang for `blocked`,
nothing for `awaiting_gate`, nothing for `done`. A task could sit in
`awaiting_input` for the full 24-hour `input_timeout`, fail on expiry, and the
first anyone knew was the next time they opened the board.

This adds a config-declared exec hook: one new top-level block in
`config.yaml`, and `internal/notify`, a subscriber on the existing post-commit
event fan-out that spawns a user-supplied command when a task enters a listed
state.

```yaml
notify:
  on: [blocked, awaiting_gate, awaiting_input, done]
  command: ["/usr/local/bin/notify-me"]   # the envelope arrives on stdin
```

**No new event type.** The selector reads the `to` field of
`task.state_changed` — exactly what the TUI bell already keys off.
`task.blocked` and `task.gate_pending` do not exist and were not invented.

**The payload is an enriched envelope**, assembled by the daemon and written as
one JSON object to the child's stdin: `event_id`, `ts`, `type`; `task_id`,
`title`, `from`, `to`, `block_reason`, `queued_reason`, `current_step`,
`steps_total`, `worktree_path`, `branch`; `project_id`, `project`, `workflow`;
plus `input` (`{kind, summary}`) on a transition into `awaiting_input`. A
notifier handed `{task_id, to}` would have to call back into the API with a
bearer token to write a useful message, which defeats a one-line script.
`steps_total` comes from the task's own workflow snapshot, so it is the honest
*n* for that run.

**Validation is real.** An unknown state name in `on:` fails `config.Load`
naming the offending value, so a typo is refused whole and the watcher keeps the
last good configuration. That is why `internal/config` now imports
`internal/taskstate` — its one internal import, and a deliberate narrowing of
CLAUDE.md's leaf-package rule, recorded and justified in the task document
(decision 4). `taskstate` is itself a leaf, so the dependency direction stays
one-way.

**Delivery is fire-and-forget and bounded.** Root tasks only — a `fan_out` lane
is an ordinary task row, so a twenty-lane tree would otherwise send twenty-one
messages. A 64-entry FIFO drained by at most 4 concurrent children; only a full
*queue* drops, so the ordinary burst of five tasks blocking together is
lossless. A fixed 10 s per child, after which its whole **process tree** is
killed (`procx.Start`/`Proc.Kill`, which also gives `NoWindow` on Windows).
Failures logged and never retried; nothing persisted; nothing replayed on
restart, so a weekend of downtime cannot produce a notification storm.

`command` is argv, never a shell string — there is no portable shell to assume.
Children inherit the §12.3 `environment` policy like every other process the
daemon spawns, and get no `VINCENT_*` variables.

**The TUI bell is untouched**, and `notify` is deliberately not exposed on
`GET /v1/config`: no client needs it, and `command` can reasonably carry a
webhook URL with a token in its argv.

### Spec

This crosses two recorded deferrals, and amends both rather than working around
them (task 044 decision 1):

- **§2 / §20 — OS desktop notifications.** The *platform-native stack* stays
  deferred; the exec hook is recorded as the reason it is now cheap to leave
  deferred, since `terminal-notifier`, `notify-send` and `msg` are one
  `command:` line away. M4's acceptance was met and v1 shipped, so the §20 line
  is a spent scope boundary rather than a decision against — the same reading
  task 035 applied when it promoted GitHub issue reading out of §20.
- **§3 decision record row 22 — "TUI-level alerts only".** Narrowed in place to
  what it actually decided: how one agent question is normalized, surfaced and
  answered *inside a client*. It never bound the daemon against signalling
  outward, and it never spoke to `blocked` or `awaiting_gate` at all.

Also amends §12.3 (the key, written up in the style of its neighbours), §13.3
(explicitly: no new event type), §15 (the bell is unchanged), §16 (this is
arbitrary code run as the invoking user, and its argv can hold a secret), and
§17 (what it logs, and at which level).

### Testing

- `internal/config` — unknown state, duplicate state and empty argv element all
  refused with the key named; every §6 state accepted; an absent block inert and
  moving no other default; both `Warnings()` entries firing on exactly their
  conditions; the generated `config.yaml` still loading to a disabled hook.
- `internal/notify` — the child is a **re-exec of the test binary**, guarded by
  a `--` argv sentinel, so every case runs identically on Windows, macOS and
  Linux with no shell and no environment variable that has to survive the
  environment policy. Covers argv byte-identical to the configured list and the
  stdin JSON decoding to the documented envelope; four ways a transition must be
  ignored; a fan-out lane skipped while its root parent still fires; a hung
  child killed and logged; a non-zero exit logged with its code and a truncated
  stderr tail and never retried; the concurrency cap, the queue drop, and
  `OnEvent` staying prompt across a burst past both.
- `internal/notify/notify_live_test.go` — a real SQLite store, the real broker
  and the daemon's own hook wiring driving a real child process off a real
  `TransitionTask`, with no client attached. That is the acceptance sentence the
  issue wrote.
- **Gate:** a notify leg on `scripts/m1-gate.sh`, which CI already runs on all
  three platforms. `notify.on` starts on a state nothing in the script reaches,
  so the legs above must fire nothing; the leg then rewrites `config.yaml` and
  gets exactly one fire for the next task's `done` — the hot-reload half. The
  notifier is `git config -f "$out" --add vincent.notify.fired yes`: argv only,
  no shell, and the same trick `m6`/`m7` use to write a file from a step body.

`go test ./...` (2327 tests), `go test -race` on the touched packages,
`go run mage.go lint`, and `golangci-lint` cross-built for `windows`, `darwin`
and `linux` are all green. `./scripts/m1-gate.sh` passes locally on macOS.

**One local `-race` failure is pre-existing and not from this branch.**
`go test -race ./...` on a developer machine can fail
`internal/cli`'s `TestGitHubIssueCommandsAgainstLiveDaemon/doctor reports the
integration` and `TestGitHubUnusableLeavesTaskCreationAlone` with
`GET /v1/doctor: context deadline exceeded`. `master` (93350c2) fails the same
two tests at the same lines with the same error, so this branch neither causes
nor worsens it, and nothing was changed to chase it.

The cause is a timeout mismatch that predates the change: `GET /v1/doctor`
forces a live re-probe of every adapter (`CatalogCache.Entry(..., refresh=true)`,
`internal/api/doctor.go`), each adapter's probes bounded at 20 s
(`versionTimeout`, `modelsTimeout`) and run serially, while `internal/apiclient`
allows a flat 10 s per REST call (`requestTimeout`). On a machine with `claude`,
`codex` and `cursor-agent` really installed — cursor's `status` and `models`
probes are authenticated *network* calls — a cold `vincent doctor` measured
8.0 s on master and 8.4 s on this branch, so suite load or network jitter tips it
past 10 s. CI is unaffected: no agent CLI is installed there, so every probe
fails instantly on a missing binary. Tightening that mismatch is its own change,
not a notify PR.

## Related

Closes #90
Closes 044.1, 044.2, 044.3, 044.4, 044.5, 044.6 — see
[`docs/tasks/044-notify-hook.md`](docs/tasks/044-notify-hook.md) for the eleven
decisions and the alternatives they beat.

This **revisits decision record row 22** in `docs/spec.md` §3 and the §2/§20
deferral of OS desktop notifications. Both are amended in place with dated
notes in this PR, with the reasoning above and in the task document; neither is
worked around silently.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
      — `docs/reference/configuration.md` (the `notify` key, tracking
      `internal/config`), plus `docs/security-model.md`, `docs/features.md` and
      `docs/guides/scripting.md`. No CLI, API-route, TUI-key or block-reason
      surface changed: this adds no subcommand, no route, no binding and no
      `Reason*` constant. A follow-up documentation commit restores that page's
      "The default file" listing to the verbatim `defaultConfigYAML`, which had
      stopped matching (see below).

## Documentation audit

Every derivation CLAUDE.md names was checked against the source rather than
against this branch's plan. One page needed a change.

**`docs/reference/configuration.md` — "The default file".** The listing is
introduced with *"This is what first start writes, verbatim"* and was not that.
This branch added a commented `notify:` block to `defaultConfigYAML` in
`internal/config/bootstrap.go` and the listing did not follow. Auditing it
turned up drift in both directions that predates this branch: the listing had
grown `parallel:`, `fan_out:` and `loop:` blocks that first start does not
write at all — each already documented in its own `###` section, with the same
defaults — while `environment:`, which first start *does* write, was missing
entirely, and most of the explanatory comments had been trimmed to a line. The
block is now spliced from the constant with nothing edited. The same commit
fixes the one wrong path in the new envelope example
(`/Users/you/.local/share/...` is a macOS home carrying the Linux data
directory; every other example path under `docs/` uses `/home/you`).

**Checked and already correct:** the cobra tree, the `internal/api/server.go`
route table, `internal/tui/bindings.go`, the `Reason*` constants, and the
`internal/workflow` / `internal/taskrun` step types — this branch touches none
of them, so `cli.md`, `api.md`, `guides/tui.md`, the block-reason tables,
`workflow-schema.md` and `task-lifecycle.md` are unaffected. No adapter
capability changed, so `guides/agents.md` and §9.x stand.
`skills/vincent-workflows/SKILL.md` is **not** out of date: the workflow schema
is untouched — no step type, field, validation rule, template variable or
human-interaction mechanism moved — so the built-in prompts that splice it need
nothing. `internal/config`'s `Notify` struct, `Fires`, `validate` and the two
`Warnings()` entries match the `### notify` section key for key, including the
ten-state vocabulary, the argv-not-a-shell rule and the "both keys or it never
fires" warning. `configResponse` carries no `notify` field, which is what
`security-model.md` and the spec both claim. §17's logging table matches the
`slog` calls in `internal/notify/notify.go` (fire and skipped lane at debug;
queue-full, unreadable task, non-zero exit and timeout at warn, the last two
carrying the code and a truncated stderr tail through `ExitError` /
`TimeoutError` and `tailBuffer`). Task 044's six subtasks are all `[x]` and the
`docs/tasks/README.md` row reads `✅ done (6/6)` to match. No spec section was
renumbered. `m1-gate.sh` gained a leg but has no walkthrough in `docs/gates/` —
it asserts for itself — so there is nothing there to update.

**No screenshot is stale.** Nothing in `internal/tui` changed, so every
`docs/assets/tui-*.png` still matches the code.

**Noted, not fixed — pre-existing and outside this change.** `GET /v1/config`
is described as "the effective global config" in `docs/reference/api.md` and
"The API exposes it read-only" in `configuration.md`, but `configResponse` is a
curated DTO: it has never carried `branch_template`, `environment`, `debug`,
`github`, `include`, `parallel`, `fan_out` or `loop`, and now also omits
`notify` by design. Both sentences were already loose before this branch and
neither is made false by it — the `### notify` section states the exclusion
plainly, two lines from the example — so tightening them belongs in its own
change rather than in a notify PR.
