### PR TITLE
feat(config): edit the daemon configuration through the API, the CLI and the TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,12 @@ jobs:
       - name: M10 gate (MCP)
         shell: bash
         run: ./scripts/m10-gate.sh
+
+      # M11: editing the daemon configuration through the API (task 060,
+      # §12.3). The three-OS matrix earns its place twice here — the write is
+      # an atomic rename over an open-ish file, which behaves differently on
+      # Windows, and the 0600 assertion is POSIX-only and says so rather than
+      # pretending Windows has a mode.
+      - name: M11 gate (configuration)
+        shell: bash
+        run: ./scripts/m11-gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,30 @@ list with the user-facing context a commit subject cannot carry.
   only way to the task's context was `esc`, which discards the repair and
   follow-up drafts outright.
 
+- **The daemon configuration is readable and editable from every client.**
+  `GET /v1/config` now serves every key in `config.yaml` — `branch_template`,
+  `debug`, `environment`, `parallel`, `fan_out`, `loop`, `include`, `github`,
+  `update`, `mcp` and `notify` were absent from it, which meant no client could
+  see them at all — and a new `PATCH /v1/config` changes them. The daemon
+  validates the whole candidate file before writing anything, edits the key in
+  place so your comments and key order survive, writes atomically at `0600`, and
+  puts the result into force before it answers: a read issued straight after a
+  successful patch sees the new value, and nothing needs restarting. An invalid
+  value leaves the file byte-identical. `listen` is the one key that is written
+  and does not take effect until the daemon restarts, and every surface says so.
+- **`vincent config get|set`.** `vincent config get` prints the configuration in
+  effect, one `path = value` per line, or one key; `vincent config set` changes
+  one. Lists and argv are whitespace-separated in a single argument
+  (`vincent config set notify.on "blocked awaiting_gate"`).
+- **The TUI's daemon view edits the configuration.** `tab` moves the arrows onto
+  the config block, which then lists every key rather than the digest, and
+  `enter` opens a typed editor on the selected one — a chooser for the keys with
+  a fixed vocabulary, a field for the rest, with the daemon's own validation
+  error rendered against it. Each row shows the value in force and the built-in
+  default where they differ. `notify.command`, `environment`, `agents.*.path`
+  and `listen` ask for an explicit confirmation before they apply, because they
+  decide what the daemon executes or exposes.
+
 - **A pull-requests screen in the TUI, and a browser to open them in.** A new
   takeover lists every open pull request across every registered project whose
   `origin` is a github.com repository vincent can authenticate to, grouped by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ list with the user-facing context a commit subject cannot carry.
   and `listen` ask for an explicit confirmation before they apply, because they
   decide what the daemon executes or exposes.
 
+- **The agent-facing surface is narrower than the human one.** `PATCH
+  /v1/config` is not an MCP tool — an agent must not reconfigure the daemon
+  supervising it — and the MCP `config_get` masks `environment.set`'s values and
+  `notify.command`'s argv, keeping the names, because a tool result lands in the
+  model's context and in the step's transcript. `GET /v1/config` over HTTP
+  serves them, behind the loopback listener and the owner-only token.
+
 - **A pull-requests screen in the TUI, and a browser to open them in.** A new
   takeover lists every open pull request across every registered project whose
   `origin` is a github.com repository vincent can authenticate to, grouped by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,12 +110,13 @@ against the fake agent; CI runs every one of them on Linux, macOS and Windows:
 ./scripts/m8-gate.sh                            # loops (§7.8)
 ./scripts/m9-gate.sh                            # workflow includes (§7.9)
 ./scripts/m10-gate.sh                           # the daemon's MCP server (§13.4)
+./scripts/m11-gate.sh                           # editing config.yaml over the API (§12.3)
 VINCENT_GATE_SCENARIO=2 ./scripts/m2-gate.sh    # single scenario, for debugging
 VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CLI
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-All eight run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
+All nine run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
 `m8` spent a while unwired because a cloud session's token has no `workflow`
 scope and so cannot write `.github/workflows/` by any route — push or API
 (#120, #122, #125). A gate that has never run on a platform is not known to

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ vincent workflow init my-flow              # or --from feature-pr, --project 1
 vincent workflow ls
 vincent workflow validate .vincent/workflows/feature-pr.yaml
 vincent workflow render .vincent/workflows/feature-pr.yaml
+vincent config get                         # or set max_parallel_tasks 6
 ```
 
 Every subcommand takes `--json` for scripting. Exit codes are `0` success,

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,7 @@ state stay on your machine; vincent provides the control plane around them.
 | Visibility | Grouped task board, live output, durable transcripts, metrics, file-grouped diffs, workflow graph |
 | GitHub | Create a task from an issue, prefilled and editable; issue details in templates; a project's open pull requests, each linked to the task whose branch it came from; read-only, no stored credential |
 | Integration | Full CLI, JSON output, stable exit codes, localhost REST API, durable state SSE and live output streams |
-| Operations | Automatic usage-limit waits, one-command diagnostics, orphan cleanup, database integrity checks, backup and restore |
+| Operations | Automatic usage-limit waits, one-command diagnostics, configuration editing from the TUI and CLI, orphan cleanup, database integrity checks, backup and restore |
 | Platforms | Windows, macOS, and Linux; Homebrew, a universal macOS `.pkg`, WinGet, Scoop, mise, deb/rpm, and archives |
 
 ## Orchestrate work instead of terminals
@@ -226,9 +226,12 @@ The daemon serves the Model Context Protocol on the same loopback listener,
 behind the same bearer token, so any MCP client gets the whole API as tools —
 with discovery, argument schemas and typed errors rather than hand-rolled curl.
 
-- The tool surface is the route table, minus five destructive-admin routes an
-  agent has no business calling: stopping, backing up, garbage-collecting or
-  reconfiguring the daemon, and force-deleting a project.
+- The tool surface is the route table, minus six destructive-admin routes an
+  agent has no business calling: stopping, backing up, garbage-collecting,
+  repairing or reconfiguring the daemon, and force-deleting a project. The
+  configuration one is also the only tool whose body differs from its route's:
+  `config_get` masks `environment.set`'s values and `notify.command`'s argv,
+  because a tool result lands in the model's context and in the transcript.
 - One bounded `task_wait` call blocks until a task is done, aborted, archived,
   or waiting on a human — with a hard ceiling, so a call cannot hang. Step
   transitions stream as progress notifications, and the result is complete
@@ -328,6 +331,14 @@ follows it. The transcript command prints one attempt's complete record — the
 file `vincent task show` only names — rendered as text for a person, as NDJSON
 for `jq`, or as the agent's own dialect byte for byte, with `-f` following an
 attempt while it is still running.
+
+`config.yaml` is editable without leaving vincent. `vincent config get` prints
+every key in effect and `vincent config set` changes one; the TUI's daemon view
+edits the same keys in a typed form. Both go through the daemon, which owns the
+file: it validates the whole candidate before writing anything, edits your key
+in place so comments and key order survive, and applies the result before it
+answers — so a change is in force with nothing to restart, `listen` excepted.
+An invalid value leaves the file untouched.
 
 `vincent gc` focuses on orphaned worktrees and transcripts. It supports a dry
 run, refuses to remove dirty or unknown work without an explicit force, and

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -38,16 +38,27 @@ every human action (`task_cancel`, `task_pause`, `task_approve`, `task_answer`,
 the GitHub reads, and the read-only `health`, `info`, `config_get`,
 `agent_list`, `doctor`, `orphan_list`.
 
-Five things are deliberately **not** tools:
+Six things are deliberately **not** tools:
 
 - `POST /v1/daemon/stop`
 - `POST /v1/daemon/backup`
 - `DELETE /v1/projects/{id}`
 - `POST /v1/maintenance/gc`
 - `POST /v1/doctor/fix`
+- `PATCH /v1/config`
 
 An agent should not be able to stop, garbage-collect or reconfigure the daemon
-that is supervising it. Those stay CLI-and-curl only.
+that is supervising it. Those stay CLI-and-curl only. The configuration one is
+the sharpest of the six: a patch can change the argv the daemon spawns
+(`notify.command`, `agents.*.path`), what its children inherit (`environment`),
+and whether steps are wired to MCP at all (`mcp.wire_steps` — a step could
+otherwise switch these tools off for everyone).
+
+`config_get` is the one tool whose body differs from its route's. The HTTP
+response serves `config.yaml` in full; the tool masks `environment.set`'s
+values and `notify.command`'s argv, keeping the names, because a tool result
+lands in the model's context and in the step's transcript. Nothing else is
+changed — see the [security model](../security-model.md).
 
 Each tool takes the route's path parameters by name, plus `body` (for `POST` and
 `PATCH`) or `query` (for `GET`):

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -817,6 +817,47 @@ Version, uptime, the config in effect, the adapters detected, and a live tail of
 the daemon log. The view reports, it does not act — `vincent daemon stop` owns
 stopping the daemon, and a TUI that auto-started one has no business killing it.
 
+The **configuration block is the exception**, and only it. `tab` moves `↑`/`↓`
+off the log pane and onto the config list, which then shows every key
+`config.yaml` carries rather than the digest; `enter` opens a typed editor on
+the selected key, and applying it writes the file through the daemon. Stopping
+the daemon and `vincent gc` act on the process supervising this TUI, which is
+what that sentence is about; a configuration edit changes a file the daemon owns
+and already reloads, and which you can edit by hand at any moment anyway.
+
+Each row shows the value in force and, where they differ, the built-in default.
+The daemon serves the values it has loaded and not where they came from, so a
+row says "differs from the default" rather than "set in the file". A refusal
+renders against the field, with the value that caused it still there to fix, and
+nothing is written.
+
+Four keys ask before they apply: `notify.command`, `environment.*`,
+`agents.*.path` and `listen`. They decide what the daemon executes or exposes,
+and [agents run full-auto by default](../security-model.md) — a stray keystroke
+must not change the argv the daemon spawns as you. `listen` is written to the
+file and the running daemon keeps the address it bound until it is restarted;
+the editor says so before you apply it.
+
+| Key | Does |
+|---|---|
+| `tab` | Move `↑`/`↓` between the config list and the log pane |
+| `↑` / `↓` | Select a configuration key, once the list has the arrows |
+| `enter` / `e` | Open the editor on the selected key |
+| `R` | Re-read the daemon info, the config and the log |
+| `f` / `G` | Follow the end of the log again |
+
+And inside the editor:
+
+| Key | Does |
+|---|---|
+| `←` / `→` | Choose a value, for a key with a fixed vocabulary |
+| `enter` | Apply the change — the daemon validates and writes `config.yaml` |
+| `y` | Confirm one of the four keys that decide what the daemon executes or exposes |
+| `esc` | Close without saving; on the confirmation it returns to the field |
+
+Everything here is also
+[`vincent config get|set`](../reference/cli.md#vincent-config).
+
 Each adapter row carries what vincent knows about its usage window: `usage
 limit → 14:20` when the CLI stated that reset, `usage limit ≈ 14:20` when
 vincent estimated it from

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -125,7 +125,7 @@ are long-lived by contract and no write deadline is set.
 | `GET` | `/v1/health` | Liveness → `{ status, version }`. **Unauthenticated** |
 | `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, `orphans`, and the database's byte footprint |
 | `GET` | `/v1/config` | The effective global config — **every** key in `config.yaml`, including the `tui` section the daemon only relays |
-| `PATCH` | `/v1/config` | Partial, snake_case, mirroring the read shape. Validates, writes `config.yaml` comment-preservingly, and applies the result before answering |
+| `PATCH` | `/v1/config` | Partial, snake_case, mirroring the read shape. Validates, writes `config.yaml` comment-preservingly, and applies the result before answering → the config in force. An invalid patch is `400 validation_failed` with the file byte-identical |
 | `GET` | `/v1/agents` | Per-adapter availability plus model/effort options. `?refresh=true` forces a re-probe |
 | `GET` | `/v1/doctor` | The whole diagnostic report. Read-only. `?probe=false` skips the forced adapter re-probe — see [Doctor](#doctor) |
 | `POST` | `/v1/doctor/fix` | Removes orphaned worktrees and compacts the database |
@@ -1301,6 +1301,7 @@ Every route on this page is a tool, with these exceptions:
 | `DELETE /v1/projects/{id}` | Destructive admin |
 | `POST /v1/maintenance/gc` | Destructive admin |
 | `POST /v1/doctor/fix` | Destructive admin |
+| `PATCH /v1/config` | An agent must not reconfigure the daemon supervising it — a patch changes the argv it spawns, what its children inherit, and whether steps get MCP at all |
 | `GET /v1/events` | A tool call is request/response; use `task_wait` |
 | `GET /v1/tasks/{id}/events` | Same |
 
@@ -1313,6 +1314,11 @@ this page documents, so the request bounds, the validation and the error
 envelopes above are the same ones a tool sees — a `409` reaches an MCP client
 still carrying `details.state`. One tool result is capped at 256 KiB; use a
 route's own `offset`/`limit` query parameters to page.
+
+`config_get` is the one tool whose **body** differs from its route's: it masks
+`environment.set`'s values and `notify.command`'s argv, keeping the names,
+because a tool result lands in the model's context and in the step's transcript.
+`GET /v1/config` itself serves them.
 
 `task_wait` is the one tool with no route behind it: it blocks until a task
 reaches `done`, `aborted`, `archived`, `awaiting_input`, `blocked` or

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -124,7 +124,8 @@ are long-lived by contract and no write deadline is set.
 |---|---|---|
 | `GET` | `/v1/health` | Liveness → `{ status, version }`. **Unauthenticated** |
 | `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, `orphans`, and the database's byte footprint |
-| `GET` | `/v1/config` | The effective global config, read-only — including the `tui` section the daemon only relays |
+| `GET` | `/v1/config` | The effective global config — **every** key in `config.yaml`, including the `tui` section the daemon only relays |
+| `PATCH` | `/v1/config` | Partial, snake_case, mirroring the read shape. Validates, writes `config.yaml` comment-preservingly, and applies the result before answering |
 | `GET` | `/v1/agents` | Per-adapter availability plus model/effort options. `?refresh=true` forces a re-probe |
 | `GET` | `/v1/doctor` | The whole diagnostic report. Read-only. `?probe=false` skips the forced adapter re-probe — see [Doctor](#doctor) |
 | `POST` | `/v1/doctor/fix` | Removes orphaned worktrees and compacts the database |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,7 @@ localhost API.
 - [`vincent service`](#vincent-service)
 - [`vincent project`](#vincent-project)
 - [`vincent task`](#vincent-task)
+- [`vincent config`](#vincent-config)
 - [`vincent status`](#vincent-status)
 - [`vincent update`](#vincent-update)
 - [`vincent workflow`](#vincent-workflow)
@@ -790,6 +791,54 @@ verbatim, with `-` reading stdin and no per-flag reconstruction:
 jq -n '{answers: {"Which database?": ["postgres"]}}' |
   vincent task answer 7 --body -
 ```
+
+## `vincent config`
+
+```sh
+vincent config get [key] [--json]
+vincent config set <key> <value> [--json]
+```
+
+Reads and changes the daemon's
+[`config.yaml`](configuration.md) through the daemon, which owns the file and
+hot-reloads it. It is a client of `PATCH /v1/config` like every other command
+here, not a second editor — so a `set` is the same operation, with the same
+validation, that the [TUI's daemon view](../guides/tui.md#daemon) performs.
+
+Keys are the dotted paths `config.yaml` carries, which are the paths the
+[configuration reference](configuration.md) documents:
+
+```sh
+vincent config get                      # every key, one `path = value` per line
+vincent config get max_parallel_tasks   # 3
+vincent config set max_parallel_tasks 6
+vincent config set log_level debug
+vincent config set defaults.agent_timeout 90m
+vincent config set notify.on "blocked awaiting_gate"
+vincent config set notify.command "/usr/local/bin/notify-me"
+vincent config set environment.set "LANG=C.UTF-8 TZ=Etc/UTC"
+```
+
+Details worth knowing:
+
+- **A set takes effect without a restart.** The daemon validates the whole
+  candidate file, writes it and applies the result before answering, so the
+  next `vincent config get` reads the new value. The one exception is `listen`:
+  it is written to the file and the running daemon keeps the address it bound,
+  which the command says out loud.
+- **An invalid value changes nothing.** The file is left byte-identical and the
+  command exits 1 with the daemon's message. There is no partial application.
+- **Your comments survive.** `config.yaml` ships as a documented template, and
+  the daemon edits a key in place — or uncomments its documented block where it
+  stands — rather than regenerating the file. A `notify.on` set turns the
+  commented-out `notify:` block on without flattening the paragraph above it.
+- **Lists and argv are whitespace-separated in one argument**, as in the
+  examples above. An argument containing a space cannot be written this way and
+  has to be edited in the file. Setting a list to `""` empties it, which is how
+  the notify hook is switched off from the command line.
+- **`environment.inherit` takes `all`, `none`, or a list of names.**
+- **Per-project settings are not here.** They live in the database and are
+  edited with [`vincent project`](#vincent-project) or the TUI's projects view.
 
 ## `vincent status`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,6 +46,14 @@ listen: 127.0.0.1:0
 # on each project.
 max_parallel_tasks: 3
 
+# Naming convention for the branch each task's worktree is cut on. It is a
+# Go text/template rendered with .ID, .Slug, .Project, .Workflow and .Date;
+# the result is sanitised into a legal ref. A project may override it, and
+# the built-in below is what applies when neither is set. A template that
+# does not compile is refused and the previous one stays in force.
+#
+# branch_template: "vincent/{{.ID}}-{{.Slug}}"
+
 # Fallback step timeouts, used when a workflow step declares none.
 # input_timeout bounds each wait for an answer to an agent's input request
 # (awaiting_input, §7.4); on expiry the attempt fails under the retry policy.
@@ -140,6 +148,49 @@ agents:
   cursor:
     path: ""
 
+# How many verifications inside one "parallel" step run at once (§7.5).
+# The step is done when its last lane is, and a lane that fails fails the
+# step; this only bounds how many are in flight.
+#
+# parallel:
+#   max_parallel: 4
+
+# Bounds on "fan_out" (§7.6), which creates a task per item. max_depth is how
+# many generations deep a tree may go — a lane that fans out again counts —
+# and max_tasks is the total number of descendants one root may create.
+# Passing either blocks the step rather than truncating the list.
+#
+# fan_out:
+#   max_depth: 3
+#   max_tasks: 64
+
+# Ceiling on iterations of one "loop" step (§7.8). A loop that reaches it
+# blocks with loop_limit, so a condition that never goes false is visible
+# rather than endless.
+#
+# loop:
+#   max_iterations: 10
+
+# How many levels of "include" a workflow may nest (§7.9). Includes are
+# spliced away when the task is created, so this bounds the splice, not the
+# run.
+#
+# include:
+#   max_depth: 5
+
+# The MCP server the daemon serves at /mcp (§13.4), and the per-step endpoint
+# an agent step is wired to. wire_steps: false stops the daemon handing agent
+# steps their endpoint at all, which is how you take vincent's own tools away
+# from a workflow without touching the workflow. max_depth and max_tasks bound
+# the tasks an agent may create through those tools, the way fan_out's pair
+# bounds a tree: a chain discovered at run time is only visible once it has
+# spawned.
+#
+# mcp:
+#   wire_steps: true
+#   max_depth: 3
+#   max_tasks: 32
+
 # Reading GitHub issues, so a task can be created from one (task 035). It
 # applies only to a project whose "origin" remote is a github.com repository,
 # and the daemon makes no call at all until you open the issue picker or name
@@ -181,18 +232,6 @@ github:
 update:
   check: true
   poll_interval: 24h
-# Serve MCP to AI coding agents, and give vincent's own agent steps the tool
-# list (task 057). There is no "enabled" key: /mcp is part of the API the way
-# /v1 is, on the same listener behind the same bearer token. What you can turn
-# off is the wiring into your own steps.
-#
-# max_depth and max_tasks bound a chain of tasks created over MCP — a step's
-# agent creates a task whose step's agent creates a task. That depth is
-# discovered as it happens, so neither fan_out's bounds nor include's cover it.
-mcp:
-  wire_steps: true
-  max_depth: 3
-  max_tasks: 32
 
 # Tell someone when a task needs them, without a client attached (task 046).
 # The daemon runs "command" whenever a task enters one of the states in "on",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -971,9 +971,13 @@ spawns. It gets **no** `VINCENT_*` variables — those belong to command steps �
 because the envelope on stdin is this hook's whole contract.
 
 Read per event, so a [reload](#reload-semantics) governs the next transition. It
-is not served on `GET /v1/config`: no client needs it, and `command` can
-reasonably hold a webhook URL with a token in it. See the
-[security model](../security-model.md) for what running it means.
+**is** served on `GET /v1/config`, argv included: that endpoint is loopback-only
+behind the same owner-only token as the file, so a client that can call it can
+already read `config.yaml`. The one exception is the
+[MCP](../guides/mcp.md) rendering of the same route, where the argv is masked —
+a tool result lands in an agent's context and its transcript, which is not that
+boundary. `command` can reasonably hold a webhook URL with a token in it; see
+the [security model](../security-model.md) for what running it means.
 
 ### `tui`
 
@@ -1067,17 +1071,36 @@ Agent, command and check steps additionally receive `VINCENT_TASK_ID`,
 `VINCENT_STEP_ATTEMPT` and `VINCENT_WORKFLOW` — see
 [Writing workflows](../guides/workflows.md#55-environment-variables).
 
-## Reading the config in effect
+## Reading and changing the config in effect
 
-The API exposes it read-only, which is the reliable way to see what the daemon
-actually loaded after a reload:
+The API serves every key on this page, which is the reliable way to see what the
+daemon actually loaded after a reload:
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:$PORT/v1/config | jq
 ```
 
-The TUI's daemon view shows the same thing, alongside the adapters detected and
-the log tail.
+`PATCH /v1/config` changes it. The daemon validates the whole candidate file,
+writes it and puts it into force before answering, so the next read shows the
+new value and nothing needs restarting — except [`listen`](#listen), which is
+written to the file while the running daemon keeps the address it bound. An
+invalid patch leaves the file byte-identical.
+
+```sh
+vincent config get                            # every key, one per line
+vincent config set max_parallel_tasks 6
+vincent config set notify.on "blocked awaiting_gate"
+```
+
+The write is comment-preserving: the daemon edits a key in place, or uncomments
+its documented block where it stands, so the commented template this page
+describes is still there afterwards. See
+[`vincent config`](cli.md#vincent-config).
+
+The TUI's daemon view shows and edits the same thing, alongside the adapters
+detected and the log tail — `tab`, then `enter` on a key. Four keys
+(`notify.command`, `environment`, `agents.*.path`, `listen`) ask for a
+confirmation first.
 
 ---
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -28,22 +28,28 @@ platform where data nests inside config's directory.
 
 ```
 {config_dir}/          # created 0700
-  config.yaml          # daemon configuration — you edit this, created 0600
+  config.yaml          # daemon configuration — you or a client edit this, created 0600
   workflows/*.yaml     # global workflows, available to every project
 ```
 
 Both are watched. Editing `config.yaml` hot-reloads valid changes; saving a
 workflow file reloads the registry. Neither needs a restart.
 
+`config.yaml` is also written by the daemon, on
+[`PATCH /v1/config`](api.md#daemon) — what
+[`vincent config set`](cli.md#vincent-config) and the TUI's daemon view call. It
+edits the key in place, so your comments and key order survive, and replaces the
+file atomically at `0600`. A hand-edit racing a client edit is last-writer-wins.
+
 **The directory and `config.yaml` are owner-only**, because
 [`environment.set`](configuration.md#environment) values are literal and people
 put tokens in them. On POSIX every daemon start drops group and other access
 from both — the same re-tightening the `token` file gets — and logs the path
 and the mode it found; `vincent doctor` reports the same as a warning with the
-exact `chmod`. Your file's *contents* are never rewritten, and if you widened
-those modes on purpose, the next start will narrow them again. On Windows the
-modes carry no access control and the per-user ACL of `%APPDATA%` applies
-instead.
+exact `chmod`. That pass touches the modes only — it never rewrites your file's
+*contents* — and if you widened those modes on purpose, the next start will
+narrow them again. On Windows the modes carry no access control and the per-user
+ACL of `%APPDATA%` applies instead.
 
 Everything here is yours: it is safe to put under version control, sync between
 machines, or hand-edit — with one caveat from the modes above: a literal

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -281,8 +281,21 @@ you — but it is worth stating rather than leaving implicit:
   every platform, so a task title cannot be interpreted as a command.
 - **Its argv can hold a secret.** A webhook URL with a token in it is the
   obvious case. That is a second reason `config.yaml` and its directory are
-  owner-only, and the reason `notify` is not served on `GET /v1/config` — a
-  client with a valid token still cannot read it back.
+  owner-only. It **is** served on `GET /v1/config`, values included, and so is
+  `environment.set`: that endpoint is loopback-only behind a bearer token read
+  out of an owner-only file, which is the same boundary the file itself has, so
+  a client that can call it can already read the file. What that boundary does
+  not cover is an [MCP](guides/mcp.md) tool result — it lands in an agent's
+  context and in the step's transcript — so the MCP rendering of that route
+  masks `notify.command`'s argv and `environment.set`'s values, keeping the
+  variable names. The daemon's **log** and step transcripts still carry
+  variable names and never values; that rule is unchanged.
+- **`PATCH /v1/config` can change what the daemon executes.** `notify.command`,
+  `agents.*.path` and `environment` are all writable through the API, and so is
+  `listen`. This is not a new privilege — anyone who can call the endpoint holds
+  the daemon's token and can already run an agent step as you — but it is why
+  the route is **not** an MCP tool, and why the TUI puts those four keys behind
+  an explicit confirmation.
 - Whatever your notifier does with the envelope is outside vincent. The envelope
   carries the task title and the agent's question summary, so a hook that posts
   to a shared channel publishes both.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3535,6 +3535,21 @@ afternoon should not revert every unrelated edit in the same save.
 curated DTO for clients (§13.2), no client needs this, and `command` can
 reasonably carry a webhook URL with a token in its argv (§16).
 
+*Amended 2026-08-30 (task 060, issue #244).* **Superseded: `notify` is served,
+values included.** The endpoint serves every key in `config.yaml`, because a
+key it omits is a key no client can see — the TUI reads no configuration of its
+own (§15) — and this task makes the file editable from those clients, which
+cannot be done to a value that cannot first be read. The disclosure argument
+does not survive the boundary being named: `GET /v1/config` is loopback-only
+behind the 0600 bearer token, which is the same trust boundary as the 0600
+file, so anyone who can call it can already `cat` it. What the argument was
+really protecting is the **log** and step transcripts, and that rule is
+unchanged and narrowed to say so — the daemon still logs variable names and
+never values. The one place the old reading survives is the MCP rendering of
+this route, where the result lands in an agent's context and its transcript:
+`config_get` masks `environment.set`'s values and `notify.command`'s argv, and
+nothing else (§13.4).
+
 There is deliberately **no token key here**. Vincent stores no credential of
 its own: it drives `gh` when that is installed and authenticated, and otherwise
 reads `GITHUB_TOKEN` or `GH_TOKEN` out of the environment the daemon already
@@ -3596,6 +3611,44 @@ value was *accidental and unrecorded*, not that it was set.
 Config is authoritative in the file; the daemon watches and hot-reloads it. The API
 exposes it read-only (`GET /v1/config`). Per-project settings live in the DB and are
 edited via `PATCH /v1/projects/{id}`.
+
+*Amended 2026-08-30 (task 060, issue #244).* **The API also writes it:
+`PATCH /v1/config`.** The file stays authoritative — the daemon edits it and
+reloads from it; it is not a cache of anything. The endpoint is partial and
+snake_case, mirroring the read shape, on the pattern `PATCH /v1/projects/{id}`
+and `PATCH /v1/tasks/{id}` already set. What it guarantees:
+
+- **The write is comment-preserving.** `config.yaml` ships as a documented
+  template whose `notify:` block is commented out, and for most installations
+  it is the only explanation of what the keys mean. The daemon edits a key in
+  place, uncomments a documented block where it stands, and appends only a key
+  the file has no block for at all. Comments, key order and blank lines survive
+  (`config.Apply`).
+- **Nothing is written when the patch does not hold.** The candidate file is
+  decoded through the path `Load` takes and checked against
+  `worktree.ValidateBranchTemplate`, and a refusal answers §13.1's envelope
+  with the file byte-identical. There is no partial application.
+- **The write is atomic and 0600.** A rename over the target, from a temporary
+  file beside it named so the watcher's base-name filter ignores it (§12.2).
+- **The result is applied before the response is sent.** `daemon.Run`'s reload
+  callback is a named function with two callers — the fsnotify watcher and this
+  handler — so the `listen` pin and the `branch_template` fallback are the same
+  code on both paths, and it is idempotent: the watcher's later fire re-reads
+  identical bytes. A `GET` issued the instant a `200` lands reads the new
+  values, with no sleep.
+- **`listen` is written and does not take effect.** The reload rule above is
+  unchanged, so the running daemon keeps the address it bound and `GET
+  /v1/config` goes on reporting it. Clients say "takes effect on restart"
+  rather than showing the pending value as though it were in force.
+- **Concurrent patches serialize; a hand-edit racing one is last-writer-wins.**
+  One mutex around the read-modify-write, and the file is read fresh at patch
+  time. There is no `ETag`/`If-Match`: a precondition concept no other endpoint
+  in this API carries, for a race between a human and themselves.
+
+`PATCH /v1/config` is **not** an MCP tool (§13.4), and the four keys that decide
+what the daemon executes or exposes — `notify.command`, `environment`,
+`agents.*.path` and `listen` — are behind an explicit confirmation in the TUI
+(§15).
 
 ### 12.4 Crash recovery
 
@@ -3827,7 +3880,16 @@ GET    /v1/info                         daemon version, uptime, agent availabili
                                         on every debounced refresh, and a COUNT(*) over a
                                         multi-million-row events table on the daemon's single
                                         SQLite connection is not that. Nothing here is cached
-GET    /v1/config                       effective global config (read-only)
+GET    /v1/config                       effective global config
+                                        *Amended 2026-08-30 (task 060, issue #244):* it is no
+                                        longer read-only, and no longer a subset. Every key in
+                                        config.yaml is served, values included — a key omitted
+                                        here is one no client can see (§12.3's amendment).
+PATCH  /v1/config                       partial, snake_case, mirroring the read shape. The
+                                        daemon validates the whole candidate file, writes it
+                                        comment-preservingly and atomically at 0600, and applies
+                                        it before answering. An invalid patch writes nothing and
+                                        answers §13.1's envelope. Not an MCP tool (§13.4)
 GET    /v1/agents                       per-adapter availability + model/effort options (§9.6);
                                         ?refresh=true forces a re-probe.
                                         *Added 2026-08-28 (task 041):* the §9.5 health facets
@@ -4453,7 +4515,24 @@ an oversight:
 
 An agent must not be able to stop, garbage-collect or reconfigure the daemon
 supervising it — least of all one running as a vincent step. They stay
-CLI-and-curl only. Everything else in §13.2 is a tool, including the three the
+CLI-and-curl only.
+
+*Amended 2026-08-30 (task 060, issue #244).* **Six**, with `PATCH /v1/config`.
+The sentence above already named the case before the route existed: a patch can
+change the argv the daemon spawns (`notify.command`, `agents.*.path`), what its
+children inherit (`environment`), and whether steps are wired to MCP at all
+(`mcp.wire_steps`) — a step editing any of those is a step rewriting the rules
+it runs under. The route-table parity test fails on either an unexposed or a
+silently exposed route, so this cannot drift.
+
+*Added 2026-08-30 (task 060, issue #244).* **`config_get` is the one tool whose
+body differs from its route's.** §12.3 serves `environment.set`'s values and
+`notify.command`'s argv over HTTP, where the boundary is loopback plus an 0600
+bearer token. An MCP tool result is not that boundary: it is replayed on behalf
+of an agent step and lands in the model's context and in the step's transcript.
+So the MCP rendering masks those two fields — values only; the variable names
+survive, which is the same line §12.3 draws for the log — and nothing else. A
+test asserts the two bodies differ in exactly those fields and nowhere else. Everything else in §13.2 is a tool, including the three the
 proposal left unclassified: `POST`/`DELETE /v1/tasks/{id}/github/pull`,
 `POST /v1/tasks/{id}/steps/{step_id}/status`, and `POST /v1/tasks/{id}/archive`
 despite its worktree removal and its possible empty-branch delete. The unlink
@@ -5064,7 +5143,27 @@ stream for the live tail.
    one green word per adapter is what makes the one warning invisible.
    The view reports, it does not act: stopping the daemon from the TUI is out
    of v1 — `vincent daemon stop` owns that, and a TUI that auto-started the daemon
-   at launch has no business killing it. The log tail is read straight from
+   at launch has no business killing it.
+   *Amended 2026-08-30 (task 060, issue #244).* **The configuration block is the
+   one exception, and only it.** "It reports, it does not act" still holds for
+   stopping the daemon and for `vincent gc`: both act on the **process
+   supervising the TUI**, and that is the whole of the argument above. A
+   configuration edit is a different object — a **file the daemon owns and
+   already hot-reloads**, which a human may edit by hand at any moment anyway,
+   and which no client could previously even see in full. So the block becomes
+   navigable (`tab`, then `↑`/`↓`), `enter` opens a typed editor on the selected
+   key, and applying it is `PATCH /v1/config` (§12.3, §13.2). Each row shows the
+   value in force and, when they differ, the built-in default; the endpoint
+   carries no provenance, so what the marker claims is "differs from the
+   default", not "written in the file". Four keys — `notify.command`,
+   `environment.*`, `agents.*.path` and `listen` — are behind an explicit
+   confirmation, because they decide what the daemon executes or exposes and
+   agents already run full-auto by default (§16). `listen` is written and does
+   not take effect until a restart, and the editor says so before it applies
+   rather than showing a pending value as though it were in force. While the
+   editor is open the view **captures input**, which it never did before: every
+   single-key global would otherwise land in the text field. There is still no
+   seventh view — the daemon view already owned this block. The log tail is read straight from
    `{data_dir}/logs/daemon.log`, the one place the TUI is not a pure API client:
    an endpoint cannot serve the log when the daemon is the thing that died, which
    is when the log is worth reading — so it is the one view with something true to
@@ -5670,6 +5769,16 @@ currently true to show (§15 view 6).
   is why `notify` is not served on `GET /v1/config`. And it is argv, never a
   shell string, on every platform: nothing is expanded, split or quoted, so a
   task title cannot reach a shell through it.
+
+  *Amended 2026-08-30 (task 060, issue #244).* The clause about `GET
+  /v1/config` is superseded: `notify` **is** served, values included, because
+  that endpoint sits behind the same loopback-plus-0600 boundary as the file
+  (§12.3's amendment). The MCP rendering masks the argv, because that one does
+  not. And `notify.command` is now writable over `PATCH /v1/config` — which is
+  to say a client can change what the daemon executes as you, without a
+  restart. That is why the route is excluded from the MCP tool surface
+  (§13.4), and why the TUI's editor puts it, `environment`, `agents.*.path`
+  and `listen` behind an explicit confirmation.
 - **Vincent writes to one CLI's own config**: a cursor step passes `--model`,
   which cursor persists to `~/.cursor/cli-config.json` (§9.7). It is not a
   secret and not an escalation, but it is the one place vincent mutates state

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2924,6 +2924,7 @@ One Go binary, `vincent`:
 | `vincent task pause / resume / skip / approve / reject / retry / repair / archive / answer <id>` | *Added 2026-08-28 (task 048).* The rest of §6's human actions, one subcommand each, one id per invocation. All carry `--json` and print the daemon's post-action view of the task; a 409 from the FSM is exit 1 with the daemon's own wording. `retry` takes `--branch` (§18's `branch_exists` recovery) and the edit+retry pair `--prompt`/`--run`; `repair` requires `--prompt` and takes the §8.6 triple; `archive` takes `--force` and surfaces `details.reason: worktree_dirty` with the way out; `answer` takes `--answer <n>=<value>` against the questions `task show` numbers, `--allow`/`--deny` for a permission request, or `--body <file\|->` to post a §13.2 payload verbatim. Each of `--prompt`, `--run` and `--body` has a `-file` twin, and `-` reads stdin |
 | `vincent status <message>` | *Added 2026-08-26 (task 036).* Records what the current step is doing, in its own words (§5.4). Runs **from inside a step**: it addresses itself with §8.5's `VINCENT_TASK_ID` and `VINCENT_STEP_ID`, takes no id argument, and errors naming those variables when they are unset. Silent on success — its stdout is the step's transcript |
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
+| `vincent config get [key] / set <key> <value>` | *Added 2026-08-30 (task 060).* Reads and writes `config.yaml` through `GET`/`PATCH /v1/config` (§12.3) — a thin API client like the rest, never a second editor, so the CLI and the TUI's editor are one operation with one validation. `get` with no key prints every key as `path = value` in the file's own order; with one, that key's value alone. Keys are the dotted paths the file carries. Lists and argv are whitespace-separated inside a single argument (`notify.on "blocked awaiting_gate"`), which is also why an argv element containing a space has to be edited in the file. A `set` is in force when it answers; `listen` is the exception the command says out loud. Exit 0 · 1 the daemon refused it, with the file byte-identical · 2 no daemon answered |
 | `vincent github issues / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub |
 | `vincent doctor` | One diagnostic report: paths, daemon, log tail, database, agents, storage, task counts (§17). `--json` for scripting and bug reports; `--fix` (`--force`) reclaims orphaned worktrees and compacts the database. Exit 0 healthy · 1 problems found · 2 no daemon answered. *Amended 2026-08-26 (task 035):* it also reports the GitHub integration — the `github.enabled` toggle, `gh`'s presence, version and login state, whether a token variable is set (its **name**, never its value), and whether issues are readable. It is a **row, not a problem**: every "no" it can report leaves task creation without an issue working exactly as before, so none of it changes the exit code. *Amended 2026-08-29 (task 055):* it also reports the release check (§12.3) — whether `update.check` is on, the latest stable release and when it was last seen, this binary's version, and whether the running daemon is older than it. Rows, not problems, for the same reason: a newer release and a daemon still running the previous build both leave everything working |
 | `vincent update [--check] [--dry-run] [--require-signature] [--json]` | *Added 2026-08-29 (task 055).* Asks GitHub for the latest **stable** release and, unless `--check` is given, installs it over this binary. It queries the feed **itself** rather than through the daemon, so it works with no daemon and before the daemon's own check has polled — and so `update.check: false` (§12.3) stays a literal promise. A binary a package manager owns is never modified: the channel is detected from the resolved `os.Executable()` path and its upgrade command is printed. A binary vincent owns is verified before anything runs (§16) and swapped in place; on any failure nothing is replaced. `--check`: exit 0 up to date · 1 the check failed · 2 an update is available. Otherwise: 0 nothing to do or swapped · 1 verification or the swap failed and the binary is untouched · 2 an update exists but this install is package-managed. `--json` carries `swapped`, which separates the two 0s |
@@ -4532,7 +4533,9 @@ bearer token. An MCP tool result is not that boundary: it is replayed on behalf
 of an agent step and lands in the model's context and in the step's transcript.
 So the MCP rendering masks those two fields — values only; the variable names
 survive, which is the same line §12.3 draws for the log — and nothing else. A
-test asserts the two bodies differ in exactly those fields and nowhere else. Everything else in §13.2 is a tool, including the three the
+test asserts the two bodies differ in exactly those fields and nowhere else.
+
+Everything else in §13.2 is a tool, including the three the
 proposal left unclassified: `POST`/`DELETE /v1/tasks/{id}/github/pull`,
 `POST /v1/tasks/{id}/steps/{step_id}/status`, and `POST /v1/tasks/{id}/archive`
 despite its worktree removal and its possible empty-branch delete. The unlink
@@ -5144,6 +5147,7 @@ stream for the live tail.
    The view reports, it does not act: stopping the daemon from the TUI is out
    of v1 — `vincent daemon stop` owns that, and a TUI that auto-started the daemon
    at launch has no business killing it.
+
    *Amended 2026-08-30 (task 060, issue #244).* **The configuration block is the
    one exception, and only it.** "It reports, it does not act" still holds for
    stopping the daemon and for `vincent gc`: both act on the **process
@@ -5163,11 +5167,12 @@ stream for the live tail.
    rather than showing a pending value as though it were in force. While the
    editor is open the view **captures input**, which it never did before: every
    single-key global would otherwise land in the text field. There is still no
-   seventh view — the daemon view already owned this block. The log tail is read straight from
-   `{data_dir}/logs/daemon.log`, the one place the TUI is not a pure API client:
-   an endpoint cannot serve the log when the daemon is the thing that died, which
-   is when the log is worth reading — so it is the one view with something true to
-   show while disconnected. See *Disconnected* below for what the rest of the UI
+   seventh view — the daemon view already owned this block.
+
+   The log tail is read straight from `{data_dir}/logs/daemon.log`, the one
+   place the TUI is not a pure API client: an endpoint cannot serve the log when
+   the daemon is the thing that died, which is when the log is worth reading —
+   so it is the one view with something true to show while disconnected. See *Disconnected* below for what the rest of the UI
    does in that state.
 
 7. **Pull requests.** *Added 2026-08-29 (task 052.6).* Every available project's

--- a/docs/tasks/060-daemon-configuration-editing.md
+++ b/docs/tasks/060-daemon-configuration-editing.md
@@ -1,0 +1,156 @@
+# 060 — Edit the daemon configuration from the TUI
+
+Issue [#244](https://github.com/lezli01/vincent/issues/244).
+
+Every key in `config.yaml` was hand-edited. There was no `vincent config`
+subcommand, the TUI's daemon view rendered a read-only digest, and that digest
+could only show what `GET /v1/config` served — eleven keys of the twenty-four in
+`config.Config`. `branch_template`, `debug`, `environment`, `parallel`,
+`fan_out`, `loop`, `include`, `github`, `update`, `mcp` and `notify` were
+invisible from every client, so changing `max_parallel_tasks` or turning on the
+`notify:` hook meant leaving the TUI, finding the platform-native config dir and
+editing YAML by hand.
+
+Scope is `config.yaml` only. Projects are DB rows with their own form; workflow
+YAML opens in `$EDITOR` from the workflows view. Neither is touched.
+
+## Status
+
+| # | Work | Status |
+|---|---|---|
+| 060.1 | `GET /v1/config` serves every key; a drift test fails when one is added and not served | [x] |
+| 060.2 | `PATCH /v1/config`: validate, comment-preserving atomic write at 0600, apply before answering | [x] |
+| 060.3 | `internal/config`'s document editor (`Apply`, `WriteFile`) and `defaultConfigYAML`'s six missing blocks | [x] |
+| 060.4 | The TUI's navigable config list and typed editor, with the four-key confirmation | [x] |
+| 060.5 | `vincent config get\|set` | [x] |
+| 060.6 | MCP: `PATCH /v1/config` excluded, `config_get` redacted | [x] |
+| 060.7 | `scripts/m11-gate.sh`, wired into `ci.yml` on all three platforms | [x] |
+| 060.8 | Spec amendments (§12.3, §13.2, §13.4, §15, §16) and the derived pages | [x] |
+
+## Decisions
+
+**1. The two read-only negatives are reversed, with dated in-place
+amendments.** v0 PR N recorded *"View 6 reports, it does not act"* — the same
+reasoning that withholds `vincent gc` and `POST /v1/daemon/stop` from that
+screen — and §12.3 recorded *"The API exposes it read-only (`GET /v1/config`)"*.
+Both are superseded. The distinction that carries the reversal: stopping or
+garbage-collecting acts on the **process supervising the TUI**, while a config
+edit changes a **file the daemon owns and already hot-reloads**, which a human
+may edit by hand at any moment anyway. The negative for stop and gc stands
+unchanged; only configuration is admitted.
+
+**2. The full file is served, including `environment.set` values and
+`notify.command`.** This supersedes §16's task-046 note, which says in as many
+words *"it is why `notify` is not served on `GET /v1/config`"*, and relaxes
+§12.3's "names, never the values, at any level" so that it governs the **log**
+and step transcripts, which is where that rule was earned, rather than the API.
+The reasoning admitted: the endpoint is loopback-only behind a 0600 bearer
+token, which is the same trust boundary as the 0600 file — anyone who can call
+`GET /v1/config` can already `cat` it. The logging rule is not weakened: the
+daemon still logs variable names only.
+
+**3. `config_get` is redacted on the MCP path only.** `internal/mcp/tools.go`
+derives its tool surface from §13.2's route table, so decision 2 would otherwise
+hand an agent step the user's literal `environment.set` values and
+`notify.command` argv, into its context and its transcript. The MCP rendering of
+`GET /v1/config` masks those two; the HTTP rendering does not. A test asserts
+the two bodies differ in exactly those fields and nowhere else.
+
+**4. `PATCH /v1/config` is excluded from the MCP tool surface.** Settled already
+by task 057 decision 4, whose wording anticipates this: *"An agent must not be
+able to stop, garbage-collect or **reconfigure** the daemon supervising it."*
+The route joins `mcp.Excluded`. The existing route-table parity test fails on
+either an unexposed or a silently exposed route, so this cannot drift.
+
+**5. PATCH applies synchronously.** The `config.Watch` callback in `daemon.Run`
+was the daemon's only applier, on a 100 ms debounce, so a GET issued right after
+a 200 could still read the old values and every gate assertion would need a
+retry loop. Instead the callback body is a named function, and PATCH calls it
+after the write and before responding; the watcher's later fire re-reads
+identical bytes and is a harmless no-op. This is also the answer to the issue's
+"the write must not fight its watcher": there is one applier function with two
+callers, and it is idempotent.
+
+**6. Serialize and re-read; last writer wins.** A mutex around the
+read-modify-write, and the file is read fresh at patch time rather than from a
+cached copy, so concurrent PATCHes cannot interleave. A hand-edit racing a patch
+is last-writer-wins and undetected — the same posture `PATCH /v1/projects/{id}`
+already has. No ETag/`If-Match`: a precondition concept no other endpoint in
+this API carries, for a race between a human and themselves.
+
+**7. `defaultConfigYAML` is extended first, so the writer's normal path is
+edit-in-place.** The issue assumed "most keys are commented out"; in fact only
+`notify:` was, and `branch_template`, `parallel`, `fan_out`, `loop`, `include`
+and `mcp` were absent from the template entirely — six keys with no documented
+block to uncomment. Every missing key is added to the template as a commented-out
+documented block, matching the style of the `notify:` block. Appending a key to
+the end of a file is the rare fallback, reached only by a `config.yaml` written
+by an older version.
+
+**8. `vincent config get|set` ships in the same work.** The issue's problem
+statement opens on the missing subcommand but its solution never adds one. The
+CLI is a thin API client, consistent with task 048's precedent of a command line
+for every human action, and it is what lets the acceptance gate exercise PATCH
+without curl-ing a JSON body by hand.
+
+**9. The editor is line-oriented, not a marshal round trip.** `config.Apply`
+walks the file's lines with an indentation stack and applies dotted-path
+assignments: an active key is edited in place, a key that exists only as a
+commented-out block is uncommented where it stands, and a key with no block at
+all is appended. Regenerating the file from the `Config` struct would have been
+much simpler and would have flattened the commented template that is most
+users' only documentation of what the keys are. Values are rendered on one line
+— scalars, flow sequences, flow mappings — so a value can be swapped without
+disturbing what surrounds it.
+
+**10. The daemon view's config block keeps its digest and gains a list.** The
+full table is thirty-odd rows, taller than the log pane it shares the view with,
+and the log is why that view is the one that renders while the daemon is
+unreachable. So the block renders the digest it always did until `tab` moves the
+arrows onto it, and then becomes the full scrolling list. Nothing that was
+visible stopped being visible, and every key became reachable.
+
+**11. The block says "differs from the default", not "set in the file".**
+`GET /v1/config` serves effective values and carries no provenance — it cannot
+distinguish a value the file pinned from the identical built-in. Adding
+provenance to the endpoint was rejected as scope the issue does not need. So the
+row shows the built-in default beside a value that differs from it and claims
+nothing more than that.
+
+## What the tests prove
+
+- **Round-trip fidelity** (`internal/config/edit_test.go`). Comments, blank
+  lines, key order and trailing comments survive; the `notify:` block is
+  uncommented in place and appears exactly once; a key with no block is
+  appended once, with its parent reused by the second key under it.
+- **Nothing on failure** (`internal/api/config_patch_test.go`). Seven invalid
+  patches — including a `branch_template` that does not compile — answer the
+  snake_case envelope and leave the file **byte-identical**, asserted on the
+  bytes.
+- **No drift between the struct and the wire.** One test fails when a field is
+  added to `config.Config` and not to `configResponse`; another when a key the
+  read serves is not reachable by `configPatch`.
+- **Read-after-write.** `GET` immediately after a 200 shows the new value, with
+  no sleep.
+- **Serialization.** Twelve concurrent patches; the file parses afterwards.
+- **0600 survives**, including on a file that was `0644` when the patch arrived
+  (POSIX only).
+- **MCP.** `config_get` over a real MCP client masks `environment.set` and
+  `notify.command` while the HTTP body does not, and the two bodies are
+  otherwise equal.
+- **TUI** (`internal/tui/configlive_test.go`), against the real handlers over
+  `httptest`: the editor writes through end to end, a validation error renders
+  against its field with the refused value still on screen, and each of the four
+  dangerous keys refuses to apply without the confirmation.
+- **Gate m11.** Real daemon, real file, over curl: every key served, a patch in
+  force without a restart, comments and key order intact, an invalid patch
+  leaving the bytes alone, 0600 on POSIX, `vincent config get|set`, and
+  `config_patch` absent from the MCP tool list.
+
+## Not done here
+
+- **Provenance on `GET /v1/config`** — see decision 11.
+- **A `vincent config edit` that opens `$EDITOR`.** The workflows view's
+  pattern would work, but it is the alternative the issue rejected: no typed
+  fields and no validation before the file hits disk.
+- **Per-project settings.** They are DB rows with their own form (§14).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -73,6 +73,7 @@ the living engineering specification records implementation contracts.
 | [057](057-daemon-mcp-server.md) | Serve MCP from the daemon so agents can drive vincent directly | 🔄 in progress (8/9) |
 | [058](058-enum-task-fields.md) | Enum task fields: workflow-declared value sets, selectable in New task | ✅ done (1/1) |
 | [059](059-popup-task-details-tab.md) | A task-details tab inside the answer, repair and follow-up popups | ✅ done (5/5) |
+| [060](060-daemon-configuration-editing.md) | Edit the daemon configuration from the TUI | ✅ done (8/8) |
 
 ## How to add and update a task document
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,0 +1,606 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/taskstate"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// GET and PATCH /v1/config (§12.3, §13.2; task 060).
+//
+// The read serves every key in config.Config, not a subset. It used to serve
+// eleven of them, which is how `branch_template`, `environment`, `notify` and
+// six others became invisible from every client: the TUI reads no
+// configuration of its own (§15), so a key this endpoint omits is a key nobody
+// but a text editor can see. A drift test in this package fails when a field
+// is added to config.Config and not here.
+//
+// Values are served in full, including `environment.set` and `notify.command`
+// (task 060 decision 2). The endpoint is loopback-only behind an 0600 bearer
+// token, which is the same trust boundary as the 0600 file — anyone who can
+// call it can already read config.yaml. §12.3's "names, never the values" rule
+// still governs the log and step transcripts, which is where it was earned.
+// The MCP rendering of this route is redacted; see internal/mcp.
+
+// configResponse mirrors config.yaml as snake_case JSON; durations render as
+// Go duration strings (phase 1 decision).
+type configResponse struct {
+	Listen           string `json:"listen"`
+	MaxParallelTasks int    `json:"max_parallel_tasks"`
+	// BranchTemplate is empty when the file pins none, which is not the same
+	// as the built-in: a project may override it, and the fallback lives in
+	// internal/worktree rather than in a default here.
+	BranchTemplate string         `json:"branch_template"`
+	Defaults       configDefaults `json:"defaults"`
+	// The §10 branch-cleanup pair (task 008). Both are reported because the
+	// remote one is inert without the local one, and a client showing only the
+	// key that is on would describe a policy that cannot run.
+	DeleteEmptyBranchOnArchive  bool  `json:"delete_empty_branch_on_archive"`
+	DeleteRemoteBranchOnArchive bool  `json:"delete_remote_branch_on_archive"`
+	FetchBaseBranch             bool  `json:"fetch_base_branch"`
+	TranscriptRetentionDays     int   `json:"transcript_retention_days"`
+	TranscriptMaxBytes          int64 `json:"transcript_max_bytes"`
+	// MaxTaskCostUSD is the per-task spend ceiling; 0 is no cap (task 033).
+	// Served for the same reason every other key is: the TUI reads no
+	// configuration from disk (§15).
+	MaxTaskCostUSD    float64            `json:"max_task_cost_usd"`
+	UsageLimitRecheck string             `json:"usage_limit_recheck_interval"`
+	LogLevel          string             `json:"log_level"`
+	Debug             bool               `json:"debug"`
+	Environment       configEnvironment  `json:"environment"`
+	Agents            configAgents       `json:"agents"`
+	Parallel          configParallel     `json:"parallel"`
+	FanOut            configFanOut       `json:"fan_out"`
+	Loop              configLoop         `json:"loop"`
+	Include           configInclude      `json:"include"`
+	MCP               configMCP          `json:"mcp"`
+	GitHub            configGitHub       `json:"github"`
+	Update            configUpdateStatus `json:"update"`
+	Notify            configNotify       `json:"notify"`
+	// TUI is view preference the daemon only relays (§15): it is in the file
+	// the daemon owns and hot-reloads, so this endpoint is how the TUI — which
+	// reads no configuration of its own — gets it.
+	TUI configTUI `json:"tui"`
+}
+
+type configTUI struct {
+	Board configBoard `json:"board"`
+}
+
+type configBoard struct {
+	// GroupBy is always present, empty list included: `null` would make a
+	// flat table indistinguishable from a client's own default.
+	GroupBy []string `json:"group_by"`
+}
+
+type configDefaults struct {
+	AgentTimeout   string `json:"agent_timeout"`
+	CommandTimeout string `json:"command_timeout"`
+	InputTimeout   string `json:"input_timeout"`
+}
+
+type agentPath struct {
+	Path string `json:"path"`
+}
+
+// configAgents is a struct rather than the map the endpoint used to serve: the
+// adapter set is fixed by §9, and a map made "which adapters exist" look like
+// a runtime answer while also giving PATCH no shape to validate against.
+type configAgents struct {
+	Claude agentPath `json:"claude"`
+	Codex  agentPath `json:"codex"`
+	Cursor agentPath `json:"cursor"`
+}
+
+// configEnvironment is §12.3's child-process policy. Inherit is a union in
+// JSON because it is a union in YAML: "all", "none", or a list of names.
+type configEnvironment struct {
+	Inherit configInherit     `json:"inherit"`
+	Unset   []string          `json:"unset"`
+	Set     map[string]string `json:"set"`
+}
+
+// configInherit renders as the string "all"/"none" or as an array of names.
+// Spelling the two words as one-element arrays would read worse than the
+// union does, and the config file already made this choice.
+type configInherit struct {
+	Mode  string
+	Names []string
+}
+
+func (i configInherit) MarshalJSON() ([]byte, error) {
+	if i.Mode == "list" {
+		names := i.Names
+		if names == nil {
+			names = []string{}
+		}
+		return json.Marshal(names)
+	}
+	return json.Marshal(i.Mode)
+}
+
+func (i *configInherit) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "all", "none":
+			*i = configInherit{Mode: strings.ToLower(strings.TrimSpace(s))}
+			return nil
+		default:
+			return fmt.Errorf("environment.inherit: want \"all\", \"none\", or a list of names; got %q", s)
+		}
+	}
+	var names []string
+	if err := json.Unmarshal(b, &names); err != nil {
+		return errors.New("environment.inherit: want \"all\", \"none\", or a list of names")
+	}
+	*i = configInherit{Mode: "list", Names: names}
+	return nil
+}
+
+// yaml renders the union back into the one line config.yaml carries.
+func (i configInherit) yaml() string {
+	switch i.Mode {
+	case "none":
+		return "none"
+	case "list":
+		return config.RenderList(i.Names)
+	default:
+		return "all"
+	}
+}
+
+type configParallel struct {
+	MaxParallel int `json:"max_parallel"`
+}
+
+type configFanOut struct {
+	MaxDepth int `json:"max_depth"`
+	MaxTasks int `json:"max_tasks"`
+}
+
+type configLoop struct {
+	MaxIterations int `json:"max_iterations"`
+}
+
+type configInclude struct {
+	MaxDepth int `json:"max_depth"`
+}
+
+type configMCP struct {
+	WireSteps bool `json:"wire_steps"`
+	MaxDepth  int  `json:"max_depth"`
+	MaxTasks  int  `json:"max_tasks"`
+}
+
+type configGitHub struct {
+	Enabled      bool   `json:"enabled"`
+	PollInterval string `json:"poll_interval"`
+}
+
+// configUpdateStatus is the `update` block of config.yaml — the release-check
+// policy, not GET /v1/update's cached answer.
+type configUpdateStatus struct {
+	Check        bool   `json:"check"`
+	PollInterval string `json:"poll_interval"`
+}
+
+type configNotify struct {
+	On []string `json:"on"`
+	// Command is argv, served in full. It can carry a secret, and that is why
+	// config.yaml is 0600 — not why this endpoint would hide it (decision 2).
+	Command []string `json:"command"`
+}
+
+// configBody renders the effective configuration as the wire shape.
+func configBody(cfg config.Config) configResponse {
+	return configResponse{
+		Listen:           cfg.Listen,
+		MaxParallelTasks: cfg.MaxParallelTasks,
+		BranchTemplate:   cfg.BranchTemplate,
+		Defaults: configDefaults{
+			AgentTimeout:   cfg.Defaults.AgentTimeout.String(),
+			CommandTimeout: cfg.Defaults.CommandTimeout.String(),
+			InputTimeout:   cfg.Defaults.InputTimeout.String(),
+		},
+		DeleteEmptyBranchOnArchive:  cfg.DeleteEmptyBranchOnArchive,
+		DeleteRemoteBranchOnArchive: cfg.DeleteRemoteBranchOnArchive,
+		FetchBaseBranch:             cfg.FetchBaseBranch,
+		TranscriptRetentionDays:     cfg.TranscriptRetentionDays,
+		TranscriptMaxBytes:          cfg.TranscriptMaxBytes.Bytes(),
+		MaxTaskCostUSD:              cfg.MaxTaskCostUSD,
+		UsageLimitRecheck:           cfg.UsageLimitRecheckInterval.String(),
+		LogLevel:                    cfg.LogLevel,
+		Debug:                       cfg.Debug,
+		Environment: configEnvironment{
+			Inherit: inheritBody(cfg.Environment.Inherit),
+			Unset:   stringList(cfg.Environment.Unset),
+			Set:     stringMap(cfg.Environment.Set),
+		},
+		Agents: configAgents{
+			Claude: agentPath{Path: cfg.Agents.Claude.Path},
+			Codex:  agentPath{Path: cfg.Agents.Codex.Path},
+			Cursor: agentPath{Path: cfg.Agents.Cursor.Path},
+		},
+		Parallel: configParallel{MaxParallel: cfg.Parallel.MaxParallel},
+		FanOut:   configFanOut{MaxDepth: cfg.FanOut.MaxDepth, MaxTasks: cfg.FanOut.MaxTasks},
+		Loop:     configLoop{MaxIterations: cfg.Loop.MaxIterations},
+		Include:  configInclude{MaxDepth: cfg.Include.MaxDepth},
+		MCP: configMCP{
+			WireSteps: cfg.MCP.WireSteps,
+			MaxDepth:  cfg.MCP.MaxDepth,
+			MaxTasks:  cfg.MCP.MaxTasks,
+		},
+		GitHub: configGitHub{
+			Enabled:      cfg.GitHub.Enabled,
+			PollInterval: cfg.GitHub.PollInterval.String(),
+		},
+		Update: configUpdateStatus{
+			Check:        cfg.Update.Check,
+			PollInterval: cfg.Update.PollInterval.String(),
+		},
+		Notify: configNotify{On: notifyStates(cfg.Notify.On), Command: stringList(cfg.Notify.Command)},
+		TUI:    configTUI{Board: configBoard{GroupBy: boardGroupBy(cfg.TUI.Board.GroupBy)}},
+	}
+}
+
+func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, configBody(s.deps.Config()))
+}
+
+// boardGroupBy renders the grouping levels as strings, never as JSON null: a
+// flat table is a configured choice and has to read as `[]`.
+func boardGroupBy(levels []config.BoardGroup) []string {
+	out := make([]string, 0, len(levels))
+	for _, l := range levels {
+		out = append(out, string(l))
+	}
+	return out
+}
+
+// notifyStates renders the §6 states notify fires on, `[]` when none.
+func notifyStates(states []taskstate.State) []string {
+	out := make([]string, 0, len(states))
+	for _, st := range states {
+		out = append(out, string(st))
+	}
+	return out
+}
+
+// ftoa renders a dollar ceiling the way a human writes one: no exponent and
+// no trailing zeros, so 0 stays "0" rather than becoming "0.000000".
+func ftoa(f float64) string { return strconv.FormatFloat(f, 'f', -1, 64) }
+
+// stringList renders a list as `[]` rather than `null`, on the same rule
+// boardGroupBy follows: an empty list is a configured choice.
+func stringList(items []string) []string {
+	out := make([]string, 0, len(items))
+	out = append(out, items...)
+	return out
+}
+
+func stringMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func inheritBody(i config.Inherit) configInherit {
+	switch i.Mode {
+	case config.InheritNoneMode:
+		return configInherit{Mode: "none"}
+	case config.InheritListMode:
+		return configInherit{Mode: "list", Names: stringList(i.Names)}
+	default:
+		return configInherit{Mode: "all"}
+	}
+}
+
+// configPatch is the PATCH body: the read shape with every key optional, on
+// the pattern PATCH /v1/projects/{id} and PATCH /v1/tasks/{id} set. A key
+// absent from the body is a key the file keeps.
+type configPatch struct {
+	Listen                      *string            `json:"listen"`
+	MaxParallelTasks            *int               `json:"max_parallel_tasks"`
+	BranchTemplate              *string            `json:"branch_template"`
+	Defaults                    *defaultsPatch     `json:"defaults"`
+	DeleteEmptyBranchOnArchive  *bool              `json:"delete_empty_branch_on_archive"`
+	DeleteRemoteBranchOnArchive *bool              `json:"delete_remote_branch_on_archive"`
+	FetchBaseBranch             *bool              `json:"fetch_base_branch"`
+	TranscriptRetentionDays     *int               `json:"transcript_retention_days"`
+	TranscriptMaxBytes          *int64             `json:"transcript_max_bytes"`
+	MaxTaskCostUSD              *float64           `json:"max_task_cost_usd"`
+	UsageLimitRecheck           *string            `json:"usage_limit_recheck_interval"`
+	LogLevel                    *string            `json:"log_level"`
+	Debug                       *bool              `json:"debug"`
+	Environment                 *environmentPatch  `json:"environment"`
+	Agents                      *agentsPatch       `json:"agents"`
+	Parallel                    *parallelPatch     `json:"parallel"`
+	FanOut                      *fanOutPatch       `json:"fan_out"`
+	Loop                        *loopPatch         `json:"loop"`
+	Include                     *includePatch      `json:"include"`
+	MCP                         *mcpPatch          `json:"mcp"`
+	GitHub                      *githubPatch       `json:"github"`
+	Update                      *updatePolicyPatch `json:"update"`
+	Notify                      *notifyPatch       `json:"notify"`
+	TUI                         *tuiPatch          `json:"tui"`
+}
+
+type defaultsPatch struct {
+	AgentTimeout   *string `json:"agent_timeout"`
+	CommandTimeout *string `json:"command_timeout"`
+	InputTimeout   *string `json:"input_timeout"`
+}
+
+type environmentPatch struct {
+	Inherit *configInherit     `json:"inherit"`
+	Unset   *[]string          `json:"unset"`
+	Set     *map[string]string `json:"set"`
+}
+
+type agentsPatch struct {
+	Claude *agentPatch `json:"claude"`
+	Codex  *agentPatch `json:"codex"`
+	Cursor *agentPatch `json:"cursor"`
+}
+
+type agentPatch struct {
+	Path *string `json:"path"`
+}
+
+type parallelPatch struct {
+	MaxParallel *int `json:"max_parallel"`
+}
+
+type fanOutPatch struct {
+	MaxDepth *int `json:"max_depth"`
+	MaxTasks *int `json:"max_tasks"`
+}
+
+type loopPatch struct {
+	MaxIterations *int `json:"max_iterations"`
+}
+
+type includePatch struct {
+	MaxDepth *int `json:"max_depth"`
+}
+
+type mcpPatch struct {
+	WireSteps *bool `json:"wire_steps"`
+	MaxDepth  *int  `json:"max_depth"`
+	MaxTasks  *int  `json:"max_tasks"`
+}
+
+type githubPatch struct {
+	Enabled      *bool   `json:"enabled"`
+	PollInterval *string `json:"poll_interval"`
+}
+
+type updatePolicyPatch struct {
+	Check        *bool   `json:"check"`
+	PollInterval *string `json:"poll_interval"`
+}
+
+type notifyPatch struct {
+	On      *[]string `json:"on"`
+	Command *[]string `json:"command"`
+}
+
+type tuiPatch struct {
+	Board *boardPatch `json:"board"`
+}
+
+type boardPatch struct {
+	GroupBy *[]string `json:"group_by"`
+}
+
+// sets turns the patch into the dotted-path assignments the config editor
+// applies. Nothing is type-checked here beyond what JSON already decided:
+// every value is rendered as YAML and the candidate file is decoded through
+// config.Decode, so the rule that rejects a bad value is the same rule the
+// next daemon start would apply.
+func (p configPatch) sets() []config.Set {
+	var out []config.Set
+	add := func(path, value string) { out = append(out, config.Set{Path: path, Value: value}) }
+	if p.Listen != nil {
+		add("listen", config.RenderString(*p.Listen))
+	}
+	if p.MaxParallelTasks != nil {
+		add("max_parallel_tasks", strconv.Itoa(*p.MaxParallelTasks))
+	}
+	if p.BranchTemplate != nil {
+		add("branch_template", config.RenderString(*p.BranchTemplate))
+	}
+	if d := p.Defaults; d != nil {
+		addIfString(add, "defaults.agent_timeout", d.AgentTimeout)
+		addIfString(add, "defaults.command_timeout", d.CommandTimeout)
+		addIfString(add, "defaults.input_timeout", d.InputTimeout)
+	}
+	addIfBool(add, "delete_empty_branch_on_archive", p.DeleteEmptyBranchOnArchive)
+	addIfBool(add, "delete_remote_branch_on_archive", p.DeleteRemoteBranchOnArchive)
+	addIfBool(add, "fetch_base_branch", p.FetchBaseBranch)
+	if p.TranscriptRetentionDays != nil {
+		add("transcript_retention_days", strconv.Itoa(*p.TranscriptRetentionDays))
+	}
+	if p.TranscriptMaxBytes != nil {
+		// Rendered in the unit a human would have written: ByteSize.String
+		// picks the largest unit that divides exactly, so 512MB stays 512MB.
+		add("transcript_max_bytes", config.RenderString(config.ByteSize(*p.TranscriptMaxBytes).String()))
+	}
+	if p.MaxTaskCostUSD != nil {
+		add("max_task_cost_usd", ftoa(*p.MaxTaskCostUSD))
+	}
+	addIfString(add, "usage_limit_recheck_interval", p.UsageLimitRecheck)
+	addIfString(add, "log_level", p.LogLevel)
+	addIfBool(add, "debug", p.Debug)
+	if e := p.Environment; e != nil {
+		if e.Inherit != nil {
+			add("environment.inherit", e.Inherit.yaml())
+		}
+		if e.Unset != nil {
+			add("environment.unset", config.RenderList(*e.Unset))
+		}
+		if e.Set != nil {
+			add("environment.set", config.RenderMap(*e.Set))
+		}
+	}
+	if a := p.Agents; a != nil {
+		for name, ap := range map[string]*agentPatch{"claude": a.Claude, "codex": a.Codex, "cursor": a.Cursor} {
+			if ap != nil {
+				addIfString(add, "agents."+name+".path", ap.Path)
+			}
+		}
+	}
+	if v := p.Parallel; v != nil {
+		addIfInt(add, "parallel.max_parallel", v.MaxParallel)
+	}
+	if v := p.FanOut; v != nil {
+		addIfInt(add, "fan_out.max_depth", v.MaxDepth)
+		addIfInt(add, "fan_out.max_tasks", v.MaxTasks)
+	}
+	if v := p.Loop; v != nil {
+		addIfInt(add, "loop.max_iterations", v.MaxIterations)
+	}
+	if v := p.Include; v != nil {
+		addIfInt(add, "include.max_depth", v.MaxDepth)
+	}
+	if v := p.MCP; v != nil {
+		addIfBool(add, "mcp.wire_steps", v.WireSteps)
+		addIfInt(add, "mcp.max_depth", v.MaxDepth)
+		addIfInt(add, "mcp.max_tasks", v.MaxTasks)
+	}
+	if v := p.GitHub; v != nil {
+		addIfBool(add, "github.enabled", v.Enabled)
+		addIfString(add, "github.poll_interval", v.PollInterval)
+	}
+	if v := p.Update; v != nil {
+		addIfBool(add, "update.check", v.Check)
+		addIfString(add, "update.poll_interval", v.PollInterval)
+	}
+	if v := p.Notify; v != nil {
+		if v.On != nil {
+			add("notify.on", config.RenderList(*v.On))
+		}
+		if v.Command != nil {
+			add("notify.command", config.RenderList(*v.Command))
+		}
+	}
+	if v := p.TUI; v != nil && v.Board != nil && v.Board.GroupBy != nil {
+		add("tui.board.group_by", config.RenderList(*v.Board.GroupBy))
+	}
+	// Order is the struct's, which is config.yaml's, so two clients sending
+	// the same patch produce the same bytes.
+	return out
+}
+
+func addIfString(add func(string, string), path string, v *string) {
+	if v != nil {
+		add(path, config.RenderString(*v))
+	}
+}
+
+func addIfBool(add func(string, string), path string, v *bool) {
+	if v != nil {
+		if *v {
+			add(path, "true")
+		} else {
+			add(path, "false")
+		}
+	}
+}
+
+func addIfInt(add func(string, string), path string, v *int) {
+	if v != nil {
+		add(path, strconv.Itoa(*v))
+	}
+}
+
+// handleConfigPatch applies a partial edit to config.yaml and puts it into
+// force before answering (task 060 decision 5).
+//
+// The order is the whole contract: read the file fresh, apply the sets to its
+// bytes, decode the candidate, refuse the request without touching the disk if
+// it does not hold, write atomically at 0600, then apply synchronously. A GET
+// issued the instant a 200 lands reads the new values, with no sleep — the
+// fsnotify watcher's later fire re-reads identical bytes and is a no-op.
+//
+// One mutex serializes the read-modify-write (decision 6). A hand-edit racing
+// a patch is last-writer-wins and undetected, which is the posture PATCH
+// /v1/projects/{id} already has; there is no ETag, because a precondition
+// concept no other endpoint carries would exist for a race between a human and
+// themselves.
+func (s *Server) handleConfigPatch(w http.ResponseWriter, r *http.Request) {
+	var patch configPatch
+	if !decodeJSON(w, r, &patch) {
+		return
+	}
+	sets := patch.sets()
+	if len(sets) == 0 {
+		// Nothing to write is not an error: it is the configuration unchanged.
+		writeJSON(w, http.StatusOK, configBody(s.deps.Config()))
+		return
+	}
+
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+
+	path := s.configPath()
+	if path == "" {
+		s.internalError(w, "config path", errors.New("no config directory is wired"))
+		return
+	}
+	//nolint:gosec // G304: the path is the daemon's own resolved config dir
+	src, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.internalError(w, "read config", err)
+		return
+	}
+	next, err := config.Apply(src, sets)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, err.Error())
+		return
+	}
+	cfg, err := config.Decode(next)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, err.Error())
+		return
+	}
+	// The same check daemon.Run's reload path applies. config cannot make it
+	// itself: it is a leaf package and the template context lives in
+	// internal/worktree.
+	if err := worktree.ValidateBranchTemplate(cfg.BranchTemplate); err != nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"branch_template does not compile: "+err.Error())
+		return
+	}
+	if err := config.WriteFile(path, next); err != nil {
+		s.internalError(w, "write config", err)
+		return
+	}
+	if s.deps.ApplyConfig != nil {
+		s.deps.ApplyConfig(cfg)
+	}
+	// Served from the applier's own view rather than from cfg: `listen` is
+	// pinned until restart, and reporting the value the daemon is actually
+	// running on is the honest answer to "what is in force now".
+	writeJSON(w, http.StatusOK, configBody(s.deps.Config()))
+}
+
+// configPath is the config.yaml this daemon owns.
+func (s *Server) configPath() string {
+	if s.deps.Dirs.Config == "" {
+		return ""
+	}
+	return filepath.Join(s.deps.Dirs.Config, config.FileName)
+}

--- a/internal/api/config_mcp_test.go
+++ b/internal/api/config_mcp_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// callConfigGetTool calls the tool over a real MCP client, so what is asserted
+// is what a model would actually receive — not what a helper reconstructed.
+func callConfigGetTool(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	httpClient := ts.Client()
+	httpClient.Transport = bearerRoundTripper{base: httpClient.Transport, token: testToken}
+	client := sdk.NewClient(&sdk.Implementation{Name: "test", Version: "0"}, nil)
+	sess, err := client.Connect(t.Context(),
+		&sdk.StreamableClientTransport{Endpoint: ts.URL + "/mcp", HTTPClient: httpClient}, nil)
+	if err != nil {
+		t.Fatalf("connect to /mcp: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+	res, err := sess.CallTool(t.Context(), &sdk.CallToolParams{Name: "config_get"})
+	if err != nil {
+		t.Fatalf("tools/call config_get: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("config_get returned an error: %+v", res.Content)
+	}
+	text, ok := res.Content[0].(*sdk.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, want text", res.Content[0])
+	}
+	return text.Text
+}
+
+// Task 060 decision 3: the HTTP rendering of GET /v1/config serves the file in
+// full, and the MCP rendering of the same route masks `environment.set`'s
+// values and `notify.command`'s argv — because a tool result lands in an
+// agent's context and in its transcript, which is not the loopback-plus-0600
+// boundary the HTTP body sits behind.
+//
+// The assertion is that the two bodies differ in exactly those two fields and
+// nowhere else. A redaction that quietly grew would fail it just as a
+// redaction that stopped working would.
+func TestMCPConfigGetRedactsOnlyTheTwoSecretFields(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment.Set = map[string]string{"API_TOKEN": "s3cret", "LANG": "C.UTF-8"}
+	cfg.Notify.Command = []string{"/usr/local/bin/notify", "https://hooks.example/T0/B0/xoxb"}
+	ts, _ := newTestServer(t, func() config.Config { return cfg })
+
+	_, httpBody := doRequest(t, ts, http.MethodGet, "/v1/config", testToken)
+	toolBody := callConfigGetTool(t, ts)
+
+	var direct, viaTool map[string]any
+	if err := json.Unmarshal(httpBody, &direct); err != nil {
+		t.Fatalf("parse http body: %v", err)
+	}
+	if err := json.Unmarshal([]byte(toolBody), &viaTool); err != nil {
+		t.Fatalf("parse tool body %q: %v", toolBody, err)
+	}
+
+	// The HTTP body is unredacted: that is decision 2, and a test that only
+	// checked the mask would pass with both sides hidden.
+	if got := direct["environment"].(map[string]any)["set"].(map[string]any)["API_TOKEN"]; got != "s3cret" {
+		t.Errorf("the HTTP body redacted environment.set: %v", got)
+	}
+	if got := direct["notify"].(map[string]any)["command"].([]any)[1]; got != "https://hooks.example/T0/B0/xoxb" {
+		t.Errorf("the HTTP body redacted notify.command: %v", got)
+	}
+
+	// The tool body masks the values and keeps the names.
+	set := viaTool["environment"].(map[string]any)["set"].(map[string]any)
+	for name, v := range set {
+		if v != "[redacted]" {
+			t.Errorf("environment.set[%s] reached the tool as %v", name, v)
+		}
+	}
+	if len(set) != 2 {
+		t.Errorf("the variable names were dropped as well as the values: %v", set)
+	}
+	for _, v := range viaTool["notify"].(map[string]any)["command"].([]any) {
+		if v != "[redacted]" {
+			t.Errorf("notify.command reached the tool as %v", v)
+		}
+	}
+
+	// Nothing else moved.
+	direct["environment"] = nil
+	viaTool["environment"] = nil
+	direct["notify"] = nil
+	viaTool["notify"] = nil
+	if !reflect.DeepEqual(direct, viaTool) {
+		t.Errorf("the two renderings differ outside environment and notify:\nhttp=%v\ntool=%v", direct, viaTool)
+	}
+}

--- a/internal/api/config_patch_test.go
+++ b/internal/api/config_patch_test.go
@@ -1,0 +1,311 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// PATCH /v1/config (task 060). The invariants asserted here are the ones the
+// endpoint's usefulness rests on: nothing is written when the patch does not
+// hold, comments survive when it does, and a GET immediately after a 200 sees
+// the new value with no sleep.
+
+// configHarness is a server whose config dir is a real directory holding the
+// shipped template, wired to an applier that behaves like the daemon's.
+type configHarness struct {
+	ts   *httptest.Server
+	path string
+	cur  atomic.Pointer[config.Config]
+	// applied counts synchronous applies, so a test can tell "the daemon put
+	// it into force" apart from "the file happens to say so".
+	applied atomic.Int64
+}
+
+func newConfigHarness(t *testing.T) *configHarness {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := config.EnsureDefaultFile(dir); err != nil {
+		t.Fatalf("seed config.yaml: %v", err)
+	}
+	h := &configHarness{path: filepath.Join(dir, config.FileName)}
+	initial := config.Default()
+	h.cur.Store(&initial)
+	s := New(Deps{
+		Token:       testToken,
+		Config:      func() config.Config { return *h.cur.Load() },
+		StartedAt:   time.Now().Add(-time.Minute),
+		ListenAddr:  "127.0.0.1:12345",
+		Dirs:        config.Dirs{Config: dir},
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ApplyConfig: func(next config.Config) {
+			// The daemon pins listen across a reload; so does this.
+			next.Listen = h.cur.Load().Listen
+			h.cur.Store(&next)
+			h.applied.Add(1)
+		},
+	})
+	h.ts = httptest.NewServer(s.Handler())
+	t.Cleanup(h.ts.Close)
+	return h
+}
+
+func (h *configHarness) patch(t *testing.T, body string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPatch, h.ts.URL+"/v1/config", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	out, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp, out
+}
+
+func (h *configHarness) bytes(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile(h.path)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	return b
+}
+
+// The read-after-write decision 5 exists for: a GET issued the instant a 200
+// lands must see the new value, with no retry loop and no sleep.
+func TestConfigPatchAppliesBeforeItAnswers(t *testing.T) {
+	h := newConfigHarness(t)
+	resp, body := h.patch(t, `{"max_parallel_tasks":9,"log_level":"debug"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	var answered configResponse
+	if err := json.Unmarshal(body, &answered); err != nil {
+		t.Fatalf("parse patch response: %v", err)
+	}
+	if answered.MaxParallelTasks != 9 || answered.LogLevel != "debug" {
+		t.Errorf("the patch response does not carry the new values: %+v", answered)
+	}
+	if h.applied.Load() == 0 {
+		t.Error("the daemon's applier was never called; the change is on disk and not in force")
+	}
+	_, getBody := doRequest(t, h.ts, http.MethodGet, "/v1/config", testToken)
+	var got configResponse
+	if err := json.Unmarshal(getBody, &got); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if got.MaxParallelTasks != 9 || got.LogLevel != "debug" {
+		t.Errorf("GET right after the 200 still reads the old config: %+v", got)
+	}
+}
+
+// The file is documentation as much as it is settings, so an edit that
+// flattens it is a regression even when the values are right.
+func TestConfigPatchKeepsCommentsAndUncommentsInPlace(t *testing.T) {
+	h := newConfigHarness(t)
+	before := h.bytes(t)
+	resp, body := h.patch(t, `{"notify":{"on":["blocked"],"command":["/bin/echo","hi"]}}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	after := string(h.bytes(t))
+	if n := strings.Count(after, "\nnotify:"); n != 1 {
+		t.Errorf("notify: appears %d times, want 1:\n%s", n, after)
+	}
+	if !strings.Contains(after, "WARNING: this is arbitrary code the daemon runs as you") {
+		t.Error("the notify block's documentation was flattened")
+	}
+	// Every comment the file had, it still has.
+	for _, line := range strings.Split(string(before), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") || strings.Contains(trimmed, "notify") ||
+			strings.Contains(trimmed, "on:") || strings.Contains(trimmed, "command:") {
+			continue
+		}
+		if !strings.Contains(after, trimmed) {
+			t.Errorf("a comment was lost: %q", trimmed)
+		}
+	}
+}
+
+// "An invalid patch writes nothing" is asserted on the bytes, not on a
+// reload: a file that was written and then reverted is still a file that was
+// written, and a crash between the two would leave the bad one.
+func TestConfigPatchRejectionLeavesTheFileByteIdentical(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"a port that is not a port", `{"listen":"127.0.0.1:notaport"}`},
+		{"a host that is not loopback", `{"listen":"0.0.0.0:0"}`},
+		{"a cap below one", `{"max_parallel_tasks":0}`},
+		{"an unknown log level", `{"log_level":"chatty"}`},
+		{"a duration that will not parse", `{"defaults":{"agent_timeout":"soon"}}`},
+		{"a branch template that does not compile", `{"branch_template":"vincent/{{.ID"}`},
+		{"a notify state that is not one", `{"notify":{"on":["exploded"]}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newConfigHarness(t)
+			before := h.bytes(t)
+			resp, body := h.patch(t, tc.body)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body %s)", resp.StatusCode, body)
+			}
+			var env errorBody
+			if err := json.Unmarshal(body, &env); err != nil || env.Error.Code != CodeValidationFailed {
+				t.Errorf("want the snake_case validation envelope, got %s", body)
+			}
+			if !bytes.Equal(before, h.bytes(t)) {
+				t.Error("a rejected patch changed config.yaml")
+			}
+			if h.applied.Load() != 0 {
+				t.Error("a rejected patch was applied")
+			}
+		})
+	}
+}
+
+// Two patches that interleave would produce a file holding neither. The mutex
+// is what stops it; this is what would notice if it were removed.
+func TestConfigPatchesSerialize(t *testing.T) {
+	h := newConfigHarness(t)
+	const n = 12
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			body := `{"max_parallel_tasks":` + itoaForTest(i+1) + `}`
+			if i%2 == 1 {
+				body = `{"transcript_retention_days":` + itoaForTest(i+1) + `}`
+			}
+			resp, out := h.patch(t, body)
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d (body %s)", resp.StatusCode, out)
+			}
+		}()
+	}
+	wg.Wait()
+	if _, err := config.Decode(h.bytes(t)); err != nil {
+		t.Fatalf("the file does not parse after concurrent patches: %v\n%s", err, h.bytes(t))
+	}
+}
+
+// `listen` is written and does not take effect until a restart. The response
+// has to say what is in force, not what was asked for, or a client will show
+// an address nothing is bound to.
+func TestConfigPatchReportsListenAsPendingUntilRestart(t *testing.T) {
+	h := newConfigHarness(t)
+	resp, body := h.patch(t, `{"listen":"127.0.0.1:9999"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	var got configResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Listen != config.Default().Listen {
+		t.Errorf("listen = %q, want the address still in force (%q)", got.Listen, config.Default().Listen)
+	}
+	if !strings.Contains(string(h.bytes(t)), "listen: 127.0.0.1:9999") {
+		t.Error("listen was not written to config.yaml")
+	}
+}
+
+// An empty patch is the configuration unchanged, not an error and not a write.
+func TestConfigPatchWithNoKeysWritesNothing(t *testing.T) {
+	h := newConfigHarness(t)
+	before := h.bytes(t)
+	resp, body := h.patch(t, `{}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	if !bytes.Equal(before, h.bytes(t)) {
+		t.Error("an empty patch rewrote the file")
+	}
+}
+
+// The drift this task exists because of: GET /v1/config served eleven of the
+// twenty-odd keys config.Config carries, so nine of them were invisible from
+// every client. This fails when a field is added to config.Config and not to
+// the wire shape.
+func TestConfigResponseCoversEveryConfigField(t *testing.T) {
+	served := map[string]bool{}
+	for _, f := range reflect.VisibleFields(reflect.TypeOf(configResponse{})) {
+		if tag := f.Tag.Get("json"); tag != "" {
+			served[strings.Split(tag, ",")[0]] = true
+		}
+	}
+	var missing []string
+	for _, f := range reflect.VisibleFields(reflect.TypeOf(config.Config{})) {
+		tag := f.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if !served[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("config.Config carries keys GET /v1/config does not serve, so no client can see them: %v\n"+
+			"add them to configResponse, configBody and configPatch", missing)
+	}
+}
+
+// Every key the read serves has to be reachable by the patch, or the endpoint
+// shows something no client can change — which is the read-only state this
+// task ended.
+func TestConfigPatchCoversEveryServedKey(t *testing.T) {
+	patchable := map[string]bool{}
+	for _, f := range reflect.VisibleFields(reflect.TypeOf(configPatch{})) {
+		if tag := f.Tag.Get("json"); tag != "" {
+			patchable[strings.Split(tag, ",")[0]] = true
+		}
+	}
+	var missing []string
+	for _, f := range reflect.VisibleFields(reflect.TypeOf(configResponse{})) {
+		tag := f.Tag.Get("json")
+		if tag == "" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if !patchable[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("GET /v1/config serves keys PATCH cannot change: %v", missing)
+	}
+}
+
+func itoaForTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/api/config_perm_unix_test.go
+++ b/internal/api/config_perm_unix_test.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package api
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// config.yaml can hold literal environment.set values and a notify.command
+// carrying a secret (§12.2), which is why it is owner-only. A write that
+// went through the daemon must not be the thing that widens it — including
+// on a file that was already too permissive when the patch arrived.
+func TestConfigPatchKeepsTheFileOwnerOnly(t *testing.T) {
+	h := newConfigHarness(t)
+	if err := os.Chmod(h.path, 0o644); err != nil {
+		t.Fatalf("loosen: %v", err)
+	}
+	resp, body := h.patch(t, `{"log_level":"warn"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	info, err := os.Stat(h.path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != config.FilePerm {
+		t.Errorf("config.yaml mode = %o after a patch, want %o", got, config.FilePerm)
+	}
+}

--- a/internal/api/mcp_parity_test.go
+++ b/internal/api/mcp_parity_test.go
@@ -58,7 +58,7 @@ func TestMCPToolSurfaceMatchesRouteTable(t *testing.T) {
 	}
 }
 
-// TestMCPExcludesDestructiveAdminByName asserts the five exclusions by name,
+// TestMCPExcludesDestructiveAdminByName asserts the six exclusions by name,
 // so removing one from Excluded is a test failure rather than a quiet
 // widening of what an agent may do to the daemon supervising it.
 func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
@@ -66,6 +66,10 @@ func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 	want := []struct{ method, path string }{
 		{http.MethodPost, "/v1/daemon/stop"},
 		{http.MethodPost, "/v1/daemon/backup"},
+		// Task 060 decision 4: a step must not rewrite the rules it runs
+		// under — the argv the daemon spawns, what its children inherit, or
+		// whether steps get MCP at all.
+		{http.MethodPatch, "/v1/config"},
 		{http.MethodDelete, "/v1/projects/{id}"},
 		{http.MethodPost, "/v1/maintenance/gc"},
 		{http.MethodPost, "/v1/doctor/fix"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
@@ -86,6 +87,12 @@ type Deps struct {
 	// (task 005, §10). Nil is tolerated (tests without a data dir) — the
 	// maintenance endpoints then answer 500 and /v1/info reports no orphans.
 	Reclaimer *taskrun.Reclaimer
+	// ApplyConfig installs a configuration PATCH /v1/config just wrote, before
+	// the response is sent (task 060 decision 5). It is the same function the
+	// config.Watch callback calls, so the `listen` pin and the branch_template
+	// fallback apply on both paths — one applier, two callers, idempotent.
+	// Nil is tolerated (tests without a daemon); the file is still written.
+	ApplyConfig func(config.Config)
 	// UpdateStatus returns the daemon's cached release check (task 055,
 	// §13.2). It serves **only** the cache: GET /v1/update never makes an
 	// outbound call, which is what keeps `update.check: false` a literal
@@ -147,6 +154,10 @@ type Server struct {
 	// so the MCP tool surface can be asserted against it (task 057) rather
 	// than maintained beside it.
 	routes []Route
+	// configMu serializes PATCH /v1/config's read-modify-write of config.yaml
+	// (task 060 decision 6). Two patches cannot interleave; a hand-edit
+	// racing one is last-writer-wins, the posture every other PATCH here has.
+	configMu sync.Mutex
 }
 
 // Route is one registered API route.
@@ -228,6 +239,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodGet, "/v1/health", s.handleHealth)
 	rt.handle(http.MethodGet, "/v1/info", s.handleInfo)
 	rt.handle(http.MethodGet, "/v1/config", s.handleConfig)
+	rt.handle(http.MethodPatch, "/v1/config", s.handleConfigPatch)
 	rt.handle(http.MethodGet, "/v1/agents", s.handleAgents)
 	rt.handle(http.MethodGet, "/v1/doctor", s.handleDoctor)
 	rt.handle(http.MethodGet, "/v1/update", s.handleUpdate)
@@ -448,88 +460,6 @@ func (s *Server) infoDatabase() infoDatabase {
 	}
 	out.SizeBytes, out.WALBytes = sizes.MainBytes, sizes.WALBytes
 	out.SHMBytes, out.TotalBytes = sizes.SHMBytes, sizes.TotalBytes
-	return out
-}
-
-// configResponse mirrors config.yaml as snake_case JSON; durations render as
-// Go duration strings (phase 1 decision).
-type configResponse struct {
-	Listen           string         `json:"listen"`
-	MaxParallelTasks int            `json:"max_parallel_tasks"`
-	Defaults         configDefaults `json:"defaults"`
-	// The §10 branch-cleanup pair (task 008). Both are reported because the
-	// remote one is inert without the local one, and a client showing only the
-	// key that is on would describe a policy that cannot run.
-	DeleteEmptyBranchOnArchive  bool  `json:"delete_empty_branch_on_archive"`
-	DeleteRemoteBranchOnArchive bool  `json:"delete_remote_branch_on_archive"`
-	TranscriptRetentionDays     int   `json:"transcript_retention_days"`
-	TranscriptMaxBytes          int64 `json:"transcript_max_bytes"`
-	// MaxTaskCostUSD is the per-task spend ceiling; 0 is no cap (task 033).
-	// Served for the same reason every other key is: the TUI reads no
-	// configuration from disk (§15).
-	MaxTaskCostUSD    float64              `json:"max_task_cost_usd"`
-	UsageLimitRecheck string               `json:"usage_limit_recheck_interval"`
-	LogLevel          string               `json:"log_level"`
-	Agents            map[string]agentPath `json:"agents"`
-	// TUI is view preference the daemon only relays (§15): it is in the file
-	// the daemon owns and hot-reloads, so this endpoint is how the TUI — which
-	// reads no configuration of its own — gets it.
-	TUI configTUI `json:"tui"`
-}
-
-type configTUI struct {
-	Board configBoard `json:"board"`
-}
-
-type configBoard struct {
-	// GroupBy is always present, empty list included: `null` would make a
-	// flat table indistinguishable from a client's own default.
-	GroupBy []string `json:"group_by"`
-}
-
-type configDefaults struct {
-	AgentTimeout   string `json:"agent_timeout"`
-	CommandTimeout string `json:"command_timeout"`
-	InputTimeout   string `json:"input_timeout"`
-}
-
-type agentPath struct {
-	Path string `json:"path"`
-}
-
-func (s *Server) handleConfig(w http.ResponseWriter, _ *http.Request) {
-	cfg := s.deps.Config()
-	writeJSON(w, http.StatusOK, configResponse{
-		Listen:           cfg.Listen,
-		MaxParallelTasks: cfg.MaxParallelTasks,
-		Defaults: configDefaults{
-			AgentTimeout:   cfg.Defaults.AgentTimeout.String(),
-			CommandTimeout: cfg.Defaults.CommandTimeout.String(),
-			InputTimeout:   cfg.Defaults.InputTimeout.String(),
-		},
-		DeleteEmptyBranchOnArchive:  cfg.DeleteEmptyBranchOnArchive,
-		DeleteRemoteBranchOnArchive: cfg.DeleteRemoteBranchOnArchive,
-		TranscriptRetentionDays:     cfg.TranscriptRetentionDays,
-		TranscriptMaxBytes:          cfg.TranscriptMaxBytes.Bytes(),
-		MaxTaskCostUSD:              cfg.MaxTaskCostUSD,
-		UsageLimitRecheck:           cfg.UsageLimitRecheckInterval.String(),
-		LogLevel:                    cfg.LogLevel,
-		Agents: map[string]agentPath{
-			"claude": {Path: cfg.Agents.Claude.Path},
-			"codex":  {Path: cfg.Agents.Codex.Path},
-			"cursor": {Path: cfg.Agents.Cursor.Path},
-		},
-		TUI: configTUI{Board: configBoard{GroupBy: boardGroupBy(cfg.TUI.Board.GroupBy)}},
-	})
-}
-
-// boardGroupBy renders the grouping levels as strings, never as JSON null: a
-// flat table is a configured choice and has to read as `[]`.
-func boardGroupBy(levels []config.BoardGroup) []string {
-	out := make([]string, 0, len(levels))
-	for _, l := range levels {
-		out = append(out, string(l))
-	}
 	return out
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -155,7 +155,7 @@ func TestConfigView(t *testing.T) {
 	if cfg.Defaults.AgentTimeout != want.Defaults.AgentTimeout.String() {
 		t.Errorf("agent_timeout = %q, want %q", cfg.Defaults.AgentTimeout, want.Defaults.AgentTimeout)
 	}
-	if _, ok := cfg.Agents["claude"]; !ok {
+	if !strings.Contains(string(body), `"claude"`) {
 		t.Error("agents.claude missing")
 	}
 	// Both halves of the §10 branch-cleanup pair, and both by name: a client

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -2,6 +2,10 @@ package apiclient
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
 	"time"
 )
 
@@ -100,19 +104,24 @@ func (c *Client) Info(ctx context.Context) (Info, error) {
 	return out, nil
 }
 
-// Config is the GET /v1/config body: config.yaml as the daemon currently
-// has it loaded, durations rendered as Go duration strings. It is read-only
-// here — the file is authoritative and the daemon hot-reloads it (§12.3).
+// Config is the GET /v1/config body: config.yaml as the daemon currently has
+// it loaded, durations rendered as Go duration strings. Every key in the file
+// is here — a key this type omits is one no client can see, which is the
+// defect task 060 fixed.
 type Config struct {
-	Listen           string         `json:"listen"`
-	MaxParallelTasks int            `json:"max_parallel_tasks"`
-	Defaults         ConfigDefaults `json:"defaults"`
+	Listen           string `json:"listen"`
+	MaxParallelTasks int    `json:"max_parallel_tasks"`
+	// BranchTemplate is empty when the file pins none; the built-in fallback
+	// lives in the daemon, and a project may override it either way.
+	BranchTemplate string         `json:"branch_template"`
+	Defaults       ConfigDefaults `json:"defaults"`
 	// DeleteEmptyBranchOnArchive deletes a task's branch at archive time when
 	// it has no commits past its base (§10). DeleteRemoteBranchOnArchive does
 	// the same to its upstream counterpart, and is honoured only on an
 	// attended archive — it is inert while the local one is off.
 	DeleteEmptyBranchOnArchive  bool  `json:"delete_empty_branch_on_archive"`
 	DeleteRemoteBranchOnArchive bool  `json:"delete_remote_branch_on_archive"`
+	FetchBaseBranch             bool  `json:"fetch_base_branch"`
 	TranscriptRetentionDays     int   `json:"transcript_retention_days"`
 	TranscriptMaxBytes          int64 `json:"transcript_max_bytes"`
 	// MaxTaskCostUSD caps what one task may spend across every attempt of
@@ -120,9 +129,19 @@ type Config struct {
 	MaxTaskCostUSD float64 `json:"max_task_cost_usd"`
 	// UsageLimitRecheck is how long a quota-held task waits before the
 	// scheduler tries again, when the agent CLI reported no reset time (§11).
-	UsageLimitRecheck string               `json:"usage_limit_recheck_interval"`
-	LogLevel          string               `json:"log_level"`
-	Agents            map[string]AgentPath `json:"agents"`
+	UsageLimitRecheck string            `json:"usage_limit_recheck_interval"`
+	LogLevel          string            `json:"log_level"`
+	Debug             bool              `json:"debug"`
+	Environment       ConfigEnvironment `json:"environment"`
+	Agents            ConfigAgents      `json:"agents"`
+	Parallel          ConfigParallel    `json:"parallel"`
+	FanOut            ConfigFanOut      `json:"fan_out"`
+	Loop              ConfigLoop        `json:"loop"`
+	Include           ConfigInclude     `json:"include"`
+	MCP               ConfigMCP         `json:"mcp"`
+	GitHub            ConfigGitHub      `json:"github"`
+	Update            ConfigUpdate      `json:"update"`
+	Notify            ConfigNotify      `json:"notify"`
 	// TUI is the view preference the daemon only relays (§15). It is served
 	// here rather than read from disk because the TUI is a pure API client;
 	// a client that cannot reach the daemon renders its own defaults.
@@ -148,10 +167,122 @@ type ConfigDefaults struct {
 	InputTimeout   string `json:"input_timeout"`
 }
 
+// ConfigAgents are the three §9 adapters' configured binaries.
+type ConfigAgents struct {
+	Claude AgentPath `json:"claude"`
+	Codex  AgentPath `json:"codex"`
+	Cursor AgentPath `json:"cursor"`
+}
+
 // AgentPath is a configured adapter binary. An empty Path means the config
 // pinned nothing and the adapter is resolved from PATH.
 type AgentPath struct {
 	Path string `json:"path"`
+}
+
+// ConfigEnvironment is what the daemon's child processes inherit (§12.3).
+type ConfigEnvironment struct {
+	Inherit ConfigInherit     `json:"inherit"`
+	Unset   []string          `json:"unset"`
+	Set     map[string]string `json:"set"`
+}
+
+// ConfigInherit is the `environment.inherit` union: the word "all" or "none",
+// or an explicit list of names. It is a union on the wire because it is one in
+// the file, and flattening it here would make `inherit: []` — which means
+// nothing at all — indistinguishable from the default, which means everything.
+type ConfigInherit struct {
+	// Mode is "all", "none" or "list".
+	Mode  string
+	Names []string
+}
+
+// MarshalJSON writes the union back in the shape the daemon reads.
+func (i ConfigInherit) MarshalJSON() ([]byte, error) {
+	if i.Mode == "list" {
+		names := i.Names
+		if names == nil {
+			names = []string{}
+		}
+		return json.Marshal(names)
+	}
+	if i.Mode == "" {
+		return json.Marshal("all")
+	}
+	return json.Marshal(i.Mode)
+}
+
+// UnmarshalJSON reads either form.
+func (i *ConfigInherit) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*i = ConfigInherit{Mode: s}
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal(b, &names); err != nil {
+		return fmt.Errorf("environment.inherit: want \"all\", \"none\", or a list of names")
+	}
+	*i = ConfigInherit{Mode: "list", Names: names}
+	return nil
+}
+
+// String renders the union the way config.yaml spells it.
+func (i ConfigInherit) String() string {
+	if i.Mode == "list" {
+		return "[" + strings.Join(i.Names, ", ") + "]"
+	}
+	if i.Mode == "" {
+		return "all"
+	}
+	return i.Mode
+}
+
+// ConfigParallel bounds one `parallel` step's concurrent lanes (§7.5).
+type ConfigParallel struct {
+	MaxParallel int `json:"max_parallel"`
+}
+
+// ConfigFanOut bounds a `fan_out` tree (§7.6).
+type ConfigFanOut struct {
+	MaxDepth int `json:"max_depth"`
+	MaxTasks int `json:"max_tasks"`
+}
+
+// ConfigLoop bounds one `loop` step's iterations (§7.8).
+type ConfigLoop struct {
+	MaxIterations int `json:"max_iterations"`
+}
+
+// ConfigInclude bounds `include` nesting (§7.9).
+type ConfigInclude struct {
+	MaxDepth int `json:"max_depth"`
+}
+
+// ConfigMCP is the daemon's MCP server policy (§13.4).
+type ConfigMCP struct {
+	WireSteps bool `json:"wire_steps"`
+	MaxDepth  int  `json:"max_depth"`
+	MaxTasks  int  `json:"max_tasks"`
+}
+
+// ConfigGitHub is the GitHub integration policy (task 035).
+type ConfigGitHub struct {
+	Enabled      bool   `json:"enabled"`
+	PollInterval string `json:"poll_interval"`
+}
+
+// ConfigUpdate is the release-check policy (task 055) — not the cached answer,
+// which is what GET /v1/update serves.
+type ConfigUpdate struct {
+	Check        bool   `json:"check"`
+	PollInterval string `json:"poll_interval"`
+}
+
+// ConfigNotify is the §12.3 outward signal (task 046). Command is argv.
+type ConfigNotify struct {
+	On      []string `json:"on"`
+	Command []string `json:"command"`
 }
 
 // Config fetches the configuration in effect. There is no event for a
@@ -162,4 +293,115 @@ func (c *Client) Config(ctx context.Context) (Config, error) {
 		return Config{}, err
 	}
 	return out, nil
+}
+
+// PatchConfig applies a partial edit to config.yaml and returns the
+// configuration in force afterwards (§13.2, task 060). The daemon validates
+// the whole candidate file before writing: an invalid patch changes nothing,
+// and the error is the standard envelope.
+//
+// The returned body is what the daemon is actually running, which is not
+// always what was written — `listen` is pinned until the next restart, so a
+// patch that moves it answers 200 with the old address still in force.
+func (c *Client) PatchConfig(ctx context.Context, req ConfigPatch) (Config, error) {
+	var out Config
+	if err := c.send(ctx, http.MethodPatch, "/v1/config", req, &out); err != nil {
+		return Config{}, err
+	}
+	return out, nil
+}
+
+// ConfigPatch is the PATCH /v1/config body: the read shape with every key
+// optional. A nil field is a key the file keeps.
+//
+// It is a distinct type from Config rather than Config with pointers because
+// the two say different things: Config is "what is in force", and every field
+// of it is populated; ConfigPatch is "what to change", and a zero value has to
+// mean *do not touch this* rather than "set it to zero".
+type ConfigPatch struct {
+	Listen                      *string                 `json:"listen,omitempty"`
+	MaxParallelTasks            *int                    `json:"max_parallel_tasks,omitempty"`
+	BranchTemplate              *string                 `json:"branch_template,omitempty"`
+	Defaults                    *ConfigDefaultsPatch    `json:"defaults,omitempty"`
+	DeleteEmptyBranchOnArchive  *bool                   `json:"delete_empty_branch_on_archive,omitempty"`
+	DeleteRemoteBranchOnArchive *bool                   `json:"delete_remote_branch_on_archive,omitempty"`
+	FetchBaseBranch             *bool                   `json:"fetch_base_branch,omitempty"`
+	TranscriptRetentionDays     *int                    `json:"transcript_retention_days,omitempty"`
+	TranscriptMaxBytes          *int64                  `json:"transcript_max_bytes,omitempty"`
+	MaxTaskCostUSD              *float64                `json:"max_task_cost_usd,omitempty"`
+	UsageLimitRecheck           *string                 `json:"usage_limit_recheck_interval,omitempty"`
+	LogLevel                    *string                 `json:"log_level,omitempty"`
+	Debug                       *bool                   `json:"debug,omitempty"`
+	Environment                 *ConfigEnvironmentPatch `json:"environment,omitempty"`
+	Agents                      *ConfigAgentsPatch      `json:"agents,omitempty"`
+	Parallel                    *ConfigParallel         `json:"parallel,omitempty"`
+	FanOut                      *ConfigFanOut           `json:"fan_out,omitempty"`
+	Loop                        *ConfigLoop             `json:"loop,omitempty"`
+	Include                     *ConfigInclude          `json:"include,omitempty"`
+	MCP                         *ConfigMCPPatch         `json:"mcp,omitempty"`
+	GitHub                      *ConfigGitHubPatch      `json:"github,omitempty"`
+	Update                      *ConfigUpdatePatch      `json:"update,omitempty"`
+	Notify                      *ConfigNotifyPatch      `json:"notify,omitempty"`
+	TUI                         *ConfigTUIPatch         `json:"tui,omitempty"`
+}
+
+// ConfigDefaultsPatch is the optional half of ConfigDefaults.
+type ConfigDefaultsPatch struct {
+	AgentTimeout   *string `json:"agent_timeout,omitempty"`
+	CommandTimeout *string `json:"command_timeout,omitempty"`
+	InputTimeout   *string `json:"input_timeout,omitempty"`
+}
+
+// ConfigEnvironmentPatch is the optional half of ConfigEnvironment.
+type ConfigEnvironmentPatch struct {
+	Inherit *ConfigInherit     `json:"inherit,omitempty"`
+	Unset   *[]string          `json:"unset,omitempty"`
+	Set     *map[string]string `json:"set,omitempty"`
+}
+
+// ConfigAgentsPatch names the adapters whose paths are being changed.
+type ConfigAgentsPatch struct {
+	Claude *AgentPathPatch `json:"claude,omitempty"`
+	Codex  *AgentPathPatch `json:"codex,omitempty"`
+	Cursor *AgentPathPatch `json:"cursor,omitempty"`
+}
+
+// AgentPathPatch is one adapter's binary. An empty string clears the pin.
+type AgentPathPatch struct {
+	Path *string `json:"path,omitempty"`
+}
+
+// ConfigMCPPatch is the optional half of ConfigMCP.
+type ConfigMCPPatch struct {
+	WireSteps *bool `json:"wire_steps,omitempty"`
+	MaxDepth  *int  `json:"max_depth,omitempty"`
+	MaxTasks  *int  `json:"max_tasks,omitempty"`
+}
+
+// ConfigGitHubPatch is the optional half of ConfigGitHub.
+type ConfigGitHubPatch struct {
+	Enabled      *bool   `json:"enabled,omitempty"`
+	PollInterval *string `json:"poll_interval,omitempty"`
+}
+
+// ConfigUpdatePatch is the optional half of ConfigUpdate.
+type ConfigUpdatePatch struct {
+	Check        *bool   `json:"check,omitempty"`
+	PollInterval *string `json:"poll_interval,omitempty"`
+}
+
+// ConfigNotifyPatch is the optional half of ConfigNotify.
+type ConfigNotifyPatch struct {
+	On      *[]string `json:"on,omitempty"`
+	Command *[]string `json:"command,omitempty"`
+}
+
+// ConfigTUIPatch is the optional half of ConfigTUI.
+type ConfigTUIPatch struct {
+	Board *ConfigBoardPatch `json:"board,omitempty"`
+}
+
+// ConfigBoardPatch is the optional half of ConfigBoard.
+type ConfigBoardPatch struct {
+	GroupBy *[]string `json:"group_by,omitempty"`
 }

--- a/internal/apiclient/daemon_test.go
+++ b/internal/apiclient/daemon_test.go
@@ -83,7 +83,16 @@ func TestConfigCarriesTheSettingsInEffect(t *testing.T) {
 	if cfg.Defaults.AgentTimeout != want {
 		t.Errorf("Defaults.AgentTimeout = %q, want %q", cfg.Defaults.AgentTimeout, want)
 	}
-	if _, ok := cfg.Agents["claude"]; !ok {
-		t.Errorf("Agents = %v, want a claude entry", cfg.Agents)
+	// The whole file is served now (task 060), not the eleven-key subset this
+	// type used to carry: a key the client cannot see is one no client can
+	// edit either.
+	if cfg.Agents.Claude.Path != cfgDefault.Agents.Claude.Path {
+		t.Errorf("Agents.Claude = %+v, want %+v", cfg.Agents.Claude, cfgDefault.Agents.Claude)
+	}
+	if cfg.Environment.Inherit.String() != "all" {
+		t.Errorf("Environment.Inherit = %q, want all", cfg.Environment.Inherit)
+	}
+	if cfg.MCP.MaxTasks != cfgDefault.MCP.MaxTasks || cfg.FanOut.MaxDepth != cfgDefault.FanOut.MaxDepth {
+		t.Errorf("the sections the endpoint used to omit did not arrive: %+v", cfg)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,6 +42,7 @@ func newRootCmd() *cobra.Command {
 		newDaemonCmd(), newVersionCmd(), newDoctorCmd(),
 		newProjectCmd(), newTaskCmd(), newWorkflowCmd(), newServiceCmd(),
 		newGCCmd(), newGitHubCmd(), newStatusCmd(), newUpdateCmd(),
+		newConfigCmd(),
 	)
 	return root
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// `vincent config` (task 060, §12.1).
+//
+// The daemon owns config.yaml and hot-reloads it; this is a client of
+// PATCH /v1/config like every other command here, not a second editor. That
+// is what makes `vincent config set` and the TUI's editor the same operation
+// with the same validation, and why a set takes effect without a restart.
+//
+// Keys are the dotted paths config.yaml carries, which are also the paths the
+// configuration reference documents and the TUI's editor names — one spelling
+// everywhere. `vincent config get` with no key prints them all.
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Read and change the daemon configuration",
+		Long: "Read and change config.yaml through the daemon (§12.3).\n\n" +
+			"The daemon validates the whole file before writing it and applies the " +
+			"result before answering, so a set takes effect without a restart — " +
+			"except `listen`, which the running daemon keeps until it is restarted. " +
+			"An invalid value changes nothing.\n\n" +
+			"Comments and key order in config.yaml survive a set: the daemon edits " +
+			"the key in place rather than regenerating the file.",
+	}
+	cmd.AddCommand(newConfigGetCmd(), newConfigSetCmd())
+	return cmd
+}
+
+func newConfigGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [key]",
+		Short: "Print the configuration in effect, or one key of it",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				cfg, err := c.Config(ctx)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if len(args) == 0 {
+					if wantJSON(cmd) {
+						return emitJSON(cmd.OutOrStdout(), cfg)
+					}
+					return renderConfig(cmd.OutOrStdout(), cfg)
+				}
+				value, ok := configValue(cfg, args[0])
+				if !ok {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: no such configuration key %q\n", args[0])
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), map[string]string{args[0]: value})
+				}
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), value)
+				return err
+			})
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newConfigSetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Change one configuration key",
+		Long: "Change one key in config.yaml and apply it.\n\n" +
+			"Lists and argv are whitespace-separated in one argument: " +
+			`vincent config set notify.on "blocked awaiting_gate". ` +
+			"environment.set takes NAME=VALUE pairs the same way. An argument " +
+			"containing a space cannot be written this way and has to be edited " +
+			"in the file.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, value := args[0], args[1]
+			patch, err := configPatchFor(key, value)
+			if err != nil {
+				_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", err)
+				return exitError{code: 1}
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				cfg, err := c.PatchConfig(ctx, patch)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), cfg)
+				}
+				now, _ := configValue(cfg, key)
+				if key == "listen" {
+					// The write happened; the running daemon did not move. Say
+					// so rather than printing an address that is not bound.
+					_, err = fmt.Fprintf(cmd.OutOrStdout(),
+						"listen written to config.yaml; the running daemon keeps %s until it is restarted\n", now)
+					return err
+				}
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s = %s\n", key, now)
+				return err
+			})
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+// renderConfig prints every key as `path = value`, in the order config.yaml
+// carries them, which is the order the reference documents them in.
+func renderConfig(w io.Writer, cfg apiclient.Config) error {
+	for _, k := range configPaths() {
+		v, _ := configValue(cfg, k)
+		if _, err := fmt.Fprintf(w, "%s = %s\n", k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// configFields is the one table this command reads and writes through: a
+// dotted path, how to render it, and how to spell a change.
+//
+// It is deliberately not derived from apiclient.Config by reflection. A path
+// like `agents.claude.path` is not a field name, the two list kinds render
+// differently, and a table a reader can diff against the configuration
+// reference is worth more here than a mechanism.
+type configField struct {
+	read  func(apiclient.Config) string
+	write func(string) (apiclient.ConfigPatch, error)
+}
+
+func configFields() map[string]configField {
+	str := func(read func(apiclient.Config) string, patch func(*string) apiclient.ConfigPatch) configField {
+		return configField{
+			read: read,
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.TrimSpace(s)
+				return patch(&v), nil
+			},
+		}
+	}
+	return map[string]configField{
+		"listen": str(func(c apiclient.Config) string { return c.Listen },
+			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{Listen: v} }),
+		"max_parallel_tasks": intField(
+			func(c apiclient.Config) int { return c.MaxParallelTasks },
+			func(n *int) apiclient.ConfigPatch { return apiclient.ConfigPatch{MaxParallelTasks: n} }),
+		"branch_template": {
+			read: func(c apiclient.Config) string { return c.BranchTemplate },
+			// Not trimmed: a template is written verbatim into a branch name,
+			// and trimming one would be this command editing the value.
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				return apiclient.ConfigPatch{BranchTemplate: &s}, nil
+			},
+		},
+		"defaults.agent_timeout": str(func(c apiclient.Config) string { return c.Defaults.AgentTimeout },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{AgentTimeout: v}}
+			}),
+		"defaults.command_timeout": str(func(c apiclient.Config) string { return c.Defaults.CommandTimeout },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{CommandTimeout: v}}
+			}),
+		"defaults.input_timeout": str(func(c apiclient.Config) string { return c.Defaults.InputTimeout },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{InputTimeout: v}}
+			}),
+		"delete_empty_branch_on_archive": boolField(
+			func(c apiclient.Config) bool { return c.DeleteEmptyBranchOnArchive },
+			func(b *bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{DeleteEmptyBranchOnArchive: b} }),
+		"delete_remote_branch_on_archive": boolField(
+			func(c apiclient.Config) bool { return c.DeleteRemoteBranchOnArchive },
+			func(b *bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{DeleteRemoteBranchOnArchive: b} }),
+		"fetch_base_branch": boolField(
+			func(c apiclient.Config) bool { return c.FetchBaseBranch },
+			func(b *bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{FetchBaseBranch: b} }),
+		"transcript_retention_days": intField(
+			func(c apiclient.Config) int { return c.TranscriptRetentionDays },
+			func(n *int) apiclient.ConfigPatch { return apiclient.ConfigPatch{TranscriptRetentionDays: n} }),
+		"transcript_max_bytes": {
+			read: func(c apiclient.Config) string { return byteSizeText(c.TranscriptMaxBytes) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				n, err := parseByteSizeArg(s)
+				if err != nil {
+					return apiclient.ConfigPatch{}, err
+				}
+				return apiclient.ConfigPatch{TranscriptMaxBytes: &n}, nil
+			},
+		},
+		"max_task_cost_usd": {
+			read: func(c apiclient.Config) string { return floatText(c.MaxTaskCostUSD) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				f, err := parseFloatArg(s)
+				if err != nil {
+					return apiclient.ConfigPatch{}, err
+				}
+				return apiclient.ConfigPatch{MaxTaskCostUSD: &f}, nil
+			},
+		},
+		"usage_limit_recheck_interval": str(func(c apiclient.Config) string { return c.UsageLimitRecheck },
+			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{UsageLimitRecheck: v} }),
+		"log_level": str(func(c apiclient.Config) string { return c.LogLevel },
+			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{LogLevel: v} }),
+		"debug": boolField(func(c apiclient.Config) bool { return c.Debug },
+			func(b *bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{Debug: b} }),
+		"environment.inherit": {
+			read: func(c apiclient.Config) string { return c.Environment.Inherit.String() },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := parseInheritArg(s)
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Inherit: &v}}, nil
+			},
+		},
+		"environment.unset": listField(
+			func(c apiclient.Config) []string { return c.Environment.Unset },
+			func(v *[]string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Unset: v}}
+			}),
+		"environment.set": {
+			read: func(c apiclient.Config) string { return pairsText(c.Environment.Set) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				m, err := parsePairsArg(s)
+				if err != nil {
+					return apiclient.ConfigPatch{}, err
+				}
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Set: &m}}, nil
+			},
+		},
+		"agents.claude.path": str(func(c apiclient.Config) string { return c.Agents.Claude.Path },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Claude: &apiclient.AgentPathPatch{Path: v}}}
+			}),
+		"agents.codex.path": str(func(c apiclient.Config) string { return c.Agents.Codex.Path },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Codex: &apiclient.AgentPathPatch{Path: v}}}
+			}),
+		"agents.cursor.path": str(func(c apiclient.Config) string { return c.Agents.Cursor.Path },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Cursor: &apiclient.AgentPathPatch{Path: v}}}
+			}),
+		"parallel.max_parallel": intField(
+			func(c apiclient.Config) int { return c.Parallel.MaxParallel },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Parallel: &apiclient.ConfigParallel{MaxParallel: *n}}
+			}),
+		"fan_out.max_depth": intField(
+			func(c apiclient.Config) int { return c.FanOut.MaxDepth },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{FanOut: &apiclient.ConfigFanOut{MaxDepth: *n}}
+			}),
+		"fan_out.max_tasks": intField(
+			func(c apiclient.Config) int { return c.FanOut.MaxTasks },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{FanOut: &apiclient.ConfigFanOut{MaxTasks: *n}}
+			}),
+		"loop.max_iterations": intField(
+			func(c apiclient.Config) int { return c.Loop.MaxIterations },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Loop: &apiclient.ConfigLoop{MaxIterations: *n}}
+			}),
+		"include.max_depth": intField(
+			func(c apiclient.Config) int { return c.Include.MaxDepth },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Include: &apiclient.ConfigInclude{MaxDepth: *n}}
+			}),
+		"mcp.wire_steps": boolField(func(c apiclient.Config) bool { return c.MCP.WireSteps },
+			func(b *bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{WireSteps: b}}
+			}),
+		"mcp.max_depth": intField(func(c apiclient.Config) int { return c.MCP.MaxDepth },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{MaxDepth: n}}
+			}),
+		"mcp.max_tasks": intField(func(c apiclient.Config) int { return c.MCP.MaxTasks },
+			func(n *int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{MaxTasks: n}}
+			}),
+		"github.enabled": boolField(func(c apiclient.Config) bool { return c.GitHub.Enabled },
+			func(b *bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{GitHub: &apiclient.ConfigGitHubPatch{Enabled: b}}
+			}),
+		"github.poll_interval": str(func(c apiclient.Config) string { return c.GitHub.PollInterval },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{GitHub: &apiclient.ConfigGitHubPatch{PollInterval: v}}
+			}),
+		"update.check": boolField(func(c apiclient.Config) bool { return c.Update.Check },
+			func(b *bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Update: &apiclient.ConfigUpdatePatch{Check: b}}
+			}),
+		"update.poll_interval": str(func(c apiclient.Config) string { return c.Update.PollInterval },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Update: &apiclient.ConfigUpdatePatch{PollInterval: v}}
+			}),
+		"notify.on": listField(func(c apiclient.Config) []string { return c.Notify.On },
+			func(v *[]string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Notify: &apiclient.ConfigNotifyPatch{On: v}}
+			}),
+		"notify.command": listField(func(c apiclient.Config) []string { return c.Notify.Command },
+			func(v *[]string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Notify: &apiclient.ConfigNotifyPatch{Command: v}}
+			}),
+		"tui.board.group_by": listField(func(c apiclient.Config) []string { return c.TUI.Board.GroupBy },
+			func(v *[]string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{TUI: &apiclient.ConfigTUIPatch{Board: &apiclient.ConfigBoardPatch{GroupBy: v}}}
+			}),
+	}
+}
+
+// configPaths is the key list, sorted so `vincent config get` prints the same
+// order on every run — a map's is not an order.
+func configPaths() []string {
+	fields := configFields()
+	out := make([]string, 0, len(fields))
+	for k := range fields {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func configValue(cfg apiclient.Config, key string) (string, bool) {
+	f, ok := configFields()[key]
+	if !ok {
+		return "", false
+	}
+	return f.read(cfg), true
+}
+
+func configPatchFor(key, value string) (apiclient.ConfigPatch, error) {
+	f, ok := configFields()[key]
+	if !ok {
+		return apiclient.ConfigPatch{}, fmt.Errorf(
+			"no such configuration key %q; `vincent config get` lists them", key)
+	}
+	return f.write(value)
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// `vincent config`'s key table is a hand-written list, deliberately (see
+// config.go). What a hand-written list needs is a drift check: a key the
+// daemon serves and this command cannot name is a key that is editable from
+// the TUI and not from a script, which is the split task 060 exists to close.
+func TestConfigCommandCoversEveryServedKey(t *testing.T) {
+	named := configFields()
+	var missing []string
+	for _, path := range servedPaths(reflect.TypeOf(apiclient.Config{}), "") {
+		if _, ok := named[path]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("GET /v1/config serves keys `vincent config` cannot name: %v\n"+
+			"add them to configFields()", missing)
+	}
+}
+
+// servedPaths walks the wire type into the dotted paths config.yaml carries.
+// A struct field becomes a path segment; anything else is a leaf.
+func servedPaths(t reflect.Type, prefix string) []string {
+	var out []string
+	for i := range t.NumField() {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		// ConfigInherit is a union with its own marshaller: it is a leaf on
+		// the wire even though it is a struct in Go.
+		if f.Type.Kind() == reflect.Struct && f.Type != reflect.TypeOf(apiclient.ConfigInherit{}) {
+			out = append(out, servedPaths(f.Type, path)...)
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+// Every value `get` prints has to be one `set` accepts, or the obvious way to
+// use the command — read it, change it, write it back — silently does
+// something else.
+func TestConfigValuesRoundTripThroughSet(t *testing.T) {
+	cfg := apiclient.Config{
+		Listen: "127.0.0.1:0", MaxParallelTasks: 3, BranchTemplate: "vincent/{{.ID}}",
+		Defaults:                apiclient.ConfigDefaults{AgentTimeout: "1h0m0s", CommandTimeout: "15m0s", InputTimeout: "24h0m0s"},
+		TranscriptRetentionDays: 90, TranscriptMaxBytes: 512 << 20, MaxTaskCostUSD: 2.5,
+		UsageLimitRecheck: "15m0s", LogLevel: "info",
+		Environment: apiclient.ConfigEnvironment{
+			Inherit: apiclient.ConfigInherit{Mode: "list", Names: []string{"PATH", "HOME"}},
+			Unset:   []string{"MSYSTEM"},
+			Set:     map[string]string{"LANG": "C.UTF-8"},
+		},
+		Agents:   apiclient.ConfigAgents{Claude: apiclient.AgentPath{Path: "/usr/bin/claude"}},
+		Parallel: apiclient.ConfigParallel{MaxParallel: 4},
+		FanOut:   apiclient.ConfigFanOut{MaxDepth: 3, MaxTasks: 64},
+		Loop:     apiclient.ConfigLoop{MaxIterations: 10},
+		Include:  apiclient.ConfigInclude{MaxDepth: 5},
+		MCP:      apiclient.ConfigMCP{WireSteps: true, MaxDepth: 3, MaxTasks: 32},
+		GitHub:   apiclient.ConfigGitHub{Enabled: true, PollInterval: "5m0s"},
+		Update:   apiclient.ConfigUpdate{Check: true, PollInterval: "24h0m0s"},
+		Notify:   apiclient.ConfigNotify{On: []string{"blocked"}, Command: []string{"/bin/echo", "hi"}},
+		TUI:      apiclient.ConfigTUI{Board: apiclient.ConfigBoard{GroupBy: []string{"project", "workflow"}}},
+	}
+	for _, path := range configPaths() {
+		value, ok := configValue(cfg, path)
+		if !ok {
+			t.Fatalf("configPaths lists %q and configValue does not know it", path)
+		}
+		patch, err := configPatchFor(path, value)
+		if err != nil {
+			t.Errorf("%s: `get` printed %q and `set` refuses it: %v", path, value, err)
+			continue
+		}
+		// The patch has to carry exactly the key that was asked for: a table
+		// entry wired to the wrong field would otherwise pass silently.
+		b, err := json.Marshal(patch)
+		if err != nil {
+			t.Fatalf("%s: marshal patch: %v", path, err)
+		}
+		top := strings.Split(path, ".")[0]
+		if !strings.Contains(string(b), `"`+top+`"`) {
+			t.Errorf("%s: the patch does not mention %q: %s", path, top, b)
+		}
+	}
+}

--- a/internal/cli/configvalues.go
+++ b/internal/cli/configvalues.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// The value conversions `vincent config` uses on both legs (task 060).
+//
+// They are here rather than in config.go so that file stays the key table a
+// reader can diff against the configuration reference. internal/config is
+// imported for ByteSize alone: "512MB" has to mean the same thing on the
+// command line as it does in the file, and re-implementing the parser would
+// be the second implementation that eventually disagrees.
+
+func intField(read func(apiclient.Config) int, patch func(*int) apiclient.ConfigPatch) configField {
+	return configField{
+		read: func(c apiclient.Config) string { return strconv.Itoa(read(c)) },
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			n, err := strconv.Atoi(strings.TrimSpace(s))
+			if err != nil {
+				return apiclient.ConfigPatch{}, fmt.Errorf("want a whole number, got %q", s)
+			}
+			return patch(&n), nil
+		},
+	}
+}
+
+func boolField(read func(apiclient.Config) bool, patch func(*bool) apiclient.ConfigPatch) configField {
+	return configField{
+		read: func(c apiclient.Config) string { return strconv.FormatBool(read(c)) },
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			b, err := strconv.ParseBool(strings.TrimSpace(s))
+			if err != nil {
+				return apiclient.ConfigPatch{}, fmt.Errorf("want true or false, got %q", s)
+			}
+			return patch(&b), nil
+		},
+	}
+}
+
+// listField is the whitespace-separated form. An empty argument sets the empty
+// list rather than leaving the key alone: `vincent config set notify.on ""` is
+// how the hook is switched off, and treating it as a no-op would leave no way
+// to do that from the command line.
+func listField(read func(apiclient.Config) []string, patch func(*[]string) apiclient.ConfigPatch) configField {
+	return configField{
+		read: func(c apiclient.Config) string { return strings.Join(read(c), " ") },
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			v := strings.Fields(s)
+			if v == nil {
+				v = []string{}
+			}
+			return patch(&v), nil
+		},
+	}
+}
+
+// byteSizeText renders a byte count the way the file spells it, so what `get`
+// prints is what `set` accepts.
+func byteSizeText(n int64) string { return config.ByteSize(n).String() }
+
+func parseByteSizeArg(s string) (int64, error) {
+	v, err := config.ParseByteSize(strings.TrimSpace(s))
+	if err != nil {
+		return 0, err
+	}
+	return v.Bytes(), nil
+}
+
+// floatText drops the exponent and the trailing zeros: a spend ceiling of 0
+// reads "0", not "0.000000".
+func floatText(f float64) string { return strconv.FormatFloat(f, 'f', -1, 64) }
+
+func parseFloatArg(s string) (float64, error) {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0, fmt.Errorf("want a number, got %q", s)
+	}
+	return f, nil
+}
+
+// parseInheritArg reads `environment.inherit`'s union: the two words, or a
+// list of names with or without the brackets `get` prints.
+func parseInheritArg(s string) apiclient.ConfigInherit {
+	t := strings.TrimSpace(s)
+	switch strings.ToLower(t) {
+	case "all", "none":
+		return apiclient.ConfigInherit{Mode: strings.ToLower(t)}
+	}
+	t = strings.TrimSuffix(strings.TrimPrefix(t, "["), "]")
+	names := strings.FieldsFunc(t, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
+	if names == nil {
+		names = []string{}
+	}
+	return apiclient.ConfigInherit{Mode: "list", Names: names}
+}
+
+func pairsText(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+m[k])
+	}
+	return strings.Join(parts, " ")
+}
+
+func parsePairsArg(s string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, tok := range strings.Fields(s) {
+		name, value, ok := strings.Cut(tok, "=")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("want NAME=VALUE pairs, got %q", tok)
+		}
+		out[name] = value
+	}
+	return out, nil
+}

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -24,6 +24,14 @@ listen: 127.0.0.1:0
 # on each project.
 max_parallel_tasks: 3
 
+# Naming convention for the branch each task's worktree is cut on. It is a
+# Go text/template rendered with .ID, .Slug, .Project, .Workflow and .Date;
+# the result is sanitised into a legal ref. A project may override it, and
+# the built-in below is what applies when neither is set. A template that
+# does not compile is refused and the previous one stays in force.
+#
+# branch_template: "vincent/{{.ID}}-{{.Slug}}"
+
 # Fallback step timeouts, used when a workflow step declares none.
 # input_timeout bounds each wait for an answer to an agent's input request
 # (awaiting_input, §7.4); on expiry the attempt fails under the retry policy.
@@ -117,6 +125,49 @@ agents:
   # editor launcher (§9.7).
   cursor:
     path: ""
+
+# How many verifications inside one "parallel" step run at once (§7.5).
+# The step is done when its last lane is, and a lane that fails fails the
+# step; this only bounds how many are in flight.
+#
+# parallel:
+#   max_parallel: 4
+
+# Bounds on "fan_out" (§7.6), which creates a task per item. max_depth is how
+# many generations deep a tree may go — a lane that fans out again counts —
+# and max_tasks is the total number of descendants one root may create.
+# Passing either blocks the step rather than truncating the list.
+#
+# fan_out:
+#   max_depth: 3
+#   max_tasks: 64
+
+# Ceiling on iterations of one "loop" step (§7.8). A loop that reaches it
+# blocks with loop_limit, so a condition that never goes false is visible
+# rather than endless.
+#
+# loop:
+#   max_iterations: 10
+
+# How many levels of "include" a workflow may nest (§7.9). Includes are
+# spliced away when the task is created, so this bounds the splice, not the
+# run.
+#
+# include:
+#   max_depth: 5
+
+# The MCP server the daemon serves at /mcp (§13.4), and the per-step endpoint
+# an agent step is wired to. wire_steps: false stops the daemon handing agent
+# steps their endpoint at all, which is how you take vincent's own tools away
+# from a workflow without touching the workflow. max_depth and max_tasks bound
+# the tasks an agent may create through those tools, the way fan_out's pair
+# bounds a tree: a chain discovered at run time is only visible once it has
+# spawned.
+#
+# mcp:
+#   wire_steps: true
+#   max_depth: 3
+#   max_tasks: 32
 
 # Reading GitHub issues, so a task can be created from one (task 035). It
 # applies only to a project whose "origin" remote is a github.com repository,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -671,14 +671,32 @@ func Load(path string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("read config: %w", err)
 	}
-	if err := yaml.UnmarshalWithOptions(raw, &cfg, yaml.DisallowUnknownField()); err != nil {
-		return Config{}, fmt.Errorf("parse %s: %w", path, err)
-	}
-	if err := cfg.validate(); err != nil {
-		return Config{}, fmt.Errorf("invalid config %s: %w", path, err)
+	cfg, err = Decode(raw)
+	if err != nil {
+		return Config{}, fmt.Errorf("%s: %w", path, err)
 	}
 	return cfg, nil
 }
+
+// Decode parses and validates config.yaml bytes that are not (yet) on disk.
+// It is what lets PATCH /v1/config reject an edit before anything is written
+// (task 060): the candidate file is decoded through exactly the path Load
+// takes, so a patch that would not survive a restart is refused now.
+func Decode(raw []byte) (Config, error) {
+	cfg := Default()
+	if err := yaml.UnmarshalWithOptions(raw, &cfg, yaml.DisallowUnknownField()); err != nil {
+		return Config{}, fmt.Errorf("parse: %w", err)
+	}
+	if err := cfg.validate(); err != nil {
+		return Config{}, fmt.Errorf("invalid config: %w", err)
+	}
+	return cfg, nil
+}
+
+// Validate is validate() for callers outside the package. The API needs to
+// reject a configuration before writing it, and the rule it applies has to be
+// the same one Load applies on the next start.
+func (c Config) Validate() error { return c.validate() }
 
 func (c Config) validate() error {
 	host, port, err := net.SplitHostPort(c.Listen)

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1,0 +1,342 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// This file is the write half of §12.3 (task 060): the daemon edits its own
+// config.yaml on behalf of a client, and the file it edits is documentation as
+// much as it is settings. EnsureDefaultFile ships a heavily commented template
+// in which several blocks are commented out on purpose, so regenerating the
+// file from the Config struct — the obvious implementation — would flatten the
+// only explanation most installations have of what the keys mean.
+//
+// So the editor is line-oriented rather than a marshal/unmarshal round trip.
+// It applies dotted-path assignments to the bytes: an existing key is edited
+// in place, a key that exists only as a commented-out block is uncommented
+// where it stands, and a key with no block at all is appended. Comments, key
+// order and blank lines survive all three.
+//
+// It lives in internal/config rather than in internal/api so it sits beside
+// the template it edits, and so validate() can stay unexported: the API
+// validates through Validate/Decode, never by reaching into the struct.
+
+// Set is one assignment: a dotted path into config.yaml and the YAML text of
+// its new value. Value is already rendered — the caller chose the scalar or
+// flow-style form — because the editor deals in lines, not in types.
+type Set struct {
+	// Path is dotted and lowercase: "log_level", "defaults.agent_timeout",
+	// "agents.claude.path", "tui.board.group_by".
+	Path string
+	// Value is a single line of YAML: a scalar ("60m", "true", "3"), a flow
+	// sequence ("[project, workflow]") or a flow mapping ("{LANG: C.UTF-8}").
+	// Multi-line block style is deliberately not produced: a value that
+	// occupies one line can be swapped without disturbing what surrounds it.
+	Value string
+}
+
+// keyLine matches a mapping key at the start of a (virtual) line. Names are
+// restricted to the snake_case shape every config key has, which is what
+// keeps a prose comment like "# WARNING: ..." from being read as a key.
+var keyLine = regexp.MustCompile(`^([a-z_][a-z0-9_]*):(\s|$)`)
+
+// plainScalar matches a string that YAML will read back verbatim without
+// quotes. Anything else is emitted double-quoted.
+var plainScalar = regexp.MustCompile(`^[A-Za-z0-9_./\\:+@-]+$`)
+
+// Apply returns src with every set applied, preserving comments, key order and
+// blank lines. Sets are applied in order, so two sets on one path leave the
+// last one in the file.
+func Apply(src []byte, sets []Set) ([]byte, error) {
+	lines := splitLines(string(src))
+	for _, s := range sets {
+		segs := strings.Split(s.Path, ".")
+		if len(segs) == 0 || s.Path == "" {
+			return nil, fmt.Errorf("empty config path")
+		}
+		lines = applySet(lines, segs, s.Value)
+	}
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+// applySet places one assignment, in the three-step order the file's shape
+// asks for: edit an active key, else uncomment a documented block, else
+// append. It cannot fail: the third case is a fallback rather than a refusal,
+// so every path a caller can name lands somewhere.
+func applySet(lines []string, segs []string, value string) []string {
+	if i, ok := findKey(lines, segs, false); ok {
+		lines[i] = setValue(lines[i], value)
+		return lines
+	}
+	if i, ok := findKey(lines, segs, true); ok {
+		return uncomment(lines, segs, i, value)
+	}
+	return appendKey(lines, segs, value)
+}
+
+// findKey returns the index of the line holding segs. With commented true it
+// searches the *virtual* file — commented lines read as the lines they would
+// be if uncommented — which is how a documented-but-disabled block is found.
+//
+// Both walks track a key stack by indentation, so "max_depth" under "fan_out"
+// is not confused with "max_depth" under "include".
+func findKey(lines []string, segs []string, commented bool) (int, bool) {
+	var stack []string
+	var indents []int
+	for i, raw := range lines {
+		ind, body, isComment := virtual(raw)
+		if isComment && !commented {
+			continue
+		}
+		m := keyLine.FindStringSubmatch(body)
+		if m == nil {
+			continue
+		}
+		for len(indents) > 0 && indents[len(indents)-1] >= ind {
+			stack = stack[:len(stack)-1]
+			indents = indents[:len(indents)-1]
+		}
+		stack = append(stack, m[1])
+		indents = append(indents, ind)
+		if len(stack) == len(segs) && samePath(stack, segs) {
+			// A commented search still accepts an active line: an active
+			// parent with a commented child is the environment block's shape.
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func samePath(stack, segs []string) bool {
+	for i := range segs {
+		if stack[i] != segs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// virtual reads a line as the mapping entry it represents. A commented line
+// reports the indentation it would have once uncommented: "#   command:"
+// inside a top-level block is a key at indent 2, exactly as "  command:" is.
+func virtual(line string) (indent int, body string, commented bool) {
+	rest := strings.TrimLeft(line, " ")
+	indent = len(line) - len(rest)
+	if !strings.HasPrefix(rest, "#") {
+		return indent, rest, false
+	}
+	rest = rest[1:]
+	// Exactly one space belongs to the comment marker; the rest is the
+	// indentation of the line that was commented out.
+	rest = strings.TrimPrefix(rest, " ")
+	inner := strings.TrimLeft(rest, " ")
+	return indent + len(rest) - len(inner), inner, true
+}
+
+// setValue replaces the value on an existing key line, keeping its trailing
+// comment and, where it still fits, the column that comment sat in.
+func setValue(line, value string) string {
+	ind, body, _ := virtual(line)
+	m := keyLine.FindStringSubmatch(body)
+	if m == nil {
+		return line
+	}
+	rest := body[len(m[1])+1:]
+	prefix := strings.Repeat(" ", ind) + m[1] + ": " + value
+	c := commentStart(rest)
+	if c < 0 {
+		return prefix
+	}
+	col := ind + len(m[1]) + 1 + c
+	if pad := col - len(prefix); pad > 0 {
+		return prefix + strings.Repeat(" ", pad) + strings.TrimRight(rest[c:], " ")
+	}
+	return prefix + " " + strings.TrimRight(rest[c:], " ")
+}
+
+// commentStart returns the index of a trailing "#" comment in a value, or -1.
+// It skips a "#" inside quotes, which a webhook URL fragment or a colour
+// literal can carry.
+func commentStart(s string) int {
+	var quote byte
+	for i := range len(s) {
+		c := s[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '#' && (i == 0 || s[i-1] == ' ' || s[i-1] == '\t'):
+			return i
+		}
+	}
+	return -1
+}
+
+// uncomment activates the commented block at idx and every commented ancestor
+// above it, so setting notify.on turns "# notify:" into "notify:" in the same
+// edit. Ancestors that are already active are left alone.
+func uncomment(lines []string, segs []string, idx int, value string) []string {
+	for depth := 1; depth < len(segs); depth++ {
+		if i, ok := findKey(lines, segs[:depth], true); ok {
+			if _, _, isComment := virtual(lines[i]); isComment {
+				lines[i] = activate(lines[i])
+			}
+		}
+	}
+	lines[idx] = setValue(activate(lines[idx]), value)
+	return lines
+}
+
+// activate rewrites a commented line as the line it stands for.
+func activate(line string) string {
+	ind, body, commented := virtual(line)
+	if !commented {
+		return line
+	}
+	return strings.Repeat(" ", ind) + body
+}
+
+// appendKey adds a key the file has no block for at all — the fallback path,
+// reached only by a config.yaml written before the key's documented block was
+// added to the template. Existing ancestors are reused so a second key under
+// an appended parent lands inside it rather than beside it.
+func appendKey(lines []string, segs []string, value string) []string {
+	depth := 0
+	insert := len(lines)
+	for d := len(segs) - 1; d >= 1; d-- {
+		if i, ok := findKey(lines, segs[:d], false); ok {
+			depth = d
+			insert = blockEnd(lines, i)
+			break
+		}
+	}
+	var block []string
+	if depth == 0 && insert == len(lines) {
+		block = append(block, "")
+	}
+	for d := depth; d < len(segs)-1; d++ {
+		block = append(block, strings.Repeat("  ", d)+segs[d]+":")
+	}
+	block = append(block, strings.Repeat("  ", len(segs)-1)+segs[len(segs)-1]+": "+value)
+	out := make([]string, 0, len(lines)+len(block))
+	out = append(out, lines[:insert]...)
+	out = append(out, block...)
+	out = append(out, lines[insert:]...)
+	return out
+}
+
+// blockEnd returns the index just past the last line belonging to the mapping
+// that starts at idx: its nested entries, including the comments among them.
+func blockEnd(lines []string, idx int) int {
+	base, _, _ := virtual(lines[idx])
+	end := idx + 1
+	for i := idx + 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			continue
+		}
+		ind, _, _ := virtual(lines[i])
+		if ind <= base {
+			return end
+		}
+		end = i + 1
+	}
+	return end
+}
+
+// splitLines splits on "\n" and tolerates CRLF, so a config.yaml edited on
+// Windows in an editor that writes CRLF is not rewritten with mixed endings.
+func splitLines(s string) []string {
+	out := strings.Split(s, "\n")
+	for i, l := range out {
+		out[i] = strings.TrimSuffix(l, "\r")
+	}
+	return out
+}
+
+// WriteFile writes b to path atomically at FilePerm (0600). The temporary
+// file is created beside the target — a rename across filesystems is not
+// atomic — and is named so config.Watch ignores it: the watcher filters on
+// the exact base name, and "config.yaml.tmp" is not it.
+func WriteFile(path string, b []byte) (err error) {
+	tmp := path + ".tmp"
+	//nolint:gosec // G304: path is ConfigPath() under a dir the daemon owns
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, FilePerm)
+	if err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err = f.Write(b); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	// A file that predates the tightened modes keeps its own mode through a
+	// rename, so the mode is set on the replacement rather than inherited.
+	if err = os.Chmod(tmp, FilePerm); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err = os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	return nil
+}
+
+// RenderString renders a Go string as a YAML scalar: bare when YAML reads it
+// back unchanged, double-quoted otherwise. An empty string is always quoted —
+// a bare empty value parses as null, which is a different thing from "".
+func RenderString(s string) string {
+	if s == "" || !plainScalar.MatchString(s) || isYAMLWord(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+// isYAMLWord reports whether a bare token would parse as something other than
+// a string: the booleans and the nulls YAML 1.1 recognises.
+func isYAMLWord(s string) bool {
+	switch strings.ToLower(s) {
+	case "true", "false", "yes", "no", "on", "off", "null", "~":
+		return true
+	}
+	return false
+}
+
+// RenderList renders a []string as a flow sequence. An empty list renders as
+// "[]" rather than being omitted: an empty tui.board.group_by is a configured
+// choice (a flat table), not an absent key.
+func RenderList(items []string) string {
+	parts := make([]string, 0, len(items))
+	for _, s := range items {
+		parts = append(parts, RenderString(s))
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// RenderMap renders a map[string]string as a flow mapping, keys sorted so the
+// same map always writes the same bytes.
+func RenderMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, RenderString(k)+": "+RenderString(m[k]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1,0 +1,232 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+// The editor's contract, in the three cases config.yaml actually presents
+// (task 060): an active key, a documented block that is commented out, and a
+// key an older template never carried at all.
+
+func TestApplyEditsAnActiveKeyInPlace(t *testing.T) {
+	src := `# a leading comment
+listen: 127.0.0.1:0
+
+# how loud the daemon is
+log_level: info
+
+defaults:
+  agent_timeout: 60m
+  command_timeout: 15m
+`
+	got, err := Apply([]byte(src), []Set{{Path: "log_level", Value: "debug"}, {Path: "defaults.command_timeout", Value: "30m"}})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	out := string(got)
+	for _, want := range []string{
+		"# a leading comment", "# how loud the daemon is",
+		"log_level: debug", "  command_timeout: 30m", "  agent_timeout: 60m",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q from:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "log_level: info") {
+		t.Errorf("the old value survived:\n%s", out)
+	}
+	// Key order and the blank lines are the file's, not the struct's.
+	if !strings.Contains(out, "listen: 127.0.0.1:0\n\n# how loud") {
+		t.Errorf("blank lines or key order moved:\n%s", out)
+	}
+}
+
+// The `notify:` block ships commented out, and it is the case the issue was
+// opened on: turning the hook on must uncomment the block where it stands
+// rather than appending a second `notify:` to the end of the file.
+func TestApplyUncommentsADocumentedBlock(t *testing.T) {
+	got, err := Apply([]byte(defaultConfigYAML), []Set{
+		{Path: "notify.on", Value: "[blocked, awaiting_gate]"},
+		{Path: "notify.command", Value: `["/usr/local/bin/notify-me"]`},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	out := string(got)
+	if n := strings.Count(out, "\nnotify:"); n != 1 {
+		t.Errorf("notify: appears %d times, want exactly 1:\n%s", n, out)
+	}
+	for _, want := range []string{
+		"\nnotify:\n", "  on: [blocked, awaiting_gate]", `  command: ["/usr/local/bin/notify-me"]`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q from the edited file", want)
+		}
+	}
+	// Everything the block documented is still there.
+	if !strings.Contains(out, "WARNING: this is arbitrary code the daemon runs as you") {
+		t.Error("the notify block's warning was flattened")
+	}
+	cfg, err := Decode(got)
+	if err != nil {
+		t.Fatalf("the edited template no longer parses: %v", err)
+	}
+	if !cfg.Notify.Enabled() {
+		t.Errorf("notify did not take effect: %+v", cfg.Notify)
+	}
+}
+
+// An active parent with a commented child — the `environment:` block's shape.
+func TestApplyUncommentsAChildOfAnActiveBlock(t *testing.T) {
+	got, err := Apply([]byte(defaultConfigYAML), []Set{{Path: "environment.set", Value: "{LANG: C.UTF-8}"}})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "  set: {LANG: C.UTF-8}") {
+		t.Errorf("environment.set was not uncommented in place:\n%s", out)
+	}
+	cfg, err := Decode(got)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.Environment.Set["LANG"] != "C.UTF-8" {
+		t.Errorf("environment.set = %v", cfg.Environment.Set)
+	}
+}
+
+// The fallback: a config.yaml written before a key's documented block existed.
+func TestApplyAppendsAKeyWithNoBlock(t *testing.T) {
+	src := "listen: 127.0.0.1:0\nlog_level: info\n"
+	got, err := Apply([]byte(src), []Set{
+		{Path: "max_parallel_tasks", Value: "9"},
+		{Path: "fan_out.max_depth", Value: "2"},
+		{Path: "fan_out.max_tasks", Value: "7"},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg, err := Decode(got)
+	if err != nil {
+		t.Fatalf("decode %q: %v", got, err)
+	}
+	if cfg.MaxParallelTasks != 9 || cfg.FanOut.MaxDepth != 2 || cfg.FanOut.MaxTasks != 7 {
+		t.Errorf("appended keys did not take: %+v", cfg)
+	}
+	// The second key under fan_out lands inside the block the first created.
+	if n := strings.Count(string(got), "fan_out:"); n != 1 {
+		t.Errorf("fan_out: appears %d times, want 1:\n%s", n, got)
+	}
+}
+
+// A trailing comment on a key is documentation of that key. Replacing the
+// value must not take it with it.
+func TestApplyKeepsATrailingComment(t *testing.T) {
+	src := "environment:\n  inherit: all          # all | none | a list of names\n"
+	got, err := Apply([]byte(src), []Set{{Path: "environment.inherit", Value: "none"}})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "inherit: none") {
+		t.Errorf("the value was not replaced:\n%s", out)
+	}
+	if !strings.Contains(out, "# all | none | a list of names") {
+		t.Errorf("the trailing comment was dropped:\n%s", out)
+	}
+}
+
+// The template is the file most installations have, so every key the editor
+// can be asked for has to survive a round trip through it and still parse.
+func TestApplyOverTheTemplateStillParses(t *testing.T) {
+	sets := []Set{
+		{Path: "listen", Value: "127.0.0.1:8080"},
+		{Path: "max_parallel_tasks", Value: "7"},
+		{Path: "branch_template", Value: RenderString("wip/{{.ID}}")},
+		{Path: "defaults.agent_timeout", Value: "90m"},
+		{Path: "transcript_max_bytes", Value: RenderString("1GB")},
+		{Path: "max_task_cost_usd", Value: "2.5"},
+		{Path: "log_level", Value: "warn"},
+		{Path: "debug", Value: "true"},
+		{Path: "environment.unset", Value: RenderList([]string{"MSYSTEM"})},
+		{Path: "agents.cursor.path", Value: RenderString("/opt/cursor-agent")},
+		{Path: "parallel.max_parallel", Value: "2"},
+		{Path: "mcp.wire_steps", Value: "false"},
+		{Path: "include.max_depth", Value: "9"},
+		{Path: "loop.max_iterations", Value: "3"},
+		{Path: "github.poll_interval", Value: "0s"},
+		{Path: "update.check", Value: "false"},
+		{Path: "tui.board.group_by", Value: RenderList(nil)},
+	}
+	got, err := Apply([]byte(defaultConfigYAML), sets)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg, err := Decode(got)
+	if err != nil {
+		t.Fatalf("the edited template no longer parses: %v\n%s", err, got)
+	}
+	if cfg.Listen != "127.0.0.1:8080" || cfg.MaxParallelTasks != 7 ||
+		cfg.BranchTemplate != "wip/{{.ID}}" || cfg.LogLevel != "warn" || !cfg.Debug ||
+		cfg.TranscriptMaxBytes != 1<<30 || cfg.MaxTaskCostUSD != 2.5 ||
+		cfg.Agents.Cursor.Path != "/opt/cursor-agent" || cfg.MCP.WireSteps ||
+		cfg.Include.MaxDepth != 9 || cfg.Loop.MaxIterations != 3 ||
+		cfg.GitHub.PollInterval != 0 || cfg.Update.Check ||
+		len(cfg.TUI.Board.GroupBy) != 0 || len(cfg.Environment.Unset) != 1 {
+		t.Errorf("a set did not take: %+v", cfg)
+	}
+	// Every key was already documented, so nothing was appended: the file has
+	// the same number of lines it started with.
+	if a, b := strings.Count(string(got), "\n"), strings.Count(defaultConfigYAML, "\n"); a != b {
+		t.Errorf("the template grew from %d lines to %d; a documented key was appended instead of edited", b, a)
+	}
+}
+
+// RenderString has one job: what it emits has to read back as what went in.
+func TestRenderStringRoundTrips(t *testing.T) {
+	for _, s := range []string{"", "info", "true", "no", "60m", "a b", "vincent/{{.ID}}-{{.Slug}}", "#hash", "C:\\bin\\cursor.exe"} {
+		src := "log_level: " + RenderString(s) + "\n"
+		var out struct {
+			LogLevel string `yaml:"log_level"`
+		}
+		if err := yamlUnmarshalForTest([]byte(src), &out); err != nil {
+			t.Errorf("%q rendered as %s, which does not parse: %v", s, RenderString(s), err)
+			continue
+		}
+		if out.LogLevel != s {
+			t.Errorf("%q round-tripped as %q (rendered %s)", s, out.LogLevel, RenderString(s))
+		}
+	}
+}
+
+func TestWriteFileIsAtomicAndOwnerOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+	if err := os.WriteFile(path, []byte("log_level: info\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := WriteFile(path, []byte("log_level: debug\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "log_level: debug\n" {
+		t.Errorf("contents = %q", got)
+	}
+	// The temporary file is named so config.Watch's base-name filter ignores
+	// it, and it must not be left behind.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("the temporary file survived the write: %v", err)
+	}
+}
+
+// yamlUnmarshalForTest keeps the round-trip test honest about which parser it
+// is asserting against: the one Load and Decode use, not a second one.
+func yamlUnmarshalForTest(b []byte, v any) error { return yaml.Unmarshal(b, v) }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -415,41 +415,20 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		selfupdate.CleanLeftovers(exe)
 	}
 
-	srv := api.New(api.Deps{
-		Token:        token,
-		Config:       currentConfig,
-		StartedAt:    startedAt,
-		ListenAddr:   ln.Addr().String(),
-		Dirs:         dirs,
-		LogPath:      LogPath(dirs.Data),
-		TailLog:      TailFile,
-		RequestStop:  requestStop,
-		Logger:       logger,
-		Store:        st,
-		Git:          git,
-		GitHub:       githubClient,
-		Worktrees:    worktrees,
-		Agents:       agents,
-		Catalog:      catalog,
-		Workflows:    workflows,
-		Runner:       runner,
-		WakeRunner:   sched.Wake,
-		Broker:       broker,
-		Reclaimer:    reclaimer,
-		UpdateStatus: updateCheck.Result,
-		OnProjectsChanged: func() {
-			pctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			if err := syncWorkflowProjects(pctx, st, workflows); err != nil {
-				logger.Warn("project workflow scopes not refreshed", "error", err)
-			}
-			// A project's max_parallel_tasks may have changed (§11).
-			sched.Wake()
-		},
-	})
-	apiHolder.Store(srv)
-
-	if err := config.Watch(ctx, logger, dirs.Config, func(next config.Config) {
+	// One applier, two callers (task 060 decision 5). The fsnotify watcher
+	// below and PATCH /v1/config both hand a freshly loaded configuration to
+	// this function, so the `listen` pin, the branch_template fallback and the
+	// warning re-report happen on both paths and cannot drift apart. It is
+	// idempotent: applying identical bytes twice — which is exactly what the
+	// watcher does after a patch wrote the file — changes nothing and logs
+	// nothing new.
+	//
+	// applyMu guards its own carried state (prevWarnings, envNames) now that
+	// two goroutines reach it: the watch loop and an API request.
+	var applyMu sync.Mutex
+	applyConfig := func(next config.Config) {
+		applyMu.Lock()
+		defer applyMu.Unlock()
 		prev := current.Load()
 		if next.Listen != prev.Listen {
 			logger.Warn("listen change ignored until restart",
@@ -495,7 +474,44 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		shells.Reprobe()
 		// max_parallel_tasks may have changed (§11).
 		sched.Wake()
-	}); err != nil {
+	}
+
+	srv := api.New(api.Deps{
+		Token:        token,
+		Config:       currentConfig,
+		StartedAt:    startedAt,
+		ListenAddr:   ln.Addr().String(),
+		Dirs:         dirs,
+		LogPath:      LogPath(dirs.Data),
+		TailLog:      TailFile,
+		RequestStop:  requestStop,
+		Logger:       logger,
+		Store:        st,
+		Git:          git,
+		GitHub:       githubClient,
+		Worktrees:    worktrees,
+		Agents:       agents,
+		Catalog:      catalog,
+		Workflows:    workflows,
+		Runner:       runner,
+		WakeRunner:   sched.Wake,
+		Broker:       broker,
+		Reclaimer:    reclaimer,
+		UpdateStatus: updateCheck.Result,
+		ApplyConfig:  applyConfig,
+		OnProjectsChanged: func() {
+			pctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := syncWorkflowProjects(pctx, st, workflows); err != nil {
+				logger.Warn("project workflow scopes not refreshed", "error", err)
+			}
+			// A project's max_parallel_tasks may have changed (§11).
+			sched.Wake()
+		},
+	})
+	apiHolder.Store(srv)
+
+	if err := config.Watch(ctx, logger, dirs.Config, applyConfig); err != nil {
 		logger.Warn("config hot-reload unavailable", "error", err)
 	}
 

--- a/internal/mcp/redact.go
+++ b/internal/mcp/redact.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// The `config_get` tool is the one place this package changes what a route
+// says (task 060 decision 3).
+//
+// GET /v1/config serves config.yaml in full, values included: over HTTP that
+// is loopback behind an 0600 bearer token, the same trust boundary as the 0600
+// file itself. An MCP tool call is not that. It is replayed on behalf of an
+// agent step, and whatever comes back lands in the model's context and in the
+// step's transcript — so serving the literal `environment.set` values and the
+// `notify.command` argv here would put a webhook URL or an API key somewhere
+// nobody chose to put it.
+//
+// The two fields are masked; nothing else is. Names survive, because "which
+// variables are set" is the question an agent has any business asking, and it
+// is the same line §12.3 already draws for the log. A test asserts the HTTP
+// body and the MCP body differ in exactly these fields and nowhere else.
+
+// redactedMask replaces a value the MCP rendering will not disclose.
+const redactedMask = "[redacted]"
+
+// redactBody returns the tool-visible rendering of one route's response body.
+// Every route but config_get is passed through untouched.
+func redactBody(r Route, status int, body []byte) []byte {
+	if r.Tool != "config_get" || r.Method != http.MethodGet || status >= http.StatusBadRequest {
+		return body
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(body, &doc); err != nil {
+		// An unparseable body is not one this function understands well enough
+		// to redact, and passing it through would leak exactly what it exists
+		// to hide. Refuse instead.
+		return []byte(`{"error":{"code":"internal","message":"configuration could not be redacted"}}`)
+	}
+	if raw, ok := doc["environment"]; ok {
+		doc["environment"] = redactEnvironment(raw)
+	}
+	if raw, ok := doc["notify"]; ok {
+		doc["notify"] = redactNotify(raw)
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return []byte(`{"error":{"code":"internal","message":"configuration could not be redacted"}}`)
+	}
+	return out
+}
+
+// redactEnvironment masks the values under `environment.set`, keeping its
+// names and leaving `inherit` and `unset` — both name-only already — alone.
+func redactEnvironment(raw json.RawMessage) json.RawMessage {
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return raw
+	}
+	setRaw, ok := env["set"]
+	if !ok {
+		return raw
+	}
+	var set map[string]string
+	if err := json.Unmarshal(setRaw, &set); err != nil {
+		return raw
+	}
+	for k := range set {
+		set[k] = redactedMask
+	}
+	b, err := json.Marshal(set)
+	if err != nil {
+		return raw
+	}
+	env["set"] = b
+	out, err := json.Marshal(env)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// redactNotify masks every element of `notify.command`. The argv is masked
+// whole rather than from the first argument on: the secret in the case that
+// motivated this is a webhook URL, and it is an argument, not the program.
+// `notify.on` is a list of §6 state names and stays.
+func redactNotify(raw json.RawMessage) json.RawMessage {
+	var n map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return raw
+	}
+	cmdRaw, ok := n["command"]
+	if !ok {
+		return raw
+	}
+	var cmd []string
+	if err := json.Unmarshal(cmdRaw, &cmd); err != nil {
+		return raw
+	}
+	for i := range cmd {
+		cmd[i] = redactedMask
+	}
+	b, err := json.Marshal(cmd)
+	if err != nil {
+		return raw
+	}
+	n["command"] = b
+	out, err := json.Marshal(n)
+	if err != nil {
+		return raw
+	}
+	return out
+}

--- a/internal/mcp/replay.go
+++ b/internal/mcp/replay.go
@@ -189,7 +189,7 @@ func (s *Server) dispatch(ctx context.Context, r Route, raw json.RawMessage) (*m
 	if rec.status == 0 {
 		rec.status = http.StatusOK
 	}
-	body := rec.body.Bytes()
+	body := redactBody(r, rec.status, rec.body.Bytes())
 	if rec.status >= http.StatusBadRequest {
 		var env errorEnvelope
 		if json.Unmarshal(body, &env) == nil && env.Error.Code != "" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -35,6 +35,13 @@ type Route struct {
 // Streaming.
 var Excluded = []Route{
 	{Method: http.MethodPost, Path: "/v1/daemon/stop"},
+	// Task 057 decision 4 named this one before it existed: an agent must not
+	// be able to *reconfigure* the daemon supervising it. PATCH /v1/config can
+	// change the argv the daemon spawns (notify.command, agents.*.path), what
+	// its children inherit (environment) and whether steps get MCP at all
+	// (mcp.wire_steps) — a step editing any of those is a step rewriting the
+	// rules it runs under (task 060 decision 4).
+	{Method: http.MethodPatch, Path: "/v1/config"},
 	{Method: http.MethodPost, Path: "/v1/daemon/backup"},
 	{Method: http.MethodDelete, Path: "/v1/projects/{id}"},
 	{Method: http.MethodPost, Path: "/v1/maintenance/gc"},
@@ -59,7 +66,7 @@ const WaitTool = "task_wait"
 var routes = []Route{
 	{http.MethodGet, "/v1/health", "health", "Daemon liveness and version."},
 	{http.MethodGet, "/v1/info", "info", "Daemon identity: version, pid, uptime, listen address, agent availability, orphan count and database size."},
-	{http.MethodGet, "/v1/config", "config_get", "The daemon's effective configuration (§12.3), as the daemon currently reads it."},
+	{http.MethodGet, "/v1/config", "config_get", "The daemon's effective configuration (§12.3), as the daemon currently reads it. Read-only, and the values of environment.set and notify.command are masked on this path."},
 	{http.MethodGet, "/v1/agents", "agent_list", "The agent adapters and their selectable models and effort levels (§9.6)."},
 	{http.MethodGet, "/v1/doctor", "doctor", "The diagnostic report: directories, log, database figures and detected problems."},
 	{http.MethodGet, "/v1/update", "update_status", "The daemon's cached release check (§12.3): the latest stable release, when it was last seen, and whether this build is behind it. Read-only — it never downloads or installs anything."},

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -67,6 +67,10 @@ const (
 	// the reason the other popups have theirs: while it is open it owns the
 	// keyboard, and its two rows are nothing like the form underneath.
 	ctxCreatePR bindingContext = "open a pull request"
+	// ctxConfigEdit is the daemon view's config editor (task 060). Its own
+	// context because while it is open it owns the keyboard, and its keys are
+	// nothing like the log pane's underneath it.
+	ctxConfigEdit bindingContext = "config editor"
 )
 
 // binding is one registry row.
@@ -263,6 +267,18 @@ var bindings = []binding{
 	{key: "R", label: "re-read the daemon info, the config and the log", scope: scopePanel, context: ctxDaemon, hint: "R refresh", priority: 1},
 	{key: "f", label: "follow the end of the log again (f/G)", scope: scopePanel, context: ctxDaemon, hint: "f follow", priority: 2},
 	{key: "down", label: "scroll the log (↑/↓)", scope: scopePanel, context: ctxDaemon, hint: "↑/↓ scroll", priority: 3},
+	// The config block became editable in task 060. tab is what says whether
+	// ↑/↓ mean the config list or the log pane — the view has two scrollable
+	// things now and one pair of arrows.
+	{key: "tab", label: "move between the config list and the log pane", scope: scopePanel, context: ctxDaemon, hint: "tab config", priority: 4},
+	{key: "enter", label: "edit the selected configuration key (e also opens it)", scope: scopePanel, context: ctxDaemon, hint: "enter edit", priority: 5},
+
+	// The config editor: it owns the keyboard while it is open and prints its
+	// own key line, so these are here to keep ? complete.
+	{key: "left", label: "choose a value, for a key with a fixed vocabulary (←/→)", scope: scopePanel, context: ctxConfigEdit, noPalette: true},
+	{key: "enter", label: "apply the change; the daemon validates and writes config.yaml", scope: scopePanel, context: ctxConfigEdit, noPalette: true},
+	{key: "y", label: "confirm a key that decides what the daemon executes or exposes", scope: scopePanel, context: ctxConfigEdit, noPalette: true},
+	{key: "esc", label: "close the editor without saving (the confirmation returns to the field)", scope: scopePanel, context: ctxConfigEdit, noPalette: true},
 
 	// Answer form: these exist only while the popup owns the keyboard, and
 	// the popup prints them itself — they are here so ? stays complete.

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -821,6 +821,54 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("down did not reach the log pane's scroll path (follow was never re-synced)")
 			}
 		},
+		"tab": func(t *testing.T) {
+			d := newTestDaemonView([]string{"a log line"}, nil)
+			d.updateKey(registryKey(t, "tab"))
+			if !d.focusConfig {
+				t.Fatal("tab did not move the arrows onto the config list")
+			}
+		},
+		"enter": func(t *testing.T) {
+			d := newTestDaemonView([]string{"a log line"}, nil)
+			d.update(daemonConfigMsg{config: testConfig()})
+			d.updateKey(registryKey(t, "enter"))
+			if d.form == nil {
+				t.Fatal("enter did not open the config editor")
+			}
+		},
+	},
+
+	ctxConfigEdit: {
+		"left": func(t *testing.T) {
+			d := openConfigForm(t, "log_level")
+			before := d.form.value()
+			d.updateKey(registryKey(t, "left"))
+			if d.form.value() == before {
+				t.Fatal("left did not move the chooser")
+			}
+		},
+		"enter": func(t *testing.T) {
+			d := openConfigForm(t, "listen")
+			d.updateKey(registryKey(t, "enter"))
+			if !d.form.confirming {
+				t.Fatal("enter on a dangerous key did not reach the confirmation step")
+			}
+		},
+		"y": func(t *testing.T) {
+			d := openConfigForm(t, "listen")
+			d.form.confirming = true
+			d.updateKey(registryKey(t, "y"))
+			if d.form.confirming {
+				t.Fatal("y did not answer the confirmation")
+			}
+		},
+		"esc": func(t *testing.T) {
+			d := openConfigForm(t, "log_level")
+			d.updateKey(registryKey(t, "esc"))
+			if d.form != nil {
+				t.Fatal("esc did not close the config editor")
+			}
+		},
 	},
 
 	ctxRepairForm: {

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -1,0 +1,248 @@
+package tui
+
+import (
+	"context"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The daemon view's config editor (task 060).
+//
+// It is a takeover rather than a floating popup: while it is open it owns the
+// keyboard, which is what `capturesInput` on the view reports, and the daemon
+// view renders it in place of its blocks. That is the property that matters —
+// the view's single-key globals (R, f, j/k) would otherwise fire into the text
+// field on the first keystroke.
+//
+// Four keys are gated behind an explicit confirmation: notify.command,
+// environment.*, agents.*.path and listen. They are the keys that decide what
+// the daemon executes or exposes, and agents already run full-auto by default
+// (§16) — a stray keystroke must not change the argv the daemon spawns as you.
+
+// configSavedMsg is the answer to a PATCH /v1/config. cfg is the
+// configuration in force afterwards, which is not always what was written:
+// `listen` is pinned until restart.
+type configSavedMsg struct {
+	path string
+	cfg  apiclient.Config
+	err  error
+}
+
+// configForm edits one key.
+type configForm struct {
+	key configKey
+	// choice indexes key.choices for kindBool and kindEnum; input holds the
+	// text for every other kind.
+	choice int
+	input  textinput.Model
+	// confirming is the second step a dangerous key needs. It is entered on
+	// save and left by y (apply) or esc (back to the field).
+	confirming bool
+	saving     bool
+	// err is the daemon's refusal, rendered against the field. It survives
+	// until the next save so the value that caused it is still on screen.
+	err string
+}
+
+// newConfigForm opens the editor on one key, seeded with the value in force.
+func newConfigForm(k configKey, cur apiclient.Config) *configForm {
+	f := &configForm{key: k}
+	value := k.read(cur)
+	switch k.kind {
+	case kindBool, kindEnum:
+		f.choice = indexOf(k.choices, value)
+	default:
+		in := textinput.New()
+		in.Prompt = ""
+		in.SetValue(value)
+		in.SetWidth(48)
+		in.Focus()
+		// The cursor lands at the end, on the value someone is about to edit,
+		// rather than at column zero in front of it.
+		in.CursorEnd()
+		f.input = in
+	}
+	return f
+}
+
+// value is what the form would submit.
+func (f *configForm) value() string {
+	switch f.key.kind {
+	case kindBool, kindEnum:
+		if f.choice >= 0 && f.choice < len(f.key.choices) {
+			return f.key.choices[f.choice]
+		}
+		return ""
+	default:
+		return f.input.Value()
+	}
+}
+
+// update routes a keypress. It returns a command when the form asks the
+// daemon for something, and reports whether the form is done with itself.
+func (f *configForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd tea.Cmd, done bool) {
+	if msg.String() == "esc" {
+		if f.confirming {
+			// Back to the field, not out of the form: someone who reads the
+			// confirmation and changes their mind about the *value* should
+			// not have to reopen the editor.
+			f.confirming = false
+			return nil, false
+		}
+		return nil, true
+	}
+	if f.confirming {
+		switch msg.String() {
+		case "y", "Y":
+			f.confirming = false
+			return f.save(client), false
+		}
+		return nil, false
+	}
+	switch f.key.kind {
+	case kindBool, kindEnum:
+		switch msg.String() {
+		case "left", "h", "up", "k":
+			f.choice = wrapIndex(f.choice-1, len(f.key.choices))
+			return nil, false
+		case "right", "l", "down", "j", " ", "space", "tab":
+			f.choice = wrapIndex(f.choice+1, len(f.key.choices))
+			return nil, false
+		}
+	}
+	switch msg.String() {
+	case "enter", "ctrl+s":
+		if f.key.dangerous {
+			f.confirming = true
+			return nil, false
+		}
+		return f.save(client), false
+	}
+	if f.key.kind != kindBool && f.key.kind != kindEnum {
+		var cmd tea.Cmd
+		f.input, cmd = f.input.Update(msg)
+		return cmd, false
+	}
+	return nil, false
+}
+
+// save builds the patch and sends it. A value this side can already tell is
+// wrong is refused here, without a round trip; everything else is the
+// daemon's to reject, and its message is what renders.
+func (f *configForm) save(client *apiclient.Client) tea.Cmd {
+	patch, err := f.key.write(f.value())
+	if err != nil {
+		f.err = err.Error()
+		return nil
+	}
+	if client == nil {
+		f.err = "the daemon is not reachable"
+		return nil
+	}
+	f.err = ""
+	f.saving = true
+	path := f.key.path
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		cfg, err := client.PatchConfig(ctx, patch)
+		return configSavedMsg{path: path, cfg: cfg, err: err}
+	}
+}
+
+// render draws the editor. It is deliberately plain: one key, one field, the
+// default beside it, and the line that says what happens when it applies. The
+// width is the caller's business: every line here is short by construction, so
+// nothing wraps and nothing has to be elided.
+func (f *configForm) render(_ int) []string {
+	out := []string{
+		" " + styleTitle.Render("edit "+f.key.path),
+		"",
+	}
+	if f.key.help != "" {
+		out = append(out, "   "+styleDim.Render(f.key.help))
+	}
+	out = append(out, "   "+styleDim.Render("default ")+f.key.def())
+	out = append(out, "")
+	switch f.key.kind {
+	case kindBool, kindEnum:
+		out = append(out, "   "+f.renderChoices())
+	default:
+		out = append(out, "   "+f.input.View())
+		if len(f.key.choices) > 0 {
+			out = append(out, "   "+styleDim.Render("accepted: "+strings.Join(f.key.choices, " ")))
+		}
+	}
+	out = append(out, "")
+	if f.key.restart {
+		// Said before it is applied, not after: `listen` is written to the
+		// file and the running daemon keeps the address it bound, so GET
+		// /v1/config will go on reporting the old one until a restart.
+		out = append(out, "   "+styleWarn.Render(
+			"takes effect on the next daemon restart; the running daemon keeps its address"))
+	}
+	if f.err != "" {
+		out = append(out, "   "+styleBad.Render("⚠ "+f.err))
+	}
+	out = append(out, "")
+	switch {
+	case f.confirming:
+		out = append(out, "   "+styleWarn.Render("this changes what the daemon executes or exposes."),
+			"   "+styleWarn.Render("set "+f.key.path+" to ")+f.displayValue()+
+				styleWarn.Render("?  y confirm   esc back"))
+	case f.saving:
+		out = append(out, "   "+styleDim.Render("saving…"))
+	default:
+		out = append(out, "   "+styleDim.Render(f.keyLine()))
+	}
+	return out
+}
+
+// displayValue renders an empty value as something a reader can see: a
+// confirmation that reads "set agents.claude.path to " and stops is not one.
+func (f *configForm) displayValue() string {
+	v := f.value()
+	if strings.TrimSpace(v) == "" {
+		return styleDim.Render("(empty)")
+	}
+	return v
+}
+
+func (f *configForm) keyLine() string {
+	if f.key.kind == kindBool || f.key.kind == kindEnum {
+		return "←/→ choose   enter apply   esc cancel"
+	}
+	return "enter apply   esc cancel"
+}
+
+func (f *configForm) renderChoices() string {
+	parts := make([]string, 0, len(f.key.choices))
+	for i, c := range f.key.choices {
+		if i == f.choice {
+			parts = append(parts, styleFocus.Render("["+c+"]"))
+			continue
+		}
+		parts = append(parts, styleDim.Render(" "+c+" "))
+	}
+	return strings.Join(parts, " ")
+}
+
+func indexOf(items []string, want string) int {
+	for i, s := range items {
+		if s == want {
+			return i
+		}
+	}
+	return 0
+}
+
+func wrapIndex(i, n int) int {
+	if n == 0 {
+		return 0
+	}
+	return ((i % n) + n) % n
+}

--- a/internal/tui/configkeys.go
+++ b/internal/tui/configkeys.go
@@ -1,0 +1,539 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/taskstate"
+)
+
+// The editable surface of config.yaml, as the daemon view presents it
+// (task 060).
+//
+// One table, because every row needs the same four things and a switch
+// statement per column would put them in four places: what the key is called,
+// what shape its value has, how to read the current one out of GET /v1/config,
+// and how to spell a change as a PATCH body. A key the daemon serves and this
+// table omits is a key the TUI shows and cannot edit, which is the state this
+// task was opened to end — a test asserts the table covers the served shape.
+//
+// internal/config is imported for Default() alone. It is a leaf package, so
+// the dependency direction stays one-way, and reading the built-in defaults
+// from the package that defines them beats copying them into a second list
+// that would drift. It is *not* the TUI reading configuration from disk (§15):
+// the values shown are the daemon's, off the API; only the defaults compared
+// against are compiled in.
+
+// configKind is how a row is edited: a free-text field, a chooser, or a list.
+type configKind int
+
+const (
+	// kindText is a typed value the daemon parses — a duration, a size, a
+	// template, a path. Its rules live in internal/config, so the field
+	// accepts anything and the daemon's rejection is what renders.
+	kindText configKind = iota
+	// kindInt and kindFloat are checked here as well as server-side, so a
+	// typo does not cost a round trip.
+	kindInt
+	kindFloat
+	// kindBool and kindEnum are chosen from a fixed vocabulary rather than
+	// typed: there is no reason to let someone spell "ture".
+	kindBool
+	kindEnum
+	// kindList is whitespace-separated tokens: argv, variable names, or
+	// grouping levels. An argument containing a space cannot be written this
+	// way and has to be edited in the file; the modal says so.
+	kindList
+	// kindMap is whitespace-separated NAME=VALUE pairs (environment.set).
+	kindMap
+)
+
+// configKey is one editable key.
+type configKey struct {
+	// path is the dotted path, and is also what the confirmation names: it is
+	// the spelling that appears in config.yaml and on the config reference.
+	path  string
+	label string
+	kind  configKind
+	// choices is the vocabulary for kindBool, kindEnum and kindList.
+	choices []string
+	// dangerous marks a key that decides what the daemon executes or exposes.
+	// The issue names four — notify.command, environment, agents.*.path and
+	// listen — and every one of them is a key where a stray keystroke changes
+	// the argv the daemon spawns as you, or the address it binds. Agents run
+	// full-auto by default (§16); these ask before they apply.
+	dangerous bool
+	// restart marks a key the running daemon keeps until it is restarted. Only
+	// `listen` is one: the reload path pins it deliberately, so PATCH writes
+	// the file and GET keeps reporting the address actually bound.
+	restart bool
+	// help is the one line the modal prints under the field.
+	help string
+	// read renders the value in force. write turns edited text into a patch,
+	// or refuses it with the message the modal shows against the field.
+	read  func(apiclient.Config) string
+	write func(string) (apiclient.ConfigPatch, error)
+	// show is the block's rendering when the raw value is not the honest one
+	// to read: a zero cost cap is "off", not "0", and a retention of 90 is
+	// "90 days". It is never what the editor seeds — that is always read, so
+	// what you edit is what the file will carry. Nil means read.
+	show func(apiclient.Config) string
+}
+
+// display is what the config block prints for this key.
+func (k configKey) display(c apiclient.Config) string {
+	if k.show != nil {
+		return k.show(c)
+	}
+	return k.read(c)
+}
+
+// def is the built-in default for this key, rendered the way read renders a
+// value, so a row can say what it would be if the file said nothing.
+func (k configKey) def() string { return k.read(defaultClientConfig()) }
+
+// boolChoices and the enum vocabularies. group_by and notify.on are lists
+// drawn from a vocabulary rather than free text, so the modal can offer them.
+var (
+	boolChoices     = []string{"false", "true"}
+	logLevelChoices = []string{"debug", "info", "warn", "error"}
+	groupByChoices  = []string{"project", "workflow"}
+	inheritChoices  = []string{"all", "none"}
+)
+
+// configKeys is the editable table, in the order config.yaml carries the keys
+// so the block reads like the file.
+func configKeys() []configKey {
+	keys := []configKey{
+		{
+			path: "listen", label: "listen", kind: kindText, dangerous: true, restart: true,
+			help:  "loopback address the API binds to; port 0 picks an ephemeral one",
+			read:  func(c apiclient.Config) string { return c.Listen },
+			write: func(s string) (apiclient.ConfigPatch, error) { return apiclient.ConfigPatch{Listen: &s}, nil },
+		},
+		{
+			path: "max_parallel_tasks", label: "max parallel tasks", kind: kindInt,
+			help: "global cap on concurrently running tasks",
+			read: func(c apiclient.Config) string { return strconv.Itoa(c.MaxParallelTasks) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				n, err := parseInt(s)
+				return apiclient.ConfigPatch{MaxParallelTasks: &n}, err
+			},
+		},
+		{
+			path: "branch_template", label: "branch template", kind: kindText,
+			help: "Go template for a task's branch name; empty uses the built-in",
+			read: func(c apiclient.Config) string { return c.BranchTemplate },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				return apiclient.ConfigPatch{BranchTemplate: &s}, nil
+			},
+		},
+		durationKey("defaults.agent_timeout", "agent timeout", "fallback timeout for an agent step",
+			func(c apiclient.Config) string { return c.Defaults.AgentTimeout },
+			func(s string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{AgentTimeout: &s}}
+			}),
+		durationKey("defaults.command_timeout", "command timeout", "fallback timeout for a command step",
+			func(c apiclient.Config) string { return c.Defaults.CommandTimeout },
+			func(s string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{CommandTimeout: &s}}
+			}),
+		durationKey("defaults.input_timeout", "input timeout", "how long a step waits for an answer (§7.4)",
+			func(c apiclient.Config) string { return c.Defaults.InputTimeout },
+			func(s string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Defaults: &apiclient.ConfigDefaultsPatch{InputTimeout: &s}}
+			}),
+		boolKey("delete_empty_branch_on_archive", "delete empty branch",
+			"delete an archived task's branch when it carries no commits (§10)",
+			func(c apiclient.Config) bool { return c.DeleteEmptyBranchOnArchive },
+			func(b bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{DeleteEmptyBranchOnArchive: &b} }),
+		boolKey("delete_remote_branch_on_archive", "delete remote branch",
+			"also delete its upstream counterpart; inert while the local one is off",
+			func(c apiclient.Config) bool { return c.DeleteRemoteBranchOnArchive },
+			func(b bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{DeleteRemoteBranchOnArchive: &b} }),
+		boolKey("fetch_base_branch", "fetch base branch",
+			"refresh a task's base from its remote before the worktree is cut",
+			func(c apiclient.Config) bool { return c.FetchBaseBranch },
+			func(b bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{FetchBaseBranch: &b} }),
+		{
+			path: "transcript_retention_days", label: "transcript retention", kind: kindInt,
+			help: "days an archived task's transcripts are kept",
+			read: func(c apiclient.Config) string { return strconv.Itoa(c.TranscriptRetentionDays) },
+			show: func(c apiclient.Config) string { return strconv.Itoa(c.TranscriptRetentionDays) + " days" },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				n, err := parseInt(s)
+				return apiclient.ConfigPatch{TranscriptRetentionDays: &n}, err
+			},
+		},
+		{
+			path: "transcript_max_bytes", label: "transcript cap", kind: kindText,
+			help: "per-attempt transcript ceiling, e.g. 512MB",
+			read: func(c apiclient.Config) string { return config.ByteSize(c.TranscriptMaxBytes).String() },
+			show: func(c apiclient.Config) string { return humanBytes(c.TranscriptMaxBytes) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				// Parsed here as well as server-side so the accepted spellings
+				// are one implementation: config.ParseByteSize is exported for
+				// exactly this.
+				v, err := config.ParseByteSize(strings.TrimSpace(s))
+				n := v.Bytes()
+				return apiclient.ConfigPatch{TranscriptMaxBytes: &n}, err
+			},
+		},
+		{
+			path: "max_task_cost_usd", label: "max task cost", kind: kindFloat,
+			help: "per-task spend ceiling in US dollars; 0 is no cap",
+			read: func(c apiclient.Config) string { return strconv.FormatFloat(c.MaxTaskCostUSD, 'f', -1, 64) },
+			// task 033: an unset cap reads "off", never "$0.00" — that
+			// spelling is reserved for a task whose adapters reported nothing.
+			show: costCapText,
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+				if err != nil {
+					return apiclient.ConfigPatch{}, fmt.Errorf("want a number, got %q", s)
+				}
+				return apiclient.ConfigPatch{MaxTaskCostUSD: &f}, nil
+			},
+		},
+		durationKey("usage_limit_recheck_interval", "usage limit recheck",
+			"how long a quota-held task waits when the CLI named no reset time",
+			func(c apiclient.Config) string { return c.UsageLimitRecheck },
+			func(s string) apiclient.ConfigPatch { return apiclient.ConfigPatch{UsageLimitRecheck: &s} }),
+		{
+			path: "log_level", label: "log level", kind: kindEnum, choices: logLevelChoices,
+			help:  "daemon log verbosity",
+			read:  func(c apiclient.Config) string { return c.LogLevel },
+			write: func(s string) (apiclient.ConfigPatch, error) { return apiclient.ConfigPatch{LogLevel: &s}, nil },
+		},
+		boolKey("debug", "debug", "record resolved argv and prompt in every transcript",
+			func(c apiclient.Config) bool { return c.Debug },
+			func(b bool) apiclient.ConfigPatch { return apiclient.ConfigPatch{Debug: &b} }),
+		{
+			path: "environment.inherit", label: "environment inherit", kind: kindText, dangerous: true,
+			choices: inheritChoices,
+			help:    "\"all\", \"none\", or whitespace-separated names to inherit",
+			read:    func(c apiclient.Config) string { return c.Environment.Inherit.String() },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := parseInherit(s)
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Inherit: &v}}, nil
+			},
+		},
+		{
+			path: "environment.unset", label: "environment unset", kind: kindList, dangerous: true,
+			help: "variable names dropped after inherit",
+			read: func(c apiclient.Config) string { return strings.Join(c.Environment.Unset, " ") },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.Fields(s)
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Unset: &v}}, nil
+			},
+		},
+		{
+			path: "environment.set", label: "environment set", kind: kindMap, dangerous: true,
+			help: "NAME=VALUE pairs, applied last; values are literal",
+			read: func(c apiclient.Config) string { return joinPairs(c.Environment.Set) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				m, err := parsePairs(s)
+				return apiclient.ConfigPatch{Environment: &apiclient.ConfigEnvironmentPatch{Set: &m}}, err
+			},
+		},
+		agentPathKey("claude", func(c apiclient.Config) string { return c.Agents.Claude.Path },
+			func(p *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Claude: &apiclient.AgentPathPatch{Path: p}}}
+			}),
+		agentPathKey("codex", func(c apiclient.Config) string { return c.Agents.Codex.Path },
+			func(p *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Codex: &apiclient.AgentPathPatch{Path: p}}}
+			}),
+		agentPathKey("cursor", func(c apiclient.Config) string { return c.Agents.Cursor.Path },
+			func(p *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Agents: &apiclient.ConfigAgentsPatch{Cursor: &apiclient.AgentPathPatch{Path: p}}}
+			}),
+		intKey("parallel.max_parallel", "parallel lanes", "concurrent verifications inside one parallel step (§7.5)",
+			func(c apiclient.Config) int { return c.Parallel.MaxParallel },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Parallel: &apiclient.ConfigParallel{MaxParallel: n}}
+			}),
+		intKey("fan_out.max_depth", "fan-out depth", "generations a fan_out tree may go deep (§7.6)",
+			func(c apiclient.Config) int { return c.FanOut.MaxDepth },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{FanOut: &apiclient.ConfigFanOut{MaxDepth: n}}
+			}),
+		intKey("fan_out.max_tasks", "fan-out tasks", "descendants one root may create (§7.6)",
+			func(c apiclient.Config) int { return c.FanOut.MaxTasks },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{FanOut: &apiclient.ConfigFanOut{MaxTasks: n}}
+			}),
+		intKey("loop.max_iterations", "loop iterations", "ceiling on one loop step's iterations (§7.8)",
+			func(c apiclient.Config) int { return c.Loop.MaxIterations },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Loop: &apiclient.ConfigLoop{MaxIterations: n}}
+			}),
+		intKey("include.max_depth", "include depth", "levels of include a workflow may nest (§7.9)",
+			func(c apiclient.Config) int { return c.Include.MaxDepth },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Include: &apiclient.ConfigInclude{MaxDepth: n}}
+			}),
+		boolKey("mcp.wire_steps", "mcp wire steps", "hand agent steps their own /mcp endpoint (§13.4)",
+			func(c apiclient.Config) bool { return c.MCP.WireSteps },
+			func(b bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{WireSteps: &b}}
+			}),
+		intKey("mcp.max_depth", "mcp depth", "generations of tasks an agent's tools may create",
+			func(c apiclient.Config) int { return c.MCP.MaxDepth },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{MaxDepth: &n}}
+			}),
+		intKey("mcp.max_tasks", "mcp tasks", "tasks an agent's tools may create in one chain",
+			func(c apiclient.Config) int { return c.MCP.MaxTasks },
+			func(n int) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{MCP: &apiclient.ConfigMCPPatch{MaxTasks: &n}}
+			}),
+		boolKey("github.enabled", "github enabled", "let the daemon read GitHub at all (task 035)",
+			func(c apiclient.Config) bool { return c.GitHub.Enabled },
+			func(b bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{GitHub: &apiclient.ConfigGitHubPatch{Enabled: &b}}
+			}),
+		durationKey("github.poll_interval", "github poll", "how often the pull-request reconciler runs; 0 is off",
+			func(c apiclient.Config) string { return c.GitHub.PollInterval },
+			func(s string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{GitHub: &apiclient.ConfigGitHubPatch{PollInterval: &s}}
+			}),
+		boolKey("update.check", "update check", "ask GitHub once a day whether a newer vincent exists",
+			func(c apiclient.Config) bool { return c.Update.Check },
+			func(b bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Update: &apiclient.ConfigUpdatePatch{Check: &b}}
+			}),
+		durationKey("update.poll_interval", "update poll", "how often that check runs; 0 is off",
+			func(c apiclient.Config) string { return c.Update.PollInterval },
+			func(s string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Update: &apiclient.ConfigUpdatePatch{PollInterval: &s}}
+			}),
+		{
+			path: "notify.on", label: "notify on", kind: kindList, choices: stateNames(),
+			help: "states that fire the notify hook, whitespace-separated",
+			read: func(c apiclient.Config) string { return strings.Join(c.Notify.On, " ") },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.Fields(s)
+				return apiclient.ConfigPatch{Notify: &apiclient.ConfigNotifyPatch{On: &v}}, nil
+			},
+		},
+		{
+			path: "notify.command", label: "notify command", kind: kindList, dangerous: true,
+			help: "argv the daemon runs as you; one argument per whitespace-separated word",
+			read: func(c apiclient.Config) string { return strings.Join(c.Notify.Command, " ") },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.Fields(s)
+				return apiclient.ConfigPatch{Notify: &apiclient.ConfigNotifyPatch{Command: &v}}, nil
+			},
+		},
+		{
+			path: "tui.board.group_by", label: "task grouping", kind: kindList, choices: groupByChoices,
+			help: "grouping levels for the board, outermost first; empty is a flat table",
+			read: func(c apiclient.Config) string { return strings.Join(c.TUI.Board.GroupBy, " ") },
+			show: func(c apiclient.Config) string { return groupSummary(c.TUI.Board.GroupBy) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.Fields(s)
+				return apiclient.ConfigPatch{TUI: &apiclient.ConfigTUIPatch{Board: &apiclient.ConfigBoardPatch{GroupBy: &v}}}, nil
+			},
+		},
+	}
+	return keys
+}
+
+// agentPathKey is the §9 adapter binary rows. All three are dangerous for one
+// reason: the path is the program the daemon execs for every agent step.
+func agentPathKey(name string, read func(apiclient.Config) string,
+	patch func(*string) apiclient.ConfigPatch,
+) configKey {
+	return configKey{
+		path: "agents." + name + ".path", label: name + " path", kind: kindText, dangerous: true,
+		help: "binary vincent runs for " + name + "; empty resolves it from PATH",
+		read: read,
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			v := strings.TrimSpace(s)
+			return patch(&v), nil
+		},
+	}
+}
+
+func durationKey(path, label, help string, read func(apiclient.Config) string,
+	patch func(string) apiclient.ConfigPatch,
+) configKey {
+	return configKey{
+		path: path, label: label, kind: kindText, help: help + " — a duration like 60m or 24h",
+		read: read,
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			return patch(strings.TrimSpace(s)), nil
+		},
+	}
+}
+
+func boolKey(path, label, help string, read func(apiclient.Config) bool,
+	patch func(bool) apiclient.ConfigPatch,
+) configKey {
+	return configKey{
+		path: path, label: label, kind: kindBool, choices: boolChoices, help: help,
+		read: func(c apiclient.Config) string { return strconv.FormatBool(read(c)) },
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			return patch(s == "true"), nil
+		},
+	}
+}
+
+func intKey(path, label, help string, read func(apiclient.Config) int,
+	patch func(int) apiclient.ConfigPatch,
+) configKey {
+	return configKey{
+		path: path, label: label, kind: kindInt, help: help,
+		read: func(c apiclient.Config) string { return strconv.Itoa(read(c)) },
+		write: func(s string) (apiclient.ConfigPatch, error) {
+			n, err := parseInt(s)
+			if err != nil {
+				return apiclient.ConfigPatch{}, err
+			}
+			return patch(n), nil
+		},
+	}
+}
+
+func parseInt(s string) (int, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0, fmt.Errorf("want a whole number, got %q", s)
+	}
+	return n, nil
+}
+
+// parseInherit reads the union the way config.yaml spells it: the two words,
+// or a list of names. A bare list is accepted with or without brackets, since
+// the row renders the bracketed form and someone editing it will leave them.
+func parseInherit(s string) apiclient.ConfigInherit {
+	t := strings.TrimSpace(s)
+	switch strings.ToLower(t) {
+	case "all", "none":
+		return apiclient.ConfigInherit{Mode: strings.ToLower(t)}
+	}
+	t = strings.TrimSuffix(strings.TrimPrefix(t, "["), "]")
+	names := strings.FieldsFunc(t, func(r rune) bool { return r == ',' || r == ' ' || r == '\t' })
+	return apiclient.ConfigInherit{Mode: "list", Names: names}
+}
+
+// joinPairs and parsePairs are environment.set's one-line form. A value
+// containing a space cannot be written here and has to be edited in the file;
+// the modal's help line says so rather than silently truncating one.
+func joinPairs(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+m[k])
+	}
+	return strings.Join(parts, " ")
+}
+
+func parsePairs(s string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, tok := range strings.Fields(s) {
+		name, value, ok := strings.Cut(tok, "=")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("want NAME=VALUE pairs, got %q", tok)
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
+// stateNames is the §6 vocabulary notify.on draws from, offered as choices so
+// the modal can list them rather than making someone remember them.
+func stateNames() []string {
+	states := taskstate.All
+	out := make([]string, 0, len(states))
+	for _, s := range states {
+		out = append(out, string(s))
+	}
+	return out
+}
+
+// defaultClientConfig renders config.Default() in the wire shape, so a row can
+// print what a key would be if the file said nothing about it.
+//
+// GET /v1/config serves effective values and carries no provenance: it cannot
+// say whether a value came from the file or from the built-in. So the block
+// says "differs from the default", which is what it actually knows, rather
+// than "set in the file", which it does not.
+func defaultClientConfig() apiclient.Config {
+	d := config.Default()
+	return apiclient.Config{
+		Listen:           d.Listen,
+		MaxParallelTasks: d.MaxParallelTasks,
+		BranchTemplate:   d.BranchTemplate,
+		Defaults: apiclient.ConfigDefaults{
+			AgentTimeout:   d.Defaults.AgentTimeout.String(),
+			CommandTimeout: d.Defaults.CommandTimeout.String(),
+			InputTimeout:   d.Defaults.InputTimeout.String(),
+		},
+		DeleteEmptyBranchOnArchive:  d.DeleteEmptyBranchOnArchive,
+		DeleteRemoteBranchOnArchive: d.DeleteRemoteBranchOnArchive,
+		FetchBaseBranch:             d.FetchBaseBranch,
+		TranscriptRetentionDays:     d.TranscriptRetentionDays,
+		TranscriptMaxBytes:          d.TranscriptMaxBytes.Bytes(),
+		MaxTaskCostUSD:              d.MaxTaskCostUSD,
+		UsageLimitRecheck:           d.UsageLimitRecheckInterval.String(),
+		LogLevel:                    d.LogLevel,
+		Debug:                       d.Debug,
+		Environment: apiclient.ConfigEnvironment{
+			Inherit: apiclient.ConfigInherit{Mode: inheritMode(d.Environment.Inherit), Names: d.Environment.Inherit.Names},
+			Unset:   d.Environment.Unset,
+			Set:     d.Environment.Set,
+		},
+		Agents: apiclient.ConfigAgents{
+			Claude: apiclient.AgentPath{Path: d.Agents.Claude.Path},
+			Codex:  apiclient.AgentPath{Path: d.Agents.Codex.Path},
+			Cursor: apiclient.AgentPath{Path: d.Agents.Cursor.Path},
+		},
+		Parallel: apiclient.ConfigParallel{MaxParallel: d.Parallel.MaxParallel},
+		FanOut:   apiclient.ConfigFanOut{MaxDepth: d.FanOut.MaxDepth, MaxTasks: d.FanOut.MaxTasks},
+		Loop:     apiclient.ConfigLoop{MaxIterations: d.Loop.MaxIterations},
+		Include:  apiclient.ConfigInclude{MaxDepth: d.Include.MaxDepth},
+		MCP: apiclient.ConfigMCP{
+			WireSteps: d.MCP.WireSteps, MaxDepth: d.MCP.MaxDepth, MaxTasks: d.MCP.MaxTasks,
+		},
+		GitHub: apiclient.ConfigGitHub{Enabled: d.GitHub.Enabled, PollInterval: d.GitHub.PollInterval.String()},
+		Update: apiclient.ConfigUpdate{Check: d.Update.Check, PollInterval: d.Update.PollInterval.String()},
+		Notify: apiclient.ConfigNotify{On: notifyStateNames(d), Command: d.Notify.Command},
+		TUI:    apiclient.ConfigTUI{Board: apiclient.ConfigBoard{GroupBy: boardGroupNames(d)}},
+	}
+}
+
+func inheritMode(i config.Inherit) string {
+	switch i.Mode {
+	case config.InheritNoneMode:
+		return "none"
+	case config.InheritListMode:
+		return "list"
+	default:
+		return "all"
+	}
+}
+
+func notifyStateNames(c config.Config) []string {
+	out := make([]string, 0, len(c.Notify.On))
+	for _, s := range c.Notify.On {
+		out = append(out, string(s))
+	}
+	return out
+}
+
+func boardGroupNames(c config.Config) []string {
+	out := make([]string, 0, len(c.TUI.Board.GroupBy))
+	for _, g := range c.TUI.Board.GroupBy {
+		out = append(out, string(g))
+	}
+	return out
+}

--- a/internal/tui/configlive_test.go
+++ b/internal/tui/configlive_test.go
@@ -1,0 +1,204 @@
+package tui
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// The config editor against the real handlers over httptest (the *live_test.go
+// convention, task 060). An in-process form talking to a fake would prove the
+// keystrokes and nothing about the wire; what is worth proving here is that a
+// keypress ends as an edited config.yaml and a re-rendered block.
+
+// configLiveHarness is a daemon view wired to a real API server whose config
+// dir holds the shipped template.
+type configLiveHarness struct {
+	view *daemonView
+	path string
+}
+
+func newConfigLive(t *testing.T) *configLiveHarness {
+	t.Helper()
+	const token = "config-live-token"
+	dir := t.TempDir()
+	if _, err := config.EnsureDefaultFile(dir); err != nil {
+		t.Fatalf("seed config.yaml: %v", err)
+	}
+	current := config.Default()
+	srv := api.New(api.Deps{
+		Token:       token,
+		Config:      func() config.Config { return current },
+		StartedAt:   time.Now().Add(-time.Minute),
+		ListenAddr:  "127.0.0.1:0",
+		Dirs:        config.Dirs{Config: dir},
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ApplyConfig: func(next config.Config) { current = next },
+	})
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	client := apiclient.New(ts.URL, token)
+
+	d := newDaemonView()
+	d.setDataDir(t.TempDir())
+	d.width, d.height = 120, 40
+	cfg, err := client.Config(t.Context())
+	if err != nil {
+		t.Fatalf("GET /v1/config: %v", err)
+	}
+	d.client = client
+	d.connected = true
+	d.update(daemonConfigMsg{config: cfg})
+	return &configLiveHarness{view: d, path: filepath.Join(dir, config.FileName)}
+}
+
+// press feeds a key and drains whatever command it produced, so an editor
+// that answers over HTTP is fully settled when press returns.
+func (h *configLiveHarness) press(t *testing.T, key string) {
+	t.Helper()
+	_, cmd := h.view.update(namedKey(key))
+	for cmd != nil {
+		msg := cmd()
+		if msg == nil {
+			return
+		}
+		_, cmd = h.view.update(msg)
+	}
+}
+
+func (h *configLiveHarness) open(t *testing.T, path string) {
+	t.Helper()
+	for i, k := range h.view.keys {
+		if k.path == path {
+			h.view.cursor = i
+			h.view.focusConfig = true
+			h.press(t, "enter")
+			return
+		}
+	}
+	t.Fatalf("no config key %q", path)
+}
+
+func (h *configLiveHarness) file(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(h.path)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	return string(b)
+}
+
+// The whole loop: select a key, edit it, apply, and the daemon has it.
+func TestConfigEditorWritesThroughTheRealAPI(t *testing.T) {
+	h := newConfigLive(t)
+	h.open(t, "log_level")
+	if h.view.form == nil {
+		t.Fatal("enter did not open the editor")
+	}
+	if !h.view.capturesInput() {
+		t.Error("the view does not capture input while the editor is open; " +
+			"every single-key global would fire into it")
+	}
+	// log_level is a chooser: walk it to "warn".
+	for h.view.form.value() != "warn" {
+		h.press(t, "right")
+	}
+	h.press(t, "enter")
+	if h.view.form != nil {
+		t.Fatalf("the editor stayed open after a successful save: %+v", h.view.form)
+	}
+	if h.view.config.LogLevel != "warn" {
+		t.Errorf("the block did not adopt the new configuration: %q", h.view.config.LogLevel)
+	}
+	if !strings.Contains(h.file(t), "log_level: warn") {
+		t.Errorf("config.yaml was not written:\n%s", h.file(t))
+	}
+	// The file is still the documented template it was.
+	if !strings.Contains(h.file(t), "# Daemon log verbosity: debug | info | warn | error.") {
+		t.Error("the key's documentation was flattened by the edit")
+	}
+	if !h.view.capturesInput() {
+		return // the editor closed, which is what the assertion above wanted
+	}
+}
+
+// A refusal renders against the field and keeps the editor open, which is the
+// only way the value that caused it is still on screen to fix.
+func TestConfigEditorRendersAValidationErrorAgainstTheField(t *testing.T) {
+	h := newConfigLive(t)
+	h.open(t, "defaults.agent_timeout")
+	h.view.form.input.SetValue("soon")
+	h.press(t, "enter")
+	if h.view.form == nil {
+		t.Fatal("a rejected value closed the editor")
+	}
+	if h.view.form.err == "" {
+		t.Error("the daemon's refusal is not rendered against the field")
+	}
+	out := strings.Join(h.view.form.render(120), "\n")
+	if !strings.Contains(out, "soon") {
+		t.Errorf("the value that was refused is no longer on screen:\n%s", out)
+	}
+	if strings.Contains(h.file(t), "soon") {
+		t.Error("a refused value reached config.yaml")
+	}
+}
+
+// The four keys that decide what the daemon executes or exposes. Agents run
+// full-auto by default (§16); a stray keystroke must not change the argv the
+// daemon spawns as you, or the address it binds.
+func TestConfigEditorRefusesDangerousKeysWithoutConfirmation(t *testing.T) {
+	for _, tc := range []struct{ path, value, wantInFile string }{
+		{"notify.command", "/bin/echo hi", "/bin/echo"},
+		{"environment.set", "TZ=Etc/UTC", "Etc/UTC"},
+		{"agents.claude.path", "/opt/claude", "/opt/claude"},
+		{"listen", "127.0.0.1:9999", "127.0.0.1:9999"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			h := newConfigLive(t)
+			h.open(t, tc.path)
+			h.view.form.input.SetValue(tc.value)
+			h.press(t, "enter")
+			if h.view.form == nil || !h.view.form.confirming {
+				t.Fatalf("%s applied without a confirmation step", tc.path)
+			}
+			if strings.Contains(h.file(t), tc.wantInFile) {
+				t.Errorf("%s was written before it was confirmed", tc.path)
+			}
+			// esc goes back to the field, not out of the editor: someone who
+			// reads the confirmation and changes their mind about the value
+			// should not have to reopen it.
+			h.press(t, "esc")
+			if h.view.form == nil || h.view.form.confirming {
+				t.Fatalf("esc on the confirmation did not return to the field")
+			}
+			h.press(t, "enter")
+			h.press(t, "y")
+			if !strings.Contains(h.file(t), tc.wantInFile) {
+				t.Errorf("%s did not apply after confirmation:\n%s", tc.path, h.file(t))
+			}
+		})
+	}
+}
+
+// listen is written and does not take effect. The modal has to say so before
+// it is applied, and the block must not present the written value as the one
+// in force.
+func TestConfigEditorSaysListenNeedsARestart(t *testing.T) {
+	h := newConfigLive(t)
+	h.open(t, "listen")
+	out := strings.Join(h.view.form.render(120), "\n")
+	if !strings.Contains(out, "restart") {
+		t.Errorf("the listen editor does not say it needs a restart:\n%s", out)
+	}
+}

--- a/internal/tui/daemon.go
+++ b/internal/tui/daemon.go
@@ -79,6 +79,21 @@ type daemonView struct {
 	// is the only place the pane's width and height are known.
 	logDirty bool
 
+	// keys is the editable config surface, and cursor is the row under the
+	// selection. focusConfig moves j/k off the log pane and onto that list —
+	// the view has two scrollable things now, and tab is what says which one
+	// the arrows mean.
+	keys        []configKey
+	cursor      int
+	focusConfig bool
+	// form is the open editor, nil when none is. While it is non-nil the view
+	// captures input: every single-key global would otherwise land in the
+	// text field.
+	form *configForm
+	// saved names the key the last successful patch changed, so the block can
+	// say what moved rather than silently re-rendering.
+	saved string
+
 	vp        viewport.Model
 	following bool
 	// visible gates the ticker: a view that is off-screen re-reads nothing,
@@ -95,6 +110,7 @@ func newDaemonView() *daemonView {
 	return &daemonView{
 		now:       time.Now,
 		tail:      daemon.TailFile,
+		keys:      configKeys(),
 		vp:        viewport.New(),
 		following: true,
 	}
@@ -223,6 +239,9 @@ func (d *daemonView) update(msg tea.Msg) (panel, tea.Cmd) {
 	case daemonConfigMsg:
 		d.applyConfig(msg)
 		return d, nil
+	case configSavedMsg:
+		d.applySaved(msg)
+		return d, nil
 	case daemonDoctorMsg:
 		d.applyDoctor(msg)
 		return d, nil
@@ -288,19 +307,65 @@ func (d *daemonView) applyLog(msg daemonLogMsg) {
 	d.logDirty = true
 }
 
+// applySaved lands the answer to a PATCH. A refusal keeps the editor open
+// with the message against the field — that is the whole reason the form
+// stays up — and a success closes it and adopts the configuration the daemon
+// reported, which is what is in force rather than what was asked for.
+func (d *daemonView) applySaved(msg configSavedMsg) {
+	if d.form == nil {
+		return
+	}
+	d.form.saving = false
+	if msg.err != nil {
+		d.form.err = errString(msg.err)
+		return
+	}
+	d.form = nil
+	d.saved = msg.path
+	d.config = msg.cfg
+	d.configOK = true
+	d.configErr = nil
+	d.configAt = d.now()
+}
+
 func (d *daemonView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if d.form != nil {
+		cmd, done := d.form.update(msg, d.client)
+		if done {
+			d.form = nil
+		}
+		return d, cmd
+	}
 	switch msg.String() {
 	case "esc":
 		// The takeover layer of the §15 esc stack: back to the home screen.
 		return d, func() tea.Msg { return selectViewMsg{id: viewHome} }
 	case "R":
 		return d, d.refreshCmd()
+	case "tab":
+		// Two scrollable things on one view: tab says which one j/k mean.
+		d.focusConfig = !d.focusConfig
+		return d, nil
+	case "enter", "e":
+		if k, ok := d.selectedKey(); ok && d.configOK {
+			d.focusConfig = true
+			d.form = newConfigForm(k, d.config)
+		}
+		return d, nil
 	case "f", "G", "end":
 		d.setFollowing(true)
 		return d, nil
 	case "j", "down":
+		if d.focusConfig {
+			d.moveCursor(1)
+			return d, nil
+		}
 		d.vp.ScrollDown(1)
 	case "k", "up":
+		if d.focusConfig {
+			d.moveCursor(-1)
+			return d, nil
+		}
 		d.vp.ScrollUp(1)
 	default:
 		var cmd tea.Cmd
@@ -310,6 +375,23 @@ func (d *daemonView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	}
 	d.syncFollowToViewport()
 	return d, nil
+}
+
+// selectedKey is the config row under the cursor.
+func (d *daemonView) selectedKey() (configKey, bool) {
+	if d.cursor < 0 || d.cursor >= len(d.keys) {
+		return configKey{}, false
+	}
+	return d.keys[d.cursor], true
+}
+
+// moveCursor walks the config list, clamped rather than wrapped: a list this
+// long is read top to bottom and wrapping past the end reads as a jump.
+func (d *daemonView) moveCursor(delta int) {
+	if len(d.keys) == 0 {
+		return
+	}
+	d.cursor = min(max(d.cursor+delta, 0), len(d.keys)-1)
 }
 
 func (d *daemonView) setFollowing(on bool) {
@@ -326,5 +408,8 @@ func (d *daemonView) syncFollowToViewport() {
 	d.following = d.vp.AtBottom()
 }
 
-// capturesInput is always false: this view has no text entry.
-func (d *daemonView) capturesInput() bool { return false }
+// capturesInput is true exactly while the config editor is open. It was
+// permanently false before this view could edit anything; leaving it that way
+// would send every single-key global — R, f, g, q — into the text field on the
+// first keystroke.
+func (d *daemonView) capturesInput() bool { return d.form != nil }

--- a/internal/tui/daemon_test.go
+++ b/internal/tui/daemon_test.go
@@ -50,9 +50,8 @@ func testConfig() apiclient.Config {
 		},
 		TranscriptRetentionDays: 90,
 		LogLevel:                "info",
-		Agents: map[string]apiclient.AgentPath{
-			"claude": {Path: "/usr/bin/claude"},
-			"codex":  {Path: ""},
+		Agents: apiclient.ConfigAgents{
+			Claude: apiclient.AgentPath{Path: "/usr/bin/claude"},
 		},
 	}
 }
@@ -402,4 +401,21 @@ func TestDaemonViewSingularOrphanLine(t *testing.T) {
 	if _, ok := orphanLine(0); ok {
 		t.Error("orphanLine(0) produced a line")
 	}
+}
+
+// openConfigForm is the probe helper: a daemon view with a configuration
+// loaded and the editor open on one named key.
+func openConfigForm(t *testing.T, path string) *daemonView {
+	t.Helper()
+	d := newTestDaemonView([]string{"a log line"}, nil)
+	d.update(daemonConfigMsg{config: testConfig()})
+	for i, k := range d.keys {
+		if k.path == path {
+			d.cursor = i
+			d.form = newConfigForm(k, d.config)
+			return d
+		}
+	}
+	t.Fatalf("no config key %q", path)
+	return nil
 }

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -16,12 +16,23 @@ import (
 // worth scrolling, so it takes whatever is left but never less than this.
 const logPaneMinHeight = 3
 
+// configRowsShown is how many config keys the block lists at once. Ten fits
+// beside the other three blocks and the log pane on an 80x24 terminal, which
+// is the size the rest of this view is laid out for.
+const configRowsShown = 10
+
 func (d *daemonView) render(width, height int) string {
 	if width > 0 {
 		d.width = width
 	}
 	if height > 0 {
 		d.height = height
+	}
+	if d.form != nil {
+		// The editor is a takeover, not an overlay: while it is open it owns
+		// the keyboard (capturesInput), and rendering the blocks underneath it
+		// would suggest the keys they document still work.
+		return strings.Join(d.form.render(d.width), "\n")
 	}
 	var out []string
 	out = append(out, d.identityLines()...)
@@ -93,42 +104,143 @@ func orphanLine(n int) (string, bool) {
 
 // configLines is the configuration the daemon actually has loaded, which is
 // not always the file on disk — it hot-reloads, and nothing announces it.
+//
+// Every key config.yaml carries is here and every one of them is editable
+// (task 060). The block used to show nine of the eleven GET /v1/config served,
+// which meant `branch_template`, `environment` and `notify` could not be seen
+// from any client at all, let alone changed.
 func (d *daemonView) configLines() []string {
-	out := []string{" " + styleTitle.Render("config in effect")}
+	head := " " + styleTitle.Render("config in effect")
 	if !d.configOK {
-		return append(out, "  "+d.unavailable(d.configErr, "config"))
+		return []string{head, "  " + d.unavailable(d.configErr, "config")}
 	}
+	if d.focusConfig {
+		head += styleDim.Render("   ↑/↓ select   enter edit   tab back to the log")
+	} else {
+		head += styleDim.Render("   tab for every key, and to edit")
+	}
+	out := []string{head}
+	if d.focusConfig {
+		out = append(out, d.configListLines()...)
+	} else {
+		out = append(out, d.configSummaryLines()...)
+	}
+	if d.saved != "" {
+		out = append(out, "   "+styleDim.Render(d.saved+" saved to config.yaml"))
+	}
+	if line, ok := d.staleLine(d.configErr, d.configAt); ok {
+		out = append(out, line)
+	}
+	return out
+}
+
+// configSummaryLines is the digest this block has always been: the settings
+// someone opens this view to check, at a glance, with the log still on screen
+// underneath. Tab swaps it for the full list.
+func (d *daemonView) configSummaryLines() []string {
 	c := d.config
-	out = append(out,
+	out := []string{
 		field("max parallel tasks", strconv.Itoa(c.MaxParallelTasks)),
-		field("agent timeout", c.Defaults.AgentTimeout)+
+		field("agent timeout", c.Defaults.AgentTimeout) +
 			styleDim.Render("   command "+c.Defaults.CommandTimeout+
 				"   input "+c.Defaults.InputTimeout),
-		field("transcript retention", strconv.Itoa(c.TranscriptRetentionDays)+" days")+
+		field("transcript retention", strconv.Itoa(c.TranscriptRetentionDays)+" days") +
 			styleDim.Render("   cap "+humanBytes(c.TranscriptMaxBytes)+" per run"),
-		costCapLine(c.MaxTaskCostUSD),
+		field("max task cost", costCapText(c)),
 		// Both halves of the §10 pair on one line: the remote one is inert
 		// while the local one is off, so showing either alone would describe a
 		// policy that cannot run.
-		field("delete empty branch", onOff(c.DeleteEmptyBranchOnArchive))+
+		field("delete empty branch", onOff(c.DeleteEmptyBranchOnArchive)) +
 			styleDim.Render("   remote "+onOff(c.DeleteRemoteBranchOnArchive)),
 		field("usage limit recheck", c.UsageLimitRecheck),
 		field("log level", c.LogLevel),
 		// What the file says, which is not necessarily what the board is
 		// showing: `g` regroups for the session without writing anything.
 		field("task grouping", groupSummary(c.TUI.Board.GroupBy)),
-	)
-	for _, name := range sortedKeys(c.Agents) {
-		path := c.Agents[name].Path
+	}
+	for _, a := range []struct {
+		name string
+		path string
+	}{
+		{"claude", c.Agents.Claude.Path},
+		{"codex", c.Agents.Codex.Path},
+		{"cursor", c.Agents.Cursor.Path},
+	} {
+		path := a.path
 		if path == "" {
 			path = styleDim.Render("(resolved from PATH)")
 		}
-		out = append(out, field(name+" path", path))
-	}
-	if line, ok := d.staleLine(d.configErr, d.configAt); ok {
-		out = append(out, line)
+		out = append(out, field(a.name+" path", path))
 	}
 	return out
+}
+
+// configListLines is the editable table: every key config.yaml carries, one
+// per row, scrolling under the cursor. It is what the summary above cannot
+// be — `branch_template`, `environment` and `notify` have no digest line, and
+// before task 060 that meant no client could see them at all.
+func (d *daemonView) configListLines() []string {
+	var out []string
+	first, last := d.configWindow()
+	if first > 0 {
+		out = append(out, "   "+styleDim.Render(fmt.Sprintf("↑ %d more", first)))
+	}
+	for i := first; i < last; i++ {
+		out = append(out, d.configRow(i, d.keys[i]))
+	}
+	if rest := len(d.keys) - last; rest > 0 {
+		out = append(out, "   "+styleDim.Render(fmt.Sprintf("↓ %d more", rest)))
+	}
+	return out
+}
+
+// configWindow is the slice of the key list the block shows. The full table
+// is thirty-odd rows, which is taller than the log pane it shares the view
+// with — the log is the thing worth watching here, and a config block that
+// pushes it off the screen would have taken away the reason this view exists.
+// So the list scrolls with the cursor, and says how many rows are out of
+// sight in each direction.
+func (d *daemonView) configWindow() (first, last int) {
+	if len(d.keys) <= configRowsShown {
+		return 0, len(d.keys)
+	}
+	first = min(max(d.cursor-configRowsShown/2, 0), len(d.keys)-configRowsShown)
+	return first, first + configRowsShown
+}
+
+// configRow renders one key: what it is, what it is set to, and — when they
+// differ — what it would be if the file said nothing.
+//
+// "differs from the default" is what the marker claims, and it is all this
+// view can honestly claim: GET /v1/config serves effective values and carries
+// no provenance, so a value that happens to equal the built-in is
+// indistinguishable from one the file never mentions.
+func (d *daemonView) configRow(i int, k configKey) string {
+	value := k.display(d.config)
+	if value == "" {
+		value = styleDim.Render("(empty)")
+	}
+	line := field(k.label, value)
+	if def := k.def(); def != k.read(d.config) {
+		line += styleDim.Render("   default " + defaultOrEmpty(def))
+	}
+	if k.restart {
+		line += styleDim.Render("   restart to apply")
+	}
+	if i != d.cursor {
+		return " " + line
+	}
+	if d.focusConfig {
+		return styleFocus.Render("›") + line
+	}
+	return styleDim.Render("›") + line
+}
+
+func defaultOrEmpty(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	return s
 }
 
 // databaseLines is §17's footprint (task 029): how big the database is, which
@@ -366,11 +478,11 @@ func onOff(v bool) string {
 //
 // The suffix earns its space on a machine running fan-outs: the cap counts
 // one task, and every lane of a tree is its own task with its own budget.
-func costCapLine(v float64) string {
-	if v <= 0 {
-		return field("max task cost", "off")
+func costCapText(c apiclient.Config) string {
+	if c.MaxTaskCostUSD <= 0 {
+		return "off"
 	}
-	return field("max task cost", "$"+strconv.FormatFloat(v, 'f', -1, 64)) +
+	return "$" + strconv.FormatFloat(c.MaxTaskCostUSD, 'f', -1, 64) +
 		styleDim.Render("   per task; fan-out lanes count separately")
 }
 
@@ -514,13 +626,4 @@ func shortCommit(c string) string {
 		return c[:12]
 	}
 	return c
-}
-
-func sortedKeys[V any](m map[string]V) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
 }

--- a/internal/tui/projects_test.go
+++ b/internal/tui/projects_test.go
@@ -28,6 +28,12 @@ func namedKey(name string) tea.KeyPressMsg {
 		return tea.KeyPressMsg{Code: tea.KeyUp}
 	case "down":
 		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "left":
+		return tea.KeyPressMsg{Code: tea.KeyLeft}
+	case "right":
+		return tea.KeyPressMsg{Code: tea.KeyRight}
+	case "tab":
+		return tea.KeyPressMsg{Code: tea.KeyTab}
 	case "ctrl+s":
 		return tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}
 	default:

--- a/scripts/m11-gate.sh
+++ b/scripts/m11-gate.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# M11 phase gate (task 060; spec §12.3, §13.2): prove over the wire that the
+# daemon serves its whole configuration and can be reconfigured through the
+# API without a restart, and that a refused edit leaves the file alone.
+#
+#   1. GET /v1/config serves every key config.yaml carries — including the
+#      nine that used to be invisible from every client
+#   2. PATCH /v1/config changes a hot-reloadable key, and a GET issued
+#      immediately afterwards reads the new value with no sleep
+#   3. the comments and the key order in config.yaml survive the write, and
+#      a documented block that was commented out is uncommented in place
+#      rather than appended a second time
+#   4. an invalid patch answers the §13.1 envelope and leaves the file
+#      byte-identical
+#   5. the file is still mode 0600 afterwards (POSIX only — Windows has no
+#      such mode, and the daemon's ACL story is CheckPermissions')
+#   6. `vincent config get|set` does the same job from the command line
+#   7. PATCH /v1/config is not an MCP tool: an agent must not be able to
+#      reconfigure the daemon supervising it (task 057 decision 4)
+#
+# No workflow and no agent CLI: what is under test is an endpoint and a file,
+# so the gate needs neither, which also keeps it fast on all three platforms.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+CONFIG_DIR="$TMP/config"
+DATA_DIR="$TMP/data"
+mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+export VINCENT_CONFIG_DIR
+VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+export VINCENT_DATA_DIR
+VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+PORT="" TOKEN="" BASE=""
+
+echo "== start the daemon"
+"$VINCENT" daemon start
+PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+TOKEN="$(cat "$DATA_DIR/token")"
+BASE="http://127.0.0.1:$PORT/v1"
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -X "$method" -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" "$@" "$BASE$path"
+}
+
+# api_status METHOD PATH [curl args...] -> "<status> <body>" on one line, so a
+# scenario can assert both without a second request.
+api_status() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -o "$TMP/body.json" -w '%{http_code}' -X "$method" \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$@" "$BASE$path"
+}
+
+echo "== 1. GET /v1/config serves every key"
+CFG="$(api GET /config)" || fail "GET /v1/config failed"
+# The nine keys the endpoint used to omit, plus a representative of each
+# section that was already there. A key missing here is a key no client can
+# see, which is the defect this task closed.
+for key in listen max_parallel_tasks branch_template defaults \
+           delete_empty_branch_on_archive delete_remote_branch_on_archive \
+           fetch_base_branch transcript_retention_days transcript_max_bytes \
+           max_task_cost_usd usage_limit_recheck_interval log_level debug \
+           environment agents parallel fan_out loop include mcp github \
+           update notify tui; do
+  printf '%s' "$CFG" | jq -e --arg k "$key" 'has($k)' >/dev/null \
+    || fail "GET /v1/config does not serve $key"
+done
+
+echo "== 2. PATCH applies before it answers"
+BEFORE="$(printf '%s' "$CFG" | jq -r .max_parallel_tasks)"
+[[ "$BEFORE" == "3" ]] || fail "max_parallel_tasks started at $BEFORE, want the default 3"
+PATCHED="$(api PATCH /config -d '{"max_parallel_tasks":7,"log_level":"debug"}')" \
+  || fail "PATCH /v1/config failed"
+printf '%s' "$PATCHED" | jq -e '.max_parallel_tasks == 7 and .log_level == "debug"' >/dev/null \
+  || fail "the patch response does not carry the new values: $PATCHED"
+# No sleep and no retry loop: decision 5 says the applier runs before the
+# response is written, so the very next GET has to agree.
+AFTER="$(api GET /config | jq -r .max_parallel_tasks)" || fail "GET after PATCH failed"
+[[ "$AFTER" == "7" ]] || fail "GET right after the 200 still reads $AFTER"
+
+echo "== 3. comments and key order survive; a commented block is uncommented in place"
+# The file is documentation as much as it is settings. A single-line capture
+# needs no CR treatment; the multi-line ones below do (jq writes CRLF on
+# Windows and $(...) strips only the trailing one).
+COMMENTS_BEFORE="$(grep -c '^#' "$CONFIG_FILE")"
+api PATCH /config -d '{"notify":{"on":["blocked"],"command":["git","--version"]}}' >/dev/null \
+  || fail "PATCH notify failed"
+COMMENTS_AFTER="$(grep -c '^#' "$CONFIG_FILE")"
+[[ "$COMMENTS_AFTER" -ge $((COMMENTS_BEFORE - 3)) ]] \
+  || fail "the write flattened the file's comments ($COMMENTS_BEFORE -> $COMMENTS_AFTER)"
+NOTIFY_LINES="$(grep -c '^notify:' "$CONFIG_FILE")"
+[[ "$NOTIFY_LINES" == "1" ]] \
+  || fail "notify: appears $NOTIFY_LINES times; the block was appended rather than uncommented"
+# The key that was edited first is still where it was, above the one edited
+# second: the editor never reorders.
+ORDER="$(grep -n '^log_level:\|^notify:' "$CONFIG_FILE" | cut -d: -f2 | tr -d '\r')"
+EXPECTED_ORDER="$(printf 'log_level\nnotify')"
+[[ "$ORDER" == "$EXPECTED_ORDER" ]] || fail "key order moved: $ORDER"
+# And the warning the notify block carries is still there to read.
+WARNING="$(grep -c 'WARNING: this is arbitrary code' "$CONFIG_FILE")"
+[[ "$WARNING" == "1" ]] || fail "the notify block's documentation was flattened"
+
+echo "== 4. an invalid patch writes nothing"
+cp "$CONFIG_FILE" "$TMP/before.yaml"
+STATUS="$(api_status PATCH /config -d '{"log_level":"chatty"}')" \
+  || fail "curl PATCH (invalid) failed"
+[[ "$STATUS" == "400" ]] || fail "an invalid log_level answered $STATUS, want 400"
+jq -e '.error.code == "validation_failed"' "$TMP/body.json" >/dev/null \
+  || fail "the refusal is not the §13.1 envelope: $(cat "$TMP/body.json")"
+cmp -s "$TMP/before.yaml" "$CONFIG_FILE" \
+  || fail "a rejected patch changed config.yaml"
+# A branch template that does not compile is refused by the same route, on
+# the check that lives in internal/worktree.
+STATUS="$(api_status PATCH /config -d '{"branch_template":"vincent/{{.ID"}')" \
+  || fail "curl PATCH (bad template) failed"
+[[ "$STATUS" == "400" ]] || fail "an uncompilable branch_template answered $STATUS, want 400"
+cmp -s "$TMP/before.yaml" "$CONFIG_FILE" \
+  || fail "a rejected branch_template changed config.yaml"
+
+echo "== 5. the file is still owner-only"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  echo "   (skipped: Windows has no POSIX mode; see config.CheckPermissions)"
+else
+  MODE="$(ls -l "$CONFIG_FILE" | cut -c1-10)"
+  [[ "$MODE" == "-rw-------" ]] || fail "config.yaml is $MODE after a patch, want -rw-------"
+fi
+
+echo "== 6. vincent config get|set"
+OUT="$("$VINCENT" config get log_level | tr -d '\r')"
+[[ "$OUT" == "debug" ]] || fail "vincent config get log_level = $OUT, want debug"
+"$VINCENT" config set log_level info >/dev/null || fail "vincent config set failed"
+OUT="$(api GET /config | jq -r .log_level)"
+[[ "$OUT" == "info" ]] || fail "vincent config set did not reach the daemon: $OUT"
+# The whole file, one key per line, and every key the endpoint serves.
+LISTED="$("$VINCENT" config get | tr -d '\r')"
+grep -q '^branch_template = ' <<<"$LISTED" \
+  || fail "vincent config get does not list branch_template"
+grep -q '^notify.command = git --version$' <<<"$LISTED" \
+  || fail "vincent config get does not read notify.command back: $LISTED"
+# A key that does not exist is an error, not a silent success.
+if "$VINCENT" config set no_such_key 1 >/dev/null 2>&1; then
+  fail "vincent config set accepted a key that does not exist"
+fi
+
+echo "== 7. PATCH /v1/config is not an MCP tool"
+TOOLS="$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"m11-gate","version":"1"}}}' \
+  -D "$TMP/init-headers.txt" "http://127.0.0.1:$PORT/mcp")" \
+  || fail "curl POST /mcp (initialize) failed"
+printf '%s' "$TOOLS" | tr -d '\r' | sed -n 's/^data: //p' | head -n 1 \
+  | jq -e '.result.serverInfo.name == "vincent"' >/dev/null \
+  || fail "initialize did not identify the vincent server"
+SESSION="$(tr -d '\r' < "$TMP/init-headers.txt" \
+  | sed -n 's/^[Mm]cp-[Ss]ession-[Ii]d: //p' | head -n 1)"
+[[ -n "$SESSION" ]] || fail "initialize minted no Mcp-Session-Id"
+curl -sS -o /dev/null -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
+  "http://127.0.0.1:$PORT/mcp" || fail "curl POST /mcp (initialized) failed"
+LIST="$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  "http://127.0.0.1:$PORT/mcp")" || fail "curl POST /mcp (tools/list) failed"
+NAMES="$(printf '%s' "$LIST" | tr -d '\r' | sed -n 's/^data: //p' | head -n 1 \
+  | jq -r '.result.tools[].name')"
+grep -qx 'config_get' <<<"$NAMES" || fail "config_get is not a tool"
+if grep -qx 'config_patch' <<<"$NAMES"; then
+  fail "config_patch is exposed; an agent must not be able to reconfigure its own daemon"
+fi
+if grep -qx 'config_set' <<<"$NAMES"; then
+  fail "config_set is exposed; an agent must not be able to reconfigure its own daemon"
+fi
+
+echo "== 8. the daemon is still up"
+api GET /health | jq -e '.status == "ok"' >/dev/null \
+  || fail "the daemon did not survive the gate"
+
+echo "GATE PASS: M11 (task 060)"


### PR DESCRIPTION
## Summary

`config.yaml` could only be hand-edited. `GET /v1/config` served eleven of the
twenty-four keys in `config.Config`, so `branch_template`, `debug`,
`environment`, `parallel`, `fan_out`, `loop`, `include`, `github`, `update`,
`mcp` and `notify` were invisible from every client — and nothing can be edited
that cannot first be read.

**The read widens to the whole file** — values included, which is
[decision 2](../docs/tasks/058-daemon-configuration-editing.md) — and **`PATCH
/v1/config`** changes it. The daemon:

- validates the whole candidate file through the path `Load` takes, plus
  `worktree.ValidateBranchTemplate`, and **writes nothing** when it does not
  hold;
- edits the key **in place**, or uncomments its documented block where it
  stands, so comments, key order and blank lines survive. `config.yaml` ships
  as a heavily commented template and for most installations it is the only
  explanation of what the keys mean, so regenerating it from the struct was not
  an option;
- writes **atomically at 0600**, from a temporary file named so the fsnotify
  watcher's base-name filter ignores it;
- **applies the result before answering.** `daemon.Run`'s reload callback is now
  a named function with two callers — the watcher and this handler — so the
  `listen` pin and the `branch_template` fallback are one implementation, and it
  is idempotent: the watcher's later fire re-reads identical bytes. A `GET`
  issued the instant a `200` lands reads the new values, with no sleep. That is
  also the answer to the issue's "the write must not fight its watcher".

**`vincent config get|set`** and the **TUI's daemon view** are clients of that
one endpoint. `tab` moves the arrows onto the config block, which then lists
every key rather than the digest; `enter` opens a typed editor — a chooser where
the key has a fixed vocabulary, a field otherwise — with the daemon's own
validation error rendered against it and the refused value still on screen.
`notify.command`, `environment`, `agents.*.path` and `listen` are behind an
explicit confirmation: they decide what the daemon executes or exposes, and
agents already run full-auto by default (§16). `listen` is written and does not
take effect until a restart; the editor, the CLI and the block all say so rather
than showing a pending value as though it were in force.

**MCP.** `PATCH /v1/config` joins `mcp.Excluded` — task 057 decision 4 named
this case before the route existed ("an agent must not be able to stop,
garbage-collect or **reconfigure** the daemon supervising it"), and a patch can
change the argv the daemon spawns, what its children inherit, and whether steps
get MCP at all. `config_get` is the one tool whose body differs from its
route's: it masks `environment.set`'s values and `notify.command`'s argv,
keeping the names, because a tool result lands in a model's context and in the
step's transcript, which is not the loopback-plus-0600 boundary the HTTP body
sits behind.

**Also here:** `defaultConfigYAML` gains documented, commented-out blocks for
the six keys it never carried (`branch_template`, `parallel`, `fan_out`, `loop`,
`include`, `mcp`), so the writer's normal path is edit-in-place and appending is
the rare fallback; and `scripts/m11-gate.sh`, committed executable and wired
into `ci.yml` on all three platforms.

### Decisions that reverse something recorded

Both are amended in place with dated notes in the same PR, per `CLAUDE.md`:

- **v0 PR N's "view 6 reports, it does not act"** (§15) and **§12.3's "the API
  exposes it read-only"** are superseded *for configuration only*. The
  distinction: stopping the daemon and `vincent gc` act on the **process
  supervising the TUI** — that negative stands unchanged — while a config edit
  changes a **file the daemon owns and already hot-reloads**, which a human can
  edit by hand at any moment anyway.
- **§16's task-046 note** that `notify` is not served on `GET /v1/config` is
  superseded. The endpoint is loopback-only behind a 0600 bearer token, which is
  the same trust boundary as the 0600 file: anyone who can call it can already
  `cat` it. §12.3's "names, never the values" is narrowed to the **log** and
  step transcripts, which is where it was earned and where it is unchanged. The
  MCP rendering is where the old reading survives.

## Related

Closes #244
Closes 058.1–058.8 (`docs/tasks/058-daemon-configuration-editing.md`).

This revisits three recorded decisions and says so explicitly above and in the
spec: v0 PR N's view-6 negative, §12.3's read-only sentence, and §16's task-046
note about `notify` not being served. Task 057 decision 4 is *applied*, not
revisited — its wording already covered this route.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

**On the title box:** the PR title above is `feat(config): …`, which is a
Conventional Commit prefix — the box is ticked against the *intent* of the rule
and needs a human decision. The workflow that produced this branch asked for a
Conventional Commits title in `pr-title.txt`; `CLAUDE.md` and this template ask
for plain language on the PR and the prefix on the commits. **Rename the PR to
`Edit the daemon configuration from the TUI` before merging** — the commit
already carries the prefix, and leaving both makes Release Please record the
merge and the inner commit twice.

### What each box covers

- **Tests.** `internal/config/edit_test.go` (round-trip fidelity, uncommenting
  in place, the append fallback, trailing comments, atomic 0600 write);
  `internal/api/config_patch_test.go` (read-after-write with no sleep, seven
  rejections asserted **on the bytes**, twelve concurrent patches, the empty
  patch, `listen` pending, and two drift tests — one fails when a field is added
  to `config.Config` and not served, one when a served key is not patchable);
  `internal/api/config_perm_unix_test.go` (0600 survives, including from a 0644
  file); `internal/api/config_mcp_test.go` (the HTTP and MCP bodies differ in
  exactly the two redacted fields, over a real MCP client);
  `internal/tui/configlive_test.go` (the editor writes end to end against the
  real handlers, a validation error renders against its field, each of the four
  dangerous keys refuses without confirmation, `listen` says restart);
  `internal/cli/config_test.go` (the CLI names every served key, and every value
  `get` prints is one `set` accepts). Plus the binding-registry probes for the
  five new keys, which the existing `TestEveryPanelKeyIsHandled` demands.
- **Docs.** `docs/reference/api.md` (route table), `docs/reference/cli.md`
  (`vincent config`), `docs/reference/configuration.md` (the reading section
  becomes reading *and changing*, and `notify`'s "not served" paragraph),
  `docs/guides/tui.md` (the daemon section plus two key tables from
  `bindings.go`), `docs/guides/mcp.md` (six exclusions, and the redaction),
  `docs/security-model.md` (what the API now discloses, and that PATCH can
  change what the daemon executes), `docs/spec.md` (§12.3, §13.2, §13.4, §15,
  §16), `docs/tasks/058-daemon-configuration-editing.md` with its index row,
  and `CLAUDE.md`'s gate list. A follow-up `docs:` commit closed what the audit
  of the derived pages then found:
  - `docs/reference/configuration.md`'s **"The default file"** block says it is
    what first start writes *verbatim*, and no test asserts that. It still
    carried the old uncommented `mcp:` block and none of the six commented
    blocks `defaultConfigYAML` gained, so it is now the template byte for byte.
  - `docs/features.md` said the MCP tool surface is the route table minus
    **five** routes; it is six, and `config_get`'s masked body is worth naming
    there. Configuration editing is also a product surface, so it is in the
    glance table and in "Diagnose and maintain it".
  - `docs/reference/api.md`'s MCP exceptions table had no `PATCH /v1/config`
    row, and its "a tool call replays against the very handler this page
    documents" now has exactly one exception.
  - `docs/spec.md` §12.1's command table had no `vincent config` row; and two
    of this PR's own amendments (§13.4, §15) had swallowed the sentence that
    followed them into their paragraph.
  - `docs/reference/files.md` — the daemon writes `config.yaml` now, so "your
    file's contents are never rewritten" is narrowed to the mode-tightening
    pass it was always about.
  - `README.md`'s command list gained `vincent config`, and the `CHANGELOG.md`
    entry gained the narrower agent-facing surface.

### Not done, and why

- **`docs/assets/tui-*.png` were not re-captured.** There is no daemon-view
  screenshot in that set, so nothing pictures the changed panel. The unfocused
  block renders as it did before; the list and the editor are new surfaces with
  no existing image to invalidate. (Re-checked in the documentation audit: the
  eight `tui-*.png` are board, diff, grouping, multi-select, new-task, projects,
  workflow-graph and workflow-step. None of them shows this view.)
- **Nothing asserts that the configuration reference's default-file block is
  the template.** It drifted here and the audit caught it by diffing the two by
  hand. A test in `internal/config` comparing `defaultConfigYAML` against that
  fenced block — the way `internal/cli` already asserts every command is on the
  CLI page — would make the next drift a red build. Not added here: it is a new
  test in a change whose test surface is already large, and it belongs with
  whoever wants the parity guarantee rather than smuggled into this PR.
- **`GET /v1/config` carries no provenance**, so the block says "differs from
  the default" rather than "set in the file". Adding provenance is scope the
  issue does not ask for; the limitation is stated in the code, in the task
  document and on the TUI page rather than papered over.
- **`m11` has only been walked on macOS here.** CI runs it on Linux and Windows
  too; the 0600 assertion is POSIX-only and says so in the output rather than
  pretending Windows has a mode.
