### PR TITLE
Add a pull requests view to the TUI and open pull requests in a browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **A pull-requests screen in the TUI, and a browser to open them in.** A new
+  takeover lists every open pull request across every registered project whose
+  `origin` is a github.com repository vincent can authenticate to, grouped by
+  project, with the task that claims each row and whether the daemon matched it
+  by head branch or a human linked it. `o` opens the selected one in a browser,
+  `enter` jumps to the claiming task's workspace, and `l`/`u` link and unlink —
+  `u` being the sticky refusal the reconciler will not undo, which the
+  confirmation says out loud. A project whose listing fails shows its reason
+  without hiding the others, and a reconciler tick re-renders the screen with no
+  keypress. The entry appears in the command palette only when at least one
+  project qualifies. The task workspace's **Task Details** tab gains a matching
+  **GitHub pull request** section: the linked pull request with its live state,
+  the reason the integration is unusable, or — with nothing linked — `P` to open
+  GitHub's own new-pull-request page with an editable prefill. vincent builds
+  that URL and never fetches it; nothing is created on GitHub from here.
+  Opening a URL uses `open`, `xdg-open` or the Windows shell handler, and says
+  so on screen when there is no browser to open — unlike the clipboard
+  fallback, which is silent by design.
+
 - **Vincent tells you when a newer release exists, and can install it.** The
   daemon asks GitHub once a day for the latest **stable** release, caches the
   answer and serves it on `GET /v1/update`; `vincent doctor` grows an `UPDATE`

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ and design choices that made a durable orchestrator feel necessary.
 |---|---|
 | [Writing workflows](guides/workflows.md) | The authoring guide, in 14 sections: the nine step types, control flow, templates, checks, retries, agents, portability |
 | [Agent CLIs](guides/agents.md) | Claude Code, Codex and Cursor: installing, authenticating, and what each one can and cannot do |
-| [Using the TUI](guides/tui.md) | The board, task detail, the four takeover screens, every key |
+| [Using the TUI](guides/tui.md) | The board, task detail, the five takeover screens, every key |
 | [Scripting vincent](guides/scripting.md) | `--json`, exit codes, and driving the API directly from a script or CI |
 | [Running at login](guides/running-at-login.md) | `vincent service install` on launchd, systemd and Task Scheduler |
 | [Troubleshooting](guides/troubleshooting.md) | The failures people actually hit, and what each one means |

--- a/docs/features.md
+++ b/docs/features.md
@@ -170,6 +170,9 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual
   details on wider terminals and fall back to compact layouts when needed.
+- A pull-requests screen lists what is open across every GitHub-based project at
+  once, with the task claiming each one, and is where a link is made or removed
+  by hand. It is offered only when at least one project qualifies.
 - The workflow graph visualizes parallel groups, fan-out lanes and merges,
   conditions, loops, guards, checks, and nested includes — and, on a task's own
   Workflow tab, what each step of that task did on it, live. `enter` opens any
@@ -259,11 +262,14 @@ default — the daemon lists each GitHub-based project's **open** pull requests
 and links the ones whose head branch is a task's own branch. It never overwrites
 a link you made by hand, and a link you removed is never re-applied.
 
-`vincent github prs --project ID` prints a project's open pull requests with the
-task each one belongs to. Only the *link* is stored: a pull request's title,
-state, draft and merged status are re-read every time it is shown, which is what
-lets a task still name a pull request that has since merged and dropped off the
-open listing. A task with no pull request is offered a prefilled compare URL
+The TUI's pull-requests screen shows every GitHub-based project's listing at
+once and carries the two human actions — link a pull request the head-branch
+rule missed, unlink one it got wrong — and a task's own workspace shows its
+pull request beside its branch. `vincent github prs --project ID` prints one
+project's open pull requests with the task each one belongs to. Only the *link*
+is stored: a pull request's title, state, draft and merged status are re-read
+every time it is shown, which is what lets a task still name a pull request that
+has since merged and dropped off the open listing. A task with no pull request is offered a prefilled compare URL
 instead — GitHub's own "open a pull request" page, carrying the task's title and
 description, and `Closes #N` when the task came from an issue.
 
@@ -275,7 +281,8 @@ whose `origin` is a github.com repository, so a daemon with no such project neve
 makes it. It writes nothing to GitHub either — the compare URL is built, never
 fetched, and a human presses GitHub's button.
 
-See the [CLI reference](reference/cli.md#vincent-github-prs) and the
+See the [pull-requests screen](guides/tui.md#pull-requests), the
+[CLI reference](reference/cli.md#vincent-github-prs) and the
 [API reference](reference/api.md#github-pull-requests).
 
 ## Diagnose and maintain it

--- a/docs/gates/052-github-pull-requests.md
+++ b/docs/gates/052-github-pull-requests.md
@@ -1,0 +1,85 @@
+# Task 052 gate — GitHub pull requests
+
+**Acceptance (task 052.7):** a real daemon, over curl alone, lists a GitHub
+project's open pull requests, links one to the task whose branch heads it,
+lets a human override that link and remove it, and does not undo the removal
+on the next tick — with the compare URL produced without a single call to
+GitHub.
+
+The scripted half is [`scripts/052-gate.sh`](../../scripts/052-gate.sh). It is
+task-numbered rather than `m10` because this is not a §19 milestone; 017 and
+032 set that precedent.
+
+```sh
+./scripts/052-gate.sh                            # all five scenarios
+VINCENT_GATE_SCENARIO=4 ./scripts/052-gate.sh    # one, for debugging
+```
+
+It needs bash, go, git, curl and jq, and nothing else: `cmd/fakegh` is built
+**as `gh`** onto the daemon's PATH, which is how the daemon finds the real CLI
+too (there is no `gh_path` config key — `GHPath` empty means "resolve `gh`
+from PATH"). No agent CLI is involved: the gate's one workflow is a single
+`command` step whose whole body is `exit 0`, so it is portable to the daemon's
+pwsh on Windows and settles in seconds. What the gate wants from it is the
+branch the worktree was made on, which is what a pull request's head is
+matched against.
+
+## What the script asserts
+
+1. **The capability probe and the open-only listing.** `GET
+   /v1/projects/{id}/github` answers `available: true` for a repository whose
+   `origin` is `github.com` — which is the whole of what makes a project a
+   GitHub project, since §13.2 deliberately stores no flag. `GET
+   …/github/pulls` then returns exactly the corpus's two open rows, newest
+   first, with the draft among them and the **merged** row absent: an
+   open-only listing can never answer for a merged pull request, which is what
+   the durable link exists to serve through the task route instead.
+2. **The reconciler's auto-link.** With `github.poll_interval: 1s` and the
+   fake's first pull request pointed at a real task's branch
+   (`FAKEGH_PR_BRANCH`), the link appears on `GET /v1/tasks/{id}/github/pull`
+   with `source: auto` and the live pull request beside it — and the project
+   listing agrees about which task claims the row.
+3. **The human link.** `POST /v1/tasks/{id}/github/pull` with a different
+   number takes, and comes back as `source: human`.
+4. **The sticky unlink.** `DELETE` clears the link, and several reconciler
+   ticks later it is still gone and still `suppressed: true`. This is the one
+   assertion a UI cannot make on its own behalf, and the reason the
+   confirmation in the TUI says the refusal sticks.
+5. **The compare URL is built, never fetched.** A task with a branch and no
+   link carries a `compare_url` on a github.com compare page, and the fake
+   `gh`'s argv log — every call the daemon actually made — contains nothing
+   about it and no `pr create`. Decision record row 11 stands: vincent pushes
+   nothing, opens nothing and merges nothing.
+
+## What the script does not assert
+
+The TUI. The takeover, the workspace section and the compare-URL editor are
+covered by `internal/tui`'s own tests, including a `*live_test.go` against the
+real API handlers and the same `cmd/fakegh`; what a screen *looks like* is a
+judgement, the way M3's and 017's are, and this gate deliberately stops at the
+API. The browser opener is likewise not exercised here — a gate that launched
+a browser on CI would be a gate nobody could run.
+
+## Not wired into CI
+
+`.github/workflows/ci.yml` enumerates its gate steps by hand, and the session
+that wrote this gate could not edit `.github/workflows/` — an agent session's
+token has no `workflow` scope, by push or by API (#120, #122, #125). The step
+to add to the `gates` job is:
+
+```yaml
+      - name: 052 gate (GitHub pull requests)
+        run: ./scripts/052-gate.sh
+        shell: bash
+```
+
+Until that lands, **this gate is not known to pass on Windows**: it has only
+been run on macOS. That is the exact failure mode CLAUDE.md records for m6, m7
+and m8, where wiring them in turned up two Windows-only faults in a script
+that had been green on Linux for weeks.
+
+## Runs
+
+| Date | Platform | Result | By |
+|---|---|---|---|
+| 2026-08-29 | macOS (darwin/arm64) | GATE PASS, all five scenarios | task 052.7 |

--- a/docs/gates/m3-gate.md
+++ b/docs/gates/m3-gate.md
@@ -64,7 +64,7 @@ gate unless they blocked Section A.
 
 | ID | §19 phrase | Look at |
 |---|---|---|
-| **S1** | "All six views" | All six §15 surfaces render, none blank or panicking: the home panels plus the four takeovers reached from the `:` palette; `?` lists the keys each surface actually has, straight from the registry. |
+| **S1** | "All six views" | The six §15 surfaces this seed has render, none blank or panicking: the home panels plus the four takeovers reached from the `:` palette; `?` lists the keys each surface actually has, straight from the registry. *(§15 gained a seventh view, Pull requests, in task 052.6 — its nav row is withheld unless a project's `origin` is a github.com repository vincent can authenticate to, and none of this seed's are, so four takeovers is what a walker should see here.)* |
 | **S2** | "live tail" | Covered by L7; additionally, a tail left open across a task's completion ends cleanly rather than hanging on "following". |
 | **S3** | "diff view" | `d` on a task with no commits yet, on a finished task, and on an archived one (worktree removed) — three different situations, three intelligible messages. On a task with a multi-file change (task 012): every file collapsed on arrival, `↑`/`↓` walking the list, `enter` folding one, `O`/`C` the lot, the summary line's totals matching the per-file counts. |
 | **S4** | "all actions" | `p` pause/resume a running task · `c` cancel (asks first) · `s` skip a step · `r` retry a blocked task · `E` edit the failing step in `$EDITOR` and retry · `x` reject a gate. Each offered only when valid for that task's state. |

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -43,7 +43,8 @@ workspace has five full-view tabs — **Steps & Attempts**, **Task Details**,
 whole terminal. `tab` advances through them, `shift+tab` goes back, and `1`–`5`
 jump directly. `esc` returns to the board.
 
-New task, projects, workflows, and daemon are full-screen takeovers too. `esc`
+New task, projects, workflows, daemon, and — for GitHub projects — pull
+requests are full-screen takeovers too. `esc`
 closes one layer at a time (popup → task/screen → selection → filter) and
 **never quits**.
 
@@ -236,6 +237,24 @@ and the task's workflow-step snapshot. Its left sidebar selects one section at
 a time, so unrelated metadata does not compete for the screen. Use `↑`/`↓` or
 the mouse to choose a section and `pgup`/`pgdn` to scroll long section content;
 the inspector never edits anything.
+
+Its **GitHub pull request** section follows the captured issue and shows one of
+three things: the pull request linked to this task with its live state, the
+reason the integration is unusable, or — when nothing is linked — the offer to
+open one. Two keys work there, and both only reach a browser:
+
+| Key | Does |
+|---|---|
+| `o` | Open this task's pull request in a browser |
+| `P` | Open a pull request for this task's branch — the prefilled title and body are editable first, and nothing is sent to GitHub from here |
+
+`P` opens a small popup with the title and body vincent guessed from the task,
+both editable. `ctrl+s` opens GitHub's own new-pull-request page with whatever
+you left there; `esc` closes the popup and discards the draft. vincent builds
+that URL and never fetches it — nothing is created on GitHub until you press
+the button on GitHub's own page. Both keys are absent unless the project's
+GitHub integration is usable. Linking and unlinking live on the pull-requests
+screen below.
 
 **Output** gives the selected attempt's live tail or historical transcript the
 entire view. Its selector names the attempt and its position in the task; use
@@ -576,6 +595,34 @@ defaults and current workload on the right](../assets/tui-projects.png)
 | `d` | Remove it (asks first; its task rows go with it) |
 | `/` | Filter by name or path |
 | `ctrl+s` | Save, in the form |
+
+### Pull requests
+
+Every open pull request across every registered project whose `origin` is a
+github.com repository vincent can authenticate to, grouped by project. Each row
+carries the number, its state (`open`, `draft`, `closed` or `merged`), the
+title, the head branch, and the task that claims it — with `auto` when the
+daemon's reconciler matched it by head branch and `human` when somebody linked
+it by hand.
+
+The entry appears in the palette only when at least one project qualifies; with
+none, the screen is unreachable rather than empty. A project whose listing fails
+shows its reason on that group and does not hide the others. A reconciler tick
+that links or unlinks a pull request re-renders the screen with no keypress.
+
+| Key | Does |
+|---|---|
+| `enter` | Open the workspace of the task that claims this pull request |
+| `o` | Open the selected pull request in a browser |
+| `l` | Link it to a task in the same project |
+| `u` | Unlink it (asks first) |
+| `R` | Re-list every project |
+| `↑`/`↓` | Move the selection |
+| `/` | Filter by number, title, branch or project |
+
+`u` is a **sticky** refusal, not a reset: the daemon records that a human
+removed this link, and the reconciler will not re-apply it on its next tick.
+The confirmation says so.
 
 ### Workflows
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -249,12 +249,23 @@ open one. Two keys work there, and both only reach a browser:
 | `P` | Open a pull request for this task's branch — the prefilled title and body are editable first, and nothing is sent to GitHub from here |
 
 `P` opens a small popup with the title and body vincent guessed from the task,
-both editable. `ctrl+s` opens GitHub's own new-pull-request page with whatever
-you left there; `esc` closes the popup and discards the draft. vincent builds
-that URL and never fetches it — nothing is created on GitHub until you press
-the button on GitHub's own page. Both keys are absent unless the project's
-GitHub integration is usable. Linking and unlinking live on the pull-requests
-screen below.
+both editable:
+
+| Key | Does |
+|---|---|
+| `↑` / `↓` | Move between the title and the body |
+| `enter` | Edit the row under the cursor |
+| `e` | Write that row in `$EDITOR` instead |
+| `ctrl+s` | Open GitHub's own new-pull-request page with this prefill |
+| `esc` | Close without opening anything — the draft is discarded |
+
+Inside a field `enter` is a newline (a pull-request body usually wants more than
+one line), `ctrl+s` keeps the text, and `esc` discards it. A title is required:
+`ctrl+s` without one says so rather than opening a page GitHub cannot use.
+vincent builds that URL and never fetches it — nothing is created on GitHub
+until you press the button on GitHub's own page. `o` and `P` are absent unless
+at least one registered project's GitHub integration is usable. Linking and
+unlinking live on the pull-requests screen below.
 
 **Output** gives the selected attempt's live tail or historical transcript the
 entire view. Its selector names the attempt and its position in the task; use
@@ -821,8 +832,7 @@ reading.
 to every screen, and every task action the daemon currently offers. Type to
 filter, `enter` to run, `esc` to close.
 
-The palette exists so the four takeover screens do not need memorized number
-keys. If you cannot remember a binding, `:` and `?` are the two keys worth
+The palette exists so the takeover screens do not need memorized number keys. If you cannot remember a binding, `:` and `?` are the two keys worth
 knowing.
 
 ## Every key

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4598,6 +4598,16 @@ stream for the live tail.
 	   fields, project, workflow and recorded origin, branch/worktree, state,
    priority, usage/cost, lifecycle timestamps, holds/blocks, pending input,
    fan-out/loop state, captured issue, available actions and workflow snapshot.
+	   *Amended 2026-08-29 (task 052.6): a **GitHub pull request** section follows
+	   the captured issue, from `GET /v1/tasks/{id}/github/pull` — a linked pull
+	   request with its live state, the named reason when the integration is
+	   unusable, or the compare-URL offer when nothing is linked. It carries two
+	   keys, and the narrowing is to this section rather than to the tab: `o`
+	   opens the linked pull request in a browser and `P` opens the compare-URL
+	   editor. Both only reach a browser; neither writes anything in vincent,
+	   which is the sense in which "read-only inspector" was written. Link and
+	   unlink — the two actions that do write vincent's own column — live only in
+	   view 7.*
 	   **Output** renders the selected attempt's live or historical transcript and
 	   lets the reader move that selection with `←`/`→` (or `h`/`l`) without
 	   returning to the timeline. `enter` on a Steps & Attempts row opens Output
@@ -4773,13 +4783,61 @@ stream for the live tail.
    show while disconnected. See *Disconnected* below for what the rest of the UI
    does in that state.
 
+7. **Pull requests.** *Added 2026-08-29 (task 052.6).* Every available project's
+   **open** pull requests, grouped by project, from
+   `GET /v1/projects/{id}/github/pulls` — one call per project, issued
+   concurrently on open. The screen answers the cross-project question, "what is
+   open across everything I run", which one project at a time cannot. Rows carry
+   the number, the folded status word (merged beats closed beats draft beats
+   open, §13.2), the title, the head branch and the task that claims the row with
+   its `link_source`. A project whose listing answers 409 renders as a failed
+   group carrying that reason's message and does not affect the others: each
+   group holds its own error.
+
+   **Availability.** The entry is a keyless nav row like Projects, Workflows and
+   Daemon, and it is present only when at least one registered project answers
+   `GET /v1/projects/{id}/github` with `available: true`. There is no stored
+   notion of a GitHub project — it is derived from `origin` plus a credential
+   probe, which is why §13.2 keeps it off the project DTO — so the TUI issues one
+   probe per project as the connection comes up, concurrently, and again on
+   reconnect, where the daemon's short cache absorbs the repeat cost. While every
+   answer is unavailable, **including while they are all still in flight**, the
+   row is withheld from the palette, the `?` overlay and the footer alike, and
+   the view is unreachable. This is the `fold` precedent (task 054) applied to a
+   nav row: a row whose screen would have nothing on it is withheld rather than
+   shown dead.
+
+   **Actions.** `o` opens the selected pull request in a browser. `enter` opens
+   the workspace of the task that claims it, and is inert on a row no task
+   claims — the link key is its own, and a key that means two unrelated things
+   depending on the row is worse than one that sometimes does nothing. A link key
+   opens a task picker **scoped to the row's own project**: `POST
+   /v1/tasks/{id}/github/pull` takes a bare number and the daemon resolves the
+   repository from the task's project, so offering a task from elsewhere would
+   link that project's repository to a number that means something else there. An
+   unlink key asks first, and the confirmation says the refusal is sticky and the
+   reconciler will not re-apply it — which is what `DELETE` does, and a UI that
+   said "clear" would be lying. `R` re-lists, `/` filters, `↑`/`↓` move.
+   The view subscribes to nothing of its own: the root broadcasts every event to
+   every view, so a `task.github_pull_changed` tick re-renders it with no
+   keypress.
+
 ### Layout
 
 The list above is also the screen contract. View 1 is the board-only home
 screen. `enter` on its selected row opens view 2, the full-screen task workspace;
 `esc` returns. The workspace's five tabs each take its whole body (four until
-task 051, 2026-08-29, added the Workflow tab). Views 3–6 are
-full-screen takeovers reached from the command palette.
+task 051, 2026-08-29, added the Workflow tab). Views 3–7 are
+full-screen takeovers reached from the command palette (view 7 added
+2026-08-29 by task 052.6).
+
+**Opening a URL (task 052.6, added 2026-08-29).** The two screens above hand a
+URL to the platform's own opener — `open` on macOS, `xdg-open` on the other
+unixes, the shell's protocol handler on Windows — and to nothing else. Only
+`http` and `https` are opened. Unlike the clipboard fallback, which is silent
+by design because the terminal's own paste is the working path, this one
+**fails visibly**: a human pressed a key expecting a browser, and silence is
+indistinguishable from a browser that opened on another desktop.
 
 **Guided takeovers (task 020, added 2026-08-20).** At a terminal size of at
 least **128 columns by 24 rows**, New task, Projects and Workflows use a
@@ -5014,7 +5072,7 @@ cursor's is the entire turn concatenated. The text is kept when the attempt
 rendered no output at all — a codex turn with no `agent_message` — and always
 on an error, where it is the error and may be the only content there is.
 
-Views 3–6 stay full-screen because they are forms and lists, not observations: the
+Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
 serves neither. Takeovers are for surfaces you visit deliberately; popups are for
 small things — the palette, confirmations, and the answer form.

--- a/docs/tasks/052-github-pull-requests.md
+++ b/docs/tasks/052-github-pull-requests.md
@@ -1,9 +1,10 @@
 # 052 — List a GitHub project's open pull requests and link them to board tasks
 
-**Status:** 🚧 in progress (5/7)
+**Status:** ✅ done (7/7)
 **Spec:** amends §3 (decision record row 27, row 26 narrowed), §12.3, §13.2,
 §13.3, §14, §20
-**Issue:** [#231](https://github.com/lezli01/vincent/issues/231)
+**Issue:** [#231](https://github.com/lezli01/vincent/issues/231),
+[#242](https://github.com/lezli01/vincent/issues/242) (052.6, 052.7)
 
 ## Problem
 
@@ -117,6 +118,62 @@ a wrong one shows as `not_found` the moment it is displayed. `DELETE` marks the
 link suppressed rather than clearing it, keeping repo and number — the
 reconciler has to be able to read the refusal.
 
+**6. The offer to create is in the workspace; link and unlink are in the
+takeover.** *(2026-08-29, #242)*
+
+The takeover lists what GitHub says is open. A task with a branch and no pull
+request is not a row in that list, so hanging "create" off it would mean either
+mixing vincent rows into a GitHub listing or hiding the offer behind a key with
+no visible row; the offer belongs beside the branch it is about, which is the
+workspace. Link and unlink go the other way for the mirror-image reason: they
+are the two actions that write vincent's own column, and they belong on the one
+screen that can see a pull request no task claims — the case they exist for.
+Spec §15's view 2 is narrowed in the same change: the pull-request *section* may
+open a URL, which is not a write and leaves "read-only inspector" true in the
+sense it was written.
+
+`enter` on an unclaimed takeover row is deliberately inert rather than
+overloaded into "link this one". The link key is its own, and a key that means
+two unrelated things depending on the row is worse than one that sometimes does
+nothing. The link picker is scoped to the row's own project: `POST` takes a bare
+number and the repo comes from the task's project daemon-side, so a task from
+elsewhere would silently link a different repository's number.
+
+**7. The prefill is edited in the TUI and the URL re-encoded client-side.**
+*(2026-08-29, #242)*
+
+Decision 4 requires the prefill be visible and editable before it is used, and
+`compare_url` arrives with title and body already encoded as query parameters.
+So the TUI decodes them into a popup's editable rows, in the shape the repair
+and follow-up popups already take, and rebuilds the URL with `net/url` on the
+way out — preserving `expand=1` and the daemon's compare path. Handing GitHub's
+own page the unedited URL was considered and rejected: it satisfies the letter
+of "editable before submit" only by relying on a surface vincent does not own.
+`TestCreatePRFormMakesNoRequest` asserts the whole path contacts nothing,
+mirroring `TestCompareURLMakesNoRequest`; row 11 still stands.
+
+**8. Availability is derived per connect, and the nav row is withheld until it
+says yes.** *(2026-08-29, #242)*
+
+There is no stored notion of a GitHub project (035 decision 5), so the TUI
+issues one §13.2 probe per registered project as the connection comes up,
+concurrently, and again on reconnect. While every answer is unavailable —
+including while they are all still in flight — the pull-requests nav row and the
+workspace's two pull-request keys are withheld from the palette, the `?` overlay
+and the footer alike. This is task 054 decision 5's `fold` precedent applied to
+a nav row. The filter goes at the root rather than in `shell.liveBindings`,
+because that seam is shell-scoped and the nav rows are global.
+
+**9. The gate ships as a script and a record; `ci.yml` is the maintainer's.**
+*(2026-08-29, #242)*
+
+`scripts/052-gate.sh` and `docs/gates/052-github-pull-requests.md` are committed
+and runnable locally from day one. `.github/workflows/ci.yml` enumerates its
+gate steps by hand and an agent session's token has no `workflow` scope, so it
+cannot write that directory by push or API (#120, #122, #125) — the step to add
+is given in the pull request instead. Task-numbered rather than `m10` because
+this is not a §19 milestone, following 017 and 032.
+
 ## Sub-tasks
 
 | ID | Task | Status |
@@ -126,8 +183,8 @@ reconciler has to be able to read the refusal.
 | 052.3 | `internal/config`: `github.poll_interval`; `internal/daemon`: the reconciler, wired in `Run` | [x] |
 | 052.4 | `internal/api` + `internal/apiclient`: the four routes, `github_pull` on the task DTO | [x] |
 | 052.5 | `internal/cli`: `vincent github prs`; `cmd/fakegh`: `pr list` and `pr view` | [x] |
-| 052.6 | `internal/tui`: `viewPullRequests` takeover, the PR block in the task workspace, the create-PR editor | [ ] |
-| 052.7 | The browser opener (`_unix.go`/`_darwin.go`/`_windows.go`), failing visibly; a gate script for the listing | [ ] |
+| 052.6 | `internal/tui`: `viewPullRequests` takeover, the PR block in the task workspace, the create-PR editor | [x] |
+| 052.7 | The browser opener (`_unix.go`/`_darwin.go`/`_windows.go`), failing visibly; a gate script for the listing | [x] |
 
 ## What was split off, and why
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -65,7 +65,7 @@ the living engineering specification records implementation contracts.
 | [049](049-full-screen-task-workspace.md) | Board-only home and full-screen task workspace | ✅ done (5/5) |
 | [050](050-board-column-widths-and-wrapping.md) | Cap the board TITLE column and wrap overflowing cells | ✅ done (2/2) |
 | [051](051-live-workflow-graph-tab.md) | Live workflow graph tab on the task workspace | ✅ done (5/5) |
-| [052](052-github-pull-requests.md) | List a GitHub project's open pull requests and link them to board tasks | 🚧 in progress (5/7) |
+| [052](052-github-pull-requests.md) | List a GitHub project's open pull requests and link them to board tasks | ✅ done (7/7) |
 | [053](053-workflow-step-detail.md) | A full step-detail modal in the workflow graph | ✅ done (5/5) |
 | [054](054-collapsible-board-groups.md) | Collapsible groups on the task board | ✅ done (1/1) |
 | [055](055-release-check-and-self-update.md) | Check for a newer release, and offer an in-place update | ✅ done (2/2) |

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -32,6 +32,8 @@ const (
 	ctxNewTask     bindingContext = "new task"
 	ctxProjects    bindingContext = "projects"
 	ctxWorkflows   bindingContext = "workflows"
+	// ctxPullRequests is the pull-requests takeover (§15 view 7, task 052.6).
+	ctxPullRequests bindingContext = "pull requests"
 	// ctxWorkflowGraph is the graph sub-layer of the workflows takeover. It
 	// is its own context because its keys are entirely different from the
 	// list's, and the footer and the ? overlay must say which set is live.
@@ -61,6 +63,10 @@ const (
 	// a chooser above its text, and a row shared with the others could only
 	// describe one of them.
 	ctxFollowUpForm bindingContext = "follow-up form"
+	// ctxCreatePR is the compare-URL editor (task 052.6). Its own context for
+	// the reason the other popups have theirs: while it is open it owns the
+	// keyboard, and its two rows are nothing like the form underneath.
+	ctxCreatePR bindingContext = "open a pull request"
 )
 
 // binding is one registry row.
@@ -78,6 +84,13 @@ type binding struct {
 	priority int
 	// action is the §6 action a scopeTaskAction row is gated on.
 	action string
+	// github marks a row that only means something when at least one
+	// registered project has a usable GitHub integration (§13.2). There is no
+	// stored notion of one, so the root's probe fan-out is the answer and the
+	// row is withheld until it says yes — including while the probes are
+	// still in flight. Mechanically this is `fold`'s precedent (task 054
+	// decision 5) applied to a nav row and to two workspace keys.
+	github bool
 	// fold marks a row whose key only means something while the board has
 	// groups. With `group_by: []` there are none, so shell.liveBindings drops
 	// these and the footer never names a press that does nothing (task 054
@@ -111,13 +124,14 @@ var bindings = []binding{
 	{key: "q", label: "quit the TUI (the daemon keeps running)", scope: scopeGlobal},
 	{key: "ctrl+c", label: "quit the TUI", scope: scopeGlobal, noPalette: true},
 
-	// Navigation: the four takeover screens (§15 views 3–6). Only new task
+	// Navigation: the five takeover screens (§15 views 3–7). Only new task
 	// keeps a direct key; the rest live here, in the palette — retiring
 	// 1..6 without substituting new memorized keys is the point.
 	{key: "n", label: "new task — for the project you are looking at", scope: scopeGlobal, nav: true, navTarget: viewNewTask},
 	{label: "projects — list, add, edit, remove", scope: scopeGlobal, nav: true, navTarget: viewProjects},
 	{label: "workflows — registry with scopes and validity", scope: scopeGlobal, nav: true, navTarget: viewWorkflows},
 	{label: "daemon — identity, config, adapters, log", scope: scopeGlobal, nav: true, navTarget: viewDaemon},
+	{label: "pull requests — what is open across every GitHub project", scope: scopeGlobal, nav: true, navTarget: viewPullRequests, github: true},
 
 	// Task actions, gated on available_actions. `p` appears twice because
 	// pause and resume are distinct actions behind one key; the palette
@@ -160,6 +174,11 @@ var bindings = []binding{
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxTaskDetails, hint: "tab views", priority: 1},
 	{key: "]", label: "move to the next task view ([ goes back)", scope: scopePanel, context: ctxTaskDetails, hint: "[/] views", priority: 2},
 	{key: "down", label: "select a task-detail section (↑/↓); pgup/pgdn scrolls that section", scope: scopePanel, context: ctxTaskDetails, hint: "↑/↓ sections", priority: 3},
+	// The pull-request section's two keys (task 052.6, decision 2). Both only
+	// reach a browser: neither writes anything in vincent, which is what
+	// keeps §15's "read-only inspector" true in the sense it was written.
+	{key: "o", label: "open this task's pull request in a browser", scope: scopePanel, context: ctxTaskDetails, hint: "o pull request", priority: 4, github: true},
+	{key: "P", label: "open a pull request for this task's branch — the prefill is editable first, and nothing is sent to GitHub from here", scope: scopePanel, context: ctxTaskDetails, hint: "P open a PR", priority: 5, github: true},
 
 	// Output pane.
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxOutput, hint: "tab views", priority: 1},
@@ -228,6 +247,18 @@ var bindings = []binding{
 	{key: "shift+down", label: "pan the canvas (shift+↑/↓/←/→); pgup/pgdn page it", scope: scopePanel, context: ctxTaskWorkflow, hint: "⇧ pan", priority: 2},
 	{key: "5", label: "the workflow this task ran, with what each step did on it", scope: scopePanel, context: ctxTaskWorkflow, hint: "5 workflow", priority: 3},
 
+	// Pull requests (task 052.6). Link and unlink live only here: they are the
+	// two actions that write vincent's own column, and they belong on the one
+	// screen that can see a pull request no task claims — the case they exist
+	// for.
+	{key: "enter", label: "open the workspace of the task that claims this pull request", scope: scopePanel, context: ctxPullRequests, hint: "enter task", priority: 1},
+	{key: "o", label: "open the selected pull request in a browser", scope: scopePanel, context: ctxPullRequests, hint: "o browser", priority: 2},
+	{key: "l", label: "link this pull request to a task in the same project", scope: scopePanel, context: ctxPullRequests, hint: "l link", priority: 3},
+	{key: "u", label: "unlink it (asks first — the refusal sticks, and the reconciler will not link it again)", scope: scopePanel, context: ctxPullRequests, hint: "u unlink", priority: 4},
+	{key: "R", label: "re-list every project", scope: scopePanel, context: ctxPullRequests, hint: "R refresh", priority: 5},
+	{key: "down", label: "move the selection (↑/↓)", scope: scopePanel, context: ctxPullRequests, priority: 6},
+	{key: "/", label: "filter by number, title, branch or project", scope: scopePanel, context: ctxPullRequests, priority: 7},
+
 	// Daemon.
 	{key: "R", label: "re-read the daemon info, the config and the log", scope: scopePanel, context: ctxDaemon, hint: "R refresh", priority: 1},
 	{key: "f", label: "follow the end of the log again (f/G)", scope: scopePanel, context: ctxDaemon, hint: "f follow", priority: 2},
@@ -253,6 +284,13 @@ var bindings = []binding{
 	{key: "e", label: "write the prompt or command in $EDITOR", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 	{key: "ctrl+s", label: "start the follow-up run", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 	{key: "esc", label: "close the popup without running anything (the draft is discarded)", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
+
+	// The compare-URL editor (task 052.6). Same again: the popup owns the
+	// keyboard while it is open and prints its own key line.
+	{key: "enter", label: "edit the row under the cursor — the pull request's title or its body", scope: scopePanel, context: ctxCreatePR, noPalette: true},
+	{key: "e", label: "write the body in $EDITOR", scope: scopePanel, context: ctxCreatePR, noPalette: true},
+	{key: "ctrl+s", label: "open GitHub's own new-pull-request page with this prefill", scope: scopePanel, context: ctxCreatePR, noPalette: true},
+	{key: "esc", label: "close the popup without opening anything (the draft is discarded)", scope: scopePanel, context: ctxCreatePR, noPalette: true},
 }
 
 // isHomeContext reports whether a context belongs to the board/task daily loop
@@ -272,6 +310,23 @@ func bindingsFor(ctx bindingContext) []binding {
 	out := make([]binding, 0, 8)
 	for _, b := range bindings {
 		if b.scope == scopePanel && b.context == ctx {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// withoutGitHub drops the rows that only mean something while a project's
+// GitHub integration is usable. It is applied at the root, where the probe
+// results live: shell.liveBindings is the wrong seam because it is
+// shell-scoped and the nav row is global.
+func withoutGitHub(rows []binding, available bool) []binding {
+	if available {
+		return rows
+	}
+	out := make([]binding, 0, len(rows))
+	for _, b := range rows {
+		if !b.github {
 			out = append(out, b)
 		}
 	}

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -320,6 +320,76 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatalf("down selected %q, want Overview", v.detailsSection)
 			}
 		},
+		"o": func(t *testing.T) {
+			withFakeOpener(t, nil)
+			v := taskPullFixture(t, apiclient.GitHubTaskPull{
+				Linked: true, Repo: "octo/api", Number: 41,
+				Pull: &apiclient.GitHubPullRequest{URL: "https://github.com/octo/api/pull/41"},
+			})
+			if cmd := v.updateKey(registryKey(t, "o")); cmd == nil {
+				t.Fatal("o did not open the task's pull request")
+			}
+		},
+		"P": func(t *testing.T) {
+			v := taskPullFixture(t, apiclient.GitHubTaskPull{CompareURL: compareURLFixture})
+			v.updateKey(registryKey(t, "P"))
+			if v.createPR == nil {
+				t.Fatal("P did not open the compare-URL editor")
+			}
+		},
+	},
+
+	ctxPullRequests: {
+		"enter": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "claimed", claimedBy(7, "auto")))
+			if _, cmd := v.updateKey(registryKey(t, "enter")); cmd == nil {
+				t.Fatal("enter did not open the claiming task's workspace")
+			}
+		},
+		"o": func(t *testing.T) {
+			opened := withFakeOpener(t, nil)
+			v := pullRequestsFixture(testPull(11, "ship it"))
+			if _, cmd := v.updateKey(registryKey(t, "o")); cmd != nil {
+				drain(cmd)
+			}
+			if len(*opened) != 1 {
+				t.Fatalf("o opened %v, want the selected row", *opened)
+			}
+		},
+		"l": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "unclaimed"))
+			v.updateKey(registryKey(t, "l"))
+			if v.picker == nil {
+				t.Fatal("l did not open the task picker")
+			}
+		},
+		"u": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "claimed", claimedBy(8, "human")))
+			v.updateKey(registryKey(t, "u"))
+			if v.confirm == nil {
+				t.Fatal("u did not ask before unlinking")
+			}
+		},
+		"R": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "ship it"))
+			if _, cmd := v.updateKey(registryKey(t, "R")); cmd == nil {
+				t.Fatal("R did not re-list")
+			}
+		},
+		"down": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "one"), testPull(12, "two"))
+			v.updateKey(registryKey(t, "down"))
+			if v.cursor != 1 {
+				t.Fatalf("down left the cursor at %d, want 1", v.cursor)
+			}
+		},
+		"/": func(t *testing.T) {
+			v := pullRequestsFixture(testPull(11, "ship it"))
+			v.updateKey(registryKey(t, "/"))
+			if !v.filtering {
+				t.Fatal("/ did not open the filter")
+			}
+		},
 	},
 
 	ctxOutput: {
@@ -827,6 +897,43 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 		"esc": func(t *testing.T) {
 			f := newAnswerForm(questionRequest())
 			if _, exit := f.update(registryKey(t, "esc"), nil, 1); !exit {
+				t.Fatal("esc did not close the form")
+			}
+		},
+	},
+
+	ctxCreatePR: {
+		"enter": func(t *testing.T) {
+			f := createPRFixture(t)
+			f.update(registryKey(t, "enter"))
+			if !f.editing {
+				t.Fatal("enter did not open the row under the cursor")
+			}
+		},
+		"e": func(t *testing.T) {
+			f := createPRFixture(t)
+			called := false
+			f.openEditor = func(string) tea.Cmd { called = true; return nil }
+			f.update(registryKey(t, "e"))
+			if !called {
+				t.Fatal("e did not reach $EDITOR")
+			}
+		},
+		"ctrl+s": func(t *testing.T) {
+			opened := withFakeOpener(t, nil)
+			f := createPRFixture(t)
+			cmd, exit := f.update(registryKey(t, "ctrl+s"))
+			if !exit {
+				t.Fatal("ctrl+s did not close the popup")
+			}
+			drain(cmd)
+			if len(*opened) != 1 {
+				t.Fatalf("ctrl+s opened %v, want the compare URL", *opened)
+			}
+		},
+		"esc": func(t *testing.T) {
+			f := createPRFixture(t)
+			if _, exit := f.update(registryKey(t, "esc")); !exit {
 				t.Fatal("esc did not close the form")
 			}
 		},

--- a/internal/tui/createprform.go
+++ b/internal/tui/createprform.go
@@ -1,0 +1,289 @@
+package tui
+
+import (
+	"net/url"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+)
+
+// The compare-URL editor (task 052.6, decision 4).
+//
+// `compare_url` arrives from the daemon with a title and a body already
+// encoded as query parameters — a guess of the same kind task 035 decision 2
+// already sanctions for task creation. 052 decision 4 requires that guess be
+// visible and editable *before* it is used, so it lands in the form's own
+// rows and the URL is re-encoded here on the way out.
+//
+// Handing GitHub's own page the unedited URL was considered and rejected: it
+// satisfies the letter of "editable before submit" only by relying on a
+// surface vincent does not own.
+//
+// Nothing here talks to GitHub. The form parses a URL, edits two strings and
+// re-encodes it; opening it is a hand-off to a browser, and vincent still
+// writes nothing there.
+
+// cprRow is one line of the form.
+type cprRow int
+
+const (
+	cprTitle cprRow = iota
+	cprBody
+	cprRowCount
+)
+
+// createPREditMsg carries the text an $EDITOR session left behind.
+type createPREditMsg struct {
+	taskID int64
+	text   string
+	err    error
+}
+
+type createPRForm struct {
+	taskID int64
+	// base is the compare URL as served, kept whole: the path carries the
+	// base and head refs, and re-deriving it from parts would be a second
+	// implementation of a URL the daemon already built.
+	base    *url.URL
+	branch  string
+	title   string
+	body    string
+	cursor  cprRow
+	editor  textarea.Model
+	editing bool
+
+	// openEditor hands the focused row's text to $EDITOR. Injected by the
+	// task view, which owns the exec path, so the form needs no terminal.
+	openEditor func(text string) tea.Cmd
+
+	err string
+}
+
+// newCreatePRForm decodes the daemon's prefill into editable rows. A compare
+// URL that will not parse is refused here rather than opened: a browser given
+// a malformed URL fails in a place vincent cannot explain.
+func newCreatePRForm(taskID int64, compareURL, branch string) (*createPRForm, error) {
+	u, err := url.Parse(strings.TrimSpace(compareURL))
+	if err != nil {
+		return nil, err
+	}
+	ed := textarea.New()
+	ed.Prompt = ""
+	ed.ShowLineNumbers = false
+	ed.DynamicHeight = true
+	ed.MinHeight = 1
+	ed.MaxHeight = editorLines
+	ed.SetHeight(3)
+	ed.SetWidth(40)
+	q := u.Query()
+	return &createPRForm{
+		taskID: taskID,
+		base:   u,
+		branch: branch,
+		title:  q.Get("title"),
+		body:   q.Get("body"),
+		editor: ed,
+	}, nil
+}
+
+// url rebuilds the compare URL from the edited rows. Every other query
+// parameter the daemon set — `expand=1`, which is what makes GitHub open the
+// form rather than the diff — is preserved.
+func (f *createPRForm) url() string {
+	out := *f.base
+	q := out.Query()
+	setOrDelete(q, "title", f.title)
+	setOrDelete(q, "body", f.body)
+	out.RawQuery = q.Encode()
+	return out.String()
+}
+
+func setOrDelete(q url.Values, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		q.Del(key)
+		return
+	}
+	q.Set(key, value)
+}
+
+func (f *createPRForm) paste(text string) tea.Cmd {
+	if !f.editing {
+		return nil
+	}
+	var cmd tea.Cmd
+	f.editor, cmd = f.editor.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+// applyEdit installs what an $EDITOR session produced.
+func (f *createPRForm) applyEdit(msg createPREditMsg) {
+	if msg.taskID != f.taskID {
+		return
+	}
+	if msg.err != nil {
+		f.err = errString(msg.err)
+		return
+	}
+	f.setRow(f.cursor, strings.TrimRight(msg.text, "\n"))
+	f.err = ""
+}
+
+// update handles one key. exit asks the caller to close the form; cmd is the
+// browser hand-off when ctrl+s was pressed.
+func (f *createPRForm) update(msg tea.KeyPressMsg) (cmd tea.Cmd, exit bool) {
+	if f.editing {
+		switch msg.String() {
+		case "esc":
+			// esc discards, enter is a newline: a pull-request body is prose
+			// and wants more than one line, so the field cannot spend enter
+			// on committing. ctrl+s is what leaves it.
+			f.editing = false
+			f.editor.Blur()
+			return nil, false
+		case "ctrl+s":
+			f.commit()
+			return nil, false
+		}
+		var c tea.Cmd
+		f.editor, c = f.editor.Update(msg)
+		return c, false
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		f.cursor = max(f.cursor-1, 0)
+	case "down", "j":
+		f.cursor = min(f.cursor+1, cprRowCount-1)
+	case "enter":
+		f.startEdit(f.cursor)
+	case "e":
+		if f.openEditor != nil {
+			return f.openEditor(f.rowValue(f.cursor)), false
+		}
+		f.startEdit(f.cursor)
+	case "ctrl+s":
+		return f.open(), true
+	case "esc":
+		return nil, true
+	}
+	return nil, false
+}
+
+// open hands the re-encoded URL to a browser. The title is required because
+// GitHub's form is unusable without one and finding that out in a browser tab
+// is a round trip wasted.
+func (f *createPRForm) open() tea.Cmd {
+	if strings.TrimSpace(f.title) == "" {
+		f.err = "give the pull request a title first"
+		return nil
+	}
+	return openURLCmd(f.url())
+}
+
+func (f *createPRForm) startEdit(row cprRow) {
+	f.editing = true
+	f.cursor = row
+	f.editor.SetValue(f.rowValue(row))
+	f.editor.Focus()
+}
+
+func (f *createPRForm) commit() {
+	f.editing = false
+	f.editor.Blur()
+	f.setRow(f.cursor, f.editor.Value())
+	f.err = ""
+}
+
+func (f *createPRForm) rowValue(row cprRow) string {
+	if row == cprBody {
+		return f.body
+	}
+	return f.title
+}
+
+func (f *createPRForm) setRow(row cprRow, value string) {
+	if row == cprBody {
+		f.body = strings.TrimRight(value, "\n")
+		return
+	}
+	// A title is one line by construction; a pasted paragraph collapses
+	// rather than encoding newlines GitHub would render as spaces anyway.
+	f.title = strings.TrimSpace(strings.ReplaceAll(value, "\n", " "))
+}
+
+func (f *createPRForm) height(width int) int { return len(f.lines(width)) }
+
+func (f *createPRForm) render(width, height int) string {
+	lines := f.lines(width)
+	return strings.Join(windowRange(lines, 0, len(lines), height), "\n")
+}
+
+// lines is the whole form: what it is about, the two rows, and the key line.
+func (f *createPRForm) lines(width int) []string {
+	out := make([]string, 0, 16)
+	out = append(out, styleDim.Render("  "+f.subject()))
+	out = append(out, "")
+	for _, row := range []cprRow{cprTitle, cprBody} {
+		out = append(out, f.rowLines(row, width)...)
+	}
+	out = append(out, "")
+	// The URL is shown because it is what will actually be opened, and
+	// because a prefill nobody can see the effect of is the thing decision 4
+	// exists to prevent.
+	out = append(out, styleDim.Render("  opens"))
+	for _, line := range wrapPlain(f.url(), max(width-4, 20)) {
+		out = append(out, styleDim.Render("    "+line))
+	}
+	switch {
+	case f.err != "":
+		out = append(out, styleBad.Render("  ⚠ "+f.err))
+	case f.editing:
+		out = append(out, styleDim.Render("  ctrl+s keeps this text · esc discards it"))
+	default:
+		out = append(out, styleDim.Render(
+			"  enter edit · e $EDITOR · ctrl+s open in a browser · esc leave the form"))
+	}
+	return out
+}
+
+func (f *createPRForm) subject() string {
+	out := "a pull request for this task's branch"
+	if f.branch != "" {
+		out = "a pull request for " + f.branch
+	}
+	return out + " — GitHub's own page opens with this prefill; nothing is sent from here"
+}
+
+func (f *createPRForm) rowLines(row cprRow, width int) []string {
+	cursor := "  "
+	if f.cursor == row && !f.editing {
+		cursor = styleFocus.Render("› ")
+	}
+	label := "title"
+	if row == cprBody {
+		label = "body "
+	}
+	out := []string{cursor + label}
+	if f.cursor == row && f.editing {
+		return append(out, f.editorLines(width)...)
+	}
+	value := f.rowValue(row)
+	if value == "" {
+		return append(out, styleDim.Render(strings.Repeat(" ", editorIndent)+"(empty)"))
+	}
+	for _, line := range wrapPlain(value, max(width-editorIndent, 20)) {
+		out = append(out, strings.Repeat(" ", editorIndent)+styleOK.Render(line))
+	}
+	return out
+}
+
+func (f *createPRForm) editorLines(width int) []string {
+	f.editor.SetWidth(max(width-editorIndent-2, 20))
+	indent := strings.Repeat(" ", editorIndent)
+	out := make([]string, 0, 6)
+	for _, line := range strings.Split(f.editor.View(), "\n") {
+		out = append(out, indent+line)
+	}
+	return out
+}

--- a/internal/tui/createprform_test.go
+++ b/internal/tui/createprform_test.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// compareURLFixture is what GET /v1/tasks/{id}/github/pull serves for a task
+// with a branch and no link — the daemon's own construction, ampersand and
+// all.
+const compareURLFixture = "https://github.com/octo/api/compare/master...vincent/7-add-a-thing" +
+	"?body=Add+a+thing%0A%0ACloses+%23231&expand=1&title=Add+a+thing"
+
+func createPRFixture(t *testing.T) *createPRForm {
+	t.Helper()
+	f, err := newCreatePRForm(7, compareURLFixture, "vincent/7-add-a-thing")
+	if err != nil {
+		t.Fatalf("newCreatePRForm: %v", err)
+	}
+	return f
+}
+
+// The prefill arrives encoded in the URL's query and lands in the form's own
+// rows: 052 decision 4 requires it be visible and editable before it is used.
+func TestCreatePRFormDecodesThePrefill(t *testing.T) {
+	f := createPRFixture(t)
+	if f.title != "Add a thing" {
+		t.Errorf("title = %q, want the decoded prefill", f.title)
+	}
+	if f.body != "Add a thing\n\nCloses #231" {
+		t.Errorf("body = %q, want the decoded prefill", f.body)
+	}
+	if !strings.Contains(f.render(80, 20), "Closes #231") {
+		t.Error("the body is not on screen before it is used")
+	}
+}
+
+// An edit changes the URL that is opened — which is the whole point of
+// editing it, and the thing handing GitHub the unedited URL could not do.
+func TestCreatePRFormEditChangesTheOpenedURL(t *testing.T) {
+	opened := withFakeOpener(t, nil)
+	f := createPRFixture(t)
+	f.setRow(cprTitle, "A better title")
+	f.setRow(cprBody, "Rewritten body")
+	drain(f.open())
+	if len(*opened) != 1 {
+		t.Fatalf("opened %v, want one URL", *opened)
+	}
+	u, err := url.Parse((*opened)[0])
+	if err != nil {
+		t.Fatalf("the rebuilt URL does not parse: %v", err)
+	}
+	q := u.Query()
+	if q.Get("title") != "A better title" {
+		t.Errorf("title = %q, want the edited one", q.Get("title"))
+	}
+	if q.Get("body") != "Rewritten body" {
+		t.Errorf("body = %q, want the edited one", q.Get("body"))
+	}
+	// expand=1 is what makes GitHub open the form rather than the diff; the
+	// rebuild must not drop what the daemon set.
+	if q.Get("expand") != "1" {
+		t.Errorf("expand = %q, want the daemon's 1", q.Get("expand"))
+	}
+	if u.Path != "/octo/api/compare/master...vincent/7-add-a-thing" {
+		t.Errorf("path = %q, want the daemon's compare path", u.Path)
+	}
+}
+
+// An emptied row drops its parameter rather than sending an empty one.
+func TestCreatePRFormEmptyBodyDropsTheParameter(t *testing.T) {
+	f := createPRFixture(t)
+	f.setRow(cprBody, "  ")
+	u, err := url.Parse(f.url())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := u.Query()["body"]; ok {
+		t.Error("an emptied body is still encoded in the URL")
+	}
+}
+
+// A title is required here rather than in a browser tab: GitHub's form is
+// unusable without one, and finding that out over there is a round trip
+// wasted.
+func TestCreatePRFormRefusesAnEmptyTitle(t *testing.T) {
+	opened := withFakeOpener(t, nil)
+	f := createPRFixture(t)
+	f.setRow(cprTitle, "")
+	if cmd := f.open(); cmd != nil {
+		t.Fatal("an empty title was opened")
+	}
+	if f.err == "" {
+		t.Error("nothing said why")
+	}
+	if len(*opened) != 0 {
+		t.Fatalf("the opener was called with %v", *opened)
+	}
+}
+
+// The acceptance criterion stated as a test rather than left to inspection:
+// the whole editor path contacts nothing. Mirrors internal/github's
+// TestCompareURLMakesNoRequest — vincent still writes nothing at GitHub, and
+// decision record row 11 stands.
+func TestCreatePRFormMakesNoRequest(t *testing.T) {
+	var reached bool
+	prev := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		reached = true
+		return nil, errNoOpener
+	})
+	t.Cleanup(func() { http.DefaultTransport = prev })
+	withFakeOpener(t, nil)
+
+	f := createPRFixture(t)
+	f.update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	f.setRow(cprBody, "edited")
+	drain(f.open())
+	_ = f.render(80, 20)
+	if reached {
+		t.Fatal("the compare-URL editor made an HTTP request")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// esc leaves the draft behind and ctrl+s opens; both close the popup, which
+// is what lets the task view drop it.
+func TestCreatePRFormClosesOnEscAndSubmit(t *testing.T) {
+	withFakeOpener(t, nil)
+	f := createPRFixture(t)
+	if _, exit := f.update(tea.KeyPressMsg{Code: tea.KeyEscape}); !exit {
+		t.Error("esc did not close the form")
+	}
+	f = createPRFixture(t)
+	if _, exit := f.update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}); !exit {
+		t.Error("ctrl+s did not close the form")
+	}
+}

--- a/internal/tui/diffshell_test.go
+++ b/internal/tui/diffshell_test.go
@@ -43,7 +43,7 @@ func TestDiffTabIsItsOwnSurface(t *testing.T) {
 			t.Errorf("the diff footer does not mention %q:\n%s", want, line)
 		}
 	}
-	if help := helpText(ctxDiff); !strings.Contains(help, "expand every file") ||
+	if help := helpText(ctxDiff, true); !strings.Contains(help, "expand every file") ||
 		!strings.Contains(help, "approve the gate") {
 		t.Errorf("? on the diff tab lost the tab's own keys or the task's actions:\n%s", help)
 	}

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -285,3 +285,33 @@ func (d *detail) openTranscript() tea.Cmd {
 		return transcriptOpenedMsg{err: err}
 	})
 }
+
+// editCreatePRBody opens the compare-URL editor's focused row in $EDITOR
+// (task 052.6). Same argument as the two above: a pull-request body is prose
+// of a length nobody chose, and the popup's field is three lines. It opens
+// nothing — what the editor leaves goes back into the form, and the human
+// still has to press ctrl+s.
+func (d *detail) editCreatePRBody(text string) tea.Cmd {
+	path, err := writeEditorFile(fmt.Sprintf("task%d-pr", d.taskID), ".md", text)
+	if err != nil {
+		return func() tea.Msg { return createPREditMsg{taskID: d.taskID, err: err} }
+	}
+	argv := append(editorCommand(), path)
+	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the editor is the user's own choice
+	taskID := d.taskID
+	return d.exec(cmd, func(runErr error) tea.Msg {
+		defer func() { _ = os.Remove(path) }()
+		msg := createPREditMsg{taskID: taskID}
+		if runErr != nil {
+			msg.err = runErr
+			return msg
+		}
+		edited, readErr := os.ReadFile(path) //nolint:gosec // path is this process's temp file
+		if readErr != nil {
+			msg.err = readErr
+			return msg
+		}
+		msg.text = string(edited)
+		return msg
+	})
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -28,7 +28,7 @@ func helpFooter(width int) string {
 // work *here*: the focused surface's own, the global ones, the task actions,
 // and the palette's navigation. Printing all eight surfaces' sections at
 // once meant reading past seven irrelevant ones (T3.8 finding).
-func helpText(ctx bindingContext) string {
+func helpText(ctx bindingContext, github bool) string {
 	var b strings.Builder
 	writeSection := func(title string, rows []binding) {
 		if len(rows) == 0 {
@@ -49,7 +49,7 @@ func helpText(ctx bindingContext) string {
 	}
 
 	var global, nav, actions []binding
-	for _, r := range bindings {
+	for _, r := range withoutGitHub(bindings, github) {
 		switch {
 		case r.nav:
 			nav = append(nav, r)
@@ -61,7 +61,7 @@ func helpText(ctx bindingContext) string {
 	}
 	// This surface first: it is the answer to "what can I do here".
 	if ctx != "" {
-		writeSection(string(ctx), bindingsFor(ctx))
+		writeSection(string(ctx), withoutGitHub(bindingsFor(ctx), github))
 	}
 	if isHomeContext(ctx) {
 		writeSection("task actions (on the selected task, offered only when valid)", actions)

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -289,7 +289,7 @@ func TestRootMouseToggle(t *testing.T) {
 		t.Fatalf("mouse mode = %v after M M, want cell motion again", v.MouseMode)
 	}
 	// The toggle is discoverable: a registry row, so palette and ? carry it.
-	if !strings.Contains(helpText(ctxTasks), "toggle the mouse") {
+	if !strings.Contains(helpText(ctxTasks, true), "toggle the mouse") {
 		t.Error("the mouse toggle is not in the help overlay")
 	}
 }

--- a/internal/tui/openurl.go
+++ b/internal/tui/openurl.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// The browser opener (task 052.6). Every screen that shows a pull request
+// needs a way to reach it, and the only thing vincent can do about that is
+// hand the URL to whatever the platform already uses to open one.
+//
+// Unlike clipboard.go this fails **visibly**. Reading a clipboard silently
+// falls back to the terminal's own paste, so a failure there costs nothing;
+// here a human pressed a key expecting a browser, and silence is
+// indistinguishable from a browser that opened on another desktop.
+
+// openTimeout bounds the helper process. The helpers all hand off to a
+// running browser and return immediately; one that has not returned in this
+// long is not going to.
+const openTimeout = 10 * time.Second
+
+// errNoOpener is what a platform's helper reports when it is not installed —
+// a headless Linux box with no xdg-open is the usual case.
+var errNoOpener = errors.New("no browser opener found")
+
+// openedURLMsg reports what came of an open. It carries the URL so the note
+// can name it: a failure a human can copy out of is one they can still act
+// on.
+type openedURLMsg struct {
+	url string
+	err error
+}
+
+// openURL is the platform hand-off, indirected through a variable so tests
+// can assert what would have been opened without launching a browser.
+var openURL = openURLPlatform
+
+// openURLCmd validates the URL and hands it over.
+//
+// Only http and https are opened. The URLs the TUI opens are built by the
+// daemon or by this package, but the platform helpers will happily launch a
+// registered handler for any scheme, and a URL is the one thing on these
+// screens that originated outside vincent — refusing everything else costs
+// nothing and closes that door.
+func openURLCmd(raw string) tea.Cmd {
+	raw = strings.TrimSpace(raw)
+	return func() tea.Msg {
+		if raw == "" {
+			return openedURLMsg{err: errors.New("nothing to open")}
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			return openedURLMsg{url: raw, err: fmt.Errorf("not a URL: %w", err)}
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return openedURLMsg{url: raw, err: fmt.Errorf("refusing to open a %q URL", u.Scheme)}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), openTimeout)
+		defer cancel()
+		return openedURLMsg{url: raw, err: openURL(ctx, raw)}
+	}
+}
+
+// openFailure is the sentence a view puts on screen when an open failed.
+func openFailure(msg openedURLMsg) string {
+	if msg.url == "" {
+		return "could not open a browser: " + errString(msg.err)
+	}
+	return "could not open " + msg.url + ": " + errString(msg.err)
+}
+
+// openerError prefers the helper's own message over the exit status, which
+// on its own says nothing a human can act on.
+func openerError(err error, out []byte) error {
+	if text := trimOutput(out); text != "" {
+		return errors.New(text)
+	}
+	return err
+}
+
+// trimOutput is the first line a helper printed, collapsed to one sentence:
+// the note is a single line of footer, not a place to spill stderr.
+func trimOutput(out []byte) string {
+	text := strings.TrimSpace(string(out))
+	if text == "" {
+		return ""
+	}
+	if line, _, ok := strings.Cut(text, "\n"); ok {
+		text = strings.TrimSpace(line)
+	}
+	return strings.TrimSpace(strings.TrimSuffix(text, "\r"))
+}

--- a/internal/tui/openurl_darwin.go
+++ b/internal/tui/openurl_darwin.go
@@ -1,0 +1,21 @@
+package tui
+
+import (
+	"context"
+	"os/exec"
+)
+
+// openURLPlatform uses macOS's own `open`, which hands the URL to whatever
+// the user set as their default handler.
+func openURLPlatform(ctx context.Context, url string) error {
+	if _, err := exec.LookPath("open"); err != nil {
+		return errNoOpener
+	}
+	// The URL is a separate argv element, never a shell string, and
+	// openURLCmd has already refused every scheme but http and https.
+	out, err := exec.CommandContext(ctx, "open", url).CombinedOutput() //nolint:gosec // a validated http(s) URL, passed as argv
+	if err != nil {
+		return openerError(err, out)
+	}
+	return nil
+}

--- a/internal/tui/openurl_unix.go
+++ b/internal/tui/openurl_unix.go
@@ -1,0 +1,25 @@
+//go:build !darwin && !windows
+
+package tui
+
+import (
+	"context"
+	"os/exec"
+)
+
+// openURLPlatform uses xdg-open, the freedesktop.org convention every
+// desktop environment implements. A machine without it — a server, a bare
+// container — has nothing to open a browser with, and says so rather than
+// guessing at firefox.
+func openURLPlatform(ctx context.Context, url string) error {
+	if _, err := exec.LookPath("xdg-open"); err != nil {
+		return errNoOpener
+	}
+	// The URL is a separate argv element, never a shell string, and
+	// openURLCmd has already refused every scheme but http and https.
+	out, err := exec.CommandContext(ctx, "xdg-open", url).CombinedOutput() //nolint:gosec // a validated http(s) URL, passed as argv
+	if err != nil {
+		return openerError(err, out)
+	}
+	return nil
+}

--- a/internal/tui/openurl_windows.go
+++ b/internal/tui/openurl_windows.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	"context"
+	"os/exec"
+)
+
+// openURLPlatform uses the shell's own protocol handler through rundll32
+// rather than `cmd /c start`. `start` is a cmd builtin, so it needs a shell,
+// and cmd treats `&` inside a URL as a command separator — a compare URL
+// carries a query string full of them.
+func openURLPlatform(ctx context.Context, url string) error {
+	exe, err := exec.LookPath("rundll32.exe")
+	if err != nil {
+		return errNoOpener
+	}
+	// The URL is a separate argv element, never a shell string, and
+	// openURLCmd has already refused every scheme but http and https.
+	out, err := exec.CommandContext(ctx, exe, "url.dll,FileProtocolHandler", url).CombinedOutput() //nolint:gosec // a validated http(s) URL, passed as argv
+	if err != nil {
+		return openerError(err, out)
+	}
+	return nil
+}

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -42,8 +42,9 @@ func newPalette(entries []paletteEntry) *palette {
 // paletteEntries builds the palette for one surface. target is the selected
 // task as the action bar sees it; editable reports whether the current step
 // has text E could edit; connected gates the action group — nothing can act
-// on a task the daemon cannot see.
-func paletteEntries(ctx bindingContext, target taskActions, editable, connected bool) []paletteEntry {
+// on a task the daemon cannot see; github gates the rows that only mean
+// something when some project's integration is usable (task 052.6).
+func paletteEntries(ctx bindingContext, target taskActions, editable, connected, github bool) []paletteEntry {
 	out := make([]paletteEntry, 0, len(bindings))
 	if connected && (target.id != 0 || target.bulk()) {
 		// A selection is what the keys act on, so it is what the section is
@@ -66,7 +67,7 @@ func paletteEntries(ctx bindingContext, target taskActions, editable, connected 
 	// Views get their own section: navigating to them is the reason the
 	// digits could be retired, so it must not read as one more command
 	// (T3.8 finding).
-	for _, b := range bindings {
+	for _, b := range withoutGitHub(bindings, github) {
 		if b.nav {
 			out = append(out, paletteEntry{
 				group: "views", label: b.label, key: b.key,
@@ -74,7 +75,7 @@ func paletteEntries(ctx bindingContext, target taskActions, editable, connected 
 			})
 		}
 	}
-	for _, b := range bindingsFor(ctx) {
+	for _, b := range withoutGitHub(bindingsFor(ctx), github) {
 		if b.noPalette {
 			continue
 		}

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -28,7 +28,7 @@ func TestPaletteReachesEveryRegistryEntry(t *testing.T) {
 	contexts := []bindingContext{
 		ctxTasks, ctxTimeline, ctxTaskDetails, ctxOutput, ctxDiff,
 		ctxNewTask, ctxProjects, ctxWorkflows, ctxWorkflowGraph, ctxTaskWorkflow,
-		ctxDaemon,
+		ctxDaemon, ctxPullRequests,
 	}
 	for _, b := range bindings {
 		if b.noPalette {
@@ -36,7 +36,7 @@ func TestPaletteReachesEveryRegistryEntry(t *testing.T) {
 		}
 		found := false
 		for _, ctx := range contexts {
-			for _, e := range paletteEntries(ctx, everyAction, true, true) {
+			for _, e := range paletteEntries(ctx, everyAction, true, true, true) {
 				if e.label == b.label {
 					found = true
 				}
@@ -55,7 +55,7 @@ func TestPaletteOmitsInvalidActions(t *testing.T) {
 		apiclient.ActionApprove, apiclient.ActionReject,
 	}}
 	labels := strings.Builder{}
-	for _, e := range paletteEntries(ctxTasks, target, false, true) {
+	for _, e := range paletteEntries(ctxTasks, target, false, true, true) {
 		labels.WriteString(e.label + "\n")
 	}
 	got := labels.String()
@@ -73,7 +73,7 @@ func TestPaletteOmitsInvalidActions(t *testing.T) {
 // to edit — a gate has none, so the palette must not offer it.
 func TestPaletteEditGate(t *testing.T) {
 	target := taskActions{id: 3, state: stateBlocked, actions: []string{apiclient.ActionRetry}}
-	for _, e := range paletteEntries(ctxTasks, target, false, true) {
+	for _, e := range paletteEntries(ctxTasks, target, false, true, true) {
 		if strings.Contains(e.label, "edit the step's prompt") {
 			t.Fatal("palette offers edit+retry on a step with nothing to edit")
 		}
@@ -84,7 +84,7 @@ func TestPaletteEditGate(t *testing.T) {
 // nothing can act on a task, but `:` is how §15 says the daemon view stays
 // reachable — navigation and panel commands survive.
 func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
-	entries := paletteEntries(ctxTasks, everyAction, true, false)
+	entries := paletteEntries(ctxTasks, everyAction, true, false, true)
 	var nav, actions int
 	for _, e := range entries {
 		if e.nav {
@@ -97,8 +97,8 @@ func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
 	if actions != 0 {
 		t.Errorf("palette offers %d task actions while disconnected, want 0", actions)
 	}
-	if nav != 4 {
-		t.Errorf("palette lists %d navigation entries while disconnected, want all 4", nav)
+	if nav != 5 {
+		t.Errorf("palette lists %d navigation entries while disconnected, want all 5", nav)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
 // wall — and navigation needs its own section, since reaching the takeover
 // screens is why the digits could be retired.
 func TestPaletteSectionsAreVisiblySeparate(t *testing.T) {
-	p := newPalette(paletteEntries(ctxTasks, everyAction, true, true))
+	p := newPalette(paletteEntries(ctxTasks, everyAction, true, true, true))
 	out := p.render(60, 18)
 	plain := ansi.Strip(out)
 
@@ -190,7 +190,7 @@ func TestPaletteSearchNarrowsAndEscCloses(t *testing.T) {
 // TestHelpRendersFromRegistry: the ? overlay is generated, not hand-written
 // — a registry row's label must appear verbatim.
 func TestHelpRendersFromRegistry(t *testing.T) {
-	got := helpText(ctxTasks)
+	got := helpText(ctxTasks, true)
 	for _, want := range []string{
 		"jump to the next task needing a human",
 		"open the command palette",
@@ -208,7 +208,7 @@ func TestHelpRendersFromRegistry(t *testing.T) {
 // here", so it carries the focused surface's keys — not all eight
 // surfaces' sections at once.
 func TestHelpIsContextual(t *testing.T) {
-	tasks := helpText(ctxTasks)
+	tasks := helpText(ctxTasks, true)
 	if !strings.Contains(tasks, "filter by id") {
 		t.Error("the task table's help lacks its own filter key")
 	}
@@ -218,7 +218,7 @@ func TestHelpIsContextual(t *testing.T) {
 		}
 	}
 
-	projects := helpText(ctxProjects)
+	projects := helpText(ctxProjects, true)
 	if !strings.Contains(projects, "register a repository") {
 		t.Error("the projects help lacks its own add key")
 	}
@@ -231,12 +231,12 @@ func TestHelpIsContextual(t *testing.T) {
 	if strings.Contains(projects, "approve the gate") {
 		t.Error("the projects help offers task actions")
 	}
-	if !strings.Contains(helpText(ctxTasks), "approve the gate") {
+	if !strings.Contains(helpText(ctxTasks, true), "approve the gate") {
 		t.Error("the task table's help omits the task actions")
 	}
 	// The globals are everywhere, because they work everywhere.
 	for _, ctx := range []bindingContext{ctxTasks, ctxProjects, ctxDaemon, ctxNewTask} {
-		if !strings.Contains(helpText(ctx), "quit the TUI") {
+		if !strings.Contains(helpText(ctx, true), "quit the TUI") {
 			t.Errorf("%s help omits the global keys", ctx)
 		}
 	}

--- a/internal/tui/paste_test.go
+++ b/internal/tui/paste_test.go
@@ -148,7 +148,7 @@ func enterKey() tea.KeyPressMsg {
 // TestPasteIsDocumented keeps the fallback discoverable: ? renders from the
 // registry, so a key that is not a row is a key nobody finds.
 func TestPasteIsDocumented(t *testing.T) {
-	if !strings.Contains(helpText(ctxProjects), "ctrl+v") {
+	if !strings.Contains(helpText(ctxProjects, true), "ctrl+v") {
 		t.Error("ctrl+v is not in the help overlay")
 	}
 }

--- a/internal/tui/pullrequests.go
+++ b/internal/tui/pullrequests.go
@@ -1,0 +1,657 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The pull-requests takeover (§15 view 7, task 052.6).
+//
+// The question this screen exists to answer is the cross-project one — what
+// is open across everything I run — which one project at a time cannot. So
+// it lists every available project's open pull requests, grouped, with the
+// task that claims each row.
+//
+// It makes no GitHub call of its own: every row here came from the daemon,
+// which owns every call it makes on a client's behalf. What the TUI adds is
+// the two writes to vincent's own column (link and unlink) and a hand-off to
+// a browser.
+
+// eventTaskGitHubPullChanged is the durable event the daemon writes when a
+// task's pull-request link is applied or removed (§13.3) — the reconciler
+// tick this screen re-renders on rather than leaving a stale list.
+const eventTaskGitHubPullChanged = "task.github_pull_changed"
+
+// githubProject pairs a registered project with its §13.2 capability probe.
+// There is no stored notion of a "GitHub project": it is derived from the
+// origin remote plus a credential probe, which is exactly why the probe is
+// its own endpoint rather than three more fields on the project DTO.
+type githubProject struct {
+	project apiclient.Project
+	status  apiclient.GitHubStatus
+}
+
+// githubProbeMsg carries the whole fan-out of probes. It is one message
+// rather than one per project because the nav row is gated on *any* project
+// answering yes, and a per-project message would make the row flicker into
+// existence as answers trickle in.
+type githubProbeMsg struct {
+	projects []githubProject
+	// err is the project listing failing, which is not the same as every
+	// probe saying no — the difference is between "no GitHub projects" and
+	// "could not ask".
+	err error
+}
+
+// available is the projects whose integration answered yes, in listing order.
+func (m githubProbeMsg) available() []githubProject {
+	out := make([]githubProject, 0, len(m.projects))
+	for _, p := range m.projects {
+		if p.status.Available {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// probeGitHubCmd asks every registered project whether its GitHub
+// integration is usable, concurrently. The daemon's short cache absorbs the
+// repeat cost, which is the reason §13.2 gives for the probe being cheap
+// enough to ask per project.
+func probeGitHubCmd(client *apiclient.Client) tea.Cmd {
+	if client == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		projects, err := client.ListProjects(ctx)
+		if err != nil {
+			return githubProbeMsg{err: err}
+		}
+		out := make([]githubProject, len(projects))
+		var wg sync.WaitGroup
+		for i, project := range projects {
+			out[i] = githubProject{project: project}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// A probe that fails is "not available": a nav row offered on
+				// the strength of a question nobody could answer leads to a
+				// screen that then cannot list anything.
+				status, err := client.ProjectGitHub(ctx, project.ID)
+				if err == nil {
+					out[i].status = status
+				}
+			}()
+		}
+		wg.Wait()
+		return githubProbeMsg{projects: out}
+	}
+}
+
+// Pull-requests messages.
+type (
+	prRefreshMsg struct{}
+	// prLoadedMsg is one whole screen's worth of listings: every available
+	// project's, each carrying its own outcome, plus the task rows the
+	// claiming column and the link picker read from.
+	prLoadedMsg struct {
+		groups []pullGroup
+		tasks  []apiclient.Task
+	}
+	// prLinkedMsg reports a completed link or unlink.
+	prLinkedMsg struct {
+		taskID int64
+		number int
+		unlink bool
+		err    error
+	}
+)
+
+// pullGroup is one project's listing. err holds that project's own failure —
+// a 409 from an integration that stopped working sinks this group and no
+// other, which is the whole reason the groups are fetched separately.
+type pullGroup struct {
+	project apiclient.Project
+	pulls   []apiclient.GitHubPullRequest
+	err     string
+}
+
+// prRow is one selectable line: a pull request and the project it is in.
+// Group headings are drawn by the renderer and are not rows — there is
+// nothing to do on one.
+type prRow struct {
+	project apiclient.Project
+	pull    apiclient.GitHubPullRequest
+}
+
+// unlinkPrompt is the inline confirmation. It says the refusal is sticky
+// because that is what DELETE does: the reconciler reads the suppression and
+// will not re-apply the link on its next tick. A prompt that said "clear"
+// would be lying.
+type unlinkPrompt struct {
+	taskID int64
+	number int
+	text   string
+}
+
+// pullRequestsView is §15's view 7.
+type pullRequestsView struct {
+	client *apiclient.Client
+	now    func() time.Time
+
+	// available is what the root's probe fan-out found. The view does not
+	// probe: the root does, because the nav row that reaches this screen is
+	// gated on the same answer.
+	available []githubProject
+
+	groups []pullGroup
+	tasks  []apiclient.Task
+
+	loaded   bool
+	loading  bool
+	lastLoad time.Time
+
+	cursor int
+
+	filter    textinput.Model
+	filtering bool
+
+	// picker is the link picker, scoped to the row's own project: POST takes
+	// a bare number and the daemon resolves the repo from the task's project,
+	// so offering a task from another project would link that project's repo
+	// to a number that means something else there.
+	picker      *picker
+	pickerPull  int
+	pickerRepo  string
+	confirm     *unlinkPrompt
+	note        string
+	noteBad     bool
+	refreshWait bool
+
+	width, height int
+}
+
+func newPullRequestsView() *pullRequestsView {
+	fi := textinput.New()
+	fi.Placeholder = "filter by number, title, branch or project"
+	fi.Prompt = "/"
+	return &pullRequestsView{now: time.Now, filter: fi}
+}
+
+func (v *pullRequestsView) title() string { return "Pull requests" }
+
+// setClient takes the connection as it comes up and again after a reconnect.
+// It re-lists rather than waiting for the next probe: a reconnect is exactly
+// when what GitHub said last is most likely to be stale.
+func (v *pullRequestsView) setClient(c *apiclient.Client) tea.Cmd {
+	v.client = c
+	return v.loadCmd()
+}
+
+func (v *pullRequestsView) capturesInput() bool {
+	if v.filtering {
+		return true
+	}
+	// The picker owns the keyboard only while its filter or free-text entry
+	// is being typed into; its list is single-key like the confirmations.
+	return v.picker != nil && (v.picker.filtering || v.picker.editing)
+}
+
+func (v *pullRequestsView) paste(text string) tea.Cmd {
+	if v.picker != nil {
+		return v.picker.paste(text)
+	}
+	if !v.filtering {
+		return nil
+	}
+	var cmd tea.Cmd
+	v.filter, cmd = v.filter.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+// hintedProject lets `n` open the new-task form on the project the cursor is
+// standing in.
+func (v *pullRequestsView) hintedProject() int64 {
+	if row, ok := v.current(); ok {
+		return row.project.ID
+	}
+	return 0
+}
+
+func (v *pullRequestsView) update(msg tea.Msg) (panel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width, v.height = msg.Width, msg.Height
+		return v, nil
+	case githubProbeMsg:
+		return v, v.applyProbe(msg)
+	case viewActivatedMsg:
+		if msg.id == viewPullRequests {
+			// A view that was off-screen through a burst of events opens on
+			// what it last fetched; refetching on activation is what keeps
+			// "off-screen" from meaning "stale".
+			return v, v.loadCmd()
+		}
+		return v, nil
+	case prRefreshMsg:
+		v.refreshWait = false
+		return v, v.loadCmd()
+	case prLoadedMsg:
+		v.applyLoaded(msg)
+		return v, nil
+	case prLinkedMsg:
+		return v, v.applyLinked(msg)
+	case openedURLMsg:
+		v.applyOpened(msg)
+		return v, nil
+	case noteMsg:
+		return v, v.updateNote(msg.note)
+	case tea.KeyPressMsg:
+		return v.updateKey(msg)
+	}
+	return v, nil
+}
+
+// applyProbe records what the root found and reloads when the set of
+// available projects changed — a project registered mid-session is one this
+// screen has never listed.
+func (v *pullRequestsView) applyProbe(msg githubProbeMsg) tea.Cmd {
+	next := msg.available()
+	if sameGitHubProjects(v.available, next) {
+		return nil
+	}
+	v.available = next
+	return v.loadCmd()
+}
+
+func sameGitHubProjects(a, b []githubProject) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].project.ID != b[i].project.ID {
+			return false
+		}
+	}
+	return true
+}
+
+// loadCmd fetches every available project's listing concurrently, and the
+// task rows the claiming column reads. Each listing keeps its own error:
+// this is the endpoint that answers 409 when an integration stops working,
+// and one project's credentials expiring must not blank the others.
+func (v *pullRequestsView) loadCmd() tea.Cmd {
+	client := v.client
+	if client == nil || len(v.available) == 0 {
+		return nil
+	}
+	v.loading = true
+	projects := append([]githubProject(nil), v.available...)
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		groups := make([]pullGroup, len(projects))
+		var wg sync.WaitGroup
+		for i, gp := range projects {
+			groups[i] = pullGroup{project: gp.project}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pulls, err := client.ListGitHubPulls(ctx, gp.project.ID, 0)
+				if err != nil {
+					groups[i].err = githubReasonMessage(err)
+					return
+				}
+				groups[i].pulls = pulls
+			}()
+		}
+		wg.Wait()
+		// The claiming column names a task, and a name is worth more than an
+		// id. The listing failing is not a reason to hide the pull requests.
+		tasks, err := client.ListTasks(ctx, apiclient.ListTasksOptions{})
+		if err != nil {
+			tasks = nil
+		}
+		return prLoadedMsg{groups: groups, tasks: tasks}
+	}
+}
+
+// githubReasonMessage is the sentence a failed listing puts on its group.
+// The daemon's 409 carries its named reason in details and the sentence in
+// the message, and the message is what a human reads.
+func githubReasonMessage(err error) string {
+	var apiErr *apiclient.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.Message != "" {
+			return apiErr.Message
+		}
+		if reason := apiErr.Details["reason"]; reason != "" {
+			return reason
+		}
+	}
+	return errString(err)
+}
+
+func (v *pullRequestsView) applyLoaded(msg prLoadedMsg) {
+	v.loading = false
+	v.loaded = true
+	v.lastLoad = v.now()
+	v.groups = msg.groups
+	if msg.tasks != nil {
+		v.tasks = msg.tasks
+	}
+	v.clampCursor()
+}
+
+func (v *pullRequestsView) scheduleRefresh() tea.Cmd {
+	if v.refreshWait {
+		return nil
+	}
+	v.refreshWait = true
+	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg { return prRefreshMsg{} })
+}
+
+// updateNote re-lists on the events that change what is on screen: a
+// reconciler tick that linked or unlinked a pull request, and any task event,
+// which moves the claiming column's titles and states.
+func (v *pullRequestsView) updateNote(n apiclient.Note) tea.Cmd {
+	ev, ok := n.(apiclient.EventNote)
+	if !ok {
+		return nil
+	}
+	if ev.Event.Type == eventTaskGitHubPullChanged || isTaskEvent(ev.Event.Type) {
+		return v.scheduleRefresh()
+	}
+	return nil
+}
+
+func (v *pullRequestsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if v.picker != nil {
+		return v.updatePickerKey(msg)
+	}
+	if v.confirm != nil {
+		return v.updateConfirmKey(msg)
+	}
+	if v.filtering {
+		switch msg.String() {
+		case "esc":
+			v.filtering = false
+			v.filter.SetValue("")
+			v.filter.Blur()
+			v.clampCursor()
+			return v, nil
+		case "enter":
+			v.filtering = false
+			v.filter.Blur()
+			return v, nil
+		}
+		var cmd tea.Cmd
+		v.filter, cmd = v.filter.Update(msg)
+		v.clampCursor()
+		return v, cmd
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		v.cursor = max(v.cursor-1, 0)
+		return v, nil
+	case "down", "j":
+		v.cursor = min(v.cursor+1, max(len(v.rows())-1, 0))
+		return v, nil
+	case "/":
+		v.filtering = true
+		v.filter.Focus()
+		return v, nil
+	case "esc":
+		// One layer per press (§15): a committed filter or a note clears
+		// first; with nothing left, the takeover closes.
+		if v.filter.Value() != "" || v.note != "" {
+			v.filter.SetValue("")
+			v.note = ""
+			v.clampCursor()
+			return v, nil
+		}
+		return v, func() tea.Msg { return selectViewMsg{id: viewHome} }
+	case "R":
+		return v, v.loadCmd()
+	case "o":
+		return v, v.openSelected()
+	case "enter":
+		return v, v.openTask()
+	case "l":
+		v.openLinkPicker()
+		return v, nil
+	case "u":
+		v.askUnlink()
+		return v, nil
+	}
+	return v, nil
+}
+
+// openSelected hands the row's URL to a browser. The URL is GitHub's own,
+// served on the row; nothing is constructed here.
+func (v *pullRequestsView) openSelected() tea.Cmd {
+	row, ok := v.current()
+	if !ok {
+		return nil
+	}
+	v.setNote("opening "+row.pull.URL+"…", false)
+	return openURLCmd(row.pull.URL)
+}
+
+func (v *pullRequestsView) applyOpened(msg openedURLMsg) {
+	if msg.err != nil {
+		v.setNote(openFailure(msg), true)
+		return
+	}
+	v.note = ""
+}
+
+// openTask jumps to the workspace of the task that claims the row. A row no
+// task claims has nowhere to go, and enter is deliberately not overloaded
+// into "link this one": the link key is its own, and a key that means two
+// unrelated things depending on the row is worse than one that sometimes
+// does nothing.
+func (v *pullRequestsView) openTask() tea.Cmd {
+	row, ok := v.current()
+	if !ok || row.pull.TaskID == nil {
+		return nil
+	}
+	id := *row.pull.TaskID
+	state := ""
+	if t, found := v.taskByID(id); found {
+		state = t.State
+	}
+	return func() tea.Msg { return selectTaskMsg{id: id, state: state} }
+}
+
+// openLinkPicker offers the tasks of the row's own project (decision 5).
+func (v *pullRequestsView) openLinkPicker() {
+	row, ok := v.current()
+	if !ok {
+		return
+	}
+	v.note = ""
+	v.pickerPull = row.pull.Number
+	v.pickerRepo = row.pull.Repo
+	v.picker = newPicker(0, "task in "+row.project.Name, v.taskOptions(row.project.ID), false, "")
+}
+
+// taskOptions is the picker's rows: this project's tasks, newest first, with
+// the branch beside each — the branch is what a pull request's head is
+// matched against, so it is the field that makes the right task obvious.
+func (v *pullRequestsView) taskOptions(projectID int64) []pickerOption {
+	rows := make([]apiclient.Task, 0, len(v.tasks))
+	for _, t := range v.tasks {
+		if t.ProjectID == projectID {
+			rows = append(rows, t)
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].ID > rows[j].ID })
+	out := make([]pickerOption, 0, len(rows))
+	for _, t := range rows {
+		note := t.State
+		if t.BranchName != "" {
+			note += " · " + t.BranchName
+		}
+		out = append(out, pickerOption{
+			value: strconv.FormatInt(t.ID, 10),
+			label: "#" + strconv.FormatInt(t.ID, 10) + "  " + t.Title,
+			note:  note,
+		})
+	}
+	return out
+}
+
+func (v *pullRequestsView) updatePickerKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	res := v.picker.update(msg)
+	var cmd tea.Cmd
+	if res.chosen {
+		if id, err := strconv.ParseInt(res.value, 10, 64); err == nil {
+			cmd = v.linkCmd(id, v.pickerPull)
+		}
+	}
+	if res.closed {
+		v.picker = nil
+	}
+	return v, tea.Batch(res.cmd, cmd)
+}
+
+func (v *pullRequestsView) linkCmd(taskID int64, number int) tea.Cmd {
+	client := v.client
+	if client == nil {
+		v.setNote("not connected", true)
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		_, err := client.LinkGitHubPull(ctx, taskID, number)
+		return prLinkedMsg{taskID: taskID, number: number, err: err}
+	}
+}
+
+// askUnlink opens the confirmation. It names the stickiness because that is
+// the part a human cannot see: the row disappears either way, and only one
+// of the two outcomes survives the next reconciler tick.
+func (v *pullRequestsView) askUnlink() {
+	row, ok := v.current()
+	if !ok || row.pull.TaskID == nil {
+		v.setNote("no task claims this pull request", true)
+		return
+	}
+	v.note = ""
+	v.confirm = &unlinkPrompt{
+		taskID: *row.pull.TaskID,
+		number: row.pull.Number,
+		text: "unlink #" + strconv.Itoa(row.pull.Number) + " from task #" +
+			strconv.FormatInt(*row.pull.TaskID, 10) +
+			"? the refusal sticks — the reconciler will not link it again",
+	}
+}
+
+func (v *pullRequestsView) updateConfirmKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	c := v.confirm
+	v.confirm = nil
+	if msg.String() != "y" && msg.String() != "Y" {
+		return v, nil
+	}
+	client := v.client
+	if client == nil {
+		v.setNote("not connected", true)
+		return v, nil
+	}
+	return v, func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		_, err := client.UnlinkGitHubPull(ctx, c.taskID)
+		return prLinkedMsg{taskID: c.taskID, number: c.number, unlink: true, err: err}
+	}
+}
+
+// applyLinked reports the write and re-lists. The daemon publishes
+// task.github_pull_changed too, so the refresh is belt and braces — but a
+// human who pressed a key is owed an answer that does not depend on a
+// stream being up.
+func (v *pullRequestsView) applyLinked(msg prLinkedMsg) tea.Cmd {
+	verb := "linked"
+	if msg.unlink {
+		verb = "unlinked"
+	}
+	if msg.err != nil {
+		v.setNote("could not "+strings.TrimSuffix(verb, "ed")+" #"+
+			strconv.Itoa(msg.number)+": "+githubReasonMessage(msg.err), true)
+		return nil
+	}
+	v.setNote("#"+strconv.Itoa(msg.number)+" "+verb+" "+
+		linkPreposition(msg.unlink)+" task #"+strconv.FormatInt(msg.taskID, 10), false)
+	return v.loadCmd()
+}
+
+func linkPreposition(unlink bool) string {
+	if unlink {
+		return "from"
+	}
+	return "to"
+}
+
+func (v *pullRequestsView) setNote(text string, bad bool) {
+	v.note, v.noteBad = text, bad
+}
+
+// rows is the flattened, filtered selection order: the groups in listing
+// order, each project's pull requests in the order the daemon served them.
+func (v *pullRequestsView) rows() []prRow {
+	q := strings.ToLower(strings.TrimSpace(v.filter.Value()))
+	out := make([]prRow, 0, 16)
+	for _, g := range v.groups {
+		for _, p := range g.pulls {
+			if q != "" && !pullMatches(g.project, p, q) {
+				continue
+			}
+			out = append(out, prRow{project: g.project, pull: p})
+		}
+	}
+	return out
+}
+
+func pullMatches(project apiclient.Project, p apiclient.GitHubPullRequest, q string) bool {
+	hay := strings.ToLower(strings.Join([]string{
+		"#" + strconv.Itoa(p.Number), p.Title, p.HeadBranch, p.Repo,
+		p.Status(), p.Author, project.Name,
+	}, " "))
+	return strings.Contains(hay, q)
+}
+
+func (v *pullRequestsView) current() (prRow, bool) {
+	rows := v.rows()
+	if v.cursor < 0 || v.cursor >= len(rows) {
+		return prRow{}, false
+	}
+	return rows[v.cursor], true
+}
+
+func (v *pullRequestsView) clampCursor() {
+	v.cursor = min(max(v.cursor, 0), max(len(v.rows())-1, 0))
+}
+
+func (v *pullRequestsView) taskByID(id int64) (apiclient.Task, bool) {
+	for _, t := range v.tasks {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return apiclient.Task{}, false
+}

--- a/internal/tui/pullrequests_test.go
+++ b/internal/tui/pullrequests_test.go
@@ -1,0 +1,266 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// testPull is one listing row.
+func testPull(number int, title string, opts ...func(*apiclient.GitHubPullRequest)) apiclient.GitHubPullRequest {
+	p := apiclient.GitHubPullRequest{
+		Repo: "octo/api", Number: number, Title: title, State: "open",
+		URL:        "https://github.com/octo/api/pull/" + strconv.Itoa(number),
+		HeadBranch: "vincent/" + strconv.Itoa(number) + "-branch",
+	}
+	for _, opt := range opts {
+		opt(&p)
+	}
+	return p
+}
+
+func claimedBy(id int64, source string) func(*apiclient.GitHubPullRequest) {
+	return func(p *apiclient.GitHubPullRequest) { p.TaskID, p.LinkSource = &id, source }
+}
+
+// pullRequestsFixture is the takeover with one available project and its
+// listing already in.
+func pullRequestsFixture(pulls ...apiclient.GitHubPullRequest) *pullRequestsView {
+	project := testProject(1, "api")
+	v := newPullRequestsView()
+	v.client = offlineClient()
+	v.available = []githubProject{{
+		project: project,
+		status:  apiclient.GitHubStatus{Enabled: true, Available: true, Repo: "octo/api"},
+	}}
+	v.groups = []pullGroup{{project: project, pulls: pulls}}
+	v.tasks = []apiclient.Task{
+		{ID: 7, ProjectID: 1, Title: "add a thing", State: stateRunning, BranchName: "vincent/7-add"},
+		{ID: 8, ProjectID: 1, Title: "another thing", State: stateQueued, BranchName: "vincent/8-another"},
+		{ID: 9, ProjectID: 2, Title: "somewhere else", State: stateQueued},
+	}
+	v.loaded = true
+	return v
+}
+
+// withFakeOpener swaps the platform hand-off for a recorder, so the tests
+// assert what would have been opened without launching a browser.
+func withFakeOpener(t *testing.T, err error) *[]string {
+	t.Helper()
+	opened := &[]string{}
+	prev := openURL
+	openURL = func(_ context.Context, url string) error {
+		*opened = append(*opened, url)
+		return err
+	}
+	t.Cleanup(func() { openURL = prev })
+	return opened
+}
+
+// drain runs a tea.Cmd to its message, in-process: every command these
+// tests exercise is either pure or points at offlineClient.
+func drain(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+// The nav row is withheld while no project answers the §13.2 probe — from
+// the palette, the ? overlay and the footer alike. A screen that exists only
+// to explain that it has nothing to show is not a view.
+func TestPullRequestsNavRowIsWithheldWithoutAGitHubProject(t *testing.T) {
+	for _, e := range paletteEntries(ctxTasks, taskActions{}, false, true, false) {
+		if e.navTarget == viewPullRequests && e.nav {
+			t.Fatal("the palette offers the pull-requests view with no GitHub project")
+		}
+	}
+	if strings.Contains(helpText(ctxTasks, false), "pull requests —") {
+		t.Error("the ? overlay names the pull-requests view with no GitHub project")
+	}
+	if got := len(bindingsFor(ctxTaskDetails)) - len(withoutGitHub(bindingsFor(ctxTaskDetails), false)); got != 2 {
+		t.Errorf("withoutGitHub dropped %d task-details rows, want the 2 pull-request keys", got)
+	}
+	// And with one, it is back.
+	found := false
+	for _, e := range paletteEntries(ctxTasks, taskActions{}, false, true, true) {
+		if e.nav && e.navTarget == viewPullRequests {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the palette hides the pull-requests view even with a GitHub project")
+	}
+}
+
+// Probes that have not answered yet are not "available": the row must not
+// flicker into existence and out again while the fan-out lands.
+func TestPullRequestsProbeInFlightIsNotAvailable(t *testing.T) {
+	m := &root{views: newViews(t.Context())}
+	if m.githubAvailable() {
+		t.Fatal("the nav row is offered before any probe answered")
+	}
+	m.Update(githubProbeMsg{projects: []githubProject{
+		{project: testProject(1, "api"), status: apiclient.GitHubStatus{Available: false, Reason: "no_remote"}},
+	}})
+	if m.githubAvailable() {
+		t.Fatal("a project that answered no made the nav row appear")
+	}
+	m.Update(githubProbeMsg{projects: []githubProject{
+		{project: testProject(1, "api"), status: apiclient.GitHubStatus{Available: true, Repo: "octo/api"}},
+	}})
+	if !m.githubAvailable() {
+		t.Fatal("a project that answered yes did not make the nav row appear")
+	}
+}
+
+// A project whose listing failed renders its reason, and the other groups
+// still render their rows: each group holds its own error.
+func TestPullRequestsFailedGroupDoesNotSinkTheOthers(t *testing.T) {
+	v := pullRequestsFixture()
+	other := testProject(2, "web")
+	v.available = append(v.available, githubProject{
+		project: other,
+		status:  apiclient.GitHubStatus{Available: true, Repo: "octo/web"},
+	})
+	v.groups = []pullGroup{
+		{project: v.available[0].project, err: "GitHub is not available for this project: not authenticated"},
+		{project: other, pulls: []apiclient.GitHubPullRequest{testPull(12, "ship the thing")}},
+	}
+	out := v.render(120, 24)
+	if !strings.Contains(out, "not authenticated") {
+		t.Error("the failed group does not carry its reason")
+	}
+	if !strings.Contains(out, "ship the thing") {
+		t.Error("a failed group hid the healthy group's rows")
+	}
+}
+
+// The listing's 409 arrives as an apiclient.Error; what a human reads is the
+// daemon's sentence, not the status code.
+func TestPullRequestsGroupErrorUsesTheDaemonsMessage(t *testing.T) {
+	err := &apiclient.Error{
+		Status: 409, Code: "conflict",
+		Message: "GitHub is not available for this project: not authenticated",
+		Details: map[string]string{"reason": "not_authenticated"},
+	}
+	if got := githubReasonMessage(err); got != err.Message {
+		t.Errorf("githubReasonMessage = %q, want the daemon's message", got)
+	}
+	if got := githubReasonMessage(errors.New("boom")); got != "boom" {
+		t.Errorf("githubReasonMessage = %q, want the plain error", got)
+	}
+}
+
+// `o` hands the row's own URL to the opener, and a failing opener produces a
+// visible note rather than nothing — the one way this differs from the
+// clipboard, which fails silently by design.
+func TestPullRequestsOpenReportsAFailingOpener(t *testing.T) {
+	opened := withFakeOpener(t, errNoOpener)
+	v := pullRequestsFixture(testPull(11, "ship it"))
+	msg := drain(v.openSelected())
+	if len(*opened) != 1 || (*opened)[0] != "https://github.com/octo/api/pull/11" {
+		t.Fatalf("opened %v, want the row's URL", *opened)
+	}
+	v.applyOpened(msg.(openedURLMsg))
+	if !v.noteBad || !strings.Contains(v.note, "could not open") {
+		t.Fatalf("a failed open left note %q (bad=%v), want a visible failure", v.note, v.noteBad)
+	}
+	if !strings.Contains(v.render(120, 24), "could not open") {
+		t.Error("the failure is not on screen")
+	}
+}
+
+// A URL that is not http(s) is refused rather than handed to a shell handler
+// that would launch whatever is registered for its scheme.
+func TestOpenURLRefusesForeignSchemes(t *testing.T) {
+	opened := withFakeOpener(t, nil)
+	msg := drain(openURLCmd("file:///etc/passwd")).(openedURLMsg)
+	if msg.err == nil {
+		t.Fatal("a file:// URL was accepted")
+	}
+	if len(*opened) != 0 {
+		t.Fatalf("the platform opener was called with %v", *opened)
+	}
+}
+
+// enter routes to the claiming task's workspace; on an unclaimed row it is
+// inert rather than overloaded into "link this one".
+func TestPullRequestsEnterRoutesOnlyForAClaimedRow(t *testing.T) {
+	v := pullRequestsFixture(testPull(11, "claimed", claimedBy(7, "auto")), testPull(12, "unclaimed"))
+	msg := drain(v.openTask())
+	sel, ok := msg.(selectTaskMsg)
+	if !ok || sel.id != 7 {
+		t.Fatalf("enter produced %#v, want selectTaskMsg for task 7", msg)
+	}
+	if sel.state != stateRunning {
+		t.Errorf("enter carried state %q, want the board's %q", sel.state, stateRunning)
+	}
+	v.cursor = 1
+	if cmd := v.openTask(); cmd != nil {
+		t.Fatal("enter on an unclaimed row is not inert")
+	}
+}
+
+// The link picker offers only the row's own project: POST takes a bare
+// number and the daemon resolves the repo from the task's project, so a task
+// from elsewhere would link a different repository's number.
+func TestPullRequestsLinkPickerIsScopedToTheProject(t *testing.T) {
+	v := pullRequestsFixture(testPull(11, "unclaimed"))
+	v.openLinkPicker()
+	if v.picker == nil {
+		t.Fatal("l did not open the task picker")
+	}
+	for _, opt := range v.picker.options {
+		if strings.Contains(opt.label, "somewhere else") {
+			t.Fatalf("the picker offers %q, a task in another project", opt.label)
+		}
+	}
+	if len(v.picker.options) != 2 {
+		t.Fatalf("the picker offers %d tasks, want the 2 in this project", len(v.picker.options))
+	}
+}
+
+// Unlink asks first, and the confirmation says the refusal is sticky —
+// which is what DELETE does. A prompt that said "clear" would be lying.
+func TestPullRequestsUnlinkSaysTheRefusalSticks(t *testing.T) {
+	v := pullRequestsFixture(testPull(11, "claimed", claimedBy(7, "auto")))
+	v.askUnlink()
+	if v.confirm == nil {
+		t.Fatal("u did not ask before unlinking")
+	}
+	if !strings.Contains(v.confirm.text, "will not link it again") {
+		t.Errorf("the confirmation reads %q and does not say the refusal sticks", v.confirm.text)
+	}
+	if !strings.Contains(v.render(120, 24), "will not link it again") {
+		t.Error("the confirmation is not on screen")
+	}
+	// An unclaimed row has nothing to unlink, and says so.
+	v.confirm = nil
+	v.cursor = 0
+	v.groups[0].pulls = []apiclient.GitHubPullRequest{testPull(12, "unclaimed")}
+	v.askUnlink()
+	if v.confirm != nil {
+		t.Fatal("u asked about an unclaimed row")
+	}
+}
+
+// A reconciler tick re-lists without a keypress.
+func TestPullRequestsRefreshOnLinkChangedEvent(t *testing.T) {
+	v := pullRequestsFixture(testPull(11, "claimed", claimedBy(7, "auto")))
+	cmd := v.updateNote(apiclient.EventNote{
+		Event: apiclient.Event{Type: eventTaskGitHubPullChanged},
+	})
+	if cmd == nil {
+		t.Fatal("task.github_pull_changed did not schedule a re-list")
+	}
+	if !v.refreshWait {
+		t.Error("the debounce was not armed")
+	}
+}

--- a/internal/tui/pullrequestslive_test.go
+++ b/internal/tui/pullrequestslive_test.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/github"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// The pull-requests takeover against the **real** API handlers and a real
+// daemon-side GitHub client pointed at cmd/fakegh — which is what keeps the
+// client and server wire types from drifting.
+
+// pullsView is the takeover as the root holds it.
+func pullsView(t *testing.T, h *newTaskLiveHarness) *pullRequestsView {
+	t.Helper()
+	v, ok := h.m.views[viewPullRequests].(*pullRequestsView)
+	if !ok {
+		t.Fatalf("view %d is %T, want *pullRequestsView", viewPullRequests, h.m.views[viewPullRequests])
+	}
+	return v
+}
+
+// A project with a github.com origin and a working credential puts the nav
+// row on the palette and fills the view; one without does neither.
+func TestPullRequestsListsEveryAvailableProject(t *testing.T) {
+	h, _ := newGitHubLiveHarness(t, liveOptions{remote: ghLiveOrigin})
+	h.p.until(10*time.Second, "the GitHub probes to answer", func() bool {
+		return h.m.githubAvailable()
+	})
+	v := pullsView(t, h)
+	h.p.until(10*time.Second, "the pull-request listing", func() bool {
+		return v.loaded && len(v.rows()) > 0
+	})
+
+	out := v.render(160, 30)
+	// Open only: the merged row is in fakegh's corpus and must not be here,
+	// which is the listing's own contract.
+	if !strings.Contains(out, "Add a thing") {
+		t.Errorf("the open pull request is not listed:\n%s", out)
+	}
+	if strings.Contains(out, "already merged") {
+		t.Errorf("the merged pull request leaked into an open-only listing:\n%s", out)
+	}
+	if !strings.Contains(out, "draft") {
+		t.Errorf("the draft's folded status word is missing:\n%s", out)
+	}
+}
+
+// A reconciler tick that links a pull request re-renders an open view with
+// no keypress: the root broadcasts to every view, active or not.
+func TestPullRequestsRefreshesOnAReconcilerTick(t *testing.T) {
+	h, _ := newGitHubLiveHarness(t, liveOptions{remote: ghLiveOrigin})
+	h.p.until(10*time.Second, "the GitHub probes to answer", func() bool {
+		return h.m.githubAvailable()
+	})
+	v := pullsView(t, h)
+	h.p.until(10*time.Second, "the pull-request listing", func() bool {
+		return v.loaded && len(v.rows()) > 0
+	})
+	if strings.Contains(v.render(160, 30), "task #") {
+		t.Fatal("a row is claimed before anything linked one")
+	}
+
+	task := &store.Task{
+		ProjectID: h.projectID, Title: "Add a thing", WorkflowName: "implement",
+		BaseBranch: "main", BranchName: "vincent/1-add-a-thing",
+		State: store.TaskQueued,
+	}
+	if err := h.st.CreateTask(context.Background(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	// What the daemon's reconciler writes on a head-branch match. The store
+	// publishes task.github_pull_changed, which is the note the view acts on.
+	if _, err := h.st.SetTaskGitHubPull(context.Background(), task.ID, &github.PullLink{
+		Repo: "octo/repo", Number: 412, Source: "auto", LinkedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SetTaskGitHubPull: %v", err)
+	}
+
+	h.p.until(10*time.Second, "the linked row to appear with no keypress", func() bool {
+		return strings.Contains(v.render(160, 30), "(auto)")
+	})
+}

--- a/internal/tui/pullrequestsrender.go
+++ b/internal/tui/pullrequestsrender.go
@@ -1,0 +1,234 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The pull-requests takeover's rendering. It is split from the view for the
+// reason the board and the detail panes are: what a screen *is* and what it
+// *looks like* change for different reasons and at different rates.
+
+var (
+	// stylePullMerged and friends give the one status word its own colour.
+	// Merged beats closed and draft beats open, the order a human reads them
+	// in — the same fold GitHubPullRequest.Status applies.
+	stylePullMerged = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
+	stylePullDraft  = lipgloss.NewStyle().Faint(true)
+)
+
+func (v *pullRequestsView) render(width, height int) string {
+	if width < 4 || height < 2 {
+		return ""
+	}
+	lines := make([]string, 0, height)
+	lines = append(lines, v.headerLine(width))
+	if v.filtering || v.filter.Value() != "" {
+		lines = append(lines, " "+v.filter.View())
+	}
+	lines = append(lines, "")
+
+	body, cursorRow := v.bodyLines(width)
+	footer := v.footerLines()
+	room := max(height-len(lines)-len(footer), 1)
+	lines = append(lines, window(body, cursorRow, room)...)
+	lines = append(lines, footer...)
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, width, "…")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// headerLine says what the screen is showing and how fresh it is.
+func (v *pullRequestsView) headerLine(width int) string {
+	left := " " + styleTitle.Render("open pull requests")
+	switch {
+	case len(v.available) == 0:
+		left += styleDim.Render("  ·  no project with a usable GitHub integration")
+	case !v.loaded && v.loading:
+		left += styleDim.Render("  ·  listing…")
+	default:
+		left += styleDim.Render(fmt.Sprintf("  ·  %d across %s",
+			v.countPulls(), plural(len(v.available), "project", "projects")))
+	}
+	right := ""
+	if !v.lastLoad.IsZero() {
+		right = styleDim.Render("updated "+v.lastLoad.Format("15:04:05")) + " "
+	}
+	return padBetween(left, right, width)
+}
+
+func (v *pullRequestsView) countPulls() int {
+	n := 0
+	for _, g := range v.groups {
+		n += len(g.pulls)
+	}
+	return n
+}
+
+// bodyLines is the grouped list, and the index of the line the cursor is on
+// so the window can follow it.
+func (v *pullRequestsView) bodyLines(width int) (lines []string, cursorRow int) {
+	if len(v.available) == 0 {
+		return []string{
+			styleDim.Render("  No registered project has a usable GitHub integration."),
+			"",
+			styleDim.Render("  A project qualifies when its origin remote is a github.com"),
+			styleDim.Render("  repository and vincent can authenticate to it."),
+		}, 0
+	}
+	if !v.loaded {
+		return []string{styleDim.Render("  listing pull requests…")}, 0
+	}
+
+	q := strings.TrimSpace(v.filter.Value())
+	rows := v.rows()
+	seen := 0
+	for _, g := range v.groups {
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, v.groupHeader(g, width))
+		if g.err != "" {
+			// One group's failure, on that group. The others still render:
+			// that separation is the whole point of listing per project.
+			lines = append(lines, styleBad.Render("    ⚠ "+g.err))
+			continue
+		}
+		shown := 0
+		for _, p := range g.pulls {
+			if q != "" && !pullMatches(g.project, p, strings.ToLower(q)) {
+				continue
+			}
+			selected := seen < len(rows) && seen == v.cursor
+			if selected {
+				cursorRow = len(lines)
+			}
+			lines = append(lines, v.pullLine(p, width, selected))
+			shown++
+			seen++
+		}
+		if shown == 0 {
+			lines = append(lines, styleDim.Render("    "+emptyGroupNote(len(g.pulls), q)))
+		}
+	}
+	return lines, cursorRow
+}
+
+func emptyGroupNote(total int, query string) string {
+	if total == 0 {
+		return "no open pull requests"
+	}
+	return fmt.Sprintf("none of %s match %q",
+		plural(total, "pull request", "pull requests"), query)
+}
+
+func (v *pullRequestsView) groupHeader(g pullGroup, width int) string {
+	repo := ""
+	for _, gp := range v.available {
+		if gp.project.ID == g.project.ID {
+			repo = gp.status.Repo
+			break
+		}
+	}
+	left := " " + styleTitle.Render(g.project.Name)
+	if repo != "" {
+		left += styleDim.Render("  " + repo)
+	}
+	count := ""
+	if g.err == "" {
+		count = styleDim.Render(fmt.Sprintf("%d open ", len(g.pulls)))
+	}
+	return padBetween(left, count, width)
+}
+
+// pullLine is one row: the number, the folded status word, the title, the
+// head branch and the task that claims it, with how the claim was made —
+// `auto` is the reconciler's head-branch match and `human` is a link
+// somebody made by hand, and a screen that offers to unlink should say which
+// it is about to override.
+func (v *pullRequestsView) pullLine(p apiclient.GitHubPullRequest, width int, selected bool) string {
+	marker := "  "
+	if selected {
+		marker = styleFocus.Render("› ")
+	}
+	number := padRight("#"+strconv.Itoa(p.Number), 7)
+	status := padRight(p.Status(), 7)
+	claim := v.claimText(p)
+	branch := p.HeadBranch
+	if branch != "" {
+		branch = "⎇ " + branch
+	}
+
+	// The title takes what the fixed columns leave; nothing else is
+	// truncatable without becoming a lie.
+	fixed := 2 + len(number) + len(status) + ansi.StringWidth(branch) + ansi.StringWidth(ansi.Strip(claim)) + 6
+	titleW := max(width-fixed, 12)
+	title := ansi.Truncate(p.Title, titleW, "…")
+
+	line := marker + styleKey.Render(number) + pullStatusStyle(p).Render(status) +
+		padDisplayWidth(title, titleW) + "  " + styleDim.Render(branch)
+	if claim != "" {
+		line += "  " + claim
+	}
+	return line
+}
+
+func pullStatusStyle(p apiclient.GitHubPullRequest) lipgloss.Style {
+	switch p.Status() {
+	case "merged":
+		return stylePullMerged
+	case "closed":
+		return styleBad
+	case "draft":
+		return stylePullDraft
+	default:
+		return styleOK
+	}
+}
+
+// claimText names the task that claims a row, or says nothing claims it —
+// those are the rows a human is here to link.
+func (v *pullRequestsView) claimText(p apiclient.GitHubPullRequest) string {
+	if p.TaskID == nil {
+		return styleDim.Render("unclaimed")
+	}
+	label := "task #" + strconv.FormatInt(*p.TaskID, 10)
+	if t, ok := v.taskByID(*p.TaskID); ok && t.Title != "" {
+		label += " " + ansi.Truncate(t.Title, 24, "…")
+	}
+	if p.LinkSource != "" {
+		label += " (" + p.LinkSource + ")"
+	}
+	return styleDim.Render(label)
+}
+
+// footerLines are the popup-ish rows that own the keyboard while they are up,
+// plus whatever the last action had to say.
+func (v *pullRequestsView) footerLines() []string {
+	switch {
+	case v.picker != nil:
+		out := append([]string{""}, v.picker.renderBody()...)
+		return append(out, styleDim.Render(
+			"  ↑/↓ choose · / filter · enter link · esc close the list"))
+	case v.confirm != nil:
+		return []string{
+			"",
+			styleWarn.Render("  " + v.confirm.text),
+			styleDim.Render("  y unlink · any other key cancels"),
+		}
+	case v.note != "":
+		style := styleDim
+		if v.noteBad {
+			style = styleBad
+		}
+		return []string{"", style.Render("  " + v.note)}
+	}
+	return nil
+}

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -84,6 +84,16 @@ type root struct {
 	// reads it from the same message that sets it.
 	selectedTask int64
 
+	// github is the §13.2 capability probe per registered project, refreshed
+	// as the connection comes up and again on reconnect. It lives here rather
+	// than in the pull-requests view because the *nav row that reaches that
+	// view* is gated on it, and the nav rows are global (task 052.6).
+	//
+	// While every answer is unavailable — including while the probes are
+	// still in flight — the row is withheld everywhere: the palette, the ?
+	// overlay and the footer.
+	github []githubProject
+
 	width  int
 	height int
 }
@@ -148,6 +158,15 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 	case selectViewMsg:
 		return m, m.switchTo(msg.id)
+	case githubProbeMsg:
+		// The listing failing leaves the previous answer standing: a probe
+		// that could not be made is not an integration that stopped working,
+		// and dropping the nav row under a human mid-session on a transient
+		// error would be worse than a row that briefly outlives its project.
+		if msg.err == nil {
+			m.github = msg.available()
+		}
+		return m, m.broadcast(msg)
 	case taskCreatedMsg:
 		return m.updateTaskCreated(msg)
 	case connectedMsg:
@@ -329,7 +348,8 @@ func (m *root) openPalette() {
 		target = t.target()
 		editable = t.detail.stepEditable()
 	}
-	m.palette = newPalette(paletteEntries(ctx, target, editable, m.phase == phaseConnected))
+	m.palette = newPalette(paletteEntries(
+		ctx, target, editable, m.phase == phaseConnected, m.githubAvailable()))
 }
 
 // activeContext names the active surface for the binding registry.
@@ -348,6 +368,8 @@ func (m *root) activeContext() bindingContext {
 		return ctxWorkflows
 	case viewDaemon:
 		return ctxDaemon
+	case viewPullRequests:
+		return ctxPullRequests
 	default:
 		s := m.views[viewHome].(*shell)
 		return s.focusedContext()
@@ -447,7 +469,7 @@ func (m *root) updateConnected(msg connectedMsg) (tea.Model, tea.Cmd) {
 	streamCtx, cancel := context.WithCancel(m.ctx)
 	m.stopStream = cancel
 	m.notes = m.client.StreamEvents(streamCtx, apiclient.StreamOptions{})
-	cmds := []tea.Cmd{waitNote(m.notes)}
+	cmds := []tea.Cmd{waitNote(m.notes), probeGitHubCmd(m.client)}
 	for i := range m.views {
 		if ca, ok := m.views[i].(clientAware); ok {
 			if cmd := ca.setClient(m.client); cmd != nil {
@@ -459,6 +481,7 @@ func (m *root) updateConnected(msg connectedMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *root) updateNote(n apiclient.Note) (tea.Model, tea.Cmd) {
+	var reprobe tea.Cmd
 	if m.notes == nil {
 		// A stale note from a stream torn down by retry; never re-arm on a
 		// nil channel — that receive would block forever.
@@ -468,6 +491,12 @@ func (m *root) updateNote(n apiclient.Note) (tea.Model, tea.Cmd) {
 	case apiclient.ConnectedNote:
 		m.phase = phaseConnected
 		m.connErr = nil
+		if !m.streamLive {
+			// A reconnect: a project may have been registered, or a token may
+			// have expired, while the stream was down. The daemon's short
+			// cache absorbs the repeat cost.
+			reprobe = probeGitHubCmd(m.client)
+		}
 		// Distinct from phaseConnected, which only means the health probe
 		// answered: this is the event stream itself being established, and
 		// until it is, a committed event will not reach us (a stream with no
@@ -482,7 +511,7 @@ func (m *root) updateNote(n apiclient.Note) (tea.Model, tea.Cmd) {
 		m.setConnected(false)
 	}
 	// Every view sees the note, not just the visible one.
-	return m, tea.Batch(m.broadcast(noteMsg{note: n}), waitNote(m.notes))
+	return m, tea.Batch(m.broadcast(noteMsg{note: n}), waitNote(m.notes), reprobe)
 }
 
 // delegate routes a message to the active view.
@@ -612,10 +641,11 @@ func (m *root) body() string {
 		// every other surface (T3.8 findings).
 		ctx := m.activeContext()
 		h := m.bodyHeight()
+		text := helpText(ctx, m.githubAvailable())
 		if m.width < 4 || h < 3 {
-			return helpText(ctx)
+			return text
 		}
-		return frame(helpTitle(ctx), helpText(ctx), m.width, h, true)
+		return frame(helpTitle(ctx), text, m.width, h, true)
 	}
 	// The daemon view is the exception to the connection gate (§15): its log
 	// tail comes off the filesystem, and a daemon that is down is exactly
@@ -701,6 +731,11 @@ func (m *root) homeLoaded() bool {
 	return ok && s.board.loaded
 }
 
+// githubAvailable reports whether any registered project answered the §13.2
+// probe with available: true. It is what withholds the pull-requests nav row
+// and the workspace's two pull-request keys.
+func (m *root) githubAvailable() bool { return len(m.github) > 0 }
+
 func (m *root) taskLoaded() bool {
 	t, ok := m.views[viewTask].(*taskView)
 	return ok && t.detail.loaded
@@ -738,7 +773,7 @@ func (m *root) footerLine() string {
 			target = t.target()
 		}
 	}
-	rows := bindingsFor(ctx)
+	rows := withoutGitHub(bindingsFor(ctx), m.githubAvailable())
 	if s, ok := m.views[m.active].(*shell); ok {
 		rows = s.liveBindings(rows)
 	}

--- a/internal/tui/taskpull.go
+++ b/internal/tui/taskpull.go
@@ -1,0 +1,192 @@
+package tui
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/github"
+)
+
+// The task workspace's pull-request section (task 052.6).
+//
+// GET /v1/tasks/{id}/github/pull always answers 200, deliberately: a task
+// workspace asks it on every open, and refusing the whole row because GitHub
+// is switched off would take the stored link away from a client that can
+// still render it. So three states render inline here and none of them is an
+// error — a linked pull request with its live state, the daemon's named
+// reason when the integration is unusable, and the compare-URL offer when
+// nothing is linked.
+
+// taskPullMsg carries GET /v1/tasks/{id}/github/pull.
+type taskPullMsg struct {
+	taskID int64
+	pull   apiclient.GitHubTaskPull
+	err    error
+}
+
+// pullCmd fetches this task's pull request, live. It is refetched on open, on
+// re-entering the workspace, and on the reconciler's own
+// task.github_pull_changed — everything else on the row is live by nature and
+// caching it would be the snapshot 052 refused to store.
+func (t *taskView) pullCmd() tea.Cmd {
+	client, id := t.detail.client, t.detail.taskID
+	if client == nil || id == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		pull, err := client.TaskGitHubPull(ctx, id)
+		return taskPullMsg{taskID: id, pull: pull, err: err}
+	}
+}
+
+func (t *taskView) applyPull(msg taskPullMsg) {
+	if msg.taskID != t.detail.taskID {
+		return
+	}
+	t.pullLoaded = true
+	if msg.err != nil {
+		t.pull, t.pullErr = apiclient.GitHubTaskPull{}, errString(msg.err)
+		return
+	}
+	t.pull, t.pullErr = msg.pull, ""
+}
+
+// pullWebURL is the page `o` opens: GitHub's own URL when the live fetch
+// carried one, and otherwise the one built from the stored link. A task's
+// link is a repo and a number and nothing else, so a merged pull request
+// whose fetch failed still has somewhere to go.
+func (t *taskView) pullWebURL() string {
+	if t.pull.Pull != nil && t.pull.Pull.URL != "" {
+		return t.pull.Pull.URL
+	}
+	if !t.pull.Linked || t.pull.Number == 0 {
+		return ""
+	}
+	owner, name, ok := strings.Cut(t.pull.Repo, "/")
+	if !ok {
+		return ""
+	}
+	return github.PullURL(github.Repo{Owner: owner, Name: name}, t.pull.Number)
+}
+
+// openPullCmd is `o` on the Task Details tab.
+func (t *taskView) openPullCmd() tea.Cmd {
+	url := t.pullWebURL()
+	if url == "" {
+		t.pullNote, t.pullNoteBad = "no pull request is linked to this task", true
+		return nil
+	}
+	t.pullNote, t.pullNoteBad = "", false
+	return openURLCmd(url)
+}
+
+// openCreatePR is `P`: the compare-URL editor. The offer exists only while
+// nothing is linked and the daemon could build a compare URL, which needs the
+// task to have both a branch and a base.
+func (t *taskView) openCreatePR() tea.Cmd {
+	if t.pull.Linked {
+		t.pullNote, t.pullNoteBad = "this task already has a pull request — press o to open it", true
+		return nil
+	}
+	if t.pull.CompareURL == "" {
+		t.pullNote, t.pullNoteBad = pullNoOfferReason(t.pull, t.detail.task.BranchName), true
+		return nil
+	}
+	form, err := newCreatePRForm(t.detail.taskID, t.pull.CompareURL, t.detail.task.BranchName)
+	if err != nil {
+		t.pullNote, t.pullNoteBad = "the daemon's compare URL will not parse: "+errString(err), true
+		return nil
+	}
+	form.openEditor = t.detail.editCreatePRBody
+	t.createPR = form
+	t.popup = true
+	t.pullNote, t.pullNoteBad = "", false
+	return nil
+}
+
+// pullNoOfferReason says why there is nothing to open, in the daemon's own
+// vocabulary where it named one.
+func pullNoOfferReason(pull apiclient.GitHubTaskPull, branch string) string {
+	if pull.Reason != "" {
+		return "GitHub is not usable for this project: " + pull.Reason
+	}
+	if branch == "" {
+		return "this task has no branch yet"
+	}
+	return "the daemon offered no compare URL for this task"
+}
+
+// pullSectionLines renders the "GitHub pull request" section of the Task
+// Details tab.
+func (t *taskView) pullSectionLines(width int) []string {
+	if !t.pullLoaded {
+		if t.pullErr != "" {
+			return []string{styleBad.Render("  could not read this task's pull request: " + t.pullErr)}
+		}
+		return []string{styleDim.Render("  loading…")}
+	}
+	if t.pullErr != "" {
+		return []string{styleBad.Render("  could not read this task's pull request: " + t.pullErr)}
+	}
+	out := make([]string, 0, 12)
+	switch {
+	case t.pull.Linked:
+		out = append(out, renderTaskDetailFacts(width, t.linkedPullFacts())...)
+		if t.pull.Reason != "" {
+			// A stored link vincent cannot currently read. The link is still
+			// true; only the live half is missing, and saying which is which
+			// is the difference between a stale row and a broken one.
+			out = append(out, "", styleWarn.Render(
+				"  ⚠ could not read its current state: "+t.pull.Reason))
+		}
+		out = append(out, "", styleDim.Render("  o opens it in a browser"))
+	case t.pull.Reason != "":
+		out = append(out, styleWarn.Render("  GitHub is not usable for this project: "+t.pull.Reason))
+	case t.pull.CompareURL != "":
+		out = append(out, styleDim.Render("  No pull request is linked to this task."))
+		out = append(out, "")
+		out = append(out, renderTaskDetailFacts(width, []taskDetailFact{
+			{"branch", valueOr(t.detail.task.BranchName, "not created")},
+			{"base", valueOr(t.detail.task.BaseBranch, "unknown")},
+		})...)
+		out = append(out, "", styleDim.Render(
+			"  P opens GitHub's own page with an editable prefill — vincent sends nothing"))
+	default:
+		out = append(out, styleDim.Render("  No pull request is linked to this task."))
+		out = append(out, "", styleDim.Render(
+			"  "+pullNoOfferReason(t.pull, t.detail.task.BranchName)))
+	}
+	if t.pullNote != "" {
+		style := styleDim
+		if t.pullNoteBad {
+			style = styleBad
+		}
+		out = append(out, "", style.Render("  "+t.pullNote))
+	}
+	return out
+}
+
+func (t *taskView) linkedPullFacts() []taskDetailFact {
+	facts := []taskDetailFact{
+		{"pull request", t.pull.Repo + "#" + strconv.Itoa(t.pull.Number)},
+		{"linked by", valueOr(t.pull.Source, "unknown")},
+	}
+	if p := t.pull.Pull; p != nil {
+		facts = append(facts,
+			taskDetailFact{"title", p.Title},
+			taskDetailFact{"state", p.Status()},
+			taskDetailFact{"head", valueOr(p.HeadBranch, "unknown")},
+			taskDetailFact{"base", valueOr(p.BaseBranch, "unknown")},
+			taskDetailFact{"author", valueOr(p.Author, "unknown")},
+			taskDetailFact{"url", p.URL},
+		)
+		return facts
+	}
+	return append(facts, taskDetailFact{"url", t.pullWebURL()})
+}

--- a/internal/tui/taskpull_test.go
+++ b/internal/tui/taskpull_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// taskPullFixture is the workspace sitting on the Task Details tab with one
+// answer from GET /v1/tasks/{id}/github/pull already in.
+func taskPullFixture(t *testing.T, pull apiclient.GitHubTaskPull) *taskView {
+	t.Helper()
+	v := tabbedTaskFixture(t, taskTabDetails)
+	v.applyPull(taskPullMsg{taskID: v.detail.taskID, pull: pull})
+	return v
+}
+
+// The route always answers 200, so all three states render inline and none
+// of them is an error.
+func TestTaskWorkspacePullSectionRendersEveryState(t *testing.T) {
+	linked := taskPullFixture(t, apiclient.GitHubTaskPull{
+		Linked: true, Repo: "octo/api", Number: 41, Source: "auto",
+		Pull: &apiclient.GitHubPullRequest{
+			Repo: "octo/api", Number: 41, Title: "Add a thing", State: "open",
+			URL: "https://github.com/octo/api/pull/41", HeadBranch: "vincent/4-add",
+		},
+	})
+	out := strings.Join(linked.pullSectionLines(100), "\n")
+	if !strings.Contains(out, "octo/api#41") || !strings.Contains(out, "open") {
+		t.Errorf("the linked state does not render its pull request:\n%s", out)
+	}
+
+	unusable := taskPullFixture(t, apiclient.GitHubTaskPull{Reason: "not_authenticated"})
+	out = strings.Join(unusable.pullSectionLines(100), "\n")
+	if !strings.Contains(out, "not_authenticated") {
+		t.Errorf("the unusable state does not render its reason:\n%s", out)
+	}
+	if strings.Contains(out, "could not read") {
+		t.Error("an unusable integration rendered as an error")
+	}
+
+	offered := taskPullFixture(t, apiclient.GitHubTaskPull{CompareURL: compareURLFixture})
+	out = strings.Join(offered.pullSectionLines(100), "\n")
+	if !strings.Contains(out, "No pull request is linked") || !strings.Contains(out, "P opens") {
+		t.Errorf("the compare-URL offer does not render:\n%s", out)
+	}
+
+	// And the section is in the tab's own sidebar order, so it is reachable.
+	found := false
+	for _, title := range taskDetailSectionOrder {
+		if title == "GitHub pull request" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the section is not in taskDetailSectionOrder")
+	}
+}
+
+// A stored link vincent cannot currently read is still a link: the live half
+// is what is missing, and saying which is which is the difference between a
+// stale row and a broken one.
+func TestTaskWorkspacePullSectionSeparatesTheLinkFromTheLiveState(t *testing.T) {
+	v := taskPullFixture(t, apiclient.GitHubTaskPull{
+		Linked: true, Repo: "octo/api", Number: 41, Source: "human",
+		Reason: "network_unavailable",
+	})
+	out := strings.Join(v.pullSectionLines(100), "\n")
+	if !strings.Contains(out, "octo/api#41") {
+		t.Error("the stored link was dropped because its live state could not be read")
+	}
+	if !strings.Contains(out, "could not read its current state") {
+		t.Errorf("nothing says the live state is missing:\n%s", out)
+	}
+	// The URL is built from the stored link so a merged pull request whose
+	// fetch failed still has somewhere to go.
+	if got := v.pullWebURL(); got != "https://github.com/octo/api/pull/41" {
+		t.Errorf("pullWebURL = %q, want the constructed link", got)
+	}
+}
+
+// `o` opens the linked pull request; with nothing linked it says so rather
+// than opening nothing silently.
+func TestTaskWorkspaceOpenPull(t *testing.T) {
+	opened := withFakeOpener(t, nil)
+	v := taskPullFixture(t, apiclient.GitHubTaskPull{
+		Linked: true, Repo: "octo/api", Number: 41,
+		Pull: &apiclient.GitHubPullRequest{URL: "https://github.com/octo/api/pull/41"},
+	})
+	drain(v.openPullCmd())
+	if len(*opened) != 1 || (*opened)[0] != "https://github.com/octo/api/pull/41" {
+		t.Fatalf("opened %v, want the linked pull request", *opened)
+	}
+
+	empty := taskPullFixture(t, apiclient.GitHubTaskPull{})
+	if cmd := empty.openPullCmd(); cmd != nil {
+		t.Fatal("o opened something with nothing linked")
+	}
+	if !empty.pullNoteBad || empty.pullNote == "" {
+		t.Error("o said nothing with nothing linked")
+	}
+}
+
+// `P` opens the editor, and only when there is a prefill to edit.
+func TestTaskWorkspaceCreatePR(t *testing.T) {
+	v := taskPullFixture(t, apiclient.GitHubTaskPull{CompareURL: compareURLFixture})
+	v.openCreatePR()
+	if v.createPR == nil {
+		t.Fatal("P did not open the compare-URL editor")
+	}
+	if !v.popup {
+		t.Error("the editor does not own the keyboard")
+	}
+	if v.bindingContext() != ctxCreatePR {
+		t.Errorf("binding context = %q, want %q", v.bindingContext(), ctxCreatePR)
+	}
+
+	linked := taskPullFixture(t, apiclient.GitHubTaskPull{Linked: true, Repo: "octo/api", Number: 41})
+	linked.openCreatePR()
+	if linked.createPR != nil {
+		t.Fatal("P offered to create a second pull request for a linked task")
+	}
+	if !strings.Contains(linked.pullNote, "already has a pull request") {
+		t.Errorf("note = %q, want the reason", linked.pullNote)
+	}
+
+	unusable := taskPullFixture(t, apiclient.GitHubTaskPull{Reason: "not_authenticated"})
+	unusable.openCreatePR()
+	if unusable.createPR != nil {
+		t.Fatal("P opened an editor with no compare URL")
+	}
+	if !strings.Contains(unusable.pullNote, "not_authenticated") {
+		t.Errorf("note = %q, want the daemon's reason", unusable.pullNote)
+	}
+}
+
+// A reconciler tick re-reads the section without a keypress.
+func TestTaskWorkspaceRefetchesOnLinkChanged(t *testing.T) {
+	v := tabbedTaskFixture(t, taskTabDetails)
+	v.detail.client = offlineClient()
+	_, cmd := v.update(noteMsg{note: apiclient.EventNote{
+		Event: apiclient.Event{Type: eventTaskGitHubPullChanged},
+	}})
+	if cmd == nil {
+		t.Fatal("task.github_pull_changed did not re-read the task's pull request")
+	}
+}

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -48,6 +48,16 @@ type taskView struct {
 	// workflows screen.
 	workflow *workflowTab
 
+	// pull is this task's pull-request row (task 052.6), refetched rather
+	// than snapshotted: draft, state and merged status are live by nature.
+	// createPR is the compare-URL editor, open only while a human has it up.
+	pull        apiclient.GitHubTaskPull
+	pullLoaded  bool
+	pullErr     string
+	pullNote    string
+	pullNoteBad bool
+	createPR    *createPRForm
+
 	connected bool
 	width     int
 	height    int
@@ -96,6 +106,9 @@ func (t *taskView) paste(text string) tea.Cmd {
 	if !t.popup {
 		return nil
 	}
+	if f := t.createPR; f != nil {
+		return f.paste(text)
+	}
 	if f := t.detail.followUp; f != nil {
 		return f.paste(text)
 	}
@@ -109,6 +122,9 @@ func (t *taskView) paste(text string) tea.Cmd {
 }
 
 func (t *taskView) bindingContext() bindingContext {
+	if t.createPR != nil {
+		return ctxCreatePR
+	}
 	switch t.tab {
 	case taskTabDetails:
 		return ctxTaskDetails
@@ -136,14 +152,17 @@ func (t *taskView) update(msg tea.Msg) (panel, tea.Cmd) {
 		t.detailsTop = 0
 		t.detailsSection = ""
 		t.popup = false
+		t.createPR = nil
+		t.pull, t.pullLoaded, t.pullErr = apiclient.GitHubTaskPull{}, false, ""
+		t.pullNote, t.pullNoteBad = "", false
 		t.detail.active = true
-		return t, t.detail.open(msg.id, msg.state)
+		return t, tea.Batch(t.detail.open(msg.id, msg.state), t.pullCmd())
 	case viewActivatedMsg:
 		if msg.id != viewTask {
 			return t, nil
 		}
 		t.detail.active = true
-		return t, tea.Batch(t.detail.loadCmd(), t.detail.syncStream())
+		return t, tea.Batch(t.detail.loadCmd(), t.detail.syncStream(), t.pullCmd())
 	case viewDeactivatedMsg:
 		if msg.id != viewTask {
 			return t, nil
@@ -163,9 +182,39 @@ func (t *taskView) update(msg tea.Msg) (panel, tea.Cmd) {
 	case taskLanesMsg:
 		t.applyLanes(msg)
 		return t, nil
+	case taskPullMsg:
+		t.applyPull(msg)
+		return t, nil
+	case createPREditMsg:
+		if t.createPR != nil {
+			t.createPR.applyEdit(msg)
+		}
+		return t, nil
+	case openedURLMsg:
+		// Every view sees this; only the one a human is looking at should
+		// speak for it.
+		if !t.detail.active {
+			return t, nil
+		}
+		if msg.err != nil {
+			t.pullNote, t.pullNoteBad = openFailure(msg), true
+		} else {
+			t.pullNote, t.pullNoteBad = "", false
+		}
+		return t, nil
+	case noteMsg:
+		// A reconciler tick that linked or unlinked this task's pull request
+		// re-reads the section; the detail sub-model still sees the note.
+		cmd := t.detail.update(msg)
+		if ev, ok := msg.note.(apiclient.EventNote); ok &&
+			ev.Event.Type == eventTaskGitHubPullChanged {
+			return t, tea.Batch(cmd, t.pullCmd())
+		}
+		return t, cmd
 	}
 	cmd := t.detail.update(msg)
-	if t.popup && t.detail.form == nil && t.detail.repair == nil && t.detail.followUp == nil {
+	if t.popup && t.detail.form == nil && t.detail.repair == nil &&
+		t.detail.followUp == nil && t.createPR == nil {
 		t.popup = false
 	}
 	return t, cmd
@@ -249,6 +298,13 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 }
 
 func (t *taskView) updatePopupKey(msg tea.KeyPressMsg) tea.Cmd {
+	if f := t.createPR; f != nil {
+		cmd, exit := f.update(msg)
+		if exit {
+			t.createPR, t.popup = nil, false
+		}
+		return cmd
+	}
 	if f := t.detail.followUp; f != nil {
 		cmd, exit := f.update(msg, t.detail.client)
 		if exit {
@@ -309,6 +365,12 @@ func (t *taskView) updateDetailsKey(msg tea.KeyPressMsg) tea.Cmd {
 		t.detailsTop -= page
 	case "pgdown":
 		t.detailsTop += page
+	case "o":
+		// The pull-request section's two keys (decision 2). Both only reach
+		// a browser, which is what keeps the tab a read-only inspector.
+		return t.openPullCmd()
+	case "P":
+		return t.openCreatePR()
 	case "home", "g":
 		t.selectDetailsSection(0)
 	case "end", "G":
@@ -427,7 +489,8 @@ func (t *taskView) render(width, height int) string {
 	body := t.renderTabBody(t.width, max(bodyH, 1))
 	lines = append(lines, body)
 	out := strings.Join(lines, "\n")
-	if t.popup && (t.detail.form != nil || t.detail.repair != nil || t.detail.followUp != nil) {
+	if t.popup && (t.detail.form != nil || t.detail.repair != nil ||
+		t.detail.followUp != nil || t.createPR != nil) {
 		// overlay clips to the background it is given. The root adds visual
 		// padding only after this render returns, so give the popup the full
 		// content height here or a short timeline would clip it away.
@@ -436,8 +499,12 @@ func (t *taskView) render(width, height int) string {
 			padded = append(padded, "")
 		}
 		out = strings.Join(padded, "\n")
-		host := shell{detail: t.detail, bodyW: t.width, bodyH: t.height}
-		out = host.overlayPopup(out)
+		if t.createPR != nil {
+			out = t.overlayCreatePR(out)
+		} else {
+			host := shell{detail: t.detail, bodyW: t.width, bodyH: t.height}
+			out = host.overlayPopup(out)
+		}
 	}
 	return out
 }
@@ -599,6 +666,7 @@ var taskDetailSectionOrder = []string{
 	"Warnings",
 	"Pending input",
 	"GitHub issue",
+	"GitHub pull request",
 	"Workflow snapshot",
 }
 
@@ -800,6 +868,7 @@ func (t *taskView) detailLines(width int) []string {
 		}
 		out = appendTaskDetailSection(out, "GitHub issue", issueLines)
 	}
+	out = appendTaskDetailSection(out, "GitHub pull request", t.pullSectionLines(width))
 
 	workflow := make([]string, 0, len(task.WorkflowSteps)*4)
 	if len(task.WorkflowSteps) == 0 {
@@ -1049,4 +1118,19 @@ func joinInt64(values []int64) string {
 		out[i] = strconv.FormatInt(value, 10)
 	}
 	return strings.Join(out, ", ")
+}
+
+// overlayCreatePR draws the compare-URL editor over the workspace, on the
+// same geometry the shell's popups use — the popup is the same kind of thing
+// and should not sit somewhere else on the screen.
+func (t *taskView) overlayCreatePR(bg string) string {
+	pw := min(t.width-6, 120)
+	if pw < 20 {
+		pw = t.width
+	}
+	inner := pw - 2
+	ph := min(t.createPR.height(inner)+2, max(t.height-4, 6))
+	popup := frame("Open a pull request — #"+strconv.FormatInt(t.detail.taskID, 10),
+		t.createPR.render(inner, ph-2), pw, ph, true)
+	return overlay(bg, popup, max((t.width-pw)/2, 0), max((t.height-ph)/3, 1))
 }

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -9,7 +9,7 @@ import (
 )
 
 // viewID indexes the root's routed screens: the board-only home screen, the
-// full-screen task workspace, and the four management takeovers (§15).
+// full-screen task workspace, and the five management takeovers (§15).
 type viewID int
 
 const (
@@ -19,6 +19,7 @@ const (
 	viewProjects
 	viewWorkflows
 	viewDaemon
+	viewPullRequests
 	viewCount
 )
 
@@ -111,5 +112,10 @@ func newViews(ctx context.Context) [viewCount]panel {
 		viewProjects:  newProjectsView(),
 		viewWorkflows: newWorkflowsView(),
 		viewDaemon:    newDaemonView(),
+		// The pull-requests takeover is constructed unconditionally and
+		// reached only when at least one project's §13.2 probe says yes: it
+		// is the *nav row* that is withheld, not the screen, so nothing here
+		// has to know the answer before the probes land.
+		viewPullRequests: newPullRequestsView(),
 	}
 }

--- a/scripts/052-gate.sh
+++ b/scripts/052-gate.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# Task 052 gate (§13.2, §12.3): prove via curl alone that vincent can list a
+# GitHub project's open pull requests, that its reconciler links one to the
+# task whose branch matches, that a human can link and unlink by hand, and
+# that the unlink survives the next reconciler tick.
+#
+#   1. the listing: open only, newest first, with the merged row absent —
+#      and the capability probe saying yes before it
+#   2. the reconciler's auto-link on a head-branch match, and the task DTO
+#      and GET /tasks/{id}/github/pull agreeing about it
+#   3. the human link: POST names a different number and wins over `auto`
+#   4. the sticky unlink: DELETE, then a second reconciler tick, and the link
+#      is still gone
+#   5. the compare URL for a task with a branch and no link — built, and
+#      never fetched: the fake `gh` records every call it is asked to make,
+#      and none of them is for this
+#
+# Task-numbered rather than `mN` because this is not a §19 milestone; the
+# `docs/gates/` records are already task-numbered (017, 032).
+#
+# No agent CLI is involved: every task here is created and then left where it
+# is. What is exercised is the GitHub half, against cmd/fakegh installed as
+# `gh` on the daemon's PATH — there is no `gh_path` config key, and the
+# daemon resolves `gh` from PATH when GHPath is empty.
+#
+# The gate observes the rules CLAUDE.md records: no `grep -q` on a pipe
+# (capture first, match a here-string), `| tr -d '\r'` on multi-line `jq`
+# captures, and committed executable.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+EXE=""
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  EXE=".exe"
+fi
+VINCENT="$BIN/vincent$EXE"
+
+ONLY="${VINCENT_GATE_SCENARIO:-}"
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent and the fake gh"
+mkdir -p "$BIN"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+# cmd/fakegh is built *as* `gh`, so the daemon's PATH lookup finds it exactly
+# the way it would find the real CLI. Nothing else about the daemon changes.
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/gh$EXE" ./cmd/fakegh)
+PATH="$BIN:$PATH"
+export PATH
+
+# GH_ARGV is where the fake records every call it was asked to make, so the
+# "built, never fetched" assertion is about observed process behaviour rather
+# than about reading the daemon's source.
+GH_ARGV="$TMP/gh-argv.txt"
+export FAKEGH_ARGV_FILE="$(hostpath "$GH_ARGV")"
+export FAKEGH_SCENARIO=success
+
+CONFIG_DIR="" DATA_DIR=""
+scenario_dirs() { # scenario_dirs NAME
+  CONFIG_DIR="$TMP/$1/config"
+  DATA_DIR="$TMP/$1/data"
+  mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+  export VINCENT_CONFIG_DIR
+  VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+  export VINCENT_DATA_DIR
+  VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+  : > "$GH_ARGV"
+}
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+# The gate's projects need a github.com origin: that is the whole of what
+# makes a project a GitHub project (there is no stored flag — §13.2).
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+  git -C "$1" remote add origin https://github.com/octo/repo.git
+}
+
+register_project() { api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+# The gate's one workflow. A single command step, so no agent CLI is involved
+# and the task settles in seconds — what the gate needs from it is the branch
+# the worktree was made on, which is what a pull request's head is matched
+# against. `exit 0` is the whole body, which is what makes it portable to the
+# daemon's pwsh on Windows (§8.3).
+GATE_WORKFLOW='name: gate
+steps:
+  - id: noop
+    type: command
+    run: exit 0
+'
+
+create_task() { # create_task PROJECT_ID TITLE -> id
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg t "$2" \
+    '{project_id: $p, workflow: "gate", title: $t, description: "gate task"}')" | jq -r .id
+}
+
+wait_for_branch() { # wait_for_branch TASK_ID -> branch
+  local id="$1" branch=""
+  for _ in $(seq 1 30); do
+    branch="$(api GET "/tasks/$id" | jq -r .branch_name)"
+    [[ -n "$branch" && "$branch" != "null" ]] && { printf '%s' "$branch"; return 0; }
+    sleep 1
+  done
+  fail "task $id never got a branch"
+}
+
+# gh_calls is every argv the fake recorded, as one string safe to match a
+# here-string against. jq is not involved, so no CRLF dance is needed here —
+# but the file is written by a Go program on Windows, so strip anyway.
+gh_calls() { tr -d '\r' < "$GH_ARGV"; }
+
+run_scenario() { # run_scenario N NAME
+  [[ -z "$ONLY" || "$ONLY" == "$1" ]]
+}
+
+# ---------------------------------------------------------------- scenario 1
+# The probe answers yes, and the listing is open-only.
+if run_scenario 1; then
+  echo "== scenario 1: the capability probe and the open-only listing"
+  scenario_dirs s1
+  make_repo "$TMP/s1/repo"
+  write_workflow gate "$GATE_WORKFLOW"
+  daemon_up
+  pid="$(register_project "$TMP/s1/repo")"
+
+  probe="$(api GET "/projects/$pid/github")"
+  [[ "$(jq -r .available <<<"$probe")" == "true" ]] \
+    || fail "the probe says unavailable for a github.com origin: $probe"
+  [[ "$(jq -r .repo <<<"$probe")" == "octo/repo" ]] \
+    || fail "the probe named repo $(jq -r .repo <<<"$probe"), want octo/repo"
+
+  pulls="$(api GET "/projects/$pid/github/pulls")"
+  numbers="$(jq -r '.[].number' <<<"$pulls" | tr -d '\r')"
+  [[ "$numbers" == $'412\n401' ]] \
+    || fail "listing returned numbers $(printf '%s' "$numbers" | tr '\n' ' '), want 412 401"
+
+  # The merged row is in the corpus and must not be in an open listing: it is
+  # what the durable link exists to serve, through the task route instead.
+  merged="$(jq -r '[.[] | select(.merged)] | length' <<<"$pulls")"
+  [[ "$merged" == "0" ]] || fail "an open-only listing carried $merged merged rows"
+
+  draft="$(jq -r '[.[] | select(.draft)] | length' <<<"$pulls")"
+  [[ "$draft" == "1" ]] || fail "the draft row is missing from the listing"
+
+  daemon_down
+fi
+
+# ---------------------------------------------------------------- scenario 2
+# The reconciler links a pull request to the task whose branch it heads.
+if run_scenario 2; then
+  echo "== scenario 2: the reconciler's auto-link on a head-branch match"
+  scenario_dirs s2
+  make_repo "$TMP/s2/repo"
+  write_workflow gate "$GATE_WORKFLOW"
+  # A short poll interval so the tick happens inside the gate's patience.
+  printf 'github:\n  enabled: true\n  poll_interval: 1s\n' > "$CONFIG_DIR/config.yaml"
+  daemon_up
+  pid="$(register_project "$TMP/s2/repo")"
+  tid="$(create_task "$pid" "Add a thing")"
+  branch="$(wait_for_branch "$tid")"
+
+  # Point the fake's first pull request at this task's branch and let the
+  # reconciler tick.
+  daemon_down
+  export FAKEGH_PR_BRANCH="$branch"
+  daemon_up
+
+  linked=""
+  for _ in $(seq 1 30); do
+    linked="$(api GET "/tasks/$tid/github/pull" | jq -r .number)"
+    [[ "$linked" == "412" ]] && break
+    sleep 1
+  done
+  [[ "$linked" == "412" ]] || fail "the reconciler never linked #412 (last: $linked)"
+
+  row="$(api GET "/tasks/$tid/github/pull")"
+  [[ "$(jq -r .source <<<"$row")" == "auto" ]] \
+    || fail "link source is $(jq -r .source <<<"$row"), want auto"
+  [[ "$(jq -r .pull.title <<<"$row")" == "Add a thing" ]] \
+    || fail "the live pull request did not come back with the link: $row"
+
+  # And the listing agrees about who claims the row.
+  claim="$(api GET "/projects/$pid/github/pulls" | jq -r '.[] | select(.number == 412) | .task_id')"
+  [[ "$claim" == "$tid" ]] || fail "the listing says task $claim claims #412, want $tid"
+
+  unset FAKEGH_PR_BRANCH
+  daemon_down
+fi
+
+# ---------------------------------------------------------------- scenario 3
+# A human names a different number, and it wins.
+if run_scenario 3; then
+  echo "== scenario 3: the human link"
+  scenario_dirs s3
+  make_repo "$TMP/s3/repo"
+  write_workflow gate "$GATE_WORKFLOW"
+  daemon_up
+  pid="$(register_project "$TMP/s3/repo")"
+  tid="$(create_task "$pid" "Rework the board header")"
+
+  api POST "/tasks/$tid/github/pull" '{"number": 401}' > /dev/null
+  row="$(api GET "/tasks/$tid/github/pull")"
+  [[ "$(jq -r .number <<<"$row")" == "401" ]] \
+    || fail "the human link did not take: $row"
+  [[ "$(jq -r .source <<<"$row")" == "human" ]] \
+    || fail "link source is $(jq -r .source <<<"$row"), want human"
+
+  daemon_down
+fi
+
+# ---------------------------------------------------------------- scenario 4
+# The unlink is sticky: the next reconciler tick does not undo it.
+if run_scenario 4; then
+  echo "== scenario 4: the sticky unlink"
+  scenario_dirs s4
+  make_repo "$TMP/s4/repo"
+  write_workflow gate "$GATE_WORKFLOW"
+  printf 'github:\n  enabled: true\n  poll_interval: 1s\n' > "$CONFIG_DIR/config.yaml"
+  daemon_up
+  pid="$(register_project "$TMP/s4/repo")"
+  tid="$(create_task "$pid" "Ship the thing")"
+  branch="$(wait_for_branch "$tid")"
+
+  daemon_down
+  export FAKEGH_PR_BRANCH="$branch"
+  daemon_up
+
+  linked=""
+  for _ in $(seq 1 30); do
+    linked="$(api GET "/tasks/$tid/github/pull" | jq -r .number)"
+    [[ "$linked" == "412" ]] && break
+    sleep 1
+  done
+  [[ "$linked" == "412" ]] || fail "the reconciler never linked #412 (last: $linked)"
+
+  api DELETE "/tasks/$tid/github/pull" > /dev/null
+  row="$(api GET "/tasks/$tid/github/pull")"
+  [[ "$(jq -r .linked <<<"$row")" == "false" ]] || fail "DELETE left the link in place: $row"
+
+  # Several ticks' worth of patience: the point is that it never comes back.
+  sleep 5
+  row="$(api GET "/tasks/$tid/github/pull")"
+  [[ "$(jq -r .linked <<<"$row")" == "false" ]] \
+    || fail "the reconciler re-applied a link a human removed: $row"
+  [[ "$(jq -r .suppressed <<<"$row")" == "true" ]] \
+    || fail "the refusal was not recorded as suppressed: $row"
+
+  unset FAKEGH_PR_BRANCH
+  daemon_down
+fi
+
+# ---------------------------------------------------------------- scenario 5
+# The compare URL is built and never fetched.
+if run_scenario 5; then
+  echo "== scenario 5: the compare URL is built, never fetched"
+  scenario_dirs s5
+  make_repo "$TMP/s5/repo"
+  write_workflow gate "$GATE_WORKFLOW"
+  daemon_up
+  pid="$(register_project "$TMP/s5/repo")"
+  tid="$(create_task "$pid" "Add a thing")"
+  wait_for_branch "$tid" > /dev/null
+
+  : > "$GH_ARGV"
+  row="$(api GET "/tasks/$tid/github/pull")"
+  [[ "$(jq -r .linked <<<"$row")" == "false" ]] || fail "a fresh task is already linked: $row"
+  compare="$(jq -r .compare_url <<<"$row")"
+  [[ "$compare" == https://github.com/octo/repo/compare/* ]] \
+    || fail "compare_url is $compare, want a github.com compare page"
+
+  # Never piped into grep: the producer would die of SIGPIPE on the match.
+  calls="$(gh_calls)"
+  if grep -q 'compare' <<<"$calls"; then
+    fail "building the compare URL made a gh call: $calls"
+  fi
+  if grep -q 'pr create' <<<"$calls"; then
+    fail "vincent asked gh to create a pull request: $calls"
+  fi
+
+  daemon_down
+fi
+
+echo "GATE PASS"


### PR DESCRIPTION
## Summary

Closes 052.6 and 052.7 — the client half of task 052, which shipped everywhere
except the client most people actually use.

**A seventh view, `viewPullRequests`.** Every available project's open pull
requests, grouped by project, one `ListGitHubPulls` per project issued
concurrently on open. Rows carry the number, the folded status word, the title,
the head branch and the task that claims it with its `link_source`. A project
whose listing answers 409 renders as a failed group carrying that reason's
message and does not sink the others — each group holds its own error. The root
already broadcasts to every view, so a `task.github_pull_changed` tick
re-renders it with no keypress. Keys: `o` browser, `enter` the claiming task's
workspace, `l` link, `u` unlink, `R` re-list, `/` filter, `↑`/`↓`.

**Availability is derived, not stored.** There is no notion of a "GitHub
project" to read — it is `origin` plus a credential probe, which is why §13.2
keeps it off the project DTO. The root fans out one `GET
/v1/projects/{id}/github` per project as the connection comes up, concurrently,
and again on reconnect. While every answer is unavailable — *including while
they are all still in flight* — the nav row is withheld from the palette, the
`?` overlay and the footer alike, and the view is unreachable. Mechanically
this is task 054's `fold` precedent applied to a nav row: a new `github` flag on
`binding`, filtered at the root, where the probe results live. `shell.liveBindings`
is the wrong seam — it is shell-scoped and the nav rows are global.

**A pull-request section in the task workspace.** After the captured issue, from
`GET /v1/tasks/{id}/github/pull`. That route always answers 200, so three states
render inline and none is an error: a linked pull request with its live state,
the named reason when the integration is unusable, and the compare-URL offer
when nothing is linked. Two keys, `o` and `P`, and both only reach a browser.

**The compare-PR editor.** `P` opens a popup with the title and body decoded out
of `compare_url`'s query parameters, editable, re-encoded with `net/url` on the
way out — preserving `expand=1` and the daemon's compare path. This is what 052
decision 4 asks for. Handing GitHub's page the unedited URL satisfies the letter
of "editable before submit" only by relying on a surface vincent does not own.

**The opener.** New `openurl_darwin.go` (`open`), `openurl_unix.go`
(`xdg-open`) and `openurl_windows.go` (the shell's protocol handler via
`rundll32`, not `cmd /c start` — cmd treats a compare URL's `&` as a command
separator). The first build-tagged files in `internal/tui`, so the lint was
cross-built for all three. Only `http` and `https` are opened. Unlike
`clipboard.go` this fails **visibly**: a human pressed a key expecting a
browser, and silence is indistinguishable from a browser that opened on another
desktop.

### Decisions taken here

- **The create offer is in the workspace; link and unlink are in the takeover.**
  A task with a branch and no pull request is not a row in a GitHub listing, so
  the offer belongs beside the branch it is about. Link and unlink go the other
  way: they write vincent's own column, and belong on the one screen that can
  see a pull request no task claims.
- **`enter` on an unclaimed row is inert**, not overloaded into "link this".
- **The link picker is scoped to the row's project.** `POST` takes a bare number
  and the daemon resolves the repo from the task's project, so a task from
  elsewhere would silently link a different repository's number.

### Spec

`docs/spec.md` §15 is amended in this branch: view 7 added, "Views 3–6" becomes
3–7, the opener gets its own paragraph, and **view 2 is narrowed** — the new
pull-request section may open a URL. Neither key writes anything in vincent,
which is the sense in which "a read-only inspector" was written; the section is
named specifically rather than the tab. Decision record rows 11 and 27 and 035
decision 5 are untouched: this makes no GitHub call of its own, adds no write
method to `internal/github`, and builds the compare URL rather than fetching it.

### The gate, and what is left for a maintainer

`scripts/052-gate.sh` (committed executable) drives a real daemon over curl
against `cmd/fakegh` built **as `gh`** on its PATH: the probe and the open-only
listing, the reconciler's auto-link on a head-branch match, the human link, the
sticky unlink surviving several ticks, and the compare URL being produced with
nothing in the fake's argv log to show for it. It passes locally, all five
scenarios. `docs/gates/052-github-pull-requests.md` records the run.

It is **not wired into CI**, because `.github/workflows/` needs a token scope
this session does not have (#120, #122, #125). The step to add to `ci.yml`'s
`gates` job:

```yaml
      - name: 052 gate (GitHub pull requests)
        run: ./scripts/052-gate.sh
        shell: bash
```

Until that lands the gate is not known to pass on Windows — the exact failure
mode CLAUDE.md records for m6/m7/m8.

### Verification

- `go test ./...` green; `go test ./internal/tui` green.
- `go tool golangci-lint run ./...` clean cross-built for `windows`, `darwin`
  and `linux` — required rather than nice to have here, since the opener is the
  package's first build-tagged code and a host-only lint would not see two of
  the three files.
- `./scripts/052-gate.sh` — GATE PASS, macOS.

## Related

Closes #242
Closes 052.6 and 052.7 (`docs/tasks/052-github-pull-requests.md`, now ✅ 7/7).
Follows #231, which shipped 052.1–052.5.

Records decisions 6–9 on task 052. Nothing recorded is relitigated: 052
decisions 1–5, decision record rows 11 and 27, and 035 decision 5 all stand
unamended. Spec §15 view 2 **is** narrowed, deliberately and in writing —
see *Spec* above.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

**On the last box:** `docs/guides/tui.md` gains the new screen and every key
table, derived from `internal/tui/bindings.go` as they always are — including
the compare-PR popup's `enter` and `e`, which are registered bindings and so
already show in the `?` overlay. `docs/features.md` gains the screen in its TUI
list and says where a human link or unlink is made. `docs/spec.md` §15 is
amended, and the takeover count is now five in the docs index and the palette
section. `docs/gates/m3-gate.md`'s S1 sweep records why a walker there still
sees four takeovers: that seed's repos have no github.com origin, so the nav
row is withheld.

**Found, not fixed here:**

- **No picture of the screen.** Nothing under `docs/assets/` went *stale* —
  there is no screenshot of the Task Details tab, and the ones that exist do
  not show a surface this change alters — but there is no shot of the
  pull-requests takeover either. `scripts/screenshots.sh` seeds seven repos
  with no GitHub origin, so photographing it needs a fake `gh` on the seeded
  daemon's PATH, which is a change to the seeding script rather than a re-run
  of it. Drawing one instead is not an option. Follow-up.
- **`CLAUDE.md`'s gate list does not mention `scripts/052-gate.sh`.** Its
  neighbouring sentence, "all seven run in `ci.yml`'s `gates` job", stays true
  precisely because this one is not wired in (decision 9), so the file is not
  wrong — just incomplete. Left to the maintainer along with the `ci.yml` step
  above.
- **A binding label is narrower than its key.** `internal/tui/bindings.go`
  labels the popup's `e` as "write the body in $EDITOR"; `createPRForm.update`
  opens `$EDITOR` on whichever row has the cursor, title included. Harmless,
  and a code change rather than a documentation one — the guide documents the
  behaviour.
