### PR TITLE
feat(tui): add a task-details tab inside the three form popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ list with the user-facing context a commit subject cannot carry.
   is a visibly invalid workflow with a source path, not a surprise at task
   creation.
 
+- **A task-details tab inside the answer, repair and follow-up popups.** All
+  three form popups now carry a two-tab strip of their own — the form and
+  **Task details** — switched with `ctrl+t` while the popup stays open. The
+  second tab is the same read-only inspector the task workspace's Task Details
+  tab shows, with its own sidebar and scroll, so the prompt, the workflow and
+  step that is asking, the agent and model, the timings and the linked GitHub
+  issue are all readable while you decide. Nothing about the draft changes
+  across the switch: picked options, typed answers and half-written repair or
+  follow-up prompts are exactly where you left them. `ctrl+t` works while a text
+  field or a picker has the keyboard and types nothing into it; on the details
+  tab `esc` returns to the form rather than closing the popup. Previously the
+  only way to the task's context was `esc`, which discards the repair and
+  follow-up drafts outright.
+
 - **A pull-requests screen in the TUI, and a browser to open them in.** A new
   takeover lists every open pull request across every registered project whose
   `origin` is a github.com repository vincent can authenticate to, grouped by
@@ -226,6 +240,13 @@ list with the user-facing context a commit subject cannot carry.
   filesystem and the shell, and that is all it claims to bound.
 
 ### Fixed
+
+- **The footer and `?` described the wrong surface while an answer, repair or
+  follow-up popup was open.** The task workspace fell through to the current
+  tab's context, so a popup that owned the keyboard was documented as the Steps
+  tab and the keys registered for the three forms were unreachable from the
+  footer. The `?` sheet also never printed a follow-up form section at all. All
+  three popups now name themselves, and the sheet prints all three.
 
 - **`GET /v1/tasks/{id}/diff` measured the diff from the wrong commit once a task
   started from a fetched base.** The merge-base was computed against the base

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -519,11 +519,8 @@ keystroke is how an answer gets lost. It announces itself and waits for you.
 ### Reading the task without leaving the popup
 
 All three popups — the answer form, the repair form and the follow-up form —
-have a two-tab strip of their own along the top:
-
-```
- Question │ Task details   ctrl+t
-```
+have a two-tab strip of their own along the top: the form itself, named
+**Question**, **Repair** or **Follow-up**, and **Task details**.
 
 `ctrl+t` switches between them and the popup stays open. **Task details** is
 the same inspector the workspace's Task Details tab shows, with the same

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -424,6 +424,7 @@ this task's worktree, on this task's branch.
 | `enter` | Open the row under the cursor — the prompt field, or that row's picker |
 | `e` | Write the prompt in `$EDITOR` instead |
 | `ctrl+s` | Start the repair |
+| `ctrl+t` | Switch between the form and this task's details, without leaving the popup |
 | `esc` | Close without repairing — the draft is discarded |
 
 The prompt is the only required row, and it is prose: write what you want done,
@@ -457,6 +458,7 @@ the commit a reviewer asked for, drop the stray file the agent left.
 | `enter` | Open the row under the cursor — the run-form list, the text field, or that row's picker |
 | `e` | Write the prompt or command in `$EDITOR` instead |
 | `ctrl+s` | Start the follow-up |
+| `ctrl+t` | Switch between the form and this task's details, without leaving the popup |
 | `esc` | Close without running anything — the draft is discarded |
 
 The top row picks what kind of run this is, and it decides what the row under it
@@ -502,6 +504,7 @@ answer form.
 | `space` | Pick an option (toggles, for a multi-select question) |
 | `e` | Type your own answer — options are suggestions, never a list |
 | `enter` | Submit; the run resumes in the same session where it stopped |
+| `ctrl+t` | Switch between the question and this task's details, without leaving the popup |
 | `esc` | Close without answering (what you picked is kept) |
 
 While `e` has a field open, `enter` keeps what you typed and `esc` discards it —
@@ -512,6 +515,33 @@ the same way.
 
 The form is a popup, and it **never steals focus**: auto-opening under a
 keystroke is how an answer gets lost. It announces itself and waits for you.
+
+### Reading the task without leaving the popup
+
+All three popups — the answer form, the repair form and the follow-up form —
+have a two-tab strip of their own along the top:
+
+```
+ Question │ Task details   ctrl+t
+```
+
+`ctrl+t` switches between them and the popup stays open. **Task details** is
+the same inspector the workspace's Task Details tab shows, with the same
+sidebar and the same `↑`/`↓` and `pgup`/`pgdn` keys: the original prompt, the
+project, the workflow and the step that is asking, the agent, model and effort,
+the timings and cost, and the linked GitHub issue or pull request.
+
+Nothing about your draft changes while you read. Options you picked, an answer
+you typed, a half-written repair or follow-up prompt and the agent/model/effort
+you chose are all exactly where you left them when you press `ctrl+t` again.
+That matters most on the repair and follow-up forms, where `esc` throws the
+draft away — before this, looking something up meant retyping the prompt.
+
+`ctrl+t` works while a text field or a picker is open, and types nothing into
+it. On the Task details tab the pane is strictly read-only: no task action
+fires from it, and it offers neither `o` nor `P`. `esc` there goes back to the
+form rather than closing the popup — one layer per press — so closing a popup
+from the details tab takes two.
 
 ## The takeover screens
 
@@ -859,7 +889,7 @@ Global bindings — active whenever the focused surface is not capturing text:
 | `!` | Jump to the next task needing a human |
 | `n` | New task |
 | `M` | Toggle the mouse |
-| `esc` | Close one layer: popup → screen → selection → filter — never quits |
+| `esc` | Close one layer: popup tab → popup → screen → selection → filter — never quits |
 | `q` | Quit the TUI (the daemon keeps running) |
 | `ctrl+c` | Quit |
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4932,9 +4932,9 @@ stream for the live tail.
    `GET /v1/agents` pickers the new-task flow uses (§8.6, with the request
    standing in for the step level). `ctrl+s` starts the repair, `esc` closes it
    and discards the draft — which is why `ctrl+t` (above, task 059) rather than
-   `esc` is the way out to the task's details. It is a popup and not an action key because a repair
-   needs prose written for this one task — which is also why it is excluded from
-   bulk actions.
+   `esc` is the way out to the task's details. It is a popup and not an action
+   key because a repair needs prose written for this one task — which is also
+   why it is excluded from bulk actions.
 
    The detail timeline must render a repair's StepRun as **its own labeled
    entry** under the blocked step, never as another attempt of that step (§5.4):
@@ -4952,9 +4952,9 @@ stream for the live tail.
    picked from `GET /v1/workflows` — and the same agent/model/effort pickers
    follow. `ctrl+s` starts the run, `esc` closes and discards the draft; as with
    repair, `ctrl+t` (above, task 059) is the way to read the task's details
-   without paying that. Like
-   repair it is excluded from bulk actions (task 011): the input is written for
-   one task, and the batch case is `vincent task follow-up` (§12.1).
+   without paying that. Like repair it is excluded from bulk actions (task 011):
+   the input is written for one task, and the batch case is
+   `vincent task follow-up` (§12.1).
 
    The detail timeline must render a follow-up round as **its own tier**, headed
    as a round rather than numbered as a step: its rows sit at
@@ -5362,8 +5362,11 @@ on an error, where it is the error and may be the only content there is.
 
 Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
-serves neither. Takeovers are for surfaces you visit deliberately; popups are for
-small things — the palette, confirmations, and the answer form.
+serves neither. Takeovers are for surfaces you visit deliberately; popups are
+for what interrupts you — the palette, confirmations, and the three form popups.
+*(Amended 2026-08-30, task 059: the dividing line is the interruption, not the
+size. A form popup with a tab strip takes the whole height budget and carries
+the task inspector inside it, and is no longer a small thing.)*
 
 ### Workflow graph
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4901,13 +4901,38 @@ stream for the live tail.
    auto-opening under a keystroke is how an answer gets lost, so it announces
    itself with a badge on the row and a footer hint, and the human opens it.
 
+   **The popup's own tab strip (task 059, added 2026-08-30).** All three form
+   popups below — answer, repair and follow-up — carry a two-tab strip of their
+   own as their first body line: the form (**Question** / **Repair** /
+   **Follow-up**) and **Task details**. `ctrl+t` cycles them while the popup
+   stays open. The second tab is the same read-only inspector the workspace's
+   Task Details tab shows — the section sidebar, every section, its own scroll —
+   and it is the popup's own instance of it, so reading inside the popup never
+   moves the workspace tab behind it and switching tabs never disturbs the
+   draft. That is the point: deciding what to answer needs the prompt, the
+   workflow and step asking, the agent, and the linked GitHub issue, and until
+   this the only way to any of them was `esc`, which costs the repair and
+   follow-up forms their draft outright.
+
+   Inside the popup the details tab is read-only more strictly than the
+   workspace tab is: unhandled keys stop at the pane rather than reaching the
+   task's actions, and neither `o` (open the pull request) nor `P` (open the
+   compare-URL editor) is offered — a popup that can raise a second popup is
+   not a reference surface. `ctrl+t` is taken by the workspace *before* the form
+   sees the press, which is what makes it work while the free-text editor, a
+   prompt `textarea` or an agent/model/effort picker has the keyboard. A popup
+   with tabs takes the whole height budget on both tabs rather than shrinking to
+   its form, so the frame does not resize under the reader on a `ctrl+t`. The
+   compare-URL editor (§13.2, task 052.6) has no tab strip.
+
    **Repair popup (task 025, added 2026-08-24).** On a `blocked` task, `R` opens
    a second popup that owns the keyboard the way the answer form does: a
    required free-text prompt (`enter` edits it inline, `e` opens it in
    `$EDITOR`) and optional agent/model/effort rows fed by the same
    `GET /v1/agents` pickers the new-task flow uses (§8.6, with the request
    standing in for the step level). `ctrl+s` starts the repair, `esc` closes it
-   and discards the draft. It is a popup and not an action key because a repair
+   and discards the draft — which is why `ctrl+t` (above, task 059) rather than
+   `esc` is the way out to the task's details. It is a popup and not an action key because a repair
    needs prose written for this one task — which is also why it is excluded from
    bulk actions.
 
@@ -4925,7 +4950,9 @@ stream for the live tail.
    "prompt" and "shell command" would guess wrong half the time. The chooser
    decides what the row under it means — a prompt, a command, or a workflow
    picked from `GET /v1/workflows` — and the same agent/model/effort pickers
-   follow. `ctrl+s` starts the run, `esc` closes and discards the draft. Like
+   follow. `ctrl+s` starts the run, `esc` closes and discards the draft; as with
+   repair, `ctrl+t` (above, task 059) is the way to read the task's details
+   without paying that. Like
    repair it is excluded from bulk actions (task 011): the input is written for
    one task, and the batch case is `vincent task follow-up` (§12.1).
 
@@ -5523,9 +5550,12 @@ re-reads a registry or the daemon blocks. One key jumps to the next task needing
 human, surfaced in the footer only when that count is non-zero — the board has
 always pinned and belled those tasks without offering any way to *go* to one.
 
-**`esc` cancels one layer per press**, by a fixed stack: popup (palette,
-confirmation, answer form) → takeover screen → bulk selection → active filter →
-nothing. It is a
+**`esc` cancels one layer per press**, by a fixed stack: *(amended 2026-08-30,
+task 059)* a form popup's Task details tab → popup (palette, confirmation,
+answer form) → takeover screen → bulk selection → active filter →
+nothing. The innermost layer is the newest: on a form popup's details tab `esc`
+returns to the form tab with the draft untouched and the popup still open, and
+only a second press carries the popup's own `esc` meaning. It is a
 no-op at the bottom and it **never quits** — `esc`-to-exit surprises anyone who
 pressed it meaning "back". "Back to the board" is not among its meanings any more,
 because the board is always on screen.

--- a/docs/tasks/059-popup-task-details-tab.md
+++ b/docs/tasks/059-popup-task-details-tab.md
@@ -23,7 +23,7 @@ practice people decide without looking. A step can sit in `awaiting_input` for
 `input_timeout` (24 h by default) while someone works this out.
 
 Two premises from the issue did not survive reading the code, and are corrected
-in decision 1 and decision 2 below.
+in decision 1 and decision 7 below.
 
 ## Decisions
 
@@ -48,19 +48,7 @@ follow-up if it is ever wanted.
 **Beat:** deleting the shell's dead popup path in the same change. It is a
 second reviewable thing with its own risk of taking a live test with it.
 
-**2. `overlayPopup` becomes a free function, because it is already shared.**
-*(2026-08-30)*
-
-`shell.overlayPopup` *is* live, despite decision 1: `taskView.render` builds a
-throwaway `shell{detail: t.detail, bodyW: t.width, bodyH: t.height}` and calls
-it, borrowing the renderer rather than duplicating it. That throwaway is
-constructed fresh every frame and can carry no tab state, so `overlayPopup` now
-takes the popup state it draws — `overlayPopup(bg, bodyW, bodyH, popupOverlay)`
-— and the tab and its pane live on the view that owns the popup. The three
-forms reach it through a small `popupForm` interface (`height`, `render`),
-which is all three already had in common.
-
-**3. The Details tab is the sidebar renderer, from an extracted sub-model.**
+**2. The Details tab is the sidebar renderer, from an extracted sub-model.**
 *(2026-08-30)*
 
 `renderDetails` is a two-pane layout — a 16–24 column section sidebar against an
@@ -77,7 +65,7 @@ reads `t.pull`, which the pane has no business fetching.
 is a second thing to keep in sync and reintroduces "leave to see the rest",
 which is the whole complaint.
 
-**4. A popup with tabs takes the full height budget.** *(2026-08-30)*
+**3. A popup with tabs takes the full height budget.** *(2026-08-30)*
 
 `ph = max(bodyH-4, 6)`, replacing `min(height(inner)+2, max(bodyH-4, 6))` for
 these three. No frame jitter across a `ctrl+t`, and the Details tab gets every
@@ -86,7 +74,7 @@ now floats in a full-height box. Accepted as the cost of a frame that does not
 resize under the reader. The compare-URL editor, outside this change, keeps
 sizing to its content.
 
-**5. `ctrl+t` switches the tabs, intercepted before the form.** *(2026-08-30)*
+**4. `ctrl+t` switches the tabs, intercepted before the form.** *(2026-08-30)*
 
 It is unbound anywhere in `bindings.go`, non-printable, and passes through
 every sub-mode these popups have: the answer form's free-text `textarea`, the
@@ -96,13 +84,13 @@ these popups already use. `taskView.updatePopupKey` takes it **before** the form
 sees it — that seam is the one thing that makes it survive a focused editor —
 and the forms themselves stay unaware that they have tabs.
 
-**6. `esc` on the Task details tab returns to the form tab.** *(2026-08-30)*
+**5. `esc` on the Task details tab returns to the form tab.** *(2026-08-30)*
 
 One layer per press, which is 017 decision 13's rule as task 053 restated it. It
 does not close the popup and it does not touch the draft. `esc` on the form tab
 keeps its existing per-popup meaning. §15's `esc` stack gains this inner layer.
 
-**7. The Task details tab is read-only, and more strictly than the workspace
+**6. The Task details tab is read-only, and more strictly than the workspace
 tab is.** *(2026-08-30)*
 
 `updateDetailsKey`'s `default` arm forwards unhandled keys to
@@ -110,6 +98,18 @@ tab is.** *(2026-08-30)*
 the popup that arm is not taken, and `o` (open the pull request) and `P` (open
 the create-PR form) are not offered: a popup that can raise a second popup is
 not a reference surface.
+
+**7. `overlayPopup` becomes a free function, because it is already shared.**
+*(2026-08-30)*
+
+`shell.overlayPopup` *is* live, despite decision 1: `taskView.render` builds a
+throwaway `shell{detail: t.detail, bodyW: t.width, bodyH: t.height}` and calls
+it, borrowing the renderer rather than duplicating it. That throwaway is
+constructed fresh every frame and can carry no tab state, so `overlayPopup` now
+takes the popup state it draws — `overlayPopup(bg, bodyW, bodyH, popupOverlay)`
+— and the tab and its pane live on the view that owns the popup. The three
+forms reach it through a small `popupForm` interface (`height`, `render`),
+which is all three already had in common.
 
 ## A gap this closed on the way
 
@@ -137,10 +137,10 @@ answer form's multi-select. A shot of the new tab would need a new tape in
   against it. ✓ 2026-08-30
 - [x] **059.2** Turn `shell.overlayPopup` into a free function over a
   `popupOverlay`, drawing the two-tab strip as the popup's first body line and
-  sizing per decision 4. ✓ 2026-08-30
+  sizing per decision 3. ✓ 2026-08-30
 - [x] **059.3** Give `taskView` a per-popup tab index and details pane, with
   `ctrl+t` and the details-tab `esc` intercepted in `updatePopupKey` ahead of
-  the form, and the tab read-only per decision 7. ✓ 2026-08-30
+  the form, and the tab read-only per decision 6. ✓ 2026-08-30
 - [x] **059.4** Register `ctrl+t` in `ctxForm`, `ctxRepairForm` and
   `ctxFollowUpForm` with probes; add the three `bindingContext` arms and the
   follow-up section to the `?` sheet; add each form's hint. ✓ 2026-08-30

--- a/docs/tasks/059-popup-task-details-tab.md
+++ b/docs/tasks/059-popup-task-details-tab.md
@@ -1,0 +1,149 @@
+# 059 — A task-details tab inside the answer, repair and follow-up popups
+
+**Status:** ✅ done (5/5)
+**Spec:** amends §15 (the three form popups, and the `esc` stack)
+**Issue:** #251
+
+## Problem
+
+When an agent raises a §7.4 input request the task parks in `awaiting_input`
+and the TUI offers the answer popup. Deciding what to answer usually needs the
+task's own context — the original prompt, which workflow and step is asking,
+the agent and model, the linked GitHub issue — and while the popup is open none
+of it is reachable. The popup owns the keyboard (`taskView.capturesInput`
+returns true while `popup` is set, and `updateKey` returns early into
+`updatePopupKey` before the `tab` / `1`–`5` cases), and it is drawn at nearly
+the full body width, so the panels it floats over carry little of the answer.
+
+The only escape was `esc`, and what it costs differs per popup. The answer form
+keeps `detail.form`, so the picks come back on the next `enter` — a round trip
+through a closed question. The repair (`R`) and follow-up (`F`) forms discard
+the draft outright, so looking something up means retyping the prompt, and in
+practice people decide without looking. A step can sit in `awaiting_input` for
+`input_timeout` (24 h by default) while someone works this out.
+
+Two premises from the issue did not survive reading the code, and are corrected
+in decision 1 and decision 2 below.
+
+## Decisions
+
+**1. Scope is `taskView` only — three popups, not two surfaces.**
+*(2026-08-30)*
+
+The issue asks for "both surfaces": `shell.overlayPopup` on the board home
+screen and `taskView`'s popup path. There is only one. Since task 049,
+`views.go` sets `home.boardOnly = true` and `updateBoardOnly` sends `enter` out
+as a `selectTaskMsg` and drops `R`/`F` into the board, so `shell.popup` is never
+set on the shipped path: `shell.updateKey`'s three popup branches,
+`shell.capturesInput`'s popup arm and `shell.paste`'s popup arm are reachable
+only from the focused component tests in `shell_test.go`. The issue's "on the
+board home screen there is no Details tab to arrive at once you are out" no
+longer describes anything — there is no way to be in a popup there.
+
+That routing is left exactly as it is. This change does not clean up that
+surface, and the create-PR form (task 052.6) does not get the tab either, even
+though its `esc` discards a draft for the same reason. It is a separable
+follow-up if it is ever wanted.
+
+**Beat:** deleting the shell's dead popup path in the same change. It is a
+second reviewable thing with its own risk of taking a live test with it.
+
+**2. `overlayPopup` becomes a free function, because it is already shared.**
+*(2026-08-30)*
+
+`shell.overlayPopup` *is* live, despite decision 1: `taskView.render` builds a
+throwaway `shell{detail: t.detail, bodyW: t.width, bodyH: t.height}` and calls
+it, borrowing the renderer rather than duplicating it. That throwaway is
+constructed fresh every frame and can carry no tab state, so `overlayPopup` now
+takes the popup state it draws — `overlayPopup(bg, bodyW, bodyH, popupOverlay)`
+— and the tab and its pane live on the view that owns the popup. The three
+forms reach it through a small `popupForm` interface (`height`, `render`),
+which is all three already had in common.
+
+**3. The Details tab is the sidebar renderer, from an extracted sub-model.**
+*(2026-08-30)*
+
+`renderDetails` is a two-pane layout — a 16–24 column section sidebar against an
+independently scrolled content pane (task 049.8) — and held its state in seven
+fields on `taskView`. Those fields and their methods are now `detailsPane`
+(`internal/tui/detailspane.go`), and the workspace tab and each open popup own
+an instance. One implementation, identical navigation in both places.
+
+The pane is *fed* its lines rather than owning the data: `detailLines` and
+`pullSectionLines` stay on `taskView`, because the "GitHub pull request" section
+reads `t.pull`, which the pane has no business fetching.
+
+**Beat:** rendering a second, summarized details body for the popup. A summary
+is a second thing to keep in sync and reintroduces "leave to see the rest",
+which is the whole complaint.
+
+**4. A popup with tabs takes the full height budget.** *(2026-08-30)*
+
+`ph = max(bodyH-4, 6)`, replacing `min(height(inner)+2, max(bodyH-4, 6))` for
+these three. No frame jitter across a `ctrl+t`, and the Details tab gets every
+line it can. This does change how the three popups look: a two-line question
+now floats in a full-height box. Accepted as the cost of a frame that does not
+resize under the reader. The compare-URL editor, outside this change, keeps
+sizing to its content.
+
+**5. `ctrl+t` switches the tabs, intercepted before the form.** *(2026-08-30)*
+
+It is unbound anywhere in `bindings.go`, non-printable, and passes through
+every sub-mode these popups have: the answer form's free-text `textarea`, the
+repair/follow-up prompt `textarea` (which spends `enter` on newlines), and the
+agent/model/effort `picker`. It matches `ctrl+s` as the modifier convention
+these popups already use. `taskView.updatePopupKey` takes it **before** the form
+sees it — that seam is the one thing that makes it survive a focused editor —
+and the forms themselves stay unaware that they have tabs.
+
+**6. `esc` on the Task details tab returns to the form tab.** *(2026-08-30)*
+
+One layer per press, which is 017 decision 13's rule as task 053 restated it. It
+does not close the popup and it does not touch the draft. `esc` on the form tab
+keeps its existing per-popup meaning. §15's `esc` stack gains this inner layer.
+
+**7. The Task details tab is read-only, and more strictly than the workspace
+tab is.** *(2026-08-30)*
+
+`updateDetailsKey`'s `default` arm forwards unhandled keys to
+`t.detail.update(msg)` so task actions stay live on the workspace tab. Inside
+the popup that arm is not taken, and `o` (open the pull request) and `P` (open
+the create-PR form) are not offered: a popup that can raise a second popup is
+not a reference surface.
+
+## A gap this closed on the way
+
+`taskView.bindingContext()` returned `ctxCreatePR` when the create-PR form was
+open but had no arm for the other three popups — it fell through to the current
+tab's context. So while the answer, repair or follow-up popup owned the
+keyboard, `?` and the footer described the *Steps* tab, and the `ctxForm` /
+`ctxRepairForm` / `ctxFollowUpForm` rows added in tasks 025 and 027 were
+unreachable from the footer on the shipped surface. (`help.go` printed the first
+two unconditionally for home contexts, which is why this stayed invisible — and
+it never printed a follow-up section at all.) Both are fixed here: the three
+arms are added, and `help.go` prints all three popups' sections.
+
+## Screenshots
+
+No re-capture was needed: none of the eight `docs/assets/tui-*.png` shows any of
+the three popups — `tui-multi-select.png` is the board's bulk selection, not the
+answer form's multi-select. A shot of the new tab would need a new tape in
+`scripts/screenshots.sh` and is optional.
+
+## Tasks
+
+- [x] **059.1** Extract `detailsPane` from `taskView`'s seven `details*` fields
+  and four methods, keeping the existing `taskview_test.go` cases passing
+  against it. ✓ 2026-08-30
+- [x] **059.2** Turn `shell.overlayPopup` into a free function over a
+  `popupOverlay`, drawing the two-tab strip as the popup's first body line and
+  sizing per decision 4. ✓ 2026-08-30
+- [x] **059.3** Give `taskView` a per-popup tab index and details pane, with
+  `ctrl+t` and the details-tab `esc` intercepted in `updatePopupKey` ahead of
+  the form, and the tab read-only per decision 7. ✓ 2026-08-30
+- [x] **059.4** Register `ctrl+t` in `ctxForm`, `ctxRepairForm` and
+  `ctxFollowUpForm` with probes; add the three `bindingContext` arms and the
+  follow-up section to the `?` sheet; add each form's hint. ✓ 2026-08-30
+- [x] **059.5** Spec §15 amendment, `docs/guides/tui.md`, and the tests that
+  prove the draft survives the round trip — including a live one against the
+  real handlers. ✓ 2026-08-30

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -72,6 +72,7 @@ the living engineering specification records implementation contracts.
 | [056](056-fetch-base-branch.md) | Fetch the base branch before creating a task worktree | ✅ done (1/1) |
 | [057](057-daemon-mcp-server.md) | Serve MCP from the daemon so agents can drive vincent directly | 🔄 in progress (8/9) |
 | [058](058-enum-task-fields.md) | Enum task fields: workflow-declared value sets, selectable in New task | ✅ done (1/1) |
+| [059](059-popup-task-details-tab.md) | A task-details tab inside the answer, repair and follow-up popups | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/tui/answerform.go
+++ b/internal/tui/answerform.go
@@ -340,7 +340,7 @@ func (f *answerForm) lines(width int) (lines []string, from, to int) {
 		lines = append(lines, styleDim.Render("  submitting…"))
 	default:
 		lines = append(lines, styleDim.Render(
-			"  space select · e type an answer · enter submit · esc leave the form"))
+			"  space select · e type an answer · enter submit · ctrl+t task details · esc leave the form"))
 	}
 	return lines, from, to
 }

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -269,6 +269,7 @@ var bindings = []binding{
 	{key: "space", label: "pick an option (toggles, for a multi-select question)", scope: scopePanel, context: ctxForm, noPalette: true},
 	{key: "e", label: "type your own answer — options are suggestions, never a list", scope: scopePanel, context: ctxForm, noPalette: true},
 	{key: "enter", label: "submit the answer; the run resumes where it stopped", scope: scopePanel, context: ctxForm, noPalette: true},
+	{key: "ctrl+t", label: "read this task's details without leaving the form — the picks and the typed answer are kept (ctrl+t again, or esc, comes back)", scope: scopePanel, context: ctxForm, noPalette: true},
 	{key: "esc", label: "close the popup without answering (what you picked is kept)", scope: scopePanel, context: ctxForm, noPalette: true},
 
 	// Repair form: as with the answer form, these exist only while the popup
@@ -276,6 +277,7 @@ var bindings = []binding{
 	{key: "enter", label: "edit the row under the cursor — the prompt, or the agent/model/effort list", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 	{key: "e", label: "write the repair prompt in $EDITOR", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 	{key: "ctrl+s", label: "start the repair agent", scope: scopePanel, context: ctxRepairForm, noPalette: true},
+	{key: "ctrl+t", label: "read this task's details without leaving the form — the draft is kept (ctrl+t again, or esc, comes back)", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 	{key: "esc", label: "close the popup without repairing (the draft is discarded)", scope: scopePanel, context: ctxRepairForm, noPalette: true},
 
 	// Follow-up form: same again — the popup owns the keyboard while it is
@@ -283,6 +285,7 @@ var bindings = []binding{
 	{key: "enter", label: "edit the row under the cursor — the run form, what to run, or the agent/model/effort list", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 	{key: "e", label: "write the prompt or command in $EDITOR", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 	{key: "ctrl+s", label: "start the follow-up run", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
+	{key: "ctrl+t", label: "read this task's details without leaving the form — the draft is kept (ctrl+t again, or esc, comes back)", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 	{key: "esc", label: "close the popup without running anything (the draft is discarded)", scope: scopePanel, context: ctxFollowUpForm, noPalette: true},
 
 	// The compare-URL editor (task 052.6). Same again: the popup owns the

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -50,6 +50,8 @@ func registryKey(t *testing.T, key string) tea.KeyPressMsg {
 		msg = tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl}
 	case "ctrl+c":
 		msg = tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	case "ctrl+t":
+		msg = tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}
 	default:
 		r := []rune(key)
 		if len(r) != 1 {
@@ -122,6 +124,34 @@ func foldingShell(t *testing.T) *shell {
 
 func followUpFormFixture() *followUpForm {
 	return newFollowUpForm(7, 1, "done")
+}
+
+// popupTaskViewFixture is a task workspace with one of the three form popups
+// raised on it. ctrl+t belongs to the view rather than to a form (task 059
+// decision 4) — it is taken before the form ever sees the press — so its
+// probes drive this rather than a bare form.
+func popupTaskViewFixture(t *testing.T, open func(*detail)) *taskView {
+	t.Helper()
+	v := newTaskView(taskDetailFixture(t))
+	open(v.detail)
+	v.openPopup()
+	v.width, v.height = 100, 30
+	return v
+}
+
+// popupTabProbe is the shared ctrl+t assertion: the press reaches the view
+// through whatever the form has open, and the popup changes tab.
+func popupTabProbe(open func(*detail)) func(*testing.T) {
+	return func(t *testing.T) {
+		v := popupTaskViewFixture(t, open)
+		v.updateKey(registryKey(t, "ctrl+t"))
+		if v.popupTab != popupTabDetails {
+			t.Fatal("ctrl+t did not switch the popup to its Task details tab")
+		}
+		if !v.popup {
+			t.Fatal("ctrl+t closed the popup instead of switching its tab")
+		}
+	}
 }
 
 // panelKeyProbes proves one panel-scoped binding each. A probe drives the
@@ -316,8 +346,8 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			v := tabbedTaskFixture(t, taskTabDetails)
 			v.renderDetails(100, 24)
 			v.updateKey(registryKey(t, "down"))
-			if v.detailsSection != "Overview" {
-				t.Fatalf("down selected %q, want Overview", v.detailsSection)
+			if v.details.section != "Overview" {
+				t.Fatalf("down selected %q, want Overview", v.details.section)
 			}
 		},
 		"o": func(t *testing.T) {
@@ -825,6 +855,7 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("esc did not close the repair form")
 			}
 		},
+		"ctrl+t": popupTabProbe(func(d *detail) { d.repair = repairFormFixture() }),
 	},
 
 	ctxFollowUpForm: {
@@ -868,6 +899,7 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("esc did not close the follow-up form")
 			}
 		},
+		"ctrl+t": popupTabProbe(func(d *detail) { d.followUp = followUpFormFixture() }),
 	},
 
 	ctxForm: {
@@ -900,6 +932,7 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("esc did not close the form")
 			}
 		},
+		"ctrl+t": popupTabProbe(func(d *detail) { d.form = newAnswerForm(questionRequest()) }),
 	},
 
 	ctxCreatePR: {

--- a/internal/tui/detailspane.go
+++ b/internal/tui/detailspane.go
@@ -1,0 +1,216 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// detailsPane is the §15 Task Details inspector: a section sidebar against an
+// independently scrolled content pane (task 049.8). It is a sub-model rather
+// than fields on taskView because task 059 gives every open answer, repair and
+// follow-up popup its own instance of the same inspector — one implementation,
+// so the navigation is identical wherever it is read from.
+//
+// The pane is *fed* its lines rather than owning the data: the document comes
+// from taskView.detailLines, which reads the task and — for the "GitHub pull
+// request" section — the separately fetched pull row. Fetching is not the
+// pane's business.
+type detailsPane struct {
+	// top is the scroll offset within the selected section's body; count and
+	// h are what it was last clamped against, so a key press can page without
+	// re-splitting the document.
+	top   int
+	count int
+	h     int
+	// section is the selected title and sections is the document's, in
+	// document order. sidebarW/Y/Top are the last drawn geometry, kept for
+	// hit-testing: a click lands on what was on screen.
+	section    string
+	sections   []string
+	sidebarW   int
+	sidebarY   int
+	sidebarTop int
+}
+
+// reset returns the pane to the top of the first section, which is where a
+// newly opened task — or a newly opened popup — should start reading.
+func (p *detailsPane) reset() {
+	p.top = 0
+	p.section = ""
+}
+
+// render draws the pane at width×height. ready says the task document is real
+// rather than a placeholder ("loading…", "task unavailable"): a placeholder has
+// no sections to put in a sidebar, so it is windowed at the full width instead.
+// lines produces the document at the content width the pane settles on.
+func (p *detailsPane) render(width, height int, ready bool, lines func(width int) []string) string {
+	if !ready {
+		body := lines(width)
+		p.count, p.h = len(body), height
+		p.top = min(max(p.top, 0), max(len(body)-height, 0))
+		return strings.Join(windowRange(body, p.top, p.top+height, height), "\n")
+	}
+
+	p.sidebarW = min(24, max(width/3, 16))
+	contentWidth := max(width-p.sidebarW-3, 12)
+	document := splitTaskDetailDocument(lines(contentWidth))
+	if len(document.sections) == 0 {
+		return strings.Join(document.header, "\n")
+	}
+
+	p.sections = p.sections[:0]
+	selected := 0
+	for i, item := range document.sections {
+		p.sections = append(p.sections, item.title)
+		if item.title == p.section {
+			selected = i
+		}
+	}
+	if p.section == "" || p.sections[selected] != p.section {
+		p.section = p.sections[0]
+		p.top = 0
+		selected = 0
+	}
+
+	header := append([]string(nil), document.header...)
+	for len(header) > 0 && header[len(header)-1] == "" {
+		header = header[:len(header)-1]
+	}
+	if len(header) > 0 && len(header) < height {
+		header = append(header, "")
+	}
+	p.sidebarY = len(header)
+	bodyH := max(height-len(header), 1)
+	content := document.sections[selected].lines
+	p.count, p.h = len(content), bodyH
+	p.top = min(max(p.top, 0), max(len(content)-bodyH, 0))
+	visible := windowRange(content, p.top, p.top+bodyH, bodyH)
+	sidebar := p.renderSidebar(bodyH)
+
+	out := make([]string, 0, len(header)+bodyH)
+	for _, line := range header {
+		out = append(out, ansi.Truncate(line, max(width, 1), "…"))
+	}
+	separator := " " + styleDim.Render("│") + " "
+	for row := range bodyH {
+		left := ""
+		if row < len(sidebar) {
+			left = sidebar[row]
+		}
+		right := ""
+		if row < len(visible) {
+			right = ansi.Truncate(visible[row], contentWidth, "…")
+		}
+		out = append(out, padDisplayWidth(left, p.sidebarW)+separator+right)
+	}
+	return strings.Join(out, "\n")
+}
+
+func (p *detailsPane) renderSidebar(height int) []string {
+	lines := make([]string, 0, height)
+	selected := 0
+	for i, title := range p.sections {
+		if title == p.section {
+			selected = i
+			break
+		}
+	}
+	p.sidebarTop = windowStart(len(p.sections), selected, height)
+	end := min(p.sidebarTop+height, len(p.sections))
+	for _, title := range p.sections[p.sidebarTop:end] {
+		label := "  " + ansi.Truncate(title, max(p.sidebarW-4, 1), "…")
+		label = padDisplayWidth(label, p.sidebarW)
+		if title == p.section {
+			label = styleSelected.Render("› " + strings.TrimPrefix(label, "  "))
+		} else {
+			label = styleDim.Render(label)
+		}
+		lines = append(lines, label)
+	}
+	if p.sidebarTop == 0 && end == len(p.sections) && len(lines)+3 <= height {
+		lines = append(lines, "", styleDim.Render("  ↑/↓ select"), styleDim.Render("  pgup/pgdn scroll"))
+	}
+	return lines
+}
+
+// updateKey applies the pane's own navigation and reports whether it took the
+// press. Every key it owns only moves a cursor or a window: nothing here posts
+// an action, which is what lets the popup hand it unhandled keys and stop
+// (task 059 decision 6), while the workspace tab forwards the rest on to the
+// task actions.
+func (p *detailsPane) updateKey(msg tea.KeyPressMsg) bool {
+	page := max(p.h-1, 1)
+	switch msg.String() {
+	case "up", "k":
+		p.moveSection(-1)
+	case "down", "j":
+		p.moveSection(1)
+	case "pgup":
+		p.top -= page
+	case "pgdown":
+		p.top += page
+	case "home", "g":
+		p.selectSection(0)
+	case "end", "G":
+		p.selectSection(len(p.sections) - 1)
+	default:
+		return false
+	}
+	p.clamp()
+	return true
+}
+
+// clickSidebar selects the section under a click, where x and y are relative
+// to the pane's own top-left corner. It reports whether the click landed on
+// the sidebar at all.
+func (p *detailsPane) clickSidebar(x, y int) bool {
+	row := y - p.sidebarY
+	section := p.sidebarTop + row
+	if x > p.sidebarW+1 || row < 0 || section >= len(p.sections) {
+		return false
+	}
+	p.selectSection(section)
+	return true
+}
+
+// scrollAt is the wheel: over the sidebar it walks sections, over the content
+// it scrolls the body — the two panes scroll independently by design.
+func (p *detailsPane) scrollAt(x, delta int) {
+	if x <= p.sidebarW+1 {
+		p.moveSection(delta)
+		return
+	}
+	p.top += delta
+	p.clamp()
+}
+
+func (p *detailsPane) moveSection(delta int) {
+	if len(p.sections) == 0 {
+		return
+	}
+	i := 0
+	for at, title := range p.sections {
+		if title == p.section {
+			i = at
+			break
+		}
+	}
+	p.selectSection(min(max(i+delta, 0), len(p.sections)-1))
+}
+
+func (p *detailsPane) selectSection(i int) {
+	if i < 0 || i >= len(p.sections) {
+		return
+	}
+	if p.section == p.sections[i] {
+		return
+	}
+	p.section = p.sections[i]
+	p.top = 0
+}
+
+func (p *detailsPane) clamp() {
+	p.top = min(max(p.top, 0), max(p.count-p.h, 0))
+}

--- a/internal/tui/followupform.go
+++ b/internal/tui/followupform.go
@@ -474,7 +474,7 @@ func (f *followUpForm) lines(width int) []string {
 		out = append(out, styleDim.Render("  queueing the follow-up…"))
 	default:
 		out = append(out, styleDim.Render(
-			"  enter edit · e $EDITOR · ctrl+s start the follow-up · esc leave the form"))
+			"  enter edit · e $EDITOR · ctrl+s start the follow-up · ctrl+t task details · esc leave the form"))
 	}
 	return out
 }

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -67,16 +67,17 @@ func helpText(ctx bindingContext, github bool) string {
 		writeSection("task actions (on the selected task, offered only when valid)", actions)
 	}
 	writeSection("global keys", global)
-	// The two popups' keys ride along with the panels they pop up over —
-	// neither has a focus of its own to be the context — and they come after
-	// the keys that work *now* rather than before them. Both popups print
-	// their own keys inside themselves while they own the keyboard, so these
-	// rows are here for completeness; the sheet has no scroll, and what it
-	// drops off the bottom should be the hypothetical rather than `esc`
-	// (task 025 — a second popup section is what made the difference visible).
+	// The three popups' keys ride along with the panels they pop up over, and
+	// they come after the keys that work *now* rather than before them. Each
+	// popup prints its own keys inside itself while it owns the keyboard, and
+	// while one is open it is the context (task 059), so these rows are here
+	// for completeness; the sheet has no scroll, and what it drops off the
+	// bottom should be the hypothetical rather than `esc` (task 025 — a
+	// second popup section is what made the difference visible).
 	if isHomeContext(ctx) {
 		writeSection("answer form (while a task is waiting on you)", bindingsFor(ctxForm))
 		writeSection("repair form (R on a blocked task)", bindingsFor(ctxRepairForm))
+		writeSection("follow-up form (F on a finished task)", bindingsFor(ctxFollowUpForm))
 	}
 	writeSection("go to (from the : palette)", nav)
 	return b.String()

--- a/internal/tui/popuptabs_test.go
+++ b/internal/tui/popuptabs_test.go
@@ -1,0 +1,381 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Task 059: the three §6/§7.4 form popups carry their own two-tab strip, so
+// the context needed to answer a question is reachable without closing the
+// question. What every test here is really guarding is the draft: leaving to
+// look something up used to cost the repair and follow-up prompts outright.
+
+// ctrlT is the tab-switch chord, taken by taskView before the form sees it.
+func ctrlT() tea.KeyPressMsg { return tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl} }
+
+// popupTaskView raises one of the three popups on a task workspace sized to a
+// real terminal, and returns it ready for keys.
+func popupTaskView(t *testing.T, open func(*detail)) *taskView {
+	t.Helper()
+	v := newTaskView(taskDetailFixture(t))
+	open(v.detail)
+	v.openPopup()
+	v.width, v.height = 100, 30
+	return v
+}
+
+// typeInto sends one key per rune, the way a terminal delivers typing.
+func typeInto(v *taskView, text string) {
+	for _, r := range text {
+		v.updateKey(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+}
+
+// TestAnswerPopupTabKeepsThePicksAndTheTypedAnswer is the feature's point at
+// its most expensive surface: a §7.4 question whose options are picked and
+// whose free text is committed must survive the round trip through the
+// details tab untouched.
+func TestAnswerPopupTabKeepsThePicksAndTheTypedAnswer(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.form = newAnswerForm(questionRequest()) })
+	f := v.detail.form
+
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}) // pick Blue
+	v.updateKey(tea.KeyPressMsg{Code: 'e', Text: "e"})          // free text
+	typeInto(v, "teal")
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter}) // commit it
+	before := f.typedAnswers(f.req.Questions[0])
+	if before == "" || len(f.answers) == 0 {
+		t.Fatalf("the fixture never built a draft: answers=%v typed=%q", f.answers, before)
+	}
+
+	v.updateKey(ctrlT())
+	if v.popupTab != popupTabDetails {
+		t.Fatal("ctrl+t did not reach the Task details tab")
+	}
+	strip := ansi.Strip(v.render(v.width, v.height))
+	if !strings.Contains(strip, "Task details") || !strings.Contains(strip, "Question") {
+		t.Fatalf("the popup does not name both tabs:\n%s", strip)
+	}
+	// Read around on the details tab, then come back.
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	v.updateKey(ctrlT())
+
+	if v.popupTab != popupTabForm {
+		t.Fatal("ctrl+t did not come back to the Question tab")
+	}
+	if !v.popup || v.detail.form != f {
+		t.Fatal("the round trip closed the popup or replaced the form")
+	}
+	if got := f.typedAnswers(f.req.Questions[0]); got != before {
+		t.Fatalf("the typed answer became %q, want %q", got, before)
+	}
+	if len(f.answers) == 0 {
+		t.Fatal("the picked options were lost across the tab switch")
+	}
+	if f.err != "" {
+		t.Fatalf("the tab switch reached the form as an error: %q", f.err)
+	}
+}
+
+// TestPopupTabReachesTheStripThroughAFocusedEditor: ctrl+t is intercepted
+// before the form sees it (decision 4), which is the only reason it works
+// while a textarea has the keyboard. It must also insert nothing.
+func TestPopupTabReachesTheStripThroughAFocusedEditor(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.repair = repairFormFixture() })
+	f := v.detail.repair
+
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter}) // open the prompt field
+	if !f.editing {
+		t.Fatal("enter did not open the prompt field")
+	}
+	typeInto(v, "half a thought")
+	v.updateKey(ctrlT())
+	if v.popupTab != popupTabDetails {
+		t.Fatal("ctrl+t did not switch tab from inside the prompt editor")
+	}
+	if got := f.editor.Value(); got != "half a thought" {
+		t.Fatalf("the editor holds %q — ctrl+t typed into it", got)
+	}
+	// Keys pressed on the details tab must not reach the editor either.
+	v.updateKey(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	v.updateKey(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	if got := f.editor.Value(); got != "half a thought" {
+		t.Fatalf("the editor holds %q — the details tab leaked keys into it", got)
+	}
+
+	v.updateKey(ctrlT())
+	if !f.editing {
+		t.Fatal("the prompt field lost focus across the round trip")
+	}
+	if got := f.editor.Value(); got != "half a thought" {
+		t.Fatalf("the draft came back as %q", got)
+	}
+}
+
+// TestPopupTabReachesTheStripThroughAnOpenPicker: the same seam, through the
+// other sub-mode these popups have.
+func TestPopupTabReachesTheStripThroughAnOpenPicker(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.followUp = newFollowUpForm(7, 3, "done") })
+	f := v.detail.followUp
+
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter}) // the run-form chooser
+	if f.picker == nil {
+		t.Fatal("enter did not open the run-form list")
+	}
+	v.updateKey(ctrlT())
+	if v.popupTab != popupTabDetails {
+		t.Fatal("ctrl+t did not switch tab with a picker open")
+	}
+	v.updateKey(ctrlT())
+	if f.picker == nil {
+		t.Fatal("the open picker did not survive the round trip")
+	}
+}
+
+// TestFollowUpPopupTabKeepsTheRunFormAndItsBody: the follow-up's draft is the
+// chooser's answer plus the text under it, and both must come back.
+func TestFollowUpPopupTabKeepsTheRunFormAndItsBody(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.followUp = newFollowUpForm(7, 3, "done") })
+	f := v.detail.followUp
+	f.form = "command"
+	f.cursor = fuBody
+
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	typeInto(v, "go test ./...")
+	v.updateKey(ctrlT())
+	v.updateKey(ctrlT())
+
+	if f.form != "command" {
+		t.Fatalf("the run form became %q, want command", f.form)
+	}
+	if got := f.editor.Value(); got != "go test ./..." {
+		t.Fatalf("the command draft came back as %q", got)
+	}
+}
+
+// TestPopupDetailsTabIsReadOnly is decision 6: inside the popup the details
+// tab forwards nothing. No task action is posted, and neither of the
+// pull-request keys is offered — a popup that can raise a second popup is not
+// a reference surface.
+func TestPopupDetailsTabIsReadOnly(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.form = newAnswerForm(questionRequest()) })
+	// Make `P` offerable on the workspace tab, so the test proves the popup
+	// withholds it rather than that the task never had it.
+	v.pull.CompareURL = "https://github.com/o/r/compare/main...vincent/7-task-workspace"
+	v.pullLoaded = true
+	v.updateKey(ctrlT())
+
+	for _, key := range []string{"o", "P", "p", "c", "A", "r", "s", "R", "F", "E"} {
+		if cmd := v.updateKey(tea.KeyPressMsg{Code: rune(key[0]), Text: key}); cmd != nil {
+			t.Errorf("%q posted a command from the popup's details tab", key)
+		}
+	}
+	if v.createPR != nil {
+		t.Fatal("P opened the create-PR form from inside a popup")
+	}
+	if v.detail.repair != nil || v.detail.followUp != nil {
+		t.Fatal("a popup key raised a second popup")
+	}
+	if v.pullNote != "" {
+		t.Fatalf("a pull-request key spoke from the popup: %q", v.pullNote)
+	}
+	if v.popupTab != popupTabDetails || !v.popup {
+		t.Fatal("a read-only key changed tab or closed the popup")
+	}
+}
+
+// TestPopupDetailsTabScrollsAndSelectsSections: the pane inside the popup is
+// the pane on the workspace tab, so it navigates the same way — and a
+// document taller than the popup still reaches its last section.
+func TestPopupDetailsTabScrollsAndSelectsSections(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.repair = repairFormFixture() })
+	v.updateKey(ctrlT())
+	v.render(v.width, v.height)
+
+	first := v.popupDetails.section
+	if first == "" {
+		t.Fatal("the popup's details tab selected no section")
+	}
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	if v.popupDetails.section == first {
+		t.Fatalf("↓ did not change section (still %q)", first)
+	}
+
+	// A section long enough to scroll: pgdown must move the content window.
+	v.detail.task.Description = strings.TrimSpace(strings.Repeat("a long description line\n", 200))
+	v.popupDetails.selectSection(0)
+	v.render(v.width, v.height)
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	if v.popupDetails.top == 0 {
+		t.Fatal("pgdown did not scroll the popup's details body")
+	}
+
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnd})
+	got := ansi.Strip(v.render(v.width, v.height))
+	last := v.popupDetails.sections[len(v.popupDetails.sections)-1]
+	if v.popupDetails.section != last {
+		t.Fatalf("end selected %q, want the last section %q", v.popupDetails.section, last)
+	}
+	if !strings.Contains(got, last) {
+		t.Fatalf("the last section is not on screen:\n%s", got)
+	}
+	// The workspace tab behind the popup never moved: the popup owns its own
+	// reading position (task 059).
+	if v.details.section != "" || v.details.top != 0 {
+		t.Fatalf("the popup moved the workspace's details tab to %q@%d",
+			v.details.section, v.details.top)
+	}
+}
+
+// TestPopupEscOnDetailsReturnsToTheForm is decision 5: esc closes one layer,
+// and inside a popup the innermost layer is the tab — not the popup, and
+// never the draft.
+func TestPopupEscOnDetailsReturnsToTheForm(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.followUp = newFollowUpForm(7, 3, "done") })
+	f := v.detail.followUp
+	f.cursor = fuBody
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	typeInto(v, "retry the flaky test")
+	v.updateKey(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}) // commit the text
+
+	v.updateKey(ctrlT())
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if v.popupTab != popupTabForm {
+		t.Fatal("esc on the details tab did not return to the form tab")
+	}
+	if !v.popup || v.detail.followUp == nil {
+		t.Fatal("esc on the details tab closed the popup")
+	}
+	if f.prompt != "retry the flaky test" {
+		t.Fatalf("esc discarded the draft: prompt = %q", f.prompt)
+	}
+
+	// esc on the form tab keeps its own meaning: the follow-up closes.
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if v.popup || v.detail.followUp != nil {
+		t.Fatal("esc on the form tab did not close the follow-up popup")
+	}
+}
+
+// TestAnswerPopupEscOnTheFormTabStillKeepsThePicks: the answer form's esc is
+// the one that keeps what was picked, and the inner layer must not have
+// changed that.
+func TestAnswerPopupEscOnTheFormTabStillKeepsThePicks(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.form = newAnswerForm(questionRequest()) })
+	f := v.detail.form
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+
+	v.updateKey(ctrlT())
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEscape}) // back to the form
+	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEscape}) // close the popup
+	if v.popup {
+		t.Fatal("esc on the form tab did not close the answer popup")
+	}
+	if v.detail.form != f || len(f.answers) == 0 {
+		t.Fatal("closing the answer popup discarded what was picked")
+	}
+}
+
+// TestPopupFrameIsTheSameHeightOnBothTabs is decision 3: the popup takes the
+// whole height budget whenever it has tabs, so nothing resizes under the
+// reader on a ctrl+t.
+func TestPopupFrameIsTheSameHeightOnBothTabs(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.form = newAnswerForm(questionRequest()) })
+
+	before := popupFrameRows(t, ansi.Strip(v.render(v.width, v.height)))
+	v.updateKey(ctrlT())
+	after := popupFrameRows(t, ansi.Strip(v.render(v.width, v.height)))
+	if before != after {
+		t.Fatalf("the popup frame is %d rows on the form tab and %d on the details tab",
+			before, after)
+	}
+	if before < v.height-6 {
+		t.Fatalf("the popup is %d rows tall in a %d-row body — decision 3 asks for the "+
+			"whole budget", before, v.height)
+	}
+}
+
+// popupFrameRows counts the rows between the popup's top and bottom border.
+func popupFrameRows(t *testing.T, screen string) int {
+	t.Helper()
+	top, bottom := -1, -1
+	for i, line := range strings.Split(screen, "\n") {
+		switch {
+		case top < 0 && strings.Contains(line, "┌─"):
+			top = i
+		case top >= 0 && strings.Contains(line, "└─"):
+			bottom = i
+		}
+	}
+	if top < 0 || bottom < 0 {
+		t.Fatalf("no popup frame on screen:\n%s", screen)
+	}
+	return bottom - top + 1
+}
+
+// TestPopupOwnsTheBindingContext closes the gap task 059 found on the way: a
+// popup that owns the keyboard must own the footer and the ? sheet too, or
+// the rows tasks 025 and 027 registered are unreachable from either.
+func TestPopupOwnsTheBindingContext(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(*detail)
+		want bindingContext
+	}{
+		{"answer", func(d *detail) { d.form = newAnswerForm(questionRequest()) }, ctxForm},
+		{"repair", func(d *detail) { d.repair = repairFormFixture() }, ctxRepairForm},
+		{"follow-up", func(d *detail) { d.followUp = newFollowUpForm(7, 3, "done") }, ctxFollowUpForm},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := popupTaskView(t, tc.open)
+			if got := v.bindingContext(); got != tc.want {
+				t.Fatalf("binding context = %q, want %q", got, tc.want)
+			}
+			sheet := ansi.Strip(helpText(v.bindingContext(), true))
+			if !strings.Contains(sheet, "ctrl+t") {
+				t.Fatalf("? does not print ctrl+t for %s:\n%s", tc.want, sheet)
+			}
+		})
+	}
+}
+
+// TestHelpPrintsAllThreePopupSections: the sheet printed the answer and
+// repair popups and silently omitted the follow-up one (task 059).
+func TestHelpPrintsAllThreePopupSections(t *testing.T) {
+	sheet := strings.ToLower(ansi.Strip(helpText(ctxTimeline, true)))
+	for _, want := range []string{"answer form", "repair form", "follow-up form"} {
+		if !strings.Contains(sheet, want) {
+			t.Errorf("the ? sheet has no %q section:\n%s", want, sheet)
+		}
+	}
+}
+
+// TestCreatePRPopupHasNoTabs: decision 1 leaves the compare-URL editor out of
+// this change, and it must keep sizing itself to its own content.
+func TestCreatePRPopupHasNoTabs(t *testing.T) {
+	v := newTaskView(taskDetailFixture(t))
+	v.width, v.height = 100, 30
+	v.pull.CompareURL = "https://github.com/o/r/compare/main...vincent/7-task-workspace"
+	v.tab = taskTabDetails
+	if cmd := v.updateKey(tea.KeyPressMsg{Code: 'P', Text: "P"}); cmd != nil {
+		t.Fatalf("P posted a command: %v", cmd)
+	}
+	if v.createPR == nil {
+		t.Fatalf("P did not open the create-PR form: %q", v.pullNote)
+	}
+	screen := ansi.Strip(v.render(v.width, v.height))
+	if strings.Contains(screen, "Task details │") || strings.Contains(screen, "ctrl+t") {
+		t.Fatalf("the compare-URL editor grew a tab strip:\n%s", screen)
+	}
+	if rows := popupFrameRows(t, screen); rows >= v.height-4 {
+		t.Fatalf("the compare-URL editor is %d rows tall — it should size to its content", rows)
+	}
+	v.updateKey(ctrlT())
+	if v.popupTab != popupTabForm {
+		t.Fatal("ctrl+t switched a tab the compare-URL editor does not have")
+	}
+}

--- a/internal/tui/popuptabslive_test.go
+++ b/internal/tui/popuptabslive_test.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestRepairPopupTaskDetailsTabLive drives task 059 against the real API
+// handlers: a task the daemon actually blocked, its repair popup, and the
+// details tab inside it. What the unit tests cannot prove is that the popup's
+// inspector reads the same document the workspace's Task Details tab reads —
+// the sections come from a live task detail, not a fixture — and that a draft
+// typed into a live form survives the round trip.
+func TestRepairPopupTaskDetailsTabLive(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	h := newActionLiveHarness(t)
+	task := h.createTask(t, "inspectable")
+	h.blockTask(t, task.ID, "check_failed")
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the task", func() bool {
+		return detailOf(h.m).taskID == task.ID && detailOf(h.m).loaded
+	})
+	h.p.until(30*time.Second, "the daemon to offer repair", func() bool {
+		return detailOf(h.m).target().has("repair")
+	})
+
+	h.press(t, "R")
+	v := h.m.views[viewTask].(*taskView)
+	form := detailOf(h.m).repair
+	if form == nil || !v.popup {
+		t.Fatal("R did not raise the repair popup")
+	}
+
+	// A half-written prompt: the draft this feature exists to protect.
+	const draft = "the check needs the fixture committed"
+	h.press(t, "enter")
+	h.typeText(t, draft)
+
+	h.pressCtrlT(t)
+	if v.popupTab != popupTabDetails {
+		t.Fatal("ctrl+t did not reach the popup's Task details tab")
+	}
+	screen := ansi.Strip(content(h.m))
+	if !strings.Contains(screen, "Task details") || !strings.Contains(screen, "Repair") {
+		t.Fatalf("the popup does not name both tabs:\n%s", screen)
+	}
+	popupSections := append([]string(nil), v.popupDetails.sections...)
+	if len(popupSections) == 0 {
+		t.Fatalf("the popup's details tab found no sections:\n%s", screen)
+	}
+
+	// The same document the workspace tab reads. Rendering the workspace pane
+	// directly is what keeps the popup open — closing it to look would throw
+	// the draft away, which is the whole complaint.
+	v.renderDetails(v.width, max(v.height-3, 1))
+	if got, want := strings.Join(popupSections, ","), strings.Join(v.details.sections, ","); got != want {
+		t.Fatalf("the popup shows sections %q, the workspace tab %q", got, want)
+	}
+	for _, want := range []string{"Description", "Overview", "Lifecycle"} {
+		if !strings.Contains(strings.Join(popupSections, ","), want) {
+			t.Errorf("the popup's sidebar has no %q section: %v", want, popupSections)
+		}
+	}
+	if !strings.Contains(screen, "inspectable") {
+		t.Errorf("the popup's details body does not name the task:\n%s", screen)
+	}
+
+	// Walk to another section, then back to the form: the draft is intact and
+	// the popup never closed.
+	h.press(t, "j")
+	if v.popupDetails.section == popupSections[0] {
+		t.Fatalf("j did not move off %q", popupSections[0])
+	}
+	h.pressCtrlT(t)
+	if v.popupTab != popupTabForm || !v.popup || detailOf(h.m).repair != form {
+		t.Fatal("the round trip did not come back to the same open repair form")
+	}
+	if got := form.editor.Value(); got != draft {
+		t.Fatalf("the repair draft came back as %q, want %q", got, draft)
+	}
+}
+
+// pressCtrlT sends the popup's tab-switch chord.
+func (h *actionLiveHarness) pressCtrlT(t *testing.T) {
+	t.Helper()
+	_, cmd := h.m.Update(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	h.p.push(cmd)
+}

--- a/internal/tui/repairform.go
+++ b/internal/tui/repairform.go
@@ -359,7 +359,7 @@ func (f *repairForm) lines(width int) []string {
 		out = append(out, styleDim.Render("  starting the repair agent…"))
 	default:
 		out = append(out, styleDim.Render(
-			"  enter edit · e $EDITOR · ctrl+s start the repair · esc leave the form"))
+			"  enter edit · e $EDITOR · ctrl+s start the repair · ctrl+t task details · esc leave the form"))
 	}
 	return out
 }

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -726,7 +726,7 @@ func (s *shell) render(width, height int) string {
 	}
 	out := strings.Join(parts, "\n")
 	if s.popup && (s.detail.form != nil || s.detail.repair != nil || s.detail.followUp != nil) {
-		out = s.overlayPopup(out)
+		out = overlayPopup(out, s.bodyW, s.bodyH, popupOverlayFor(s.detail))
 	}
 	return out
 }
@@ -822,43 +822,112 @@ func (s *shell) detailPlaceholder() (string, bool) {
 	}
 }
 
-// overlayPopup draws the answer form over the panels. A popup gets the full
-// width a quarter-pane could not give multi-select options and free text
-// (§15), and the panels stay visible around it — the tail underneath is
-// what says why the agent is asking.
-func (s *shell) overlayPopup(bg string) string {
+// popupForm is what the three §6/§7.4 popups have in common as far as drawing
+// them goes: each lays itself out at the width it will be drawn at, so a long
+// question wraps inside the popup instead of losing its tail to the frame.
+type popupForm interface {
+	height(width int) int
+	render(width, height int) string
+}
+
+// popupOverlay is one form popup's drawing. The tab state is deliberately a
+// field rather than something overlayPopup can reach: taskView.render builds
+// this fresh every frame, so a popup's tab and its details pane live on the
+// view that owns the popup, not in its picture (task 059).
+type popupOverlay struct {
+	title string
+	// tabName is what the form's own tab is called on the strip — "Question",
+	// "Repair", "Follow-up" — as opposed to title, which names the task too.
+	tabName string
+	form    popupForm
+	tab     popupTab
+	// details draws the Task details tab. Nil means this popup has no tabs,
+	// and then no strip is drawn and the frame is sized to the form.
+	details func(width, height int) string
+}
+
+// popupOverlayFor picks the open form and names it. The three are mutually
+// exclusive; the precedence here is the one updatePopupKey dispatches in.
+func popupOverlayFor(d *detail) popupOverlay {
+	switch {
+	case d.followUp != nil:
+		return popupOverlay{
+			title:   fmt.Sprintf("Follow-up — #%d", d.taskID),
+			tabName: "Follow-up", form: d.followUp,
+		}
+	case d.repair != nil:
+		return popupOverlay{
+			title:   fmt.Sprintf("Repair — #%d", d.taskID),
+			tabName: "Repair", form: d.repair,
+		}
+	case d.form != nil:
+		return popupOverlay{
+			title:   fmt.Sprintf("Answer — #%d", d.taskID),
+			tabName: "Question", form: d.form,
+		}
+	}
+	return popupOverlay{}
+}
+
+// overlayPopup draws a form popup over whatever is behind it. A popup gets the
+// full width a quarter-pane could not give multi-select options and free text
+// (§15), and what is behind it stays visible around it — the tail underneath
+// is what says why the agent is asking.
+//
+// It is a free function rather than a method because taskView borrows it for
+// its own popup path and has no shell to hang it on (task 059).
+func overlayPopup(bg string, bodyW, bodyH int, p popupOverlay) string {
+	if p.form == nil {
+		return bg
+	}
 	// Take nearly the whole body: a §7.4 question is prose and its options are
-	// sentences, so every column the popup gives back to the panels behind it
+	// sentences, so every column the popup gives back to what is behind it
 	// is another wrapped line to read. The cap is a reading measure, not a
 	// layout constraint — past it a line stops being comfortable to scan.
-	pw := min(s.bodyW-6, 120)
+	pw := min(bodyW-6, 120)
 	if pw < 20 {
-		pw = s.bodyW
+		pw = bodyW
 	}
-	// The form lays itself out at the width it will be drawn at, so a long
-	// question wraps inside the popup instead of losing its tail to frame.
 	inner := pw - 2
-	var (
-		height func(int) int
-		render func(int, int) string
-		title  string
-	)
-	if f := s.detail.followUp; f != nil {
-		height, render = f.height, f.render
-		title = fmt.Sprintf("Follow-up — #%d", s.detail.taskID)
-	} else if f := s.detail.repair; f != nil {
-		height, render = f.height, f.render
-		title = fmt.Sprintf("Repair — #%d", s.detail.taskID)
+
+	var ph int
+	var body string
+	if p.details == nil {
+		ph = min(p.form.height(inner)+2, max(bodyH-4, 6))
+		body = p.form.render(inner, ph-2)
 	} else {
-		f := s.detail.form
-		height, render = f.height, f.render
-		title = fmt.Sprintf("Answer — #%d", s.detail.taskID)
+		// With tabs the popup takes the whole height budget rather than
+		// shrinking to the form (task 059 decision 3): the frame must not
+		// resize under the reader on a ctrl+t, and the details tab wants
+		// every line it can have.
+		ph = max(bodyH-4, 6)
+		contentH := max(ph-4, 1) // the two border rows, the strip, its blank
+		content := p.form.render(inner, contentH)
+		if p.tab == popupTabDetails {
+			content = p.details(inner, contentH)
+		}
+		body = popupTabStrip(p.tabName, p.tab) + "\n\n" + content
 	}
-	ph := min(height(inner)+2, max(s.bodyH-4, 6))
-	popup := frame(title, render(inner, ph-2), pw, ph, true)
-	x := max((s.bodyW-pw)/2, 0)
-	y := max((s.bodyH-ph)/3, 1)
+
+	popup := frame(p.title, body, pw, ph, true)
+	x := max((bodyW-pw)/2, 0)
+	y := max((bodyH-ph)/3, 1)
 	return overlay(bg, popup, x, y)
+}
+
+// popupTabStrip is the popup's own two-tab strip, drawn as its first body
+// line the way the task workspace draws its five (task 059).
+func popupTabStrip(formName string, active popupTab) string {
+	var b strings.Builder
+	b.WriteString(" ")
+	for i, name := range []string{formName, "Task details"} {
+		if i > 0 {
+			b.WriteString(styleDim.Render(" │ "))
+		}
+		b.WriteString(tabLabel(name, active == popupTab(i)))
+	}
+	b.WriteString(styleDim.Render("   ctrl+t"))
+	return b.String()
 }
 
 // frame draws content inside a bordered box of exactly w×h cells, the title

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -62,17 +62,29 @@ type taskView struct {
 	width     int
 	height    int
 
-	detailsTop        int
-	detailsCount      int
-	detailsH          int
-	detailsSection    string
-	detailsSections   []string
-	detailsSidebarW   int
-	detailsSidebarY   int
-	detailsSidebarTop int
-	tabHits           []taskTabHit
-	bodyY             int
+	// details is the Task Details tab's inspector. popupDetails is the
+	// second instance of the same pane, owned by whichever answer, repair or
+	// follow-up popup is open (task 059): a popup's reading position is its
+	// own, and switching to Task details inside the popup must not move the
+	// workspace tab behind it.
+	details      detailsPane
+	popupDetails detailsPane
+	popupTab     popupTab
+
+	tabHits []taskTabHit
+	bodyY   int
 }
+
+// popupTab names the two tabs the three §6/§7.4 form popups carry (task 059).
+// The form is first: the popup opened to ask something, and Task details is
+// the reference you reach for while answering it.
+type popupTab int
+
+const (
+	popupTabForm popupTab = iota
+	popupTabDetails
+	popupTabCount
+)
 
 func newTaskView(detail *detail) *taskView {
 	return &taskView{detail: detail, connected: true, workflow: newWorkflowTab()}
@@ -125,6 +137,20 @@ func (t *taskView) bindingContext() bindingContext {
 	if t.createPR != nil {
 		return ctxCreatePR
 	}
+	// While a form popup owns the keyboard it owns the footer and the ? sheet
+	// too. Without these three arms both described the tab underneath, which
+	// is what kept the rows tasks 025 and 027 registered unreachable from the
+	// footer on the shipped surface (task 059).
+	if t.popup {
+		switch {
+		case t.detail.followUp != nil:
+			return ctxFollowUpForm
+		case t.detail.repair != nil:
+			return ctxRepairForm
+		case t.detail.form != nil:
+			return ctxForm
+		}
+	}
 	switch t.tab {
 	case taskTabDetails:
 		return ctxTaskDetails
@@ -149,8 +175,8 @@ func (t *taskView) update(msg tea.Msg) (panel, tea.Cmd) {
 	case selectTaskMsg:
 		t.tab = taskTabSteps
 		t.workflow = newWorkflowTab()
-		t.detailsTop = 0
-		t.detailsSection = ""
+		t.details.reset()
+		t.popupDetails.reset()
 		t.popup = false
 		t.createPR = nil
 		t.pull, t.pullLoaded, t.pullErr = apiclient.GitHubTaskPull{}, false, ""
@@ -249,7 +275,7 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 		return func() tea.Msg { return selectViewMsg{id: viewHome} }
 	case "enter":
 		if t.detail.form != nil {
-			t.popup = true
+			t.openPopup()
 			return nil
 		}
 		if t.tab == taskTabSteps && t.detail.selectedRun != 0 {
@@ -258,13 +284,13 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "R":
 		cmd := t.detail.update(msg)
 		if t.detail.repair != nil {
-			t.popup = true
+			t.openPopup()
 		}
 		return cmd
 	case "F":
 		cmd := t.detail.update(msg)
 		if t.detail.followUp != nil {
-			t.popup = true
+			t.openPopup()
 		}
 		return cmd
 	}
@@ -297,6 +323,21 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	return t.detail.update(msg)
 }
 
+// openPopup raises one of the three form popups on its own Question/Repair/
+// Follow-up tab, with a fresh reading position for its Task details tab.
+func (t *taskView) openPopup() {
+	t.popup = true
+	t.popupTab = popupTabForm
+	t.popupDetails.reset()
+}
+
+// hasFormPopup reports whether the open popup is one of the three that carry
+// the task-details tab. The compare-URL editor (task 052.6) does not.
+func (t *taskView) hasFormPopup() bool {
+	return t.createPR == nil &&
+		(t.detail.followUp != nil || t.detail.repair != nil || t.detail.form != nil)
+}
+
 func (t *taskView) updatePopupKey(msg tea.KeyPressMsg) tea.Cmd {
 	if f := t.createPR; f != nil {
 		cmd, exit := f.update(msg)
@@ -304,6 +345,11 @@ func (t *taskView) updatePopupKey(msg tea.KeyPressMsg) tea.Cmd {
 			t.createPR, t.popup = nil, false
 		}
 		return cmd
+	}
+	if t.hasFormPopup() && t.popupTabKey(msg) {
+		// Nothing the strip or the read-only pane does posts a command; that
+		// is the point of decision 6, not an oversight.
+		return nil
 	}
 	if f := t.detail.followUp; f != nil {
 		cmd, exit := f.update(msg, t.detail.client)
@@ -328,6 +374,35 @@ func (t *taskView) updatePopupKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 	t.popup = false
 	return nil
+}
+
+// popupTabKey is the seam that makes the popup's tab strip survive a focused
+// editor (task 059 decision 4): ctrl+t is taken here, before the form sees the
+// press, so it works while the answer form's free-text textarea, the repair or
+// follow-up prompt, or an agent/model/effort picker is open. The forms
+// themselves stay unaware that they have tabs.
+//
+// While the Task details tab shows, the pane is a strictly read-only
+// reference: unhandled keys stop here rather than reaching the task actions,
+// and neither `o` nor `P` is offered — a popup that can raise a second popup
+// is not a reference surface (decision 6).
+func (t *taskView) popupTabKey(msg tea.KeyPressMsg) bool {
+	if msg.String() == "ctrl+t" {
+		t.popupTab = (t.popupTab + 1) % popupTabCount
+		return true
+	}
+	if t.popupTab != popupTabDetails {
+		return false
+	}
+	// esc closes one layer, which here is the tab and not the popup: the
+	// draft underneath is exactly what the tab exists to protect (§15, 017
+	// decision 13).
+	if msg.String() == "esc" {
+		t.popupTab = popupTabForm
+		return true
+	}
+	t.popupDetails.updateKey(msg)
+	return true
 }
 
 func (t *taskView) switchTab(delta int) tea.Cmd {
@@ -355,57 +430,20 @@ func (t *taskView) setTab(tab taskViewTab) tea.Cmd {
 }
 
 func (t *taskView) updateDetailsKey(msg tea.KeyPressMsg) tea.Cmd {
-	page := max(t.detailsH-1, 1)
 	switch msg.String() {
-	case "up", "k":
-		t.moveDetailsSection(-1)
-	case "down", "j":
-		t.moveDetailsSection(1)
-	case "pgup":
-		t.detailsTop -= page
-	case "pgdown":
-		t.detailsTop += page
 	case "o":
-		// The pull-request section's two keys (decision 2). Both only reach
-		// a browser, which is what keeps the tab a read-only inspector.
+		// The pull-request section's two keys (task 052.6 decision 2). Both
+		// only reach a browser, which is what keeps the tab a read-only
+		// inspector. Neither is offered inside a popup (task 059 decision 6).
 		return t.openPullCmd()
 	case "P":
 		return t.openCreatePR()
-	case "home", "g":
-		t.selectDetailsSection(0)
-	case "end", "G":
-		t.selectDetailsSection(len(t.detailsSections) - 1)
-	default:
-		// Task actions remain available from the read-only details tab.
-		return t.detail.update(msg)
 	}
-	t.detailsTop = min(max(t.detailsTop, 0), max(t.detailsCount-t.detailsH, 0))
-	return nil
-}
-
-func (t *taskView) moveDetailsSection(delta int) {
-	if len(t.detailsSections) == 0 {
-		return
+	if t.details.updateKey(msg) {
+		return nil
 	}
-	i := 0
-	for at, title := range t.detailsSections {
-		if title == t.detailsSection {
-			i = at
-			break
-		}
-	}
-	t.selectDetailsSection(min(max(i+delta, 0), len(t.detailsSections)-1))
-}
-
-func (t *taskView) selectDetailsSection(i int) {
-	if i < 0 || i >= len(t.detailsSections) {
-		return
-	}
-	if t.detailsSection == t.detailsSections[i] {
-		return
-	}
-	t.detailsSection = t.detailsSections[i]
-	t.detailsTop = 0
+	// Task actions remain available from the read-only details tab.
+	return t.detail.update(msg)
 }
 
 func (t *taskView) updateClick(msg tea.MouseClickMsg) tea.Cmd {
@@ -425,11 +463,7 @@ func (t *taskView) updateClick(msg tea.MouseClickMsg) tea.Cmd {
 	case taskTabSteps:
 		return t.detail.clickTimeline(msg.Y - t.bodyY)
 	case taskTabDetails:
-		row := msg.Y - t.bodyY - t.detailsSidebarY
-		section := t.detailsSidebarTop + row
-		if msg.X <= t.detailsSidebarW+1 && row >= 0 && section < len(t.detailsSections) {
-			t.selectDetailsSection(section)
-		}
+		t.details.clickSidebar(msg.X, msg.Y-t.bodyY)
 	case taskTabDiff:
 		t.detail.diff.clickRow(msg.Y - t.bodyY)
 	case taskTabWorkflow:
@@ -449,11 +483,7 @@ func (t *taskView) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
 	case taskTabSteps:
 		return t.detail.moveSelection(delta)
 	case taskTabDetails:
-		if msg.X <= t.detailsSidebarW+1 {
-			t.moveDetailsSection(delta)
-		} else {
-			t.detailsTop = min(max(t.detailsTop+delta, 0), max(t.detailsCount-t.detailsH, 0))
-		}
+		t.details.scrollAt(msg.X, delta)
 	case taskTabOutput:
 		if delta > 0 {
 			t.detail.vp.ScrollDown(1)
@@ -502,8 +532,9 @@ func (t *taskView) render(width, height int) string {
 		if t.createPR != nil {
 			out = t.overlayCreatePR(out)
 		} else {
-			host := shell{detail: t.detail, bodyW: t.width, bodyH: t.height}
-			out = host.overlayPopup(out)
+			p := popupOverlayFor(t.detail)
+			p.tab, p.details = t.popupTab, t.renderPopupDetails
+			out = overlayPopup(out, t.width, t.height, p)
 		}
 	}
 	return out
@@ -583,67 +614,22 @@ func (t *taskView) renderOutputAttemptSelector(width int) string {
 	return ansi.Truncate(line, max(width, 1), "…")
 }
 
+// renderDetails is the workspace's Task Details tab. Both it and the popup's
+// own tab (task 059) draw the same pane against the same document; only the
+// instance holding the scroll and the selection differs.
 func (t *taskView) renderDetails(width, height int) string {
-	if !t.detail.loaded || t.detail.taskID == 0 {
-		lines := t.detailLines(width)
-		t.detailsCount, t.detailsH = len(lines), height
-		t.detailsTop = min(max(t.detailsTop, 0), max(len(lines)-height, 0))
-		return strings.Join(windowRange(lines, t.detailsTop, t.detailsTop+height, height), "\n")
-	}
+	return t.details.render(width, height, t.detailsReady(), t.detailLines)
+}
 
-	t.detailsSidebarW = min(24, max(width/3, 16))
-	contentWidth := max(width-t.detailsSidebarW-3, 12)
-	document := splitTaskDetailDocument(t.detailLines(contentWidth))
-	if len(document.sections) == 0 {
-		return strings.Join(document.header, "\n")
-	}
+// renderPopupDetails is the Task details tab inside an open form popup.
+func (t *taskView) renderPopupDetails(width, height int) string {
+	return t.popupDetails.render(width, height, t.detailsReady(), t.detailLines)
+}
 
-	t.detailsSections = t.detailsSections[:0]
-	selected := 0
-	for i, item := range document.sections {
-		t.detailsSections = append(t.detailsSections, item.title)
-		if item.title == t.detailsSection {
-			selected = i
-		}
-	}
-	if t.detailsSection == "" || t.detailsSections[selected] != t.detailsSection {
-		t.detailsSection = t.detailsSections[0]
-		t.detailsTop = 0
-		selected = 0
-	}
-
-	header := append([]string(nil), document.header...)
-	for len(header) > 0 && header[len(header)-1] == "" {
-		header = header[:len(header)-1]
-	}
-	if len(header) > 0 && len(header) < height {
-		header = append(header, "")
-	}
-	t.detailsSidebarY = len(header)
-	bodyH := max(height-len(header), 1)
-	content := document.sections[selected].lines
-	t.detailsCount, t.detailsH = len(content), bodyH
-	t.detailsTop = min(max(t.detailsTop, 0), max(len(content)-bodyH, 0))
-	visible := windowRange(content, t.detailsTop, t.detailsTop+bodyH, bodyH)
-	sidebar := t.renderDetailsSidebar(bodyH)
-
-	lines := make([]string, 0, len(header)+bodyH)
-	for _, line := range header {
-		lines = append(lines, ansi.Truncate(line, max(width, 1), "…"))
-	}
-	separator := " " + styleDim.Render("│") + " "
-	for row := range bodyH {
-		left := ""
-		if row < len(sidebar) {
-			left = sidebar[row]
-		}
-		right := ""
-		if row < len(visible) {
-			right = ansi.Truncate(visible[row], contentWidth, "…")
-		}
-		lines = append(lines, padDisplayWidth(left, t.detailsSidebarW)+separator+right)
-	}
-	return strings.Join(lines, "\n")
+// detailsReady says the document is the task rather than a placeholder, which
+// is what decides whether the pane draws a sidebar at all.
+func (t *taskView) detailsReady() bool {
+	return t.detail.loaded && t.detail.taskID != 0
 }
 
 type taskDetailSection struct {
@@ -695,33 +681,6 @@ func taskDetailSectionTitle(line string) string {
 		}
 	}
 	return ""
-}
-
-func (t *taskView) renderDetailsSidebar(height int) []string {
-	lines := make([]string, 0, height)
-	selected := 0
-	for i, title := range t.detailsSections {
-		if title == t.detailsSection {
-			selected = i
-			break
-		}
-	}
-	t.detailsSidebarTop = windowStart(len(t.detailsSections), selected, height)
-	end := min(t.detailsSidebarTop+height, len(t.detailsSections))
-	for _, title := range t.detailsSections[t.detailsSidebarTop:end] {
-		label := "  " + ansi.Truncate(title, max(t.detailsSidebarW-4, 1), "…")
-		label = padDisplayWidth(label, t.detailsSidebarW)
-		if title == t.detailsSection {
-			label = styleSelected.Render("› " + strings.TrimPrefix(label, "  "))
-		} else {
-			label = styleDim.Render(label)
-		}
-		lines = append(lines, label)
-	}
-	if t.detailsSidebarTop == 0 && end == len(t.detailsSections) && len(lines)+3 <= height {
-		lines = append(lines, "", styleDim.Render("  ↑/↓ select"), styleDim.Render("  pgup/pgdn scroll"))
-	}
-	return lines
 }
 
 func (t *taskView) detailLines(width int) []string {

--- a/internal/tui/taskview_test.go
+++ b/internal/tui/taskview_test.go
@@ -179,8 +179,8 @@ func TestTaskDetailsSidebarSelectsOneSectionAtATime(t *testing.T) {
 	v.tab = taskTabDetails
 
 	got := ansi.Strip(v.renderDetails(100, 30))
-	if v.detailsSection != "Description" || !strings.Contains(got, "A complete description") {
-		t.Fatalf("default section = %q, want visible Description:\n%s", v.detailsSection, got)
+	if v.details.section != "Description" || !strings.Contains(got, "A complete description") {
+		t.Fatalf("default section = %q, want visible Description:\n%s", v.details.section, got)
 	}
 	if !strings.Contains(got, "Warnings") || strings.Contains(got, "review the generated lockfile") {
 		t.Fatalf("dynamic Warnings section was missing or leaked its content:\n%s", got)
@@ -188,8 +188,8 @@ func TestTaskDetailsSidebarSelectsOneSectionAtATime(t *testing.T) {
 
 	v.updateKey(tea.KeyPressMsg{Code: tea.KeyEnd})
 	got = ansi.Strip(v.renderDetails(100, 30))
-	if v.detailsSection != "Workflow snapshot" || !strings.Contains(got, "write the change") {
-		t.Fatalf("end selected %q, want Workflow snapshot:\n%s", v.detailsSection, got)
+	if v.details.section != "Workflow snapshot" || !strings.Contains(got, "write the change") {
+		t.Fatalf("end selected %q, want Workflow snapshot:\n%s", v.details.section, got)
 	}
 	if strings.Contains(got, "A complete description") {
 		t.Fatalf("Workflow snapshot leaked Description content:\n%s", got)
@@ -203,7 +203,7 @@ func TestTaskDetailsSidebarSupportsMouseSelection(t *testing.T) {
 	v.renderDetails(100, 30)
 
 	fields := -1
-	for i, title := range v.detailsSections {
+	for i, title := range v.details.sections {
 		if title == "Fields" {
 			fields = i
 			break
@@ -214,12 +214,12 @@ func TestTaskDetailsSidebarSupportsMouseSelection(t *testing.T) {
 	}
 	v.updateClick(tea.MouseClickMsg{
 		X: 3,
-		Y: v.bodyY + v.detailsSidebarY + fields - v.detailsSidebarTop,
+		Y: v.bodyY + v.details.sidebarY + fields - v.details.sidebarTop,
 	})
 
 	got := ansi.Strip(v.renderDetails(100, 30))
-	if v.detailsSection != "Fields" || !strings.Contains(got, "OPS-42") {
-		t.Fatalf("mouse selected %q, want visible Fields:\n%s", v.detailsSection, got)
+	if v.details.section != "Fields" || !strings.Contains(got, "OPS-42") {
+		t.Fatalf("mouse selected %q, want visible Fields:\n%s", v.details.section, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

The answer, repair and follow-up popups own the keyboard while they are open, so
the context needed to decide — the original prompt, which workflow and step is
asking, the agent and model, the linked GitHub issue — was reachable only by
pressing `esc`. On the answer form that is a round trip through a closed
question; on the repair and follow-up forms `esc` discards the draft outright,
so in practice people decide without looking. A step can sit in
`awaiting_input` for `input_timeout` (24 h by default) while that is worked out.

All three popups now carry a two-tab strip of their own as their first body
line — **Question** / **Repair** / **Follow-up**, and **Task details** — cycled
with `ctrl+t` while the popup stays open. The second tab is the same read-only
inspector the workspace's Task Details tab shows: the section sidebar, all
eleven sections, its own scroll. Switching tabs never disturbs the draft, which
is the point of the feature.

- **`ctrl+t` is intercepted in `taskView.updatePopupKey` before the form sees
  it.** That seam is the one thing that makes it survive the answer form's
  free-text `textarea`, the repair/follow-up prompt `textarea` (which spends
  `enter` on newlines) and an open agent/model/effort `picker`. The forms
  themselves stay unaware that they have tabs.
- **`esc` on the details tab returns to the form tab** with the draft intact and
  the popup still open — one layer per press, which is 017 decision 13's rule as
  task 053 restated it. `esc` on the form tab keeps each popup's existing
  meaning.
- **The tab is read-only, more strictly than the workspace tab is.** Unhandled
  keys stop at the pane rather than reaching the task's actions, and neither `o`
  nor `P` is offered: a popup that can raise a second popup is not a reference
  surface.
- **`detailsPane` (new) is the extracted inspector.** `taskView`'s seven
  `details*` fields and four methods move into a sub-model the workspace tab and
  each open popup own an instance of, so the navigation is one implementation
  and a popup's reading position never moves the tab behind it. The pane is
  *fed* its lines — `detailLines` stays on `taskView`, because the "GitHub pull
  request" section reads `t.pull`.
- **`shell.overlayPopup` becomes a free function** over a `popupOverlay`.
  `taskView.render` already borrowed it through a throwaway
  `shell{detail: …}` built fresh every frame, which can carry no tab state.
- **A popup with tabs takes the whole height budget** (`ph = max(bodyH-4, 6)`)
  on both tabs, so the frame does not resize under the reader on a `ctrl+t`.
  This changes how the three popups look today: a two-line question now floats
  in a full-height box, accepted as the cost of a stable frame. The compare-URL
  editor (task 052.6) is out of scope and keeps sizing to its content.

Two premises in the issue did not survive reading the code, and are corrected in
the task record. The issue asks for "both surfaces"; there is one. Since task
049 `views.go` sets `home.boardOnly = true`, so `shell.popup` is never set on the
shipped path and the board home screen has no popup to add a tab to — its
routing is left exactly as it is. But `shell.overlayPopup` itself is live, as the
shared renderer, which is why the drawing still had to change.

**A gap this closed on the way.** `taskView.bindingContext()` had an arm for the
create-PR form and none for the other three popups, so while one owned the
keyboard `?` and the footer described the *Steps* tab and the `ctxForm` /
`ctxRepairForm` / `ctxFollowUpForm` rows from tasks 025 and 027 were unreachable
from the footer. `help.go` also never printed a follow-up section at all. Both
are fixed here, since the issue requires the new key to appear in `?` and the
footer.

No daemon, API, store or workflow code changes — this is `internal/tui` only.

## Related

Closes #251
Closes 058.1, 058.2, 058.3, 058.4, 058.5 — new record
`docs/tasks/058-popup-task-details-tab.md`.

Builds on task 049.8's two-pane details layout and task 052.6's `o`/`P` keys;
extends 017 decision 13's one-layer-per-`esc` rule the way task 053 did, rather
than revisiting it. Task 025's and task 027's popups gain a key each and are
otherwise unchanged.

## Checklist

- [ ] PR title is plain language (no Conventional Commit prefix) — **not done:**
  the title this PR was opened with is
  `feat(tui): add a task-details tab inside the three form popups`, because the
  workflow that produced it asks for `pr-title.txt` in Conventional Commits
  form. `CLAUDE.md` and the `PR title` workflow want a plain-language title such
  as *Add a task-details tab inside the answer, repair and follow-up popups* —
  please rename before merging, or CI will fail this check.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated — `docs/guides/tui.md` (all three key
  tables, the global `esc` row, and a new *Reading the task without leaving the
  popup* section) and `docs/spec.md` §15. The TUI key tables track
  `internal/tui/bindings.go`, which gained the three `ctrl+t` rows. A separate
  `docs:` commit carries the audit fixes below.

### What the tests prove

`internal/tui/popuptabs_test.go` (new) and `popuptabslive_test.go` (new):

- `ctrl+t` switches to Task details and back in each of the three popups, and
  the strip names the tab that is showing.
- The draft survives the round trip — the answer form's picked options and
  committed free text, the repair form's half-written prompt, the follow-up
  form's run-form choice and its body.
- `ctrl+t` reaches the strip while a `textarea` is focused and while a `picker`
  is open, and inserts nothing into the editor; keys pressed on the details tab
  do not leak into it either.
- The details tab is read-only: ten keys post no command, `o` and `P` do
  nothing, and the create-PR form cannot be opened from it.
- The body scrolls: `pgdown` moves the content window, `↑`/`↓` change section,
  and a document taller than the popup still reaches its last section — while
  the workspace tab behind it does not move.
- `esc` on the details tab returns to the form tab with the draft intact and the
  popup open; `esc` on the form tab keeps each popup's existing meaning.
- The popup frame is the same height on both tabs, and the compare-URL editor
  grew neither a strip nor the full-height sizing.
- `bindings_test.go`: `ctrl+t` is registered in all three contexts with a probe
  each (`TestEveryPanelKeyIsHandled` demands one), and the `?` sheet prints all
  three popups' sections.
- A live test against the real API handlers blocks a real task, opens its repair
  popup, types a draft, and asserts the popup's details body lists the same
  sections as the workspace's Task Details tab for the same task — then returns
  to the form with the draft intact.

The existing `taskview_test.go` details cases (`renderDetails`, section
selection, the sidebar mouse hit) were repointed at the extracted pane and pass
unchanged in substance.

`go run mage.go test` and `go run mage.go lint` are green, `go test -race
./internal/tui` is green, and `golangci-lint` was run for `GOOS=windows`,
`darwin` and `linux` (0 issues each) per `CLAUDE.md`.

### Spec

`docs/spec.md` §15 is amended in place, dated 2026-08-30: a new paragraph on the
popup's tab strip ahead of the repair-popup paragraph, a clause each on the
repair and follow-up `esc` sentences, and the `esc` stack gains the inner layer
(`a form popup's Task details tab → popup → takeover screen → …`).

### Documentation audit

Audited every derivation `CLAUDE.md` names against the source. `internal/config`,
the cobra tree, `internal/api`'s route table, the `Reason*` constants, the
workflow and step types, and the adapters are untouched by a change confined to
`internal/tui`, so their pages are unchanged; `docs/features.md` describes the
TUI at the level of surfaces rather than keys and stays true. Three things were
wrong and are fixed in the `docs:` commit:

- **The code cited task 058's decisions by the brief's numbering.** The record
  inserted a new decision 2 (`overlayPopup` becomes a free function) and shifted
  every later number by one, so nine `decision N` citations in `taskview.go`,
  `shell.go`, `bindings.go` and the new tests pointed at the wrong decision —
  `updatePopupKey`'s "decision 6" for read-only landed on `esc`, and
  `popupTabKey`'s "decision 4" for the seam landed on the height budget. The
  record is renumbered so 1–6 match the citations and `overlayPopup` is
  decision 7. **Nothing in the code was changed**; if you would rather the
  comments moved instead, that is the other half of the same fix.
- **`docs/guides/tui.md` drew the tab strip** as a fenced example frame.
  Documentation in this repository never draws a screen, and that was the only
  fenced block on the page besides the launch command. It is prose now.
- **Spec §15 contradicted itself.** "Popups are for small things — the palette,
  confirmations, and the answer form" sat three paragraphs after the new
  statement that a popup with tabs takes the whole height budget. Amended in
  place and dated on the distinction that survives: takeovers are visited,
  popups interrupt. Two paragraphs the `ctrl+t` clauses left over-long were
  rewrapped at the same time.

No bug in the implementation was found while reading it.

### Screenshots

None re-captured, and none needed — checked against the tapes in
`scripts/screenshots.sh`, which capture the board, grouping, multi-select, diff,
new-task, projects, workflow-graph and workflow-step frames. None of the eight
shows any of the three form popups (`tui-multi-select.png` is the board's bulk
selection, not the answer form's multi-select), and the workflow graph's own
node popup has its own renderer and is untouched. A shot of the new tab would need a new tape in
`scripts/screenshots.sh` and is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
