### PR TITLE
Run a task's steps inside a container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,15 @@ jobs:
       - name: M11 gate (configuration)
         shell: bash
         run: ./scripts/m11-gate.sh
+
+      # M12: container step execution (task 061, §16). The only gate that is
+      # not proven on all three platforms, and the reason is stated rather than
+      # implied: the macOS and Windows runners have no docker daemon, so the
+      # script skips itself there (exit 0, one line saying why) and the real
+      # assertions only ever run on this leg. A containerized task is refused
+      # outright on a Windows daemon anyway (decision 2), but macOS is a
+      # supported host that CI cannot exercise — a gate that has never run on a
+      # platform is not known to pass there.
+      - name: M12 gate (containers)
+        shell: bash
+        run: ./scripts/m12-gate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,11 @@ jobs:
 
   ci:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # Wide enough that `go test -timeout` (see magefile.go) is always the
+    # tighter of the two limits: a package that really hangs should be reported
+    # by the test binary's goroutine dump, not killed here with nothing to read.
+    # The Windows leg under the race detector is the one this is sized for.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Run a task's steps inside a container.** A new `container:` block in
+  `config.yaml` names an image, and every step process of a task — commands,
+  checks and gates today, agents next — runs inside **one** container, created
+  with the task's worktree and removed with it. `container.image: ""` is the
+  default, so an installation that sets nothing consults no runtime and behaves
+  exactly as it did. The image is yours and must already carry your agent CLI
+  and `git`; vincent builds, publishes and bundles nothing. The project
+  repository and the task's worktree are bind-mounted **at their own absolute
+  host paths**, so a path means one thing on both sides and `.Worktree`,
+  `VINCENT_WORKTREE` and a worktree's absolute `gitdir:` all resolve with no
+  translation — which is also why a **Windows daemon refuses a containerized
+  task**, since `C:\...` cannot exist in a Linux container. A workflow can pin
+  its own image in `defaults.container:`, which merges over the daemon's block
+  per field. What the container confines is the filesystem outside those two
+  mounts, the shell and the image's tooling; outbound network is open by
+  default and your agent's configuration is mounted inside it so the CLI can
+  authenticate, both stated in [the security model](docs/security-model.md)
+  rather than implied. A missing runtime, a Windows host, a
+  `network: false`/`mcp.wire_steps: true` contradiction and a `shell: pwsh` step
+  are refused when the task is created; a missing or unpullable image blocks the
+  task at admission with `container_image_unavailable`, before a worktree, a
+  branch or a retry is spent. A step timeout signals the process **inside** the
+  container and leaves the container running, so a retry finds what an earlier
+  step installed, and crash recovery removes a container only after confirming
+  it still carries the label naming that task. `vincent doctor` gained a
+  container row, which probes the runtime even when the feature is off.
+
 - **Enum task fields, with a value picker in New task, and a `default:` for
   every field type.** A workflow's `fields:` gains `type: enum`, whose members
   are declared in `values:` and published through `GET /v1/workflows` — which a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ list with the user-facing context a commit subject cannot carry.
 ### Added
 
 - **Run a task's steps inside a container.** A new `container:` block in
-  `config.yaml` names an image, and every step process of a task — commands,
-  checks and gates today, agents next — runs inside **one** container, created
-  with the task's worktree and removed with it. `container.image: ""` is the
+  `config.yaml` names an image, and a task's step processes run inside **one**
+  container, created with the task's worktree and removed with it. That is every
+  command step and every `check:` today; the **agent process itself still runs
+  on the host**, with your whole filesystem in reach, until the launch seam that
+  moves it lands — so a containerized task with agent steps is a mixed run, and
+  it is neither refused nor warned about. `container.image: ""` is the
   default, so an installation that sets nothing consults no runtime and behaves
   exactly as it did. The image is yours and must already carry your agent CLI
   and `git`; vincent builds, publishes and bundles nothing. The project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,16 @@ against the fake agent; CI runs every one of them on Linux, macOS and Windows:
 ./scripts/m9-gate.sh                            # workflow includes (§7.9)
 ./scripts/m10-gate.sh                           # the daemon's MCP server (§13.4)
 ./scripts/m11-gate.sh                           # editing config.yaml over the API (§12.3)
+./scripts/m12-gate.sh                           # container step execution (§16); skips without docker
 VINCENT_GATE_SCENARIO=2 ./scripts/m2-gate.sh    # single scenario, for debugging
 VINCENT_GATE_AGENT=claude ./scripts/m2-gate.sh  # manual run against the real CLI
 VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 ```
 
-All nine run in `ci.yml`'s `gates` job on all three platforms. `m6`, `m7` and
+All nine of those run in `ci.yml`'s `gates` job on all three platforms. `m12`
+is the tenth and the exception: it needs a real container runtime, so it runs
+its assertions on the Linux leg only and skips itself (exit 0, one line saying
+why) on the macOS and Windows runners, which have no docker daemon. `m6`, `m7` and
 `m8` spent a while unwired because a cloud session's token has no `workflow`
 scope and so cannot write `.github/workflows/` by any route — push or API
 (#120, #122, #125). A gate that has never run on a platform is not known to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,11 @@ VINCENT_GATE_AGENT=cursor ./scripts/m5-gate.sh  # ditto, for cursor-agent
 All nine of those run in `ci.yml`'s `gates` job on all three platforms. `m12`
 is the tenth and the exception: it needs a real container runtime, so it runs
 its assertions on the Linux leg only and skips itself (exit 0, one line saying
-why) on the macOS and Windows runners, which have no docker daemon. `m6`, `m7` and
+why) on the other two — but for two different reasons, and only one of them is
+"no docker". The macOS runner has no daemon. The **Windows runner does**, in
+Windows-container mode, where `FROM alpine:3` fails with "no matching manifest
+for windows/amd64"; probing for a daemon is therefore not enough to skip there,
+and the gate refuses on the host platform first. `m6`, `m7` and
 `m8` spent a while unwired because a cloud session's token has no `workflow`
 scope and so cannot write `.github/workflows/` by any route — push or API
 (#120, #122, #125). A gate that has never run on a platform is not known to

--- a/docs/features.md
+++ b/docs/features.md
@@ -201,6 +201,27 @@ to workflow default to adapter default. The TUI shows which level won, and free
 text remains available when a newly released model is not in a catalog yet.
 Read [Agent CLIs](guides/agents.md) for installation and capability details.
 
+## Run steps in a container
+
+Point `container.image` at an image you already have and every step of a task —
+commands, checks, gates and agents — runs inside one container, created with the
+task's worktree and removed with it. What that confines is the filesystem
+outside the worktree and the project repository, the shell, and the tooling the
+image carries. Leave the key empty, which is the default, and nothing changes:
+every step runs on the host exactly as before.
+
+The image is yours and must already carry your agent CLI and `git` — vincent
+builds, publishes and bundles nothing. The repository and the worktree are
+mounted at their own absolute paths, so a path means the same thing inside and
+out and workflow templates need no translation. A workflow can pin its own image
+in `defaults.container:`.
+
+macOS and Linux hosts only, and the container is a filesystem boundary rather
+than a network or credential one — outbound traffic is open by default and your
+agent's configuration is mounted inside it so it can authenticate. Read
+[the security model](security-model.md) for what that means and
+[`container`](reference/configuration.md#container) for the knobs.
+
 ## Script and integrate it
 
 The TUI, command-line subcommands, and external integrations all use the same

--- a/docs/features.md
+++ b/docs/features.md
@@ -203,12 +203,18 @@ Read [Agent CLIs](guides/agents.md) for installation and capability details.
 
 ## Run steps in a container
 
-Point `container.image` at an image you already have and every step of a task —
-commands, checks, gates and agents — runs inside one container, created with the
-task's worktree and removed with it. What that confines is the filesystem
-outside the worktree and the project repository, the shell, and the tooling the
-image carries. Leave the key empty, which is the default, and nothing changes:
-every step runs on the host exactly as before.
+Point `container.image` at an image you already have and a task's step processes
+run inside one container, created with the task's worktree and removed with it.
+What that confines is the filesystem outside the worktree and the project
+repository, the shell, and the tooling the image carries. Leave the key empty,
+which is the default, and nothing changes: every step runs on the host exactly
+as before.
+
+Today that covers **command steps and every `check:`**, including a check on an
+agent step. The **agent process itself still runs on the host** — putting it in
+the container needs a launch seam across all three adapters, and that is the
+next piece of this work. A containerized task with agent steps is a mixed run
+until then, and vincent neither refuses it nor warns about it.
 
 The image is yours and must already carry your agent CLI and `git` — vincent
 builds, publishes and bundles nothing. The repository and the worktree are

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -503,7 +503,8 @@ The container runtime answered when the task was created and does not now — th
 desktop app quit, the socket was revoked, the binary was uninstalled — or it
 refused to create the container. Start the runtime and retry.
 
-A containerized step is **never** run on the host instead. A step that is not
+A step the container was going to run is **never** moved to the host because
+the runtime failed — the task blocks instead. A step that is not
 contained after asking to be contained has inverted the choice the workflow
 made, which is the same rule that makes an agent refuse an unsupported
 `restricted` mode rather than quietly running full-auto.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -478,6 +478,36 @@ The shell a command step asked for is not installed. On Windows vincent uses
 `shell: sh` on a machine with no POSIX shell fails here. Pin a shell that exists,
 or write the command so the platform default can run it.
 
+### `container_image_unavailable`
+
+The task's `container.image` is not on this machine and could not be pulled —
+a typo in the tag, a private registry the daemon is not logged in to, or no
+network. The task blocks **before** a worktree or a branch is created and
+**without** spending a retry, so nothing has to be cleaned up: fix the image or
+the login, then retry the task.
+
+The check is deliberately not made when the task is created. Pulling a
+multi-gigabyte image inside the create request would run it against the API's
+timeouts, and refusing anything not already on disk would reject every first run
+on a fresh machine.
+
+Pull it by hand to see the runtime's own error:
+
+```sh
+docker pull ghcr.io/acme/dev:latest
+```
+
+### `container_unavailable`
+
+The container runtime answered when the task was created and does not now — the
+desktop app quit, the socket was revoked, the binary was uninstalled — or it
+refused to create the container. Start the runtime and retry.
+
+A containerized step is **never** run on the host instead. A step that is not
+contained after asking to be contained has inverted the choice the workflow
+made, which is the same rule that makes an agent refuse an unsupported
+`restricted` mode rather than quietly running full-auto.
+
 ### Validation warns about a model
 
 A value in no catalog at all passes with a **warning** rather than an error: the

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -380,9 +380,15 @@ step, where the step wins.
 | `max_retries` | all steps | `1` |
 | `retry_backoff` | all steps | `0s` — an immediate retry ([§8.2](#82-retries)) |
 | `timeout` | all steps | `defaults.agent_timeout` (60m) or `defaults.command_timeout` (15m) in config |
+| `container` | command steps and checks | the daemon's [`container:`](../reference/configuration.md#container) block, merged per field |
 
 Durations are Go duration strings: `90s`, `45m`, `1h30m`. A bare number is a
 validation error.
+
+`container` is the one mapping here rather than a scalar, and it merges over the
+daemon's block key by key — see
+[the schema page](../reference/workflow-schema.md#defaults) for the fields and
+[`container`](../reference/configuration.md#container) for what they do.
 
 Three deliberate absences:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -123,7 +123,7 @@ are long-lived by contract and no write deadline is set.
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/v1/health` | Liveness → `{ status, version }`. **Unauthenticated** |
-| `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, `orphans`, and the database's byte footprint |
+| `GET` | `/v1/info` | Version, uptime, agent availability, caps in effect, `orphans`, the database's byte footprint, and the container runtime |
 | `GET` | `/v1/config` | The effective global config — **every** key in `config.yaml`, including the `tui` section the daemon only relays |
 | `PATCH` | `/v1/config` | Partial, snake_case, mirroring the read shape. Validates, writes `config.yaml` comment-preservingly, and applies the result before answering → the config in force. An invalid patch is `400 validation_failed` with the file byte-identical |
 | `GET` | `/v1/agents` | Per-adapter availability plus model/effort options. `?refresh=true` forces a re-probe |
@@ -406,6 +406,22 @@ directories is a different promise from a report.
 a readdir and one id query — no size walk, no git — so it is cheap and drops the
 moment `gc` runs. It is deliberately **not** on `/v1/health`, which stays
 `{ status, version }` and is the one unauthenticated endpoint.
+
+`container` on `GET /v1/info` reports the container runtime the way `agents[]`
+reports the adapters — presence, never a verdict on an image:
+
+```json
+{ "container": { "enabled": true, "image": "ghcr.io/acme/dev:latest",
+                 "runtime": "docker", "available": true } }
+```
+
+`enabled` is whether `container.image` names an image at all; `available` is
+whether that runtime binary answered, which is probed either way so a client can
+say "this would work if you turned it on". A failure adds `error` with the
+runtime's own words, and on a Windows daemon `available` is `false` with an
+`error` saying containerized tasks are not supported there. Whether a particular
+image exists is **not** here: that is a registry pull, and it happens when a task
+is admitted.
 
 `database` on `GET /v1/info` carries the byte figures and **only** those:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -75,7 +75,7 @@ empty.
 vincent doctor [--json] [--fix [--force]]
 ```
 
-One report answering "why is nothing running?". Nine groups:
+One report answering "why is nothing running?". Ten groups:
 
 | Group | Rows |
 |---|---|
@@ -85,6 +85,7 @@ One report answering "why is nothing running?". Nine groups:
 | Database | path, size, total on disk including WAL/SHM, applied schema version, `PRAGMA integrity_check`, per-table row counts, workflow-snapshot bytes, and how far back the events table reaches |
 | Agents | per adapter: found, path, version, `logged_in`, whether the build is one vincent has been tested against, and whether the adapter can restrict on this OS |
 | GitHub | whether [`github.enabled`](configuration.md#github) is on, whether `gh` is installed and logged in, whether a token variable is set, and whether issues are readable |
+| Container | whether [`container.image`](configuration.md#container) names an image, which image, whether the configured runtime answered, and whether steps run in it or on this host |
 | Update | whether [`update.check`](configuration.md#update) is on, the latest stable release and when it was last seen, this binary's version, and whether the running daemon is older than it |
 | Storage | disk free under the data dir, worktree count and bytes, orphans |
 | Tasks | counts by state, so "12 blocked" is visible without opening the board, plus any task whose state and step runs contradict each other |
@@ -108,6 +109,11 @@ leaves task creation without an issue working exactly as before, so the row ends
 with *tasks can still be created without an issue*. The token row names the
 **variable** (`GITHUB_TOKEN` or `GH_TOKEN`), never its value: a diagnostic is
 something people paste into issues.
+The **Container** rows follow the same rule and for the same reason:
+containerization is off by default, so a machine with no runtime — or a Windows
+daemon, which cannot host one — runs every step on the host exactly as it always
+has. The runtime is probed **even when `container.image` is unset**, because
+"would this work if I turned it on" is the question the group exists to answer.
 
 An adapter row also ends with what vincent knows about the build itself:
 `untested version` and the builds it was judged against, `incompatible version`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -961,6 +961,13 @@ inside the container with no translation, and
 directory on both sides. It is also why **a Windows daemon refuses a
 containerized task**: `C:\...` cannot exist inside a Linux container.
 
+One consequence is worth knowing before you hit it: "the same absolute path"
+means the **physical** one. A project path that runs through a symlink — the
+common case being macOS's `/tmp` and `/var`, which are symlinks into
+`/private` — is mounted as written while git resolves the worktree's pointer to
+the physical path, and the step then reports `not a git repository`. Register
+such a project by its resolved path (`cd project && pwd -P`).
+
 **`runtime`** is a docker-CLI-compatible binary. Only **`docker`** is verified in
 CI; `podman` and `nerdctl` are accepted because they take the same argv, which
 is not the same claim as tested.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -233,6 +233,17 @@ update:
   check: true
   poll_interval: 24h
 
+# Run a task's steps inside a container instead of on this host (task 061).
+# "image" is the whole switch and "" is the default: no image, and every step
+# runs here exactly as it always has. The image is yours — it must already
+# carry the agent CLI your workflows use, and git. macOS and Linux only.
+container:
+  image: ""
+  runtime: docker
+  mount_agent_config: true
+  network: true
+  extra_mounts: []
+
 # Tell someone when a task needs them, without a client attached (task 046).
 # The daemon runs "command" whenever a task enters one of the states in "on",
 # and writes a JSON envelope describing the transition to the command's stdin
@@ -918,6 +929,81 @@ must be at least 1; a smaller value fails the load.
 An adapter that cannot carry an MCP server fails the step with
 `mcp_unsupported` rather than running an agent that silently has no vincent
 tools. If that is not what you want, turn `wire_steps` off.
+
+### `container`
+
+```yaml
+container:
+  image: ""
+  runtime: docker
+  mount_agent_config: true
+  network: true
+  extra_mounts: []
+```
+
+Run every step process of a task inside **one container** instead of on this
+host. **`image` is the whole switch.** Empty — the default — means no runtime is
+consulted and every step runs here, byte for byte what it did before this key
+existed. Name an image and every `command`, `check`, `manual` and `agent` step
+of the task runs inside a container created with the task's worktree and removed
+with it.
+
+**The image is yours.** It must already carry the agent CLI your workflows'
+agent steps resolve to, and `git`. Vincent builds no image, publishes none and
+bundles none — the same posture it takes toward `gh` and `cosign`.
+
+Two mounts are made for you and need no `extra_mounts` entry: the project
+repository and the task's worktree, each **at its own absolute host path**. That
+is deliberate — a worktree's `.git` file holds an absolute `gitdir:` into the
+parent repository, so mounting both where they already live makes git work
+inside the container with no translation, and
+[`.Worktree`](workflow-schema.md) and `VINCENT_WORKTREE` name the same
+directory on both sides. It is also why **a Windows daemon refuses a
+containerized task**: `C:\...` cannot exist inside a Linux container.
+
+**`runtime`** is a docker-CLI-compatible binary. Only **`docker`** is verified in
+CI; `podman` and `nerdctl` are accepted because they take the same argv, which
+is not the same claim as tested.
+
+**`mount_agent_config`** bind-mounts `~/.claude`, `~/.codex` and `~/.cursor`
+into the container **read-write**, and is on by default. Subscription-based auth
+takes no key from the environment, and cursor persists `--model` to its own
+config, so without this an agent CLI in the container cannot authenticate. It
+also means the container can read your agent credentials — see
+[the security model](../security-model.md).
+
+**`network`** keeps outbound traffic on, which is the default. `false` drops the
+container off the network entirely; combined with `mcp.wire_steps: true` that is
+a contradiction — a container with no network cannot reach the daemon's per-step
+MCP endpoint — and the task is refused at creation. Turn `mcp.wire_steps` off,
+or leave the network on.
+
+**`extra_mounts`** are additional bind mounts, each `host:container` or
+`host:container:ro`.
+
+A workflow may override any of these in its `defaults.container:` block, which
+beats this one per field. There is no per-task override.
+
+**What is refused, and when:**
+
+| Condition | When | What you see |
+|---|---|---|
+| The daemon runs on Windows | task creation | `400 validation_failed` |
+| `runtime` missing or not usable | task creation | `400 validation_failed` naming the binary |
+| `network: false` with `mcp.wire_steps: true` | task creation | `400 validation_failed` naming both keys |
+| A step pins `shell: pwsh` or `shell: cmd` | workflow load, or task creation | a validation error naming the step |
+| The image is missing and cannot be pulled | when the task is admitted | the task blocks `container_image_unavailable` |
+| The runtime went away after creation | when the task is admitted | the task blocks `container_unavailable` |
+
+The image check waits until admission on purpose: pulling a multi-gigabyte image
+inside `POST /v1/tasks` would run it against the API's request timeouts, and
+checking only what is already on disk would refuse every first run on a fresh
+machine. Blocking at admission still costs you no worktree, no branch and no
+retry. A containerized step is **never** quietly run on the host instead.
+
+Run `vincent doctor` to see whether the runtime answers on this machine — it
+probes even when `image` is empty, because "would this work if I turned it on"
+is the question worth asking.
 
 ### `notify`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -992,7 +992,12 @@ MCP endpoint — and the task is refused at creation. Turn `mcp.wire_steps` off,
 or leave the network on.
 
 **`extra_mounts`** are additional bind mounts, each `host:container` or
-`host:container:ro`.
+`host:container:ro`. Both paths must start with `/`, on every platform — a
+relative source would resolve against the daemon's working directory, and a
+`C:\...` source is refused even on Windows, where the containerized task that
+would have used it is itself refused at creation. That keeps one `config.yaml`
+loadable everywhere: a Windows machine reads a Linux daemon's mounts without
+complaining about a key it will never act on.
 
 A workflow may override any of these in its `defaults.container:` block, which
 beats this one per field. There is no per-task override.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -941,12 +941,18 @@ container:
   extra_mounts: []
 ```
 
-Run every step process of a task inside **one container** instead of on this
-host. **`image` is the whole switch.** Empty — the default — means no runtime is
+Run a task's step processes inside **one container** instead of on this host.
+**`image` is the whole switch.** Empty — the default — means no runtime is
 consulted and every step runs here, byte for byte what it did before this key
-existed. Name an image and every `command`, `check`, `manual` and `agent` step
-of the task runs inside a container created with the task's worktree and removed
-with it.
+existed. Name an image and the task's steps run inside a container created with
+the task's worktree and removed with it.
+
+**Which steps, today.** Every `command` step, and every `check:` — including a
+check hanging off an agent step. A `manual` step runs no process, so there is
+nothing to contain. The **agent process itself still runs on the host**: moving
+it needs a launch seam across all three adapters and is the next piece of this
+work. A containerized task whose workflow has agent steps is therefore a mixed
+run, and it is neither refused at creation nor warned about.
 
 **The image is yours.** It must already carry the agent CLI your workflows'
 agent steps resolve to, and `git`. Vincent builds no image, publishes none and
@@ -1006,7 +1012,10 @@ The image check waits until admission on purpose: pulling a multi-gigabyte image
 inside `POST /v1/tasks` would run it against the API's request timeouts, and
 checking only what is already on disk would refuse every first run on a fresh
 machine. Blocking at admission still costs you no worktree, no branch and no
-retry. A containerized step is **never** quietly run on the host instead.
+retry. A step the container was going to run is **never** quietly moved to the
+host when the runtime or the image fails — the task blocks instead. (Agent
+steps, which this delivery has not moved in yet, are a separate matter and are
+described above.)
 
 Run `vincent doctor` to see whether the runtime answers on this machine — it
 probes even when `image` is empty, because "would this work if I turned it on"

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -271,6 +271,8 @@ same thing wherever it originated.
 | `transcript_io_error` | The attempt's transcript could not be written, encoded or closed — a full disk, a revoked permission, a short write. The step fails rather than reporting a success over a record that is missing the run it describes. Retries as usual (a new attempt writes a new file), then blocks. **Not** what an over-long line produces: those are captured in `partial` pieces |
 | `agent_protocol_error` | Vincent could not read the agent's stream to the end, so the transcript is missing lines the CLI wrote. Not `agent_error` — the CLI may have behaved perfectly; the reader that failed is vincent's |
 | `shell_unavailable` | The requested shell is not installed |
+| `container_image_unavailable` | The task's [`container.image`](configuration.md#container) is not on this machine and could not be pulled. Blocks at **admission**, before a worktree, a branch or a retry is spent — the image check is deliberately not made when the task is created |
+| `container_unavailable` | The container runtime answered when the task was created and does not now, or refused to create the container. A step the container was going to run is **never** moved to the host because of it — the task blocks instead |
 | `rejected` | You rejected a manual gate |
 | `canceled` | You cancelled the task |
 | `invalid_snapshot` | The task's stored workflow snapshot is unusable |

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -238,7 +238,31 @@ Every key here is also settable per step, where it wins.
 | `retry_backoff` | duration | `0s` | all steps |
 | `timeout` | duration | `60m` agent / `15m` command (config) | all steps |
 
+| `container` | mapping | daemon `container:` | all steps — where the task's step processes run |
+
 Durations are Go duration strings: `45m`, `1h30m`, `90s`.
+
+`container` is the one key here that is a mapping rather than a scalar, and it
+merges **per field** over the daemon's [`container:`](configuration.md#container)
+block rather than replacing it:
+
+```yaml
+defaults:
+  container:
+    image: ghcr.io/acme/dev:latest   # "" here forces this workflow onto the host
+    network: false                   # inherit runtime, mount_agent_config from config.yaml
+```
+
+Every field is optional and an absent one keeps the daemon's value; `image: ""`
+is a real value meaning "run this workflow's tasks on the host", distinct from
+saying nothing. There is no per-step and no per-task container override.
+
+Pinning an image here also makes one check possible at load rather than at task
+creation: a step that pins `shell: pwsh` or `shell: cmd` fails validation
+straight away, because a containerized `run:` body executes under the image's
+`/bin/sh`. A workflow that pins no image is only refused when a task is created
+from it, since containerization can also come from the hot-reloadable
+`config.yaml`.
 
 `max_retries` counts attempts **after** the first, so the default of 1 means up
 to two attempts.

--- a/docs/reference/workflow-schema.md
+++ b/docs/reference/workflow-schema.md
@@ -237,8 +237,7 @@ Every key here is also settable per step, where it wins.
 | `max_retries` | int | `1` | all steps |
 | `retry_backoff` | duration | `0s` | all steps |
 | `timeout` | duration | `60m` agent / `15m` command (config) | all steps |
-
-| `container` | mapping | daemon `container:` | all steps — where the task's step processes run |
+| `container` | mapping | daemon `container:` | command steps and checks — where the task's step processes run |
 
 Durations are Go duration strings: `45m`, `1h30m`, `90s`.
 
@@ -256,6 +255,12 @@ defaults:
 Every field is optional and an absent one keeps the daemon's value; `image: ""`
 is a real value meaning "run this workflow's tasks on the host", distinct from
 saying nothing. There is no per-step and no per-task container override.
+
+**What runs inside it today** is every `command` step and every `check:`,
+including a check on an agent step. A `manual` step runs no process. The
+**agent process itself is still spawned on the host**; moving it is the next
+piece of this work, and until it lands a workflow that pins an image and has
+agent steps is a mixed run.
 
 Pinning an image here also makes one check possible at load rather than at task
 creation: a step that pins `shell: pwsh` or `shell: cmd` fails validation

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -105,10 +105,16 @@ command.
 
 ## What the container does and does not isolate
 
-Set [`container.image`](reference/configuration.md#container) and every step
-process of a task runs inside one container, created with the task's worktree
-and removed with it. It is the first thing vincent offers that confines an agent
-beyond the worktree, and it is worth being exact about how far it goes.
+Set [`container.image`](reference/configuration.md#container) and a task's step
+processes run inside one container, created with the task's worktree and removed
+with it. It is the first thing vincent offers that confines a task's work beyond
+the worktree, and it is worth being exact about how far it goes.
+
+**Start with what it does not cover yet.** Today the container holds every
+`command` step and every `check:`. The **agent process itself still runs on the
+host**, with your whole home directory and filesystem in reach — the launch seam
+that moves it is the next piece of this work. Do not read a containerized task
+as a sandboxed agent until that lands.
 
 **Does:** confine the filesystem to two bind mounts — the project repository and
 the task's worktree, each at its own absolute path — plus whatever you list in
@@ -125,8 +131,9 @@ image's, not your machine's.
 - **Withhold your agent credentials.** `mount_agent_config` is on by default and
   bind-mounts `~/.claude`, `~/.codex` and `~/.cursor` into the container
   **read-write**, because subscription auth takes no key from the environment
-  and cursor writes its model choice back to its own config. An agent inside the
-  container can read those credentials and write to those directories. Turning
+  and cursor writes its model choice back to its own config. Anything running
+  inside the container can read those credentials and write to those
+  directories. Turning
   the knob off is supported; an agent CLI that then cannot log in is the
   consequence, not a bug.
 - **Raise a privilege boundary.** On a Linux host every step execs as your own

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -103,6 +103,44 @@ valid siblings stay available. The same 1 MiB bound applies to a source posted t
 content is then allowed to *do* is unchanged — a `command` step is still a shell
 command.
 
+## What the container does and does not isolate
+
+Set [`container.image`](reference/configuration.md#container) and every step
+process of a task runs inside one container, created with the task's worktree
+and removed with it. It is the first thing vincent offers that confines an agent
+beyond the worktree, and it is worth being exact about how far it goes.
+
+**Does:** confine the filesystem to two bind mounts — the project repository and
+the task's worktree, each at its own absolute path — plus whatever you list in
+`extra_mounts`. The rest of your home directory, your SSH keys, your other
+repositories and your system are not there. The shell and the tooling are the
+image's, not your machine's.
+
+**Does not:**
+
+- **Close the network.** Outbound traffic is on by default.
+  `container.network: false` closes it, and is refused together with
+  `mcp.wire_steps: true` because a container with no network cannot reach the
+  daemon.
+- **Withhold your agent credentials.** `mount_agent_config` is on by default and
+  bind-mounts `~/.claude`, `~/.codex` and `~/.cursor` into the container
+  **read-write**, because subscription auth takes no key from the environment
+  and cursor writes its model choice back to its own config. An agent inside the
+  container can read those credentials and write to those directories. Turning
+  the knob off is supported; an agent CLI that then cannot log in is the
+  consequence, not a bug.
+- **Raise a privilege boundary.** On a Linux host every step execs as your own
+  uid and gid, so files land owned correctly — and so an escape lands as the
+  same user the daemon already runs as.
+
+Containerization and `permission_mode` are separate axes and compose: restricted
+in a container is still restricted, full-auto in a container is still full-auto
+with the container's reach. There is no `contained` permission mode.
+
+A Windows daemon refuses a containerized task outright rather than translating
+paths, and the runtime is only ever `docker`-compatible; see the configuration
+reference for both.
+
 ## Restricted mode
 
 `permission_mode: restricted` maps each adapter onto its own confinement:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -85,8 +85,10 @@ amendments in this specification record superseded boundaries, while
   see §7.5 and §20.*
 - Sandboxing agents beyond worktree isolation (a worktree is not a security
   boundary). *Amended 2026-08-30 (task 061, issue #256): the **container** half
-  of this is no longer deferred — §16's container execution mode runs every step
-  process of a task inside one container, on an image the user supplies. The
+  of this is no longer deferred — §16's container execution mode runs a task's
+  step processes inside one container, on an image the user supplies. Agent
+  steps are the one kind still spawned on the host in this delivery; task 062
+  moves them in. The
   boundary the parenthesis names is unchanged and still true: a worktree is not
   a security boundary, and neither is a container whose network is open and
   whose agent credentials are mounted inside it (§16 says so in those words).
@@ -3362,10 +3364,15 @@ tui:                           # view preference; the daemon validates and relay
 **`container:` (task 061, added 2026-08-30).** `image` is the whole switch and
 `""` is the default: no image means every step runs on this host, no runtime is
 consulted, and an existing installation is byte-for-byte unchanged. Set it and
-every step process of a task — `command`, `check`, `manual` and `agent` alike —
-runs inside **one** container, created with the task's worktree and removed with
-it. The image is the user's: it must already carry the agent CLI a workflow's
-agent steps resolve to, and `git`. Vincent builds nothing, publishes nothing and
+the task's step processes run inside **one** container, created with the task's
+worktree and removed with it. *As of task 061 that is every `command` step, and
+every `check:` — including a check hanging off an agent step; a `manual` step
+runs no process, so containerizing it is vacuous. The **agent** process itself
+is still spawned on the host: moving it needs a spawn seam across all three
+adapters and is task 062. Until that lands, a containerized task whose workflow
+has agent steps is a mixed run, and it is neither refused nor warned about.* The
+image is the user's: it must already carry the agent CLI a workflow's agent
+steps resolve to, and `git`. Vincent builds nothing, publishes nothing and
 bundles nothing, the posture it already takes toward `gh` and `cosign`.
 
 The block resolves at **two** levels — a workflow's `defaults.container:` over
@@ -3396,8 +3403,9 @@ purpose: pulling inside `POST /v1/tasks` runs a multi-gigabyte download against
 on a fresh machine. Task 041 decision 4 re-affirms task 003 decision 4 — there
 is no pre-flight refusal on an unhealthy environment — and an image's contents
 sit on that side of the line. A containerized step is never quietly run on the
-host instead: that would invert the choice the workflow made, which is §9.4's
-reasoning verbatim.
+host *because the runtime or the image failed*: that would invert the choice
+the workflow made, which is §9.4's reasoning verbatim. It is not a claim about
+agent steps, which task 061 has not moved into the container at all.
 
 **`mcp:` (task 057, added 2026-08-29).** There is deliberately **no `enabled`
 key.** `/mcp` is part of the API surface the way `/v1` is — same listener, same
@@ -4797,6 +4805,14 @@ CREATE TABLE step_runs (
   -- falls back to the proc_started_at tolerance. Cleared with `pid` when the
   -- row is terminalized.
   proc_identity       TEXT,
+  -- The container this run's process lived in (§16, task 061, migration 0021).
+  -- NULL is the ordinary value and means the step ran on the host. `pid`,
+  -- `proc_started_at` and `proc_identity` stay journaled for a containerized
+  -- run — they name the host-side runtime *client*, a real process the daemon
+  -- spawned — but recovery acts on this id instead: removing the container
+  -- kills every process inside it, which is the identity a host PID cannot
+  -- supply. Cleared with `pid` when the row is terminalized.
+  container_id        TEXT,
   exit_code           INTEGER,
   check_exit_code     INTEGER,
   failure_reason      TEXT,
@@ -5822,8 +5838,12 @@ currently true to show (§15 view 6).
   itself because a parse failed has failed in the wrong direction.
 - **Container execution confines the filesystem, not the network or the
   credentials (task 061, added 2026-08-30).** With `container.image` set (§12.3)
-  every step process of a task runs inside one container created with the task's
-  worktree and removed with it. What that confines is real and is the point: the
+  a task's step processes run inside one container created with the task's
+  worktree and removed with it — every `command` step and every `check:` as of
+  task 061, and the **agent** process itself once task 062 lands the spawn seam.
+  Until then a containerized task's agent steps still run on the host, so the
+  confinement below is the container's and does not yet reach them. What that
+  confines is real and is the point: the
   filesystem outside the two bind mounts — the project repository and the task's
   worktree, both at their own absolute paths — the shell, and whatever tooling
   the image carries. An agent that `rm -rf`s the wrong directory reaches the
@@ -5840,11 +5860,13 @@ currently true to show (§15 view 6).
     therefore read the host's agent credentials and write to those directories.
     The knob turns it off; an agent CLI that then cannot authenticate is the
     documented consequence, not a bug.
-  - **The daemon is reachable.** A wired agent step gets
-    `--add-host=host.docker.internal:host-gateway` and an endpoint rewritten to
-    it, so the container can call the daemon's MCP surface — with the same
-    per-run token scoping §13.4 already specifies, and the same caveat that the
-    endpoint is not a boundary.
+  - **The daemon is reachable.** Every container is created with
+    `--add-host=host.docker.internal:host-gateway` whenever it has a network at
+    all, so a process inside it can call the daemon's MCP surface — with the
+    same per-run token scoping §13.4 already specifies, and the same caveat that
+    the endpoint is not a boundary. The per-step endpoint's *host rewrite* to
+    `host.docker.internal`, which is what makes a containerized **agent** step
+    use it, is task 062.
   - **It is not a privilege boundary.** On a Linux host every exec runs as the
     invoking user's uid:gid so files land owned correctly, which means a
     container escape lands on the same user the daemon already runs as.
@@ -6377,8 +6399,10 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
   is a sibling column (migration 0018) rather than a widening.
 - ~~Container/VM-sandboxed step execution~~ — **the container half is
   promoted out of future work, 2026-08-30** (§16, task 061, issue #256): a
-  `container:` block names an image, and every step process of a task runs
-  inside one container created with its worktree and removed with it. The image
+  `container:` block names an image, and a task's step processes run inside one
+  container created with its worktree and removed with it — command steps and
+  checks as of task 061, agent steps once **062** lands the spawn seam the three
+  adapters need. The image
   is the user's and must already carry the agent CLI and `git`; vincent builds,
   publishes and bundles nothing, which is the posture it already takes toward
   `gh` and `cosign`. **VM-level** sandboxing stays deferred, and so do three

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -83,7 +83,16 @@ amendments in this specification record superseded boundaries, while
 - Workflow branching or conditionals within one task. *Amended 2026-08-17
   (task 014): parallel steps and step fan-out are no longer deferred —
   see §7.5 and §20.*
-- Sandboxing agents beyond worktree isolation (a worktree is not a security boundary).
+- Sandboxing agents beyond worktree isolation (a worktree is not a security
+  boundary). *Amended 2026-08-30 (task 061, issue #256): the **container** half
+  of this is no longer deferred — §16's container execution mode runs every step
+  process of a task inside one container, on an image the user supplies. The
+  boundary the parenthesis names is unchanged and still true: a worktree is not
+  a security boundary, and neither is a container whose network is open and
+  whose agent credentials are mounted inside it (§16 says so in those words).
+  What moved is that the filesystem outside the two mounts, the shell and the
+  installed tooling can now be confined, which is what people were actually
+  asking this non-goal for. VM-level sandboxing stays deferred (§20).*
 - Secret management (daemon inherits the user's environment).
 
 ## 3. Decision record
@@ -1707,6 +1716,19 @@ steps is the workflow author's responsibility; the spec makes no attempt to tran
 *Amended 2026-08-16 (task 010):* an author who did not attempt it says so with
 `platforms:` (§8.1.1), which is enforced rather than translated.
 
+*Amended 2026-08-30 (task 061):* a **containerized** step (§16) inverts the
+first rule and the inversion is documented rather than translated. The body
+executes under the **container's** `/bin/sh`, not the daemon host's shell — on
+a POSIX host that is the same spelling but a different `sh`, and the image's
+`PATH` and installed tooling are what the body sees. `platforms:` keeps gating
+on the **host**, which is where the daemon and its worktrees are. A step that
+pins `shell: pwsh` or `shell: cmd` cannot be honoured by a Linux image and is
+refused: at **load** when the workflow's own `defaults.container.image` pins an
+image, which is the only case load-time validation can judge, and at **task
+creation** with `400 validation_failed` naming the step otherwise — because
+containerization also resolves from the hot-reloadable `config.yaml`, and a
+workflow being parsed does not know which task will run it.
+
 ### 8.4 Template context
 
 Templates are Go `text/template`, rendered with `missingkey=error`. Rendering failures
@@ -1784,6 +1806,18 @@ load-bearing.*
 
 Inherits the daemon's environment (which inherits the user's), with cwd set to the
 worktree, plus:
+
+*Amended 2026-08-30 (task 061):* a **containerized** step's base is the
+**image's** environment, not the daemon's. `environment.inherit: all` — §12.3's
+default — is read as `none` for such a step and logged once per task, because a
+macOS or Linux host's `PATH`, `HOME`, `TMPDIR` and `SHELL` inside a Linux image
+is a broken container rather than an inherited one. An explicit name list in
+`environment.inherit` is honoured verbatim, and `environment.unset`,
+`environment.set` and the `VINCENT_*` block below apply exactly as specified on
+top of the image's own environment. The `VINCENT_*` values stay true on both
+sides because the worktree and the repository are mounted at their own absolute
+paths (§16), so `VINCENT_WORKTREE` and `VINCENT_PROJECT_PATH` name the same
+directory inside the container as out.
 
 ```
 VINCENT_TASK_ID, VINCENT_TASK_TITLE, VINCENT_PROJECT_NAME, VINCENT_PROJECT_PATH,
@@ -3294,6 +3328,7 @@ log_level: info
 debug: false                 # record each step's resolved settings and full argv in its transcript
 environment:                 # what child processes inherit (T4.23)
   inherit: all               # all (default) | none | [PATH, HOME, …]; an empty list means none
+                             # a containerized step reads `all` as `none` (§8.5, task 061)
   unset: []                  # names dropped after inherit
   set: {}                    # literal values, applied last; no expansion
 agents:
@@ -3313,10 +3348,56 @@ mcp:                           # the §13.4 MCP server (task 057)
   wire_steps: true             # give vincent's own agent steps the tool list; opt-out
   max_depth: 3                 # how deep tasks created over MCP may chain
   max_tasks: 32                # how many tasks one MCP creation chain may hold
+container:                     # run a task's steps in a container (§16, task 061)
+  image: ""                    # "" (default) = every step runs on this host
+  runtime: docker              # a docker-CLI-compatible binary; only docker is verified in CI
+  mount_agent_config: true     # bind-mount ~/.claude, ~/.codex, ~/.cursor read-write
+  network: true                # false drops the container off the network entirely
+  extra_mounts: []             # host:container[:ro]; the repo and worktree are mounted already
 tui:                           # view preference; the daemon validates and relays it (§15)
   board:
     group_by: [project, workflow]  # task-table grouping, outermost first; [] = flat
 ```
+
+**`container:` (task 061, added 2026-08-30).** `image` is the whole switch and
+`""` is the default: no image means every step runs on this host, no runtime is
+consulted, and an existing installation is byte-for-byte unchanged. Set it and
+every step process of a task — `command`, `check`, `manual` and `agent` alike —
+runs inside **one** container, created with the task's worktree and removed with
+it. The image is the user's: it must already carry the agent CLI a workflow's
+agent steps resolve to, and `git`. Vincent builds nothing, publishes nothing and
+bundles nothing, the posture it already takes toward `gh` and `cosign`.
+
+The block resolves at **two** levels — a workflow's `defaults.container:` over
+this one, per field (task 061 decision 6). There is no task level, no
+`POST /v1/tasks` field and no CLI flag; §20 records the trigger for adding one.
+`runtime` names a docker-CLI-compatible binary, and only `docker` is verified in
+CI — podman and nerdctl are accepted because they take the same argv, which is
+a different claim from "tested". The repository and the worktree are mounted
+**at their own absolute host paths**, so §8.4's `.Worktree` and §8.5's
+`VINCENT_WORKTREE` are true on both sides and no path in a workflow means two
+things; `extra_mounts` is for anything else. Reads happen per admission, so a
+hot reload governs the next task admitted rather than one already running.
+
+What is refused, and where (task 061 decision 3):
+
+| Condition | Where | Outcome |
+|---|---|---|
+| The daemon runs on **Windows** | task creation | `400 validation_failed` — a `C:\...` path cannot exist in a Linux container, and paths are identical inside and out |
+| `runtime` is missing or cannot talk to a daemon | task creation | `400 validation_failed` — cheap, local, one `docker version` |
+| `network: false` with `mcp.wire_steps: true` | task creation | `400 validation_failed` — a container with no network cannot reach the daemon's per-step MCP endpoint |
+| A step pins `shell: pwsh` or `shell: cmd` | load (workflow pins its own image) or task creation | validation error naming the step (§8.3) |
+| The image is missing and cannot be pulled | **admission** | task blocks `container_image_unavailable`, before a worktree, a branch or a retry is spent |
+| The runtime disappeared under a created task | **admission** | task blocks `container_unavailable` |
+
+The image check is an admission block rather than a creation refusal on
+purpose: pulling inside `POST /v1/tasks` runs a multi-gigabyte download against
+§13.1's request timeouts, and inspecting local-only would `400` every first run
+on a fresh machine. Task 041 decision 4 re-affirms task 003 decision 4 — there
+is no pre-flight refusal on an unhealthy environment — and an image's contents
+sit on that side of the line. A containerized step is never quietly run on the
+host instead: that would invert the choice the workflow made, which is §9.4's
+reasoning verbatim.
 
 **`mcp:` (task 057, added 2026-08-29).** There is deliberately **no `enabled`
 key.** `/mcp` is part of the API surface the way `/v1` is — same listener, same
@@ -3672,6 +3753,22 @@ what the daemon executes or exposes — `notify.command`, `environment`,
 - Because agent steps are fresh sessions operating on a worktree whose committed state
   survives, re-running an interrupted step is safe by construction; workflow authors
   are advised to have agents commit incrementally.
+- *Added 2026-08-30 (task 061).* A **containerized** run journals the container
+  it ran in alongside its PID (`step_runs.container_id`, migration 0021). The
+  host PID such a row carries names the runtime *client*, not the process inside
+  the container, so recovery does not rely on it: it reads the container id,
+  confirms the container still carries the `com.vincent.task` label naming this
+  task, and **removes the container**, which kills every process inside it. The
+  label check is the PID-reuse rule from the other direction — a container id is
+  never reused, so there is nothing to guard there, but a container whose label
+  names a *different* task is somebody else's and what cannot be proved is not
+  killed. `procx.Identity` and the PID-reuse guard below are untouched for host
+  steps, and still apply to the runtime client the daemon really did spawn. A
+  **step** timeout, cancel or graceful shutdown is the opposite of this and does
+  **not** remove the container: it signals the process inside by the pid file the
+  step wrote to a container-private scratch mount, waits the same 15 s, then
+  kills. The task's container survives a step, so a retry finds whatever an
+  earlier step installed.
 - *Added 2026-08-15 (task 005).* Recovery reconciles **rows and processes, not
   directories**. The directory tree is reconciled by a separate startup pass that only
   reports (§10): it logs one warning per orphan and raises the `orphans` count on
@@ -5723,6 +5820,38 @@ currently true to show (§15 view 6).
   it is shown — a quit two seconds in must not bury it. Every failure reading or
   writing that file shows the notice again: a security warning that suppresses
   itself because a parse failed has failed in the wrong direction.
+- **Container execution confines the filesystem, not the network or the
+  credentials (task 061, added 2026-08-30).** With `container.image` set (§12.3)
+  every step process of a task runs inside one container created with the task's
+  worktree and removed with it. What that confines is real and is the point: the
+  filesystem outside the two bind mounts — the project repository and the task's
+  worktree, both at their own absolute paths — the shell, and whatever tooling
+  the image carries. An agent that `rm -rf`s the wrong directory reaches the
+  worktree and the repository and nothing else of the user's machine.
+  What it does **not** confine is stated here with the same honesty §16 already
+  applies to `/mcp/step/{run_id}` not being a boundary:
+  - **Outbound network is open by default.** `container.network: false` closes
+    it, and is refused together with `mcp.wire_steps: true` because a container
+    with no network cannot reach the daemon's per-step MCP endpoint.
+  - **The agent's credentials are inside it.** `mount_agent_config` defaults to
+    true and bind-mounts `~/.claude`, `~/.codex` and `~/.cursor` **read-write**,
+    because subscription auth takes no key from the environment and cursor
+    persists `--model` to its own config (§9.7). An agent in the container can
+    therefore read the host's agent credentials and write to those directories.
+    The knob turns it off; an agent CLI that then cannot authenticate is the
+    documented consequence, not a bug.
+  - **The daemon is reachable.** A wired agent step gets
+    `--add-host=host.docker.internal:host-gateway` and an endpoint rewritten to
+    it, so the container can call the daemon's MCP surface — with the same
+    per-run token scoping §13.4 already specifies, and the same caveat that the
+    endpoint is not a boundary.
+  - **It is not a privilege boundary.** On a Linux host every exec runs as the
+    invoking user's uid:gid so files land owned correctly, which means a
+    container escape lands on the same user the daemon already runs as.
+  Containerization and `permission_mode` are orthogonal axes that compose:
+  `restricted` inside a container is still restricted, and full-auto inside a
+  container is still full-auto with the container's own reach. There is no
+  `contained` permission mode.
 - **The release check and `vincent update` (task 055, added 2026-08-29).** The
   check sends **one unauthenticated GET** of the project's public
   latest-release feed and nothing else: no `Authorization` header, no
@@ -6246,4 +6375,19 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
   task column could *not* carry a PR shape, because `github_issue_json` is
   defined as "NULL = no linked issue" holding a bare `Issue`, so `github_pull_json`
   is a sibling column (migration 0018) rather than a widening.
-- Container/VM-sandboxed step execution.
+- ~~Container/VM-sandboxed step execution~~ — **the container half is
+  promoted out of future work, 2026-08-30** (§16, task 061, issue #256): a
+  `container:` block names an image, and every step process of a task runs
+  inside one container created with its worktree and removed with it. The image
+  is the user's and must already carry the agent CLI and `git`; vincent builds,
+  publishes and bundles nothing, which is the posture it already takes toward
+  `gh` and `cosign`. **VM-level** sandboxing stays deferred, and so do three
+  container-shaped things, named here so they are not rediscovered: a
+  **per-task image override** (task 061 decision 6 — two levels ship, workflow
+  `defaults:` over `config.yaml`; the trigger is the first person who needs one
+  task run against a different image), **canonical-path mounting for Windows
+  hosts** (decision 2 — paths are identical inside and out, so a Windows daemon
+  refuses a containerized task rather than translating `C:\...` into something
+  a Linux container could hold; the trigger is a Windows user asking), and
+  **Windows container images**, a no-network-by-default profile,
+  `devcontainer.json` support and vincent-published images.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3383,8 +3383,12 @@ CI — podman and nerdctl are accepted because they take the same argv, which is
 a different claim from "tested". The repository and the worktree are mounted
 **at their own absolute host paths**, so §8.4's `.Worktree` and §8.5's
 `VINCENT_WORKTREE` are true on both sides and no path in a workflow means two
-things; `extra_mounts` is for anything else. Reads happen per admission, so a
-hot reload governs the next task admitted rather than one already running.
+things; `extra_mounts` is for anything else, and both sides of each entry are
+validated as `/`-rooted paths on every platform rather than by the host's own
+rule — the only daemon that acts on the key runs Linux containers, so a shared
+`config.yaml` must not fail to *load* on a Windows machine over a mount that
+machine will never make. Reads happen per admission, so a hot reload governs
+the next task admitted rather than one already running.
 
 What is refused, and where (task 061 decision 3):
 

--- a/docs/tasks/061-container-step-execution.md
+++ b/docs/tasks/061-container-step-execution.md
@@ -1,0 +1,168 @@
+# 061 — Run a task's steps inside a container: the exec seam
+
+*Issue #256. Settled with the author on 2026-08-30.*
+
+Status: **done (1/1)** — 061.1 landed 2026-08-30.
+
+Promotes the **container** half of §20's "Container/VM-sandboxed step
+execution" and amends §2's "sandboxing agents beyond worktree isolation"
+non-goal. Agent steps inside the container are [062](062-agent-steps-in-containers.md);
+this task is the seam, proven with `command`, `check` and `manual` steps.
+
+## 061.1 — the container exec seam ✅
+
+One container per task, created with the worktree and removed with it, in which
+every step process of that task runs. `container.image: ""` is the default, so
+an existing installation is byte-for-byte unchanged.
+
+Landed: `internal/container` (new), the `container:` config block and its
+workflow-level override, migration `0021` adding `step_runs.container_id`, the
+creation gate and `GET /v1/info` reporting, the taskrun create/exec/stop/remove
+paths, container-aware recovery, the two block reasons, a `vincent doctor` row,
+and the §2/§8.3/§8.5/§12.3/§12.4/§16/§20 amendments.
+
+## Decisions
+
+These were settled before any code was written and are binding.
+
+1. **MCP reachability (§13.4).** The daemon rewrites the per-step endpoint's
+   host to `host.docker.internal` for a containerized agent step and passes
+   `--add-host=host.docker.internal:host-gateway` — native on Docker Desktop,
+   Docker ≥ 20.10 on Linux. `mcp.wire_steps` keeps its `true` default so a
+   containerized step is not quietly less capable than a host step and task
+   057's default is not inverted. *Consequence:* `container.network: false`
+   with `mcp.wire_steps: true` is a contradiction and is refused at task
+   creation with `400 validation_failed`. **The alternative it beat:**
+   `--network=host`, which does not exist on Docker Desktop (so macOS would
+   need the rewrite anyway — two paths) and silently defeats the `network`
+   knob.
+
+2. **Paths are identical inside and out; POSIX hosts only.** The project path
+   and `{data_dir}/worktrees/{task_id}` are bind-mounted at their own absolute
+   host paths. A worktree's `.git` is a file holding an absolute
+   `gitdir: {project.path}/.git/worktrees/{task_id}`, and the parent's own
+   `gitdir` file points back — both absolute — so mounting both where they live
+   makes the repository resolve with **zero translation code**, and `.Worktree`,
+   `.ProjectPath`, `VINCENT_WORKTREE` and `VINCENT_PROJECT_PATH` (§8.4, §8.5)
+   keep rendering values true on both sides. *Consequence:* `C:\...` cannot
+   exist in a Linux container, so a **Windows daemon refuses a containerized
+   task at creation**; `platforms:` keeps gating on the host. **The alternative
+   it beat:** mounting at `/vincent/repo` and `/vincent/worktree` with
+   translation, which creates two path vocabularies a workflow author has to
+   hold apart. Canonical-path mounting for Windows is a named follow-up (§20);
+   its trigger is a Windows user asking.
+
+3. **The creation gate is split; the image check moves to admission.** Task
+   creation refuses only what is cheap and local — the runtime binary missing
+   or unusable, a containerized task on a Windows host, and decision 1's
+   contradiction. A missing, unpullable image **blocks at admission** with
+   `container_image_unavailable`, before a worktree, a branch or a retry is
+   spent; `container_unavailable` is the §12.4-shaped backstop for a task whose
+   daemon changed underneath it. This is task 041's actual shape rather than
+   "an exact mirror" of it: 041 decision 3 rests on the `restricted` verdict
+   being judgeable **with no binary installed**, because it depends on adapter
+   identity and `GOOS` — no I/O at all — and 041 decision 4 re-affirms task 003
+   decision 4, that there is no pre-flight refusal on an unhealthy environment.
+   Verifying an image needs a registry pull. **The alternatives they beat:**
+   pulling inside `POST /v1/tasks`, which runs a multi-gigabyte download
+   against §13.1's request timeouts; and inspecting local-only, which `400`s
+   every first run on a fresh machine.
+
+4. **Recovery journals the container id, and the kill is `rm -f`.** Migration
+   0021 adds `step_runs.container_id`; the container carries a
+   `com.vincent.task` label. Recovery reads the id, confirms the label, and
+   removes the container — which kills every process inside it, so no second
+   exec-identity path is needed. `procx.Identity` and the §12.4 PID-reuse guard
+   are untouched for host steps, and a container id is never reused, so the
+   reuse question does not arise. **The alternative it beat:** journaling both
+   the host `docker exec` client PID and the container id; the client PID
+   proves nothing the container id does not.
+
+5. **Linux runs as the invoking user.** Every exec passes `--user {uid}:{gid}`
+   on a Linux host, so files land owned correctly and git inside the container
+   sees the same owner as the worktree on disk. macOS Docker Desktop maps
+   ownership itself, so the flag is Linux-only. An image with a baked non-root
+   user is overridden, and one whose `HOME` is writable only by its own user
+   needs `HOME` pointed at a mounted directory. **The alternative it beat:**
+   running as the image's user and `chown -R`-ing the worktree after each step,
+   which is slow on a large repository and races a still-running `parallel`
+   sub-step.
+
+6. **Two override levels, not three.** `container.image` and its siblings
+   resolve from workflow `defaults:`, else `config.yaml`. No task column, no
+   `POST /v1/tasks` field, no CLI flag, no New-task TUI control. **The
+   follow-up and its trigger:** a per-task override, when somebody needs one
+   task run against a different image. This keeps the migration count at one.
+
+7. **A containerized step's environment base is the image's, not the
+   daemon's.** `environment.inherit: all` — §12.3's default — is read as `none`
+   for a containerized step and logged once per task, because a macOS or Linux
+   host's `PATH`, `HOME`, `TMPDIR` and `SHELL` inside a Linux image is a broken
+   container, not an inherited one. An explicit name list is honoured verbatim,
+   and `environment.unset`, `environment.set` and §8.5's `VINCENT_*` block
+   apply exactly as specified on top of the image's own environment. **The
+   alternative it beat:** a separate `container.env` block, which is more
+   honest about one key meaning two things but duplicates the whole vocabulary
+   so every future environment feature lands twice.
+
+8. **`shell: pwsh | cmd` is refused twice, at the two places that can know.**
+   At **load**, when the workflow's own `defaults:` pins a `container.image` —
+   the only case load-time validation can judge. At **task creation**
+   otherwise, with `400 validation_failed` naming the step, because that is the
+   first moment the config-level and workflow-level images resolve together.
+   Containerization resolves from the hot-reloadable `config.yaml` as well as
+   from the workflow, so a workflow validated at load does not know whether the
+   task that will run it is containerized. A containerized `run:` body executes
+   under the container's `/bin/sh` even on a POSIX host whose daemon shell
+   would have been the same; §8.3's inverse is documented, never translated.
+
+9. **The step kill is a PID file in a scratch mount.** Killing the host-side
+   `docker exec` client leaves the process running inside. Each step runs as
+   `sh -c 'echo $$ > /vincent-run/{run_id}.pid; exec <cmd>'` against a
+   container-private scratch mount, under `setsid` where the image has it so
+   the tree is one process group. A §7.2 timeout, a §6 cancel and a graceful
+   shutdown exec `kill -TERM`, wait the 15 s §12.4 already specifies, then
+   `KILL`. The task's container **survives**, so a retry finds what an earlier
+   step installed; `rm -f` is reserved for whole-task teardown and recovery
+   (decision 4). **The alternatives they beat:** a container per step, which
+   reverses decision 1; and `rm -f` on any step stop, which makes a retry a
+   different run from the one that timed out.
+
+10. **`docker exec` is attached without a TTY.** `-i`, never `-t`: a TTY merges
+    stdout and stderr and translates newlines, which would corrupt the JSONL an
+    adapter's `LineParser` reads and therefore §17's token and cost records.
+
+## What the tests prove
+
+Hermetic per the repository's conventions — no real docker in `go test`. The
+`Runtime` interface is faked and the docker implementation's argv construction
+is table-driven the way adapter parsing is.
+
+- `container.image: ""` consults no runtime and changes no behaviour. This is
+  the regression that matters most.
+- Each creation refusal names what the human has to change, and the `pwsh` one
+  names the step.
+- `inherit: all` yields no host variable inside a containerized step; an
+  explicit list yields exactly the named ones.
+- A `running` step run whose container still carries this task's label is
+  removed on recovery; one whose label names another task is **not** touched —
+  §12.4's rule that what cannot be proved is not killed.
+- A `pwsh` step in an image-pinning workflow fails validation naming the step;
+  the same workflow with no image loads.
+- The two mounts are the repository and the worktree, at their own paths.
+
+`scripts/m11-gate.sh` covers what unit tests cannot: a real runtime, exactly
+one container per containerized task, a step timeout that stops the process
+while the container survives, and a daemon killed mid-step leaving no container
+behind. It **skips cleanly** when `docker info` fails, which is what keeps the
+macOS and Windows CI legs green — those runners have no docker daemon. That is
+a real coverage gap and it is stated rather than implied: a gate that has never
+run on a platform is not known to pass there.
+
+## Out of scope
+
+Windows container images, a no-network-by-default profile, `devcontainer.json`,
+vincent-published images, VM-level sandboxing, and running the daemon itself in
+a container. Added by the decisions above, each with its trigger: a per-task
+`container.image` override (decision 6) and canonical-path mounting for Windows
+hosts (decision 2). Both are recorded in §20 so they are not rediscovered.

--- a/docs/tasks/061-container-step-execution.md
+++ b/docs/tasks/061-container-step-execution.md
@@ -161,10 +161,16 @@ says so and the gate resolves its own temporary directory with `pwd -P`.
 `scripts/m12-gate.sh` covers what unit tests cannot: a real runtime, exactly
 one container per containerized task, a step timeout that stops the process
 while the container survives, and a daemon killed mid-step leaving no container
-behind. It **skips cleanly** when `docker info` fails, which is what keeps the
-macOS and Windows CI legs green — those runners have no docker daemon. That is
-a real coverage gap and it is stated rather than implied: a gate that has never
-run on a platform is not known to pass there.
+behind. It **skips cleanly** on a host that cannot run the feature, which is
+what keeps the macOS and Windows CI legs green — but the two skips are not the
+same skip. The macOS runner has no docker daemon, so `docker info` fails. The
+Windows runner ships docker and its daemon answers, in Windows-container mode,
+where the gate's `FROM alpine:3` fails with "no matching manifest for
+windows/amd64" — so the gate refuses on the host platform before it probes
+anything, which is the honest reason anyway: a Windows daemon refuses a
+containerized task at creation (decision 2), leaving nothing there to assert.
+That is a real coverage gap and it is stated rather than implied: a gate that
+has never run on a platform is not known to pass there.
 
 ## Out of scope
 

--- a/docs/tasks/061-container-step-execution.md
+++ b/docs/tasks/061-container-step-execution.md
@@ -151,7 +151,14 @@ is table-driven the way adapter parsing is.
   the same workflow with no image loads.
 - The two mounts are the repository and the worktree, at their own paths.
 
-`scripts/m11-gate.sh` covers what unit tests cannot: a real runtime, exactly
+One thing the gate found that no unit test could: decision 2's "identical
+inside and out" is about the **physical** path. A project or data directory
+reached through a symlink — macOS's `/tmp` and `/var` both are — is mounted as
+written while git resolves the worktree's `gitdir:` pointer to the physical
+path, and the step reports `not a git repository`. The configuration reference
+says so and the gate resolves its own temporary directory with `pwd -P`.
+
+`scripts/m12-gate.sh` covers what unit tests cannot: a real runtime, exactly
 one container per containerized task, a step timeout that stops the process
 while the container survives, and a daemon killed mid-step leaving no container
 behind. It **skips cleanly** when `docker info` fails, which is what keeps the

--- a/docs/tasks/062-agent-steps-in-containers.md
+++ b/docs/tasks/062-agent-steps-in-containers.md
@@ -1,0 +1,47 @@
+# 062 — Agent steps inside the task's container
+
+*Issue #256, second half. Planned 2026-08-30.*
+
+Status: **planned (0/1)**.
+
+[061](061-container-step-execution.md) built the seam and proved it with
+`command`, `check` and `manual` steps. This task puts the **agent** steps
+inside the same container. It is split off because the spawn seam it needs
+touches all three adapters, and a pull request that changes where every step
+runs *and* how every agent is launched is not independently reviewable.
+
+## 062.1 — agent steps in the container
+
+- **A spawn seam in `internal/agent`.** `claude.go`, `codex.go` and `cursor.go`
+  build argv exactly as they do now and hand it to a launcher the engine
+  chooses. Today there is no shared spawn helper — three `exec.Command` sites
+  plus the one in `taskrun/steps.go` — and introducing one is the bulk of this
+  task's risk.
+- **061 decision 1's MCP rewrite**: the per-step endpoint's host becomes
+  `host.docker.internal` for a containerized agent step, with
+  `--add-host=host.docker.internal:host-gateway` on the container. The
+  creation-time refusal of `network: false` + `mcp.wire_steps: true` already
+  landed in 061.
+- **`mount_agent_config`**: `~/.claude`, `~/.codex` and `~/.cursor`
+  bind-mounted read-write by default, because subscription auth takes no key
+  from the environment and cursor persists `--model` to its own config and
+  writes `.cursor/mcp.json` into the worktree (§9.7). The read-only knob and
+  its consequences are documented, not hidden.
+- **`RunHandle.Terminate` / `Kill` / `PID` made container-aware** via 061
+  decision 9's pid file.
+- **Transcripts, §17 token and cost parsing, and exit codes proven identical**
+  to a host run. 061 decision 10 (`-i`, never `-t`) exists for exactly this.
+- **§9.4 amended**: `permission_mode` and containerization are orthogonal axes
+  that compose; there is no `contained` mode name. Cursor's
+  restricted-needs-macOS/Linux rule keeps being evaluated against the **host**,
+  which is already true of every containerized task under 061 decision 2.
+- **§12.4's cursor `.cursor/mcp.json` recovery sweep re-checked** against a
+  containerized worktree. The file is on the host mount, so the existing sweep
+  reaches it — a test should pin that rather than assume it.
+
+## Testing
+
+`internal/agent/agenttest` gains a cross-compile of `cmd/fakeagent` for
+`linux/amd64` so the fake agent can be bind-mounted into a small image carrying
+`git`, the way `scripts/m11-gate.sh` already does it. Everything else stays
+hermetic: `go test` never needs a container daemon.

--- a/docs/tasks/062-agent-steps-in-containers.md
+++ b/docs/tasks/062-agent-steps-in-containers.md
@@ -43,5 +43,5 @@ runs *and* how every agent is launched is not independently reviewable.
 
 `internal/agent/agenttest` gains a cross-compile of `cmd/fakeagent` for
 `linux/amd64` so the fake agent can be bind-mounted into a small image carrying
-`git`, the way `scripts/m11-gate.sh` already does it. Everything else stays
+`git`, the way `scripts/m12-gate.sh` already does it. Everything else stays
 hermetic: `go test` never needs a container daemon.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -74,6 +74,8 @@ the living engineering specification records implementation contracts.
 | [058](058-enum-task-fields.md) | Enum task fields: workflow-declared value sets, selectable in New task | ✅ done (1/1) |
 | [059](059-popup-task-details-tab.md) | A task-details tab inside the answer, repair and follow-up popups | ✅ done (5/5) |
 | [060](060-daemon-configuration-editing.md) | Edit the daemon configuration from the TUI | ✅ done (8/8) |
+| [061](061-container-step-execution.md) | Run a task's steps inside a container: the exec seam | ✅ done (1/1) |
+| [062](062-agent-steps-in-containers.md) | Agent steps inside the task's container | 📋 planned (0/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -66,10 +66,26 @@ type configResponse struct {
 	GitHub            configGitHub       `json:"github"`
 	Update            configUpdateStatus `json:"update"`
 	Notify            configNotify       `json:"notify"`
+	// Container is §16's container execution mode (task 061). Served like
+	// every other key: `image: ""` — the default — is what says the steps run
+	// on the host, and a client that could not see it could not tell a
+	// containerized installation from a plain one.
+	Container configContainer `json:"container"`
 	// TUI is view preference the daemon only relays (§15): it is in the file
 	// the daemon owns and hot-reloads, so this endpoint is how the TUI — which
 	// reads no configuration of its own — gets it.
 	TUI configTUI `json:"tui"`
+}
+
+// configContainer is §16's block. ExtraMounts is always a list, empty
+// included, for the same reason group_by is: `null` would be indistinguishable
+// from a client's own default.
+type configContainer struct {
+	Image            string   `json:"image"`
+	Runtime          string   `json:"runtime"`
+	MountAgentConfig bool     `json:"mount_agent_config"`
+	Network          bool     `json:"network"`
+	ExtraMounts      []string `json:"extra_mounts"`
 }
 
 type configTUI struct {
@@ -249,7 +265,14 @@ func configBody(cfg config.Config) configResponse {
 			PollInterval: cfg.Update.PollInterval.String(),
 		},
 		Notify: configNotify{On: notifyStates(cfg.Notify.On), Command: stringList(cfg.Notify.Command)},
-		TUI:    configTUI{Board: configBoard{GroupBy: boardGroupBy(cfg.TUI.Board.GroupBy)}},
+		Container: configContainer{
+			Image:            cfg.Container.Image,
+			Runtime:          cfg.Container.Runtime,
+			MountAgentConfig: cfg.Container.MountAgentConfig,
+			Network:          cfg.Container.Network,
+			ExtraMounts:      stringList(cfg.Container.ExtraMounts),
+		},
+		TUI: configTUI{Board: configBoard{GroupBy: boardGroupBy(cfg.TUI.Board.GroupBy)}},
 	}
 }
 
@@ -334,6 +357,7 @@ type configPatch struct {
 	GitHub                      *githubPatch       `json:"github"`
 	Update                      *updatePolicyPatch `json:"update"`
 	Notify                      *notifyPatch       `json:"notify"`
+	Container                   *containerPatch    `json:"container"`
 	TUI                         *tuiPatch          `json:"tui"`
 }
 
@@ -395,6 +419,14 @@ type updatePolicyPatch struct {
 type notifyPatch struct {
 	On      *[]string `json:"on"`
 	Command *[]string `json:"command"`
+}
+
+type containerPatch struct {
+	Image            *string   `json:"image"`
+	Runtime          *string   `json:"runtime"`
+	MountAgentConfig *bool     `json:"mount_agent_config"`
+	Network          *bool     `json:"network"`
+	ExtraMounts      *[]string `json:"extra_mounts"`
 }
 
 type tuiPatch struct {
@@ -494,6 +526,15 @@ func (p configPatch) sets() []config.Set {
 		}
 		if v.Command != nil {
 			add("notify.command", config.RenderList(*v.Command))
+		}
+	}
+	if v := p.Container; v != nil {
+		addIfString(add, "container.image", v.Image)
+		addIfString(add, "container.runtime", v.Runtime)
+		addIfBool(add, "container.mount_agent_config", v.MountAgentConfig)
+		addIfBool(add, "container.network", v.Network)
+		if v.ExtraMounts != nil {
+			add("container.extra_mounts", config.RenderList(*v.ExtraMounts))
 		}
 	}
 	if v := p.TUI; v != nil && v.Board != nil && v.Board.GroupBy != nil {

--- a/internal/api/container.go
+++ b/internal/api/container.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// containerMismatch is the creation-time half of the container gate (§16,
+// task 061 decision 3). It refuses only what is cheap and local, which is
+// task 041's actual shape: 041's `restricted` verdict is judgeable with no
+// binary installed at all, because it depends on adapter identity and GOOS.
+// Verifying a container *image* needs a registry pull and an exec, and task
+// 041 decision 4 re-affirms task 003 decision 4 — there is no pre-flight
+// refusal on an unhealthy environment. So a missing or unpullable image is an
+// admission block (`container_image_unavailable`), not a 400.
+//
+// Three things are refused here:
+//
+//   - a Windows daemon, because paths are identical inside and out (decision
+//     2) and `C:\...` cannot exist in a Linux container;
+//   - a missing or unusable runtime binary, which is local and costs one
+//     `docker version`;
+//   - `container.network: false` together with `mcp.wire_steps: true`
+//     (decision 1), which is a contradiction: a container with no network
+//     cannot reach the daemon's per-step MCP endpoint, and §9.1's rule is
+//     that a missing MCP channel fails loudly rather than running a prompt
+//     premised on tools that are not there.
+//
+// It also carries decision 8's second `shell:` refusal. A workflow that pins
+// its own image is refused at load; every other case can only be judged here,
+// where the config-level and workflow-level images resolve together.
+//
+// An empty string means the task may be created.
+func (s *Server) containerMismatch(ctx context.Context, wf *workflow.Workflow) string {
+	cfg := s.deps.Config()
+	c := cfg.Container.Merge(wf.Defaults.Container)
+	if !c.Enabled() {
+		return ""
+	}
+	if runtime.GOOS == "windows" {
+		return fmt.Sprintf("workflow %q runs in container image %q, which this daemon cannot do on "+
+			"windows: a containerized task mounts its worktree and repository at their own absolute "+
+			"paths, and a windows path cannot exist inside a linux container", wf.Name, c.Image)
+	}
+	if !c.Network && cfg.MCP.WireSteps {
+		return fmt.Sprintf("workflow %q asks for container.network: false while mcp.wire_steps is true: "+
+			"a container with no network cannot reach the daemon's per-step MCP endpoint. "+
+			"Set mcp.wire_steps: false, or leave container.network on", wf.Name)
+	}
+	if conflicts := workflow.ContainerShellConflicts(wf); len(conflicts) > 0 {
+		return fmt.Sprintf("workflow %q runs in container image %q: %s",
+			wf.Name, c.Image, conflicts[0].Message)
+	}
+	if msg := s.containerRuntimeMissing(ctx, c); msg != "" {
+		return msg
+	}
+	return ""
+}
+
+// containerRuntimeMissing probes the configured runtime. It is the one part of
+// this gate that touches the world, and it is bounded: `docker version`
+// against a local socket, not a registry.
+func (s *Server) containerRuntimeMissing(ctx context.Context, c config.Container) string {
+	rt := s.containerRuntime(c.RuntimeBinary())
+	if err := rt.Available(ctx); err != nil {
+		return fmt.Sprintf("container runtime %q is not usable: %v. "+
+			"A containerized task is never silently run on the host instead", c.RuntimeBinary(), err)
+	}
+	return ""
+}
+
+// containerRuntime resolves a runtime binary through the injectable factory,
+// so the API's tests never need docker.
+func (s *Server) containerRuntime(binary string) container.Runtime {
+	if s.deps.Containers != nil {
+		return s.deps.Containers(binary)
+	}
+	return container.New(binary)
+}
+
+// containerInfo is what `GET /v1/info` reports about container execution, the
+// way it reports adapters. Presence, never a verdict on the image: the image
+// is a per-workflow fact and probing every configured one on an info request
+// is a registry pull behind a health endpoint.
+func (s *Server) containerInfo(ctx context.Context) map[string]any {
+	c := s.deps.Config().Container
+	info := map[string]any{
+		"enabled": c.Enabled(),
+		"runtime": c.RuntimeBinary(),
+		"image":   strings.TrimSpace(c.Image),
+	}
+	if runtime.GOOS == "windows" {
+		info["available"] = false
+		info["error"] = "containerized tasks are not supported on a windows daemon"
+		return info
+	}
+	if err := s.containerRuntime(c.RuntimeBinary()).Available(ctx); err != nil {
+		info["available"] = false
+		info["error"] = err.Error()
+		return info
+	}
+	info["available"] = true
+	return info
+}

--- a/internal/api/container_test.go
+++ b/internal/api/container_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// gateRuntime stands in for docker. No `go test` in this repository may need a
+// container daemon (the testing conventions), so the creation gate's one call
+// into the world is faked and the real argv is pinned in internal/container.
+type gateRuntime struct{ err error }
+
+func (g gateRuntime) Name() string                              { return "fake" }
+func (g gateRuntime) Available(context.Context) error           { return g.err }
+func (g gateRuntime) EnsureImage(context.Context, string) error { return nil }
+
+func (g gateRuntime) Create(context.Context, container.CreateSpec) (string, error) {
+	return "cid", nil
+}
+func (g gateRuntime) Exec(string, container.ExecSpec) []string             { return nil }
+func (g gateRuntime) Signal(context.Context, string, string, string) error { return nil }
+func (g gateRuntime) Remove(context.Context, string) error                 { return nil }
+func (g gateRuntime) Lookup(context.Context, string) (string, error)       { return "", nil }
+func (g gateRuntime) TaskLabel(context.Context, string) (string, error)    { return "", nil }
+
+// gateServer is a Server with nothing wired but what containerMismatch reads:
+// the config and the runtime factory. The gate is deliberately cheap and local
+// (task 061 decision 3), which is exactly what makes it testable this way.
+func gateServer(t *testing.T, cfg config.Config, rt container.Runtime) *Server {
+	t.Helper()
+	return New(Deps{
+		Token:       testToken,
+		Config:      func() config.Config { return cfg },
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Containers:  func(string) container.Runtime { return rt },
+	})
+}
+
+// testImage is any image name at all: nothing in the creation gate reads it
+// beyond "is it empty", which is decision 3's whole point — the image's
+// *contents* are an admission-time question.
+const testImage = "ghcr.io/example/dev:latest"
+
+func containerConfig() config.Config {
+	cfg := config.Default()
+	cfg.Container = config.Container{
+		Image: testImage, Runtime: "docker", MountAgentConfig: true, Network: true,
+	}
+	return cfg
+}
+
+func parseWorkflow(t *testing.T, src string) *workflow.Workflow {
+	t.Helper()
+	wf, errs, err := workflow.Parse([]byte(src), workflow.Options{KnownAgents: []string{"claude"}})
+	if err != nil || len(errs) > 0 {
+		t.Fatalf("parse workflow: %v %v", err, errs)
+	}
+	return wf
+}
+
+const gateWorkflowYAML = `name: build
+description: Build it.
+steps:
+  - {id: compile, type: command, run: "go build ./..."}
+`
+
+// TestContainerGatePassesWhenTheRuntimeAnswers is the baseline the three
+// refusals below are measured against: an image, a usable runtime, a network,
+// and the task may be created.
+func TestContainerGatePassesWhenTheRuntimeAnswers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("a windows daemon refuses every containerized task (decision 2)")
+	}
+	s := gateServer(t, containerConfig(), gateRuntime{})
+	if msg := s.containerMismatch(t.Context(), parseWorkflow(t, gateWorkflowYAML)); msg != "" {
+		t.Fatalf("refused a runnable containerized task: %s", msg)
+	}
+}
+
+// TestContainerGateIgnoresAnUncontainerizedTask is the regression that matters
+// most: `container.image: ""` is the default, and an installation that never
+// sets one must not learn that docker exists. The runtime here always fails,
+// and the gate must never ask it.
+func TestContainerGateIgnoresAnUncontainerizedTask(t *testing.T) {
+	s := gateServer(t, config.Default(), gateRuntime{err: errors.New("docker: not found")})
+	if msg := s.containerMismatch(t.Context(), parseWorkflow(t, gateWorkflowYAML)); msg != "" {
+		t.Fatalf("a host task was refused over the container runtime: %s", msg)
+	}
+}
+
+// TestContainerGateRefusesAnUnusableRuntime: the cheap, local half of decision
+// 3. A containerized task is never silently run on the host instead.
+func TestContainerGateRefusesAnUnusableRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the windows refusal fires first (decision 2)")
+	}
+	s := gateServer(t, containerConfig(),
+		gateRuntime{err: errors.New("docker: command not found")})
+	msg := s.containerMismatch(t.Context(), parseWorkflow(t, gateWorkflowYAML))
+	if !strings.Contains(msg, "docker") || !strings.Contains(msg, "not usable") {
+		t.Fatalf("refusal does not name the runtime: %q", msg)
+	}
+}
+
+// TestContainerGateRefusesNoNetworkWithWiredMCP pins decision 1's
+// contradiction. A container with no network cannot reach the daemon's
+// per-step MCP endpoint, and §9.1's rule is that a missing MCP channel fails
+// loudly rather than running a prompt premised on tools that are not there.
+func TestContainerGateRefusesNoNetworkWithWiredMCP(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the windows refusal fires first (decision 2)")
+	}
+	cfg := containerConfig()
+	cfg.Container.Network = false
+	cfg.MCP.WireSteps = true
+	s := gateServer(t, cfg, gateRuntime{})
+	msg := s.containerMismatch(t.Context(), parseWorkflow(t, gateWorkflowYAML))
+	if !strings.Contains(msg, "container.network") || !strings.Contains(msg, "mcp.wire_steps") {
+		t.Fatalf("refusal does not name both sides of the contradiction: %q", msg)
+	}
+
+	// Turning the other knob off resolves it, rather than the pair being
+	// permanently forbidden: a no-network container is a legitimate ask.
+	cfg.MCP.WireSteps = false
+	if msg := gateServer(t, cfg, gateRuntime{}).containerMismatch(
+		t.Context(), parseWorkflow(t, gateWorkflowYAML)); msg != "" {
+		t.Fatalf("a no-network task with mcp.wire_steps off was still refused: %s", msg)
+	}
+}
+
+// TestContainerGateRefusesPwshAndNamesTheStep is decision 8's second half.
+// The workflow pins no image of its own, so load-time validation could not
+// have judged it — this is the first moment the config-level and
+// workflow-level images resolve together, and the message must name the step
+// the human has to change.
+func TestContainerGateRefusesPwshAndNamesTheStep(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the windows refusal fires first (decision 2)")
+	}
+	const src = `name: build
+description: Build it.
+steps:
+  - {id: compile, type: command, run: "go build ./..."}
+  - {id: sign, type: command, shell: pwsh, run: "Write-Host hi"}
+`
+	s := gateServer(t, containerConfig(), gateRuntime{})
+	msg := s.containerMismatch(t.Context(), parseWorkflow(t, src))
+	if !strings.Contains(msg, `"sign"`) || !strings.Contains(msg, "pwsh") {
+		t.Fatalf("refusal does not name the offending step: %q", msg)
+	}
+
+	// The same workflow off the container path keeps working: §8.3 still
+	// resolves pwsh on a host that has it, and this gate does not touch it.
+	if msg := gateServer(t, config.Default(), gateRuntime{}).containerMismatch(
+		t.Context(), parseWorkflow(t, src)); msg != "" {
+		t.Fatalf("a host task with a pwsh step was refused: %s", msg)
+	}
+}
+
+// TestContainerInfoReportsPresenceNotAVerdict pins what `GET /v1/info` says.
+// It is adapter-shaped: whether the runtime answered, never whether the image
+// exists — probing every configured image behind a health endpoint is a
+// registry pull.
+func TestContainerInfoReportsPresenceNotAVerdict(t *testing.T) {
+	s := gateServer(t, containerConfig(), gateRuntime{})
+	info := s.containerInfo(t.Context())
+	if info["enabled"] != true || info["runtime"] != "docker" {
+		t.Fatalf("info = %+v", info)
+	}
+	if _, ok := info["image_available"]; ok {
+		t.Errorf("info claims a verdict on the image: %+v", info)
+	}
+	want := runtime.GOOS != "windows"
+	if info["available"] != want {
+		t.Errorf("available = %v, want %v (%+v)", info["available"], want, info)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/agent"
 	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/events"
 	"github.com/lezli01/vincent/internal/github"
 	"github.com/lezli01/vincent/internal/gitx"
@@ -50,6 +51,11 @@ type Deps struct {
 	Logger *slog.Logger
 	// Store is the persistence layer.
 	Store *store.Store
+	// Containers resolves a `container.runtime` value to the Runtime that
+	// drives it, for the §16 creation gate and `GET /v1/info` (task 061).
+	// Nil means container.New; tests substitute a fake so no handler test
+	// needs docker.
+	Containers func(binary string) container.Runtime
 	// Git runs git commands for registration validation.
 	Git *gitx.Git
 	// GitHub reads GitHub issues for the §13.2 issue endpoints and the
@@ -368,6 +374,11 @@ type infoResponse struct {
 	Orphans int `json:"orphans"`
 	// Database is the store's on-disk footprint (task 029, §17).
 	Database infoDatabase `json:"database"`
+	// Container reports the §16 container runtime the way Agents reports the
+	// adapters: presence, path-free, and never a verdict on an image (task
+	// 061). A machine with no runtime is a healthy machine — this is
+	// information, not a problem.
+	Container map[string]any `json:"container"`
 }
 
 // infoDatabase is the byte half of §17's database figures: the file plus the
@@ -441,6 +452,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		Agents:           agents,
 		Orphans:          orphans,
 		Database:         s.infoDatabase(),
+		Container:        s.containerInfo(r.Context()),
 	})
 }
 

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -633,6 +633,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
 		return
 	}
+	// The container gate (§16, task 061 decision 3), after the three
+	// capability checks: it is a fact about the host and the daemon's config,
+	// not about a field the human just typed, so it is the least surprising
+	// thing to be told about last.
+	if mismatch := s.containerMismatch(ctx, wf); mismatch != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
+		return
+	}
 	// Branch naming (§5.3, task 001): `default < config.yaml < project < literal`.
 	// Resolve before the insert so a bad name is a 400 rather than a task that
 	// blocks later, and so the git-side checks run with no transaction open.

--- a/internal/api/workflowdef.go
+++ b/internal/api/workflowdef.go
@@ -77,6 +77,35 @@ type workflowDefaults struct {
 	MaxRetries     *int    `json:"max_retries,omitempty"`
 	RetryBackoff   *string `json:"retry_backoff,omitempty"`
 	Timeout        *string `json:"timeout,omitempty"`
+	// Container is the §16 containerization override, absent when the
+	// workflow sets none. It is on the wire because it changes where every
+	// step of a task runs, which a graph editor and the workflow detail view
+	// both have to be able to say (task 061).
+	Container *workflowContainerDef `json:"container,omitempty"`
+}
+
+// workflowContainerDef is `defaults.container:` on the wire. Every field is a
+// pointer for the reason the YAML's are: `image: ""` in a workflow means "run
+// this one on the host" and must stay distinguishable from an absent key.
+type workflowContainerDef struct {
+	Image            *string  `json:"image,omitempty"`
+	Runtime          *string  `json:"runtime,omitempty"`
+	MountAgentConfig *bool    `json:"mount_agent_config,omitempty"`
+	Network          *bool    `json:"network,omitempty"`
+	ExtraMounts      []string `json:"extra_mounts,omitempty"`
+}
+
+func toWorkflowContainerDef(c *config.ContainerOverride) *workflowContainerDef {
+	if c == nil {
+		return nil
+	}
+	return &workflowContainerDef{
+		Image:            c.Image,
+		Runtime:          c.Runtime,
+		MountAgentConfig: c.MountAgentConfig,
+		Network:          c.Network,
+		ExtraMounts:      c.ExtraMounts,
+	}
 }
 
 // workflowStepDef is one step, flat across every type the way the YAML is
@@ -235,6 +264,7 @@ func toWorkflowDefinition(wf *workflow.Workflow) *workflowDefinition {
 			MaxRetries:     wf.Defaults.MaxRetries,
 			RetryBackoff:   durationString(wf.Defaults.RetryBackoff),
 			Timeout:        durationString(wf.Defaults.Timeout),
+			Container:      toWorkflowContainerDef(wf.Defaults.Container),
 		},
 		Steps: toWorkflowStepDefs(wf.Steps),
 	}

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -142,10 +142,25 @@ type Config struct {
 	GitHub            ConfigGitHub      `json:"github"`
 	Update            ConfigUpdate      `json:"update"`
 	Notify            ConfigNotify      `json:"notify"`
+	// Container is §16's container execution mode (task 061). Image empty is
+	// the default and means the steps run on this host.
+	Container ConfigContainer `json:"container"`
 	// TUI is the view preference the daemon only relays (§15). It is served
 	// here rather than read from disk because the TUI is a pure API client;
 	// a client that cannot reach the daemon renders its own defaults.
 	TUI ConfigTUI `json:"tui"`
+}
+
+// ConfigContainer is the `container` section of config.yaml as served (§16,
+// task 061). Runtime is the docker-CLI-compatible binary; ExtraMounts are
+// `host:container[:ro]` bind mounts beyond the repository and worktree the
+// daemon mounts on its own.
+type ConfigContainer struct {
+	Image            string   `json:"image"`
+	Runtime          string   `json:"runtime"`
+	MountAgentConfig bool     `json:"mount_agent_config"`
+	Network          bool     `json:"network"`
+	ExtraMounts      []string `json:"extra_mounts"`
 }
 
 // ConfigTUI is the `tui` section of config.yaml as served.
@@ -342,6 +357,7 @@ type ConfigPatch struct {
 	GitHub                      *ConfigGitHubPatch      `json:"github,omitempty"`
 	Update                      *ConfigUpdatePatch      `json:"update,omitempty"`
 	Notify                      *ConfigNotifyPatch      `json:"notify,omitempty"`
+	Container                   *ConfigContainerPatch   `json:"container,omitempty"`
 	TUI                         *ConfigTUIPatch         `json:"tui,omitempty"`
 }
 
@@ -394,6 +410,15 @@ type ConfigUpdatePatch struct {
 type ConfigNotifyPatch struct {
 	On      *[]string `json:"on,omitempty"`
 	Command *[]string `json:"command,omitempty"`
+}
+
+// ConfigContainerPatch is the optional half of ConfigContainer.
+type ConfigContainerPatch struct {
+	Image            *string   `json:"image,omitempty"`
+	Runtime          *string   `json:"runtime,omitempty"`
+	MountAgentConfig *bool     `json:"mount_agent_config,omitempty"`
+	Network          *bool     `json:"network,omitempty"`
+	ExtraMounts      *[]string `json:"extra_mounts,omitempty"`
 }
 
 // ConfigTUIPatch is the optional half of ConfigTUI.

--- a/internal/apiclient/doctor.go
+++ b/internal/apiclient/doctor.go
@@ -40,6 +40,9 @@ type DoctorAgent = doctor.Agent
 // DoctorGitHub is the report's GitHub issue integration row (task 035).
 type DoctorGitHub = doctor.GitHub
 
+// DoctorContainer is the report's container-execution row (§16, task 061).
+type DoctorContainer = doctor.Container
+
 // DoctorUpdate is the report's release-check row (task 055).
 type DoctorUpdate = doctor.Update
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -310,6 +310,28 @@ func configFields() map[string]configField {
 			func(v *[]string) apiclient.ConfigPatch {
 				return apiclient.ConfigPatch{Notify: &apiclient.ConfigNotifyPatch{Command: v}}
 			}),
+		"container.image": str(func(c apiclient.Config) string { return c.Container.Image },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Image: v}}
+			}),
+		"container.runtime": str(func(c apiclient.Config) string { return c.Container.Runtime },
+			func(v *string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Runtime: v}}
+			}),
+		"container.mount_agent_config": boolField(
+			func(c apiclient.Config) bool { return c.Container.MountAgentConfig },
+			func(b *bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{MountAgentConfig: b}}
+			}),
+		"container.network": boolField(
+			func(c apiclient.Config) bool { return c.Container.Network },
+			func(b *bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Network: b}}
+			}),
+		"container.extra_mounts": listField(func(c apiclient.Config) []string { return c.Container.ExtraMounts },
+			func(v *[]string) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{ExtraMounts: v}}
+			}),
 		"tui.board.group_by": listField(func(c apiclient.Config) []string { return c.TUI.Board.GroupBy },
 			func(v *[]string) apiclient.ConfigPatch {
 				return apiclient.ConfigPatch{TUI: &apiclient.ConfigTUIPatch{Board: &apiclient.ConfigBoardPatch{GroupBy: v}}}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -222,6 +222,7 @@ func doctorGroups(rep *apiclient.DoctorReport) []doctorGroup {
 		{"DATABASE", doctorDatabaseRows(rep.Database)},
 		{"AGENTS", doctorAgentRows(rep.Agents)},
 		{"GITHUB", doctorGitHubRows(rep.GitHub)},
+		{"CONTAINER", doctorContainerRows(rep.Container)},
 		{"UPDATE", doctorUpdateRows(rep.Update)},
 		{"STORAGE", doctorStorageRows(rep.Storage)},
 		{"TASKS", doctorTaskRows(rep.Tasks)},
@@ -501,6 +502,39 @@ func doctorGitHubRows(gh apiclient.DoctorGitHub) [][]string {
 	default:
 		rows = append(rows, []string{"issues", "unavailable: " + gh.Message +
 			"; tasks can still be created without an issue"})
+	}
+	return rows
+}
+
+// doctorContainerRows renders the container-execution row (§16, task 061).
+//
+// It follows the GitHub row's rule rather than the agents section's: nothing
+// here is a Problem and none of it changes the exit code. Containerization is
+// off by default, so a machine with no runtime — or a Windows daemon, which
+// cannot host one under decision 2 — runs every step on the host exactly as it
+// always has. The runtime is probed even when the feature is off, because
+// "would this work if I turned it on" is the question the row exists to answer.
+func doctorContainerRows(c apiclient.DoctorContainer) [][]string {
+	rows := [][]string{{"enabled", boolWord(c.Enabled)}}
+	if c.Image != "" {
+		rows = append(rows, []string{"image", c.Image})
+	}
+	runtimeState := "available"
+	switch {
+	case !c.Supported:
+		runtimeState = "unsupported: " + c.Message
+	case !c.Available:
+		runtimeState = "unavailable: " + c.Message
+	}
+	rows = append(rows, []string{"runtime", c.Runtime + "  " + runtimeState})
+	switch {
+	case c.Enabled && c.Supported && c.Available:
+		rows = append(rows, []string{"steps", "run in " + c.Image})
+	case c.Enabled:
+		rows = append(rows, []string{"steps", "would run in " + c.Image +
+			", but the task is blocked before a worktree is created"})
+	default:
+		rows = append(rows, []string{"steps", "run on this host (container.image is unset)"})
 	}
 	return rows
 }

--- a/internal/cli/doctorrows_test.go
+++ b/internal/cli/doctorrows_test.go
@@ -147,3 +147,63 @@ func TestDoctorGitHubRowDisabled(t *testing.T) {
 		t.Errorf("a disabled integration is reported as unavailable:\n%s", out)
 	}
 }
+
+// The container-execution row (§16, task 061). Like the GitHub row above it,
+// every "no" it can report leaves task creation and step execution working
+// exactly as they always have — containerization is off by default — so none
+// of this is a Problem and none of it changes the exit code.
+
+// TestDoctorContainerRowOffByDefault: the default installation. The row has to
+// say the steps run here, because "enabled no" alone reads like a fault.
+func TestDoctorContainerRowOffByDefault(t *testing.T) {
+	out := joinRows(doctorContainerRows(apiclient.DoctorContainer{
+		Runtime: "docker", Supported: true, Available: true,
+	}))
+	for _, want := range []string{"enabled", "no", "run on this host", "container.image is unset"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("row does not mention %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDoctorContainerRowProbesAnAbsentRuntimeAnyway: "would this work if I
+// turned it on" is the question `vincent doctor` is run to answer, so the
+// probe happens whether or not an image is configured.
+func TestDoctorContainerRowProbesAnAbsentRuntimeAnyway(t *testing.T) {
+	out := joinRows(doctorContainerRows(apiclient.DoctorContainer{
+		Runtime: "podman", Supported: true, Message: "podman: executable file not found in $PATH",
+	}))
+	for _, want := range []string{"podman", "unavailable", "not found"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("row does not mention %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDoctorContainerRowOnAWindowsDaemon: decision 2's refusal is a fact about
+// the host, and the row states it rather than reporting a missing binary the
+// user could go and install.
+func TestDoctorContainerRowOnAWindowsDaemon(t *testing.T) {
+	out := joinRows(doctorContainerRows(apiclient.DoctorContainer{
+		Enabled: true, Image: "ghcr.io/example/dev:latest", Runtime: "docker",
+		Message: "containerized tasks are not supported on a windows daemon",
+	}))
+	if !strings.Contains(out, "unsupported") || !strings.Contains(out, "windows daemon") {
+		t.Errorf("row does not state the windows refusal:\n%s", out)
+	}
+	if !strings.Contains(out, "blocked before a worktree is created") {
+		t.Errorf("row does not state the consequence for a task:\n%s", out)
+	}
+}
+
+// TestDoctorContainerRowEnabledAndUsable names the image, which is the one
+// fact a user comparing two machines needs.
+func TestDoctorContainerRowEnabledAndUsable(t *testing.T) {
+	out := joinRows(doctorContainerRows(apiclient.DoctorContainer{
+		Enabled: true, Image: "ghcr.io/example/dev:latest", Runtime: "docker",
+		Supported: true, Available: true,
+	}))
+	if !strings.Contains(out, "run in ghcr.io/example/dev:latest") {
+		t.Errorf("row does not name the image:\n%s", out)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -277,6 +277,10 @@ type Config struct {
 	// the daemon wires its own agent steps to it, and how deep an agent may
 	// create tasks that create tasks.
 	MCP MCP `yaml:"mcp"`
+	// Container governs §16's container execution mode (task 061): the image
+	// a task's steps run in, and how that container is wired. `image: ""` is
+	// the default and means today's behaviour — every step on the host.
+	Container Container `yaml:"container"`
 	// TUI is view preference, not daemon behaviour: the daemon validates it,
 	// hot-reloads it and serves it on `GET /v1/config`, and does nothing else
 	// with it. It lives in this file rather than one of the TUI's own because
@@ -650,6 +654,9 @@ func Default() Config {
 		GitHub: GitHub{Enabled: true, PollInterval: Duration(5 * time.Minute)},
 		// On by default with a day between calls (task 055 decision 3).
 		Update: Update{Check: true, PollInterval: Duration(24 * time.Hour)},
+		// Runtime named, mounts and network on: inert until an image is set,
+		// and the shape a container user wants when they set one (§16).
+		Container: Container{Runtime: "docker", MountAgentConfig: true, Network: true},
 		TUI: TUI{Board: BoardView{
 			GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow},
 		}},
@@ -773,6 +780,9 @@ func (c Config) validate() error {
 	// and look like it worked.
 	if c.Update.PollInterval < 0 {
 		return fmt.Errorf("update.poll_interval must not be negative, got %s", c.Update.PollInterval)
+	}
+	if err := c.Container.Validate(); err != nil {
+		return err
 	}
 	return c.Environment.validate()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,7 +115,11 @@ agents:
 		// is what "opt-out" has to mean for it to be true.
 		Update: Update{Check: true, PollInterval: Duration(24 * time.Hour)},
 		MCP:    MCP{WireSteps: true, MaxDepth: 3, MaxTasks: 32},
-		TUI:    TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
+		// And for `container:` — the file names no key, so the §16 default
+		// survives: no image, which is the whole switch. An installation that
+		// overrides everything else still runs every step on the host.
+		Container: Container{Runtime: "docker", MountAgentConfig: true, Network: true},
+		TUI:       TUI{Board: BoardView{GroupBy: []BoardGroup{BoardGroupProject, BoardGroupWorkflow}}},
 	}
 	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("got %+v, want %+v", cfg, want)

--- a/internal/config/container.go
+++ b/internal/config/container.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 )
 
@@ -116,6 +115,16 @@ func (c Container) Validate() error {
 // validateMount checks one `host:container[:ro]` entry. Both paths must be
 // absolute: a relative source resolves against the daemon's working directory,
 // which is not a thing a workflow author can reason about.
+//
+// "Absolute" is judged POSIX-style on both sides, deliberately, and not with
+// filepath.IsAbs. filepath.IsAbs answers "absolute on the platform this binary
+// was built for", and a Windows daemon answers `/srv/cache` with no. But a
+// Windows daemon refuses containerized tasks outright (decision 2 — paths are
+// identical inside and out, and `C:\...` cannot exist in a Linux container),
+// so the only host that ever acts on this key is a POSIX one. Judging it by
+// the host's own rules would make a config.yaml that is correct for the Linux
+// daemon it was written for fail to *load* on a Windows machine sharing it,
+// over a key that machine will never reach.
 func validateMount(spec string) error {
 	parts := strings.Split(spec, ":")
 	if len(parts) < 2 || len(parts) > 3 {
@@ -124,7 +133,7 @@ func validateMount(spec string) error {
 	if len(parts) == 3 && parts[2] != "ro" && parts[2] != "rw" {
 		return fmt.Errorf("container.extra_mounts %q: mode must be ro or rw, got %q", spec, parts[2])
 	}
-	if !filepath.IsAbs(parts[0]) {
+	if !strings.HasPrefix(parts[0], "/") {
 		return fmt.Errorf("container.extra_mounts %q: host path must be absolute", spec)
 	}
 	if !strings.HasPrefix(parts[1], "/") {

--- a/internal/config/container.go
+++ b/internal/config/container.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Container configures running a task's steps inside a container instead of
+// on the daemon's host (spec §16, §20 — task 061).
+//
+// Image is the whole switch. `image: ""` is the default and means today's
+// behaviour exactly: the step runs on the host, no runtime is consulted, and
+// an existing installation is byte-for-byte unchanged. Everything else in this
+// block is inert until an image is named.
+//
+// The image is the user's. It must already carry the agent CLI a workflow's
+// agent steps resolve to, and `git`; vincent builds nothing, publishes nothing
+// and bundles nothing — the posture it already takes toward `gh` and `cosign`.
+type Container struct {
+	// Image is the container image to run in. Empty runs on the host.
+	Image string `yaml:"image"`
+	// Runtime is a docker-CLI-compatible binary. Only `docker` is verified in
+	// CI; podman and nerdctl are accepted because they take the same argv,
+	// and the documentation says which of the three is tested.
+	Runtime string `yaml:"runtime"`
+	// MountAgentConfig bind-mounts the host's agent configuration directories
+	// into the container read-write. It defaults to true because
+	// subscription-based auth takes no key from the environment, and cursor
+	// persists `--model` to its own config (§9.7). Turning it off is
+	// supported and its consequence — an agent CLI that cannot authenticate —
+	// is documented rather than hidden.
+	MountAgentConfig bool `yaml:"mount_agent_config"`
+	// Network keeps outbound traffic on, which is the default. False drops
+	// the container off the network entirely; combined with
+	// `mcp.wire_steps: true` that is a contradiction, and it is refused at
+	// task creation rather than producing an agent wired to a dead endpoint
+	// (task 061 decision 1).
+	Network bool `yaml:"network"`
+	// ExtraMounts are additional bind mounts, each `host:container` or
+	// `host:container:ro`. The project repository and the task's worktree are
+	// mounted automatically at their own absolute paths (decision 2) and need
+	// no entry here.
+	ExtraMounts []string `yaml:"extra_mounts"`
+}
+
+// Enabled reports whether steps run in a container at all.
+func (c Container) Enabled() bool { return strings.TrimSpace(c.Image) != "" }
+
+// RuntimeBinary is the configured runtime with the built-in default applied,
+// so callers never have to repeat the fallback.
+func (c Container) RuntimeBinary() string {
+	if r := strings.TrimSpace(c.Runtime); r != "" {
+		return r
+	}
+	return "docker"
+}
+
+// ContainerOverride is the workflow-level form of Container (§8.6 precedence:
+// workflow `defaults:` beats `config.yaml`). Every field is a pointer so a
+// workflow can set one key without restating the block — and, in particular,
+// so `image: ""` in a workflow can mean "run this one on the host" rather than
+// being indistinguishable from an absent key.
+//
+// There is deliberately no third level in this delivery: no task column, no
+// `POST /v1/tasks` field, no CLI flag, no New-task TUI control (task 061
+// decision 6). A per-task override is a follow-up whose trigger is the first
+// person who needs one task run against a different image.
+type ContainerOverride struct {
+	Image            *string  `yaml:"image"`
+	Runtime          *string  `yaml:"runtime"`
+	MountAgentConfig *bool    `yaml:"mount_agent_config"`
+	Network          *bool    `yaml:"network"`
+	ExtraMounts      []string `yaml:"extra_mounts"`
+}
+
+// Merge layers an override onto the configured block. A nil override, or one
+// with every field unset, returns the block unchanged.
+func (c Container) Merge(o *ContainerOverride) Container {
+	if o == nil {
+		return c
+	}
+	if o.Image != nil {
+		c.Image = *o.Image
+	}
+	if o.Runtime != nil {
+		c.Runtime = *o.Runtime
+	}
+	if o.MountAgentConfig != nil {
+		c.MountAgentConfig = *o.MountAgentConfig
+	}
+	if o.Network != nil {
+		c.Network = *o.Network
+	}
+	if o.ExtraMounts != nil {
+		c.ExtraMounts = o.ExtraMounts
+	}
+	return c
+}
+
+// Validate rejects a block that cannot produce a runnable container. It is
+// called from Config.validate and again from workflow validation, so a
+// malformed mount is a load error on whichever side spelled it.
+func (c Container) Validate() error {
+	if strings.ContainsAny(c.Runtime, " \t") {
+		return fmt.Errorf("container.runtime %q must be a single binary name or path", c.Runtime)
+	}
+	for _, m := range c.ExtraMounts {
+		if err := validateMount(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateMount checks one `host:container[:ro]` entry. Both paths must be
+// absolute: a relative source resolves against the daemon's working directory,
+// which is not a thing a workflow author can reason about.
+func validateMount(spec string) error {
+	parts := strings.Split(spec, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return fmt.Errorf("container.extra_mounts %q must be host:container or host:container:ro", spec)
+	}
+	if len(parts) == 3 && parts[2] != "ro" && parts[2] != "rw" {
+		return fmt.Errorf("container.extra_mounts %q: mode must be ro or rw, got %q", spec, parts[2])
+	}
+	if !filepath.IsAbs(parts[0]) {
+		return fmt.Errorf("container.extra_mounts %q: host path must be absolute", spec)
+	}
+	if !strings.HasPrefix(parts[1], "/") {
+		return fmt.Errorf("container.extra_mounts %q: container path must be absolute", spec)
+	}
+	return nil
+}
+
+// ContainerEnvironment reinterprets the §12.3 environment policy for a
+// containerized step (task 061 decision 7). `inherit: all` — the default —
+// becomes `none`, because a macOS or Linux host's PATH, HOME, TMPDIR and SHELL
+// inside a Linux image is a broken container, not an inherited one. An
+// explicit name list is honoured verbatim, and `unset`, `set` and §8.5's
+// VINCENT_* block apply exactly as specified on top of the image's own
+// environment.
+//
+// The alternative it beat: a separate `container.env` block, which is more
+// honest about one key meaning two things but duplicates the whole vocabulary,
+// so every future environment feature would land twice.
+func ContainerEnvironment(e Environment) Environment {
+	if e.Inherit.Mode == InheritAllMode {
+		e.Inherit = Inherit{Mode: InheritNoneMode}
+	}
+	return e
+}

--- a/internal/config/container_test.go
+++ b/internal/config/container_test.go
@@ -52,6 +52,11 @@ func TestContainerValidate(t *testing.T) {
 		{"good mount", Container{ExtraMounts: []string{"/a:/b"}}, false},
 		{"good ro mount", Container{ExtraMounts: []string{"/a:/b:ro"}}, false},
 		{"relative host", Container{ExtraMounts: []string{"a:/b"}}, true},
+		// The verdict is the same on every platform, which is the point: the
+		// only daemon that acts on this key runs Linux containers, so a
+		// windows host path is wrong even on windows, and `/a` is right even
+		// there. Judged with filepath.IsAbs both of these flip on GOOS.
+		{"windows host", Container{ExtraMounts: []string{`C:\src:/src`}}, true},
 		{"relative target", Container{ExtraMounts: []string{"/a:b"}}, true},
 		{"bad mode", Container{ExtraMounts: []string{"/a:/b:rx"}}, true},
 		{"one part", Container{ExtraMounts: []string{"/a"}}, true},

--- a/internal/config/container_test.go
+++ b/internal/config/container_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestContainerDefaultIsTheHost is the regression that matters most: an
+// installation that names no image behaves exactly as it did before task 061.
+func TestContainerDefaultIsTheHost(t *testing.T) {
+	c := Default().Container
+	if c.Enabled() {
+		t.Fatalf("container is enabled by default: %+v", c)
+	}
+	if c.RuntimeBinary() != "docker" {
+		t.Errorf("default runtime = %q, want docker", c.RuntimeBinary())
+	}
+	if !c.MountAgentConfig || !c.Network {
+		t.Errorf("mounts and network should default on, got %+v", c)
+	}
+}
+
+// TestContainerMergeIsPerField pins the §8.6 precedence shape: a workflow that
+// sets one key does not restate the block, and `image: ""` from a workflow is
+// a real value meaning "run this one on the host".
+func TestContainerMergeIsPerField(t *testing.T) {
+	base := Container{Image: "ghcr.io/x:1", Runtime: "docker", MountAgentConfig: true, Network: true}
+	empty := ""
+	off := false
+	if got := base.Merge(nil); !reflect.DeepEqual(got, base) {
+		t.Errorf("Merge(nil) changed the block: %+v", got)
+	}
+	if got := base.Merge(&ContainerOverride{Network: &off}); got.Image != base.Image || got.Network {
+		t.Errorf("Merge network-only = %+v", got)
+	}
+	got := base.Merge(&ContainerOverride{Image: &empty})
+	if got.Enabled() {
+		t.Errorf("a workflow that sets image: \"\" must run on the host, got %+v", got)
+	}
+	if !got.MountAgentConfig {
+		t.Errorf("Merge overwrote an unset field: %+v", got)
+	}
+}
+
+func TestContainerValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		c       Container
+		wantErr bool
+	}{
+		{"empty", Container{}, false},
+		{"good mount", Container{ExtraMounts: []string{"/a:/b"}}, false},
+		{"good ro mount", Container{ExtraMounts: []string{"/a:/b:ro"}}, false},
+		{"relative host", Container{ExtraMounts: []string{"a:/b"}}, true},
+		{"relative target", Container{ExtraMounts: []string{"/a:b"}}, true},
+		{"bad mode", Container{ExtraMounts: []string{"/a:/b:rx"}}, true},
+		{"one part", Container{ExtraMounts: []string{"/a"}}, true},
+		{"runtime with a space", Container{Runtime: "docker --context x"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.c.Validate(); (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestContainerEnvironmentRereadsInheritAll is decision 7. A macOS or Linux
+// host's PATH, HOME, TMPDIR and SHELL inside a Linux image is a broken
+// container, not an inherited one — so the default reads as `none`, while an
+// explicit list is honoured verbatim.
+func TestContainerEnvironmentRereadsInheritAll(t *testing.T) {
+	got := ContainerEnvironment(Environment{Inherit: InheritAll()})
+	if got.Inherit.Mode != InheritNoneMode {
+		t.Errorf("inherit: all should read as none in a container, got %v", got.Inherit.Mode)
+	}
+	list := Environment{
+		Inherit: Inherit{Mode: InheritListMode, Names: []string{"TERM"}},
+		Set:     map[string]string{"CI": "1"},
+		Unset:   []string{"MSYSTEM"},
+	}
+	kept := ContainerEnvironment(list)
+	if kept.Inherit.Mode != InheritListMode || len(kept.Inherit.Names) != 1 {
+		t.Errorf("an explicit list must be honoured verbatim, got %+v", kept.Inherit)
+	}
+	if kept.Set["CI"] != "1" || len(kept.Unset) != 1 {
+		t.Errorf("set/unset must survive the reinterpretation, got %+v", kept)
+	}
+}
+
+// TestContainerEnvironmentTakesNothingFromTheHost is the same decision
+// observed at the only place it can bite: what a step actually gets.
+func TestContainerEnvironmentTakesNothingFromTheHost(t *testing.T) {
+	e := ContainerEnvironment(Environment{Inherit: InheritAll(), Set: map[string]string{"K": "v"}})
+	got := e.Resolve([]string{"PATH=/host/bin", "HOME=/Users/x"})
+	for _, kv := range got {
+		if kv == "PATH=/host/bin" || kv == "HOME=/Users/x" {
+			t.Fatalf("a host variable reached a containerized step: %q", got)
+		}
+	}
+	if len(got) != 1 || got[0] != "K=v" {
+		t.Errorf("resolved = %q, want exactly [K=v]", got)
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -1,0 +1,129 @@
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ScratchDir is the container-private mount a step writes its pid file into
+// (task 061 decision 9). It is deliberately not under either bind mount: the
+// worktree is the user's working tree and a stray `.pid` in a `git status` is
+// noise a workflow author would have to explain.
+const ScratchDir = "/vincent-run"
+
+// LabelTask names the task a container belongs to. Recovery matches on it
+// before removing anything: a container id journaled by a step run is only
+// killed when the container still claims the task that journaled it (§12.4 —
+// what cannot be proved is not killed).
+const LabelTask = "com.vincent.task"
+
+// ErrUnavailable is returned by Available when the runtime binary is missing
+// or cannot talk to a daemon. It is the creation-time gate's error and the
+// `container_unavailable` block's cause.
+var ErrUnavailable = errors.New("container runtime unavailable")
+
+// ErrImageUnavailable is returned by EnsureImage when the image is missing
+// locally and cannot be pulled. It becomes the `container_image_unavailable`
+// admission block — before a worktree, a branch or a retry is spent.
+var ErrImageUnavailable = errors.New("container image unavailable")
+
+// Mount is one bind mount. Source and Target are absolute paths; under task
+// 061 decision 2 they are equal for the repository and the worktree.
+type Mount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
+}
+
+// CreateSpec describes the container a task runs in.
+type CreateSpec struct {
+	Image string
+	Name  string
+	// Labels are applied at creation; LabelTask is always among them.
+	Labels map[string]string
+	Mounts []Mount
+	// Network false drops the container off the network entirely. It is a
+	// contradiction with `mcp.wire_steps: true` and refused at task creation
+	// (decision 1) rather than producing an agent wired to a dead endpoint.
+	Network bool
+	// AddHostGateway maps host.docker.internal to the host, which is how a
+	// containerized agent step reaches the daemon's per-step MCP endpoint
+	// (decision 1).
+	AddHostGateway bool
+	// User is passed as `--user`; empty means the image's own user. It is set
+	// on a Linux host so files land owned by the invoking user (decision 5),
+	// and left empty on macOS where Docker Desktop maps ownership itself.
+	User string
+}
+
+// ExecSpec is one step process to run inside an existing container.
+type ExecSpec struct {
+	// Key names the pid file under ScratchDir. It is the step run's id, so a
+	// parallel group's sub-steps executing into the one container do not
+	// share a file (§7.5).
+	Key string
+	// Argv is the command exactly as it would have run on the host — the
+	// resolved shell and its flags, or an agent CLI and its flags. The
+	// runtime wraps it; it never rewrites it.
+	Argv []string
+	// Env are `K=V` strings layered on top of the image's own environment.
+	// A containerized step's base is the image's, never the daemon's
+	// (decision 7).
+	Env     []string
+	WorkDir string
+	User    string
+}
+
+// Runtime is one container CLI. Implementations shell out; nothing here holds
+// a daemon connection, which is what lets a config reload change the runtime
+// binary between tasks.
+type Runtime interface {
+	// Name is the binary the runtime drives, for logs and `vincent doctor`.
+	Name() string
+	// Available reports whether the runtime can be used at all. It is the
+	// cheap, local half of the creation gate (decision 3).
+	Available(ctx context.Context) error
+	// EnsureImage makes the image present locally, pulling it if needed. It
+	// is the expensive half, and runs at admission.
+	EnsureImage(ctx context.Context, image string) error
+	// Create starts a container that stays up until Remove, and returns its
+	// id.
+	Create(ctx context.Context, spec CreateSpec) (string, error)
+	// Exec returns the **host** argv that runs one step inside the container.
+	// The caller spawns it itself, so the streaming, transcript and §17
+	// parsing paths are the same code they are for a host step — which is
+	// what makes "identical to a host run" testable rather than asserted.
+	Exec(id string, spec ExecSpec) []string
+	// Signal delivers a signal to the process ExecSpec.Key names, from
+	// inside the container. Killing the host-side client would leave that
+	// process running (decision 9).
+	Signal(ctx context.Context, id, key, signal string) error
+	// Remove force-removes the container, which kills every process in it.
+	// Reserved for whole-task teardown and recovery.
+	Remove(ctx context.Context, id string) error
+	// Lookup returns the id of a **running** container by name, or "" when
+	// there is none. It is what makes container creation idempotent across a
+	// daemon restart: the name is derived from the task id, so a task that
+	// comes back finds the container it left.
+	Lookup(ctx context.Context, name string) (string, error)
+	// TaskLabel reads LabelTask off an existing container. A container that
+	// is gone reports "" with no error: recovery treats "already gone" as
+	// success, and "not this task's" as leave-it-alone.
+	TaskLabel(ctx context.Context, id string) (string, error)
+}
+
+// New returns the Runtime for a configured `container.runtime` value. Every
+// supported value today is docker-CLI-compatible, so the name selects the
+// binary rather than an implementation.
+func New(binary string) Runtime {
+	if strings.TrimSpace(binary) == "" {
+		binary = "docker"
+	}
+	return &dockerRuntime{bin: binary}
+}
+
+// Name builds the container name for a task. It is derived rather than stored
+// so a daemon that lost its journal can still find what it left behind.
+func Name(taskID int64) string { return fmt.Sprintf("vincent-task-%d", taskID) }

--- a/internal/container/doc.go
+++ b/internal/container/doc.go
@@ -1,0 +1,31 @@
+// Package container runs a task's step processes inside a container instead of
+// on the daemon's own host (spec §16, §20 — task 061).
+//
+// The shape mirrors internal/agent: one Runtime interface, one implementation
+// per CLI, and a step engine that never learns which one it holds. Today the
+// only implementation shells out to a docker-CLI-compatible binary named by
+// `container.runtime`; only `docker` is verified in CI, and the documentation
+// says so rather than implying podman and nerdctl are tested.
+//
+// Two properties of the design live here rather than in the engine:
+//
+//   - Paths are identical inside and out (task 061 decision 2). The project
+//     repository and the task's worktree are bind-mounted at their own absolute
+//     host paths, so a worktree's `.git` file — which holds an absolute
+//     `gitdir:` into the parent repository — resolves inside the container with
+//     no translation, and §8.4's `.Worktree` and §8.5's `VINCENT_WORKTREE`
+//     render values that are true on both sides. `C:\...` cannot exist in a
+//     Linux container, which is why a Windows daemon refuses a containerized
+//     task at creation rather than translating.
+//
+//   - The container outlives a step (decision 9). Killing the host-side
+//     `docker exec` client leaves the process running inside, so each step
+//     writes its in-container pid to a private scratch mount and a stop is an
+//     exec that signals it. Removal is reserved for whole-task teardown and
+//     §12.4 recovery, so a retry finds what an earlier step installed.
+//
+// The container confines the filesystem outside the two mounts, the shell and
+// the installed tooling. It is not a network boundary — outbound traffic is on
+// by default — and it is not a credential boundary once `mount_agent_config`
+// puts the host's agent configuration inside it. §16 states both.
+package container

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -1,0 +1,178 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// dockerRuntime drives a docker-CLI-compatible binary. Every method shells
+// out; none of them holds state, so `container.runtime` can change under a hot
+// reload and the next task picks it up.
+type dockerRuntime struct{ bin string }
+
+func (d *dockerRuntime) Name() string { return d.bin }
+
+func (d *dockerRuntime) Available(ctx context.Context) error {
+	// `version --format` rather than `info`: it fails the same way when the
+	// daemon is unreachable and costs a fraction of the output.
+	out, err := d.run(ctx, "version", "--format", "{{.Server.APIVersion}}")
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrUnavailable, d.bin, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return fmt.Errorf("%w: %s reported no server version", ErrUnavailable, d.bin)
+	}
+	return nil
+}
+
+func (d *dockerRuntime) EnsureImage(ctx context.Context, image string) error {
+	if _, err := d.run(ctx, "image", "inspect", image); err == nil {
+		return nil
+	}
+	// Inspect-then-pull rather than pull-always: a pull on every admission
+	// turns an offline machine into a broken one for images it already has.
+	if _, err := d.run(ctx, "pull", image); err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrImageUnavailable, image, err)
+	}
+	return nil
+}
+
+func (d *dockerRuntime) Create(ctx context.Context, spec CreateSpec) (string, error) {
+	argv := []string{"run", "--detach", "--name", spec.Name}
+	for _, k := range sortedKeys(spec.Labels) {
+		argv = append(argv, "--label", k+"="+spec.Labels[k])
+	}
+	if !spec.Network {
+		argv = append(argv, "--network", "none")
+	}
+	if spec.AddHostGateway {
+		argv = append(argv, "--add-host=host.docker.internal:host-gateway")
+	}
+	if spec.User != "" {
+		argv = append(argv, "--user", spec.User)
+	}
+	// mode=1777 so a step running as the invoking user can write its pid file
+	// into a scratch mount an image's own user may also touch.
+	argv = append(argv, "--tmpfs", ScratchDir+":rw,mode=1777")
+	for _, m := range spec.Mounts {
+		v := m.Source + ":" + m.Target
+		if m.ReadOnly {
+			v += ":ro"
+		}
+		argv = append(argv, "--volume", v)
+	}
+	// The entrypoint is overridden so the image's own CMD — an agent CLI, a
+	// shell, an init — does not decide whether the container stays up. What
+	// keeps it up is this sleep loop, and nothing else runs until a step
+	// execs in.
+	argv = append(argv, "--entrypoint", "/bin/sh", spec.Image, "-c", "while :; do sleep 3600; done")
+	out, err := d.run(ctx, argv...)
+	if err != nil {
+		return "", fmt.Errorf("%w: create %s: %w", ErrUnavailable, spec.Image, err)
+	}
+	id := strings.TrimSpace(out)
+	if id == "" {
+		return "", fmt.Errorf("%w: create %s returned no id", ErrUnavailable, spec.Image)
+	}
+	return id, nil
+}
+
+func (d *dockerRuntime) Exec(id string, spec ExecSpec) []string {
+	// -i, never -t (decision 10): a TTY merges stdout and stderr and
+	// translates newlines, which corrupts the JSONL an adapter's LineParser
+	// reads and therefore §17's token and cost records.
+	argv := []string{d.bin, "exec", "--interactive"}
+	if spec.WorkDir != "" {
+		argv = append(argv, "--workdir", spec.WorkDir)
+	}
+	if spec.User != "" {
+		argv = append(argv, "--user", spec.User)
+	}
+	for _, e := range spec.Env {
+		argv = append(argv, "--env", e)
+	}
+	argv = append(argv, id, "/bin/sh", "-c", pidFileWrapper(spec.Key), "vincent")
+	return append(argv, spec.Argv...)
+}
+
+// pidFileWrapper writes the in-container pid and then execs the real argv, so
+// the wrapper is not a process of its own by the time the step runs. `"$@"`
+// carries the argv through with no quoting: `sh -c script name args...` passes
+// them as argv, never as text to re-parse.
+func pidFileWrapper(key string) string {
+	return "echo $$ > " + ScratchDir + "/" + key + ".pid; exec \"$@\""
+}
+
+func (d *dockerRuntime) Signal(ctx context.Context, id, key, signal string) error {
+	// The process group first, the process second. A `docker exec` process is
+	// usually its own group leader, in which case the first form reaches a
+	// `run:` body's children too; where it is not, the second still reaches
+	// the body itself, and whole-task Remove is what collects the rest.
+	script := fmt.Sprintf(
+		"p=$(cat %s/%s.pid 2>/dev/null); [ -n \"$p\" ] || exit 0; "+
+			"kill -%s -$p 2>/dev/null || kill -%s $p 2>/dev/null || true",
+		ScratchDir, key, signal, signal)
+	if _, err := d.run(ctx, "exec", id, "/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("signal %s in %s: %w", signal, id, err)
+	}
+	return nil
+}
+
+func (d *dockerRuntime) Remove(ctx context.Context, id string) error {
+	if _, err := d.run(ctx, "rm", "--force", "--volumes", id); err != nil {
+		return fmt.Errorf("remove container %s: %w", id, err)
+	}
+	return nil
+}
+
+func (d *dockerRuntime) Lookup(ctx context.Context, name string) (string, error) {
+	out, err := d.run(ctx, "inspect", "--format", "{{.Id}} {{.State.Running}}", name)
+	if err != nil {
+		// No container by that name. Not an error: "none yet" is the ordinary
+		// answer on a task's first admission.
+		return "", nil
+	}
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) != 2 || fields[1] != "true" {
+		// A stopped container cannot be exec'd into, and reviving one whose
+		// state nothing here explains would hide the failure that stopped it.
+		return "", nil
+	}
+	return fields[0], nil
+}
+
+func (d *dockerRuntime) TaskLabel(ctx context.Context, id string) (string, error) {
+	out, err := d.run(ctx, "inspect", "--format", "{{index .Config.Labels \""+LabelTask+"\"}}", id)
+	if err != nil {
+		// A container that is gone is not an error to recovery: "already
+		// removed" and "removed by me" are the same outcome.
+		return "", nil
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (d *dockerRuntime) run(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, d.bin, args...) //nolint:gosec // the runtime binary the user configured
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%s %s: %w: %s", d.bin, args[0], err, msg)
+	}
+	return string(out), nil
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Sorted so an argv assertion is a table rather than a set comparison.
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -1,0 +1,80 @@
+package container
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestExecArgv pins the host argv a step is spawned with. It is table-driven
+// against literal expectations for the reason adapter parsing is: the argv is
+// the contract with a CLI vincent does not own, and a silent change to it is a
+// change to what every containerized step runs.
+func TestExecArgv(t *testing.T) {
+	rt := New("docker")
+	wrapper := "echo $$ > /vincent-run/step-7.pid; exec \"$@\""
+	cases := []struct {
+		name string
+		spec ExecSpec
+		want []string
+	}{
+		{
+			name: "shell command",
+			spec: ExecSpec{Key: "step-7", Argv: []string{"/bin/sh", "-c", "go test ./..."}, WorkDir: "/repo/wt"},
+			want: []string{
+				"docker", "exec", "--interactive", "--workdir", "/repo/wt",
+				"cid", "/bin/sh", "-c", wrapper, "vincent", "/bin/sh", "-c", "go test ./...",
+			},
+		},
+		{
+			name: "user and env",
+			spec: ExecSpec{
+				Key: "step-7", Argv: []string{"true"},
+				Env: []string{"A=1", "B=2"}, User: "501:20",
+			},
+			want: []string{
+				"docker", "exec", "--interactive", "--user", "501:20",
+				"--env", "A=1", "--env", "B=2",
+				"cid", "/bin/sh", "-c", wrapper, "vincent", "true",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rt.Exec("cid", tc.spec)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Exec argv =\n  %q\nwant\n  %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecNeverAllocatesATTY is decision 10 as an assertion. A TTY merges
+// stdout and stderr and translates newlines, which corrupts the JSONL an
+// adapter's LineParser reads and therefore §17's token and cost records.
+func TestExecNeverAllocatesATTY(t *testing.T) {
+	argv := New("docker").Exec("cid", ExecSpec{Key: "k", Argv: []string{"true"}})
+	for _, a := range argv {
+		if a == "-t" || a == "--tty" {
+			t.Fatalf("Exec allocated a TTY: %q", argv)
+		}
+	}
+}
+
+// TestNameIsDerivedFromTheTaskID is what makes creation idempotent across a
+// daemon restart: a task that comes back finds the container it left.
+func TestNameIsDerivedFromTheTaskID(t *testing.T) {
+	if got := Name(42); got != "vincent-task-42" {
+		t.Errorf("Name(42) = %q, want vincent-task-42", got)
+	}
+}
+
+// TestRuntimeDefaultsToDocker pins the empty-string fallback so a config that
+// names no runtime does not shell out to "".
+func TestRuntimeDefaultsToDocker(t *testing.T) {
+	if got := New("").Name(); got != "docker" {
+		t.Errorf("New(\"\").Name() = %q, want docker", got)
+	}
+	if got := New("podman").Name(); got != "podman" {
+		t.Errorf("New(\"podman\").Name() = %q, want podman", got)
+	}
+}

--- a/internal/container/user_linux.go
+++ b/internal/container/user_linux.go
@@ -1,0 +1,16 @@
+package container
+
+import (
+	"os"
+	"strconv"
+)
+
+// HostUser is the `--user` value every exec and the container itself run as
+// (task 061 decision 5). On Linux that is the invoking user, so files land
+// owned correctly in the mounted worktree and git inside the container sees
+// the same owner as the worktree on disk. An image with a baked non-root user
+// is overridden; an image whose HOME is writable only by its own user needs
+// HOME pointed at a mounted directory, which the example Dockerfiles do.
+func HostUser() string {
+	return strconv.Itoa(os.Getuid()) + ":" + strconv.Itoa(os.Getgid())
+}

--- a/internal/container/user_other.go
+++ b/internal/container/user_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package container
+
+// HostUser is empty everywhere but Linux. macOS Docker Desktop maps ownership
+// itself through its file-sharing layer, so forcing a uid there would break
+// images with a baked user for no gain (task 061 decision 5). Windows never
+// reaches here: a containerized task is refused at creation on a Windows
+// daemon (decision 2).
+func HostUser() string { return "" }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lezli01/vincent/internal/agent/cursor"
 	"github.com/lezli01/vincent/internal/api"
 	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/events"
 	"github.com/lezli01/vincent/internal/github"
 	"github.com/lezli01/vincent/internal/gitx"
@@ -274,7 +275,12 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	// the recoverable state a later start can retry — and starting the
 	// scheduler over rows it could not reconcile is how a second attempt
 	// gets admitted against a first one the database still calls `running`.
-	if n, err := taskrun.Recover(ctx, st, logger); err != nil {
+	if n, err := taskrun.Recover(ctx, st, logger,
+		// Recovery reaches the containers a previous daemon left running
+		// (§12.4, task 061 decision 4): removing one kills every process
+		// inside it, which is the identity a host PID cannot supply.
+		taskrun.WithContainers(container.New, cfg.Container.RuntimeBinary()),
+	); err != nil {
 		logger.Error("startup failed: crash recovery", "error", err)
 		return fmt.Errorf("crash recovery: %w", err)
 	} else if n > 0 {

--- a/internal/doctor/container.go
+++ b/internal/doctor/container.go
@@ -1,0 +1,55 @@
+package doctor
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
+)
+
+// Container is the §14 row for container execution (§16, task 061). It sits
+// in the adapters' half of the report and follows their rule exactly: it
+// **reports and does not change the exit code**. The Problems set is closed
+// (task 041 decision 4), and a machine with no docker is a healthy machine —
+// containerization is off by default and every step runs on the host.
+type Container struct {
+	// Enabled is whether `container.image` names an image at all. False is
+	// the default and means every step runs on the host.
+	Enabled bool `json:"enabled"`
+	// Image is the configured image, empty when containerization is off.
+	Image string `json:"image,omitempty"`
+	// Runtime is the configured binary, with the `docker` default applied.
+	Runtime string `json:"runtime"`
+	// Available is whether that binary answered. It is probed whether or not
+	// containerization is enabled: "would this work if I turned it on" is the
+	// question a user runs `vincent doctor` to answer.
+	Available bool `json:"available"`
+	// Supported is false on a Windows daemon, where a containerized task is
+	// refused at creation (decision 2) — paths are identical inside and out,
+	// and a Windows path cannot exist in a Linux container.
+	Supported bool `json:"supported"`
+	// Message explains a false Available or Supported, empty otherwise.
+	Message string `json:"message,omitempty"`
+}
+
+// DetectContainer probes the configured runtime.
+func DetectContainer(ctx context.Context, cfg config.Config) Container {
+	c := cfg.Container
+	row := Container{
+		Enabled:   c.Enabled(),
+		Image:     c.Image,
+		Runtime:   c.RuntimeBinary(),
+		Supported: runtime.GOOS != "windows",
+	}
+	if !row.Supported {
+		row.Message = "containerized tasks are not supported on a windows daemon"
+		return row
+	}
+	if err := container.New(c.RuntimeBinary()).Available(ctx); err != nil {
+		row.Message = err.Error()
+		return row
+	}
+	row.Available = true
+	return row
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -62,6 +62,11 @@ type Report struct {
 	// creation without an issue is unaffected by every "no" it can report, so
 	// nothing here makes `vincent doctor` exit 1.
 	GitHub GitHub `json:"github"`
+	// Container is the container-execution row (§16, task 061). Like GitHub
+	// it is a **row, not a problem**: containerization is off by default, and
+	// a machine with no runtime runs every step on the host exactly as it
+	// always has.
+	Container Container `json:"container"`
 	// Update is the release check (task 055): what the daemon last learned
 	// from the release feed, and whether the running daemon is older than the
 	// binary on disk after a swap.
@@ -397,6 +402,7 @@ func Compose(ctx context.Context, opts Options) *Report {
 		r.Agents = DetectAgents(ctx, cfg)
 	}
 	r.GitHub = DetectGitHub(ctx, cfg)
+	r.Container = DetectContainer(ctx, cfg)
 	r.Update = updateRow(cfg, opts.Update, r.Daemon.Version)
 	r.Storage = inspectStorage(ctx, opts)
 	r.Evaluate()

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 20
+const latestSchemaVersion = 21
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0021_container.sql
+++ b/internal/store/migrations/0021_container.sql
@@ -1,0 +1,24 @@
+-- 0021_container: the container a step run's process lived in (§16, §20 —
+-- task 061).
+--
+-- §12.4's PID-reuse guard journals a platform-native process identity and
+-- kills a verified orphan by PID. A process inside a container is not the host
+-- PID the row journals, so a containerized run journals the container id
+-- instead: recovery reads it, confirms the container still carries the
+-- `com.vincent.task` label naming this task, and removes the container — which
+-- kills every process inside it. One identity, no second exec path.
+--
+-- A container id is never reused, so the reuse question the `proc_identity`
+-- column exists to answer does not arise here; the label check is against a
+-- container belonging to a *different* task, which is the same "what cannot be
+-- proved is not killed" rule from a different direction.
+--
+-- NULL is the ordinary value and means the step ran on the host — every row
+-- written before this migration, and every row of an installation that never
+-- sets `container.image`. `pid`, `proc_started_at` and `proc_identity` are
+-- unchanged and still journaled for a containerized run: they name the
+-- host-side `docker exec` client, which is a real process the daemon spawned.
+--
+-- Cleared alongside `pid` when a row is terminalized, for the same reason: a
+-- closed row must keep no pointer at something it no longer owns.
+ALTER TABLE step_runs ADD COLUMN container_id TEXT; -- NULL = the step ran on the host

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -269,7 +269,16 @@ type StepRun struct {
 	// means none was journaled — a pre-0013 row, or a spawn whose identity
 	// read failed — and recovery then falls back to the ProcStartedAt
 	// tolerance.
-	ProcIdentity  *string
+	ProcIdentity *string
+	// ContainerID is the container the step's process ran inside (§16,
+	// migration 0021). nil means the host, which is every row of an
+	// installation that never sets `container.image`.
+	//
+	// It is the recovery identity for a containerized run: the host PID a row
+	// journals names the `docker exec` client, not the process inside, so
+	// §12.4 removes the container instead of killing a PID — after confirming
+	// the container still carries the label naming this task.
+	ContainerID   *string
 	ExitCode      *int
 	CheckExitCode *int
 	FailureReason string

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -11,7 +11,8 @@ import (
 
 const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
 	state, agent, model, effort, pid,
-	proc_started_at, proc_identity, exit_code, check_exit_code, failure_reason, skip_reason, result_summary,
+	proc_started_at, proc_identity, container_id, exit_code, check_exit_code, failure_reason, skip_reason,
+	result_summary,
 	status_message,
 	prompt_override, run_override, transcript_path,
 	input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at`
@@ -34,7 +35,8 @@ func terminalizeOpenStepRuns(
 	ctx context.Context, db execer, taskID int64, state StepRunState, reason string,
 ) (int64, error) {
 	res, err := db.ExecContext(ctx, `
-		UPDATE step_runs SET state = ?, failure_reason = ?, pid = NULL, proc_identity = NULL, finished_at = ?
+		UPDATE step_runs SET state = ?, failure_reason = ?, pid = NULL, proc_identity = NULL,
+			container_id = NULL, finished_at = ?
 		WHERE task_id = ? AND state = ?`,
 		string(state), nullString(reason), formatTime(time.Now()), taskID, string(StepRunning))
 	if err != nil {
@@ -95,14 +97,15 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 	res, err := db.ExecContext(ctx, `
 		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
 			state, agent, model, effort, pid,
-			proc_started_at, proc_identity, exit_code, check_exit_code, failure_reason, skip_reason,
+			proc_started_at, proc_identity, container_id, exit_code, check_exit_code, failure_reason,
+			skip_reason,
 			result_summary, status_message, prompt_override, run_override, transcript_path,
 			input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, r.Iteration, nullString(r.LoopItem),
 		string(r.State),
 		nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
-		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity, r.ExitCode, r.CheckExitCode,
+		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity, r.ContainerID, r.ExitCode, r.CheckExitCode,
 		nullString(r.FailureReason), nullString(r.SkipReason), nullString(r.ResultSummary),
 		nullString(r.StatusMessage),
 		nullString(r.PromptOverride), nullString(r.RunOverride), nullString(r.TranscriptPath),
@@ -131,13 +134,13 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 func (s *Store) UpdateStepRun(ctx context.Context, r *StepRun) error {
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE step_runs SET state = ?, agent = ?, model = ?, effort = ?, pid = ?, proc_started_at = ?,
-			proc_identity = ?,
+			proc_identity = ?, container_id = ?,
 			exit_code = ?, check_exit_code = ?, failure_reason = ?, skip_reason = ?, result_summary = ?,
 			prompt_override = ?, run_override = ?, transcript_path = ?,
 			input_tokens = ?, output_tokens = ?, cost_usd = ?, input_wait_ms = ?, finished_at = ?
 		WHERE id = ?`,
 		string(r.State), nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
-		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity,
+		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity, r.ContainerID,
 		r.ExitCode, r.CheckExitCode, nullString(r.FailureReason), nullString(r.SkipReason),
 		nullString(r.ResultSummary),
 		nullString(r.PromptOverride), nullString(r.RunOverride), nullString(r.TranscriptPath),
@@ -341,11 +344,12 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		pid, exitCode, checkExit, inTok, outTok sql.NullInt64
 		cost                                    sql.NullFloat64
 		procStarted, procIdentity, finished     sql.NullString
+		containerID                             sql.NullString
 		started                                 string
 	)
 	if err := row.Scan(&r.ID, &r.TaskID, &r.StepIndex, &r.StepID, &r.StepType, &r.Attempt,
 		&r.Iteration, &loopItem,
-		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &procIdentity,
+		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &procIdentity, &containerID,
 		&exitCode, &checkExit,
 		&failure, &skip, &summary, &status, &promptOv, &runOv, &transcript,
 		&inTok, &outTok, &cost, &r.InputWaitMS, &started, &finished); err != nil {
@@ -369,6 +373,10 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 	if procIdentity.Valid {
 		v := procIdentity.String
 		r.ProcIdentity = &v
+	}
+	if containerID.Valid {
+		v := containerID.String
+		r.ContainerID = &v
 	}
 	if exitCode.Valid {
 		v := int(exitCode.Int64)

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -386,6 +386,11 @@ func (r *Runner) Archive(
 	if err != nil {
 		return nil, worktree.BranchOutcome{}, err
 	}
+	// The container is removed before the worktree, because it holds that
+	// worktree as a bind mount and a live mount is a reason a removal fails
+	// (§16, task 061). It is best-effort: a container that will not die must
+	// not be able to stop a task from being archived.
+	r.removeTaskContainer(ctx, task, r.deps.Logger)
 	// Remove-then-clear runs under the manager's claim lock, the mirror of
 	// creation's create-then-claim (task 005). Between the two the row still
 	// names a directory that is already gone, and a gc scan landing there

--- a/internal/taskrun/container.go
+++ b/internal/taskrun/container.go
@@ -190,11 +190,28 @@ func splitMount(spec string) []string {
 // able to stop a task from being archived, and `docker rm -f` on a container
 // that is already gone is the ordinary case after a crash.
 func (r *Runner) removeTaskContainer(ctx context.Context, task *store.Task, log *slog.Logger) {
-	c := r.deps.Config().Container
-	// The workflow's own override may have named a different runtime binary;
-	// the snapshot is the only place that survives here, and reading it for
-	// one string is not worth a parse. Runtime binaries are docker-compatible
-	// by definition, so the configured one can address any of them.
+	// The task's own settings, resolved from its snapshot exactly the way
+	// ensureContainer resolved them when it created the container: created iff
+	// enabled, removed iff enabled, one rule read from one place. The
+	// snapshot is also where a workflow's own `defaults.container.runtime`
+	// survives, so parsing it answers both questions at once.
+	//
+	// The `Enabled` guard is not an optimization. Consulting the runtime
+	// unconditionally spawns `docker` on every archive of every task on any
+	// host that has docker installed — including installations that never set
+	// `container.image`, whose behaviour `image: ""` promises is byte-for-byte
+	// what it was before task 061.
+	wf, _, err := workflow.Parse([]byte(task.WorkflowSnapshot), workflow.Options{})
+	if err != nil {
+		// An unparseable snapshot is not a reason to leak a container: fall
+		// back to the daemon's own block, which is what a task with no
+		// workflow override would have resolved to anyway.
+		wf = nil
+	}
+	c := r.containerSettings(wf)
+	if !c.Enabled() {
+		return
+	}
 	rt := r.runtimeFor(c)
 	name := container.Name(task.ID)
 	id, err := rt.Lookup(ctx, name)

--- a/internal/taskrun/container.go
+++ b/internal/taskrun/container.go
@@ -1,0 +1,328 @@
+package taskrun
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/workflow"
+)
+
+// ReasonContainerImageUnavailable blocks a task whose configured image is
+// missing and cannot be pulled (§16, task 061 decision 3). It is an admission
+// block rather than a creation refusal because verifying an image means a
+// registry pull: doing that inside `POST /v1/tasks` runs a multi-gigabyte
+// download against §13.1's request timeouts, and inspecting local-only would
+// 400 every first run on a fresh machine. Blocking here still spends no
+// worktree, no branch and no retry — which is what the acceptance criterion
+// was protecting.
+const ReasonContainerImageUnavailable = "container_image_unavailable"
+
+// ReasonContainerUnavailable blocks a task whose runtime is gone or cannot
+// create a container. Task creation already refuses a missing runtime, so this
+// is the §12.4-shaped backstop for a task whose daemon changed underneath it —
+// docker uninstalled, the desktop app quit, the socket revoked.
+//
+// A containerized step is never quietly run on the host instead: a step that
+// is not contained after asking to be contained inverts the choice it made,
+// which is §9.4's reasoning verbatim.
+const ReasonContainerUnavailable = "container_unavailable"
+
+// containerSettings resolves the §8.6 precedence chain for containerization:
+// the workflow's `defaults.container:` over the daemon's `container:` block.
+// There is no task level in this delivery (decision 6).
+//
+// It is read per admission rather than cached, so a hot reload reaches the
+// next task admitted — the same rule ensureWorktree applies to
+// `fetch_base_branch`.
+func (r *Runner) containerSettings(wf *workflow.Workflow) config.Container {
+	c := r.deps.Config().Container
+	if wf != nil {
+		c = c.Merge(wf.Defaults.Container)
+	}
+	return c
+}
+
+// runtimeFor returns the Runtime for a resolved settings block, through the
+// injectable factory so tests never need docker.
+func (r *Runner) runtimeFor(c config.Container) container.Runtime {
+	if r.deps.Containers != nil {
+		return r.deps.Containers(c.RuntimeBinary())
+	}
+	return container.New(c.RuntimeBinary())
+}
+
+// taskContainer is what a step needs to run inside one: the handle to exec
+// into and the settings that produced it. A zero value means "run on the
+// host", which is every task of an installation that never sets
+// `container.image`.
+type taskContainer struct {
+	id       string
+	settings config.Container
+	rt       container.Runtime
+}
+
+func (t taskContainer) active() bool { return t.id != "" }
+
+// ensureContainer creates the task's container on first admission and finds it
+// again on every later one (§16, task 061). It runs after ensureWorktree
+// because the worktree is one of the two bind mounts.
+//
+// A failure blocks the task, never falls back to the host.
+func (r *Runner) ensureContainer(
+	ctx context.Context, task *store.Task, project *store.Project, wf *workflow.Workflow, log *slog.Logger,
+) (taskContainer, error) {
+	c := r.containerSettings(wf)
+	if !c.Enabled() {
+		return taskContainer{}, nil
+	}
+	rt := r.runtimeFor(c)
+	name := container.Name(task.ID)
+	if id, err := rt.Lookup(ctx, name); err == nil && id != "" {
+		// The container this task left behind on an earlier admission. Reusing
+		// it is the point of decision 9: a retry finds what an earlier step
+		// installed.
+		return taskContainer{id: id, settings: c, rt: rt}, nil
+	}
+	if err := rt.Available(ctx); err != nil {
+		r.fail(task, ReasonContainerUnavailable, log, "container runtime", err)
+		return taskContainer{}, err
+	}
+	if err := rt.EnsureImage(ctx, c.Image); err != nil {
+		if ctx.Err() != nil {
+			r.interrupt(task, log)
+			return taskContainer{}, err
+		}
+		reason := ReasonContainerImageUnavailable
+		if !errors.Is(err, container.ErrImageUnavailable) {
+			reason = ReasonContainerUnavailable
+		}
+		r.fail(task, reason, log, "container image", err)
+		return taskContainer{}, err
+	}
+	id, err := rt.Create(ctx, container.CreateSpec{
+		Image:  c.Image,
+		Name:   name,
+		Labels: map[string]string{container.LabelTask: strconv.FormatInt(task.ID, 10)},
+		Mounts: containerMounts(project.Path, task.WorktreePath, c),
+		// The gateway host is mapped whenever the container has a network at
+		// all: it costs nothing when unused and is what a containerized agent
+		// step needs to reach the daemon's per-step MCP endpoint (decision 1).
+		Network:        c.Network,
+		AddHostGateway: c.Network,
+		User:           container.HostUser(),
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			r.interrupt(task, log)
+			return taskContainer{}, err
+		}
+		r.fail(task, ReasonContainerUnavailable, log, "create container", err)
+		return taskContainer{}, err
+	}
+	log.Info("container created", "task", task.ID, "image", c.Image,
+		"runtime", rt.Name(), "container", name)
+	return taskContainer{id: id, settings: c, rt: rt}, nil
+}
+
+// containerMounts is decision 2's mount set: the project repository and the
+// task's worktree, each at its own absolute host path.
+//
+// Mounting both at their own paths is what makes the repository resolve with
+// zero translation code: a worktree's `.git` is a file holding an absolute
+// `gitdir:` into `{project}/.git/worktrees/{id}`, and that directory's own
+// `gitdir` file points back at the worktree. Mount either alone and the pair
+// is broken; mount both anywhere else and both pointers are wrong.
+func containerMounts(projectPath, worktreePath string, c config.Container) []container.Mount {
+	mounts := []container.Mount{{Source: projectPath, Target: projectPath}}
+	if worktreePath != "" && worktreePath != projectPath {
+		mounts = append(mounts, container.Mount{Source: worktreePath, Target: worktreePath})
+	}
+	mounts = append(mounts, agentConfigMounts(c)...)
+	for _, spec := range c.ExtraMounts {
+		if m, ok := parseMount(spec); ok {
+			mounts = append(mounts, m)
+		}
+	}
+	return mounts
+}
+
+// parseMount splits a validated `host:container[:ro]` entry. Validation
+// already refused a malformed one at load, so an unparseable entry here is
+// dropped rather than failing an admission over a config the daemon accepted.
+func parseMount(spec string) (container.Mount, bool) {
+	parts := splitMount(spec)
+	if len(parts) < 2 {
+		return container.Mount{}, false
+	}
+	m := container.Mount{Source: parts[0], Target: parts[1]}
+	if len(parts) == 3 && parts[2] == "ro" {
+		m.ReadOnly = true
+	}
+	return m, true
+}
+
+func splitMount(spec string) []string {
+	var out []string
+	start := 0
+	for i := range len(spec) {
+		if spec[i] == ':' {
+			out = append(out, spec[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, spec[start:])
+}
+
+// removeTaskContainer tears a task's container down. It is called where the
+// worktree is removed, because the container holds that worktree as a bind
+// mount and a live mount is a reason a removal fails.
+//
+// Errors are logged, never returned: a container that will not die must not be
+// able to stop a task from being archived, and `docker rm -f` on a container
+// that is already gone is the ordinary case after a crash.
+func (r *Runner) removeTaskContainer(ctx context.Context, task *store.Task, log *slog.Logger) {
+	c := r.deps.Config().Container
+	// The workflow's own override may have named a different runtime binary;
+	// the snapshot is the only place that survives here, and reading it for
+	// one string is not worth a parse. Runtime binaries are docker-compatible
+	// by definition, so the configured one can address any of them.
+	rt := r.runtimeFor(c)
+	name := container.Name(task.ID)
+	id, err := rt.Lookup(ctx, name)
+	if err != nil || id == "" {
+		return
+	}
+	if err := rt.Remove(ctx, id); err != nil {
+		log.Warn("remove container", "task", task.ID, "container", name, "error", err)
+		return
+	}
+	log.Info("container removed", "task", task.ID, "container", name)
+}
+
+// containerEnv is a containerized step's environment (decision 7): the §12.3
+// policy with `inherit: all` read as `none`, layered on the image's own
+// environment rather than the daemon's.
+//
+// The reinterpretation is logged once per task by the caller, not here: a
+// macOS or Linux host's PATH, HOME, TMPDIR and SHELL inside a Linux image is a
+// broken container, not an inherited one, and a user who wrote nothing should
+// still learn that the default read differently.
+func (r *Runner) containerEnv() []string {
+	return config.ContainerEnvironment(r.deps.Config().Environment).Resolve(nil)
+}
+
+// containerGraceTimeout is how long a stopped step gets between TERM and KILL
+// inside the container. It is §12.4's own 15 s, applied at the only place that
+// can deliver a signal to a process the host cannot see.
+const containerGraceTimeout = 15 * time.Second
+
+// stopInContainer implements decision 9's kill: TERM the step's process from
+// inside the container, wait, then KILL. The task's container **survives** —
+// `rm -f` is reserved for whole-task teardown and recovery, so a retry finds
+// what an earlier step installed rather than starting from the image again.
+func stopInContainer(tc taskContainer, key string, log *slog.Logger) {
+	// A context of its own: the run context is already canceled by the time
+	// this runs — that cancellation is what called it — and a signal that
+	// inherits it would be dead on arrival.
+	ctx, cancel := context.WithTimeout(context.Background(), containerGraceTimeout*2)
+	defer cancel()
+	if err := tc.rt.Signal(ctx, tc.id, key, "TERM"); err != nil {
+		log.Warn("signal step in container", "container", tc.id, "signal", "TERM", "error", err)
+	}
+	select {
+	case <-time.After(containerGraceTimeout):
+	case <-ctx.Done():
+		return
+	}
+	if err := tc.rt.Signal(ctx, tc.id, key, "KILL"); err != nil {
+		log.Warn("signal step in container", "container", tc.id, "signal", "KILL", "error", err)
+	}
+}
+
+// execKey names a step run's pid file inside the scratch mount. It is the run
+// id, so a parallel group's sub-steps exec'ing into the one container do not
+// share a file (§7.5).
+func execKey(runID int64) string { return "step-" + strconv.FormatInt(runID, 10) }
+
+// envNoticeOnce keeps decision 7's reinterpretation to one line per daemon.
+var envNoticeOnce sync.Once
+
+// LogContainerEnvironmentOnce reports decision 7's reinterpretation the first
+// time a containerized step runs in this daemon. Once per process rather than
+// once per task: the message is about the policy, not about the task, and one
+// line per task on a busy board is noise.
+func LogContainerEnvironmentOnce(log *slog.Logger, e config.Environment) {
+	if e.Inherit.Mode != config.InheritAllMode {
+		return
+	}
+	envNoticeOnce.Do(func() {
+		log.Info("containerized steps read environment.inherit: all as none; " +
+			"the base environment is the image's, not the daemon's (§12.3)")
+	})
+}
+
+// agentConfigMounts are the host's agent configuration directories, mounted at
+// their own paths so subscription-based auth survives into the container
+// (`mount_agent_config`). Nothing less works: the CLIs that authenticate by
+// subscription take no key from the environment, and cursor persists `--model`
+// to its own config (§9.7).
+//
+// A directory that does not exist is skipped rather than created: an empty
+// mount would make a CLI believe it had been configured and never logged in.
+func agentConfigMounts(c config.Container) []container.Mount {
+	if !c.MountAgentConfig {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	var out []container.Mount
+	for _, dir := range []string{".claude", ".codex", ".cursor"} {
+		p := filepath.Join(home, dir)
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		out = append(out, container.Mount{Source: p, Target: p})
+	}
+	return out
+}
+
+// setTaskContainer records the container an admission is running in and
+// returns the release that forgets it. It lives on the Runner rather than on
+// stepEnv because every step of a task shares one container (decision 1) and
+// stepEnv is constructed at a dozen call sites — threading a value every one
+// of them would have to pass through unchanged is how a case gets missed.
+func (r *Runner) setTaskContainer(taskID int64, tc taskContainer) func() {
+	if !tc.active() {
+		return func() {}
+	}
+	r.mu.Lock()
+	if r.containers == nil {
+		r.containers = make(map[int64]taskContainer)
+	}
+	r.containers[taskID] = tc
+	r.mu.Unlock()
+	return func() {
+		r.mu.Lock()
+		delete(r.containers, taskID)
+		r.mu.Unlock()
+	}
+}
+
+// taskContainerOf returns the container this task's steps run in, or a zero
+// value meaning the host.
+func (r *Runner) taskContainerOf(taskID int64) taskContainer {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.containers[taskID]
+}

--- a/internal/taskrun/container_test.go
+++ b/internal/taskrun/container_test.go
@@ -1,0 +1,206 @@
+package taskrun
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// fakeRuntime stands in for docker. No `go test` in this repository may need a
+// container daemon (the testing conventions), so the seam is faked here and
+// the real argv construction is pinned in internal/container's own table test.
+type fakeRuntime struct {
+	mu      sync.Mutex
+	labels  map[string]string
+	removed []string
+	signals []string
+}
+
+func newFakeRuntime() *fakeRuntime { return &fakeRuntime{labels: map[string]string{}} }
+
+func (f *fakeRuntime) Name() string                              { return "fake" }
+func (f *fakeRuntime) Available(context.Context) error           { return nil }
+func (f *fakeRuntime) EnsureImage(context.Context, string) error { return nil }
+
+func (f *fakeRuntime) Create(_ context.Context, spec container.CreateSpec) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.labels[spec.Name] = spec.Labels[container.LabelTask]
+	return spec.Name, nil
+}
+
+func (f *fakeRuntime) Exec(id string, spec container.ExecSpec) []string {
+	return append([]string{"fake", "exec", id}, spec.Argv...)
+}
+
+func (f *fakeRuntime) Signal(_ context.Context, id, key, signal string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.signals = append(f.signals, id+"/"+key+"/"+signal)
+	return nil
+}
+
+func (f *fakeRuntime) Remove(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removed = append(f.removed, id)
+	delete(f.labels, id)
+	return nil
+}
+
+func (f *fakeRuntime) Lookup(_ context.Context, name string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.labels[name]; !ok {
+		return "", nil
+	}
+	return name, nil
+}
+
+func (f *fakeRuntime) TaskLabel(_ context.Context, id string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.labels[id], nil
+}
+
+func (f *fakeRuntime) removals() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.removed...)
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// TestRecoveryRemovesTheTasksOwnContainer is decision 4's good case: a
+// `running` step run carrying a container id whose container still claims the
+// task is removed, which kills every process inside it.
+func TestRecoveryRemovesTheTasksOwnContainer(t *testing.T) {
+	st, projectID := recoverStore(t)
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	rt := newFakeRuntime()
+	name := container.Name(task.ID)
+	if _, err := rt.Create(context.Background(), container.CreateSpec{
+		Name:   name,
+		Labels: map[string]string{container.LabelTask: strconv.FormatInt(task.ID, 10)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	run := journalRun(t, st, task.ID, nil, nil)
+	run.ContainerID = &name
+	if err := st.UpdateStepRun(context.Background(), run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+
+	if _, err := Recover(context.Background(), st, discardLogger(),
+		WithContainers(func(string) container.Runtime { return rt }, "fake")); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if got := rt.removals(); len(got) != 1 || got[0] != name {
+		t.Errorf("removed = %v, want [%s]", got, name)
+	}
+}
+
+// TestRecoveryLeavesAnotherTasksContainerAlone is §12.4's rule from the
+// container side: what cannot be proved is not killed. A row naming a
+// container whose label is a different task belongs to somebody else.
+func TestRecoveryLeavesAnotherTasksContainerAlone(t *testing.T) {
+	st, projectID := recoverStore(t)
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	rt := newFakeRuntime()
+	name := container.Name(task.ID)
+	if _, err := rt.Create(context.Background(), container.CreateSpec{
+		Name:   name,
+		Labels: map[string]string{container.LabelTask: strconv.FormatInt(task.ID+999, 10)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	run := journalRun(t, st, task.ID, nil, nil)
+	run.ContainerID = &name
+	if err := st.UpdateStepRun(context.Background(), run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+
+	if _, err := Recover(context.Background(), st, discardLogger(),
+		WithContainers(func(string) container.Runtime { return rt }, "fake")); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if got := rt.removals(); len(got) != 0 {
+		t.Errorf("removed somebody else's container: %v", got)
+	}
+}
+
+// TestRecoveryWithoutAContainerIDTouchesNothing is the regression that matters
+// most, at the recovery end: an installation that never set an image behaves
+// exactly as it did before task 061.
+func TestRecoveryWithoutAContainerIDTouchesNothing(t *testing.T) {
+	st, projectID := recoverStore(t)
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	rt := newFakeRuntime()
+	journalRun(t, st, task.ID, nil, nil)
+
+	if _, err := Recover(context.Background(), st, discardLogger(),
+		WithContainers(func(string) container.Runtime { return rt }, "fake")); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if got := rt.removals(); len(got) != 0 {
+		t.Errorf("a host step run reached the runtime: %v", got)
+	}
+}
+
+// TestContainerIDSurvivesARoundTrip pins migration 0021's column: nil is the
+// ordinary value and means the host, and a journaled id comes back verbatim.
+func TestContainerIDSurvivesARoundTrip(t *testing.T) {
+	st, projectID := recoverStore(t)
+	task := recoverTask(t, st, projectID, store.TaskRunning)
+	run := journalRun(t, st, task.ID, nil, nil)
+	if got, err := st.GetStepRun(context.Background(), run.ID); err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	} else if got.ContainerID != nil {
+		t.Errorf("a host step run journaled a container id: %v", *got.ContainerID)
+	}
+	id := "deadbeef"
+	run.ContainerID = &id
+	if err := st.UpdateStepRun(context.Background(), run); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	got, err := st.GetStepRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.ContainerID == nil || *got.ContainerID != id {
+		t.Errorf("ContainerID = %v, want %q", got.ContainerID, id)
+	}
+}
+
+// TestContainerMountsAreIdenticalInsideAndOut is decision 2. A worktree's
+// `.git` is a file holding an absolute gitdir into the parent repository, so
+// both paths have to be mounted, and both at their own path — mount either
+// alone, or either elsewhere, and the repository does not resolve.
+func TestContainerMountsAreIdenticalInsideAndOut(t *testing.T) {
+	mounts := containerMounts("/repos/app", "/data/worktrees/7", config.Container{MountAgentConfig: false})
+	want := map[string]bool{"/repos/app": true, "/data/worktrees/7": true}
+	for _, m := range mounts {
+		if m.Source != m.Target {
+			t.Errorf("mount %q is not at its own path inside (%q)", m.Source, m.Target)
+		}
+		delete(want, m.Source)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing mounts: %v", want)
+	}
+}
+
+// TestExecKeyIsPerRun is what keeps a parallel group's sub-steps from sharing
+// one pid file while exec'ing into the one container (§7.5).
+func TestExecKeyIsPerRun(t *testing.T) {
+	if execKey(1) == execKey(2) {
+		t.Fatal("two step runs share a pid file")
+	}
+}

--- a/internal/taskrun/container_test.go
+++ b/internal/taskrun/container_test.go
@@ -21,6 +21,11 @@ type fakeRuntime struct {
 	labels  map[string]string
 	removed []string
 	signals []string
+	// consulted counts every call that would have shelled out to docker. It
+	// is what proves the negative: an uncontainerized task must not reach the
+	// runtime at all, and "removed nothing" alone would also be true of a
+	// task that spawned `docker inspect` and found nothing.
+	consulted int
 }
 
 func newFakeRuntime() *fakeRuntime { return &fakeRuntime{labels: map[string]string{}} }
@@ -58,6 +63,7 @@ func (f *fakeRuntime) Remove(_ context.Context, id string) error {
 func (f *fakeRuntime) Lookup(_ context.Context, name string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.consulted++
 	if _, ok := f.labels[name]; !ok {
 		return "", nil
 	}
@@ -74,6 +80,12 @@ func (f *fakeRuntime) removals() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.removed...)
+}
+
+func (f *fakeRuntime) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consulted
 }
 
 func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
@@ -202,5 +214,91 @@ func TestContainerMountsAreIdenticalInsideAndOut(t *testing.T) {
 func TestExecKeyIsPerRun(t *testing.T) {
 	if execKey(1) == execKey(2) {
 		t.Fatal("two step runs share a pid file")
+	}
+}
+
+// hostSnapshot and imageSnapshot are the two workflow snapshots archiving has
+// to tell apart. They carry a real step because Parse refuses an empty
+// `steps:` — a snapshot that does not parse is a snapshot the fallback path
+// handles, not this one.
+const (
+	hostSnapshot = "name: adhoc\nsteps:\n  - id: s\n    type: command\n    run: exit 0\n"
+
+	imageSnapshot = "name: adhoc\ndefaults:\n  container:\n    image: alpine:3\n" +
+		"steps:\n  - id: s\n    type: command\n    run: exit 0\n"
+)
+
+// containerRunner is the smallest Runner removeTaskContainer needs: the
+// resolved config and the runtime factory, no store and no worktree manager.
+func containerRunner(image string, rt container.Runtime) *Runner {
+	cfg := config.Default()
+	cfg.Container.Image = image
+	return &Runner{deps: Deps{
+		Config:     func() config.Config { return cfg },
+		Containers: func(string) container.Runtime { return rt },
+		Logger:     discardLogger(),
+	}}
+}
+
+// TestArchiveWithoutAnImageNeverConsultsTheRuntime is the archive end of the
+// `image: ""` promise, and the regression that produced it: removeTaskContainer
+// used to look the container up unconditionally, so every archive of every
+// task on any host with docker installed spawned `docker inspect`. That is not
+// merely wasted work — on the Windows CI leg it took the archive past the API
+// client's 10 s deadline and reddened a build that had nothing to do with
+// containers.
+func TestArchiveWithoutAnImageNeverConsultsTheRuntime(t *testing.T) {
+	rt := newFakeRuntime()
+	r := containerRunner("", rt)
+	task := &store.Task{ID: 7, WorkflowSnapshot: hostSnapshot}
+
+	r.removeTaskContainer(context.Background(), task, discardLogger())
+
+	if got := rt.calls(); got != 0 {
+		t.Errorf("an uncontainerized archive reached the runtime %d time(s)", got)
+	}
+}
+
+// TestArchiveRemovesAContainerizedTasksContainer is the other half: the guard
+// must not have turned the removal off for the tasks that do have one.
+func TestArchiveRemovesAContainerizedTasksContainer(t *testing.T) {
+	rt := newFakeRuntime()
+	r := containerRunner("alpine:3", rt)
+	task := &store.Task{ID: 7, WorkflowSnapshot: hostSnapshot}
+	name := container.Name(task.ID)
+	if _, err := rt.Create(context.Background(), container.CreateSpec{
+		Name:   name,
+		Labels: map[string]string{container.LabelTask: strconv.FormatInt(task.ID, 10)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	r.removeTaskContainer(context.Background(), task, discardLogger())
+
+	if got := rt.removals(); len(got) != 1 || got[0] != name {
+		t.Errorf("removed = %v, want [%s]", got, name)
+	}
+}
+
+// TestArchiveHonoursTheWorkflowsOwnImage pins where the verdict is read from.
+// A workflow that names an image the daemon's own block does not is a
+// containerized task, and the snapshot is the only record of that once the
+// task is being archived.
+func TestArchiveHonoursTheWorkflowsOwnImage(t *testing.T) {
+	rt := newFakeRuntime()
+	r := containerRunner("", rt)
+	task := &store.Task{ID: 7, WorkflowSnapshot: imageSnapshot}
+	name := container.Name(task.ID)
+	if _, err := rt.Create(context.Background(), container.CreateSpec{
+		Name:   name,
+		Labels: map[string]string{container.LabelTask: strconv.FormatInt(task.ID, 10)},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	r.removeTaskContainer(context.Background(), task, discardLogger())
+
+	if got := rt.removals(); len(got) != 1 || got[0] != name {
+		t.Errorf("removed = %v, want [%s]", got, name)
 	}
 }

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -426,6 +426,16 @@ func (r *Runner) execute(ctx context.Context, task *store.Task) {
 	if err := r.ensureWorktree(ctx, task, project, log); err != nil {
 		return // ensureWorktree already blocked or re-queued the task
 	}
+	// The container is created with the worktree and removed with it (§16,
+	// task 061 decision 1): one per task, holding the worktree and the
+	// project repository as bind mounts, so it has to come second. A failure
+	// blocks the task — a containerized step is never quietly run on the host
+	// instead (§9.4's reasoning).
+	tc, err := r.ensureContainer(ctx, task, project, wf, log)
+	if err != nil {
+		return // ensureContainer already blocked or interrupted the task
+	}
+	defer r.setTaskContainer(task.ID, tc)()
 	// An ad-hoc repair the human asked for while the task was blocked (§6,
 	// task 025). It is a whole admission of its own: one agent runs in this
 	// worktree and the task goes back to `blocked` at the same step, so the

--- a/internal/taskrun/recover.go
+++ b/internal/taskrun/recover.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/procx"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskstate"
@@ -72,7 +74,11 @@ func journalIdentity(pid int, log *slog.Logger) *string {
 // This replaces T1.8's blocking sweep, whose bulk UPDATE also bypassed the
 // TransitionTask compare-and-swap — the invariant that no transition skips
 // the FSM holds here too.
-func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error) {
+func Recover(ctx context.Context, st *store.Store, log *slog.Logger, opts ...RecoverOption) (int, error) {
+	var ro recoverOptions
+	for _, o := range opts {
+		o(&ro)
+	}
 	runs, err := st.ListRunningStepRuns(ctx)
 	if err != nil {
 		return 0, err
@@ -110,7 +116,7 @@ func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error
 			// cannot be rolled back, and killing then failing to commit is
 			// the already-tolerated case — the row stays `running` and the
 			// next recovery finds a dead PID.
-			killOwned(open[id], id, log)
+			killOwned(ctx, open[id], id, ro, log)
 			delete(open, id)
 			if _, _, err := st.InterruptTask(ctx, id, state, tr.To, ReasonInterrupted); err != nil {
 				return requeued, fmt.Errorf("recover task %d from %s: %w", id, state, err)
@@ -130,7 +136,7 @@ func Recover(ctx context.Context, st *store.Store, log *slog.Logger) (int, error
 		if !ok {
 			continue // already reconciled, with its task, above
 		}
-		killOwned(runs, id, log)
+		killOwned(ctx, runs, id, ro, log)
 		if _, err := st.TerminalizeOpenStepRuns(ctx, id, store.StepInterrupted, ReasonInterrupted); err != nil {
 			return requeued, fmt.Errorf("recover task %d: finalize open step runs: %w", id, err)
 		}
@@ -173,10 +179,68 @@ func sweepCursorMCP(ctx context.Context, st *store.Store, log *slog.Logger) erro
 }
 
 // killOwned tree-kills the journaled process of each of one task's open runs.
-func killOwned(runs []*store.StepRun, taskID int64, log *slog.Logger) {
+func killOwned(ctx context.Context, runs []*store.StepRun, taskID int64, ro recoverOptions, log *slog.Logger) {
 	for _, run := range runs {
-		killOrphan(run, log.With("task", taskID, "run", run.ID))
+		l := log.With("task", taskID, "run", run.ID)
+		// A containerized run first: the host PID it journaled names the
+		// runtime client, and removing the container kills every process
+		// inside it, the client's included (task 061 decision 4). The PID
+		// path still runs afterwards — the client is a real process this
+		// daemon spawned, and the same PID-reuse guard applies to it.
+		removeOrphanContainer(ctx, run, taskID, ro, l)
+		killOrphan(run, l)
 	}
+}
+
+// RecoverOption configures a recovery sweep.
+type RecoverOption func(*recoverOptions)
+
+type recoverOptions struct {
+	containers func(binary string) container.Runtime
+	binary     string
+}
+
+// WithContainers lets recovery reach the containers a previous daemon left
+// running (§12.4, task 061 decision 4). Without it — every existing caller and
+// every test that never set an image — recovery is exactly what it was.
+func WithContainers(factory func(binary string) container.Runtime, binary string) RecoverOption {
+	return func(o *recoverOptions) { o.containers, o.binary = factory, binary }
+}
+
+// removeOrphanContainer removes the container a running step run journaled,
+// when that container still claims the task that journaled it.
+//
+// The label check is §12.4's rule from a different direction: a container id
+// is never reused, so there is no reuse to guard against, but a *name* a later
+// task took over would be somebody else's — and what cannot be proved is not
+// killed. Removal kills every process inside, so no second exec-identity path
+// is needed.
+func removeOrphanContainer(
+	ctx context.Context, run *store.StepRun, taskID int64, ro recoverOptions, log *slog.Logger,
+) {
+	if run.ContainerID == nil || *run.ContainerID == "" || ro.containers == nil {
+		return
+	}
+	rt := ro.containers(ro.binary)
+	label, err := rt.TaskLabel(ctx, *run.ContainerID)
+	if err != nil {
+		log.Warn("recovery: container label unreadable; leaving it alone",
+			"container", *run.ContainerID, "error", err)
+		return
+	}
+	if label == "" {
+		return // already gone, which is the outcome recovery wanted anyway
+	}
+	if label != strconv.FormatInt(taskID, 10) {
+		log.Warn("recovery: container belongs to a different task; leaving it alone",
+			"container", *run.ContainerID, "label", label)
+		return
+	}
+	if err := rt.Remove(ctx, *run.ContainerID); err != nil {
+		log.Error("recovery: remove orphaned container", "container", *run.ContainerID, "error", err)
+		return
+	}
+	log.Warn("recovery: removed orphaned container from a previous run", "container", *run.ContainerID)
 }
 
 // killOrphan tree-kills the process a running step run journaled, when it is

--- a/internal/taskrun/runner.go
+++ b/internal/taskrun/runner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/agent"
 	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/events"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/worktree"
@@ -75,6 +76,10 @@ type Deps struct {
 	// thing that can answer it: the endpoint's URL comes from the listener
 	// internal/api owns, and this package may not import that.
 	MCPForStep func(runID, taskID int64, stepID string) (*agent.MCPServer, func())
+	// Containers resolves a `container.runtime` value to the Runtime that
+	// drives it (§16, task 061). Nil means container.New, which is what the
+	// daemon wires; tests substitute a fake so no `go test` needs docker.
+	Containers func(binary string) container.Runtime
 }
 
 // Runner executes admitted tasks and applies the §6 human actions.
@@ -97,6 +102,10 @@ type Runner struct {
 
 	mu   sync.Mutex
 	live map[int64]*liveRun
+	// containers is the container each admitted task's steps exec into (§16,
+	// task 061). Absent means the host, which is every task of an
+	// installation that never sets `container.image`.
+	containers map[int64]taskContainer
 
 	// status paces the step-authored status message (§13.3, task 036). It is
 	// on the runner rather than on a live run because a status write arrives

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/procx"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskstate"
@@ -422,7 +423,7 @@ func (r *Runner) runCommandStep(
 		phase:    "run",
 		script:   script,
 		shellPin: env.step.Shell,
-		env:      commandEnv(r.childEnv(), rc, env.step.Env),
+		env:      commandEnv(r.stepBaseEnv(env.task.ID), rc, env.step.Env),
 		workDir:  env.task.WorktreePath,
 		timeout:  timeout,
 	})
@@ -442,7 +443,7 @@ func (r *Runner) runCheck(
 		phase:    "check",
 		script:   script,
 		shellPin: env.step.Shell,
-		env:      commandEnv(r.childEnv(), rc, env.step.Env),
+		env:      commandEnv(r.stepBaseEnv(env.task.ID), rc, env.step.Env),
 		workDir:  env.task.WorktreePath,
 		timeout:  resolveCheckTimeout(env.step, r.deps.Config()),
 	})
@@ -482,13 +483,30 @@ type shellCommand struct {
 func (r *Runner) runShellCommand(
 	ctx context.Context, env *stepEnv, run *store.StepRun, tr *transcript, sc shellCommand,
 ) stepOutcome {
-	sh, err := r.deps.Shells.For(sc.shellPin)
-	if err != nil {
-		tr.Note("error", map[string]any{"error": err.Error()})
-		env.log.Error("resolve shell", "shell", sc.shellPin, "error", err)
-		return stepOutcome{state: store.StepFailed, reason: ReasonShellUnavailable, result: err.Error()}
+	tc := r.taskContainerOf(env.task.ID)
+	shellName, argv := "", []string(nil)
+	if tc.active() {
+		// A containerized `run:` body executes under the *container's*
+		// /bin/sh — the inverse of §8.3, accepted and documented rather than
+		// translated (task 061 decision 8). The host's shell resolver is not
+		// consulted at all: what it found says nothing about the image, and a
+		// `pwsh` pin is refused at load or at task creation, before a step
+		// ever reaches here.
+		shellName = workflow.ShellSh
+		argv = []string{"/bin/sh", "-c", sc.script}
+	} else {
+		sh, err := r.deps.Shells.For(sc.shellPin)
+		if err != nil {
+			tr.Note("error", map[string]any{"error": err.Error()})
+			env.log.Error("resolve shell", "shell", sc.shellPin, "error", err)
+			return stepOutcome{state: store.StepFailed, reason: ReasonShellUnavailable, result: err.Error()}
+		}
+		shellName, argv = sh.Name, sh.command(sc.script)
 	}
-	argv := sh.command(sc.script)
+	sh := struct {
+		Name string
+		Path string
+	}{Name: shellName, Path: argv[0]}
 	tr.Note("command_started", map[string]any{
 		"phase": sc.phase, "shell": sh.Name, "command": sc.script, "cwd": sc.workDir,
 	})
@@ -505,6 +523,17 @@ func (r *Runner) runShellCommand(
 	runCtx, cancel := context.WithTimeout(ctx, sc.timeout)
 	defer cancel()
 
+	key := execKey(run.ID)
+	if tc.active() {
+		// The step's own environment goes in as `--env` flags, and the host
+		// process is the runtime client — which needs the daemon's own
+		// environment to find its socket. Two environments, and the step's is
+		// the one layered on the image's (decision 7).
+		argv = tc.rt.Exec(tc.id, container.ExecSpec{
+			Key: key, Argv: argv, Env: sc.env, WorkDir: sc.workDir, User: container.HostUser(),
+		})
+		sc.workDir, sc.env = "", nil
+	}
 	cmd := exec.Command(argv[0], argv[1:]...) //nolint:gosec // the workflow author's own command, by design (§9.4)
 	cmd.Dir = sc.workDir
 	cmd.Env = sc.env
@@ -534,6 +563,13 @@ func (r *Runner) runShellCommand(
 	run.PID = &pid
 	run.ProcStartedAt = &started
 	run.ProcIdentity = journalIdentity(pid, env.log)
+	if tc.active() {
+		// The host PID above names the runtime client, not the process inside
+		// the container; the container id is what §12.4 recovery can act on
+		// (task 061 decision 4, migration 0021).
+		id := tc.id
+		run.ContainerID = &id
+	}
 	if err := r.deps.Store.UpdateStepRun(r.persistCtx(), run); err != nil {
 		env.log.Error("journal command pid", "error", err)
 	}
@@ -545,7 +581,16 @@ func (r *Runner) runShellCommand(
 	go func() {
 		select {
 		case <-runCtx.Done():
-			killOnce.Do(func() { _ = proc.Kill() })
+			killOnce.Do(func() {
+				// Inside first, then the client. Killing only the host-side
+				// runtime client leaves the process running in the container
+				// (task 061 decision 9); the container itself survives, so a
+				// retry finds what an earlier step installed.
+				if tc.active() {
+					stopInContainer(tc, key, env.log)
+				}
+				_ = proc.Kill()
+			})
 		case <-killed:
 		}
 	}()
@@ -754,6 +799,19 @@ func resultChunks(results []agent.ToolResult) []map[string]any {
 // process it is about to launch.
 func (r *Runner) childEnv() []string {
 	return r.deps.Config().Environment.ResolveProcess()
+}
+
+// stepBaseEnv is childEnv for a host step and the image-based environment for
+// a containerized one (task 061 decision 7). It is one function rather than a
+// branch at each call site because "which base" is a property of the task, and
+// a call site that forgot to ask would silently ship a macOS PATH into a Linux
+// image.
+func (r *Runner) stepBaseEnv(taskID int64) []string {
+	if !r.taskContainerOf(taskID).active() {
+		return r.childEnv()
+	}
+	LogContainerEnvironmentOnce(r.deps.Logger, r.deps.Config().Environment)
+	return r.containerEnv()
 }
 
 // commandEnv builds a step's environment: the §12.3 resolved base, then the

--- a/internal/tui/configkeys.go
+++ b/internal/tui/configkeys.go
@@ -330,6 +330,51 @@ func configKeys() []configKey {
 			},
 		},
 		{
+			// §16's container execution mode (task 061). Shown and edited here
+			// for the same reason every other key is (task 060): the daemon
+			// view is the whole file, and a key it omitted would be one no
+			// client could see. Not marked dangerous — whether image and
+			// extra_mounts belong in that set is task 060's call to extend,
+			// not this one's to assume.
+			path: "container.image", label: "container image", kind: kindText,
+			help: "image a task's steps run in; empty runs them on this host",
+			read: func(c apiclient.Config) string { return c.Container.Image },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.TrimSpace(s)
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Image: &v}}, nil
+			},
+		},
+		{
+			path: "container.runtime", label: "container runtime", kind: kindText,
+			help: "docker-CLI-compatible binary; empty uses docker",
+			read: func(c apiclient.Config) string { return c.Container.Runtime },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.TrimSpace(s)
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Runtime: &v}}, nil
+			},
+		},
+		boolKey("container.mount_agent_config", "container agent config",
+			"bind-mount the agent CLI's configuration into the container",
+			func(c apiclient.Config) bool { return c.Container.MountAgentConfig },
+			func(b bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{MountAgentConfig: &b}}
+			}),
+		boolKey("container.network", "container network",
+			"leave the container on the network; false drops it off entirely",
+			func(c apiclient.Config) bool { return c.Container.Network },
+			func(b bool) apiclient.ConfigPatch {
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{Network: &b}}
+			}),
+		{
+			path: "container.extra_mounts", label: "container mounts", kind: kindList,
+			help: "extra host:container[:ro] bind mounts, whitespace-separated",
+			read: func(c apiclient.Config) string { return strings.Join(c.Container.ExtraMounts, " ") },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				v := strings.Fields(s)
+				return apiclient.ConfigPatch{Container: &apiclient.ConfigContainerPatch{ExtraMounts: &v}}, nil
+			},
+		},
+		{
 			path: "tui.board.group_by", label: "task grouping", kind: kindList, choices: groupByChoices,
 			help: "grouping levels for the board, outermost first; empty is a flat table",
 			read: func(c apiclient.Config) string { return strings.Join(c.TUI.Board.GroupBy, " ") },
@@ -507,7 +552,14 @@ func defaultClientConfig() apiclient.Config {
 		GitHub: apiclient.ConfigGitHub{Enabled: d.GitHub.Enabled, PollInterval: d.GitHub.PollInterval.String()},
 		Update: apiclient.ConfigUpdate{Check: d.Update.Check, PollInterval: d.Update.PollInterval.String()},
 		Notify: apiclient.ConfigNotify{On: notifyStateNames(d), Command: d.Notify.Command},
-		TUI:    apiclient.ConfigTUI{Board: apiclient.ConfigBoard{GroupBy: boardGroupNames(d)}},
+		Container: apiclient.ConfigContainer{
+			Image:            d.Container.Image,
+			Runtime:          d.Container.Runtime,
+			MountAgentConfig: d.Container.MountAgentConfig,
+			Network:          d.Container.Network,
+			ExtraMounts:      d.Container.ExtraMounts,
+		},
+		TUI: apiclient.ConfigTUI{Board: apiclient.ConfigBoard{GroupBy: boardGroupNames(d)}},
 	}
 }
 

--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -392,7 +392,14 @@ steps:
       9. Portability. A run: body is handed to /bin/sh on POSIX and to pwsh on
          Windows, and vincent translates nothing. A body outside the
          intersection of the two is either rewritten into it, or the workflow
-         declares platforms:, or the step carries a .Host.OS guard.
+         declares platforms:, or the step carries a .Host.OS guard. A workflow
+         that already pins defaults.container.image inverts the first half: its
+         run: bodies execute under the image's /bin/sh whatever the host is, a
+         step pinning shell: pwsh or shell: cmd is refused at load, and
+         platforms: still gates on the daemon's host rather than on the image.
+         Do not add a container: block to a workflow that has none — which
+         image a project runs in is a deployment decision, not one this pass
+         gets to make.
       10. Defensive templates. Rendering uses missingkey=error, so an optional
           field is read as {{"{{"}}with index .Task.Fields "x"}}…{{"{{"}}end}}
           and never bare. A required field may be read directly.

--- a/internal/workflow/container_test.go
+++ b/internal/workflow/container_test.go
@@ -1,0 +1,109 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestContainerizedWorkflowRefusesPwshAtLoad is decision 8's first half: a
+// workflow that pins its own image is the one case load-time validation can
+// judge, because the image is right there in the file.
+func TestContainerizedWorkflowRefusesPwshAtLoad(t *testing.T) {
+	src := `
+name: build
+defaults:
+  container:
+    image: ghcr.io/example/dev:1
+steps:
+  - id: compile
+    type: command
+    run: go build ./...
+    shell: pwsh
+`
+	_, _, err := Parse([]byte(strings.TrimSpace(src)), Options{})
+	if err == nil {
+		t.Fatal("a pwsh step in an image-pinning workflow loaded")
+	}
+	if !strings.Contains(err.Error(), "compile") {
+		t.Errorf("the error must name the step, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "pwsh") {
+		t.Errorf("the error must name the shell, got %v", err)
+	}
+}
+
+// TestUncontainerizedWorkflowKeepsPwsh is the other half. Containerization
+// also resolves from config.yaml, which is hot-reloadable and which a workflow
+// being parsed knows nothing about — so a workflow with no image of its own is
+// judged at task creation, not here.
+func TestUncontainerizedWorkflowKeepsPwsh(t *testing.T) {
+	src := `
+name: build
+steps:
+  - id: compile
+    type: command
+    run: go build ./...
+    shell: pwsh
+`
+	if _, _, err := Parse([]byte(strings.TrimSpace(src)), Options{}); err != nil {
+		t.Fatalf("a workflow with no image must still load: %v", err)
+	}
+}
+
+// TestContainerShellConflictsFindsNestedSteps keeps the refusal honest for the
+// structure steps: a group member and a loop body are steps too.
+func TestContainerShellConflictsFindsNestedSteps(t *testing.T) {
+	src := `
+name: build
+steps:
+  - id: group
+    type: parallel
+    steps:
+      - id: inner
+        type: command
+        run: go vet ./...
+        shell: cmd
+`
+	wf, _, err := Parse([]byte(strings.TrimSpace(src)), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	conflicts := ContainerShellConflicts(wf)
+	if len(conflicts) != 1 {
+		t.Fatalf("conflicts = %v, want exactly one", conflicts)
+	}
+	if !strings.Contains(conflicts[0].Message, "inner") {
+		t.Errorf("the conflict must name the step, got %q", conflicts[0].Message)
+	}
+}
+
+// TestWorkflowContainerOverrideRoundTrips pins that `defaults.container:`
+// parses into the §8.6 override rather than being silently dropped by strict
+// decoding.
+func TestWorkflowContainerOverrideRoundTrips(t *testing.T) {
+	src := `
+name: build
+defaults:
+  container:
+    image: ghcr.io/example/dev:1
+    network: false
+steps:
+  - id: compile
+    type: command
+    run: go build ./...
+`
+	wf, _, err := Parse([]byte(strings.TrimSpace(src)), Options{})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	c := wf.Defaults.Container
+	if c == nil || c.Image == nil || *c.Image != "ghcr.io/example/dev:1" {
+		t.Fatalf("image did not round-trip: %+v", c)
+	}
+	if c.Network == nil || *c.Network {
+		t.Errorf("network: false did not round-trip: %+v", c)
+	}
+	if c.MountAgentConfig != nil {
+		t.Errorf("an unset key must stay unset, got %v", *c.MountAgentConfig)
+	}
+}

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -138,6 +138,11 @@ type Defaults struct {
 	MaxRetries     *int             `yaml:"max_retries"`
 	RetryBackoff   *config.Duration `yaml:"retry_backoff"`
 	Timeout        *config.Duration `yaml:"timeout"`
+	// Container overrides the daemon's `container:` block for tasks created
+	// from this workflow (§16, task 061 decision 6). It is the second and
+	// last level of the §8.6 precedence chain for containerization: workflow
+	// `defaults:` beats `config.yaml`, and there is no task level.
+	Container *config.ContainerOverride `yaml:"container"`
 }
 
 // Step is one workflow step. The struct is flat across all three step types;
@@ -614,6 +619,61 @@ func validateDefaults(wf *Workflow, opts Options, add func(string, string, ...an
 	if d.InputTimeout != nil && *d.InputTimeout <= 0 {
 		add("defaults.input_timeout", "input_timeout must be positive, got %s", d.InputTimeout)
 	}
+	validateContainerDefaults(wf, add)
+}
+
+// validateContainerDefaults applies the two container checks load-time
+// validation can actually make (task 061 decision 8).
+//
+// The block itself is always checkable. The `shell:` refusal is not: a
+// containerized `run:` body executes under the container's /bin/sh — the
+// inverse of §8.3 — and containerization also resolves from `config.yaml`,
+// which is hot-reloadable and which a workflow being parsed knows nothing
+// about. So the refusal lands here only when the workflow pins its own image,
+// the one case load time can judge; every other case is refused at task
+// creation, where the config-level and workflow-level images resolve together.
+func validateContainerDefaults(wf *Workflow, add func(string, string, ...any)) {
+	c := wf.Defaults.Container
+	if c == nil {
+		return
+	}
+	if err := (config.Container{Runtime: derefString(c.Runtime), ExtraMounts: c.ExtraMounts}).Validate(); err != nil {
+		add("defaults.container", "%s", err.Error())
+	}
+	if c.Image == nil || strings.TrimSpace(*c.Image) == "" {
+		return
+	}
+	for _, f := range ContainerShellConflicts(wf) {
+		add(f.Path, "%s", f.Message)
+	}
+}
+
+// ContainerShellConflicts lists the steps a containerized run cannot honour:
+// a `shell:` pin of pwsh or cmd, neither of which exists in the Linux image a
+// container runs (§8.3, task 061 decision 8). It is exported because task
+// creation makes the same judgement on the resolved image, and one definition
+// is what keeps the load-time and creation-time messages identical.
+func ContainerShellConflicts(wf *Workflow) []Error {
+	var out []Error
+	WalkSteps(wf.Steps, func(step Step, path string) {
+		if step.Shell == ShellPwsh || step.Shell == ShellCmd {
+			out = append(out, Error{
+				Path: path + ".shell",
+				Message: fmt.Sprintf(
+					"step %q pins shell %q, which a containerized run cannot provide: "+
+						"a container's run bodies execute under the image's /bin/sh (§8.3)",
+					step.ID, step.Shell),
+			})
+		}
+	})
+	return out
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // validateStep checks one step: its type, the fields that type requires, the
@@ -1239,4 +1299,24 @@ func parentPath(path string) string {
 		return path[:i]
 	}
 	return ""
+}
+
+// WalkSteps visits every step in a workflow body, descending into a
+// `parallel` group's and a `loop`'s sub-steps and into a resolved `fan_out`
+// lane's, and reports the dotted path of each. It exists because more than
+// one check needs "every step, wherever it lives" and each of them had been
+// re-deriving the nesting rules.
+func WalkSteps(steps []Step, fn func(step Step, path string)) {
+	walkSteps(steps, "steps", fn)
+}
+
+func walkSteps(steps []Step, base string, fn func(step Step, path string)) {
+	for i, step := range steps {
+		path := fmt.Sprintf("%s[%d]", base, i)
+		fn(step, path)
+		walkSteps(step.Steps, path+".steps", fn)
+		for j, lane := range step.Lanes {
+			walkSteps(lane.Steps, fmt.Sprintf("%s.lanes[%d].steps", path, j), fn)
+		}
+	}
 }

--- a/magefile.go
+++ b/magefile.go
@@ -30,8 +30,17 @@ func Test() error {
 }
 
 // TestRace runs all tests with the race detector (needs a C toolchain; CI has one).
+//
+// The explicit -timeout is headroom, not a preference. It is a *per-package*
+// deadline, and on the Windows CI leg under the race detector `internal/api`
+// takes around 7.5 minutes of Go's 10-minute default while the leg's own
+// throughput varies by a factor of two between runs of the same commit. A
+// package that is healthy at 75% of the limit turns a slow runner into a red
+// build, with a goroutine dump that looks like a hang and is not one. 20
+// minutes keeps a genuine hang reported by `go test` — with that dump, which
+// is the useful artifact — rather than by the job's own timeout-minutes.
 func TestRace() error {
-	return sh.RunV("go", "test", "-race", "./...")
+	return sh.RunV("go", "test", "-race", "-timeout", "20m", "./...")
 }
 
 // Lint runs golangci-lint, pinned via the go.mod tool directive.

--- a/scripts/m12-gate.sh
+++ b/scripts/m12-gate.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# M12 phase gate (task 061; spec §16, §20): prove against a real container
+# runtime that a task's steps run inside one container, and that the container
+# is created, kept and removed at the moments the spec says.
+#
+#   1. a containerized task runs a body that can only succeed inside the image,
+#      exactly one container carries its label, and archiving removes it
+#   2. `container.image: ""` — the default — runs on the host and creates no
+#      container at all, which is the regression that matters most
+#   3. a step timeout stops the process inside the container and the task's
+#      container **survives**, so a retry finds what an earlier step installed
+#   4. a daemon killed mid-step leaves no container behind: recovery removes it
+#   5. `container.network: false` with `mcp.wire_steps: true` is refused at task
+#      creation with a 400 naming both keys
+#
+# It **skips cleanly** (exit 0, one line saying why) when `docker info` fails.
+# CI runs it on the Linux leg only — the macOS and Windows GitHub runners have
+# no docker daemon — and that skip is what keeps the other two legs green. This
+# is a real coverage gap and it is stated rather than implied: a gate that has
+# never run on a platform is not known to pass there.
+#
+# No agent CLI is involved: the steps are `command` steps, so the gate is as
+# fast on CI as it is locally. Their `run:` bodies are the one place in this
+# repository that are **not** held to the sh∩pwsh intersection, because the
+# feature under test is precisely that a containerized body executes under the
+# image's /bin/sh (§8.3's inverse). The one uncontainerized task's body is held
+# to the intersection as usual.
+#
+# Requirements: bash, go, git, curl, jq, docker.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DOCKER="${VINCENT_GATE_RUNTIME:-docker}"
+if ! command -v "$DOCKER" >/dev/null 2>&1; then
+  echo "SKIP: $DOCKER is not installed; the container gate needs a real runtime"
+  exit 0
+fi
+if ! "$DOCKER" info >/dev/null 2>&1; then
+  echo "SKIP: $DOCKER is installed but no daemon answered; the container gate needs a real runtime"
+  exit 0
+fi
+
+# `pwd -P` matters and is not tidiness: on macOS `$TMPDIR` lives under `/var`,
+# which is a symlink to `/private/var`. git resolves a worktree's `gitdir:`
+# pointer to the physical path, and mounting the logical one leaves that
+# pointer naming a directory the container does not have. The same trap waits
+# for a project whose own path runs through a symlink — decision 2's "identical
+# inside and out" is about the *physical* path, and the configuration reference
+# says so.
+TMP="$(cd "$(mktemp -d)" && pwd -P)"
+BIN="$TMP/bin"
+IMAGE="vincent-m12-gate:$$"
+
+VINCENT="$BIN/vincent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+fi
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  # Any container this gate created, by the label the daemon stamps on them.
+  local leftovers
+  leftovers="$("$DOCKER" ps -aq --filter "label=$LABEL_KEY" 2>/dev/null || true)"
+  [[ -n "$leftovers" ]] && "$DOCKER" rm -f $leftovers >/dev/null 2>&1
+  "$DOCKER" rmi -f "$IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+LABEL_KEY="com.vincent.task"
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent)
+
+echo "== build the gate image (alpine + git)"
+# The image is the user's, and this is the smallest honest stand-in for one: a
+# base with git on it. Nothing vincent ships is in it, which is the point.
+printf 'FROM alpine:3\nRUN apk add --no-cache git\n' > "$TMP/Dockerfile"
+"$DOCKER" build -q -t "$IMAGE" "$TMP" >/dev/null || fail "could not build the gate image"
+
+CONFIG_DIR="$TMP/config"
+DATA_DIR="$TMP/data"
+mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+export VINCENT_CONFIG_DIR
+VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+export VINCENT_DATA_DIR
+VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+
+PORT="" TOKEN="" BASE=""
+daemon_up() {
+  "$VINCENT" daemon start
+  PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+  TOKEN="$(cat "$DATA_DIR/token")"
+  BASE="http://127.0.0.1:$PORT/v1"
+}
+daemon_down() { "$VINCENT" daemon stop --force >/dev/null 2>&1 || true; }
+
+api() { # api METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out status
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  status="${out##*$'\n'}"
+  out="${out%$'\n'*}"
+  [[ "$status" == 2* ]] || fail "$method $path -> HTTP $status: $out"
+  printf '%s' "$out"
+}
+
+# api_status prints "STATUS<newline>BODY" without failing on a 4xx, for the
+# scenario whose whole point is the 400.
+api_status() { # api_status METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}" out
+  local args=(-sS -X "$method" -H "Authorization: Bearer $TOKEN" -w $'\n%{http_code}')
+  [[ -n "$body" ]] && args+=(-H "Content-Type: application/json" -d "$body")
+  out="$(curl "${args[@]}" "$BASE$path")" || fail "curl $method $path failed"
+  printf '%s\n%s' "${out##*$'\n'}" "${out%$'\n'*}"
+}
+
+make_repo() { # make_repo PATH
+  git init -q -b main "$1"
+  git -C "$1" config user.name gate
+  git -C "$1" config user.email gate@example.invalid
+  git -C "$1" config commit.gpgsign false
+  printf 'gate repo\n' > "$1/README.md"
+  git -C "$1" add . && git -C "$1" commit -qm init
+}
+
+register_project() { api POST /projects \
+  "$(jq -cn --arg p "$(hostpath "$1")" '{path: $p}')" | jq -r .id; }
+
+write_workflow() { # write_workflow NAME YAML
+  mkdir -p "$CONFIG_DIR/workflows"
+  printf '%s' "$2" > "$CONFIG_DIR/workflows/$1.yaml"
+}
+
+write_config() { # write_config YAML
+  printf '%s' "$1" > "$CONFIG_DIR/config.yaml"
+}
+
+create_task() { # create_task PROJECT_ID WORKFLOW TITLE
+  api POST /tasks "$(jq -cn --argjson p "$1" --arg w "$2" --arg t "$3" \
+    '{project_id: $p, workflow: $w, title: $t}')" | jq -r .id
+}
+
+wait_for_state() { # wait_for_state TASK_ID STATE TRIES
+  local id="$1" want="$2" tries="$3" state=""
+  for _ in $(seq 1 "$tries"); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" ]] && [[ "$want" != "aborted" ]]; then
+      api GET "/tasks/$id" | jq . >&2
+      fail "task $id reached $state while waiting for $want"
+    fi
+    sleep 1
+  done
+  api GET "/tasks/$id" | jq . >&2
+  fail "task $id never reached $want (last: $state)"
+}
+
+# containers_for prints the ids of every container carrying a task's label,
+# running or not. A count is the assertion: "one container per task" is the
+# issue's own decision 1, and two would mean a container per step.
+containers_for() { # containers_for TASK_ID
+  "$DOCKER" ps -aq --filter "label=$LABEL_KEY=$1"
+}
+
+count_containers_for() { # count_containers_for TASK_ID
+  local ids
+  ids="$(containers_for "$1")"
+  [[ -z "$ids" ]] && { printf '0\n'; return; }
+  printf '%s\n' "$ids" | wc -l | tr -d ' '
+}
+
+echo "== scenario 1: a containerized task runs in the image, in one container"
+REPO="$TMP/repo"
+make_repo "$REPO"
+write_config "container:
+  image: $IMAGE
+mcp:
+  wire_steps: false
+"
+# `cat /etc/alpine-release` is the assertion: it exists in the gate image and
+# on neither CI host, so a step that succeeds ran inside the container. The
+# second body proves the worktree mount is the same directory on both sides —
+# the commit it makes is read back through git on the host afterwards.
+write_workflow contained 'name: contained
+steps:
+  - id: prove-image
+    type: command
+    run: cat /etc/alpine-release
+  - id: commit
+    type: command
+    run: git commit --allow-empty -m m12-gate-ran-in-container
+'
+# Every workflow this gate uses is written before the daemon starts. The
+# registry reloads on change, but a task created in the same second as the file
+# lands can beat the watcher, and a gate must not assert on that race.
+#
+# `onhost` pins `image: ""` in its own defaults, which is the documented way to
+# force one workflow onto the host while the daemon is containerized — it
+# exercises the per-field merge as well as the default.
+write_workflow onhost 'name: onhost
+defaults:
+  container:
+    image: ""
+steps:
+  - id: commit
+    type: command
+    run: git commit --allow-empty -m m12-gate-ran-on-host
+'
+write_workflow slow 'name: slow
+steps:
+  - id: hang
+    type: command
+    timeout: 5s
+    max_retries: 0
+    run: sleep 300
+'
+daemon_up
+PROJECT="$(register_project "$REPO")"
+TASK="$(create_task "$PROJECT" contained "contained task")"
+wait_for_state "$TASK" done 120
+
+COUNT="$(count_containers_for "$TASK")"
+[[ "$COUNT" == 1 ]] || fail "task $TASK has $COUNT containers, want exactly 1"
+
+NAME="$("$DOCKER" inspect --format '{{.Name}}' "$(containers_for "$TASK")" | tr -d '/')"
+[[ "$NAME" == "vincent-task-$TASK" ]] || fail "container is named $NAME, want vincent-task-$TASK"
+
+# The commit the containerized step made is a real commit on the host's disk,
+# which is what "the worktree is the same directory on both sides" means.
+BRANCH="$(api GET "/tasks/$TASK" | jq -r .branch_name)"
+LOG="$(git -C "$REPO" log --format=%s "$BRANCH")"
+grep -qx m12-gate-ran-in-container <<<"$LOG" \
+  || fail "the containerized step's commit is not on $BRANCH: $LOG"
+
+api POST "/tasks/$TASK/archive" '{}' >/dev/null
+for _ in $(seq 1 30); do
+  [[ "$(count_containers_for "$TASK")" == 0 ]] && break
+  sleep 1
+done
+[[ "$(count_containers_for "$TASK")" == 0 ]] || fail "archiving task $TASK left its container behind"
+echo "   ok: one container, named for the task, gone with the worktree"
+
+echo "== scenario 2: container.image unset runs on the host and creates nothing"
+HOST_TASK="$(create_task "$PROJECT" onhost "host task")"
+wait_for_state "$HOST_TASK" done 120
+[[ "$(count_containers_for "$HOST_TASK")" == 0 ]] \
+  || fail "an uncontainerized task created a container"
+echo "   ok: no runtime consulted, no container created"
+
+echo "== scenario 3: a step timeout stops the process and the container survives"
+SLOW_TASK="$(create_task "$PROJECT" slow "slow task")"
+wait_for_state "$SLOW_TASK" blocked 120
+REASON="$(api GET "/tasks/$SLOW_TASK" | jq -r .block_reason)"
+[[ "$REASON" == timeout ]] || fail "task $SLOW_TASK blocked $REASON, want timeout"
+[[ "$(count_containers_for "$SLOW_TASK")" == 1 ]] \
+  || fail "the step timeout removed the task's container; a retry would lose its state"
+RUNNING="$("$DOCKER" inspect --format '{{.State.Running}}' "$(containers_for "$SLOW_TASK")")"
+[[ "$RUNNING" == true ]] || fail "the task's container is not running after a step timeout"
+# And nothing is left of the step itself: the pid file's process is gone, so
+# `sleep 300` is not still burning inside the container.
+LEFT="$("$DOCKER" exec "$(containers_for "$SLOW_TASK")" sh -c 'ps -o args= | grep -c "[s]leep 300"' || true)"
+[[ "${LEFT:-0}" == 0 ]] || fail "the timed-out process is still running inside the container"
+echo "   ok: process stopped, container kept"
+
+echo "== scenario 4: a daemon killed mid-step leaves no container behind"
+KILL_TASK="$(create_task "$PROJECT" slow "killed task")"
+wait_for_state "$KILL_TASK" running 120
+for _ in $(seq 1 30); do
+  [[ "$(count_containers_for "$KILL_TASK")" == 1 ]] && break
+  sleep 1
+done
+[[ "$(count_containers_for "$KILL_TASK")" == 1 ]] || fail "task $KILL_TASK never got a container"
+DAEMON_PID="$(jq -r .pid "$DATA_DIR/daemon.json")"
+kill -9 "$DAEMON_PID" 2>/dev/null || fail "could not kill the daemon"
+sleep 2
+daemon_up
+for _ in $(seq 1 30); do
+  [[ "$(count_containers_for "$KILL_TASK")" == 0 ]] && break
+  sleep 1
+done
+[[ "$(count_containers_for "$KILL_TASK")" == 0 ]] \
+  || fail "recovery left task $KILL_TASK's container running"
+echo "   ok: recovery removed the orphaned container"
+
+echo "== scenario 5: no network with wired MCP is refused at creation"
+write_config "container:
+  image: $IMAGE
+  network: false
+mcp:
+  wire_steps: true
+"
+daemon_down
+daemon_up
+OUT="$(api_status POST /tasks \
+  "$(jq -cn --argjson p "$PROJECT" '{project_id: $p, workflow: "contained", title: "no network"}')")"
+STATUS="${OUT%%$'\n'*}"
+BODY="${OUT#*$'\n'}"
+[[ "$STATUS" == 400 ]] || fail "a no-network containerized task returned HTTP $STATUS: $BODY"
+MESSAGE="$(printf '%s' "$BODY" | jq -r .error.message)"
+grep -q container.network <<<"$MESSAGE" || fail "the refusal does not name container.network: $MESSAGE"
+grep -q mcp.wire_steps <<<"$MESSAGE" || fail "the refusal does not name mcp.wire_steps: $MESSAGE"
+echo "   ok: 400 naming both keys"
+
+daemon_down
+echo "GATE PASS: m12 (container step execution)"

--- a/scripts/m12-gate.sh
+++ b/scripts/m12-gate.sh
@@ -13,11 +13,20 @@
 #   5. `container.network: false` with `mcp.wire_steps: true` is refused at task
 #      creation with a 400 naming both keys
 #
-# It **skips cleanly** (exit 0, one line saying why) when `docker info` fails.
-# CI runs it on the Linux leg only — the macOS and Windows GitHub runners have
-# no docker daemon — and that skip is what keeps the other two legs green. This
-# is a real coverage gap and it is stated rather than implied: a gate that has
-# never run on a platform is not known to pass there.
+# It **skips cleanly** (exit 0, one line saying why) on a host that cannot run
+# the feature. CI runs its assertions on the Linux leg only, and the two skips
+# are not the same skip:
+#
+#   - macOS: the GitHub runner has no docker daemon, so `docker info` fails.
+#   - Windows: the runner *does* ship docker, and its daemon answers — but in
+#     Windows-container mode, where `FROM alpine:3` fails with "no matching
+#     manifest for windows/amd64". A daemon probe alone therefore does not skip
+#     there, and the gate has to say so itself. It would be a pointless run in
+#     any case: a Windows daemon refuses containerized tasks at creation
+#     (decision 2), so there is nothing on that platform for this to assert.
+#
+# That is a real coverage gap and it is stated rather than implied: a gate that
+# has never run on a platform is not known to pass there.
 #
 # No agent CLI is involved: the steps are `command` steps, so the gate is as
 # fast on CI as it is locally. Their `run:` bodies are the one place in this
@@ -31,6 +40,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Before the runtime probes, because it is a statement about the daemon under
+# test and not about docker: a Windows daemon refuses a containerized task at
+# creation (decision 2), so every assertion below is unreachable there.
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  echo "SKIP: a windows daemon refuses containerized tasks (decision 2); the container gate needs a posix host"
+  exit 0
+fi
+
 DOCKER="${VINCENT_GATE_RUNTIME:-docker}"
 if ! command -v "$DOCKER" >/dev/null 2>&1; then
   echo "SKIP: $DOCKER is not installed; the container gate needs a real runtime"
@@ -38,6 +55,14 @@ if ! command -v "$DOCKER" >/dev/null 2>&1; then
 fi
 if ! "$DOCKER" info >/dev/null 2>&1; then
   echo "SKIP: $DOCKER is installed but no daemon answered; the container gate needs a real runtime"
+  exit 0
+fi
+# A daemon that answered still may not run the gate's image. Docker in
+# Windows-container mode is the case that turned up in CI: it answers `info`
+# and then fails `FROM alpine:3` with "no matching manifest for windows/amd64".
+OSTYPE_OF_RUNTIME="$("$DOCKER" info --format '{{.OSType}}' 2>/dev/null || true)"
+if [[ "$OSTYPE_OF_RUNTIME" != "linux" ]]; then
+  echo "SKIP: $DOCKER runs ${OSTYPE_OF_RUNTIME:-unknown} containers; the container gate needs linux images"
   exit 0
 fi
 
@@ -278,16 +303,25 @@ for _ in $(seq 1 30); do
   sleep 1
 done
 [[ "$(count_containers_for "$KILL_TASK")" == 1 ]] || fail "task $KILL_TASK never got a container"
+# The orphan is identified *before* the kill, and the assertion below is about
+# this id and not about a count. Recovery re-runs the interrupted step as an
+# attempt that does not consume a retry, and that admission creates the task a
+# fresh container under the same name — so "no container for this task" is true
+# only in the window between the removal and the re-creation, and polling for
+# it is a race that lost about one run in three. A container id is never
+# reused, so "this one is gone" is a settled fact instead of a moment.
+ORPHAN="$(containers_for "$KILL_TASK")"
 DAEMON_PID="$(jq -r .pid "$DATA_DIR/daemon.json")"
 kill -9 "$DAEMON_PID" 2>/dev/null || fail "could not kill the daemon"
 sleep 2
 daemon_up
 for _ in $(seq 1 30); do
-  [[ "$(count_containers_for "$KILL_TASK")" == 0 ]] && break
+  "$DOCKER" inspect "$ORPHAN" >/dev/null 2>&1 || break
   sleep 1
 done
-[[ "$(count_containers_for "$KILL_TASK")" == 0 ]] \
-  || fail "recovery left task $KILL_TASK's container running"
+if "$DOCKER" inspect "$ORPHAN" >/dev/null 2>&1; then
+  fail "recovery left task $KILL_TASK's container $ORPHAN behind"
+fi
 echo "   ok: recovery removed the orphaned container"
 
 echo "== scenario 5: no network with wired MCP is refused at creation"

--- a/skills/vincent-workflows/references/workflow-schema.md
+++ b/skills/vincent-workflows/references/workflow-schema.md
@@ -90,8 +90,8 @@ validation. Read an optional value defensively:
 ## Defaults and common fields
 
 Workflow `defaults` may set `agent`, `model`, `effort`, `permission_mode`,
-`on_input`, `input_timeout`, `max_retries`, `retry_backoff`, and `timeout`.
-Step values win. `max_retries` counts attempts after the first: `0` means one
+`on_input`, `input_timeout`, `max_retries`, `retry_backoff`, `timeout`, and
+`container`. Step values win. `max_retries` counts attempts after the first: `0` means one
 attempt and `1` means at most two. `retry_backoff` is how long to wait before
 each retry, default `0s` — an immediate retry. Use it for steps that fail on
 something transient (a network call, a lock held elsewhere); leave it at zero
@@ -99,6 +99,18 @@ where a second attempt would fail the same way immediately. It never grants an
 extra attempt, only delays one `max_retries` already allows, and the waiting
 task holds no concurrency slot. Durations use Go syntax such as `90s`, `45m`,
 or `1h30m`.
+
+`container` is a mapping, not a scalar, and it merges per field over the
+daemon's `container:` block: `image`, `runtime`, `mount_agent_config`,
+`network`, `extra_mounts`. `image` is the switch — the daemon's default is `""`,
+meaning steps run on the daemon's host; `image: ""` written here is a real value
+meaning "run this workflow on the host" and is distinct from omitting the key.
+There is no per-step and no per-task override. A workflow that pins an image
+must keep its `run:` bodies to the image's `/bin/sh`: a step pinning
+`shell: pwsh` or `shell: cmd` fails validation at load, and `platforms:` still
+gates on the daemon's host, not on the image. Do not add a `container:` block to
+a workflow that does not already ask for one — which image a project runs in is
+a deployment decision, not a workflow-authoring one.
 
 Every runtime step has a unique `id` and a `type`; `name`, `max_retries`,
 `retry_backoff`, `timeout`, and `if` are common optional fields where the step


### PR DESCRIPTION
## Summary

Promotes the **container** half of §20's "Container/VM-sandboxed step execution"
and amends §2's "sandboxing agents beyond worktree isolation" non-goal, both
with dated in-place notes in the same branch as the code that makes them true.

A new `container:` block in `config.yaml` names an image. With one set, a task's
step processes run inside **one** container, created with the task's worktree
and removed with it — **every `command` step and every `check:` in this
delivery; the agent process itself still runs on the host** (task 060 moves it).
`container.image: ""` is the default, so an
installation that sets nothing consults no runtime and behaves exactly as it
did — that regression is the one the tests and the gate spend the most effort
on.

The image is the user's and must already carry the agent CLI and `git`; vincent
builds, publishes and bundles nothing, the posture it already takes toward `gh`
and `cosign`. The project repository and the task's worktree are bind-mounted
**at their own absolute host paths**, so a worktree's absolute `gitdir:` pointer
resolves with zero translation code and `.Worktree`, `VINCENT_WORKTREE` and
friends stay true on both sides. That is also why a **Windows daemon refuses a
containerized task**: `C:\...` cannot exist in a Linux container.

Refusals split by cost. Task creation refuses only what is cheap and local — a
missing or unusable runtime, a Windows host, `network: false` together with
`mcp.wire_steps: true`, and a `shell: pwsh` step (which a Linux image cannot
provide). A missing or unpullable image **blocks at admission** with
`container_image_unavailable`, before a worktree, a branch or a retry is spent;
`container_unavailable` is the backstop for a daemon that changed underneath an
already-created task. A step the container was going to run is never quietly
moved to the host when the runtime or the image fails — the task blocks.

A step stop signals the process **inside** the container by the pid file the
step wrote to a private scratch mount, and leaves the container running, so a
retry finds what an earlier step installed. Removal is reserved for teardown and
§12.4 recovery, which reads `step_runs.container_id` (migration 0021) and
removes a container only after confirming it still carries the label naming that
task — what cannot be proved is not killed.

This is the **exec seam**, proven with `command`, `check` and `manual` steps.
Agent steps inside the same container are task 060, split off because the spawn
seam it needs touches all three adapters and a PR that changes both where every
step runs and how every agent is launched is not reviewable.

**One consequence a reviewer should decide on deliberately.** Because agent
steps are not moved yet, a containerized task whose workflow has agent steps is
a **mixed run**: its commands and checks execute in the container, its agent
executes on the host with the full home directory in reach. Nothing refuses it
and nothing warns about it — `containerMismatch` in `internal/api/container.go`
checks the host, the runtime, the network/MCP contradiction and `shell:`, and
never the presence of an agent step. Every public page now says so plainly
(features, the security model, the configuration and schema references, §12.3,
§16, §20) rather than implying the container covers everything, which is what
the first draft of those pages did. If a creation-time warning or refusal is
wanted instead, that is a code change and belongs here or in 060 — the
documentation step deliberately did not add one.

**Scope notes worth a reviewer's attention**

- The container is a **filesystem** boundary, not a network or credential one.
  Outbound traffic is open by default, and `mount_agent_config` puts the host's
  agent configuration inside it read-write because subscription auth takes no
  key from the environment. Both are stated in §16 and the security model in the
  same words, not implied.
- The `m11` gate is the first that does **not** run its assertions on all three
  platforms: the macOS and Windows GitHub runners have no docker daemon, so it
  skips there. macOS is a supported host that CI cannot exercise, and `ci.yml`,
  `CLAUDE.md` and the task document all say so rather than implying coverage.
- Running the gate turned up one thing no unit test could: "identical inside and
  out" means the **physical** path. A project reached through a symlink —
  macOS's `/tmp` and `/var` both are — is mounted as written while git resolves
  the worktree's pointer to the physical path, and the step reports `not a git
  repository`. Documented in the configuration reference.

## Related

Closes #256. Implements 059.1 of [task 059](docs/tasks/059-container-step-execution.md);
task 060 is the follow-up for agent steps. §20 records the two deferrals these
decisions added, each with its trigger: a per-task image override (decision 6)
and canonical-path mounting for Windows hosts (decision 2).

Relitigates nothing. §2's own opening says dated amendments record superseded
boundaries, and §20 has been promoted from five times before by exactly this
mechanism.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

The title is deliberately plain rather than `feat(container): …`: CLAUDE.md and
the `PR title` workflow both require it, because GitHub copies a PR title into
the merge commit body and a conventional one makes Release Please record the
merge *and* the matching inner commit. The commits themselves are conventional.

Notes on the last two boxes, since a box ticked unconditionally is worth
nothing: the docs touched are `spec.md` (§2, §8.3, §8.5, §12.3, §12.4, §16, §20
and the `step_runs` DDL), the configuration reference (the new `container:`
key), the API reference (`GET /v1/info`'s `container` object and the `/v1/info`
route row), the workflow schema and the workflows guide (`defaults.container`),
the task-lifecycle reference (both new block reasons in its table), the
troubleshooting guide (both reasons in prose), the CLI reference (`vincent
doctor`'s tenth group), `features.md`, the security model and the two task
documents. **No TUI page was touched, because no key binding or view changed** —
decision 6 puts no container control in New task, and no
`docs/assets/tui-*.png` is affected.

A documentation audit over the whole change ran after the implementation
commits and found four things the implementation commits had missed; they are
fixed in the `docs:`/`chore:` commits on this branch:

- **Every public page claimed agent steps run in the container.** They do not in
  this delivery (see the scope note above). `features.md`, the security model,
  the configuration reference, `spec.md` §2/§12.3/§16/§20 and the CHANGELOG
  entry all said or implied "every step process, agents included"; §16 went
  further and described the MCP endpoint host rewrite, which is task 060 and is
  not in this branch. All corrected.
- **`vincent doctor` gained a tenth group and `docs/reference/cli.md` still said
  "Nine groups".** The page does enumerate them in a table, contrary to the note
  that used to stand here. Added the `Container` row and the paragraph saying
  those rows never set the exit code and are probed even when the feature is off.
- **The two new block reasons were missing from
  `docs/reference/task-lifecycle.md`'s table.** They were in the troubleshooting
  guide's prose only.
- **`step_runs.container_id` was missing from `spec.md`'s schema block**, which
  carries every other migration's column, and the `defaults.container` row in
  `docs/reference/workflow-schema.md` had a blank line above it that split the
  `defaults` table in two. Both fixed; `defaults.container` also added to
  `docs/guides/workflows.md` §3.2, to the bundled
  `skills/vincent-workflows/references/workflow-schema.md`, and as a line under
  item 9 of `update-workflows`' checklist in `internal/workflow/builtin.go`,
  which CLAUDE.md requires for any workflow feature that ships.
