### PR TITLE
Add enum task fields and a default for every field type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Enum task fields, with a value picker in New task, and a `default:` for
+  every field type.** A workflow's `fields:` gains `type: enum`, whose members
+  are declared in `values:` and published through `GET /v1/workflows` — which a
+  `pattern: '^(dev|staging|prod)$'` never could, so no client could build a
+  control from one. New task opens a scrollable, filterable list on `enter` and
+  steps through the members in place with `←`/`→`, the way a boolean cycles.
+  `multiple: true` accepts more than one member; the value is stored as the
+  members joined with `,` in **declared** order, which the daemon normalizes to
+  before it checks membership, so `--field reviewers="cy, ana"` and a TUI
+  selection produce the same task row and the same branch name. Any field may
+  now carry a `default:`, written as its own YAML scalar (`default: true`,
+  `default: 3`, `default: staging`): the daemon substitutes a **required**
+  field's default when a caller omits the key, so a scripted `vincent task add`
+  no longer 400s for a value the workflow already knows, while an **optional**
+  field's default is seeded by the TUI and never invented server-side — an
+  optional key you omit is still absent from `.Task.Fields`. A bad declaration
+  is a visibly invalid workflow with a source path, not a surprise at task
+  creation.
+
 - **A pull-requests screen in the TUI, and a browser to open them in.** A new
   takeover lists every open pull request across every registered project whose
   `origin` is a github.com repository vincent can authenticate to, grouped by

--- a/docs/features.md
+++ b/docs/features.md
@@ -60,8 +60,10 @@ Six structural types compose those steps:
 Prompts, commands, checks, and instructions use Go templates. A step can read
 task and project data, declared task fields, loop context, and earlier step
 results. Workflows can declare ordered inputs with labels, descriptions,
-required flags, types, and validation patterns; the TUI renders them before the
-task is submitted, while additional ad hoc fields remain available.
+required flags, types, defaults, and validation patterns — including `enum`
+fields whose values are published as a list, so the TUI offers a picker rather
+than a text box. The TUI renders them before the task is submitted, while
+additional ad hoc fields remain available.
 
 The [workflow guide](guides/workflows.md) explains the patterns, and the
 [workflow schema](reference/workflow-schema.md) lists every field.

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -531,9 +531,12 @@ descriptions, type/required badges, and regex help; boolean values toggle betwee
 `true` and `false`. An [`enum`](../reference/workflow-schema.md#enum-fields) row
 opens a scrollable, filterable list of its declared values on `enter` — `esc`
 cancels, `enter` commits, and a `multiple` field toggles membership with the
-list open — while `←`/`→` step through the values in place without opening it,
-the way a boolean cycles. A declared `default:` seeds the row when the workflow
-is selected. Workflow-owned names are locked, but their values remain
+list open — while `←`/`→` step a single-choice row through the values in place
+without opening it, the way a boolean cycles. A `multiple` row is not stepped:
+"the next set" has no meaning, so the list is the only way to change one. An
+optional single-choice row also stops at `(unset)`, which is the only way back
+to empty for a row the workflow owns and that therefore cannot be deleted. A
+declared `default:` seeds the row when the workflow is selected. Workflow-owned names are locked, but their values remain
 editable. You can still add and delete custom key/value rows — additional,
 undeclared fields remain valid and are recorded on the task. Values are kept
 when you switch workflows, including fields that the new workflow does not

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -528,7 +528,12 @@ optional agent/model/effort override.
 When the selected workflow declares [`fields:`](../reference/workflow-schema.md#fields),
 the Fields row is pre-rendered in declaration order. It shows labels,
 descriptions, type/required badges, and regex help; boolean values toggle between
-`true` and `false`. Workflow-owned names are locked, but their values remain
+`true` and `false`. An [`enum`](../reference/workflow-schema.md#enum-fields) row
+opens a scrollable, filterable list of its declared values on `enter` — `esc`
+cancels, `enter` commits, and a `multiple` field toggles membership with the
+list open — while `←`/`→` step through the values in place without opening it,
+the way a boolean cycles. A declared `default:` seeds the row when the workflow
+is selected. Workflow-owned names are locked, but their values remain
 editable. You can still add and delete custom key/value rows — additional,
 undeclared fields remain valid and are recorded on the task. Values are kept
 when you switch workflows, including fields that the new workflow does not

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -333,6 +333,10 @@ fields:                          # optional — ordered task inputs (§5.4)
     label: Ticket
     required: true
     pattern: '^OPS-[0-9]+$'
+  - name: environment
+    type: enum
+    values: [dev, staging, prod]
+    default: staging
 
 defaults:                        # optional — inherited by every step
   agent: claude
@@ -978,6 +982,15 @@ fields:
   - name: dry-run
     label: Dry run
     type: boolean
+  - name: environment
+    type: enum
+    required: true
+    values: [dev, staging, prod]
+    default: staging
+  - name: reviewers
+    type: enum
+    multiple: true
+    values: [ana, bo, cy]
 ```
 
 The definition order is the form order. `string` is the default type;
@@ -986,8 +999,25 @@ and `boolean` accepts exactly `true` or `false`. `pattern` is a Go RE2 expressio
 for strings only — anchor it with `^` and `$` when the whole value must match.
 `label` and `description` only improve presentation.
 
-The daemon checks required/type/pattern rules at task creation, including for
-CLI and API callers. The selected root workflow owns the contract: fields from
+`enum` is the type for a closed set. Reach for it instead of
+`pattern: '^(dev|staging|prod)$'`: the members are *published*, so New task can
+draw a picker and `GET /v1/workflows` can hand the list to any other client,
+which a regex can never do. `multiple: true` lets more than one be picked; the
+value is then the members joined with `,` in declared order (`dev,prod`), which
+the daemon normalizes to, so the same selection is always the same string in a
+template and a branch name. A member may not contain `,`, and `pattern` and
+`enum` cannot be combined.
+
+Any field may carry a `default:`, written as its own YAML scalar — `default: 3`
+on an integer, `default: true` on a boolean. The daemon fills in a **required**
+field's default when a caller omits the key, so a scripted `vincent task add`
+does not have to restate it; an **optional** field's default is seeded by the
+TUI but never invented server-side, so an optional key you omit is still absent
+from `.Task.Fields` and `{{ with index .Task.Fields "x" }}` keeps working the
+way it always did.
+
+The daemon checks required/type/pattern/membership rules at task creation,
+including for CLI and API callers. The selected root workflow owns the contract: fields from
 included workflows and named fan-out lane workflows are not automatically
 merged, so a composing workflow re-declares any input it exposes.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -644,9 +644,17 @@ Registry entries carry
 
 `fields[]` is the selected workflow's ordered
 [`fields:` declaration](workflow-schema.md#fields). Each entry is
-`{ name, label?, description?, type, required, pattern? }`; `type` is always
-explicit (`string` when the YAML omitted it). An empty list means the workflow
-publishes no task-input contract, not that task fields are forbidden.
+`{ name, label?, description?, type, required, pattern?, values[]?, multiple?, default? }`;
+`type` is always explicit (`string` when the YAML omitted it). An empty list
+means the workflow publishes no task-input contract, not that task fields are
+forbidden.
+
+`values[]` is an `enum` field's members in declared order, `multiple` says it
+accepts more than one of them (joined with `,` in that order), and `default` is
+the value that applies when the caller omits the key. All three are absent when
+the declaration does not carry them. A client older than `enum` sees an unknown
+`type`, falls back to a free-text row, and relies on `POST /v1/tasks` to reject
+a non-member.
 
 `platforms[]` is the entry's [platform restriction](workflow-schema.md#platforms)
 as the file declares it, and `platform_supported` is **the daemon's own verdict**
@@ -694,7 +702,9 @@ GET /v1/workflows/definition?name=feature-pr&project_id=3
     "name": "feature-pr",
     "fields": [
       { "name": "ticket", "label": "Ticket", "type": "string",
-        "required": true, "pattern": "^OPS-[0-9]+$" }
+        "required": true, "pattern": "^OPS-[0-9]+$" },
+      { "name": "environment", "type": "enum", "required": true,
+        "values": ["dev", "staging", "prod"], "default": "staging" }
     ],
     "defaults": { "agent": "claude", "model": "sonnet" },
     "steps": [
@@ -857,10 +867,22 @@ The CLI and the TUI do not send the header: neither retries a create, so a
 failed create is reported to you and what to do next is your call.
 
 On `POST /v1/tasks`, the daemon validates the selected root workflow's
-declared fields before inserting the task. Missing required values and invalid
-types or patterns return `400 validation_failed`. The `fields` object remains
-open: additional names that the workflow did not declare are accepted, stored,
-and returned with the task.
+declared fields before inserting the task. Missing required values, invalid
+types or patterns, and values outside an `enum`'s `values[]` return
+`400 validation_failed`. The `fields` object remains open: additional names that
+the workflow did not declare are accepted, stored, and returned with the task.
+
+Two things happen before that validation. A `multiple: true` enum value is
+normalized — split on `,`, trimmed, emptied entries dropped, deduplicated,
+reordered to the declared order and rejoined — so `"reviewers": "cy, ana"` is
+stored as `"ana,cy"` and every client produces the same task row for the same
+selection; a rejection names the element that failed. And a **required** field's
+`default:` is substituted for an omitted key, so a caller that omits it gets a
+task rather than a 400, with the applied value recorded on the row. An
+**optional** field's default is never substituted: it is published in
+`GET /v1/workflows` for clients to seed, and an optional key you omit stays
+absent from the task's `fields`. A key sent with an empty value is never
+defaulted.
 
 `github_issue` is an issue **number**. The daemon fetches that issue, computes
 the [prefill](#github-issues), and fills in whatever this request left unset —

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -411,9 +411,10 @@ task 62 created: Release 2.0 (release, branch vincent/62-release-2-0)
 
 The confirmation line lists **names and a count, never values** — a field can
 carry a ticket key or a customer name, and this line ends up in scrollback and
-CI logs. It is read off the created task, so a field the daemon filled in from
-`--github-issue` is listed too. `--json` prints the task instead, values and
-all.
+CI logs. It is read off the created task, so a field the daemon filled in — from
+`--github-issue`, or from a **required** field's declared
+[`default:`](workflow-schema.md#default), which the daemon substitutes for an
+omitted key — is listed too. `--json` prints the task instead, values and all.
 
 #### Fields from a file or stdin
 
@@ -451,8 +452,8 @@ Rejected locally with exit 1, before the daemon is called:
 A name repeated *inside* the JSON object takes its last value, which is what a
 JSON decoder does. Names the workflow never declared stay valid either way —
 declaring `fields:` does not close the map — and everything the daemon
-validates (required, `type`, `pattern`, per-field size) is still checked by the
-daemon.
+validates (required, `type`, `pattern`, [`enum`](workflow-schema.md#enum-fields)
+membership, per-field size) is still checked by the daemon.
 
 Model and effort **only inherit from a level whose agent matches**, so switching
 agent without setting them resets them to the new adapter's default rather than
@@ -1031,9 +1032,11 @@ previous attempt's failure — bind to visible placeholders such as `<worktree>`
 and `<steps.plan.result>`, so the output reads as a preview and never as the
 literal prompt an agent will receive. A field a workflow declares
 [`required`](workflow-schema.md) binds too, because a real task is guaranteed
-to carry it; an optional or undeclared field stays absent, so reading one
-without `{{ with index .Task.Fields "x" }}` is reported — which is exactly the
-bug a real run would hit.
+to carry it: to its [`default:`](workflow-schema.md#default) where it has one,
+else an [`enum`](workflow-schema.md#enum-fields)'s first declared value, else
+the `<field.NAME>` placeholder. An optional or undeclared field stays absent, so
+reading one without `{{ with index .Task.Fields "x" }}` is reported — which is
+exactly the bug a real run would hit.
 
 Supply the rest yourself: `--title`, `--description`, repeated `--field k=v`,
 and `--agent`/`--model`/`--effort` for a task-level override. `--task ID` binds

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -181,8 +181,9 @@ type and pattern validation.
 
 An `enum` publishes its members, which is what a regex cannot do: a client can
 build a picker from a list and not from `'^(dev|staging|prod)$'`. New task opens
-a scrollable value list on `enter` and steps through the members in place with
-`←`/`→`, the way a boolean cycles.
+a scrollable value list on `enter`, and for a single-choice field steps through
+the members in place with `←`/`→`, the way a boolean cycles. A `multiple` field
+is changed only through the list.
 
 A `multiple: true` field stores the picked members joined with `,` in **declared
 order**, deduplicated, with no spaces — `dev,prod`. `POST /v1/tasks` normalizes

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -148,6 +148,15 @@ fields:
   - name: dry-run
     label: Dry run
     type: boolean
+  - name: environment
+    type: enum
+    required: true
+    values: [dev, staging, prod]
+    default: staging
+  - name: reviewers
+    type: enum
+    multiple: true
+    values: [ana, bo, cy]
 ```
 
 Definitions stay in source order. Each definition has:
@@ -157,22 +166,60 @@ Definitions stay in source order. Each definition has:
 | `name` | slug | ✅ | | Key in `.Task.Fields`; unique in this list |
 | `label` | string | | `name` | Presentation text only |
 | `description` | string | | | Help text shown by clients |
-| `type` | `string` \| `integer` \| `number` \| `boolean` | | `string` | Editing and validation contract; stored value is still a string |
+| `type` | `string` \| `integer` \| `number` \| `boolean` \| `enum` | | `string` | Editing and validation contract; stored value is still a string |
 | `required` | bool | | `false` | Missing or whitespace-only values are rejected when true |
 | `pattern` | string | | | Go RE2 expression, valid only for `string`; use `^` and `$` for a whole-value match |
+| `values` | list of scalars | for `enum` | | The members, in declared order. Required for `enum`, rejected on every other type; non-empty, unique, no member may be empty or contain `,` |
+| `multiple` | bool | | `false` | `enum` only: the field accepts more than one member |
+| `default` | scalar | | | Any type. Applied when the caller omits the key; validated against this declaration when the workflow loads |
 
 Integers are base-10 whole numbers, numbers must be finite decimals, and
 booleans are exactly `true` or `false`. Optional absent or empty values skip
 type and pattern validation.
 
+### `enum` fields
+
+An `enum` publishes its members, which is what a regex cannot do: a client can
+build a picker from a list and not from `'^(dev|staging|prod)$'`. New task opens
+a scrollable value list on `enter` and steps through the members in place with
+`←`/`→`, the way a boolean cycles.
+
+A `multiple: true` field stores the picked members joined with `,` in **declared
+order**, deduplicated, with no spaces — `dev,prod`. `POST /v1/tasks` normalizes
+what it is given that way before checking membership, so `--field
+reviewers="cy, ana"` is stored as `ana,cy` and the same selection always
+produces the same string. That is what keeps template output and branch names
+stable. A member may therefore not contain `,`.
+
+`pattern` and `enum` are mutually exclusive: the members are the constraint.
+
+### `default`
+
+`default:` is not `enum`-specific — any declared field may carry one — and it is
+written as the value's own YAML scalar: `default: true` on a boolean, `default:
+3` on an integer, `default: staging` on a string or an enum. A `multiple` enum
+may also take a list (`default: [dev, prod]`), normalized like any other value.
+
+The daemon substitutes a **required** field's default when the caller omits the
+key, so a scripted `vincent task add` that omits it succeeds and the task row
+records what applied. It never substitutes an **optional** field's default: that
+one is published to clients, and New task seeds the row with it, but an optional
+key the caller omitted stays absent from `.Task.Fields`. Adding a `default:` to
+an existing optional field therefore does not change what
+`{{ with index .Task.Fields "x" }}` sees.
+
 The task map remains **open**. A caller may send additional names; vincent
 records them and exposes them to templates just like declared fields. Only the
-declared names receive required, type, and pattern checks.
+declared names receive required, type, pattern and membership checks. A client
+older than `enum` sees an unknown type, falls back to a free-text row and runs
+no local check; the daemon still rejects a non-member.
 
 The selected workflow is the public boundary. Fields declared by an included
 workflow or a named `fan_out` lane are not merged into the caller's form. A
 composing workflow re-declares the inputs it exposes; lane `fields:` remains a
-separate map of values bound for that lane.
+separate map of values bound for that lane — and those overrides are not checked
+against the root's declarations, so a lane may bind a name the root declares as
+an `enum` to something that is not a member.
 
 ## `defaults`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4981,6 +4981,22 @@ stream for the live tail.
    priority, Execution, Review. The stage is derived from the field cursor,
    not independently navigated; Review summarizes the whole request and the
    existing `ctrl+s` shortcut still submits from anywhere.
+   **Enum rows (task 058, added 2026-08-30):** the boolean toggle gains a
+   sibling. `enter` on a declared `enum` row opens the same windowed,
+   type-filterable picker every other catalog uses, listing the declared
+   `values:` with the current selection highlighted and the `default:` noted;
+   `←`/`→` step a single-choice row through the members in place the way the
+   boolean toggle cycles, so a two- or three-value field stays a single
+   keypress. A `multiple: true` row is not stepped — "the next set" has no
+   meaning — and is changed only through the list, which toggles membership
+   with itself open and rewrites the row in **declared** order on every toggle,
+   so it always shows the canonical string the daemon would store. An optional
+   single-choice row gets an `(unset)` stop,
+   which is the only way back to empty for a row the workflow owns and that
+   therefore cannot be deleted. A declared `default:` seeds its row when the
+   workflow is selected, and never over a value already entered: seeding is the
+   client's job for an optional field, because the daemon deliberately does not
+   invent one (§8.1.2).
 4. **Projects.** List/add/edit/remove; per-project cap and defaults. On a wide
    terminal the project list remains as a rail while the selected repository's
    configuration, execution defaults, current workload, or add/edit form uses

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1529,9 +1529,15 @@ fields:
   - name: ticket                 # required lowercase slug; .Task.Fields key
     label: Ticket                # optional presentation label
     description: Issue tracker key.
-    type: string                 # string (default) | integer | number | boolean
+    type: string                 # string (default) | integer | number | boolean | enum
     required: true               # default false
     pattern: '^OPS-[0-9]+$'      # optional Go RE2 expression; string only
+    default: OPS-1               # optional; any type
+  - name: environment
+    type: enum
+    values: [dev, staging, prod] # required for enum, rejected on every other type
+    multiple: false              # enum only; default false
+    default: staging
 ```
 
 - `integer` is a base-10 whole number, `number` is a finite decimal, and
@@ -1549,7 +1555,43 @@ fields:
 - Only the selected root workflow owns this contract. Declarations on included
   workflows or named fan-out lane workflows are not recursively merged. A
   composing workflow re-declares any input it wants to expose; a lane's own
-  `fields:` map continues to bind internal values.
+  `fields:` map continues to bind internal values. A lane's `fields:` overrides
+  are **not** validated against the root's declarations: a lane may bind a value
+  the root declares as an enum member to something that is not one. That is the
+  original behaviour of lane overrides, not a hole this section introduces.
+
+*Amended 2026-08-30 (task 058).* The vocabulary gains a fifth type, `enum`, and
+every type gains a `default:`.
+
+- `values:` carries an `enum`'s members in declared order. It is required for
+  `enum` and an error on every other type; it must be non-empty, its members
+  unique, non-empty, and free of `,`. `pattern:` stays string-only and is an
+  error alongside `enum` — the members *are* the constraint, and only a list can
+  be published to a client that wants to build a control from it.
+- `multiple:` (default false) says an `enum` accepts more than one member. It is
+  per field and `enum`-only. The picked members are joined with `,` in
+  **declared** order, deduplicated, with no spaces (`dev,prod`): declared order
+  rather than click order is what makes the same selection the same string, so
+  template output and branch names are stable. `POST /v1/tasks` normalizes a
+  supplied value that way — split, trim, drop empties, deduplicate, reorder,
+  rejoin — *before* checking membership, so every client produces the same task
+  row and a rejection names the offending element.
+- `default:` may be declared on any field and is validated against its own
+  declaration when the workflow loads. `default:` and `values:` take native YAML
+  scalars — `default: true`, `default: 3`, `default: 1.5`, `values: [1, 2]` —
+  canonicalized to the string the field carries, using the scalar's literal
+  source text. A mapping, or a sequence anywhere but a `multiple` enum's
+  `default:`, is a load error at `fields[i].default`.
+- `POST /v1/tasks` substitutes a **required** field's `default:` for an omitted
+  key before validating and inserting, so the task row records the value that
+  actually applied and a scripted caller that omits it no longer gets a 400. An
+  **optional** field's default is published through `GET /v1/workflows` and
+  seeded by clients only; the daemon never invents it, so an optional field the
+  caller omitted stays genuinely absent from `.Task.Fields` and adding a
+  `default:` to one is not a silent change for a workflow that guards on
+  presence. A key present but empty is never defaulted.
+- A client that predates `enum` sees an unknown type, falls through to a
+  free-text row and runs no local check. The daemon still gates the value.
 
 ### 8.2 Step types and fields
 
@@ -1717,7 +1759,7 @@ agent will receive. The vocabulary is:
 |---|---|
 | `.Task.ID` | `0`, following `.Loop.Index`'s precedent |
 | `.Task.Title` / `.Description` / `.BranchName` / `.BaseBranch` | `<task.title>`, `<task.description>`, `<branch>`, `<base_branch>` |
-| `.Task.Fields` | one entry per **required** declared field (§8.1.2), bound to `<field.NAME>`. Optional declared and undeclared names stay absent, so reading one without `{{ with index … }}` is the error the defensive-read rule above says it is |
+| `.Task.Fields` | one entry per **required** declared field (§8.1.2), bound to its `default:`, else an `enum`'s first declared value, else `<field.NAME>` — a sentinel is never a member of its own enum, so a preview binds a value the workflow could actually receive where one exists *(amended 2026-08-30, task 058)*. Optional declared and undeclared names stay absent, so reading one without `{{ with index … }}` is the error the defensive-read rule above says it is |
 | `.Project.*` | `<project.name>`, `<project.path>`, `<project.default_branch>` |
 | `.Steps` | one entry per step id the **file** declares, nested bodies and inline fan-out lanes included — an `include` step and a lane naming a registry workflow contribute none, since neither survives as a step of this task (§7.9, §7.6) — each `{Status: <steps.ID.status>, Result: <steps.ID.result>, ExitCode: 0}`. A forward reference renders clean: restricting the map to steps that would have completed interacts with `parallel` blindness, loop iterations and `allow_failure` in ways that produce false positives, and a false positive exits 1 inside a pre-commit hook |
 | `.Step.Attempt` | `1`, and the `<previous-attempt-failure>` block above is not appended |

--- a/docs/tasks/058-enum-task-fields.md
+++ b/docs/tasks/058-enum-task-fields.md
@@ -1,0 +1,179 @@
+# 058 — Enum task fields: workflow-declared value sets, selectable in New task
+
+**Status:** ✅ done (1/1)
+**Spec:** amends §8.1.2 (the `enum` type, `values:`, `multiple:`, `default:`,
+create-time normalization and required-default substitution, the lane-override
+note) and §8.4 (`.Task.Fields` in a preview)
+**Issue:** [#245](https://github.com/lezli01/vincent/issues/245)
+
+## Problem
+
+§8.1.2's field vocabulary — `string`, `integer`, `number`, `boolean` — had no
+way to say "this value is one of a fixed set". An author who wanted an
+environment, a release channel or a target branch picked from three options had
+only the regex escape hatch:
+
+```yaml
+- name: environment
+  type: string
+  pattern: '^(dev|staging|prod)$'
+```
+
+That validates but does not *publish*. `GET /v1/workflows` hands a client a
+pattern, not a list, so nothing can enumerate the members: New task renders a
+free-text row, the human has to already know the spelling, and a typo is a 400
+after the fact rather than a control that cannot be wrong. The set then gets
+restated in the field's `description` prose so it is discoverable at all, and
+the prose drifts from the pattern.
+
+Booleans already get a real selector in New task for exactly this reason. A
+closed set of strings deserves the same.
+
+## Approach
+
+A fifth type, `enum`, whose members live in `values:` and whose cardinality is
+declared per field in `multiple:`, plus a `default:` that belongs to every type.
+Task fields stay `map[string]string` in storage, on the wire, in templates, in
+branch names and in fan-out inheritance — [022](022-workflow-declared-task-fields.md)
+decision 1 is untouched. The daemon stays the authoritative validation boundary
+(022 decision 5) and the map stays open (022 decision 3).
+
+022's own decision 2 ("the first type vocabulary is string, integer, number, and
+boolean") is a starting vocabulary rather than a closed one: its beat rejects "an
+open-ended type name plus a regex for every field" in favour of "a small enum [of
+types that] gives the TUI meaningful controls", which is the same argument one
+level down. `enum` extends that decision in its own direction rather than
+relitigating it.
+
+## Decisions
+
+**1. `default:` and `values:` take native YAML scalars, canonicalized to
+strings.** *(2026-08-30)*
+
+`FieldDefinition` decodes into Go strings, so a bare `default: true` on a boolean
+field or `default: 3` on an integer field would have been a yaml type error
+rather than a schema error, and `values: [1, 2, 3]` would have failed `[]string`
+decoding with a yaml message instead of a schema one. Both decode as
+`goccy/go-yaml` `ast.Node`s instead, through a `FieldDefinition.UnmarshalYAML`
+that takes each scalar's **literal source text** — so `default: 1.50` is `"1.50"`
+and not `"1.5"`. An author never has to know the value is a string underneath.
+
+A `multiple: true` enum's `default:` additionally accepts a sequence of scalars
+(`default: [dev, prod]`), normalized exactly as a task value is. Everywhere else
+a sequence, and anywhere a mapping, is a load error at `fields[i].default`.
+
+The shape errors are *recorded* during decoding and reported by
+`validateFieldDefinitions`, not returned from `UnmarshalYAML`: `Parse` turns a
+decode error into a single pathless `Error`, and a schema mistake deserves the
+same `fields[i].default` source path every other structural mistake carries.
+
+The cost is one duplication — the alias struct inside `UnmarshalYAML` restates
+FieldDefinition's yaml keys, because a custom unmarshaler bypasses the outer
+decoder's `DisallowUnknownField` and it has to be re-applied. It is guarded by
+`TestFieldDefinitionAliasCoversEveryKey`, which builds a document out of every
+tagged key and fails if the alias forgot one.
+
+**Beaten:** a `Values`/`Default` pair of custom struct types carrying their own
+shape flags. It keeps the decode local, but `field.Default.Text` at every use
+site in the API, the CLI and the preview is a worse public shape than a plain
+`string` for a feature whose entire point is that the value *is* a string.
+
+**2. The daemon normalizes a `multiple` value on create.** *(2026-08-30)*
+
+`POST /v1/tasks` splits on `,`, trims each element, drops empties, deduplicates,
+reorders to declared order and rejoins — then checks membership. `--field
+reviewers="cy, ana"` becomes `ana,cy`; `dev,dev` becomes `dev`; a non-member is
+still a 400 that names the offending element, and the message is better for
+having normalized first. The task row records the canonical string.
+
+This is what the encoding exists for: every client — TUI, `--field`,
+`--fields-file`, curl — produces the same value for the same selection, so
+template output and branch names are stable. An empty or whitespace-only value is
+treated as absent, as for every other type.
+
+It **extends** 022 decision 5 rather than reversing it, and is recorded
+explicitly because "the daemon validates, it does not rewrite" is a reasonable
+reading of 022 that a reviewer may hold. The daemon remains the one authoritative
+gate; it gains one canonicalizing step immediately ahead of it, in
+`Workflow.PrepareTaskFields`, and that step is deterministic, idempotent and
+loses nothing — an element the declaration does not know survives normalization
+in place, precisely so validation can name it.
+
+**3. Only a required field's `default:` is substituted server-side.**
+*(2026-08-30)*
+
+When the caller omits a declared **required** field's key, `POST /v1/tasks` fills
+its `default:` before normalizing, validating and inserting, so a scripted caller
+that omits it no longer gets a 400 and the task row records the value that
+actually applied.
+
+An **optional** field's default is published through `GET /v1/workflows` and
+seeded by clients — the New task row, on workflow selection — but the daemon
+never invents it. An optional field the caller omits therefore stays genuinely
+absent from `.Task.Fields`, so `{{ with index .Task.Fields "x" }}` keeps meaning
+what it means today, and adding a `default:` to an existing optional field is not
+a silent behaviour change for workflows that guard on presence. A key present but
+empty is never defaulted, at any requiredness — an explicitly cleared row is a
+decision, not an omission.
+
+**Beaten:** substituting every default. It reads more consistent and quietly
+converts the presence test §8.4 tells authors to write into a test that is always
+true.
+
+**4. Enum and `default:` ship together.** *(2026-08-30)*
+
+One task document, one pull request. They are coupled where it counts: a picker
+wants an initial selection, and decision 5's preview rule is one rule for both.
+
+**5. A preview binds a value the workflow could actually receive.**
+*(2026-08-30)*
+
+`workflow.previewFields` binds a required field, in order: its `default:` when it
+has one; else, for an enum, its first declared value; else the existing
+`SentinelField`. `SentinelField("environment")` is `<field.environment>`, which
+is by construction not a member of its own enum, so a preview that bound it would
+render something the workflow could never receive. Optional fields stay absent,
+which is exactly what decision 3 guarantees — the preview keeps binding only what
+it can honestly claim.
+
+**6. `multiple:` is enum-only, like `values:`.** *(2026-08-30)*
+
+Not asked, derived from the schema. The issue states the rule for `values:` and
+is silent on `multiple:`; "a boolean that accepts more than one boolean" has no
+meaning, so declaring it on a `string`, `integer`, `number` or `boolean` field is
+a load error. `pattern` alongside `enum` is an error for the same reason from the
+other side: the members *are* the constraint.
+
+## Consequences that follow
+
+- **Task [035](035-github-issue-prefill.md)'s prefill needs no change.** It
+  offers a value only when `FieldDefinition.Validate` accepts it (035 decision
+  7), and that is the routine `ValidateTaskFields` calls, so membership checking
+  arrives for free. A prefilled single member is already a canonical `multiple`
+  value.
+- **Fan-out lane `fields:` overrides are still not validated** against the root
+  workflow's declarations (022 decision 4). A lane may bind a non-member to a
+  name the root declares as an enum. That is unchanged behaviour, not a
+  regression this task introduces, and §8.1.2 now says so, so it is not filed as
+  a bug later.
+- **Older clients** see an unknown `type: enum`, fall through to a free-text row
+  and run no local check; the daemon still gates. Stated in §8.1.2 and in the
+  API reference.
+- **The built-ins were re-audited** per [037](037-update-workflows-builtin.md)
+  decision 5. `create-workflow`'s `workflow_name` is a free string constrained by
+  a real pattern (a file name) and no enum fits it; its `global` stays a boolean
+  whose description documents "false, or left unset" as meaningful, so giving it
+  a `default:` would change what leaving the TUI row alone means. Neither built-in
+  changes. `update-workflows`' version-coupled "The bar" checklist gains item 5,
+  *Closed sets and defaults* — a workflow feature missing from that list is one
+  the built-in will never propagate.
+
+## Work
+
+- [x] **058.1** — `enum` with `values:`/`multiple:`, `default:` on every type,
+  create-time normalization and required-default substitution, the preview
+  binding rule, the three new wire keys, and the New task value picker.
+
+No gate script: this is a schema and form-contract change with no daemon
+end-to-end behaviour a gate would exercise that the API tests do not. The New
+task picker is judged by eye, the way M3 and [017](017-workflow-graph.md) are.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -71,6 +71,7 @@ the living engineering specification records implementation contracts.
 | [055](055-release-check-and-self-update.md) | Check for a newer release, and offer an in-place update | ✅ done (2/2) |
 | [056](056-fetch-base-branch.md) | Fetch the base branch before creating a task worktree | ✅ done (1/1) |
 | [057](057-daemon-mcp-server.md) | Serve MCP from the daemon so agents can drive vincent directly | 🔄 in progress (8/9) |
+| [058](058-enum-task-fields.md) | Enum task fields: workflow-declared value sets, selectable in New task | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/enumfields_test.go
+++ b/internal/api/enumfields_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+const enumFieldsYAML = `name: deploy
+description: Ship it.
+fields:
+  - name: environment
+    label: Environment
+    type: enum
+    required: true
+    values: [dev, staging, prod]
+    default: staging
+  - name: channel
+    type: enum
+    values: [alpha, beta]
+    default: beta
+  - name: reviewers
+    type: enum
+    multiple: true
+    values: [ana, bo, cy]
+steps:
+  - {id: approve, type: manual, instructions: review}
+`
+
+// TestWorkflowEndpointsExposeEnumFields pins the three new wire keys. A
+// pattern cannot be turned into a control; a published list can, which is the
+// whole reason the type exists (§8.1.2, task 058).
+func TestWorkflowEndpointsExposeEnumFields(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "deploy", enumFieldsYAML)
+	h.reg.ReloadGlobal()
+
+	_, body := h.doJSON(t, http.MethodGet, "/v1/workflows", nil)
+	var listed struct {
+		Workflows []workflowResponse `json:"workflows"`
+	}
+	if err := json.Unmarshal(body, &listed); err != nil {
+		t.Fatalf("workflow list: %v (%s)", err, body)
+	}
+	var fields []workflowFieldResponse
+	for _, entry := range listed.Workflows {
+		if entry.Name == "deploy" {
+			fields = entry.Fields
+		}
+	}
+	if len(fields) != 3 {
+		t.Fatalf("fields = %+v", fields)
+	}
+	if fields[0].Type != "enum" || fields[0].Default != "staging" ||
+		strings.Join(fields[0].Values, ",") != "dev,staging,prod" || fields[0].Multiple {
+		t.Errorf("environment = %+v", fields[0])
+	}
+	if !fields[2].Multiple || strings.Join(fields[2].Values, ",") != "ana,bo,cy" {
+		t.Errorf("reviewers = %+v", fields[2])
+	}
+
+	_, body = h.definition(t, "deploy", 0)
+	definition := decodeDefinition(t, body).Definition
+	if definition == nil || len(definition.Fields) != 3 {
+		t.Fatalf("definition fields = %+v", definition)
+	}
+	if definition.Fields[1].Default != "beta" {
+		t.Errorf("channel default = %+v", definition.Fields[1])
+	}
+}
+
+// TestWorkflowValidateReportsEnumDeclarationErrors keeps a bad declaration a
+// *visibly* invalid workflow rather than a task-creation surprise.
+func TestWorkflowValidateReportsEnumDeclarationErrors(t *testing.T) {
+	h := newWorkflowHarness(t)
+	_, body := h.doJSON(t, http.MethodPost, "/v1/workflows/validate", map[string]any{
+		"yaml": `name: bad
+fields:
+  - {name: environment, type: enum}
+  - {name: note, type: string, values: [a]}
+  - {name: channel, type: enum, values: [a], default: z}
+steps:
+  - {id: gate, type: manual, instructions: review}
+`,
+	})
+	var got validateResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("validate: %v (%s)", err, body)
+	}
+	if got.Valid {
+		t.Fatalf("a broken enum declaration validated clean: %s", body)
+	}
+	paths := map[string]string{}
+	for _, e := range got.Errors {
+		paths[e.Path] = e.Message
+	}
+	for _, want := range []string{"fields[0].values", "fields[1].values", "fields[2].default"} {
+		if paths[want] == "" {
+			t.Errorf("no finding at %s; got %v", want, got.Errors)
+		}
+	}
+}
+
+// TestTaskCreateEnumFields is the daemon's side of decisions 2 and 3: it
+// normalizes a multiple value before judging membership, substitutes a
+// required default for an omitted key, and never invents an optional one.
+func TestTaskCreateEnumFields(t *testing.T) {
+	h := newWorkflowHarness(t)
+	writeWorkflowFile(t, h.globalDir, "deploy", enumFieldsYAML)
+	h.reg.ReloadGlobal()
+	repo := testrepo.Init(t, "main")
+	project := h.mustCreate(t, map[string]any{"path": repo})
+	projectID := int64(project["id"].(float64))
+
+	create := func(t *testing.T, title string, fields map[string]string) (*http.Response, []byte) {
+		t.Helper()
+		return h.doJSON(t, http.MethodPost, "/v1/tasks", map[string]any{
+			"project_id": projectID, "workflow": "deploy", "title": title, "fields": fields,
+		})
+	}
+
+	for _, tt := range []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{"non-member", map[string]string{"environment": "nope"}, `got \"nope\"`},
+		{"one bad element", map[string]string{"reviewers": "ana,zed"}, `got \"zed\"`},
+		{"explicit empty required", map[string]string{"environment": ""}, `field \"environment\" is required`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, body := create(t, "invalid "+tt.name, tt.fields)
+			wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+			if !strings.Contains(string(body), tt.want) {
+				t.Errorf("body %s missing %q", body, tt.want)
+			}
+		})
+	}
+
+	resp, body := create(t, "deploy it", map[string]string{"reviewers": "cy, ana, cy"})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d %s", resp.StatusCode, body)
+	}
+	var created taskResponse
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatalf("created task: %v (%s)", err, body)
+	}
+	resp, body = h.doJSON(t, http.MethodGet, "/v1/tasks/"+strconv.FormatInt(created.ID, 10), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: %d %s", resp.StatusCode, body)
+	}
+	var stored taskResponse
+	if err := json.Unmarshal(body, &stored); err != nil {
+		t.Fatalf("stored task: %v (%s)", err, body)
+	}
+	if stored.Fields["environment"] != "staging" {
+		t.Errorf("environment = %q; a required field's default must be recorded on the row",
+			stored.Fields["environment"])
+	}
+	if got, ok := stored.Fields["channel"]; ok {
+		t.Errorf("channel = %q; an optional default must not be invented server-side", got)
+	}
+	if stored.Fields["reviewers"] != "ana,cy" {
+		t.Errorf("reviewers = %q, want ana,cy in declared order", stored.Fields["reviewers"])
+	}
+}

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -472,6 +472,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	// selected root workflow. The map remains open: ValidateTaskFields checks
 	// only names the workflow declared, so existing custom metadata continues
 	// to pass through and be snapshotted on the task unchanged.
+	//
+	// PrepareTaskFields runs first (task 058): it substitutes a *required*
+	// field's declared default for an omitted key and canonicalizes a
+	// multi-valued enum to declared order, so the task row records the value
+	// that actually applied and every client produces the same string for the
+	// same selection. It never invents an optional field's default — an
+	// optional key the caller omitted stays absent from .Task.Fields.
+	req.Fields = entry.Workflow.PrepareTaskFields(req.Fields)
 	if fieldErrs := entry.Workflow.ValidateTaskFields(req.Fields); len(fieldErrs) > 0 {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, fieldErrs.Error())
 		return

--- a/internal/api/workflowdef_test.go
+++ b/internal/api/workflowdef_test.go
@@ -315,10 +315,20 @@ func TestWorkflowDefinitionIsAsAuthored(t *testing.T) {
 // wire until someone maps it. This fails when that happens, naming the field.
 //
 // A field deliberately left off the wire belongs in the omit set below, with
-// the reason. It is empty today: every field of the workflow model is
-// something a graph or a future builder reads.
+// the reason.
 func TestWorkflowDefinitionCoversEveryField(t *testing.T) {
-	omit := map[string]map[string]string{}
+	// FieldDefinition's three unexported members are decode bookkeeping: they
+	// remember the *shape* a `default:` or `values:` node had so validation
+	// can report it at its own source path (task 058). A workflow that
+	// reaches the wire has already passed validation, so they are always
+	// zero by then and carry nothing a client could use.
+	omit := map[string]map[string]string{
+		"FieldDefinition": {
+			"defaultShape": "decode bookkeeping, consumed by validation before the wire",
+			"valuesShape":  "decode bookkeeping, consumed by validation before the wire",
+			"defaultSeq":   "decode bookkeeping, consumed by validation before the wire",
+		},
+	}
 	pairs := []struct {
 		name  string
 		model any

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -50,6 +50,14 @@ type workflowFieldResponse struct {
 	Type        string `json:"type"`
 	Required    bool   `json:"required"`
 	Pattern     string `json:"pattern,omitempty"`
+	// Values, Multiple and Default publish an `enum` field's members, its
+	// cardinality and the value that applies when the key is omitted
+	// (§8.1.2, task 058). Publishing the members is the whole point of the
+	// type: a client can build a control from a list, and cannot from a
+	// pattern.
+	Values   []string `json:"values,omitempty"`
+	Multiple bool     `json:"multiple,omitempty"`
+	Default  string   `json:"default,omitempty"`
 }
 
 type workflowStepResponse struct {
@@ -108,6 +116,9 @@ func toWorkflowFieldResponses(fields []workflow.FieldDefinition) []workflowField
 			Type:        field.Type,
 			Required:    field.Required,
 			Pattern:     field.Pattern,
+			Values:      field.Values,
+			Multiple:    field.Multiple,
+			Default:     field.Default,
 		})
 	}
 	return out

--- a/internal/apiclient/enumfields_live_test.go
+++ b/internal/apiclient/enumfields_live_test.go
@@ -1,0 +1,73 @@
+package apiclient_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+const enumYAML = `name: deploy
+description: ship it
+fields:
+  - name: environment
+    label: Environment
+    type: enum
+    required: true
+    values: [dev, staging, prod]
+    default: staging
+  - name: reviewers
+    type: enum
+    multiple: true
+    values: [ana, bo, cy]
+steps:
+  - {id: gate, type: manual, instructions: review}
+`
+
+// TestEnumFieldsOverTheWire pins the server DTO and the client model against
+// each other for `values`, `multiple` and `default` (§8.1.2, task 058). The
+// TUI builds a picker out of these three keys, so a rename on either side
+// would silently turn every enum row back into a free-text box — exactly what
+// the type exists to stop. Only the real handler encoding into the real client
+// type proves they agree.
+func TestEnumFieldsOverTheWire(t *testing.T) {
+	c := newDefinitionClient(t, map[string]string{"deploy": enumYAML})
+
+	entries, err := c.ListWorkflows(t.Context(), 0)
+	if err != nil {
+		t.Fatalf("ListWorkflows: %v", err)
+	}
+	var listed []apiclient.WorkflowField
+	for _, e := range entries {
+		if e.Name == "deploy" {
+			listed = e.Fields
+		}
+	}
+	def, err := c.GetWorkflowDefinition(t.Context(), 0, "deploy")
+	if err != nil {
+		t.Fatalf("GetWorkflowDefinition: %v", err)
+	}
+	if def.Definition == nil {
+		t.Fatal("definition is nil for a valid workflow")
+	}
+	for name, fields := range map[string][]apiclient.WorkflowField{
+		"list": listed, "definition": def.Definition.Fields,
+	} {
+		if len(fields) != 2 {
+			t.Fatalf("%s fields = %+v, want 2", name, fields)
+		}
+		env := fields[0]
+		if env.Type != apiclient.WorkflowFieldEnum {
+			t.Errorf("%s environment type = %q, want %q", name, env.Type, apiclient.WorkflowFieldEnum)
+		}
+		if got := strings.Join(env.Values, apiclient.WorkflowFieldSeparator); got != "dev,staging,prod" {
+			t.Errorf("%s environment values = %q, want the declared order", name, got)
+		}
+		if env.Default != "staging" || env.Multiple {
+			t.Errorf("%s environment = %+v", name, env)
+		}
+		if !fields[1].Multiple || fields[1].Default != "" {
+			t.Errorf("%s reviewers = %+v", name, fields[1])
+		}
+	}
+}

--- a/internal/apiclient/workflows.go
+++ b/internal/apiclient/workflows.go
@@ -13,7 +13,15 @@ const (
 	WorkflowFieldInteger = "integer"
 	WorkflowFieldNumber  = "number"
 	WorkflowFieldBoolean = "boolean"
+	// WorkflowFieldEnum carries its members in Values (task 058). A client
+	// that predates it sees an unknown type, falls through to a free-text
+	// row and runs no local check; the daemon still gates the value.
+	WorkflowFieldEnum = "enum"
 )
+
+// WorkflowFieldSeparator joins the members of a `multiple: true` enum, in the
+// workflow's declared order (§8.1.2, task 058).
+const WorkflowFieldSeparator = ","
 
 // WorkflowEntry is one row of GET /v1/workflows (§13.2): the merged registry
 // with §5.2 shadowing already applied. A file that failed to parse is listed
@@ -62,6 +70,14 @@ type WorkflowField struct {
 	Type        string `json:"type"`
 	Required    bool   `json:"required"`
 	Pattern     string `json:"pattern,omitempty"`
+
+	// Values are an `enum` field's members in declared order, Multiple says
+	// it accepts more than one of them, and Default is the value that applies
+	// when the key is omitted. Absent means the daemon predates the field,
+	// which is indistinguishable from "declares none" and treated as such.
+	Values   []string `json:"values,omitempty"`
+	Multiple bool     `json:"multiple,omitempty"`
+	Default  string   `json:"default,omitempty"`
 }
 
 // DisplayLabel is the presentation label, falling back to the field name.

--- a/internal/cli/fields_e2e_test.go
+++ b/internal/cli/fields_e2e_test.go
@@ -21,6 +21,12 @@ import (
 // on POSIX, pwsh on Windows (§8.3) — so it has to be spelled in the
 // intersection of the two (CLAUDE.md), and git is in it.
 const fieldConsumerWorkflow = `name: field-consumer
+fields:
+  # Optional, so the create below is unaffected by it: what it is here for is
+  # the membership rejection asserted at the end (§8.1.2, task 058).
+  - name: environment
+    type: enum
+    values: [dev, staging, prod]
 steps:
   - id: record
     type: command
@@ -118,6 +124,33 @@ func TestTaskFieldsReachATemplate(t *testing.T) {
 	}
 	if !strings.Contains(string(written), "OPS-42") {
 		t.Errorf("the step wrote %q, want the rendered field value OPS-42", written)
+	}
+
+	// The daemon is the authoritative boundary for a declared enum too (task
+	// 022 decision 5): `task add` needs no transport change and reports the
+	// membership error it is handed, by either route in.
+	for _, tc := range []struct {
+		name  string
+		stdin string
+		args  []string
+	}{
+		{"--field", "", []string{"--field", "environment=nope"}},
+		{"--fields-file", `{"environment":"nope"}`, []string{"--fields-file", "-"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{
+				"task", "add", "--project", strconv.FormatInt(project.ID, 10),
+				"--workflow", "field-consumer", "--title", "bad " + tc.name,
+			}, tc.args...)
+			out, code := runVincentStdin(t, dataDir, cfgDir, tc.stdin, args...)
+			if code == 0 {
+				t.Fatalf("a non-member was accepted: %q", out)
+			}
+			if !strings.Contains(out, "must be one of dev, staging, prod") ||
+				!strings.Contains(out, `"nope"`) {
+				t.Errorf("error %q, want the daemon's membership message unchanged", out)
+			}
+		})
 	}
 }
 

--- a/internal/cli/workflow_render.go
+++ b/internal/cli/workflow_render.go
@@ -298,6 +298,7 @@ func workflowFromDefinition(body *apiclient.WorkflowBody) *workflow.Workflow {
 		wf.Fields = append(wf.Fields, workflow.FieldDefinition{
 			Name: f.Name, Label: f.Label, Description: f.Description,
 			Type: f.Type, Required: f.Required, Pattern: f.Pattern,
+			Values: f.Values, Multiple: f.Multiple, Default: f.Default,
 		})
 	}
 	return wf

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -52,11 +52,12 @@ const (
 type ntMode int
 
 const (
-	ntNavigating ntMode = iota // moving between rows
-	ntEditing                  // a text row owns the keys
-	ntPicking                  // a picker is open
-	ntFieldsOpen               // the key/value editor is open
-	ntConfirming               // "discard this draft?"
+	ntNavigating   ntMode = iota // moving between rows
+	ntEditing                    // a text row owns the keys
+	ntPicking                    // a picker is open
+	ntFieldsOpen                 // the key/value editor is open
+	ntFieldPicking               // an enum field's value list is open over it
+	ntConfirming                 // "discard this draft?"
 )
 
 // New-task messages.
@@ -253,6 +254,8 @@ func (n *newTask) capturesInput() bool {
 		// The key/value editor types too, and was missing here: a "q" typed
 		// into a field name quit the TUI (M3 gate finding).
 		return n.fieldsEd != nil && n.fieldsEd.editing != 0
+	case ntFieldPicking:
+		return n.pick != nil && (n.pick.editing || n.pick.filtering)
 	case ntNavigating, ntConfirming:
 	}
 	return false
@@ -289,6 +292,11 @@ func (n *newTask) paste(text string) tea.Cmd {
 			return nil
 		}
 		return n.fieldsEd.paste(text)
+	case ntFieldPicking:
+		if n.pick == nil {
+			return nil
+		}
+		return n.pick.paste(text)
 	case ntNavigating, ntConfirming:
 	}
 	return cmd
@@ -590,8 +598,17 @@ func (n *newTask) syncWorkflowFields() {
 		out = make([]kv, 0, len(entry.Fields)+len(n.fields))
 		for _, definition := range entry.Fields {
 			declared[definition.Name] = true
+			// A declared `default:` seeds the row, but only where the human
+			// has not already put something there: switching workflow to
+			// compare two must not silently overwrite a value that was
+			// typed. Optional defaults are seeded here and nowhere else —
+			// the daemon never invents one (§8.1.2, task 058 decision 3).
+			value, typed := values[definition.Name]
+			if !typed || value == "" {
+				value = definition.Default
+			}
 			out = append(out, kv{
-				key: definition.Name, value: values[definition.Name],
+				key: definition.Name, value: value,
 				declared: true, definition: definition,
 			})
 		}
@@ -639,6 +656,8 @@ func (n *newTask) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return n, n.updatePicking(msg)
 	case ntFieldsOpen:
 		return n, n.updateFields(msg)
+	case ntFieldPicking:
+		return n, n.updateFieldPicking(msg)
 	case ntConfirming:
 		return n.updateConfirm(msg)
 	case ntNavigating:

--- a/internal/tui/newtaskenum_test.go
+++ b/internal/tui/newtaskenum_test.go
@@ -1,0 +1,216 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// formWithEnumFields is the declared-field form with the two enum shapes on
+// it: a required single-choice with a default, and an optional multi-choice.
+func formWithEnumFields(t *testing.T) *newTask {
+	t.Helper()
+	n := loadedForm(t)
+	for i := range n.workflows {
+		if n.workflows[i].Name != "two-step" {
+			continue
+		}
+		n.workflows[i].Fields = []apiclient.WorkflowField{
+			{
+				Name: "environment", Label: "Environment", Description: "Deployment target.",
+				Type: apiclient.WorkflowFieldEnum, Required: true,
+				Values: []string{"dev", "staging", "prod"}, Default: "staging",
+			},
+			{
+				Name: "reviewers", Type: apiclient.WorkflowFieldEnum, Multiple: true,
+				Values: []string{"ana", "bo", "cy"},
+			},
+			{Name: "channel", Type: apiclient.WorkflowFieldEnum, Values: []string{"alpha", "beta"}},
+		}
+	}
+	n.setWorkflow("two-step")
+	return n
+}
+
+// TestNewTaskSeedsDeclaredDefaults pins the client half of decision 3: an
+// optional field's default is seeded here and nowhere else, because the daemon
+// never invents one.
+func TestNewTaskSeedsDeclaredDefaults(t *testing.T) {
+	n := formWithEnumFields(t)
+	if got := n.fields[0].value; got != "staging" {
+		t.Errorf("environment = %q, want the declared default", got)
+	}
+	if got := n.fields[1].value; got != "" {
+		t.Errorf("reviewers = %q, want empty — it declares no default", got)
+	}
+	// A value the human already entered outranks the default when the form
+	// re-syncs, which is what makes comparing two workflows non-destructive.
+	n.fields[0].value = "prod"
+	n.fields = append(n.fields, kv{key: "owner", value: "ana"})
+	n.setWorkflow("adhoc")
+	n.setWorkflow("two-step")
+	if got := n.fields[0].value; got != "prod" {
+		t.Errorf("environment after a workflow switch = %q, want the typed value kept", got)
+	}
+	if n.fields[3].key != "owner" || n.fields[3].declared {
+		t.Errorf("custom field after switching = %+v", n.fields[3])
+	}
+}
+
+func TestNewTaskEnumPickerCommits(t *testing.T) {
+	n := formWithEnumFields(t)
+	moveTo(n, ntFields)
+	press(n, "enter") // open the fields editor, cursor on environment
+	press(n, "enter") // open the value list
+	if n.mode != ntFieldPicking || n.pick == nil {
+		t.Fatalf("mode = %v, pick = %v; enter on an enum row must open the list", n.mode, n.pick)
+	}
+	out := n.render(140, 60)
+	for _, want := range []string{"enum", "required", "values: dev, staging, prod", "default"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("enum row is missing %q:\n%s", want, out)
+		}
+	}
+	press(n, "down") // staging -> prod (a required field has no "(unset)" row)
+	press(n, "enter")
+	if n.mode != ntFieldsOpen {
+		t.Errorf("mode = %v, want the editor back after a single-choice commit", n.mode)
+	}
+	if got := n.fieldsEd.rows[0].value; got != "prod" {
+		t.Errorf("environment = %q, want prod", got)
+	}
+	press(n, "esc")
+	if got := n.fieldMap()["environment"]; got != "prod" {
+		t.Errorf("committed fields = %v", n.fieldMap())
+	}
+}
+
+// TestNewTaskEnumStepsInPlace pins the boolean-shaped shortcut: a two- or
+// three-value field stays a single keypress.
+func TestNewTaskEnumStepsInPlace(t *testing.T) {
+	n := formWithEnumFields(t)
+	moveTo(n, ntFields)
+	press(n, "enter")
+	press(n, "right")
+	if got := n.fieldsEd.rows[0].value; got != "prod" {
+		t.Errorf("after right = %q, want prod", got)
+	}
+	press(n, "right") // wraps: a required field has no empty stop
+	if got := n.fieldsEd.rows[0].value; got != "dev" {
+		t.Errorf("after wrapping = %q, want dev", got)
+	}
+	press(n, "left")
+	if got := n.fieldsEd.rows[0].value; got != "prod" {
+		t.Errorf("after left = %q, want prod", got)
+	}
+	if n.mode != ntFieldsOpen || n.pick != nil {
+		t.Errorf("stepping opened a picker: mode = %v", n.mode)
+	}
+	// An optional field gets one extra stop at "unset", which is the only way
+	// back for a row that cannot be deleted.
+	press(n, "down")
+	press(n, "down")
+	press(n, "right")
+	press(n, "right")
+	if got := n.fieldsEd.rows[2].value; got != "beta" {
+		t.Errorf("optional enum = %q, want beta", got)
+	}
+	press(n, "right")
+	if got := n.fieldsEd.rows[2].value; got != "" {
+		t.Errorf("optional enum = %q, want the unset stop", got)
+	}
+}
+
+// TestNewTaskMultipleEnumTogglesAndCommitsInDeclaredOrder is the encoding
+// rule the branch names and template output depend on: the same selection is
+// the same string, whatever order it was clicked in.
+func TestNewTaskMultipleEnumTogglesAndCommitsInDeclaredOrder(t *testing.T) {
+	n := formWithEnumFields(t)
+	moveTo(n, ntFields)
+	press(n, "enter")
+	press(n, "down") // reviewers
+	press(n, "right")
+	if got := n.fieldsEd.rows[1].value; got != "" {
+		t.Errorf("a multiple enum stepped in place to %q; there is no next set", got)
+	}
+	press(n, "enter")
+	if n.mode != ntFieldPicking {
+		t.Fatalf("mode = %v, want the value list", n.mode)
+	}
+	press(n, "down")  // bo
+	press(n, "down")  // cy
+	press(n, "enter") // toggle cy on; the list stays open
+	if n.mode != ntFieldPicking {
+		t.Fatalf("mode = %v; a multiple picker must stay open to toggle again", n.mode)
+	}
+	press(n, "up")
+	press(n, "up")
+	press(n, "enter") // toggle ana on, after cy
+	if got := n.fieldsEd.rows[1].value; got != "ana,cy" {
+		t.Errorf("reviewers = %q, want declared order regardless of click order", got)
+	}
+	if !strings.Contains(n.render(140, 60), "[x]") {
+		t.Errorf("no membership marker in the multi picker:\n%s", n.render(140, 60))
+	}
+	press(n, "enter") // toggle ana back off
+	if got := n.fieldsEd.rows[1].value; got != "cy" {
+		t.Errorf("reviewers after untoggling = %q, want cy", got)
+	}
+	press(n, "esc") // close the list, back to the editor
+	if n.mode != ntFieldsOpen {
+		t.Errorf("mode = %v, want the editor", n.mode)
+	}
+	press(n, "esc")
+	if got := n.fieldMap()["reviewers"]; got != "cy" {
+		t.Errorf("committed reviewers = %q", got)
+	}
+}
+
+// TestNewTaskDeclaredEnumRowsStayLocked keeps the task 022 contract: the
+// workflow owns a declared row's key, and the row cannot be deleted.
+func TestNewTaskDeclaredEnumRowsStayLocked(t *testing.T) {
+	n := formWithEnumFields(t)
+	moveTo(n, ntFields)
+	press(n, "enter")
+	press(n, "d")
+	if !strings.Contains(n.fieldsEd.err, "cannot be deleted") {
+		t.Errorf("delete error = %q", n.fieldsEd.err)
+	}
+	if len(n.fieldsEd.rows) != 3 {
+		t.Errorf("rows = %d, want the three declarations intact", len(n.fieldsEd.rows))
+	}
+	// enter opens the list rather than the key editor, so there is no route
+	// to renaming the key at all.
+	press(n, "enter")
+	if n.fieldsEd.editing != 0 {
+		t.Errorf("editing = %d, want the list rather than a text editor", n.fieldsEd.editing)
+	}
+}
+
+// TestEnumFieldValidationMessage holds the local check to the daemon's
+// sentence: the TUI mirrors POST /v1/tasks so the message lands on the row,
+// and the daemon stays the authoritative gate.
+func TestEnumFieldValidationMessage(t *testing.T) {
+	def := apiclient.WorkflowField{
+		Name: "environment", Label: "Environment", Type: apiclient.WorkflowFieldEnum,
+		Values: []string{"dev", "staging", "prod"},
+	}
+	if got := fieldValidationMessage(kv{key: "environment", value: "prod", declared: true, definition: def}); got != "" {
+		t.Errorf("member rejected: %s", got)
+	}
+	got := fieldValidationMessage(kv{key: "environment", value: "nope", declared: true, definition: def})
+	if !strings.Contains(got, "must be one of dev, staging, prod") || !strings.Contains(got, `"nope"`) {
+		t.Errorf("message = %q, want the members and the offending element", got)
+	}
+	multi := def
+	multi.Multiple = true
+	multi.Values = []string{"ana", "bo", "cy"}
+	if got := fieldValidationMessage(kv{key: "r", value: "ana,cy", declared: true, definition: multi}); got != "" {
+		t.Errorf("member set rejected: %s", got)
+	}
+	got = fieldValidationMessage(kv{key: "r", value: "ana,zed", declared: true, definition: multi})
+	if !strings.Contains(got, `"zed"`) {
+		t.Errorf("message = %q, want the offending element named", got)
+	}
+}

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,10 @@ type pickerOption struct {
 	label    string
 	note     string
 	disabled bool
+	// selected marks a member of a multi-select list. Only a multi picker
+	// draws it, because in a single-select list the cursor already says which
+	// value would be chosen.
+	selected bool
 }
 
 // picker is the list a focused row expands into. allowFree adds a free-text
@@ -59,6 +64,11 @@ type picker struct {
 	filtering bool
 	matches   []int
 	err       string
+	// multi turns enter into a toggle instead of a commit: a `multiple: true`
+	// enum field is chosen a member at a time and the list stays open, so
+	// picking three reviewers is one visit rather than three (§8.1.2, task
+	// 058).
+	multi bool
 }
 
 func newPicker(row int, heading string, options []pickerOption, allowFree bool, current string) *picker {
@@ -213,7 +223,7 @@ func (p *picker) update(msg tea.KeyPressMsg) pickerResult {
 			p.err = firstNonEmpty(opt.note, "this option cannot be selected")
 			return pickerResult{}
 		}
-		return pickerResult{value: opt.value, chosen: true, closed: true}
+		return pickerResult{value: opt.value, chosen: true, closed: !p.multi}
 	case "esc":
 		// A narrowed list clears back to the whole catalog first; only an
 		// already-whole list closes. Otherwise escaping a typo'd filter costs
@@ -253,6 +263,13 @@ func (p *picker) renderBody() []string {
 		label := opt.label
 		if label == "" {
 			label = "(none)"
+		}
+		if p.multi {
+			box := "[ ] "
+			if opt.selected {
+				box = "[x] "
+			}
+			label = box + label
 		}
 		if opt.disabled {
 			label = styleBad.Render(label)
@@ -315,6 +332,96 @@ func (n *newTask) openPicker(row ntRow) {
 		return
 	}
 	n.mode = ntPicking
+}
+
+// openFieldPicker opens the value list for the focused declared enum row. It
+// is a second entry point into the same picker the §8.6 override rows use —
+// the list, the window, the filter and the scrolling are one implementation,
+// so a 40-member enum scrolls exactly like cursor's model catalog does.
+func (n *newTask) openFieldPicker() {
+	f := n.fieldsEd
+	if f == nil || f.cursor < 0 || f.cursor >= len(f.rows) {
+		return
+	}
+	row := f.rows[f.cursor]
+	if !row.declared || row.definition.Type != apiclient.WorkflowFieldEnum {
+		return
+	}
+	current := row.value
+	if row.definition.Multiple {
+		current = ""
+	}
+	n.pick = newPicker(f.cursor, row.definition.DisplayLabel(),
+		n.enumOptions(row), false, current)
+	n.pick.multi = row.definition.Multiple
+	n.mode = ntFieldPicking
+}
+
+// enumOptions is one row per declared member, in declared order. An optional
+// single-choice field gets a leading "(unset)" row, because clearing a
+// workflow-owned row is otherwise impossible: the row cannot be deleted.
+func (n *newTask) enumOptions(row kv) []pickerOption {
+	out := make([]pickerOption, 0, len(row.definition.Values)+1)
+	if !row.definition.Required && !row.definition.Multiple {
+		out = append(out, pickerOption{value: "", label: "(unset)"})
+	}
+	picked := enumSelection(row.value)
+	for _, member := range row.definition.Values {
+		opt := pickerOption{value: member, label: member, selected: slices.Contains(picked, member)}
+		if member == row.definition.Default {
+			opt.note = "default"
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+// updateFieldPicking runs the enum list and hands the form back to the fields
+// editor when it closes — the editor stays open underneath the whole time, so
+// esc from the list returns to the row rather than to the form.
+func (n *newTask) updateFieldPicking(msg tea.KeyPressMsg) tea.Cmd {
+	if n.pick == nil || n.fieldsEd == nil {
+		n.mode = ntFieldsOpen
+		return nil
+	}
+	res := n.pick.update(msg)
+	if res.chosen {
+		n.applyFieldPick(res.value)
+	}
+	if res.closed {
+		n.pick = nil
+		n.mode = ntFieldsOpen
+	}
+	return res.cmd
+}
+
+// applyFieldPick writes the chosen member back onto the editor row. A
+// `multiple` field toggles membership and is rewritten in **declared** order
+// every time, so the row always shows the canonical string the daemon would
+// store rather than click order (§8.1.2, task 058).
+func (n *newTask) applyFieldPick(value string) {
+	f := n.fieldsEd
+	at := n.pick.row
+	if at < 0 || at >= len(f.rows) {
+		return
+	}
+	row := &f.rows[at]
+	if !row.definition.Multiple {
+		row.value = value
+	} else {
+		picked := enumSelection(row.value)
+		if i := slices.Index(picked, value); i >= 0 {
+			picked = append(picked[:i], picked[i+1:]...)
+		} else {
+			picked = append(picked, value)
+		}
+		row.value = enumValue(row.definition, picked)
+		for i := range n.pick.options {
+			n.pick.options[i].selected = slices.Contains(picked, n.pick.options[i].value)
+		}
+	}
+	f.err = fieldValidationMessage(*row)
+	n.touched = true
 }
 
 func (n *newTask) updatePicking(msg tea.KeyPressMsg) tea.Cmd {
@@ -548,13 +655,28 @@ func (n *newTask) updateFields(msg tea.KeyPressMsg) tea.Cmd {
 		f.cursor = len(f.rows) - 1
 		f.startEdit(1)
 	case "enter", " ", "left", "right":
-		if len(f.rows) > 0 {
-			if f.rows[f.cursor].declared &&
-				f.rows[f.cursor].definition.Type == apiclient.WorkflowFieldBoolean {
-				f.toggleBoolean()
-			} else if msg.String() == "enter" {
-				f.startEdit(1)
+		if len(f.rows) == 0 {
+			return nil
+		}
+		row := f.rows[f.cursor]
+		switch {
+		case row.declared && row.definition.Type == apiclient.WorkflowFieldBoolean:
+			f.toggleBoolean()
+		case row.declared && row.definition.Type == apiclient.WorkflowFieldEnum:
+			// left/right step through the members in place the way a boolean
+			// cycles, so a two- or three-value field stays a single keypress;
+			// enter opens the list, which is the only workable control for a
+			// long one and the only one that can toggle a `multiple` set.
+			switch msg.String() {
+			case "left":
+				f.stepEnum(-1)
+			case "right":
+				f.stepEnum(1)
+			default:
+				n.openFieldPicker()
 			}
+		case msg.String() == "enter":
+			f.startEdit(1)
 		}
 	case "d":
 		if len(f.rows) > 0 {
@@ -634,6 +756,66 @@ func (f *fieldsEditor) updateEditing(msg tea.KeyPressMsg) tea.Cmd {
 	return cmd
 }
 
+// stepEnum moves a single-choice enum one member along, wrapping. An optional
+// field gets an extra stop at the empty value, which is the only way back to
+// "unset" without deleting a row the workflow owns; a required one has no such
+// stop, because it has no legal empty value.
+//
+// A `multiple` field is not stepped: "the next set" has no meaning, so
+// left/right open nothing and the picker is the way to change it.
+func (f *fieldsEditor) stepEnum(delta int) {
+	if f.cursor < 0 || f.cursor >= len(f.rows) {
+		return
+	}
+	row := &f.rows[f.cursor]
+	if row.definition.Multiple {
+		return
+	}
+	stops := append([]string(nil), row.definition.Values...)
+	if !row.definition.Required {
+		stops = append(stops, "")
+	}
+	if len(stops) == 0 {
+		return
+	}
+	at := slices.Index(stops, row.value)
+	if at < 0 {
+		// An unknown value — seeded from an issue prefill, or left behind by
+		// a workflow edit — steps to the first member rather than nowhere.
+		at = -1
+		if delta < 0 {
+			at = 1
+		}
+	}
+	row.value = stops[((at+delta)%len(stops)+len(stops))%len(stops)]
+	f.err = fieldValidationMessage(*row)
+}
+
+// enumSelection splits a stored enum value into the members it names.
+func enumSelection(value string) []string {
+	out := []string{}
+	for _, part := range strings.Split(value, apiclient.WorkflowFieldSeparator) {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+// enumValue joins a selection in the workflow's **declared** order, which is
+// the canonical string the daemon stores (§8.1.2, task 058). The TUI writes
+// the canonical form itself rather than leaning on the daemon to rewrite it,
+// so what the row shows is what the task will carry.
+func enumValue(def apiclient.WorkflowField, picked []string) string {
+	out := make([]string, 0, len(picked))
+	for _, member := range def.Values {
+		if slices.Contains(picked, member) {
+			out = append(out, member)
+		}
+	}
+	return strings.Join(out, apiclient.WorkflowFieldSeparator)
+}
+
 func (f *fieldsEditor) toggleBoolean() {
 	if f.cursor < 0 || f.cursor >= len(f.rows) {
 		return
@@ -680,6 +862,14 @@ func fieldValidationMessage(field kv) string {
 	case apiclient.WorkflowFieldBoolean:
 		if field.value != "true" && field.value != "false" {
 			return fmt.Sprintf("%s must be true or false", field.definition.DisplayLabel())
+		}
+	case apiclient.WorkflowFieldEnum:
+		for _, member := range enumSelection(field.value) {
+			if !slices.Contains(field.definition.Values, member) {
+				return fmt.Sprintf("%s must be one of %s; got %q",
+					field.definition.DisplayLabel(),
+					strings.Join(field.definition.Values, ", "), member)
+			}
 		}
 	case apiclient.WorkflowFieldString:
 		if field.definition.Pattern != "" {

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -509,7 +509,7 @@ func (n *newTask) renderExpansion(row ntRow) []string {
 	switch {
 	case n.mode == ntPicking && n.pick != nil && ntRow(n.pick.row) == row:
 		return n.renderPicker()
-	case n.mode == ntFieldsOpen && row == ntFields:
+	case (n.mode == ntFieldsOpen || n.mode == ntFieldPicking) && row == ntFields:
 		return n.renderFields()
 	case n.mode == ntEditing && row == ntDescription:
 		return append(strings.Split(n.desc.View(), "\n"),
@@ -609,14 +609,25 @@ func (n *newTask) renderFields() []string {
 				name += " (" + r.key + ")"
 			}
 			tags := []string{r.definition.Type}
+			if r.definition.Multiple {
+				tags = append(tags, "multiple")
+			}
 			if r.definition.Required {
 				tags = append(tags, "required")
 			}
 			meta = " " + styleDim.Render("["+strings.Join(tags, " · ")+"]")
 		}
 		placeholder := styleDim.Render("(empty)")
-		if r.declared && r.definition.Type == apiclient.WorkflowFieldBoolean {
-			placeholder = styleDim.Render("(choose true/false)")
+		if r.declared {
+			switch r.definition.Type {
+			case apiclient.WorkflowFieldBoolean:
+				placeholder = styleDim.Render("(choose true/false)")
+			case apiclient.WorkflowFieldEnum:
+				placeholder = styleDim.Render("(choose a value)")
+				if r.definition.Multiple {
+					placeholder = styleDim.Render("(choose one or more)")
+				}
+			}
 		}
 		out = append(out, "    "+marker+name+meta+" = "+firstNonEmpty(value, placeholder))
 		if i == f.cursor && r.declared {
@@ -626,6 +637,21 @@ func (n *newTask) renderFields() []string {
 			if r.definition.Pattern != "" {
 				out = append(out, styleDim.Render("        pattern: "+r.definition.Pattern))
 			}
+			// The members sit beside the pattern line, because they are the
+			// same thing said in the one form a client can build a control
+			// from: a list. A long list is truncated — the picker is where
+			// the whole of it is browsable.
+			if len(r.definition.Values) > 0 {
+				out = append(out, styleDim.Render("        values: "+summarizeValues(r.definition.Values)))
+			}
+		}
+		if i == f.cursor && n.mode == ntFieldPicking && n.pick != nil {
+			out = append(out, n.pick.renderBody()...)
+			hint := "    enter select · esc cancel"
+			if r.definition.Multiple {
+				hint = "    enter toggles · esc closes the list"
+			}
+			out = append(out, styleDim.Render(hint))
 		}
 	}
 	if len(f.rows) == 0 {
@@ -634,9 +660,22 @@ func (n *newTask) renderFields() []string {
 	if f.err != "" {
 		out = append(out, styleWarn.Render("    ⚠ "+f.err))
 	}
-	out = append(out, styleDim.Render(
-		"    a add custom · enter edit/toggle · d delete custom · esc done"))
+	if n.mode != ntFieldPicking {
+		out = append(out, styleDim.Render(
+			"    a add custom · enter edit/toggle/pick · ←/→ steps a choice · d delete custom · esc done"))
+	}
 	return out
+}
+
+// summarizeValues renders a declared value set on one line, cut off before it
+// wraps: an enum with 40 members is browsed in the picker, not read here.
+func summarizeValues(values []string) string {
+	const most = 6
+	if len(values) <= most {
+		return strings.Join(values, ", ")
+	}
+	return strings.Join(values[:most], ", ") +
+		fmt.Sprintf(", … (%d more)", len(values)-most)
 }
 
 func (n *newTask) statusLines() []string {

--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -370,26 +370,33 @@ steps:
          description becomes a declared field, with a type, and a pattern where
          one exists. A workflow that digs an issue number out of the task title
          reads .Issue instead.
-      5. Failure policy, per step. max_retries: 0 on a probe and on anything
+      5. Closed sets and defaults. A field whose legal values are a fixed list
+         is type: enum with values:, not a string with a pattern spelling the
+         same alternation and not a set restated in prose — only a list can be
+         published, and only a published list becomes a picker. multiple: true
+         where more than one may be chosen. A field with an obvious value
+         carries default:, which is what stops a scripted caller from having to
+         restate it.
+      6. Failure policy, per step. max_retries: 0 on a probe and on anything
          whose replay is not provably safe; allow_failure: true where a red
          result is data a later guard reads; retry_backoff where retrying
          immediately cannot help.
-      6. Human mechanism, deliberately chosen. A manual gate sits immediately
+      7. Human mechanism, deliberately chosen. A manual gate sits immediately
          before the effect it authorizes and names what to inspect.
          on_input: require only where the conversation genuinely is part of the
          run, and never on a step that resolves to an adapter with no control
          channel. on_input: deny on a step meant to run untended.
-      7. Visibility. A step that runs for minutes, or that someone waits on,
+      8. Visibility. A step that runs for minutes, or that someone waits on,
          reports through vincent status — in the script for a command step, in
          the prompt for an agent step, in the wording used above.
-      8. Portability. A run: body is handed to /bin/sh on POSIX and to pwsh on
+      9. Portability. A run: body is handed to /bin/sh on POSIX and to pwsh on
          Windows, and vincent translates nothing. A body outside the
          intersection of the two is either rewritten into it, or the workflow
          declares platforms:, or the step carries a .Host.OS guard.
-      9. Defensive templates. Rendering uses missingkey=error, so an optional
-         field is read as {{"{{"}}with index .Task.Fields "x"}}…{{"{{"}}end}}
-         and never bare. A required field may be read directly.
-      10. Secrets. Nothing in a prompt, a field, an instruction or a run: body
+      10. Defensive templates. Rendering uses missingkey=error, so an optional
+          field is read as {{"{{"}}with index .Task.Fields "x"}}…{{"{{"}}end}}
+          and never bare. A required field may be read directly.
+      11. Secrets. Nothing in a prompt, a field, an instruction or a run: body
           that you would not want sitting in a transcript.
 
       ## What you may not change

--- a/internal/workflow/enumfields_test.go
+++ b/internal/workflow/enumfields_test.go
@@ -1,0 +1,365 @@
+package workflow
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// parseFieldWorkflow wraps one `fields:` block in the smallest valid workflow.
+func parseFieldWorkflow(t *testing.T, fields string) (*Workflow, Errors) {
+	t.Helper()
+	src := "name: w\nfields:\n" + fields + "steps:\n  - {id: gate, type: manual, instructions: review}\n"
+	wf, _, err := Parse([]byte(src), Options{})
+	if err != nil {
+		var errs Errors
+		if !asErrors(err, &errs) {
+			t.Fatalf("Parse: %v", err)
+		}
+		return nil, errs
+	}
+	return wf, nil
+}
+
+// findingAt is the message reported for one source path, and "" when the path
+// reported nothing. The path is what makes a schema error actionable, so every
+// rule below asserts on it rather than on the message alone.
+func findingAt(errs Errors, path string) string {
+	for _, e := range errs {
+		if e.Path == path {
+			return e.Message
+		}
+	}
+	return ""
+}
+
+func TestParseEnumFieldDeclaration(t *testing.T) {
+	wf, errs := parseFieldWorkflow(t, `  - name: environment
+    label: Environment
+    type: enum
+    required: true
+    values: [dev, staging, prod]
+    default: staging
+  - name: reviewers
+    type: enum
+    multiple: true
+    values: [ana, bo, cy]
+    default: [cy, ana]
+`)
+	if len(errs) > 0 {
+		t.Fatalf("Parse: %v", errs)
+	}
+	env := wf.Fields[0]
+	if env.Type != FieldEnum || !env.Required || env.Default != "staging" {
+		t.Errorf("environment = %+v", env)
+	}
+	if want := []string{"dev", "staging", "prod"}; !reflect.DeepEqual(env.Values, want) {
+		t.Errorf("values = %v, want %v", env.Values, want)
+	}
+	rev := wf.Fields[1]
+	if !rev.Multiple {
+		t.Errorf("reviewers.multiple = false, want true")
+	}
+	// A sequence default is normalized exactly as a task value is: declared
+	// order, not the order it was written in.
+	if rev.Default != "ana,cy" {
+		t.Errorf("reviewers default = %q, want %q", rev.Default, "ana,cy")
+	}
+}
+
+// TestFieldNativeScalarsCanonicalize pins decision 1: an author writes the
+// value the way its type is spelled in YAML and never has to know it is a
+// string underneath. The literal source text is what survives, so 1.50 does
+// not become 1.5.
+func TestFieldNativeScalarsCanonicalize(t *testing.T) {
+	wf, errs := parseFieldWorkflow(t, `  - name: flag
+    type: boolean
+    default: true
+  - name: count
+    type: integer
+    default: 3
+  - name: ratio
+    type: number
+    default: 1.50
+  - name: environment
+    type: enum
+    values: [1, 2]
+    default: 2
+  - name: stage
+    type: string
+    default: staging
+`)
+	if len(errs) > 0 {
+		t.Fatalf("Parse: %v", errs)
+	}
+	want := []string{"true", "3", "1.50", "2", "staging"}
+	for i, field := range wf.Fields {
+		if field.Default != want[i] {
+			t.Errorf("%s default = %q, want %q", field.Name, field.Default, want[i])
+		}
+	}
+	if got := wf.Fields[3].Values; !reflect.DeepEqual(got, []string{"1", "2"}) {
+		t.Errorf("enum values = %v, want [1 2]", got)
+	}
+}
+
+func TestEnumDeclarationErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields string
+		path   string
+		want   string
+	}{
+		{"values missing", "  - name: e\n    type: enum\n", "fields[0].values", "values is required"},
+		{"values empty", "  - name: e\n    type: enum\n    values: []\n", "fields[0].values", "values is required"},
+		{
+			"values duplicated",
+			"  - name: e\n    type: enum\n    values: [a, a]\n",
+			"fields[0].values[1]", "already declared",
+		},
+		{
+			"member empty",
+			"  - name: e\n    type: enum\n    values: [a, '']\n",
+			"fields[0].values[1]", "must not be empty",
+		},
+		{
+			"member with a comma",
+			"  - name: e\n    type: enum\n    values: [a, 'b,c']\n",
+			"fields[0].values[1]", "must not contain",
+		},
+		{
+			"values on a string field",
+			"  - name: e\n    type: string\n    values: [a]\n",
+			"fields[0].values", "only valid for enum",
+		},
+		{
+			"multiple on a boolean field",
+			"  - name: e\n    type: boolean\n    multiple: true\n",
+			"fields[0].multiple", "only valid for enum",
+		},
+		{
+			"pattern alongside enum",
+			"  - name: e\n    type: enum\n    values: [a]\n    pattern: '^a$'\n",
+			"fields[0].pattern", "not valid for enum",
+		},
+		{
+			"values is not a list",
+			"  - name: e\n    type: enum\n    values: a\n",
+			"fields[0].values", "must be a list of scalar values",
+		},
+		{
+			"default is a mapping",
+			"  - name: e\n    type: string\n    default: {a: 1}\n",
+			"fields[0].default", "must be a scalar value",
+		},
+		{
+			"default is a list on a single-choice enum",
+			"  - name: e\n    type: enum\n    values: [a, b]\n    default: [a, b]\n",
+			"fields[0].default", "may only be a list",
+		},
+		{
+			"default is a list on a string field",
+			"  - name: e\n    type: string\n    default: [a, b]\n",
+			"fields[0].default", "may only be a list",
+		},
+		{
+			"default is not a member",
+			"  - name: e\n    type: enum\n    values: [a, b]\n    default: c\n",
+			"fields[0].default", `must be one of a, b; got "c"`,
+		},
+		{
+			"default fails an integer field",
+			"  - name: e\n    type: integer\n    default: nope\n",
+			"fields[0].default", "base-10 integer",
+		},
+		{
+			"default fails a number field",
+			"  - name: e\n    type: number\n    default: nope\n",
+			"fields[0].default", "finite decimal number",
+		},
+		{
+			"default fails a boolean field",
+			"  - name: e\n    type: boolean\n    default: nope\n",
+			"fields[0].default", "must be true or false",
+		},
+		{
+			"default fails a string field's pattern",
+			"  - name: e\n    type: string\n    pattern: '^OPS-[0-9]+$'\n    default: nope\n",
+			"fields[0].default", "must match pattern",
+		},
+		{
+			"one bad member of a multiple default",
+			"  - name: e\n    type: enum\n    multiple: true\n    values: [a, b]\n    default: [a, z]\n",
+			"fields[0].default", `got "z"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errs := parseFieldWorkflow(t, tc.fields)
+			got := findingAt(errs, tc.path)
+			if got == "" {
+				t.Fatalf("no finding at %s; got %v", tc.path, errs)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("%s = %q, want it to contain %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnumDeclarationRejectsUnknownKey holds the custom unmarshaler to the
+// strictness the outer decoder has: a typo inside a field item is a §8.2
+// error, not a silently dropped key.
+func TestEnumDeclarationRejectsUnknownKey(t *testing.T) {
+	_, errs := parseFieldWorkflow(t, "  - name: e\n    valuse: [a]\n")
+	if len(errs) == 0 {
+		t.Fatal("a misspelled field key parsed cleanly")
+	}
+	if !strings.Contains(errs.Error(), "valuse") {
+		t.Errorf("errors = %v, want the unknown key named", errs)
+	}
+}
+
+// TestFieldDefinitionAliasCoversEveryKey guards the one duplication
+// UnmarshalYAML costs: the alias struct restates FieldDefinition's yaml keys,
+// and a key added to one and not the other would decode as an unknown field.
+func TestFieldDefinitionAliasCoversEveryKey(t *testing.T) {
+	typ := reflect.TypeOf(FieldDefinition{})
+	var pairs []string
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		tag := strings.Split(f.Tag.Get("yaml"), ",")[0]
+		if tag == "" || tag == "-" || !f.IsExported() {
+			continue
+		}
+		pairs = append(pairs, tag+": x")
+	}
+	// Every declared key at once. A key the alias forgot would be rejected by
+	// the DisallowUnknownField re-applied inside UnmarshalYAML.
+	src := "  - " + strings.Join(pairs, "\n    ") + "\n"
+	_, errs := parseFieldWorkflow(t, src)
+	if msg := errs.Error(); strings.Contains(msg, "unknown field") {
+		t.Errorf("a declared key is missing from the decode alias: %v", errs)
+	}
+}
+
+func TestEnumValueValidation(t *testing.T) {
+	single := FieldDefinition{Name: "environment", Type: FieldEnum, Values: []string{"dev", "staging", "prod"}}
+	multi := FieldDefinition{Name: "reviewers", Type: FieldEnum, Multiple: true, Values: []string{"ana", "bo", "cy"}}
+
+	if got := single.Validate("staging"); got != "" {
+		t.Errorf("member rejected: %s", got)
+	}
+	if got := single.Validate("nope"); !strings.Contains(got, `got "nope"`) {
+		t.Errorf("non-member message = %q, want the element named", got)
+	}
+	if got := multi.Validate("ana,cy"); got != "" {
+		t.Errorf("member set rejected: %s", got)
+	}
+	if got := multi.Validate("ana,zed"); !strings.Contains(got, `got "zed"`) {
+		t.Errorf("bad element message = %q, want the element named", got)
+	}
+	// Empty is absent, which ValidateTaskFields judges by requiredness.
+	optional := &Workflow{Fields: []FieldDefinition{single}}
+	if errs := optional.ValidateTaskFields(map[string]string{"environment": ""}); len(errs) > 0 {
+		t.Errorf("empty optional enum rejected: %v", errs)
+	}
+	single.Required = true
+	required := &Workflow{Fields: []FieldDefinition{single}}
+	if errs := required.ValidateTaskFields(map[string]string{}); len(errs) != 1 {
+		t.Errorf("required enum with no value = %v, want one error", errs)
+	}
+}
+
+func TestNormalizeMultipleEnum(t *testing.T) {
+	field := FieldDefinition{
+		Name: "reviewers", Type: FieldEnum, Multiple: true,
+		Values: []string{"ana", "bo", "cy"},
+	}
+	for _, tc := range []struct{ in, want string }{
+		{"cy, ana", "ana,cy"},
+		{"cy,cy", "cy"},
+		{"ana,cy", "ana,cy"},
+		{"cy,bo,ana", "ana,bo,cy"},
+		{"  ", ""},
+		{"ana,,cy", "ana,cy"},
+		// An unknown element survives normalization so validation can name it.
+		{"cy,zed", "cy,zed"},
+	} {
+		if got := field.Normalize(tc.in); got != tc.want {
+			t.Errorf("Normalize(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// Every other type is returned untouched: normalization is the multi-value
+	// encoding's business and nothing else's.
+	plain := FieldDefinition{Name: "note", Type: FieldString}
+	if got := plain.Normalize(" b, a "); got != " b, a " {
+		t.Errorf("string Normalize rewrote the value: %q", got)
+	}
+}
+
+// TestPrepareTaskFieldsAppliesRequiredDefaults pins decision 3: only a
+// required field's default is substituted server-side, and normalization runs
+// before membership is judged.
+func TestPrepareTaskFieldsAppliesRequiredDefaults(t *testing.T) {
+	wf := &Workflow{Fields: []FieldDefinition{
+		{Name: "environment", Type: FieldEnum, Required: true, Values: []string{"dev", "staging", "prod"}, Default: "staging"},
+		{Name: "channel", Type: FieldEnum, Values: []string{"alpha", "beta"}, Default: "beta"},
+		{Name: "reviewers", Type: FieldEnum, Multiple: true, Values: []string{"ana", "bo", "cy"}},
+	}}
+	out := wf.PrepareTaskFields(map[string]string{"reviewers": "cy, ana", "custom": "kept"})
+	if out["environment"] != "staging" {
+		t.Errorf("required default = %q, want staging", out["environment"])
+	}
+	if _, ok := out["channel"]; ok {
+		t.Errorf("optional default was invented server-side: %q", out["channel"])
+	}
+	if out["reviewers"] != "ana,cy" {
+		t.Errorf("reviewers = %q, want ana,cy", out["reviewers"])
+	}
+	if out["custom"] != "kept" {
+		t.Errorf("undeclared field dropped: %v", out)
+	}
+	if errs := wf.ValidateTaskFields(out); len(errs) > 0 {
+		t.Errorf("prepared fields failed validation: %v", errs)
+	}
+	// A key present but empty is never defaulted, at any requiredness — which
+	// is what makes the required field's 400 survive an explicit blank.
+	blank := wf.PrepareTaskFields(map[string]string{"environment": ""})
+	if blank["environment"] != "" {
+		t.Errorf("an explicit empty value was defaulted to %q", blank["environment"])
+	}
+	if errs := wf.ValidateTaskFields(blank); len(errs) != 1 {
+		t.Errorf("explicit empty required field = %v, want one error", errs)
+	}
+	// Nothing to do means nothing copied: a workflow declaring no fields hands
+	// back exactly the map it was given.
+	empty := &Workflow{}
+	in := map[string]string{"a": "b"}
+	if got := empty.PrepareTaskFields(in); !reflect.DeepEqual(got, in) {
+		t.Errorf("PrepareTaskFields rewrote an undeclared map: %v", got)
+	}
+}
+
+// TestPreviewBindsDefaultsOverSentinels pins the preview rule: a required
+// field binds a value the workflow could actually receive, because
+// SentinelField is by construction not a member of its own enum.
+func TestPreviewBindsDefaultsOverSentinels(t *testing.T) {
+	wf := &Workflow{Fields: []FieldDefinition{
+		{Name: "environment", Type: FieldEnum, Required: true, Values: []string{"dev", "staging", "prod"}, Default: "staging"},
+		{Name: "channel", Type: FieldEnum, Required: true, Values: []string{"alpha", "beta"}},
+		{Name: "ticket", Type: FieldString, Required: true, Default: "OPS-1"},
+		{Name: "note", Type: FieldString, Required: true},
+		{Name: "optional", Type: FieldEnum, Values: []string{"x"}, Default: "x"},
+	}}
+	got := NewPreviewContext(wf, PreviewInput{}).Task.Fields
+	want := map[string]string{
+		"environment": "staging",
+		"channel":     "alpha",
+		"ticket":      "OPS-1",
+		"note":        SentinelField("note"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("preview fields = %v, want %v", got, want)
+	}
+}

--- a/internal/workflow/fields.go
+++ b/internal/workflow/fields.go
@@ -3,8 +3,12 @@ package workflow
 import (
 	"math"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 )
 
 // Field types are a validation and editing vocabulary (§8.1.2, task 022).
@@ -14,7 +18,17 @@ const (
 	FieldInteger = "integer"
 	FieldNumber  = "number"
 	FieldBoolean = "boolean"
+	// FieldEnum is a closed set of strings, declared in `values:` (task 058).
+	// It is the one type that *publishes* what it accepts, which is what lets
+	// a client build a control that cannot be wrong instead of a text box
+	// plus a 400 afterwards.
+	FieldEnum = "enum"
 )
+
+// MultiValueSeparator joins the members of a `multiple: true` enum. Declared
+// order, no spaces, deduplicated: two tasks with the same selection produce
+// the same string, so template output and branch names are stable (task 058).
+const MultiValueSeparator = ","
 
 var decimalNumber = regexp.MustCompile(`^[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$`)
 
@@ -28,6 +42,127 @@ type FieldDefinition struct {
 	Type        string `yaml:"type,omitempty" json:"type"`
 	Required    bool   `yaml:"required,omitempty" json:"required"`
 	Pattern     string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
+	// Values are the members of a `type: enum` field, in declared order.
+	// Declared order is the canonical order a multi-valued selection is
+	// written back in, so this slice is the ordering authority.
+	Values []string `yaml:"values,omitempty" json:"values,omitempty"`
+	// Multiple says an enum accepts more than one member, joined by
+	// MultiValueSeparator. It is per field and enum-only: "a boolean that
+	// accepts more than one boolean" has no meaning.
+	Multiple bool `yaml:"multiple,omitempty" json:"multiple,omitempty"`
+	// Default is the value that applies when the caller omits this key. It is
+	// not enum-specific — any declared field may carry one — and is checked
+	// against this very declaration at load time.
+	Default string `yaml:"default,omitempty" json:"default,omitempty"`
+
+	// defaultShape and valuesShape record a node whose *shape* was wrong —
+	// a mapping `default:`, a `values:` that is not a sequence — so
+	// validateFieldDefinitions can report it at fields[i].default with a
+	// source path like every other structural mistake, rather than as a bare
+	// yaml type error with no path at all.
+	defaultShape string
+	valuesShape  string
+	// defaultSeq records that `default:` was written as a YAML sequence,
+	// which only a `multiple: true` enum may do.
+	defaultSeq bool
+}
+
+// UnmarshalYAML decodes a field declaration, canonicalizing `default:` and
+// `values:` from native YAML scalars to the strings task fields actually
+// carry (task 058 decision 1).
+//
+// It exists because FieldDefinition decodes into Go strings: without it a
+// bare `default: true` on a boolean field or `values: [1, 2, 3]` on an enum
+// would be a yaml type error rather than a schema error, and an author would
+// have to know the value is a string underneath. A scalar's *literal* source
+// text becomes the string, so `default: 1.50` is "1.50" and not "1.5".
+//
+// Nothing here fails: a wrong shape is remembered and reported by
+// validateFieldDefinitions, which owns the `fields[i].default` source path.
+func (f *FieldDefinition) UnmarshalYAML(b []byte) error {
+	// The alias lists every key FieldDefinition declares, because a custom
+	// unmarshaler bypasses the outer decoder's strictness; DisallowUnknownField
+	// is re-applied here so a typo inside a field item is still an error
+	// (§8.2). TestFieldDefinitionAliasCoversEveryKey guards the two lists.
+	var raw struct {
+		Name        string   `yaml:"name"`
+		Label       string   `yaml:"label"`
+		Description string   `yaml:"description"`
+		Type        string   `yaml:"type"`
+		Required    bool     `yaml:"required"`
+		Pattern     string   `yaml:"pattern"`
+		Values      ast.Node `yaml:"values"`
+		Multiple    bool     `yaml:"multiple"`
+		Default     ast.Node `yaml:"default"`
+	}
+	if err := yaml.UnmarshalWithOptions(b, &raw, yaml.DisallowUnknownField()); err != nil {
+		return err
+	}
+	*f = FieldDefinition{
+		Name:        raw.Name,
+		Label:       raw.Label,
+		Description: raw.Description,
+		Type:        raw.Type,
+		Required:    raw.Required,
+		Pattern:     raw.Pattern,
+		Multiple:    raw.Multiple,
+	}
+	if raw.Values != nil {
+		if seq, ok := raw.Values.(*ast.SequenceNode); ok {
+			f.Values = make([]string, 0, len(seq.Values))
+			for _, member := range seq.Values {
+				text, ok := scalarText(member)
+				if !ok {
+					f.valuesShape = "values must be a list of scalar values"
+					f.Values = nil
+					break
+				}
+				f.Values = append(f.Values, text)
+			}
+		} else {
+			f.valuesShape = "values must be a list of scalar values"
+		}
+	}
+	if raw.Default != nil {
+		switch node := raw.Default.(type) {
+		case *ast.SequenceNode:
+			f.defaultSeq = true
+			members := make([]string, 0, len(node.Values))
+			for _, member := range node.Values {
+				text, ok := scalarText(member)
+				if !ok {
+					f.defaultShape = "default must be a scalar value, or a list of them for a multiple enum"
+					members = nil
+					break
+				}
+				members = append(members, text)
+			}
+			f.Default = strings.Join(members, MultiValueSeparator)
+		default:
+			text, ok := scalarText(raw.Default)
+			if !ok {
+				f.defaultShape = "default must be a scalar value, or a list of them for a multiple enum"
+				break
+			}
+			f.Default = text
+		}
+	}
+	return nil
+}
+
+// scalarText is a YAML scalar's literal source text. A null node — `default:`
+// with nothing after it — reads as absent rather than as the string "null",
+// which is what an author who deleted a value meant.
+func scalarText(node ast.Node) (string, bool) {
+	switch node.Type() {
+	case ast.StringType, ast.IntegerType, ast.FloatType, ast.BoolType,
+		ast.InfinityType, ast.NanType:
+		return node.GetToken().Value, true
+	case ast.NullType:
+		return "", true
+	default:
+		return "", false
+	}
 }
 
 // DisplayLabel is the human-facing name, falling back to the map key.
@@ -60,10 +195,16 @@ func validateFieldDefinitions(wf *Workflow, add func(string, string, ...any)) {
 			field.Type = FieldString
 		}
 		if !isFieldType(field.Type) {
-			add(base+".type", "field type must be one of %s, %s, %s, %s; got %q",
-				FieldString, FieldInteger, FieldNumber, FieldBoolean, field.Type)
+			add(base+".type", "field type must be one of %s, %s, %s, %s, %s; got %q",
+				FieldString, FieldInteger, FieldNumber, FieldBoolean, FieldEnum, field.Type)
 		}
-		if field.Pattern == "" {
+		validateEnumDeclaration(field, base, add)
+		validateFieldDefault(field, base, add)
+
+		// An enum's `pattern:` was already reported against the members it
+		// contradicts; saying "only valid for string fields" as well would
+		// name the weaker of the two reasons twice.
+		if field.Pattern == "" || field.Type == FieldEnum {
 			continue
 		}
 		if field.Type != FieldString {
@@ -76,8 +217,165 @@ func validateFieldDefinitions(wf *Workflow, add func(string, string, ...any)) {
 	}
 }
 
+// validateEnumDeclaration checks `values:` and `multiple:` (§8.1.2, task 058).
+// Both belong to `type: enum` and to nothing else, and a member may not carry
+// the separator a multi-valued selection is joined with — a value that cannot
+// be written back unambiguously is a declaration bug, not a run-time one.
+func validateEnumDeclaration(field *FieldDefinition, base string, add func(string, string, ...any)) {
+	if field.valuesShape != "" {
+		add(base+".values", "%s", field.valuesShape)
+		return
+	}
+	if field.Type != FieldEnum {
+		if len(field.Values) > 0 {
+			add(base+".values", "values is only valid for %s fields", FieldEnum)
+		}
+		if field.Multiple {
+			add(base+".multiple", "multiple is only valid for %s fields", FieldEnum)
+		}
+		return
+	}
+	if field.Pattern != "" {
+		// Reported here rather than left to the string-only rule below, so
+		// the message names the actual conflict.
+		add(base+".pattern", "pattern is not valid for %s fields; %s declares its members in values", FieldEnum, FieldEnum)
+	}
+	if len(field.Values) == 0 {
+		add(base+".values", "values is required for %s fields and must not be empty", FieldEnum)
+		return
+	}
+	member := map[string]int{}
+	for i, value := range field.Values {
+		path := base + ".values[" + strconv.Itoa(i) + "]"
+		switch {
+		case strings.TrimSpace(value) == "":
+			add(path, "enum value must not be empty")
+		case strings.Contains(value, MultiValueSeparator):
+			add(path, "enum value %q must not contain %q, which joins a multiple selection",
+				value, MultiValueSeparator)
+		}
+		if at, dup := member[value]; dup {
+			add(path, "enum value %q is already declared at %s.values[%d]", value, base, at)
+			continue
+		}
+		member[value] = i
+	}
+}
+
+// validateFieldDefault checks `default:` against the very declaration it sits
+// in, so a default that could never be accepted at task creation is a load
+// error rather than a surprise later.
+func validateFieldDefault(field *FieldDefinition, base string, add func(string, string, ...any)) {
+	if field.defaultShape != "" {
+		add(base+".default", "%s", field.defaultShape)
+		return
+	}
+	if field.defaultSeq && (field.Type != FieldEnum || !field.Multiple) {
+		add(base+".default", "default may only be a list on a multiple %s field", FieldEnum)
+		return
+	}
+	if field.Default == "" {
+		return
+	}
+	// A declaration that is already broken would produce a second, confusing
+	// error here — "not one of []" for an enum with no members.
+	if field.Type == FieldEnum && len(field.Values) == 0 {
+		return
+	}
+	field.Default = field.Normalize(field.Default)
+	if message := validateTaskFieldValue(*field, field.Default); message != "" {
+		add(base+".default", "%s", message)
+	}
+}
+
 func isFieldType(value string) bool {
-	return value == FieldString || value == FieldInteger || value == FieldNumber || value == FieldBoolean
+	switch value {
+	case FieldString, FieldInteger, FieldNumber, FieldBoolean, FieldEnum:
+		return true
+	}
+	return false
+}
+
+// Normalize canonicalizes one value for this declaration. For a `multiple`
+// enum that means splitting on the separator, trimming, dropping empties,
+// deduplicating and rejoining in **declared** order; every other type is
+// returned unchanged.
+//
+// It runs ahead of validation on create (task 058 decision 2) so that every
+// client — TUI, `--field`, `--fields-file`, curl — produces the same stored
+// string for the same selection, and so a membership error names the element
+// the caller actually wrote. An element the declaration does not know is
+// preserved in place, because rejecting it is validation's job and dropping
+// it would hide the mistake.
+func (f FieldDefinition) Normalize(value string) string {
+	if f.Type != FieldEnum || !f.Multiple {
+		return value
+	}
+	picked := make([]string, 0, len(f.Values))
+	var unknown []string
+	seen := map[string]bool{}
+	for _, part := range strings.Split(value, MultiValueSeparator) {
+		part = strings.TrimSpace(part)
+		if part == "" || seen[part] {
+			continue
+		}
+		seen[part] = true
+		if slices.Contains(f.Values, part) {
+			picked = append(picked, part)
+			continue
+		}
+		unknown = append(unknown, part)
+	}
+	slices.SortStableFunc(picked, func(a, b string) int {
+		return slices.Index(f.Values, a) - slices.Index(f.Values, b)
+	})
+	return strings.Join(append(picked, unknown...), MultiValueSeparator)
+}
+
+// PrepareTaskFields is what a create call runs before ValidateTaskFields: it
+// substitutes a **required** field's declared default for an omitted key and
+// canonicalizes every declared value (task 058 decisions 2 and 3).
+//
+// Only a required field's default is substituted. An optional field's default
+// is published through GET /v1/workflows and seeded by clients, but the daemon
+// never invents it: an optional field the caller omitted stays genuinely
+// absent from .Task.Fields, so `{{ with index .Task.Fields "x" }}` keeps
+// meaning what it means today and adding a `default:` to an existing optional
+// field is not a silent behaviour change for workflows that guard on presence.
+// A key that is present but empty is never defaulted, at any requiredness.
+//
+// values is never mutated: the map is copied only if something changes, so a
+// workflow that declares no fields hands back exactly what it was given.
+func (w *Workflow) PrepareTaskFields(values map[string]string) map[string]string {
+	if w == nil || len(w.Fields) == 0 {
+		return values
+	}
+	out, copied := values, false
+	for _, field := range w.Fields {
+		if field.Name == "" {
+			continue
+		}
+		value, present := values[field.Name]
+		if !present {
+			if !field.Required || field.Default == "" {
+				continue
+			}
+			value = field.Default
+		}
+		normalized := field.Normalize(value)
+		if present && normalized == value {
+			continue
+		}
+		if !copied {
+			out = make(map[string]string, len(values)+len(w.Fields))
+			for k, v := range values {
+				out[k] = v
+			}
+			copied = true
+		}
+		out[field.Name] = normalized
+	}
+	return out
 }
 
 // ValidateTaskFields validates only declared fields. Additional keys are
@@ -134,12 +432,35 @@ func validateTaskFieldValue(field FieldDefinition, value string) string {
 		if value != "true" && value != "false" {
 			return "field " + strconv.Quote(field.Name) + " must be true or false"
 		}
+	case FieldEnum:
+		return validateEnumValue(field, value)
 	case FieldString:
 		if field.Pattern != "" {
 			pattern, err := regexp.Compile(field.Pattern)
 			if err != nil || !pattern.MatchString(value) {
 				return "field " + strconv.Quote(field.Name) + " must match pattern " + strconv.Quote(field.Pattern)
 			}
+		}
+	}
+	return ""
+}
+
+// validateEnumValue checks membership, naming the element that failed rather
+// than the whole value: for a `multiple` field "reviewers" the useful sentence
+// is which of the three names is not a reviewer.
+func validateEnumValue(field FieldDefinition, value string) string {
+	parts := []string{value}
+	if field.Multiple {
+		parts = strings.Split(value, MultiValueSeparator)
+	}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if !slices.Contains(field.Values, part) {
+			return "field " + strconv.Quote(field.Name) + " must be one of " +
+				strings.Join(field.Values, ", ") + "; got " + strconv.Quote(part)
 		}
 	}
 	return ""

--- a/internal/workflow/preview.go
+++ b/internal/workflow/preview.go
@@ -102,11 +102,27 @@ func PreviewLoop() LoopContext {
 
 // previewFields binds the task fields a preview can honestly claim: every
 // declared **required** field, overridden by anything the caller supplied.
+//
+// A required field binds, in order: its `default:` when it has one; else, for
+// an enum, its first declared value; else the sentinel. The two real values
+// come first because SentinelField("environment") is `<field.environment>`,
+// which is by construction not a member of its own enum — a preview that
+// bound it would render something the workflow could never receive (task
+// 058). Optional fields stay absent, which is exactly what POST /v1/tasks
+// guarantees: the preview binds only what it can honestly claim.
 func previewFields(wf *Workflow, supplied map[string]string) map[string]string {
 	out := make(map[string]string, len(supplied))
 	if wf != nil {
 		for _, f := range wf.Fields {
-			if f.Required && f.Name != "" {
+			if !f.Required || f.Name == "" {
+				continue
+			}
+			switch {
+			case f.Default != "":
+				out[f.Name] = f.Default
+			case f.Type == FieldEnum && len(f.Values) > 0:
+				out[f.Name] = f.Values[0]
+			default:
 				out[f.Name] = SentinelField(f.Name)
 			}
 		}

--- a/skills/vincent-workflows/SKILL.md
+++ b/skills/vincent-workflows/SKILL.md
@@ -105,7 +105,13 @@ than guessing. See the cost reference for the full rules.
   returns no arbitrary value or credential, puts the task in `awaiting_gate`,
   and releases its concurrency slot.
 - Use declared task `fields` for typed choices known when the task is created.
-  Vincent has no generic between-step form that returns a new value.
+  Vincent has no generic between-step form that returns a new value. A field
+  whose legal values are a fixed set is `type: enum` with `values:`, not a
+  `string` with a pattern spelling the same alternation and not a set restated
+  in the description — only a published list becomes a picker in New task. Add
+  `multiple: true` when more than one may be chosen, and `default:` (valid on
+  any type) when there is an obvious value, so a scripted caller need not
+  restate it.
 - Use `on_input: require` only when an agent must ask a question and continue
   the same reasoning session. It requires an adapter that supports mid-run
   input and cannot be nested in `parallel` or `loop` or used by a merge

--- a/skills/vincent-workflows/references/workflow-schema.md
+++ b/skills/vincent-workflows/references/workflow-schema.md
@@ -62,9 +62,23 @@ Each field declaration supports:
 | `name` | slug | Required and unique; key in `.Task.Fields` |
 | `label` | string | Presentation only; defaults to `name` |
 | `description` | string | Help shown by clients |
-| `type` | `string`, `integer`, `number`, `boolean` | Defaults to `string`; stored value remains a string |
+| `type` | `string`, `integer`, `number`, `boolean`, `enum` | Defaults to `string`; stored value remains a string |
 | `required` | boolean | Whitespace-only counts as absent |
 | `pattern` | Go RE2 string | Only for strings; use `^...$` for whole values |
+| `values` | list of scalars | Required for `enum`, rejected on every other type. Unique, non-empty, no `,` in a member |
+| `multiple` | boolean | `enum` only: more than one member may be picked |
+| `default` | scalar | Any type. Written as its own YAML scalar (`default: true`, `default: 3`) |
+
+A closed set of values is `type: enum` with `values:`, never a `string` with a
+pattern spelling the same alternation: only a list can be published, and only a
+published list becomes a picker in New task. A `multiple: true` field stores its
+members joined with `,` in declared order (`dev,prod`), which the daemon
+normalizes to on create.
+
+`default:` applies when the caller omits the key. The daemon substitutes a
+**required** field's default and records it on the task; an **optional** field's
+default is seeded by clients only, so an optional key the caller omitted is
+still absent from `.Task.Fields`.
 
 Undeclared fields remain allowed. Optional absent values skip type and pattern
 validation. Read an optional value defensively:


### PR DESCRIPTION
## Summary

`fields:` gains a fifth type, `enum`, whose members are declared in `values:`
and whose cardinality is declared per field in `multiple:`, plus a `default:`
that belongs to every field type.

A regex validates but does not *publish*. `pattern: '^(dev|staging|prod)$'`
went out over `GET /v1/workflows` as a pattern, not a list, so no client could
enumerate the members: New task drew a free-text row for a value with three
legal spellings, a typo was a 400 after the fact, and the set ended up restated
in the field's `description` prose so it was discoverable at all — where it then
drifted from the pattern. Booleans already get a real selector for exactly this
reason.

Task fields stay `map[string]string` in storage, on the wire, in templates, in
branch names and in fan-out inheritance (task 022 decision 1). The daemon stays
the authoritative validation boundary (022 decision 5) and the field map stays
open (022 decision 3).

**Schema.** `values:` is required for `enum` and an error on every other type;
members are unique, non-empty and may not contain `,`. `multiple:` is likewise
`enum`-only. `pattern` alongside `enum` is an error — the members *are* the
constraint. Every rule reports its own source path, so a bad declaration makes
the workflow visibly invalid rather than failing at task creation.

**Native scalars.** `default:` and `values:` decode as YAML nodes and are
canonicalized to the string the field carries, using the scalar's *literal*
source text. `default: true`, `default: 3`, `default: 1.50` ("1.50", not "1.5")
and `values: [1, 2]` all load; a `multiple` enum's `default:` may also be a
sequence. A mapping, or a sequence anywhere else, is a load error at
`fields[i].default`.

**Normalization.** `POST /v1/tasks` splits a `multiple` value on `,`, trims,
drops empties, deduplicates, reorders to **declared** order and rejoins, then
checks membership. `--field reviewers="cy, ana"` is stored as `ana,cy`, so the
same selection is the same string from the TUI, `--field`, `--fields-file` and
curl — which is what keeps template output and branch names stable — and a 400
names the element that failed. This extends 022 decision 5 rather than
reversing it: the daemon remains the one gate and gains one deterministic
canonicalizing step ahead of it. Recorded as decision 2 in the task document
because "the daemon validates, it does not rewrite" is a reasonable reading of
022 that a reviewer may hold.

**Defaults.** Only a **required** field's `default:` is substituted
server-side, so a scripted caller that omits it gets a task rather than a 400
and the row records what applied. An **optional** field's default is published
and seeded by clients only; the daemon never invents it, so an optional key the
caller omitted stays absent from `.Task.Fields` and adding a `default:` to an
existing optional field is not a silent change for a workflow that guards with
`{{ with index .Task.Fields "x" }}`. A key present but empty is never
defaulted.

**Preview.** A required field binds its `default:`, else an enum's first
declared value, else the existing `SentinelField` — `<field.environment>` is by
construction not a member of its own enum, so a preview that bound it rendered
something the workflow could never receive.

**New task.** `enter` on a declared enum row opens the same scrollable,
filterable picker the override rows use, with the current selection
highlighted; `left`/`right` step through the members in place the way a boolean
cycles; a `multiple` field toggles membership with the list open and is
rewritten in declared order on every toggle. Declared rows stay locked to their
key and undeletable. An optional single-choice field gets an `(unset)` row and
an extra stepping stop, since a workflow-owned row cannot be deleted.

Older clients see an unknown `type: enum`, fall through to a free-text row and
run no local check; the daemon still gates.

## Related

Closes #245
Closes 058.1 (new task document `docs/tasks/058-enum-task-fields.md`).

Extends, and does not reopen, task 022 decisions 1, 3 and 5 — 022 decision 2's
type vocabulary is a starting list whose own beat argues for "a small enum [of
types that] gives the TUI meaningful controls", which is the argument this makes
one level down. Task 022 decision 4 is unchanged and now stated in §8.1.2: a
fan-out lane's `fields:` overrides are still not validated against the root
workflow's declarations, so a lane may bind a non-member. That is existing
behaviour, written down so it is not filed as a bug later.

Spec §8.1.2 and §8.4 are amended in place with dated notes (2026-08-30, task
058), in this PR.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`docs/` updated: `spec.md` §8.1.2, §8.4 and §14's New task item,
`reference/workflow-schema.md`, `reference/api.md`, `reference/cli.md`,
`guides/workflows.md`, `guides/tui.md`, `features.md`,
`tasks/058-enum-task-fields.md` and its index row. Also
`skills/vincent-workflows/SKILL.md` and its `references/workflow-schema.md`,
which are runtime text: the skill is spliced into both built-in prompts at build
time, so its enum guidance and `update-workflows`' new checklist item 5 (*Closed
sets and defaults*) say the same thing. The built-ins' own `fields:` were
re-audited per task 037 decision 5 and neither changes — `create-workflow`'s
`workflow_name` is a genuine free string with a file-name pattern, and its
`global` boolean documents "false, or left unset" as meaningful, which a
`default:` would quietly redefine.

`reference/cli.md` needs no *transport* change — `task add --field` and
`--fields-file` gain no flag and the cobra tree is untouched — but a docs audit
caught three behaviour claims on the page that the change did make stale, all
now fixed: the confirmation line lists a required field the daemon filled in
from its `default:` and not only one filled in from `--github-issue`;
`--fields-file`'s "everything the daemon validates" list omitted `enum`
membership; and `workflow render` binds a required field to its `default:`,
else an `enum`'s first declared value, else `<field.NAME>`, where the page said
only that it binds. The same audit qualified two sentences that read as though
`←`/`→` step a `multiple` enum row — `fieldsEditor.stepEnum` returns early for
one — and added the `(unset)` stop an optional single-choice row has, in
`guides/tui.md` and `reference/workflow-schema.md`. Spec §14's New task item
enumerates the Fields row's controls with a dated note per task that added one
(022, M5, 020, 035); the enum picker had none and now has one.

**Not done, deliberately:** `scripts/screenshots.sh` was not re-run. The Fields
*editor* changed shape (a `multiple` tag, a values line, the enum placeholder
and a new footer hint), but no image under `docs/assets/` photographs it — the
`tui-new-task` tape drives the form to its review stage without opening the
editor — and the collapsed Fields *row* renders exactly as before. Confirmed
twice over: **no workflow the script seeds declares `fields:` at all**
(`grep -n 'fields:' scripts/screenshots.sh` is empty), so every changed
rendering path is one the captured frames cannot reach. Re-running the script
would rewrite eight PNGs with no change any of them can show.

**Found, not fixed — outside this change.** `.vincent/workflows/prepare-release.yaml`
declares the exact anti-pattern this PR exists to remove, twice:
`dependencies` is `type: string` with `pattern: '^(none|security|all)$'` and
`docs` is `type: string` with `pattern: '^(none|check|fix)$'`, each with its
members restated in `description` prose. Both should be `type: enum` with
`values:` — that is precisely what the new item 5 of `update-workflows`' "The
bar" checklist tells an agent to do. Converting them is a behaviour change to
this repository's own release workflow rather than a documentation edit, so it
is left for its own piece of work.

**No gate script.** This is a schema and form-contract change with no daemon
end-to-end behaviour a gate would exercise that the API tests do not; the picker
is judged by eye, the way M3 and task 017 are.

Tests: schema rules each asserted against their source path, native-scalar
canonicalization, membership for single and `multiple`, normalization order and
idempotence, the API's required-default substitution and its refusal to invent
an optional one, a `*live_test.go` pinning the server DTO and the `apiclient`
type against each other for `values`/`multiple`/`default`, the preview binding
order, the TUI picker (open, scroll, commit, step in place, toggle in declared
order, locked rows) and its local validation message, and the CLI e2e proving
`--field` and `--fields-file` surface the daemon's membership error unchanged.
`go run mage.go test` and `go run mage.go lint` are green, and the linter was
run for `windows`, `darwin` and `linux`.
