### PR TITLE
Add collapsible groups to the task board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,19 @@ list with the user-facing context a commit subject cannot carry.
   The graph itself is unchanged: node boxes and the inspector strip render
   exactly as they did. See [Using the TUI](docs/guides/tui.md).
 
+- **Board groups fold.** `←` collapses the group the cursor is in and `←` again
+  the group around that; `→` opens one level; `C` and `O` do the whole table.
+  A collapsed header shows `▸`, keeps its task count, its `!` needs-attention
+  badge and its selected count, and the cursor rests on it. Folds are remembered
+  across restarts in `{data_dir}/tui.json`, survive `g`, a filter and a
+  reconnect, and are forgotten when the project or workflow leaves the board.
+  A fold can never hide work waiting on you: `!` opens whatever group it lands
+  in, and a collapsed group opens by itself the moment a task inside it enters
+  `awaiting_input`. `V` still selects tasks inside a fold. With
+  `tui.board.group_by: []` there are no groups and the four keys do nothing;
+  a fresh install has nothing folded. See
+  [Using the TUI](docs/guides/tui.md#folding-groups).
+
 ### Changed
 
 - **The board stops spending a wide terminal on the title column, and a cell

--- a/docs/features.md
+++ b/docs/features.md
@@ -162,6 +162,8 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
 
 - A filterable, grouped task board shows state, current step, elapsed time,
   reported cost, and — on a wide terminal — the step's own status message.
+  Groups fold away, and a folded one still carries its task count and its
+  needs-attention badge.
 - Task detail is a full-screen workspace with Steps & Attempts, Task Details,
   Output, Diff, and Workflow tabs; each tab uses the whole view.
 - Guided task creation exposes project, workflow, declared fields, git and

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -136,10 +136,44 @@ task count and its needs-attention badge](../assets/tui-grouping.png)
 - A grouped level loses its column — the header already names it — and the
   width it frees is spent on the row: on the title first, and once the title
   has reached its ceiling, on `STEP` and `STATUS`.
-- Headers are labels: the cursor steps over them, and nothing collapses.
+- An open header is a label: the cursor steps over it, and clicking it selects
+  nothing.
 
 `g` cycles project›workflow → project → workflow → flat for the session. The
 panel title names the grouping whenever it is not the configured one.
+
+### Folding groups
+
+On an installation with six projects on it, most of the board is not what you
+are working on. Fold the rest away:
+
+| Key | Does |
+|---|---|
+| `←` | Collapse the group you are in. Press it again on the header it closed to fold the group around that |
+| `→` | Expand the collapsed group under the cursor, one level |
+| `C` | Collapse every group |
+| `O` | Expand every group |
+
+A collapsed header shows `▸` instead of `▾`, and it keeps everything that made
+the group worth reading at a glance: the task count, the `!` needs-attention
+badge, and how many of its tasks are selected. **The cursor rests on a collapsed
+header** — that is what makes it a row rather than a label, and it is how `←`
+and `→` reach every nesting level. It is not a task, so the action keys, `space`
+and `enter` do nothing there.
+
+Three things mean a fold can never hide work waiting on you:
+
+- the header's badge and count survive the fold;
+- `!` (jump to the next task needing a human) opens whatever group it lands in;
+- a collapsed group **opens by itself** the moment a task inside it starts
+  waiting for input.
+
+Folds are remembered across restarts, in `{data_dir}/tui.json`
+([files](../reference/files.md)). They survive `g`, a filter and a reconnect,
+and a group is forgotten when its project or workflow leaves the board. `V`
+still selects tasks inside a collapsed group — the selection is a set of tasks,
+not of rows. With `group_by: []` there are no groups, so the four keys do
+nothing. A fresh install has nothing folded.
 
 Set the grouping you start with in `config.yaml`
 ([`tui.board.group_by`](../reference/configuration.md#tuiboardgroup_by)); `[]`

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -63,7 +63,7 @@ Project-scoped workflows live in the repository instead, at
   token                                             # API bearer token, 0600
   daemon.json                                       # { port, pid, started_at }
   daemon.lock                                       # single-instance lock
-  tui.json                                          # TUI-local state
+  tui.json                                          # TUI-local view state
   logs/daemon.log                                   # rotated, size-capped
   worktrees/{task_id}/                              # one git worktree per task
   transcripts/{task_id}/{step_index}-{attempt}.jsonl
@@ -75,7 +75,7 @@ Project-scoped workflows live in the repository instead, at
 | `token` | The API bearer token, created `0600` at first start. On Windows it relies on the per-user ACL of `%LOCALAPPDATA%`. Anyone who can read it can drive your daemon |
 | `daemon.json` | How clients find the daemon: port, pid, start time. Written atomically, removed on graceful shutdown |
 | `daemon.lock` | Single-instance enforcement; releases automatically when the process dies |
-| `tui.json` | TUI-local state, including the first-run full-auto acknowledgment |
+| `tui.json` | TUI-local view state: the first-run full-auto acknowledgment, and the board's collapsed groups. Written by the TUI, never read by the daemon; deleting it re-shows the full-auto notice and opens every group |
 | `logs/daemon.log` | The daemon log, rotated and size-capped. Read by `vincent daemon logs` and the TUI's daemon view — from disk in both cases, so it still works when the daemon is what died |
 
 ## Worktrees and branches

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4746,7 +4746,10 @@ get to bend:
   around that, `→` opens one level, `C` and `O` do the whole table. A *collapsed*
   header stands in for tasks that are not on screen, so it **is** a row: the
   cursor rests on it, and it shows `▸` rather than `▾`, its task count, its
-  attention badge and how many of its tasks the bulk selection holds. Folding is
+  attention badge and how many of its tasks the bulk selection holds. It is a
+  row and not a task: it has no state and no `available_actions`, so the §6
+  action keys, `space`, `enter` and `L` do nothing while the cursor is on one
+  and the detail panels hold the last task rather than blanking. Folding is
   a view over the same band sort — the rows that remain are in the order they
   were. It is never refused: what protects the failure the original rule named is
   that the header keeps its badge, that `!` opens whatever group it lands in, and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3013,7 +3013,7 @@ platform the standing answer to an agent that will not resolve is the §12.3
   token                      # API bearer token, created 0600 at first start
   daemon.json                # { "port": N, "pid": N, "started_at": … } for client discovery
   daemon.lock
-  tui.json                   # TUI-local state (the §16 first-run acknowledgment)
+  tui.json                   # TUI-local view state: the §16 first-run acknowledgment, the board's collapsed groups (§15)
   worktrees/{task_id}/
   transcripts/{task_id}/{step_index}-{attempt}.jsonl
   transcripts/{task_id}/{step_index}-{step_id}-{attempt}.jsonl  # sub-step of a parallel group (§7.5)
@@ -4358,8 +4358,13 @@ its task insert back, and replays the winner's.
 
 ## 15. TUI
 
-Built with Bubble Tea. The TUI is a pure API client — it holds no state the daemon
-doesn't have, and killing it never affects work. It subscribes to `/v1/events` and
+Built with Bubble Tea. The TUI is a pure API client — it holds no *task* state
+the daemon doesn't have, and killing it never affects work. What it does own is
+view state: where the cursor is, which tabs are open, and (amended 2026-08-29,
+task 054) which board groups are folded, which persists in `{data_dir}/tui.json`
+beside the §16 acknowledgment. That is not configuration — the TUI still reads
+none from disk, and `tui.board.group_by` arrives over `GET /v1/config` as it
+always did. It subscribes to `/v1/events` and
 re-renders on change; the task-detail view additionally subscribes to that task's
 stream for the live tail.
 
@@ -4733,10 +4738,23 @@ get to bend:
   amended to that; the reasoning that a **new column** must not silently
   re-spend the freed width is untouched, and is still what the `STATUS` gate
   enforces.*
-- **A header is a label, not a row.** The cursor steps over headers in the
-  direction it was travelling, clicking one selects nothing, and nothing folds
-  away: a board whose whole job is showing you every task has no business
-  hiding rows behind a collapse.
+- **An open header is a label, not a row.** The cursor steps over it in the
+  direction it was travelling, and clicking it selects nothing.
+- **Groups fold** (amended 2026-08-29, task 054; this replaces the original
+  "nothing folds away" rule, which is superseded together with task 009's
+  decision 4). `←` collapses the group the cursor is in and `←` again the group
+  around that, `→` opens one level, `C` and `O` do the whole table. A *collapsed*
+  header stands in for tasks that are not on screen, so it **is** a row: the
+  cursor rests on it, and it shows `▸` rather than `▾`, its task count, its
+  attention badge and how many of its tasks the bulk selection holds. Folding is
+  a view over the same band sort — the rows that remain are in the order they
+  were. It is never refused: what protects the failure the original rule named is
+  that the header keeps its badge, that `!` opens whatever group it lands in, and
+  that a collapsed group opens by itself the moment a task inside it enters
+  `awaiting_input`. The set is keyed by label path, persists in
+  `{data_dir}/tui.json`, survives `g` and a filter, and drops a path whose
+  project or workflow has left the board. `group_by: []` has no groups, so the
+  four keys are inert; a fresh install has nothing folded.
 - **The panel title names the grouping only when it is not the configured one**,
   the same rule the output pane's `v` follows.
 

--- a/docs/tasks/009-configurable-tasks-view.md
+++ b/docs/tasks/009-configurable-tasks-view.md
@@ -72,6 +72,33 @@ business hiding rows, and a collapsed group holding an `awaiting_input` task is 
 the failure the pinning rule and the bell exist to prevent. The `▾` glyph is a nesting
 marker, not a disclosure control.
 
+> **Superseded in part, 2026-08-29 — [task 054](054-collapsible-board-groups.md).**
+> Groups fold. The half of this decision that stands is the cursor rule for an
+> *open* header: it is still a label, it is still stepped over, and clicking it
+> still selects nothing, for the reason given above — it has no task, so it has
+> no state, no `available_actions` and nothing for the detail panels to show. A
+> **collapsed** header stands in for tasks that are not on screen, so it is a
+> row the cursor rests on; the same reasoning then says what it is *not*, and
+> the §6 action keys, `space`, `enter` and `L` all do nothing on one.
+>
+> The half that is reversed is "nothing collapses". The argument that beat it:
+> on a six-project installation the board's job is showing you every task you
+> can *act on* rather than every task there is, and the two ways out today both
+> cost something — `/` hides the work waiting on a human, `g` keeps every row.
+> The concrete failure this decision named is answered three times over, and the
+> third answer is what makes it unreachable rather than merely visible:
+>
+> - the header keeps its task count and its `! n` attention badge through a fold
+>   — the machinery decision 2 built for exactly this;
+> - `!` opens whatever group it lands in, so the key that exists for finding
+>   waiting work always reaches it;
+> - a collapsed group opens **by itself** the moment a task inside it enters
+>   `awaiting_input`.
+>
+> Nothing is ever *refused* a collapse, which is what would have made the
+> feature unpredictable on the busy board that wants it. See 050 for the fold
+> rules, where the set lives and why that is not a reversal of decision 1.
+
 ### 5. `g` cycles for the session and never writes the config
 
 *2026-08-16.* project›workflow → project → workflow → flat. The config is where the
@@ -113,7 +140,10 @@ board with one level of a two-level grouping is still a board.
 
 ## Out of scope
 
-- **Collapsing groups** — decision 4.
+- ~~**Collapsing groups** — decision 4.~~ *(2026-08-29: no longer out of scope —
+  delivered by [task 054](054-collapsible-board-groups.md), which supersedes the
+  "nothing collapses" half of decision 4. The reasoning is in the note on that
+  decision above.)*
 - **Grouping by state, agent, model or priority** — decision 6.
 - **Configurable columns or sort order.** This task makes the table's *shape*
   configurable; which columns show is still derived from the terminal width (§15), and

--- a/docs/tasks/054-collapsible-board-groups.md
+++ b/docs/tasks/054-collapsible-board-groups.md
@@ -132,6 +132,16 @@ With `group_by: []` there are no headers, so the four keys are inert and their
 footer hints are dropped (`shell.liveBindings`). The saved set is **not**
 cleared — cycling back to a grouped view restores what was folded.
 
+## Tasks
+
+- [x] **050.1** Fold the board's groups: `foldPath`/`foldSet`, `applyFolds` and
+  the four key handlers in `internal/tui/boardfold.go`; `←`/`→`/`C`/`O` in the
+  binding registry; the cursor rule for a collapsed header and the count,
+  attention badge and marked count on its cell; `!` and the incoming
+  `awaiting_input` transition opening a fold; the set persisted, pruned and
+  fail-open through `{data_dir}/tui.json`; the §15 and §12.2 amendments and
+  009's superseding note. ✓ 2026-08-29
+
 ## Implementation notes
 
 Everything is in `internal/tui` plus documentation. No daemon, API, store,

--- a/docs/tasks/054-collapsible-board-groups.md
+++ b/docs/tasks/054-collapsible-board-groups.md
@@ -134,7 +134,7 @@ cleared — cycling back to a grouped view restores what was folded.
 
 ## Tasks
 
-- [x] **050.1** Fold the board's groups: `foldPath`/`foldSet`, `applyFolds` and
+- [x] **054.1** Fold the board's groups: `foldPath`/`foldSet`, `applyFolds` and
   the four key handlers in `internal/tui/boardfold.go`; `←`/`→`/`C`/`O` in the
   binding registry; the cursor rule for a collapsed header and the count,
   attention badge and marked count on its cell; `!` and the incoming

--- a/docs/tasks/054-collapsible-board-groups.md
+++ b/docs/tasks/054-collapsible-board-groups.md
@@ -1,0 +1,166 @@
+# 054 — Collapsible groups on the task board
+
+**Status:** ✅ done (1/1)
+**Spec:** amends §15 (the grouping amendment's header rule, and the
+pure-API-client sentence), §12.2 (`tui.json`)
+**Supersedes:** [009](009-configurable-tasks-view.md) decision 4, in part
+
+## Problem
+
+The board nests its rows under group headers, `[project, workflow]` by default
+since [009](009-configurable-tasks-view.md) — but every row under every header
+is always rendered. A board carrying several projects and a long tail of
+finished tasks pushes the project you are actually working in off the bottom of
+the screen, and grouping does nothing about it: `g` changes the *shape* of the
+table, never the number of rows in it.
+
+The two ways out today both cost something. `/` filters to one project but hides
+everything else, including work waiting on a human — the case the filter is
+explicitly not allowed to be used for. `g` to a coarser grouping keeps every row.
+
+The headers already carry what you need to decide a group is not interesting
+right now — the task count, and the `! n` attention badge when the group holds
+any — so the information is on screen; there was just no way to act on it.
+
+## Decisions
+
+**1. The fold set lives in `{data_dir}/tui.json`, under a new key.**
+*(2026-08-29)*
+
+`{data_dir}/tui.json` has existed since v0 (`internal/tui/firstrun.go`, spec
+§12.2, `docs/reference/files.md`, `docs/security-model.md`), and the v0 record
+that created it says why in as many words: *"an open JSON object so later prefs
+join without a format change"* (`docs/history/v0-tasks.md`). The write already
+merges into whatever the file holds rather than rewriting it, so a field one
+build does not know about survives being read by it.
+
+So there is **no second path per platform, no second reload story, no new
+`vincent doctor` line and no new page**: the file is already resolved, already
+permissioned (`internal/config/permissions.go`), already excluded from backup
+and restore (task 030), and already documented on all three pages. The whole
+cost is one key on an object that exists.
+
+**009 decision 1 is not reversed.** It governs *configuration the TUI reads* —
+the thing that made it not a pure API client — and `tui.board.group_by` still
+arrives over `GET /v1/config` exactly as it did. A fold set is view state the
+TUI owns, which is the same category as the first-run acknowledgment that file
+was built for. §15's "holds no state the daemon doesn't have" gains a dated
+amendment naming the distinction; it is not weakened.
+
+**Beat:** session-only folds (cheapest, but re-collapsing the same five projects
+at every launch is what makes a feature like this go unused); a separate prefs
+file (a second TUI-owned file next to `tui.json` with no reason for the split);
+a daemon-side `/v1/view-state` endpoint (an endpoint, a migration and a rule for
+two disagreeing TUIs, to store a gesture).
+
+**2. A collapsed header is selectable; an expanded one stays a label.**
+*(2026-08-29)*
+
+If the cursor never lands on a header, then `→` — "expand the group the cursor's
+*task* belongs to" — can never address a group that is already collapsed,
+because collapsing moved the cursor to a task outside it. `O` would be the only
+way back, and there would be no way to reach an outer level at all.
+
+The rule instead: **a collapsed header stands in for its tasks, so it is a row;
+an expanded header names rows that are present, so it stays a label.** `↑`/`↓`
+stop on a collapsed header and step over an expanded one. `←` on a task
+collapses its innermost group and leaves the cursor on the header it just
+closed; `←` again folds the parent; `→` expands one level and the cursor moves
+onto the first thing that level now shows — a task, or a sub-header still
+folded. This is ordinary tree behaviour, it addresses every nesting level
+without a "nearest above" heuristic, and it is what `enter` already means in the
+diff pane.
+
+009 decision 4's reasoning still governs the rest: a collapsed header has no
+task, so it has no state, no `available_actions` and nothing for the detail
+panels to show. The §6 action keys, `space`, `enter` and `L` therefore do
+nothing on one, and the detail panels hold their last task rather than blanking.
+
+**Beat:** `→` expanding the nearest collapsed group above the cursor
+(unpredictable on a busy board, and still cannot reach an outer level);
+accepting the hole and letting `O` be the way back (makes `→` nearly useless);
+headers fully selectable with `enter` folding (rejected for 009 decision 4's
+reason).
+
+**3. Decision 4's failure is made impossible, not merely visible.**
+*(2026-08-29)*
+
+009 decision 4 named one concrete failure: a collapsed group holding an
+`awaiting_input` task. Three things answer it, and the third is beyond what the
+issue asked for:
+
+- The header carries the `! n` attention badge and the task count already — that
+  machinery was built in 009 decision 2 for exactly this, and it keeps working
+  through a fold. So does the bulk-selection count, so `V` reaching into a fold
+  (task 011: the selection is not a view) is never invisible.
+- `!` (jump to the next task needing a human) expands whatever group it lands
+  in. The expansion is a real fold change and is persisted like any other.
+- **A collapsed group auto-expands the moment a task inside it *enters*
+  `awaiting_input`** — read off the same `task.state_changed` event that rings
+  the bell, but read separately, because the bell is rate-limited into one
+  interruption and an expansion has to happen every time.
+
+Folds stay predictable in the direction that matters — nothing is ever *refused*
+a collapse, which is what would make the feature unpredictable on the busy board
+that wants it — while the board state decision 4 was protecting against cannot
+be reached.
+
+**Beat:** refusing to collapse a group that holds attention work, which
+preserves the concern literally and makes the fold a coin toss.
+
+**4. Pruning is against task values, not the current grouping.** *(2026-08-29)*
+
+The issue's two acceptance criteria conflict as written: folds must survive `g`
+cycling away and back, but a path whose label "no longer appears" is dropped —
+and cycling to `project`-only grouping makes every `[project, workflow]` path
+stop appearing.
+
+A saved path is kept while each segment is still a project name or a workflow
+name occurring somewhere in the **unfiltered** task list, independent of which
+levels are currently rendered. `g` cycling therefore leaves the set alone, a
+filter leaves it alone, and a project that is archived away drops out. Pruning
+runs on the task list the board holds and only on a *successful* load, so a
+disconnected TUI prunes nothing rather than forgetting everything.
+
+**Beat:** pruning once at load (a long-lived TUI accumulates dead paths); never
+pruning with an LRU cap (a stale path silently re-collapses a project that comes
+back months later).
+
+**5. Flat grouping has no folds.** *(2026-08-29)*
+
+With `group_by: []` there are no headers, so the four keys are inert and their
+footer hints are dropped (`shell.liveBindings`). The saved set is **not**
+cleared — cycling back to a grouped view restores what was folded.
+
+## Implementation notes
+
+Everything is in `internal/tui` plus documentation. No daemon, API, store,
+config or migration change, which is the strongest argument for this shape over
+the `/v1/view-state` alternative.
+
+| File | Change |
+|---|---|
+| `internal/tui/boardfold.go` | New. `foldPath`/`foldSet`, `applyFolds`, pruning, the four key handlers, the `tui.json` read/write. A sibling of `boardgroup.go` and `boardmark.go` rather than more of `boardgroup.go`, following the file convention the board package already has |
+| `internal/tui/boardgroup.go` | `boardRow` gains `path`, `collapsed` and `marked`; `groupRows` fills the path; `▸`/`▾` by state; the header cell gains the marked count |
+| `internal/tui/board.go` | `←`/`→`/`C`/`O`; `rows()` = `applyFolds(allRows())`; `visible()` reads `allRows()` and so stays filter-scoped; `skipHeaders` stops on a collapsed header; `selected()` answers "no task" on one; cursor restore by path; the prune on load; the auto-expand |
+| `internal/tui/firstrun.go` | The `tui.json` helpers generalized to `readTUIState`/`mergeTUIState`; the merge-preserving write was already there |
+| `internal/tui/bindings.go` | Four `ctxTasks` rows, marked `fold:` so a flat board can drop them |
+| `internal/tui/shell.go` | `!` expands the group it lands in; `liveBindings` |
+| `internal/tui/boardmark.go` | Unchanged by design — `visible()` is filter-scoped, not fold-scoped, so `V` marks inside collapsed groups for free. Covered by a test rather than an edit |
+
+## Out of scope
+
+- **A daemon-side view-state endpoint.** Decision 1.
+- **Remembering which task the cursor was on across restarts.** The fold set is
+  the one piece of board view state that is worth a file; a cursor is not.
+- **Folding in the diff pane or the workflow graph.** Both already have their
+  own fold rules (§15, task 012; task 017), and they are session-only on
+  purpose.
+
+## Verification
+
+- `go test ./...`, `go test -race ./internal/tui`, `go run mage.go lint` for
+  `GOOS=darwin`, `linux` and `windows`.
+- No gate script. This is a judgement about a TUI, which is why 009 had none
+  either. The board screenshots did not change shape — a fresh install has
+  nothing folded — so `scripts/screenshots.sh` was not re-run.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -67,6 +67,7 @@ the living engineering specification records implementation contracts.
 | [051](051-live-workflow-graph-tab.md) | Live workflow graph tab on the task workspace | ✅ done (5/5) |
 | [052](052-github-pull-requests.md) | List a GitHub project's open pull requests and link them to board tasks | 🚧 in progress (5/7) |
 | [053](053-workflow-step-detail.md) | A full step-detail modal in the workflow graph | ✅ done (5/5) |
+| [054](054-collapsible-board-groups.md) | Collapsible groups on the task board | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -78,6 +78,11 @@ type binding struct {
 	priority int
 	// action is the §6 action a scopeTaskAction row is gated on.
 	action string
+	// fold marks a row whose key only means something while the board has
+	// groups. With `group_by: []` there are none, so shell.liveBindings drops
+	// these and the footer never names a press that does nothing (task 054
+	// decision 5).
+	fold bool
 	// nav marks a navigation entry; navTarget is where it goes.
 	nav       bool
 	navTarget viewID
@@ -137,6 +142,13 @@ var bindings = []binding{
 	{key: "space", label: "select this task for a bulk action — the action keys then act on every selected task (space again deselects, esc clears)", scope: scopePanel, context: ctxTasks, hint: "space select", priority: 5},
 	{key: "V", label: "select every task the filter is showing, or clear that selection", scope: scopePanel, context: ctxTasks, priority: 6},
 	{key: "L", label: "drill into the selected fan-out's lanes, or back out (lanes are hidden from the board otherwise)", scope: scopePanel, context: ctxTasks, hint: "L lanes", priority: 7},
+	// Folding (task 054). ← and → walk the group tree a level at a time; the
+	// cursor rests on a collapsed header, which is how every level stays
+	// addressable. C/O are the diff pane's two letters in the same meaning.
+	{key: "left", label: "collapse the group you are in (← again folds the group around it; the header keeps the count and the ! badge)", scope: scopePanel, context: ctxTasks, hint: "←/→ fold", priority: 8, fold: true},
+	{key: "right", label: "expand the collapsed group under the cursor, one level", scope: scopePanel, context: ctxTasks, priority: 9, fold: true},
+	{key: "C", label: "collapse every group", scope: scopePanel, context: ctxTasks, hint: "C/O fold all", priority: 10, fold: true},
+	{key: "O", label: "expand every group", scope: scopePanel, context: ctxTasks, priority: 11, fold: true},
 
 	// Timeline.
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxTimeline, hint: "tab views", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -40,6 +40,8 @@ func registryKey(t *testing.T, key string) tea.KeyPressMsg {
 		msg = tea.KeyPressMsg{Code: tea.KeyDown}
 	case "right":
 		msg = tea.KeyPressMsg{Code: tea.KeyRight}
+	case "left":
+		msg = tea.KeyPressMsg{Code: tea.KeyLeft}
 	case "space":
 		msg = tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}
 	case "ctrl+s":
@@ -100,6 +102,22 @@ func tabbedTaskFixture(t *testing.T, tab taskViewTab) *taskView {
 // repairFormFixture is a repair popup as `R` on a blocked task opens it.
 func repairFormFixture() *repairForm {
 	return newRepairForm(7, "check_failed", "build")
+}
+
+// foldingShell is a shell whose board is grouped and focused on the task
+// table — the only state the four fold keys exist in. newShellFixture's board
+// is flat, where they are deliberately inert (task 054 decision 5).
+func foldingShell(t *testing.T) *shell {
+	t.Helper()
+	s, _ := newShellFixture(t,
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("web"), inWorkflow("build")),
+	)
+	s.focus = panelTasks
+	s.board.group, s.board.configGroup = defaultGrouping(), defaultGrouping()
+	s.board.dataDir, s.board.foldsLoaded = "", true
+	s.render(120, 37)
+	return s
 }
 
 func followUpFormFixture() *followUpForm {
@@ -192,6 +210,50 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			s2.update(registryKey(t, "L"))
 			if s2.board.laneParent != 0 {
 				t.Fatalf("L drilled into a task with no lanes (laneParent %d)", s2.board.laneParent)
+			}
+		},
+		"left": func(t *testing.T) {
+			s := foldingShell(t)
+			s.update(registryKey(t, "left"))
+			s.render(120, 37)
+			if !s.board.folds.has(foldPath{"api", "build"}) {
+				t.Fatalf("left did not collapse the cursor's group (folds %v)", s.board.folds)
+			}
+			// Again, on the header it just closed: ← walks outwards.
+			s.update(registryKey(t, "left"))
+			s.render(120, 37)
+			if !s.board.folds.has(foldPath{"api"}) {
+				t.Fatalf("a second left did not collapse the parent (folds %v)", s.board.folds)
+			}
+		},
+		"right": func(t *testing.T) {
+			s := foldingShell(t)
+			s.update(registryKey(t, "left"))
+			s.render(120, 37)
+			s.update(registryKey(t, "right"))
+			s.render(120, 37)
+			if s.board.folds.has(foldPath{"api", "build"}) {
+				t.Fatalf("right did not expand the group under the cursor (folds %v)", s.board.folds)
+			}
+		},
+		"C": func(t *testing.T) {
+			s := foldingShell(t)
+			s.update(registryKey(t, "C"))
+			s.render(120, 37)
+			for _, want := range []foldPath{{"api"}, {"api", "build"}} {
+				if !s.board.folds.has(want) {
+					t.Fatalf("C did not collapse %v (folds %v)", want, s.board.folds)
+				}
+			}
+		},
+		"O": func(t *testing.T) {
+			s := foldingShell(t)
+			s.update(registryKey(t, "C"))
+			s.render(120, 37)
+			s.update(registryKey(t, "O"))
+			s.render(120, 37)
+			if len(s.board.folds) != 0 {
+				t.Fatalf("O left folds behind: %v", s.board.folds)
 			}
 		},
 	},

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -85,6 +86,11 @@ type board struct {
 
 	tbl        table.Model
 	selectedID int64
+	// selectedPath is the collapsed header the cursor is resting on, empty
+	// when it is on a task. A collapsed header stands in for its tasks, so it
+	// is a row (task 054 decision 2) — and the render has to be able to put
+	// the cursor back on it, which selectedID cannot say.
+	selectedPath foldPath
 	// laneParent drills the board into one fan-out parent's lanes (§7.6,
 	// task 014). Zero is the ordinary board, which hides lanes entirely
 	// (decision 13); non-zero shows exactly that parent's lanes, in merge
@@ -95,6 +101,14 @@ type board struct {
 	// marks is the bulk selection (boardmark.go, task 011): the tasks the §6
 	// action keys act on instead of the row under the cursor.
 	marks markSet
+
+	// folds is the collapsed groups (boardfold.go, task 054), persisted in
+	// {data_dir}/tui.json — dataDir is where, and foldsLoaded stops a
+	// reconnect's second setDataDir from re-reading the file over folds made
+	// since. Empty is the board every version before this one rendered.
+	folds       foldSet
+	dataDir     string
+	foldsLoaded bool
 
 	filter    textinput.Model
 	filtering bool
@@ -178,6 +192,18 @@ func ringBell() {
 }
 
 func (b *board) title() string { return "Board" }
+
+// setDataDir hands the board the resolved data dir and reads the fold set out
+// of it (task 054 decision 1). It is called again on every reconnect, which
+// must not re-read the file: the folds on screen are newer than the ones on
+// disk whenever a key was pressed since.
+func (b *board) setDataDir(dir string) {
+	if b.foldsLoaded && b.dataDir == dir {
+		return
+	}
+	b.dataDir, b.foldsLoaded = dir, true
+	b.folds = loadFolds(dir)
+}
 
 // setClient wires the board to a connected daemon and kicks off its initial
 // load. Called again on reconnect, which is why the tick is guarded.
@@ -346,6 +372,14 @@ func (b *board) updateLoaded(msg boardLoadedMsg) {
 	// to a 404. Only a *successful* load prunes: a failed refresh is not news
 	// about which tasks exist.
 	b.marks = b.marks.keep(msg.tasks)
+	// The same argument for the fold set: a group whose project was removed
+	// would otherwise re-collapse it months later when it comes back
+	// (task 054 decision 4). Pruning is against the task values rather than
+	// the rendered grouping, so `g` and the filter leave it alone.
+	if pruned := b.folds.prune(msg.tasks); len(pruned) != len(b.folds) {
+		b.folds = pruned
+		b.persistFolds()
+	}
 }
 
 // updateNote reacts to the event stream. Every task event schedules a
@@ -362,6 +396,14 @@ func (b *board) updateNote(n apiclient.Note) tea.Cmd {
 			bell()
 			return nil
 		})
+	}
+	// A collapsed group opens by itself the moment a task inside it enters
+	// awaiting_input (task 054 decision 3). This is the safeguard that makes
+	// 009 decision 4's named failure — a fold hiding a task waiting on a
+	// human — unreachable rather than merely visible, and it hangs off the
+	// same event the bell reads.
+	if id, ok := enteredAwaitingInput(ev.Event); ok && b.expandFor(id) {
+		cmds = append(cmds, b.saveFolds())
 	}
 	if isTaskEvent(ev.Event.Type) {
 		cmds = append(cmds, b.scheduleRefresh())
@@ -412,6 +454,29 @@ func (b *board) ringsFor(ev apiclient.Event) bool {
 	}
 	b.lastBellAt = now
 	return true
+}
+
+// enteredAwaitingInput reads a state-change event for a transition *into*
+// awaiting_input and names the task it happened to.
+//
+// It is a second read of the event ringsFor already looks at, because the two
+// answers differ: the bell rings once per event id and is rate-limited into
+// one interruption, while a fold hiding a task that just started waiting has
+// to open every time.
+func enteredAwaitingInput(ev apiclient.Event) (int64, bool) {
+	if ev.Type != "task.state_changed" || ev.TaskID == nil {
+		return 0, false
+	}
+	var payload struct {
+		To string `json:"to"`
+	}
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		return 0, false
+	}
+	if payload.To != stateAwaitingInput {
+		return 0, false
+	}
+	return *ev.TaskID, true
 }
 
 func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
@@ -490,6 +555,24 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		b.group = b.group.next()
 		b.groupPinned = true
 		return b, nil
+	case "left", "right", "C", "O":
+		// Folding (boardfold.go, task 054). With `group_by: []` there are no
+		// groups, so the four keys are inert rather than doing something
+		// arbitrary — and the fold set is *not* cleared, so cycling back to a
+		// grouped view restores what was folded (decision 5).
+		if len(b.group) == 0 {
+			return b, nil
+		}
+		switch msg.String() {
+		case "left":
+			return b, b.collapseAtCursor()
+		case "right":
+			return b, b.expandAtCursor()
+		case "C":
+			return b, b.collapseAll()
+		default:
+			return b, b.expandAll()
+		}
 	}
 
 	// §15's action keys act on the row under the cursor. A key the daemon
@@ -518,12 +601,16 @@ func travelDir(before, after int) int {
 	return 1
 }
 
-// skipHeaders steps the cursor off any row it may not rest on — a group
-// header, or the continuation of a wrapped row above it — carrying on in the
-// direction of travel and turning around at either end. Headers are labels:
-// resting on one would empty the detail panels and offer no actions. A
-// continuation is the same task as the line above it, so resting there would
-// make j and k take two or three presses to move one task.
+// skipHeaders steps the cursor off any row it may not rest on — an *expanded*
+// group header, or the continuation of a wrapped row above it — carrying on in
+// the direction of travel and turning around at either end. An expanded header
+// names rows that are present, so it is a label: resting on one would empty
+// the detail panels and offer no actions. A continuation is the same task as
+// the line above it, so resting there would make j and k take two or three
+// presses to move one task. A *collapsed* header stands in for tasks that are
+// not on screen, so it is a row and the cursor stops there (task 054
+// decision 2) — which is what lets ←/→ address every nesting level without a
+// heuristic.
 //
 // It moves with MoveUp/MoveDown rather than SetCursor for the reason
 // clickRow does: the table's scroll offset is private and only those two keep
@@ -581,12 +668,13 @@ func (b *board) clickRow(line int) {
 		return
 	}
 	delta := line - cursorLine
-	// A group header is a label, not a row: clicking one leaves the selection
-	// alone rather than jumping to a task the click did not name. The clicked
-	// row is the cursor's plus the delta — a body line cannot be indexed into
-	// the row slice directly, because the table may be scrolled.
+	// An expanded group header is a label, not a row: clicking one leaves the
+	// selection alone rather than jumping to a task the click did not name. A
+	// collapsed one is a row and selects like any other. The clicked row is
+	// the cursor's plus the delta — a body line cannot be indexed into the row
+	// slice directly, because the table may be scrolled.
 	target := b.rowAt(b.tbl.Cursor() + delta)
-	if target.header {
+	if target.header && !target.collapsed {
 		return
 	}
 	// A click on the second or third line of a wrapped row names the row it
@@ -626,16 +714,37 @@ func (b *board) wheelMove(delta int) {
 }
 
 // rows is the table as it is rendered: filtered, sorted, — under a grouping —
-// interleaved with group headers (boardgroup.go), and expanded so a task that
-// wraps occupies one row per line. Every index into the table means an index
-// into this slice, which is the property the whole wrapping design is built
-// to keep: the cursor, the click math and bubbles' own paging all count rows.
+// interleaved with group headers (boardgroup.go), with the subtree of every
+// collapsed one removed (boardfold.go), and expanded so a task that wraps
+// occupies one row per line. Every index into the table means an index into
+// this slice, which is the property the whole wrapping design is built to
+// keep: the cursor, the click math and bubbles' own paging all count rows.
+//
+// Folding runs before wrapping, not after: applyFolds counts the marked tasks
+// a collapsed header swallowed, and a wrapped task is several rows carrying
+// the same task, so folding a wrapped board would count each of them. Wrapping
+// last also measures the row height against the rows actually on screen, so a
+// long title inside a collapsed group no longer makes every row taller.
 func (b *board) rows() []boardRow {
+	return b.wrapRows(applyFolds(b.allRows(), b.folds, b.marks))
+}
+
+// allRows is the same table before folds and wrapping are applied — filtered,
+// sorted and grouped, one row per task. It is what folding is a view over,
+// which is how group order and within-group order stay the band sort's (009
+// decision 2), and it is what anything that means "the tasks on this board"
+// reads.
+func (b *board) allRows() []boardRow {
 	tasks := filterTasks(b.tasks, b.filter.Value())
 	sorted := make([]apiclient.Task, len(tasks))
 	copy(sorted, tasks)
 	sortTasks(sorted)
-	rows := groupRows(sorted, b.group)
+	return groupRows(sorted, b.group)
+}
+
+// wrapRows expands each task row into one row per rendered line, so an index
+// into the table is an index into the slice.
+func (b *board) wrapRows(rows []boardRow) []boardRow {
 	// Before the first render there is no width to wrap against, and a board
 	// laid out at a guessed one would place the cursor by rows that are not
 	// the rows about to be drawn.
@@ -674,11 +783,17 @@ func (b *board) rowAt(i int) boardRow {
 	return rows[i]
 }
 
-// visible is the tasks on screen in render order, headers dropped: the list
-// for anything that walks tasks rather than lines — the attention jump, the
-// action bar's target.
+// visible is the tasks the *filter* is showing, in render order, headers
+// dropped: the list for anything that walks tasks rather than lines — the
+// attention jump, the action bar's target, `V`.
+//
+// It is deliberately filter-scoped and not fold-scoped. A fold is a way of
+// looking at the board, exactly as a `g` press is; the selection and the
+// attention jump are statements about tasks. So `V` marks inside a collapsed
+// group (task 011's rule, unchanged) and `!` can reach a task a fold is
+// hiding — which is what lets it open the group it lands in.
 func (b *board) visible() []apiclient.Task {
-	rows := b.rows()
+	rows := b.allRows()
 	out := make([]apiclient.Task, 0, len(rows))
 	for _, r := range rows {
 		if r.selectable() {
@@ -700,6 +815,14 @@ func (b *board) selected() (int64, bool) {
 	rows := b.rows()
 	i := b.tbl.Cursor()
 	if i < 0 {
+		return 0, false
+	}
+	// A collapsed header is a row, but it is not a task: it has no state, no
+	// available_actions and nothing for the detail panels to show, so the §6
+	// action keys, space, enter and L all do nothing on one and the panels
+	// hold their last task (task 054 decision 2). Resolving forward here
+	// would make every one of those keys act on a task the cursor is not on.
+	if i < len(rows) && rows[i].header && rows[i].collapsed {
 		return 0, false
 	}
 	for ; i < len(rows); i++ {
@@ -730,6 +853,14 @@ func (b *board) hintedProject() int64 {
 // its cursor index but never remaps it, so tracking the index alone would
 // silently select a different task whenever the sort shifted.
 func (b *board) rememberSelection() {
+	if r := b.rowAt(b.tbl.Cursor()); r.header && r.collapsed {
+		// The cursor is parked on a fold. selectedID cannot say that — it
+		// names a task — so the path is remembered alongside it, and the last
+		// task stays remembered for when the group opens again.
+		b.selectedPath = slices.Clone(r.path)
+		return
+	}
+	b.selectedPath = nil
 	if id, ok := b.selected(); ok {
 		b.selectedID = id
 	}
@@ -738,12 +869,24 @@ func (b *board) rememberSelection() {
 // restoreSelection moves the cursor back onto the remembered task — after a
 // refresh that reordered the rows, and after `g` regrouped them.
 func (b *board) restoreSelection(rows []boardRow) {
+	if len(b.selectedPath) > 0 {
+		if i := headerIndex(rows, b.selectedPath); i >= 0 && rows[i].collapsed {
+			b.tbl.SetCursor(i)
+			return
+		}
+	}
 	if b.selectedID != 0 {
 		for i := range rows {
 			if rows[i].selectable() && rows[i].task.ID == b.selectedID {
 				b.tbl.SetCursor(i)
 				return
 			}
+		}
+		// The row is gone because a fold swallowed it: the header standing in
+		// for the task is where the cursor belongs, not the top of the board.
+		if i := b.foldedHome(rows); i >= 0 {
+			b.tbl.SetCursor(i)
+			return
 		}
 	}
 	// The task is gone (archived, or filtered out), or nothing has been

--- a/internal/tui/boardfold.go
+++ b/internal/tui/boardfold.go
@@ -1,0 +1,430 @@
+package tui
+
+import (
+	"slices"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Collapsible groups on the task board (§15, task 054).
+//
+// A board carrying six projects and a long tail of finished tasks pushes the
+// project you are working in off the bottom of the screen, and grouping does
+// nothing about it: `g` changes the shape of the table, never the number of
+// rows in it. Folding is the missing half — and it is a *view* over the same
+// band-sorted list, applied after groupRows has already laid it out, so 009
+// decision 2 (group order and within-group order come from the band sort)
+// survives untouched.
+//
+// Task 009 decision 4 rejected collapsing outright, naming one concrete
+// failure: a collapsed group holding an awaiting_input task. That half of the
+// decision is deliberately superseded here, and three things answer the
+// failure it named — the header keeps its count and its `! n` attention badge
+// through a fold, `!` expands whatever group it lands in, and a fold opens by
+// itself the moment a task inside it enters awaiting_input (board.expandFor).
+// Nothing is ever *refused* a collapse, which is what would make the feature
+// unpredictable on exactly the busy board that wants it.
+
+// foldPath names one group by the labels of its header and every header above
+// it, outermost first: ["api", "build"] is the `build` workflow inside the
+// `api` project. Labels rather than indices, so a refetch that reorders the
+// board — or a `g` press that renders a different set of levels — leaves the
+// set meaning what it meant.
+type foldPath []string
+
+func (p foldPath) equal(other foldPath) bool { return slices.Equal(p, other) }
+
+// covers reports that p names a group containing the group (or task) named by
+// child: a fold at ["api"] hides everything under ["api", "build"].
+func (p foldPath) covers(child foldPath) bool {
+	return len(p) <= len(child) && p.equal(child[:len(p)])
+}
+
+// foldSet is the collapsed groups. A slice rather than a map for the reason
+// markSet is one: it is tens of entries at most, and a stable order makes what
+// it feeds — the JSON written to tui.json, and the tests that pin it —
+// deterministic.
+type foldSet []foldPath
+
+func (f foldSet) has(p foldPath) bool {
+	return slices.ContainsFunc(f, p.equal)
+}
+
+// with collapses a group, kept sorted so two boards that folded the same
+// groups in a different order write the same file.
+func (f foldSet) with(p foldPath) foldSet {
+	if len(p) == 0 || f.has(p) {
+		return f
+	}
+	out := append(slices.Clone(f), slices.Clone(p))
+	slices.SortFunc(out, slices.Compare)
+	return out
+}
+
+// without expands one group. It is exactly one level: `→` walks down the tree
+// a step at a time, so unfolding a project must leave a workflow inside it
+// folded if that is how it was left.
+func (f foldSet) without(p foldPath) foldSet {
+	i := slices.IndexFunc(f, p.equal)
+	if i < 0 {
+		return f
+	}
+	out := slices.Delete(slices.Clone(f), i, i+1)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// prune drops paths that name nothing on the board any more.
+//
+// A path survives while every segment is still a project name or a workflow
+// name occurring somewhere in the *unfiltered* task list, independent of which
+// levels are currently rendered (task 054 decision 4). Pruning against the
+// rendered grouping instead would make `g` destructive: cycling to
+// project-only grouping stops every [project, workflow] path from appearing,
+// and the issue's other acceptance criterion is that folds survive `g` cycling
+// away and back. A filter leaves the set alone for the same reason.
+//
+// An empty list prunes nothing: a TUI whose daemon went away holds no news
+// about which projects exist, and forgetting every fold on a reconnect blip is
+// worse than keeping a dead one until the next successful load.
+func (f foldSet) prune(tasks []apiclient.Task) foldSet {
+	if len(f) == 0 || len(tasks) == 0 {
+		return f
+	}
+	known := make(map[string]struct{}, len(tasks)*2)
+	for _, t := range tasks {
+		known[groupValue(t, groupProject)] = struct{}{}
+		known[groupValue(t, groupWorkflow)] = struct{}{}
+	}
+	out := make(foldSet, 0, len(f))
+	for _, p := range f {
+		if len(p) == 0 {
+			continue
+		}
+		live := true
+		for _, seg := range p {
+			if _, ok := known[seg]; !ok {
+				live = false
+				break
+			}
+		}
+		if live {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// taskPath is the group a task sits in under one grouping — the path `←`
+// collapses when the cursor is on it.
+func taskPath(t apiclient.Task, g grouping) foldPath {
+	p := make(foldPath, 0, len(g))
+	for _, k := range g {
+		p = append(p, groupValue(t, k))
+	}
+	return p
+}
+
+// applyFolds is the fold view: the same rows, with the subtree of every
+// collapsed header removed. It runs after groupRows rather than inside it so
+// that the ordering groupRows produces is provably untouched — a folded board
+// is the unfolded one with rows deleted, never a second sort.
+//
+// A collapsed header additionally reports how many of the tasks it swallowed
+// are marked: the bulk selection is a set of tasks and not a view (task 011),
+// so `V` marks inside a fold and the header is what keeps that honest.
+func applyFolds(rows []boardRow, folds foldSet, marks markSet) []boardRow {
+	if len(folds) == 0 {
+		return rows
+	}
+	out := make([]boardRow, 0, len(rows))
+	// depth of the collapsed header currently swallowing rows, and where it
+	// landed in out; -1 when nothing is being swallowed.
+	hidingAt, header := -1, -1
+	for _, r := range rows {
+		if hidingAt >= 0 {
+			if r.depth > hidingAt {
+				if !r.header && marks.has(r.task.ID) {
+					out[header].marked++
+				}
+				continue
+			}
+			hidingAt, header = -1, -1
+		}
+		if r.header && folds.has(r.path) {
+			r.collapsed = true
+			out = append(out, r)
+			hidingAt, header = r.depth, len(out)-1
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// headerIndex is where a path's header sits in a rendered row set, or -1.
+func headerIndex(rows []boardRow, p foldPath) int {
+	return slices.IndexFunc(rows, func(r boardRow) bool { return r.header && r.path.equal(p) })
+}
+
+// landingRow is the first row at or after i the cursor may rest on: a task, or
+// a collapsed header standing in for its tasks. An expanded header names rows
+// that are present, so it stays a label the cursor steps over (task 054
+// decision 2), and a wrapped row's continuations belong to the line above
+// them — boardRow.selectable is the one definition of both.
+// Returns -1 when there is nothing below.
+func landingRow(rows []boardRow, i int) int {
+	for ; i < len(rows); i++ {
+		if rows[i].selectable() {
+			return i
+		}
+	}
+	return -1
+}
+
+// loadFolds reads the persisted set. Every failure — no file, an unreadable
+// one, a half-written one — answers "everything expanded", which is the
+// fail-open direction tui.json's existing contract already uses and is
+// exactly the board this feature's users had yesterday.
+func loadFolds(dataDir string) foldSet {
+	return foldSet(readTUIState(dataDir).BoardFolds)
+}
+
+// writeFolds persists the set, merging into whatever else tui.json holds so
+// the first-run acknowledgment — and any field a later build adds — survives.
+func writeFolds(dataDir string, f foldSet) error {
+	if f == nil {
+		f = foldSet{}
+	}
+	return mergeTUIState(dataDir, foldsKey, f)
+}
+
+// foldsKey is the tui.json field. It is the JSON tag on tuiState.BoardFolds;
+// mergeTUIState writes into a map, so the two are held together here rather
+// than by the compiler.
+const foldsKey = "board_folds"
+
+// The four keys. `←`/`→` walk the tree one level at a time and `C`/`O` do the
+// whole table — the same two letters, in the same meaning, the diff pane
+// already teaches (task 012).
+//
+// None of them touches the cursor by index: each names the row it wants and
+// lets the next render place it (restoreSelection), which is the rule `g`
+// already follows. Reading a cursor index from the old layout against the new
+// one is how a fold would silently select a different task.
+
+// cursorRow is the row under the cursor in the current fold view.
+func (b *board) cursorRow() (boardRow, bool) {
+	rows := b.rows()
+	i := b.tbl.Cursor()
+	if i < 0 || i >= len(rows) {
+		return boardRow{}, false
+	}
+	return rows[i], true
+}
+
+// cursorPath is the group the fold keys act on: the path of the collapsed
+// header under the cursor, or the innermost group of the task under it.
+func (b *board) cursorPath() (foldPath, bool) {
+	r, ok := b.cursorRow()
+	if !ok {
+		return nil, false
+	}
+	if r.header {
+		return r.path, true
+	}
+	return taskPath(r.task, b.group), true
+}
+
+// collapseAtCursor is `←`: fold the innermost group the cursor is in, and
+// leave the cursor on the header it just closed. Pressing it again on that
+// header folds the parent, so ← walks outwards a level at a time and every
+// nesting level is addressable without a "nearest above" heuristic.
+func (b *board) collapseAtCursor() tea.Cmd {
+	// The task under the cursor is what the detail panels go on showing once
+	// the fold swallows its row, and where `→` and `O` come back to.
+	b.rememberSelection()
+	p, ok := b.cursorPath()
+	if !ok || len(p) == 0 {
+		return nil
+	}
+	if b.folds.has(p) {
+		if len(p) == 1 {
+			return nil // already at the outermost level
+		}
+		p = p[:len(p)-1]
+	}
+	b.folds = b.folds.with(p)
+	b.focusPath(p)
+	return b.saveFolds()
+}
+
+// expandAtCursor is `→`: open the collapsed header under the cursor by
+// exactly one level, and move the cursor onto the first thing it now shows —
+// a task, or a sub-header that was left folded. An expanded header is a label
+// again, so the cursor does not stay on it.
+//
+// `→` on a row that is not a collapsed header does nothing: it is a request
+// to open *this* group, not a search for one somewhere else on the board.
+func (b *board) expandAtCursor() tea.Cmd {
+	r, ok := b.cursorRow()
+	if !ok || !r.header || !r.collapsed {
+		return nil
+	}
+	b.folds = b.folds.without(r.path)
+	rows := b.rows()
+	i := headerIndex(rows, r.path)
+	if i < 0 {
+		b.selectedPath = nil
+		return b.saveFolds()
+	}
+	b.focusRow(rows, landingRow(rows, i+1))
+	return b.saveFolds()
+}
+
+// collapseAll is `C`: fold every group at every level, and leave the cursor on
+// the outermost header it was under. Every level rather than the top one
+// alone, so `→` afterwards is the same one-level walk down it is anywhere else.
+func (b *board) collapseAll() tea.Cmd {
+	p, _ := b.cursorPath()
+	next := b.folds
+	for _, r := range b.allRows() {
+		if r.header {
+			next = next.with(r.path)
+		}
+	}
+	if len(next) == len(b.folds) && len(p) == 0 {
+		return nil
+	}
+	b.folds = next
+	if len(p) > 0 {
+		b.focusPath(p[:1])
+	}
+	return b.saveFolds()
+}
+
+// expandAll is `O`: nothing folded anywhere, which is the board a fresh
+// install renders. A cursor parked on a header moves onto the first task that
+// header was standing in for.
+func (b *board) expandAll() tea.Cmd {
+	if len(b.folds) == 0 {
+		return nil
+	}
+	p, onHeader := b.cursorPath()
+	if r, ok := b.cursorRow(); !ok || !r.header {
+		onHeader = false
+	}
+	b.folds = nil
+	b.selectedPath = nil
+	if onHeader && len(p) > 0 {
+		rows := b.rows()
+		if i := headerIndex(rows, p); i >= 0 {
+			b.focusRow(rows, landingRow(rows, i+1))
+		}
+	}
+	return b.saveFolds()
+}
+
+// expandFor opens every fold standing between the board and one task, and
+// reports whether anything moved. It is what `!` and an incoming
+// awaiting_input transition both call: a fold is never allowed to be the
+// reason work waiting on a human cannot be reached (task 054 decision 3).
+func (b *board) expandFor(id int64) bool {
+	if len(b.folds) == 0 {
+		return false
+	}
+	i := slices.IndexFunc(b.tasks, func(t apiclient.Task) bool { return t.ID == id })
+	if i < 0 {
+		return false
+	}
+	// The path is read against the grouping on screen: what has to open is
+	// what is hiding the task now.
+	p := taskPath(b.tasks[i], b.group)
+	next := b.folds
+	for n := 1; n <= len(p); n++ {
+		next = next.without(p[:n])
+	}
+	if len(next) == len(b.folds) {
+		return false
+	}
+	b.folds = next
+	b.selectedPath = nil
+	return true
+}
+
+// focusPath parks the cursor on one collapsed header. The path is recorded
+// whether or not the header is on screen yet, because the render that places
+// the cursor is the one that will build the rows.
+func (b *board) focusPath(p foldPath) {
+	b.selectedPath = slices.Clone(p)
+	rows := b.rows()
+	if i := headerIndex(rows, p); i >= 0 {
+		b.tbl.SetCursor(i)
+	}
+}
+
+// focusRow parks the cursor on row i of a freshly computed row set.
+func (b *board) focusRow(rows []boardRow, i int) {
+	if i < 0 || i >= len(rows) {
+		b.selectedPath = nil
+		return
+	}
+	if rows[i].header {
+		b.focusPath(rows[i].path)
+		return
+	}
+	b.selectedPath = nil
+	b.selectedID = rows[i].task.ID
+	b.tbl.SetCursor(i)
+}
+
+// saveFolds persists the set off the update loop. A failed write is not
+// reported: the fold is applied on screen either way, and the only
+// consequence is that the next launch opens the group again — which is the
+// same fail-open direction loadFolds takes.
+func (b *board) saveFolds() tea.Cmd {
+	dir, folds := b.dataDir, slices.Clone(b.folds)
+	if dir == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		_ = writeFolds(dir, folds)
+		return nil
+	}
+}
+
+// persistFolds is saveFolds for the callers that have no command to return —
+// a prune inside a load handler. The write is small and on a file only this
+// process owns; doing it inline costs one syscall on a path that already
+// rebuilt the whole task list.
+func (b *board) persistFolds() {
+	if b.dataDir == "" {
+		return
+	}
+	_ = writeFolds(b.dataDir, b.folds)
+}
+
+// foldedHome is the collapsed header standing in for the remembered task,
+// when a fold is what took its row away — a refetch or a `g` press landing on
+// a board where the task's group is closed. The cursor belongs there rather
+// than at the top of the list.
+func (b *board) foldedHome(rows []boardRow) int {
+	i := slices.IndexFunc(b.tasks, func(t apiclient.Task) bool { return t.ID == b.selectedID })
+	if i < 0 {
+		return -1
+	}
+	p := taskPath(b.tasks[i], b.group)
+	if len(p) == 0 {
+		return -1
+	}
+	return slices.IndexFunc(rows, func(r boardRow) bool {
+		return r.header && r.collapsed && r.path.covers(p)
+	})
+}

--- a/internal/tui/boardfold_test.go
+++ b/internal/tui/boardfold_test.go
@@ -554,3 +554,53 @@ func TestReconnectDoesNotRereadTheFolds(t *testing.T) {
 		t.Errorf("a reconnect re-read the file over the folds on screen: %v", b.folds)
 	}
 }
+
+// TestFoldingAWrappedBoard is where this feature meets task 050's wrapping,
+// which is the one place the two can disagree. Folding runs *before* wrapping
+// (board.rows): a wrapped task is several rows carrying the same task, so a
+// fold applied afterwards would count each of its lines as another marked
+// task and report a collapsed group as holding more work than it does. The
+// collapsed header is also a row the cursor rests on, so it must stay one
+// line at a height where tasks take three.
+func TestFoldingAWrappedBoard(t *testing.T) {
+	long := strings.Repeat("a very long task title ", 6)
+	b := groupedBoard(
+		task(1, stateBlocked, inProject("api"), inWorkflow("build"), withTitle(long)),
+		task(2, stateQueued, inProject("api"), inWorkflow("build"), withTitle(long)),
+		task(3, stateQueued, inProject("web"), inWorkflow("build"), withTitle(long)),
+	)
+	b.render(90, 30)
+	b.marks = b.marks.add(1, 2)
+
+	// The fixture only means anything if it wraps: without continuation rows
+	// this is TestCollapsedHeaderCountsWhatItHides a second time.
+	var conts int
+	for _, r := range b.rows() {
+		if r.line > 0 {
+			conts++
+		}
+	}
+	if conts == 0 {
+		t.Fatalf("no row wrapped at 90 columns; the fixture no longer tests anything")
+	}
+
+	b.folds = b.folds.with(foldPath{"api"})
+	rows := b.rows()
+	r := rows[0]
+	if !r.collapsed || r.count != 2 || r.attention != 1 || r.marked != 2 {
+		t.Fatalf("collapsed header = %+v, want 2 tasks, 1 needing attention, 2 marked", r)
+	}
+	if r.line != 0 || !r.selectable() {
+		t.Errorf("collapsed header is not a landable single-line row: %+v", r)
+	}
+	// Nothing from inside the fold survived as a continuation.
+	for _, row := range rows {
+		if !row.header && row.task.ProjectName == "api" {
+			t.Errorf("row for a folded-away task is still on the board: %+v", row)
+		}
+	}
+	// And the header is one line: the row after it is the next group's.
+	if len(rows) < 2 || !rows[1].header || rows[1].label != "web" {
+		t.Errorf("rows after the collapsed header = %v, want the web header next", rowLabels(rows))
+	}
+}

--- a/internal/tui/boardfold_test.go
+++ b/internal/tui/boardfold_test.go
@@ -1,0 +1,556 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Collapsible board groups (task 054). The fixture is boardgroup_test.go's
+// groupedBoard — folding is a view over the grouping, so it is tested against
+// the same board the grouping is.
+
+var (
+	keyLeft  = tea.KeyPressMsg{Code: tea.KeyLeft}
+	keyRight = tea.KeyPressMsg{Code: tea.KeyRight}
+	keyFoldC = tea.KeyPressMsg{Code: 'C', Text: "C"}
+	keyFoldO = tea.KeyPressMsg{Code: 'O', Text: "O"}
+	keyGroup = tea.KeyPressMsg{Code: 'g', Text: "g"}
+)
+
+// twoProjectBoard is three tasks over two projects and three workflows: deep
+// enough that a nested fold has a sub-header to hide and a sibling to leave
+// alone. Queued, so the band sort is id order and the expected rows read off
+// the fixture.
+func twoProjectBoard() *board {
+	return groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("api"), inWorkflow("docs")),
+		task(3, stateQueued, inProject("web"), inWorkflow("build")),
+	)
+}
+
+// press drives a key and runs whatever command it returned, which is how the
+// runtime would — the fold writes ride one.
+func foldPress(b *board, msg tea.KeyPressMsg) {
+	_, cmd := b.updateKey(msg)
+	if cmd != nil {
+		cmd()
+	}
+	b.render(160, 20)
+}
+
+func wantRows(t *testing.T, b *board, want ...string) {
+	t.Helper()
+	got := rowLabels(b.rows())
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("rows =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+// TestFoldHidesTheSubtreeAndExpandsOneLevel is the shape of the feature: a
+// collapsed group takes its tasks *and* its sub-headers off the board, ← walks
+// outwards, and → puts back exactly one level — the workflow left folded
+// inside the project stays folded.
+func TestFoldHidesTheSubtreeAndExpandsOneLevel(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+
+	foldPress(b, keyLeft)
+	wantRows(t, b,
+		"▾ api",
+		" ▸ build",
+		" ▾ docs", "#2",
+		"▾ web",
+		" ▾ build", "#3",
+	)
+
+	// Again, on the header it just closed: the parent folds, taking the open
+	// `docs` sub-header with it.
+	foldPress(b, keyLeft)
+	wantRows(t, b,
+		"▸ api",
+		"▾ web",
+		" ▾ build", "#3",
+	)
+
+	foldPress(b, keyRight)
+	wantRows(t, b,
+		"▾ api",
+		" ▸ build",
+		" ▾ docs", "#2",
+		"▾ web",
+		" ▾ build", "#3",
+	)
+
+	foldPress(b, keyRight)
+	wantRows(t, b,
+		"▾ api",
+		" ▾ build", "#1",
+		" ▾ docs", "#2",
+		"▾ web",
+		" ▾ build", "#3",
+	)
+	if len(b.folds) != 0 {
+		t.Errorf("folds left over after unfolding everything: %v", b.folds)
+	}
+}
+
+// TestFoldingIsAViewOverTheBandSort is the property 009 decision 2 was not
+// allowed to lose: the folded board is the unfolded one with rows deleted.
+// Group order and within-group order are never recomputed, so a group holding
+// a task that needs a human still rises to the top.
+func TestFoldingIsAViewOverTheBandSort(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateBlocked, inProject("web"), inWorkflow("deploy")),
+		task(3, stateQueued, inProject("api"), inWorkflow("docs")),
+	)
+	b.render(160, 20)
+	unfolded := rowLabels(b.allRows())
+
+	b.folds = b.folds.with(foldPath{"web"})
+	folded := rowLabels(b.rows())
+
+	// Everything still on screen is in the order it was, and the only rows
+	// missing are the ones under the collapsed header.
+	var kept []string
+	for _, l := range unfolded {
+		if l == "▾ web" {
+			kept = append(kept, "▸ web")
+			continue
+		}
+		if strings.HasPrefix(l, " ") || l == "#2" {
+			// The `web` subtree: its workflow sub-header and its task.
+			if len(kept) > 0 && kept[len(kept)-1] == "▸ web" {
+				continue
+			}
+		}
+		kept = append(kept, l)
+	}
+	if strings.Join(folded, "|") != strings.Join(kept, "|") {
+		t.Errorf("folded rows =\n  %v\nwant the unfolded list minus the subtree\n  %v", folded, kept)
+	}
+	// And the blocked task's group is still first: the fold did not re-sort.
+	if b.rows()[0].label != "web" {
+		t.Errorf("first group = %q, want the one holding the blocked task", b.rows()[0].label)
+	}
+}
+
+// cursorRowIsLandable asserts the cursor is on a row the board says it may
+// rest on — never off the end, never on an open header, never on a row a fold
+// took away.
+func cursorRowIsLandable(t *testing.T, b *board, after string) {
+	t.Helper()
+	rows := b.rows()
+	i := b.tbl.Cursor()
+	if i < 0 || i >= len(rows) {
+		t.Fatalf("%s: cursor at %d, outside the %d rows on screen", after, i, len(rows))
+	}
+	if rows[i].header && !rows[i].collapsed {
+		t.Fatalf("%s: cursor parked on the open header %q", after, rows[i].label)
+	}
+}
+
+// TestCursorRestsOnAFoldAndStepsOverAnOpenHeader is task 054 decision 2. A
+// collapsed header stands in for its tasks, so ↑/↓ stop on it; an expanded one
+// names rows that are present, so they step over it as they always did.
+func TestCursorRestsOnAFoldAndStepsOverAnOpenHeader(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+
+	foldPress(b, keyLeft) // fold api › build, cursor lands on the header it closed
+	if r := b.rowAt(b.tbl.Cursor()); !r.header || !r.collapsed || r.label != "build" {
+		t.Fatalf("← left the cursor on %+v, want the collapsed `build` header", r)
+	}
+
+	// Down from a fold reaches the next task, stepping over `docs`.
+	foldPress(b, tea.KeyPressMsg{Code: tea.KeyDown})
+	if got, ok := b.selected(); !ok || got != 2 {
+		t.Fatalf("down selected %d (ok=%v), want 2", got, ok)
+	}
+	// And up comes back to the fold rather than sliding past it.
+	foldPress(b, tea.KeyPressMsg{Code: tea.KeyUp})
+	if r := b.rowAt(b.tbl.Cursor()); !r.header || !r.collapsed {
+		t.Fatalf("up did not stop on the collapsed header: %+v", r)
+	}
+}
+
+// TestCursorNeverLandsOnAHiddenRow walks every way the rows can change under
+// the cursor.
+func TestCursorNeverLandsOnAHiddenRow(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+
+	for _, step := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"←", keyLeft},
+		{"← again", keyLeft},
+		{"→", keyRight},
+		{"C", keyFoldC},
+		{"O", keyFoldO},
+		{"C again", keyFoldC},
+		{"g", keyGroup},
+		{"g again", keyGroup},
+	} {
+		foldPress(b, step.key)
+		cursorRowIsLandable(t, b, step.name)
+	}
+
+	// A refetch that reorders the board, with folds in place.
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{
+		task(3, stateBlocked, inProject("web"), inWorkflow("build")),
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("api"), inWorkflow("docs")),
+	}})
+	b.render(160, 20)
+	cursorRowIsLandable(t, b, "a refetch")
+}
+
+// TestFoldedGroupSwallowingTheCursorKeepsItNearby: a `g` press or a refetch
+// that puts the selected task inside a closed group leaves the cursor on the
+// header standing in for it, not at the top of the board.
+func TestFoldedGroupSwallowingTheCursorKeepsItNearby(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, tea.KeyPressMsg{Code: tea.KeyDown})
+	foldPress(b, tea.KeyPressMsg{Code: tea.KeyDown}) // #3, in web › build
+	if got, _ := b.selected(); got != 3 {
+		t.Fatalf("fixture selected %d, want 3", got)
+	}
+	b.folds = b.folds.with(foldPath{"web"})
+	b.render(160, 20)
+	if r := b.rowAt(b.tbl.Cursor()); !r.header || r.label != "web" {
+		t.Fatalf("cursor went to %+v, want the `web` header now standing in for #3", r)
+	}
+}
+
+// TestCollapsedHeaderIsNotATask is the other half of decision 2: a fold has no
+// state and no available_actions, so nothing that acts on a task acts on it.
+func TestCollapsedHeaderIsNotATask(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, keyLeft)
+
+	if id, ok := b.selected(); ok {
+		t.Fatalf("a collapsed header resolved to task %d, want no task", id)
+	}
+	if got := b.target(); got.id != 0 {
+		t.Errorf("action target on a fold = %d, want none", got.id)
+	}
+	if line := b.actionLine(); line != "" {
+		t.Errorf("a fold offered actions: %q", line)
+	}
+	// space is a statement about a task; there is none here.
+	foldPress(b, tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	if b.hasMarks() {
+		t.Errorf("space on a fold marked something: %v", b.marks)
+	}
+	// The panels keep the task they were showing rather than blanking.
+	if b.selectedID != 1 {
+		t.Errorf("selectedID = %d, want the last task (1) still remembered", b.selectedID)
+	}
+}
+
+// TestCollapsedHeaderCountsWhatItHides is what makes the fold honest, and what
+// answers the failure 009 decision 4 named: the count, the attention badge and
+// the bulk-selection count all survive the fold.
+func TestCollapsedHeaderCountsWhatItHides(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateBlocked, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("api"), inWorkflow("build")),
+	)
+	b.render(160, 20)
+	b.marks = b.marks.add(1, 2)
+	b.folds = b.folds.with(foldPath{"api"})
+
+	r := b.rows()[0]
+	if !r.collapsed || r.count != 2 || r.attention != 1 || r.marked != 2 {
+		t.Fatalf("collapsed header = %+v, want 2 tasks, 1 needing attention, 2 marked", r)
+	}
+	cell := r.headerCell()
+	for _, want := range []string{groupGlyphFolded, "api", "2", attentionBadge, markGlyph} {
+		if !strings.Contains(cell, want) {
+			t.Errorf("collapsed header cell %q does not carry %q", cell, want)
+		}
+	}
+}
+
+// TestBulkSelectionIgnoresFolds: the selection is a set of tasks, not a view
+// (task 011), so `V` reaches into a closed group — and a filter, which is also
+// only a view, changes no fold.
+func TestBulkSelectionIgnoresFolds(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, keyFoldC)
+
+	foldPress(b, tea.KeyPressMsg{Code: 'V', Text: "V"})
+	for _, id := range []int64{1, 2, 3} {
+		if !b.marks.has(id) {
+			t.Errorf("V did not mark #%d inside a collapsed group (marks %v)", id, b.marks)
+		}
+	}
+
+	before := slices.Clone(b.folds)
+	b.filter.SetValue("web")
+	b.render(160, 20)
+	if !slices.EqualFunc(b.folds, before, foldPath.equal) {
+		t.Errorf("a filter changed the fold set: %v, was %v", b.folds, before)
+	}
+}
+
+// TestFoldsSurviveRegroupingAndFilters, and drop only when the names in them
+// leave the board (task 054 decision 4). The two acceptance criteria conflict
+// unless pruning is against task values rather than the rendered grouping.
+func TestFoldsSurviveRegroupingAndFilters(t *testing.T) {
+	b := groupedBoard(
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateQueued, inProject("web"), inWorkflow("deploy")),
+	)
+	b.render(160, 20)
+	foldPress(b, keyLeft)
+	want := foldPath{"api", "build"}
+	if !b.folds.has(want) {
+		t.Fatalf("← did not fold %v (folds %v)", want, b.folds)
+	}
+
+	// `g` all the way round, including the project-only and flat views where
+	// a [project, workflow] path renders nothing at all.
+	for range groupingCycle() {
+		foldPress(b, keyGroup)
+		if !b.folds.has(want) {
+			t.Fatalf("grouping %s dropped %v (folds %v)", b.group.label(), want, b.folds)
+		}
+	}
+	b.filter.SetValue("web")
+	b.render(160, 20)
+	if !b.folds.has(want) {
+		t.Fatalf("a filter dropped %v (folds %v)", want, b.folds)
+	}
+	b.filter.SetValue("")
+
+	// A load that no longer holds the project, which is what archiving one
+	// away looks like from here.
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{
+		task(2, stateQueued, inProject("web"), inWorkflow("deploy")),
+	}})
+	if b.folds.has(want) {
+		t.Errorf("a vanished project was resurrected: %v", b.folds)
+	}
+
+	// A disconnected board holds no news about which projects exist.
+	b.folds = b.folds.with(want)
+	b.updateLoaded(boardLoadedMsg{tasks: nil})
+	if !b.folds.has(want) {
+		t.Errorf("an empty task list pruned the fold set: %v", b.folds)
+	}
+}
+
+// TestFlatGroupingHasNoFolds is decision 5: the four keys are inert, and the
+// saved set is kept rather than cleared, so cycling back restores it.
+func TestFlatGroupingHasNoFolds(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, keyLeft)
+	want := slices.Clone(b.folds)
+
+	b.group = nil
+	b.render(160, 20)
+	for _, k := range []tea.KeyPressMsg{keyLeft, keyRight, keyFoldC, keyFoldO} {
+		foldPress(b, k)
+		if !slices.EqualFunc(b.folds, want, foldPath.equal) {
+			t.Fatalf("%s changed the fold set on a flat board: %v, want %v", k.String(), b.folds, want)
+		}
+	}
+	for _, r := range b.rows() {
+		if r.header {
+			t.Fatalf("a flat board produced the header %q", r.label)
+		}
+	}
+	// And the hints are not offered for keys that do nothing.
+	s := &shell{board: b}
+	for _, row := range s.liveBindings(bindingsFor(ctxTasks)) {
+		if row.fold {
+			t.Errorf("a flat board still advertises %q", row.key)
+		}
+	}
+	b.group = defaultGrouping()
+	if !slices.EqualFunc(b.folds, want, foldPath.equal) {
+		t.Errorf("folds = %v after cycling back, want %v", b.folds, want)
+	}
+}
+
+// TestAwaitingInputOpensItsGroup is decision 3's third safeguard: a fold can
+// never *become* the board 009 decision 4 was protecting against, because the
+// transition that would create one opens it.
+func TestAwaitingInputOpensItsGroup(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, keyFoldC)
+	if len(b.folds) == 0 {
+		t.Fatal("C folded nothing")
+	}
+
+	payload, err := json.Marshal(map[string]string{"from": stateRunning, "to": stateAwaitingInput})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	id := int64(2)
+	b.updateNote(apiclient.EventNote{Event: apiclient.Event{
+		ID: 9, Type: "task.state_changed", TaskID: &id, Payload: payload,
+	}})
+	b.render(160, 20)
+
+	for _, p := range []foldPath{{"api"}, {"api", "docs"}} {
+		if b.folds.has(p) {
+			t.Errorf("%v is still folded over a task that started waiting (folds %v)", p, b.folds)
+		}
+	}
+	// The sibling project is none of the transition's business.
+	if !b.folds.has(foldPath{"web"}) {
+		t.Errorf("an unrelated group was opened too: %v", b.folds)
+	}
+	if got := rowLabels(b.rows()); !slices.Contains(got, "#2") {
+		t.Errorf("the waiting task is still hidden: %v", got)
+	}
+}
+
+// A transition to anything else leaves the folds alone: opening a group for
+// every state change would make the board unfoldable on a busy installation.
+func TestOtherTransitionsLeaveFoldsAlone(t *testing.T) {
+	b := twoProjectBoard()
+	b.render(160, 20)
+	foldPress(b, keyFoldC)
+	before := slices.Clone(b.folds)
+
+	payload, err := json.Marshal(map[string]string{"to": stateRunning})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	id := int64(2)
+	b.updateNote(apiclient.EventNote{Event: apiclient.Event{
+		ID: 9, Type: "task.state_changed", TaskID: &id, Payload: payload,
+	}})
+	if !slices.EqualFunc(b.folds, before, foldPath.equal) {
+		t.Errorf("a run transition opened a group: %v, was %v", b.folds, before)
+	}
+}
+
+// TestJumpAttentionOpensTheGroupItLandsIn: `!` is the key that exists for
+// finding work waiting on a human, so a fold is never allowed to be what
+// stops it (decision 3).
+func TestJumpAttentionOpensTheGroupItLandsIn(t *testing.T) {
+	s, _ := newShellFixture(t,
+		task(1, stateQueued, inProject("api"), inWorkflow("build")),
+		task(2, stateAwaitingInput, inProject("web"), inWorkflow("deploy")),
+	)
+	s.board.group, s.board.configGroup = defaultGrouping(), defaultGrouping()
+	s.board.foldsLoaded = true
+	s.render(120, 37)
+	s.board.updateKey(keyFoldC)
+	s.render(120, 37)
+	if !s.board.folds.has(foldPath{"web"}) {
+		t.Fatalf("C did not fold the waiting task's project: %v", s.board.folds)
+	}
+
+	s.jumpAttention()
+	if s.board.folds.has(foldPath{"web"}) || s.board.folds.has(foldPath{"web", "deploy"}) {
+		t.Errorf("! left the group it jumped into folded: %v", s.board.folds)
+	}
+	if !s.board.folds.has(foldPath{"api"}) {
+		t.Errorf("! opened a group it did not land in: %v", s.board.folds)
+	}
+}
+
+// TestFoldsRoundTripThroughTUIState: one board's folds are the next board's,
+// the §16 acknowledgment survives a fold write, and a field this build does
+// not know about survives both (task 054 decision 1).
+func TestFoldsRoundTripThroughTUIState(t *testing.T) {
+	dir := t.TempDir()
+	const seeded = `{"full_auto_notice_ack": true, "written_by_a_later_build": "keep me"}`
+	if err := os.WriteFile(filepath.Join(dir, "tui.json"), []byte(seeded), 0o600); err != nil {
+		t.Fatalf("seed tui.json: %v", err)
+	}
+
+	first := twoProjectBoard()
+	first.setDataDir(dir)
+	first.render(160, 20)
+	foldPress(first, keyLeft)
+	if len(first.folds) == 0 {
+		t.Fatal("← folded nothing")
+	}
+
+	second := twoProjectBoard()
+	second.setDataDir(dir)
+	if !slices.EqualFunc(second.folds, first.folds, foldPath.equal) {
+		t.Errorf("a second board read %v, want %v", second.folds, first.folds)
+	}
+	if !noticeAcknowledged(dir) {
+		t.Error("writing the folds lost the full-auto acknowledgment")
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "tui.json"))
+	if err != nil {
+		t.Fatalf("read tui.json: %v", err)
+	}
+	if !strings.Contains(string(raw), "keep me") {
+		t.Errorf("a field this build does not know about was rewritten away:\n%s", raw)
+	}
+
+	// And a fold write does not bury the notice for a dir that never saw it.
+	fresh := t.TempDir()
+	if err := writeFolds(fresh, foldSet{{"api"}}); err != nil {
+		t.Fatalf("writeFolds: %v", err)
+	}
+	if noticeAcknowledged(fresh) {
+		t.Error("a fold write acknowledged the full-auto notice")
+	}
+}
+
+// TestUnreadableFoldsMeanEverythingExpanded is the fail-open direction
+// tui.json's existing contract already uses: whatever is wrong with the file,
+// the answer is the board every version before this one rendered.
+func TestUnreadableFoldsMeanEverythingExpanded(t *testing.T) {
+	for name, seed := range map[string]string{
+		"no file":     "",
+		"not json":    "{{{",
+		"wrong shape": `{"board_folds": 7}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if seed != "" {
+				if err := os.WriteFile(filepath.Join(dir, "tui.json"), []byte(seed), 0o600); err != nil {
+					t.Fatalf("seed: %v", err)
+				}
+			}
+			if got := loadFolds(dir); len(got) != 0 {
+				t.Errorf("loadFolds = %v, want nothing folded", got)
+			}
+		})
+	}
+	if got := loadFolds(""); len(got) != 0 {
+		t.Errorf("loadFolds with no data dir = %v, want nothing folded", got)
+	}
+}
+
+// TestReconnectDoesNotRereadTheFolds: setDataDir runs again on every
+// reconnect, and the folds on screen are newer than the ones on disk whenever
+// a key was pressed since.
+func TestReconnectDoesNotRereadTheFolds(t *testing.T) {
+	dir := t.TempDir()
+	b := twoProjectBoard()
+	b.setDataDir(dir)
+	b.folds = b.folds.with(foldPath{"api"})
+	b.setDataDir(dir)
+	if !b.folds.has(foldPath{"api"}) {
+		t.Errorf("a reconnect re-read the file over the folds on screen: %v", b.folds)
+	}
+}

--- a/internal/tui/boardgroup.go
+++ b/internal/tui/boardgroup.go
@@ -133,18 +133,28 @@ type boardRow struct {
 	// for every task row.
 	depth int
 	// label, count and attention describe the group a header opens. The
-	// attention count is on the header so a collapsed-looking board can never
-	// hide that something is waiting on a human (§15).
+	// attention count is on the header so a collapsed group can never hide
+	// that something is waiting on a human (§15, task 054 decision 3).
 	label     string
 	count     int
 	attention int
+	// path names the group for the fold set (boardfold.go): this header's
+	// label and every label above it, outermost first. Empty on a task row.
+	path foldPath
+	// collapsed and marked are filled in by applyFolds, never by groupRows:
+	// a folded header stands in for rows that are not on screen, so it says
+	// how many of them the bulk selection holds.
+	collapsed bool
+	marked    int
 }
 
-// selectable reports whether the cursor may rest on this row. A header is a
-// label and a continuation is the tail of the row above it: neither is a
-// thing a key acts on, so both are stepped over (board.skipHeaders) and
-// skipped by everything that walks tasks rather than lines.
-func (r boardRow) selectable() bool { return !r.header && r.line == 0 }
+// selectable reports whether the cursor may rest on this row. An expanded
+// header is a label and a continuation is the tail of the row above it:
+// neither is a thing a key acts on, so both are stepped over
+// (board.skipHeaders) and skipped by everything that walks tasks rather than
+// lines. A *collapsed* header stands in for tasks that are not on screen, so
+// it is a row the cursor stops on (task 054 decision 2).
+func (r boardRow) selectable() bool { return (!r.header || r.collapsed) && r.line == 0 }
 
 // groupRows interleaves group headers into an already-sorted task list.
 // Groups appear in the order their first task does, so the band sort decides
@@ -158,8 +168,8 @@ func groupRows(tasks []apiclient.Task, g grouping) []boardRow {
 		return out
 	}
 	out := make([]boardRow, 0, len(tasks)+len(g))
-	var walk func(tasks []apiclient.Task, depth int)
-	walk = func(tasks []apiclient.Task, depth int) {
+	var walk func(tasks []apiclient.Task, depth int, path foldPath)
+	walk = func(tasks []apiclient.Task, depth int, path foldPath) {
 		if depth == len(g) {
 			for _, t := range tasks {
 				out = append(out, boardRow{task: t, depth: depth})
@@ -167,17 +177,23 @@ func groupRows(tasks []apiclient.Task, g grouping) []boardRow {
 			return
 		}
 		for _, grp := range partitionTasks(tasks, g[depth]) {
+			// A fresh slice per group: append onto a shared backing array
+			// would leave two sibling headers naming the same path.
+			sub := make(foldPath, len(path), len(path)+1)
+			copy(sub, path)
+			sub = append(sub, grp.key)
 			out = append(out, boardRow{
 				header:    true,
 				depth:     depth,
 				label:     grp.key,
 				count:     len(grp.tasks),
 				attention: countAttention(grp.tasks),
+				path:      sub,
 			})
-			walk(grp.tasks, depth+1)
+			walk(grp.tasks, depth+1, sub)
 		}
 	}
-	walk(tasks, 0)
+	walk(tasks, 0, nil)
 	return out
 }
 
@@ -224,11 +240,19 @@ func groupValue(t apiclient.Task, k groupKey) string {
 	return v
 }
 
-// groupGlyph opens a header line. A glyph rather than colour alone, so the
-// nesting survives NO_COLOR and a 16-colour terminal (§15 Colour). It marks a
-// group, not a collapse control: nothing here folds away, because a board
-// whose whole job is showing you every task has no business hiding rows.
-const groupGlyph = "▾"
+// groupGlyphOpen and groupGlyphFolded open a header line. A glyph rather than
+// colour alone, so the state survives NO_COLOR and a 16-colour terminal
+// (§15 Colour).
+//
+// It is a disclosure control since task 054, which superseded 009 decision
+// 4's "nothing folds away": on a six-project installation the board's job is
+// showing you every task you can act on rather than every task there is. What
+// a fold is not allowed to hide is that something needs a human, and the
+// count and the attention badge below survive the fold for that reason.
+const (
+	groupGlyphOpen   = "▾"
+	groupGlyphFolded = "▸"
+)
 
 // styleGroup is the header label. Bold rather than coloured: the state
 // colours are the board's colour vocabulary and a header holds no state.
@@ -237,10 +261,20 @@ var styleGroup = lipgloss.NewStyle().Bold(true)
 // headerCell renders a group header into the title column — the widest column
 // and the only one guaranteed to be there at any width (boardcols.go).
 func (r boardRow) headerCell() string {
-	label := strings.Repeat(groupIndent, r.depth) + groupGlyph + " " + r.label
+	glyph := groupGlyphOpen
+	if r.collapsed {
+		glyph = groupGlyphFolded
+	}
+	label := strings.Repeat(groupIndent, r.depth) + glyph + " " + r.label
 	out := styleGroup.Render(label) + styleDim.Render("  "+strconv.Itoa(r.count))
 	if r.attention > 0 {
 		out += "  " + styleWarn.Render(attentionBadge+" "+strconv.Itoa(r.attention))
+	}
+	if r.marked > 0 {
+		// What a bulk action would touch inside a group whose rows are not on
+		// screen. The selection is a set of tasks and not a view (task 011),
+		// so folding one away must not make it invisible.
+		out += "  " + styleKey.Render(markGlyph+" "+strconv.Itoa(r.marked))
 	}
 	return out
 }
@@ -250,13 +284,12 @@ func (r boardRow) headerCell() string {
 const groupIndent = "  "
 
 // firstTaskRow is the row a cursor with nothing to restore belongs on: the
-// first actual task. Zero when there is nothing at all, which is the same
-// answer the ungrouped board gave.
+// first row it may rest on — a task, or a collapsed header standing in for
+// tasks (task 054 decision 2). Zero when there is nothing at all, which is
+// the same answer the ungrouped board gave.
 func firstTaskRow(rows []boardRow) int {
-	for i := range rows {
-		if rows[i].selectable() {
-			return i
-		}
+	if i := landingRow(rows, 0); i >= 0 {
+		return i
 	}
 	return 0
 }

--- a/internal/tui/boardgroup_test.go
+++ b/internal/tui/boardgroup_test.go
@@ -32,13 +32,17 @@ func inWorkflow(name string) func(*apiclient.Task) {
 	return func(t *apiclient.Task) { t.Workflow = name }
 }
 
-// rowLabels renders the row structure compactly: "▾ label" for a header at
-// its depth, "#id" for a task.
+// rowLabels renders the row structure compactly: "▾ label" for an expanded
+// header at its depth, "▸ label" for a collapsed one, "#id" for a task.
 func rowLabels(rows []boardRow) []string {
 	out := make([]string, 0, len(rows))
 	for _, r := range rows {
 		if r.header {
-			out = append(out, strings.Repeat(" ", r.depth)+"▾ "+r.label)
+			glyph := groupGlyphOpen
+			if r.collapsed {
+				glyph = groupGlyphFolded
+			}
+			out = append(out, strings.Repeat(" ", r.depth)+glyph+" "+r.label)
 			continue
 		}
 		out = append(out, "#"+strconv.FormatInt(r.task.ID, 10))

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -311,10 +311,59 @@ func TestBoardHonoursAConfiguredFlatTable(t *testing.T) {
 		return len(b.group) == 0
 	})
 	got := content(h.m)
-	if strings.Contains(got, groupGlyph) {
+	// The open glyph only: ▸ is the diff pane's and the pickers' marker too,
+	// so scanning a whole frame for it proves nothing. A flat board renders no
+	// headers at all, folded or otherwise.
+	if strings.Contains(got, groupGlyphOpen) {
 		t.Errorf("a flat board rendered a group header:\n%s", got)
 	}
 	if !strings.Contains(got, "WORKFLOW") {
 		t.Errorf("a flat board dropped the WORKFLOW column:\n%s", got)
 	}
+}
+
+// TestCollapsedGroupOpensForAwaitingInput drives task 054 decision 3's third
+// safeguard through the real event path: the daemon commits a transition into
+// awaiting_input, the shell's live SSE stream carries it, and the fold hiding
+// that task opens by itself. The unit test pokes the model; this proves the
+// event the daemon actually publishes is the one the board reads.
+func TestCollapsedGroupOpensForAwaitingInput(t *testing.T) {
+	h := newBoardLiveHarness(t)
+	quiet := h.createTask(t, "quiet task")
+	noisy := h.createTask(t, "noisy task")
+	ctx := context.Background()
+
+	h.p.until(20*time.Second, "both tasks to appear", func() bool {
+		got := content(h.m)
+		return strings.Contains(got, "quiet task") && strings.Contains(got, "noisy task")
+	})
+
+	b := h.m.views[viewHome].(*shell).board
+	b.updateKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if got := content(h.m); strings.Contains(got, "noisy task") {
+		t.Fatalf("← did not fold the group away:\n%s", got)
+	}
+	if len(b.folds) == 0 {
+		t.Fatal("← folded nothing")
+	}
+
+	if _, _, err := h.st.TransitionTask(
+		ctx, quiet.ID, store.TaskQueued, store.TaskRunning, store.TaskChange{},
+	); err != nil {
+		t.Fatalf("TransitionTask(quiet): %v", err)
+	}
+	if _, _, err := h.st.TransitionTask(
+		ctx, noisy.ID, store.TaskQueued, store.TaskRunning, store.TaskChange{},
+	); err != nil {
+		t.Fatalf("TransitionTask(noisy): %v", err)
+	}
+	if _, _, err := h.st.TransitionTask(
+		ctx, noisy.ID, store.TaskRunning, store.TaskAwaitingInput, store.TaskChange{},
+	); err != nil {
+		t.Fatalf("TransitionTask(awaiting): %v", err)
+	}
+
+	h.p.until(20*time.Second, "the fold to open over the waiting task", func() bool {
+		return len(b.folds) == 0 && strings.Contains(content(h.m), "noisy task")
+	})
 }

--- a/internal/tui/firstrun.go
+++ b/internal/tui/firstrun.go
@@ -11,39 +11,43 @@ import (
 // tuiState is {data_dir}/tui.json (§12.2): state the TUI owns and the daemon
 // has no opinion about. It is a JSON object rather than a marker file so a
 // later preference joins it without a format change — and so a hand-edited
-// file is readable.
+// file is readable. Task 050's collapsed board groups are the first field to
+// take that offer up.
+//
+// This is view state, not configuration: task 009 decision 1's rule that the
+// TUI reads no *configuration* from disk is untouched — `tui.board.group_by`
+// still arrives over `GET /v1/config`, as it always did.
 type tuiState struct {
-	FullAutoNoticeAck bool `json:"full_auto_notice_ack"`
+	FullAutoNoticeAck bool       `json:"full_auto_notice_ack"`
+	BoardFolds        []foldPath `json:"board_folds,omitempty"`
 }
 
 func statePath(dataDir string) string { return filepath.Join(dataDir, "tui.json") }
 
-// noticeAcknowledged reports whether the §16 full-auto notice has already
-// been dismissed.
-//
-// Every failure answers false: no file, an unreadable one, a half-written
-// one, an object that no longer parses. A security warning that suppresses
-// itself because a parse failed has failed in the wrong direction, and
-// showing it a second time costs one keystroke.
-func noticeAcknowledged(dataDir string) bool {
+// readTUIState reads the file. Every failure answers the zero value: no file,
+// an unreadable one, a half-written one, an object that no longer parses.
+// Both readers want that direction — a security warning that suppresses
+// itself because a parse failed has failed the wrong way, and a fold set that
+// cannot be read means the board everybody had yesterday.
+func readTUIState(dataDir string) tuiState {
+	var st tuiState
 	if dataDir == "" {
-		return false
+		return st
 	}
 	b, err := os.ReadFile(statePath(dataDir))
 	if err != nil {
-		return false
+		return st
 	}
-	var st tuiState
 	if err := json.Unmarshal(b, &st); err != nil {
-		return false
+		return tuiState{}
 	}
-	return st.FullAutoNoticeAck
+	return st
 }
 
-// acknowledgeNotice records the dismissal. It merges into whatever the file
-// already holds rather than rewriting it, so a field this build does not
-// know about survives being read by it.
-func acknowledgeNotice(dataDir string) error {
+// mergeTUIState writes one field into whatever the file already holds rather
+// than rewriting it, so a field this build does not know about — and the
+// other field it does — survives being written by it.
+func mergeTUIState(dataDir, key string, value any) error {
 	if dataDir == "" {
 		return errors.New("no data directory resolved")
 	}
@@ -53,7 +57,7 @@ func acknowledgeNotice(dataDir string) error {
 			raw = map[string]any{}
 		}
 	}
-	raw["full_auto_notice_ack"] = true
+	raw[key] = value
 	b, err := json.MarshalIndent(raw, "", "  ")
 	if err != nil {
 		return err
@@ -62,6 +66,18 @@ func acknowledgeNotice(dataDir string) error {
 		return err
 	}
 	return os.WriteFile(statePath(dataDir), append(b, '\n'), 0o600)
+}
+
+// noticeAcknowledged reports whether the §16 full-auto notice has already
+// been dismissed. Every read failure answers false, and showing the warning a
+// second time costs one keystroke.
+func noticeAcknowledged(dataDir string) bool {
+	return readTUIState(dataDir).FullAutoNoticeAck
+}
+
+// acknowledgeNotice records the dismissal.
+func acknowledgeNotice(dataDir string) error {
+	return mergeTUIState(dataDir, "full_auto_notice_ack", true)
 }
 
 // noticeBody is §16's full-auto risk, compressed. It is a constant and not a

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -738,8 +738,12 @@ func (m *root) footerLine() string {
 			target = t.target()
 		}
 	}
+	rows := bindingsFor(ctx)
+	if s, ok := m.views[m.active].(*shell); ok {
+		rows = s.liveBindings(rows)
+	}
 	retry := m.phase == phaseFailed || m.phase == phaseReconnecting
-	line, hits := buildFooter(m.width, bindingsFor(ctx), bar, target, attention, retry)
+	line, hits := buildFooter(m.width, rows, bar, target, attention, retry)
 	m.footerHits = hits
 	return line
 }

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -622,7 +622,31 @@ func (s *shell) jumpAttention() tea.Cmd {
 			break
 		}
 	}
+	// A fold is never what keeps you from work that needs a human: the key
+	// that exists for finding it opens whatever group it lands in, and the
+	// expansion is a real fold change, persisted like any other (task 054
+	// decision 3).
+	if s.board.expandFor(next) {
+		return tea.Batch(s.board.saveFolds(), s.openNow(next))
+	}
 	return s.openNow(next)
+}
+
+// liveBindings drops the registry rows whose keys are inert in the shell's
+// current state, so the footer never offers a press that does nothing. The
+// board's fold keys are the only ones: with `group_by: []` the table has no
+// groups at all (task 054 decision 5).
+func (s *shell) liveBindings(rows []binding) []binding {
+	if len(s.board.group) > 0 {
+		return rows
+	}
+	out := make([]binding, 0, len(rows))
+	for _, b := range rows {
+		if !b.fold {
+			out = append(out, b)
+		}
+	}
+	return out
 }
 
 // focusedContext names the focused panel for the binding registry. The output

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -69,9 +69,12 @@ type projectHinting interface {
 	hintedProject() int64
 }
 
-// dataDirAware is implemented by views that read files the daemon writes.
-// The daemon view's log tail is the only one, and §15 records why: an
-// endpoint cannot serve the log when the daemon is what died.
+// dataDirAware is implemented by views that read files under the data dir:
+// the daemon view's log tail, for the reason §15 records — an endpoint cannot
+// serve the log when the daemon is what died — and the board, whose collapsed
+// groups live in {data_dir}/tui.json (task 054). That file is view state the
+// TUI owns, not configuration it reads: `tui.board.group_by` still arrives
+// over GET /v1/config (009 decision 1).
 type dataDirAware interface {
 	setDataDir(string)
 }


### PR DESCRIPTION
## Summary

Board groups fold.

A board carrying several projects and a long tail of finished tasks pushes the
project you are actually working in off the bottom of the screen, and grouping
does nothing about it: `g` changes the *shape* of the table, never the number of
rows in it. The two ways out today both cost something — `/` hides everything
else including work waiting on a human, `g` to a coarser grouping keeps every
row.

Four keys on the task table (`internal/tui/bindings.go`, so they are in `?` and
the palette):

| Key | Does |
|---|---|
| `←` | Collapse the group the cursor is in; again on the header it closed folds the group around that |
| `→` | Expand the collapsed group under the cursor, one level |
| `C` | Collapse every group |
| `O` | Expand every group |

- **A collapsed header is a row; an expanded one stays a label.** `↑`/`↓` stop on
  a collapsed header and step over an expanded one, which is what lets `←`/`→`
  reach every nesting level without a "nearest above" heuristic. A fold has no
  task, so the §6 action keys, `space`, `enter` and `L` do nothing on one and the
  detail panels hold their last task.
- **Folding is a view over the same band sort.** `applyFolds` runs *after*
  `groupRows` has laid the list out, so the folded board is provably the
  unfolded one with rows deleted — group order and within-group order are 009
  decision 2's, untouched.
- **A fold can never hide work waiting on you.** The header keeps its `▸` glyph,
  its task count, its `! n` attention badge and its selected count; `!` opens
  whatever group it lands in; and a collapsed group opens **by itself** the
  moment a task inside it enters `awaiting_input`, off the same
  `task.state_changed` event that rings the bell. Nothing is ever *refused* a
  collapse.
- **`V` reaches into a fold.** `visible()` is filter-scoped, not fold-scoped —
  the selection is a set of tasks, not a view (task 011). No change to
  `boardmark.go`; there is a test instead.
- **Folds persist** in `{data_dir}/tui.json` under a new `board_folds` key,
  keyed by label path. They survive `g`, a filter and a reconnect, and drop when
  the project or workflow leaves the unfiltered task list. Every read failure
  means "everything expanded". With `group_by: []` the four keys are inert and
  their footer hints are dropped; a fresh install's board looks exactly as it
  does today.

No daemon, API, store, config or migration change — everything is in
`internal/tui` plus documentation.

## Related

Closes #234 — closes 050.1.

This deliberately revisits two recorded decisions in
`docs/tasks/009-configurable-tasks-view.md`:

- **Decision 4 is superseded in part.** Its cursor rule for an *open* header
  stands and is the reasoning this PR uses for what a collapsed one is *not*.
  Its "nothing collapses" half is reversed, with the three safeguards above as
  the argument. The dated superseding note and the struck-through **Out of
  scope** entry are in 009's own document, per `docs/tasks/README.md`.
- **Decision 1 is *not* reversed**, and should not be described as such. It
  governs configuration the TUI reads from disk; `tui.board.group_by` still
  arrives over `GET /v1/config`. A fold set is view state the TUI owns — the
  same category as the §16 first-run acknowledgment `tui.json` already holds,
  in the "open JSON object so later prefs join without a format change" the v0
  ledger created it as. §15's pure-API-client sentence gains a dated amendment
  naming that distinction rather than being weakened.

`docs/tasks/050-collapsible-board-groups.md` carries the full reasoning and the
alternatives each decision beat.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`docs/guides/tui.md` gains a "Folding groups" section and its key table;
`docs/reference/files.md`'s `tui.json` row says what else the file holds;
`docs/spec.md` §15's grouping amendment and its pure-API-client sentence, and
§12.2's `tui.json` line, are amended in place with dated notes.

A documentation audit over the whole change (`docs:` commit, separate from the
implementation) closed three gaps in those same pages: `docs/tasks/050` had no
`## Tasks` section, so the index row's "(1/1)" and this PR's "closes 050" had no
marker behind them; `docs/features.md` lists the board's capabilities at the
same grain as bulk selection and did not mention folding; and §15's amendment
said a collapsed header *is* a row without saying it is not a *task* — the rule
that `selected()` answers "no task" on one, so the §6 action keys, `space`,
`enter` and `L` do nothing there and the detail panels hold their last task,
existed only in the code and in 009's note. Everything else the audit checked
was already true, and no config, CLI, API, block-reason, workflow-schema or
adapter surface changed, so those pages and
`skills/vincent-workflows/SKILL.md` are untouched.

**Not done, deliberately:** no gate script — this is a judgement about a TUI,
which is why 009 had none either. `docs/gates/m3-gate.md` walks the board but
has no grouping leg to amend (009 added none). The board screenshots under
`docs/assets/tui-*.png` were not regenerated, and the audit confirmed the
reason holds in the code rather than taking it on trust: `applyFolds` fills
`marked` only for rows a collapsed header swallowed, so an *open* header's cell
is byte-identical to before and a fresh install has nothing folded.

**For the reviewer:** with `group_by: []` the four fold keys are dropped from
the footer (`shell.liveBindings`) but still listed in the `?` overlay, which is
what the issue and the brief asked for — the wording in both is "footer hints".
Flagging it as a judgement call rather than an oversight; no page claims
otherwise.

## Testing

`go run mage.go test`, `go test -race ./internal/tui`, and
`go tool golangci-lint run ./...` for `GOOS=darwin`, `linux` and `windows`.

New coverage in `internal/tui/boardfold_test.go`: the subtree a fold hides and
the one level `→` restores; the folded board equalling the unfolded one minus
the collapsed rows, with the band sort's group order intact; the cursor landing
on a fold, stepping over an open header, and never resting on a hidden row after
`←`, `→`, `C`, `O`, a refetch or a `g` press; the count, badge and marked count
on a collapsed header; `V` reaching inside one and a filter changing no fold;
the pruning rule against `g`, a filter, a vanished project and an empty list;
the `tui.json` round trip preserving the §16 acknowledgment and an unknown
field; every read failure meaning "expanded"; the auto-expand and `!`. Four new
probes satisfy `bindings_test.go`'s registry-completeness check, and
`boardlive_test.go` drives the auto-expand through the real event stream.
