### PR TITLE
Add free chat: conversational agent sessions beside tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,23 @@ list with the user-facing context a commit subject cannot carry.
   `GET /v1/tasks`. Turns carry the same accounting a step run does — tokens,
   cost, duration, exit code — and each gets its own transcript, which closes the
   gap the feature was asked for: a conversation held outside vincent leaves no
-  record at all. Drive one with `vincent chat new|send|show|list|archive`, or
-  over the API. Mid-run questions use the existing §7.4 flow verbatim, answered
-  with `vincent chat answer`.
+  record at all. Drive one with `vincent chat start|send|list|show|archive`, or
+  over the API. Mid-run questions use the existing §7.4 flow verbatim; answering
+  one is `POST /v1/chats/{id}/answer`, which has no `vincent chat` subcommand
+  yet.
+
+  Two limits worth knowing before you reach for it. **codex and cursor cannot
+  hold a chat**: creating one on either is refused with `400
+  agent_cannot_resume`. Both CLIs have a resume of some shape, but vincent does
+  not read it yet and no fixture captured against a named CLI version pins it,
+  and replaying the conversation into the prompt would be an emulation of a
+  capability the adapter does not have — so vincent refuses instead of faking
+  it. A stored session the CLI no longer knows fails that turn with
+  `session_lost` and leaves the chat usable, for the same reason: a silently
+  fresh session answers as if it had context it does not have, and you could
+  not tell that apart from a working conversation. And **there is no chats view
+  in the TUI yet** — chats are driven from `vincent chat` and the API in this
+  release.
 - **`max_parallel_chats` (default 3).** Chats are bounded by their own cap,
   counted independently of `max_parallel_tasks`: a running chat consumes no task
   slot and never delays an admissible task. A `send` over the cap is refused
@@ -291,10 +305,9 @@ list with the user-facing context a commit subject cannot carry.
 - **Worktree directories are named by owner.** A task's is still
   `{data_dir}/worktrees/{task_id}`, unchanged and unmoved; a chat's is
   `{data_dir}/worktrees/chat-{chat_id}`. Both live under one root, so without
-  this task 7 and chat 7 would claim the same directory. `vincent gc` builds its
-  claim sets from both tables, so a chat's worktree and transcripts are not
+  this, task 7 and chat 7 would claim the same directory. `vincent gc` builds
+  its claim sets from both tables, so a chat's worktree and transcripts are not
   strays and do not inflate the orphan count on `GET /v1/info`.
-
 - **Tasks now start from the *current* base branch, not from whatever your last
   `git pull` left behind.** Before a task's worktree is created, vincent fetches
   its base branch from that branch's own remote and cuts the task branch from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Free chat: conversational agent sessions beside tasks.** A `chat` is a
+  titled conversation with an agent, scoped to a project, running in its own git
+  worktree and `vincent/{id}-{slug}` branch. Each turn resumes the agent CLI's
+  *own* session, so turn N has turns 1..N-1 in context — nothing is replayed as
+  prompt context. Chats are a first-class entity beside tasks, not a task with a
+  flag: they have their own `chats`/`chat_turns` tables, their own four-state
+  lifecycle (`idle` / `running` / `awaiting_input` / `archived`), their own
+  route family under `/v1/chats`, and they never appear on the task board or in
+  `GET /v1/tasks`. Turns carry the same accounting a step run does — tokens,
+  cost, duration, exit code — and each gets its own transcript, which closes the
+  gap the feature was asked for: a conversation held outside vincent leaves no
+  record at all. Drive one with `vincent chat new|send|show|list|archive`, or
+  over the API. Mid-run questions use the existing §7.4 flow verbatim, answered
+  with `vincent chat answer`.
+- **`max_parallel_chats` (default 3).** Chats are bounded by their own cap,
+  counted independently of `max_parallel_tasks`: a running chat consumes no task
+  slot and never delays an admissible task. A `send` over the cap is refused
+  with `409 chat_cap_reached` **immediately** rather than queued — a chat is a
+  foreground reply, and waiting behind batch work is the thing chats exist to
+  avoid.
+- **`--resume` for the claude adapter.** `RunSpec.ResumeSessionID` and
+  `RunResult.SessionID`, plus the `agent.Resumer` capability. Only chat turns
+  set it; every workflow step still gets a fresh session, unchanged.
+
 - **Run a task's steps inside a container.** A new `container:` block in
   `config.yaml` names an image, and a task's step processes run inside **one**
   container, created with the task's worktree and removed with it. That is every
@@ -42,7 +66,6 @@ list with the user-facing context a commit subject cannot carry.
   step installed, and crash recovery removes a container only after confirming
   it still carries the label naming that task. `vincent doctor` gained a
   container row, which probes the runtime even when the feature is off.
-
 - **Enum task fields, with a value picker in New task, and a `default:` for
   every field type.** A workflow's `fields:` gains `type: enum`, whose members
   are declared in `values:` and published through `GET /v1/workflows` — which a
@@ -265,6 +288,13 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Changed
 
+- **Worktree directories are named by owner.** A task's is still
+  `{data_dir}/worktrees/{task_id}`, unchanged and unmoved; a chat's is
+  `{data_dir}/worktrees/chat-{chat_id}`. Both live under one root, so without
+  this task 7 and chat 7 would claim the same directory. `vincent gc` builds its
+  claim sets from both tables, so a chat's worktree and transcripts are not
+  strays and do not inflate the orphan count on `GET /v1/info`.
+
 - **Tasks now start from the *current* base branch, not from whatever your last
   `git pull` left behind.** Before a task's worktree is created, vincent fetches
   its base branch from that branch's own remote and cuts the task branch from the
@@ -327,6 +357,20 @@ list with the user-facing context a commit subject cannot carry.
   top-level `build` are different steps — but the graph gave both boxes the same
   node id, which made selecting one ambiguous. Lane-inner nodes are now
   namespaced by their lane.
+
+### Not included
+
+- **codex and cursor cannot hold a chat yet, and say so.** Creating one on
+  either is refused with `400 agent_cannot_resume`. Both CLIs have a resume of
+  some shape, but vincent does not read it yet and no fixture captured against a
+  named CLI version pins it. Replaying the conversation into the prompt would be
+  an emulation of a capability the adapter does not have, so vincent refuses
+  instead of faking it. A stored session the CLI no longer knows fails that turn
+  with `session_lost` and leaves the chat usable, for the same reason: a silently
+  fresh session answers as if it had context it does not have, and you could not
+  tell that apart from a working conversation.
+- **No chats view in the TUI yet.** Chats are driven from `vincent chat` and the
+  API in this release.
 
 ## [0.7.0](https://github.com/lezli01/vincent/compare/v0.6.0...v0.7.0) (2026-08-29)
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ It is released under the [MIT License](LICENSE) and created by `lezli01` at
 | **Structured, reusable workflows** | Combine agent prompts, deterministic commands, approval gates, parallel groups, isolated fan-out, conditions, loops, breaks, and reusable includes in validated YAML. |
 | **Agent choice at every level** | Run Claude Code, Codex, or Cursor using the CLIs and authentication already on your machine; choose the agent, model, effort, and permission mode per workflow, step, or task. |
 | **Safe parallel development** | Every task receives its own git worktree and branch. Global and per-project concurrency caps, priorities, and platform restrictions keep many workloads organized without touching your checkout. |
+| **Conversations, not just tasks** | Start a chat with an agent in its own worktree and branch, continued through the agent CLI's own session, with every turn's transcript, tokens and cost recorded. Chats run outside the task scheduler under their own cap. |
 | **Verification and recovery** | Checks decide whether work succeeded, retries receive the real failure, timeouts are enforced, transcripts are durable, and interrupted steps recover after a daemon restart. |
 | **Human control where it matters** | Pause at approval gates, answer supported agents mid-run, inspect file-grouped diffs, edit and retry blocked steps, and decide when publishing happens. |
 | **A TUI built for active workloads** | Use a grouped task board, guided task creation, project and workflow workspaces, bulk actions, live output, cost and duration metrics, and a navigable workflow graph. |
-| **Automation-ready interfaces** | Every operation is available through CLI subcommands and a localhost REST + SSE API. `--json`, stable exit codes, and offline workflow validation make scripting and CI practical. |
+| **Automation-ready interfaces** | Every operation is available through the localhost REST + SSE API, and all but a chat's answer and cancel have a CLI subcommand too. `--json`, stable exit codes, and offline workflow validation make scripting and CI practical. |
 | **Drivable by an agent over MCP** | The daemon serves the Model Context Protocol on the same listener, so any MCP client gets the API as tools with discovery, schemas, typed errors, and one bounded call that waits for a task. Vincent's own agent steps are wired in by default. |
 | **Cross-platform delivery** | Run the same single binary on Windows, macOS, and Linux through Homebrew, WinGet, Scoop, mise, deb/rpm packages, or release archives. |
 
@@ -197,6 +198,8 @@ vincent task add --project 1 --title "Add a health endpoint"
 vincent task ls --state running
 vincent task show 7
 vincent task cancel 7
+vincent chat start "poke at the parser" --project 1
+vincent chat send 3 "what does buildArgs do with an empty model?"
 vincent workflow init my-flow              # or --from feature-pr, --project 1
 vincent workflow ls
 vincent workflow validate .vincent/workflows/feature-pr.yaml
@@ -204,7 +207,7 @@ vincent workflow render .vincent/workflows/feature-pr.yaml
 vincent config get                         # or set max_parallel_tasks 6
 ```
 
-Every subcommand takes `--json` for scripting. Exit codes are `0` success,
+Every subcommand except `vincent chat` takes `--json` for scripting. Exit codes are `0` success,
 `1` the request was rejected — by the daemon, or by a daemon-free command such as
 `workflow validate` on an invalid file — and `2` no daemon answered
 — so a script can tell "start the daemon" from "fix your request" without

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -78,6 +78,14 @@
 //	                      to this worktree-relative tracked file, so gate
 //	                      runs produce a non-empty diff
 //	FAKEAGENT_SPAWN_CHILD hang: spawn a sleeping child first and emit its pid
+//	FAKEAGENT_SESSION_DIR gives the claude dialect a memory (task 063): a
+//	                      directory of conversations keyed by the session id
+//	                      it mints and stamps on every line. `--resume <id>`
+//	                      reloads one and the run says what it recalls; an id
+//	                      the directory does not hold is refused on stderr
+//	                      with a nonzero exit and no stream, which is the
+//	                      `session_lost` leg. Unset, the run mints an id,
+//	                      remembers nothing, and behaves exactly as before
 //	                      as {"type":"fakeagent.child","pid":N} — lets tests
 //	                      verify tree-kill reaps grandchildren
 //	FAKEAGENT_ASK_MULTI   ask-question: add a second, multi-select question
@@ -228,7 +236,19 @@ func main() {
 
 	prompt, stdin := readPrompt(hasFlag("--input-format"))
 
+	// The conversation is resolved before a single stream line is emitted
+	// (task 063): a `--resume` of an id the store does not hold ends here,
+	// with the refusal on stderr and no stream at all, which is the shape
+	// internal/agent/claude classifies as `session_lost`.
+	prior := openSession()
+	rememberPrompt(prompt)
+
 	emit(map[string]any{"type": "system", "subtype": "init", "model": "fake-1"})
+	if line := recallLine(prior); line != "" {
+		// What a resumed session remembers. A fresh one says nothing here,
+		// so a vincent that dropped --resume fails by omission.
+		emitText(line)
+	}
 	switch scenario {
 	case "ask-question":
 		askQuestion(prompt, stdin)
@@ -576,6 +596,15 @@ func askPermission(prompt []byte, rd *bufio.Reader) {
 }
 
 func emit(v map[string]any) {
+	// Every claude stream line carries the session id (task 063), which is
+	// how internal/agent/claude learns the id to resume next turn. The
+	// global is only ever set by the claude dialect, so the codex and cursor
+	// emissions below are untouched.
+	if sessionID != "" {
+		if _, ok := v["session_id"]; !ok {
+			v["session_id"] = sessionID
+		}
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(err)

--- a/cmd/fakeagent/session.go
+++ b/cmd/fakeagent/session.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A fake CLI with a memory (task 063).
+//
+// Chat continuity is the one feature whose acceptance cannot be staged: the
+// question is whether turn 2 sees turn 1, and only a CLI that actually keeps
+// its own conversations can answer it. So this file gives fakeagent the same
+// shape the real one has — sessions identified by an id it mints, stored
+// outside vincent's reach, reloaded by `--resume <id>` — and vincent gets to
+// be wrong about it in exactly the ways it could be wrong about claude.
+//
+// The store is a directory of JSON files named by session id, chosen with
+// FAKEAGENT_SESSION_DIR. Unset, there is no store: the run mints an id, stamps
+// it on every line as claude does, and remembers nothing — which is every
+// existing test, unchanged.
+
+// sessionID is the conversation this run belongs to. Empty until the claude
+// dialect resolves one; emit stamps it on every line while it is set, because
+// that is what claude does and what internal/agent/claude reads back.
+var sessionID string
+
+// session is one conversation as the fake CLI stores it: the prompts it has
+// been given, oldest first. It is deliberately the whole context — a resumed
+// run answers *from* it, so a vincent that failed to pass --resume produces a
+// visibly different answer rather than a subtly stale one.
+type session struct {
+	Prompts []string `json:"prompts"`
+}
+
+// sessionDir is the store's root, or "" when this run keeps no memory.
+func sessionDir() string { return os.Getenv("FAKEAGENT_SESSION_DIR") }
+
+// sessionPath names one conversation's file. The id is minted here and never
+// arrives from anywhere but a previous run of this binary, but it still goes
+// through filepath.Base: an id that walked out of the directory would make a
+// fake CLI a file-writing primitive.
+func sessionPath(id string) string {
+	return filepath.Join(sessionDir(), filepath.Base(id)+".json")
+}
+
+// resumeArg returns the value of `--resume` on argv, and whether it was
+// present. Matching the flag by hand rather than with the flag package keeps
+// fakeagent's argv handling uniform: every other flag here is read the same
+// way, because the point is to be faithful to argv, not to parse it well.
+func resumeArg() (string, bool) {
+	for i, a := range os.Args[1:] {
+		if a != "--resume" {
+			continue
+		}
+		if i+2 < len(os.Args) {
+			return os.Args[i+2], true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+// sessionLostMessage is the wording claude uses for an id it does not know.
+// internal/agent/claude/failure.go matches it, and like the usage-limit and
+// unauthenticated wordings there it is **not fixture-verified** — the same
+// caveat, argued in the same place.
+const sessionLostMessage = "No conversation found with session ID: "
+
+// openSession resolves this run's conversation before any output is emitted.
+//
+// It returns the prior prompts a resumed session carries. A resume of an id
+// the store does not hold ends the process the way the real CLI does: the
+// refusal on stderr and a nonzero exit, with no stream at all. That is the
+// `session_lost` leg (decision 4), and it is reached by asking for a session
+// that was never written rather than by a scenario flag, so the test exercises
+// the same code path a genuinely expired id would.
+func openSession() []string {
+	id, resuming := resumeArg()
+	dir := sessionDir()
+	if resuming && id == "" {
+		fmt.Fprintln(os.Stderr, "--resume requires a session id")
+		os.Exit(1)
+	}
+	if dir == "" {
+		// No memory. Still mint an id: every claude line carries one, and a
+		// run that emitted none would hide a parse regression.
+		sessionID = id
+		if sessionID == "" {
+			sessionID = "fake-session-1"
+		}
+		return nil
+	}
+	if !resuming {
+		sessionID = newSessionID(dir)
+		return nil
+	}
+	var s session
+	b, err := os.ReadFile(sessionPath(id))
+	if err != nil || json.Unmarshal(b, &s) != nil {
+		fmt.Fprintln(os.Stderr, sessionLostMessage+id)
+		os.Exit(1)
+	}
+	sessionID = id
+	return s.Prompts
+}
+
+// newSessionID mints an id for a conversation that does not exist yet. It
+// counts what is already in the store so a test reading two ids can tell them
+// apart, and so the second chat in one directory does not silently reuse the
+// first's file.
+func newSessionID(dir string) string {
+	entries, _ := os.ReadDir(dir)
+	return fmt.Sprintf("fake-session-%d", len(entries)+1)
+}
+
+// rememberPrompt appends this turn's prompt to the conversation, so the next
+// `--resume` of it sees this turn. A store that cannot be written is fatal:
+// silently forgetting would turn the continuity test into one that passes
+// whatever vincent does.
+func rememberPrompt(prompt []byte) {
+	dir := sessionDir()
+	if dir == "" || sessionID == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "fakeagent: session store:", err)
+		os.Exit(1)
+	}
+	var s session
+	if b, err := os.ReadFile(sessionPath(sessionID)); err == nil {
+		_ = json.Unmarshal(b, &s)
+	}
+	s.Prompts = append(s.Prompts, firstLine(string(prompt)))
+	b, err := json.Marshal(s)
+	if err == nil {
+		err = os.WriteFile(sessionPath(sessionID), b, 0o600)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "fakeagent: session store:", err)
+		os.Exit(1)
+	}
+}
+
+// recallLine is what a resumed run says it remembers, and the assertion the
+// continuity test makes. A fresh session produces no such line at all, so a
+// vincent that dropped --resume fails the test by omission rather than by a
+// difference a reader has to squint at.
+func recallLine(prior []string) string {
+	if len(prior) == 0 {
+		return ""
+	}
+	return "recalled: " + strings.Join(prior, " | ")
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,6 +10,7 @@ state stay on your machine; vincent provides the control plane around them.
 |---|---|
 | Orchestration | Durable daemon, priority queue, global and per-project concurrency, per-user service installation |
 | Git isolation | One worktree and branch per task, configurable branch names, safe archive cleanup |
+| Chats | Conversations with an agent in their own worktree and branch, continued through the agent CLI's own session, with transcripts and cost |
 | Workflows | Validated YAML, templates, declared task fields, checks, retries, timeouts, platform restrictions |
 | Control flow | Parallel groups, isolated fan-out and merge, conditions, loops, breaks, reusable workflow includes |
 | Agents | Claude Code, Codex, and Cursor; per-workflow, per-step, and per-task selection |
@@ -35,6 +36,34 @@ starving other work.
 Each task runs in a dedicated git worktree on its own branch. Parallel tasks do
 not collide with one another, and vincent never changes your active checkout.
 The branch convention is configurable globally, per project, or for one task.
+
+## Talk to an agent without a workflow
+
+Not every question is a task. A **chat** is a titled conversation with an agent,
+scoped to a project, that gets its own worktree and `vincent/{id}-{slug}` branch
+exactly as a task does — so you can ask about a repository, read the answer, and
+ask the next question with the first still in context.
+
+Continuity is the agent CLI resuming **its own** session, not vincent replaying
+the conversation into the next prompt. That means only an adapter that can
+resume may hold a chat: today that is `claude`, and `codex` and `cursor` are
+refused at creation rather than having continuity faked for them.
+
+A chat is real work, not a scratchpad. The agent may commit to the chat's
+branch, every turn records its tokens, cost and duration, and each turn keeps
+its own transcript — the accounting a conversation held in a terminal never
+leaves behind. Archiving a chat cleans up its worktree, and an empty branch
+with it, the way archiving a task does.
+
+Chats never appear on the task board and never enter the scheduler. A turn
+starts the moment you send it, bounded only by its own
+[`max_parallel_chats`](reference/configuration.md#max_parallel_chats) cap — over
+that it is refused immediately rather than queued behind batch work, which is
+the wait a chat exists to avoid.
+
+Drive one with [`vincent chat`](reference/cli.md#vincent-chat) or the
+[`/v1/chats` routes](reference/api.md#chats). There is no chats view in the TUI
+yet, and no chat route is exposed as an MCP tool.
 
 ## Express the workflow the work needs
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -27,6 +27,7 @@ silently drops.
 | Binary | `claude` | `codex` | **`cursor-agent`** |
 | `agent:` value | `claude` | `codex` | `cursor` |
 | Mid-run questions (`awaiting_input`) | ✅ | — | — |
+| Resumes its own session ([chats](../reference/cli.md#vincent-chat)) | ✅ `--resume` | — | — |
 | Reports cost | ✅ | — | — |
 | `model:` | ✅ | ✅ (free text) | ✅ (~180 enumerated) |
 | `effort:` | ✅ | ✅ | **—** (it lives in the model id) |
@@ -57,6 +58,13 @@ The most capable adapter, and the only one that can be interrupted mid-step.
   `mcp__vincent__*` in full, so `restricted` bounds the filesystem and the
   shell, **not** what the step does to vincent. See
   [Driving vincent from an agent](mcp.md#what-this-is-not).
+- **Resumes its own session**, with `--resume <session_id>`. That is what makes
+  a [chat](../reference/cli.md#vincent-chat) work: vincent stores the
+  `session_id` claude stamps on its stream and hands it back on the next turn,
+  so turn N sees turns 1..N-1 without anything being replayed into the prompt.
+  Workflow steps never set it — every step still gets a fresh session. A session
+  the CLI no longer knows fails that turn with `session_lost` rather than
+  quietly starting a new one.
 - **Carries [vincent's own MCP server](mcp.md#your-own-steps-get-this-too)** on
   `--mcp-config` with an inline config, alongside `--strict-mcp-config` so your
   own MCP servers never leak into a step. Per run: nothing global is written.
@@ -124,6 +132,12 @@ a step that reaches the engine anyway fails with `input_unsupported`.
   `awaiting_input`, and `on_input: wait|deny` has no effect on it. `on_input:
   require` is the one that does: a step declaring it cannot use codex at all,
   and a workflow pinning `agent: codex` on such a step fails validation.
+- **Cannot resume a session**, so codex cannot hold a chat: creating one on it
+  is refused with `agent_cannot_resume`. The CLI does have `exec resume`, and
+  its stream does carry a `thread_id`, but vincent reads neither yet and no
+  captured fixture pins the argv against a named build. Replaying the
+  conversation into the prompt would be an emulation of continuity, which is
+  what the refusal exists to prevent.
 - **Reasoning is surfaced.** Codex emits whole reasoning blocks, which the TUI
   shows at the `normal` and `verbose` output levels (`v` cycles them) and the
   transcript records as `agent.thinking`. Whether any are emitted depends on
@@ -152,6 +166,9 @@ and would open a GUI. **Workflow value:** `agent: cursor`.
 - Reports token usage but **no cost**, and `supports_input: false` — so, like
   codex, cursor cannot back a step declaring `on_input: require`, and pinning it
   on one is a validation error.
+- **Cannot resume a session** either, and is refused for chats the same way.
+  `cursor-agent` has a `--resume` and emits a `session_id`; as with codex,
+  neither is wired here and no fixture pins the flag against a named build.
 - Errors do not arrive in the stream — an invalid model id exits 1 with a message
   on stderr and no result line — so the adapter reports "stream ended without a
   result event" plus the stderr tail, which is what makes an everyday typo

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -38,7 +38,7 @@ every human action (`task_cancel`, `task_pause`, `task_approve`, `task_answer`,
 the GitHub reads, and the read-only `health`, `info`, `config_get`,
 `agent_list`, `doctor`, `orphan_list`.
 
-Six things are deliberately **not** tools:
+Six admin routes are deliberately **not** tools:
 
 - `POST /v1/daemon/stop`
 - `POST /v1/daemon/backup`
@@ -59,6 +59,14 @@ response serves `config.yaml` in full; the tool masks `environment.set`'s
 values and `notify.command`'s argv, keeping the names, because a tool result
 lands in the model's context and in the step's transcript. Nothing else is
 changed — see the [security model](../security-model.md).
+
+**Nor is any `/v1/chats` route** — the whole
+[chat](../reference/api.md#chats) family, reads included. A chat turn starts an
+agent CLI without going through admission, so a tool that could send one would
+let an agent start unqueued agent processes, which is the exact thing
+`max_tasks` below bounds. The recursion bounds cannot help either: they walk
+`created_by_task_id`, and a chat is not in that chain. Nothing is lost — an
+agent calling these tools already has a session of its own.
 
 Each tool takes the route's path parameters by name, plus `body` (for `POST` and
 `PATCH`) or `query` (for `GET`):

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -115,7 +115,8 @@ defect.
 
 ## JSON output
 
-`--json` works on every subcommand that prints anything:
+`--json` works on every subcommand that prints anything, with one exception
+noted below:
 
 ```sh
 vincent project ls --json
@@ -134,6 +135,10 @@ Two guarantees make it safe to pipe into `jq`:
 ```sh
 vincent task ls --state blocked --json | jq -r '.[] | "\(.id)\t\(.title)"'
 ```
+
+The exception is [`vincent chat`](../reference/cli.md#vincent-chat), which has
+no `--json` on any of its subcommands — it prints for a person. Script chats
+against [`/v1/chats`](../reference/api.md#chats) directly.
 
 `vincent task show <id> --json` carries two fields worth knowing about:
 `available_actions`, which is what the daemon will accept right now — read it

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,6 +13,7 @@ The daemon serves REST + SSE on loopback. Every client — the TUI, the
 - [Projects](#projects)
 - [Workflows](#workflows)
 - [Tasks](#tasks)
+- [Chats](#chats)
 - [Transcripts and diffs](#transcripts-and-diffs)
 - [Events (SSE)](#events-sse)
 - [MCP](#mcp)
@@ -1181,7 +1182,9 @@ curl -sS -X POST http://127.0.0.1:PORT/v1/chats/3/send   -H "Authorization: Bear
 ```
 
 `202` with the new turn. Poll `GET /v1/chats/3` or follow `GET /v1/events` for
-`chat.turn_changed`; live output rides the same broker a step's does.
+`chat.turn_changed`. A chat has no live-output stream over HTTP: the turn's
+normalized output goes to the turn's transcript file, and `result_text` on the
+finished turn is the answer.
 
 Over `max_parallel_chats` it is **`409 chat_cap_reached`, immediately** — never
 queued. A chat is a foreground reply, and waiting behind batch work is the thing
@@ -1192,8 +1195,11 @@ The chat is left exactly as it was: still `idle`, with no turn row behind it.
 
 Each turn carries the accounting a step run does — `input_tokens`,
 `output_tokens`, `cost_usd`, `exit_code`, `duration_ms` — plus `session_id`, the
-session it actually ran in, and its own transcript. A turn is `running`, then
-`done`, `failed` or `interrupted`, forever.
+session it actually ran in, and its own transcript at
+`{data_dir}/transcripts/chat-{chat_id}/{seq}.jsonl`. That file is not served by
+any route: [`/v1/tasks/{id}/transcript`](#transcripts-and-diffs) is task-only,
+and a chat's is read from disk. A turn is `running`, then `done`, `failed` or
+`interrupted`, forever.
 
 Two failure reasons are worth knowing:
 
@@ -1305,6 +1311,8 @@ a client reconnecting with `Last-Event-ID` misses nothing.
 task.created            task.state_changed      task.priority_changed
 task.step_advanced      task.status_changed     task.children_changed
 task.github_pull_changed
+chat.created            chat.state_changed      chat.turn_changed
+chat.archived
 project.*               workflow.registry_changed
 agent.quota_changed     daemon.shutting_down
 ```
@@ -1338,6 +1346,14 @@ they need.
   retires an observation — never on a re-observation identical to what is
   already stored, and never merely because a window lapsed. Re-fetch
   [`quota`](#usage-quota) from `/v1/agents` or `/v1/info` when you see one.
+- The `chat.*` events belong to the [chat](#chats) family and carry the chat's
+  `project_id`, so `?project_id=` filters them the way it filters a task's.
+  Each payload is `{ id, title, state }`; `chat.turn_changed` adds `turn_id`,
+  `turn_seq`, `turn_state` and — when the turn failed — `fail_reason`.
+  Re-fetch `GET /v1/chats/{id}` when you see one. There is **no per-chat event
+  stream and no live-output route**: a chat's normalized output is written to
+  the turn's transcript file, and over HTTP a finished turn's `result_text` is
+  what you read.
 - `task.github_pull_changed` carries `{ repo, number, source, suppressed }` —
   empty when the link was cleared — and says a task's pull-request link changed:
   the daemon's reconciler matched one, or a human linked or unlinked one. It is

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1130,6 +1130,82 @@ resolved into the snapshot, so an include that cycles, names a workflow this
 project cannot see, nests past `include.max_depth`, brings a step id already in
 use, or is restricted to another platform is a `400` here.
 
+## Chats
+
+A **chat** is a titled conversation with an agent, scoped to a project, running
+in its own git worktree and `vincent/{id}-{slug}` branch. Each turn resumes the
+agent CLI's own session, so turn N has turns 1..N-1 in context. Chats are a
+separate family from tasks: they never appear in `GET /v1/tasks` or on the
+board, and tasks never appear here.
+
+```
+GET    /v1/chats?project_id=&state=   newest first; state may repeat
+POST   /v1/chats                      create, with a worktree and a branch
+GET    /v1/chats/{id}                 { chat, turns[] } — the whole conversation
+POST   /v1/chats/{id}/send            start a turn
+POST   /v1/chats/{id}/answer          answer a mid-run request
+POST   /v1/chats/{id}/cancel          stop the live turn
+POST   /v1/chats/{id}/archive         remove the worktree; terminal
+```
+
+### Creating one
+
+```bash
+curl -sS -X POST http://127.0.0.1:PORT/v1/chats   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json'   -d '{"project_id": 1, "title": "poke at the parser"}'
+```
+
+`agent` is optional and defaults to the first registered adapter that **can
+resume** — there is no `defaults.agent` key, and a chat's whole premise is
+continuity. An adapter that cannot resume is refused:
+
+```json
+{"error": {"code": "agent_cannot_resume",
+           "message": "agent \"codex\" cannot resume its own session, so it cannot hold a conversation; vincent refuses this rather than replaying the log as prompt context"}}
+```
+
+Today that is codex and cursor. Both CLIs have a resume of some shape; vincent
+does not read it yet, and faking continuity by replaying the log into the prompt
+is exactly what this refusal exists to prevent.
+
+### States
+
+`idle` → `running` → `idle`, with `awaiting_input` in the middle when the agent
+asks something, and `archived` as the only terminal state. Anything outside that
+table is a `409` — sending to an archived chat, answering one that asked
+nothing. There is no pause: a paused chat is an idle one nobody has sent to.
+
+### Sending a turn
+
+```bash
+curl -sS -X POST http://127.0.0.1:PORT/v1/chats/3/send   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json'   -d '{"message": "what does buildArgs do with an empty model?"}'
+```
+
+`202` with the new turn. Poll `GET /v1/chats/3` or follow `GET /v1/events` for
+`chat.turn_changed`; live output rides the same broker a step's does.
+
+Over `max_parallel_chats` it is **`409 chat_cap_reached`, immediately** — never
+queued. A chat is a foreground reply, and waiting behind batch work is the thing
+chats exist to avoid, so you get an error you can act on instead of a spinner.
+The chat is left exactly as it was: still `idle`, with no turn row behind it.
+
+### Turns
+
+Each turn carries the accounting a step run does — `input_tokens`,
+`output_tokens`, `cost_usd`, `exit_code`, `duration_ms` — plus `session_id`, the
+session it actually ran in, and its own transcript. A turn is `running`, then
+`done`, `failed` or `interrupted`, forever.
+
+Two failure reasons are worth knowing:
+
+- **`session_lost`** — the CLI no longer knows the stored session. The turn
+  fails, the chat stays usable and keeps its id, and nothing starts a fresh
+  session behind your back: an agent answering with none of the conversation in
+  context reads exactly like one that has it, so starting over is a decision you
+  make explicitly.
+- **`interrupted`** — the daemon restarted under a live turn. It is **not**
+  re-run, unlike a task's step: re-running would re-send your message into a
+  session that died with the process. The chat returns to `idle`.
+
 ## Step status
 
 A running step can say what it is doing, in its own words:
@@ -1320,6 +1396,7 @@ Every route on this page is a tool, with these exceptions:
 | `PATCH /v1/config` | An agent must not reconfigure the daemon supervising it — a patch changes the argv it spawns, what its children inherit, and whether steps get MCP at all |
 | `GET /v1/events` | A tool call is request/response; use `task_wait` |
 | `GET /v1/tasks/{id}/events` | Same |
+| every `/v1/chats` route | Two reasons, either sufficient: a chat turn starts an agent CLI *without* going through admission, so a tool that could send one would let an agent start unqueued agent processes — the exact thing `mcp.max_tasks` bounds; and the recursion bounds walk `created_by_task_id`, a chain a chat is not in, so exposing chats would mean inventing depth semantics for a non-task. An agent that needs a conversation already has its own session |
 
 `task_create` additionally takes an optional `idempotency_key` string, which
 becomes the `Idempotency-Key` header — a tool call has no header surface, and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -957,6 +957,74 @@ vincent update --check --json
 }
 ```
 
+## `vincent chat`
+
+Chats are conversations with an agent (spec §5.5). Each gets its own git
+worktree and `vincent/{id}-{slug}` branch, exactly as a task does, and every
+turn resumes the agent's own session — so turn N sees turns 1..N-1.
+
+Chats are not tasks. They never appear on the board, they run no workflow, and
+a chat turn never waits for a scheduler slot: it starts when you send it, or it
+is refused because `max_parallel_chats` chats are already running.
+
+Only an agent CLI that can resume its own session can hold a chat. Today that
+is `claude`; `codex` and `cursor` are refused at creation with
+`agent_cannot_resume` rather than having the conversation faked by replaying
+the log as prompt context.
+
+### `vincent chat start`
+
+```sh
+vincent chat start TITLE --project ID [--agent NAME] [--model M] [--effort E]
+                         [--base BRANCH] [--message TEXT]
+```
+
+Starts a chat and prints its id, agent and branch. `--agent` defaults to the
+first installed adapter that can resume a session. `--message` sends a first
+turn straight away and waits for it, which is `start` plus `send` in one call.
+
+### `vincent chat send`
+
+```sh
+vincent chat send CHAT_ID MESSAGE
+```
+
+Sends a message and blocks until the turn ends, then prints the agent's answer
+on stdout. A failed turn prints its reason on stderr and exits 1 — including
+`session_lost`, which means the agent CLI no longer knows the session this chat
+was resuming. The chat stays usable; starting a fresh conversation is a
+decision you make, not one vincent makes silently.
+
+Exits 1 with `chat_cap_reached` when `max_parallel_chats` chats already hold a
+live agent process. The send is refused, never queued.
+
+### `vincent chat list`
+
+```sh
+vincent chat list [--project ID]
+```
+
+One line per chat: id, state, agent, title.
+
+### `vincent chat show`
+
+```sh
+vincent chat show CHAT_ID
+```
+
+The chat's header and every turn in order, with each turn's prompt, answer and
+— where it failed — its reason.
+
+### `vincent chat archive`
+
+```sh
+vincent chat archive CHAT_ID [--force]
+```
+
+Removes the chat's worktree and, under `delete_empty_branch_on_archive`, an
+empty branch with it — the same archive a task gets. A worktree with local
+changes is refused; `--force` is the way past it.
+
 ## `vincent workflow`
 
 Aliased as `vincent wf`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,6 +16,7 @@ localhost API.
 - [`vincent config`](#vincent-config)
 - [`vincent status`](#vincent-status)
 - [`vincent update`](#vincent-update)
+- [`vincent chat`](#vincent-chat)
 - [`vincent workflow`](#vincent-workflow)
 - [`vincent github`](#vincent-github)
 - [`vincent gc`](#vincent-gc)
@@ -994,6 +995,14 @@ on stdout. A failed turn prints its reason on stderr and exits 1 — including
 `session_lost`, which means the agent CLI no longer knows the session this chat
 was resuming. The chat stays usable; starting a fresh conversation is a
 decision you make, not one vincent makes silently.
+
+There is **no `vincent chat answer`**. If the agent asks a question mid-turn the
+chat enters `awaiting_input` and the send keeps waiting, because the turn has
+not ended; answering it means calling `POST /v1/chats/{id}/answer`
+[over the API](api.md#chats). Nothing bounds that wait today — a chat turn has
+no timeout of its own — so an unanswered question leaves the turn live in the
+daemon and the send waiting on it. Interrupting `vincent chat send` stops the
+polling, not the turn; `POST /v1/chats/{id}/cancel` is what ends it.
 
 Exits 1 with `chat_cap_reached` when `max_parallel_chats` chats already hold a
 live agent process. The send is refused, never queued.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,6 +46,10 @@ listen: 127.0.0.1:0
 # on each project.
 max_parallel_tasks: 3
 
+# Cap on chats holding a live agent process. Independent of the task caps: a
+# send over it is refused 409, never queued.
+max_parallel_chats: 3
+
 # Naming convention for the branch each task's worktree is cut on. It is a
 # Go text/template rendered with .ID, .Slug, .Project, .Workflow and .Date;
 # the result is sanitised into a legal ref. A project may override it, and
@@ -318,6 +322,26 @@ agent process is alive mid-step and killing it would lose the session the answer
 belongs to.
 
 Real agents cost money; this is the knob that bounds it.
+
+### `max_parallel_chats`
+
+```yaml
+max_parallel_chats: 3
+```
+
+Cap on **chats** holding a live agent process — a separate dimension from
+`max_parallel_tasks`, which never sees a chat and is never delayed by one. Must
+be at least 1.
+
+A chat counts while it is `running` or `awaiting_input`, for the same reason a
+task does: the process is alive. A `send` over the cap is refused immediately
+with `409 chat_cap_reached` and is **never queued**. That is the point — a chat
+is a foreground conversation, and parking your reply behind someone else's batch
+work is the wait chats exist to avoid. You get an error you can act on rather
+than a spinner.
+
+The honest ceiling on concurrent agent CLIs is therefore
+`max_parallel_tasks + max_parallel_chats`, which is 6 by default.
 
 ### `branch_template`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,10 +46,6 @@ listen: 127.0.0.1:0
 # on each project.
 max_parallel_tasks: 3
 
-# Cap on chats holding a live agent process. Independent of the task caps: a
-# send over it is refused 409, never queued.
-max_parallel_chats: 3
-
 # Naming convention for the branch each task's worktree is cut on. It is a
 # Go text/template rendered with .ID, .Slug, .Project, .Workflow and .Date;
 # the result is sanitised into a legal ref. A project may override it, and
@@ -331,7 +327,8 @@ max_parallel_chats: 3
 
 Cap on **chats** holding a live agent process — a separate dimension from
 `max_parallel_tasks`, which never sees a chat and is never delayed by one. Must
-be at least 1.
+be at least 1. It is **not** in the generated default file above; omitting it
+keeps the default, as omitting any key does.
 
 A chat counts while it is `running` or `awaiting_input`, for the same reason a
 task does: the process is alive. A `send` over the cap is refused immediately
@@ -540,6 +537,11 @@ reboots rather than only on the restarts it no longer has.
 
 Task and step rows are **never** deleted — only the transcript files.
 
+**Chats are outside this.** The pruner walks archived *tasks*, so an archived
+[chat](cli.md#vincent-chat)'s turn transcripts under
+`{data_dir}/transcripts/chat-{chat_id}/` are kept until you delete them
+yourself.
+
 That same pass also drops
 [idempotency keys](api.md#transport-and-auth) older than a fixed 24 hours. This
 setting does not govern them: `0` keeps every transcript, and expired keys still
@@ -561,6 +563,9 @@ ends — a half-written line would turn a size failure into a parse failure for
 every later reader.
 
 `0` disables the cap.
+
+**Chats are outside this too**: a chat turn's transcript is written with no cap,
+so nothing latches it and no turn fails with `transcript_limit`.
 
 ### `max_task_cost_usd`
 

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -72,7 +72,9 @@ Project-scoped workflows live in the repository instead, at
   tui.json                                          # TUI-local view state
   logs/daemon.log                                   # rotated, size-capped
   worktrees/{task_id}/                              # one git worktree per task
+  worktrees/chat-{chat_id}/                         # one git worktree per chat
   transcripts/{task_id}/{step_index}-{attempt}.jsonl
+  transcripts/chat-{chat_id}/{turn_seq}.jsonl
 ```
 
 | File | What it is |
@@ -99,6 +101,14 @@ where `slug` comes from the task title. A title that sanitizes to nothing gives
 That is the **default**. The name is configurable — a template per project or in
 `config.yaml`, or a literal for one task — see
 [Configuration](configuration.md#branch_template).
+
+A [chat](cli.md#vincent-chat) gets one on exactly the same terms, at
+`{data_dir}/worktrees/chat-{chat_id}/` on its own `vincent/{id}-{slug}` branch.
+The directory is prefixed because tasks and chats share one root and are
+numbered independently — without it, chat 7 and task 7 would claim one path.
+The name is informational: `vincent gc` decides what is a stray from the
+database claims, which cover both tables, so a chat's worktree is never
+mistaken for an orphan.
 
 Two rules worth internalizing:
 
@@ -131,10 +141,11 @@ counts them on the daemon view, but it never deletes one on its own.
 
 ```
 {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl
+{data_dir}/transcripts/chat-{chat_id}/{turn_seq}.jsonl
 ```
 
-One file per **attempt**, JSONL. It contains the agent's own event stream
-verbatim — lossless and replayable — interleaved with vincent's namespaced
+One file per **attempt** — or, for a chat, per **turn** — JSONL. It contains
+the agent's own event stream verbatim — lossless and replayable — interleaved with vincent's namespaced
 `vincent.*` annotation lines.
 
 Two consequences of storing the raw stream rather than a parsed one:
@@ -147,6 +158,10 @@ Two consequences of storing the raw stream rather than a parsed one:
 Transcripts are bounded by `transcript_max_bytes` per attempt and pruned for
 **archived** tasks past `transcript_retention_days` — see
 [Configuration](configuration.md).
+
+Both of those are **task-scoped**. A chat's turn transcripts are written with no
+size cap and are not pruned when the chat is archived; they stay until you
+remove them.
 
 **What reclaims a transcript.** Retention, for as long as the task row exists.
 Deleting a project deletes its task rows, and retention walks rows — so those
@@ -183,7 +198,7 @@ vincent daemon --config-dir /srv/v-cfg --data-dir /srv/v-data
 | Path | Deleting it means |
 |---|---|
 | `logs/daemon.log` | Nothing; it is recreated |
-| `transcripts/{task_id}/` | That task's output history is gone; the task record and its metrics stay |
+| `transcripts/{task_id}/`, `transcripts/chat-{chat_id}/` | That task's or chat's output history is gone; the record and its metrics stay |
 | `worktrees/{task_id}/` | Effectively an unregistered archive — prefer archiving the task, which does it properly. For a directory whose task no longer exists, prefer `vincent gc`, which checks it is not somebody's live worktree first |
 | `daemon.json`, `daemon.lock` | Only safe while the daemon is stopped; both are recreated |
 | `token` | Recreated at next start, and every existing client must re-read it |

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -6,6 +6,11 @@ execution engine consult it, so "what may happen next" has a single definition �
 and every task representation carries `available_actions`, so no client ever
 restates it.
 
+This page is about **tasks**. A [chat](cli.md#vincent-chat) has its own, much
+smaller vocabulary — `idle`, `running`, `awaiting_input`, `archived` — kept
+deliberately separate so no task query or board legend has to decide whether it
+means chats too. It is documented with the [chat routes](api.md#chats).
+
 - [The diagram](#the-diagram)
 - [States](#states)
 - [Human actions](#human-actions)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -361,7 +361,8 @@ In rough order of value:
 4. **Read the diff before approving.** The Diff tab exists for this; the gate
    exists so you have a moment to use it.
 5. **Cap concurrency.** `max_parallel_tasks` bounds how much can be happening
-   without you.
+   without you, and `max_parallel_chats` bounds the chats running beside it —
+   they are independent, so the ceiling on live agent processes is their sum.
 6. **Turn on `debug: true` when a run surprises you.** It records the resolved
    settings and full argv of every step in its transcript.
 7. **Prefer per-project scoped workflows** (`.vincent/workflows/`) so a

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4386,8 +4386,15 @@ POST   /v1/chats/{id}/send              { message } → 202 with the new turn. `
                                         `max_parallel_chats` chats already hold a live process
                                         — **refused, never queued** (§11)
 POST   /v1/chats/{id}/answer            the §7.4 answer flow verbatim: same normalized request,
-                                        same `Respond()`, same `input_timeout`. `409` outside
-                                        `awaiting_input`
+                                        same `Respond()`. `409` outside `awaiting_input`.
+                                        *Corrected 2026-08-30 (task 063, same PR): the wait is
+                                        **not** bounded by `input_timeout`. `internal/chatrun`
+                                        applies no clock at all — neither `input_timeout` nor
+                                        `agent_timeout` — so a chat turn runs, and an
+                                        `awaiting_input` chat waits, until it is answered or
+                                        cancelled. It holds its `max_parallel_chats` slot for as
+                                        long as it does. Bounding it is open work, recorded in
+                                        `docs/tasks/063-free-chat.md`*
 POST   /v1/chats/{id}/cancel            stops the live turn and kills its process tree
 POST   /v1/chats/{id}/archive           removes the worktree and deletes the branch when it
                                         received nothing (§10, task 008 semantics), `?force=`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,6 +132,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 26 | GitHub issue linking | **Read-only, daemon-side.** A task may be created *from* a GitHub issue when the project's `origin` parses as a github.com repository and `github.enabled` is on. The daemon prefers the `gh` CLI and falls back to `GITHUB_TOKEN`/`GH_TOKEN` from its inherited environment; **vincent stores no credential**, keeping §2's secret-management non-goal intact. The issue is fetched **once at creation**, snapshotted onto the task and never re-fetched, so `.Issue` (§8.4) renders offline and a run stays reproducible. The daemon makes every call — at pick time and create time only, never in the step path — and nothing here writes to GitHub, so row 11 is untouched (§5.3, §8.4, §12.3, §13.2, §14, §15; task 035, added 2026-08-26). *Narrowed 2026-08-29 (task 052):* this row is about **issues**; pull requests are row 27, which stores a pointer rather than a snapshot and reverses nothing here |
 | 27 | GitHub pull requests | **Read-only, daemon-side**, like row 26 and through the same gate and credential. A project's **open** pull requests are listed on demand, and a task is linked to the pull request whose head branch equals its own `branch_name` — by a daemon-side reconciler on a `github.poll_interval` tick, never as a side effect of a GET. Only the *link* is stored (`github_pull_json`: repo, number, source, suppressed) and it is a **pointer, not a snapshot** — the deliberate opposite of row 26, because draft, state and merged status are live by nature and a stored copy of them would read exactly like a current one while being wrong. A human may link or unlink; a human unlink is *sticky* and the reconciler never re-applies it, never overwrites a human link and never un-suppresses one. **Row 11 stands unamended**: vincent pushes nothing, opens nothing and merges nothing, and the “create a PR” affordance is a *constructed* compare URL — no request is made to GitHub when it is built — that a human clicks. `internal/github` gains no write method, no `POST` and no mutating `gh` subcommand. Task 035 decision 5's “repo identity is not stored” was revisited exactly as it predicted: the identity landed on the **task**, beside the number, and no `github_repo` column was added to projects (§5.3, §12.3, §13.2, §13.3, §14, §20; task 052, added 2026-08-29) |
 | 28 | MCP from the daemon | **A second protocol on the existing listener, not a second server.** `/mcp` is registered in §13.2's route table inside the same `recover → log → auth` chain, so row 4 is *added to*, not reversed: same loopback listener, same `Authorization: Bearer {token}` from `{data_dir}/token`, same `daemon.json` discovery. The tool surface **is** the route table — a call replays its arguments as an in-process request against the same handler, so the §13.1 bounds, the validation, the `409` + `details.state` envelopes and `Idempotency-Key` hold by construction — **minus five destructive-admin routes** (`daemon/stop`, `daemon/backup`, `DELETE projects/{id}`, `maintenance/gc`, `doctor/fix`), which is a design line: an agent must not be able to stop, garbage-collect or reconfigure the daemon supervising it. §13.3's SSE routes are replaced by a bounded blocking `task_wait` with a hard ceiling, whose result is complete for a client that drops every progress notification. A step parked in that wait **keeps its §11 slot** and a self-blocking wait is *refused*, not released — releasing it would create a §6 state owning a live agent process and holding no slot, which no state does today. The daemon wires its own agent steps to a **per-step endpoint** (`/mcp/step/{run_id}`, per-run secret), which is identity for the refusal and the provenance column and is explicitly **not** a security boundary (§16). Recursion is bounded by `created_by_task_id` + `mcp.max_depth`/`mcp.max_tasks`, deliberately **not** by `parent_task_id`, which the `awaiting_children` join counts (§9.1, §9.2, §9.3, §9.4, §9.7, §11, §12.3, §12.4, §13.4, §14, §16, §20; task 057, issue #243, added 2026-08-29) |
+| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30) |
 
 ## 4. Architecture
 
@@ -447,7 +448,73 @@ event announces when it changed (§13.3), the row carries what it is, and a
 second column would have to be kept true by every writer for something no
 surface renders.
 
+### 5.5 Chat and ChatTurn (task 063)
+
+A **Chat** is a titled conversation with an agent, scoped to a project. It is a
+first-class entity beside §5.3's Task, not a task wearing a different hat: it
+has no workflow snapshot, no step ledger, no `current_step`, no verdict and no
+§6 lifecycle. It never appears on the board or in `GET /v1/tasks`.
+
+What it does share with a task is the isolation: a chat gets its own git
+worktree and its own `vincent/{id}-{slug}` branch (§10), so an agent it is
+talking to can edit files and make commits without colliding with any task.
+
+| Field | Notes |
+|---|---|
+| `id`, `project_id`, `title` | as a task's |
+| `state` | `idle` \| `running` \| `awaiting_input` \| `archived` (below) |
+| `agent` | fixed at creation, and must be an adapter that can resume (§9.1) |
+| `model`, `effort`, `permission_mode` | resolved once at creation, not per turn |
+| `branch`, `base_branch`, `base_sha`, `worktree_path` | §10, exactly a task's |
+| `session_id` | **the agent CLI's own conversation id** — the whole of §7.3's chat-only amendment. Empty before the first turn finishes |
+| `pending_input` | the §7.4 request being awaited; non-null exactly in `awaiting_input` |
+
+A **ChatTurn** is one exchange: the human's message and the agent run it
+produced. Its accounting columns are `step_runs`' — tokens, cost, duration,
+pid, exit code, proc identity — because closing the accounting gap is half of
+what chats are for: a conversation held outside vincent has no transcript and
+no cost record at all. `step_runs` itself is untouched and its `task_id` stays
+`NOT NULL`, so every existing query and every §17 aggregate keeps its current
+meaning. Each turn has its own transcript file.
+
+A turn is `running`, then one of `done`, `failed` or `interrupted`, forever.
+`session_id` also rides on the turn, so a reader can see which session a given
+turn actually ran in — claude may hand a resumed conversation a new id, and a
+turn that failed `session_lost` names the id that was refused.
+
+#### Chat lifecycle
+
+The vocabulary is deliberately **separate from §6's** and lives here rather
+than there. A chat has no `queued` (it is never admitted), no `blocked` (a
+failed turn is a property of the turn, and the chat is usable the instant the
+process is gone), no gate and no verdict. Folding four states into §6 would
+make every existing task query and every board legend decide whether it means
+chats too — the same objection that kept a `kind` column off `tasks`.
+
+| State | Meaning |
+|---|---|
+| `idle` | no live turn; the state a chat is created in and the one every finished turn returns it to |
+| `running` | a live turn: an agent process is up, owned by the chat's runner goroutine |
+| `awaiting_input` | a turn holding its process while the agent waits on a §7.4 request. It **holds** its cap slot, for §6's reason: the process is alive on its stdin |
+| `archived` | the only terminal state. The worktree is gone; nothing further can run in it |
+
+Human actions: `send` (idle → running), `answer` (awaiting_input → running),
+`cancel` (running/awaiting_input → idle), `archive` (idle → archived). There is
+no pause: a chat is a foreground conversation, and a paused one is just an idle
+one nobody has sent to. Anything outside this table is a `409`, decided by
+`internal/chatstate` — the pure FSM both the API and `internal/chatrun` consult,
+the arrangement `internal/taskstate` has for §6.
+
+`send` over `max_parallel_chats` is **refused, not queued** (§11). That refusal
+is not in the FSM: the cap is about how many chats are running, not about what
+this chat may do.
+
 ## 6. Task lifecycle
+
+> Chats have their own lifecycle and their own vocabulary — `idle`, `running`,
+> `awaiting_input`, `archived` — deliberately kept out of this section and
+> documented with the entity in §5.5 (task 063). Nothing in §6 changed when
+> chats landed.
 
 ```
                  create
@@ -851,6 +918,21 @@ between steps or attempts. Durable state flows between steps through:
 
 This keeps steps individually re-runnable, keeps context windows small, and avoids
 coupling to any one agent's session semantics.
+
+**Amended 2026-08-30 for chats only (task 063, issue #255).** A **chat turn**
+(§5.5) is the one run that *does* resume: it starts the agent CLI with the
+session id that CLI itself reported on the previous turn, so turn N has turns
+1..N-1 in context. The three properties above are traded away knowingly and
+only there — a chat turn is not individually re-runnable, its context window
+grows with the conversation, and it couples to the CLI's session semantics
+hard enough that an adapter which cannot resume simply cannot hold a chat
+(§9.3, §9.7). Nothing about a workflow step changed: `agent` steps still get a
+fresh session, and no step ever sets `RunSpec.ResumeSessionID`.
+
+Replaying a prior conversation into the prompt is **not** an alternative
+implementation of this and is rejected: it is an emulation of a capability the
+adapter does not have, and §9.x's rule is that a missing capability is stated,
+never faked.
 
 ### 7.4 Interactive input requests
 
@@ -1902,6 +1984,19 @@ type RunSpec struct {
     OnInput        InputPolicy       // Wait | Deny (§7.4); ignored when the adapter lacks input support
     Env            []string
     MCP            *MCPServer        // §13.4 endpoint this run is wired to; nil = no vincent tools (task 057)
+    ResumeSessionID string           // resume the CLI's own prior session (§7.3 amended; task 063).
+                                     // "" is the fresh session every workflow step gets and always got;
+                                     // only a chat turn ever sets it
+}
+
+// Resumer is the optional capability an adapter implements when its CLI can
+// resume its own session (task 063). Optional rather than a method on
+// AgentAdapter so "a new adapter is one implementation with zero core changes"
+// stays true — an adapter that says nothing cannot resume. All three shipped
+// adapters implement it anyway, because §9.x states a missing capability
+// positively: codex and cursor return false with the reason written down.
+type Resumer interface {
+    SupportsResume() bool
 }
 
 type RunHandle interface {
@@ -2092,6 +2187,16 @@ where the gap is reported ahead of a run.
 - Restricted mode maps to Claude's allowlist flags (`--allowedTools` with an
   edit/read/git/test set).
 - Model and effort pass through as `--model` / `--effort`.
+- **Resume (added 2026-08-30, task 063).** `--resume <session_id>` reloads one of
+  claude's own conversations. The id comes from claude itself: every stream line
+  carries `session_id`, and the adapter records the last one it saw as
+  `RunResult.SessionID` — the last rather than the first because a *resumed*
+  conversation may be handed a new id, and what a chat must store is the session
+  the run actually ran in. This is the only adapter that implements
+  `agent.Resumer` in the affirmative, and it is what makes a chat's second turn
+  see its first (§5.5, §7.3). An id claude refuses is classified
+  `FailureSessionLost` — matched only for a run that actually passed `--resume`,
+  so no workflow step can be misdiagnosed as a lost session.
 - `Options()` probes `claude --help` ad hoc: the `--effort` enum (`low, medium,
   high, xhigh, max` as of 2.1.x) and the documented model aliases are parsed
   from the help text (source `cli`) and merged with the curated catalog (§9.6).
@@ -2163,6 +2268,14 @@ transcript is something people paste into issues.
   worktree the real git dir lives under the main repo, so a `git commit` from
   a restricted codex step may be denied; vincent itself never needs commits
   (the diff reads the working tree).
+- **Cannot resume (stated positively, 2026-08-30, task 063).** `agent.CanResume`
+  is false for codex, so a chat on it is refused at creation (§13.2,
+  `agent_cannot_resume`). codex does have `exec resume <thread_id>` and its
+  stream does carry a `thread_id` — neither is read here yet, and no fixture
+  captured against a named codex build proves the argv, so the capability is
+  absent rather than approximate. Replaying the conversation as prompt context
+  would be an emulation, which §9.x forbids; a refusal a human can read is the
+  honest alternative. Deferred to §20 with the fixture requirement attached.
 - Normalizes Codex's JSONL events (`thread.started`, `item.started`,
   `item.completed`, `turn.completed`, `turn.failed`, `error`); token usage
   comes from `turn.completed` (`input_tokens` taken verbatim, as with claude);
@@ -2507,6 +2620,11 @@ would invalidate every one of them.
   launcher and would open a GUI; the adapter resolves `cursor-agent` only. The
   adapter's `Name()` — and therefore the workflow `agent:` value and the
   `agents.cursor.path` config key — is `cursor`.
+- **Cannot resume (stated positively, 2026-08-30, task 063).** As with codex,
+  `agent.CanResume` is false and a chat on cursor is refused at creation.
+  cursor-agent has a `--resume`, and its stream carries `session_id`, but the
+  adapter reads neither and no captured fixture pins the behaviour. Same rule,
+  same reason, same deferral (§20).
 - Invocation (pinned against cursor-agent 2026.08.04-aaa8809):
   `cursor-agent -p --output-format stream-json --trust`, cwd = worktree,
   prompt via **stdin** (piped, no prompt argument — verified: the echoed
@@ -2732,6 +2850,24 @@ Two consequences are handled rather than assumed away:
     every write in the daemon.
   - `branch_exists` is recoverable through `POST /v1/tasks/{id}/retry`'s
     `branch_override` (§12.2). Without it a blocked task would be permanently dead.
+- **Chat worktrees (added 2026-08-30, task 063).** A chat (§5.5) gets a worktree
+  and a `vincent/{id}-{slug}` branch on exactly the terms above: same root, same
+  branch template, same dirty detection, same archive semantics (§13.2's
+  `POST /v1/chats/{id}/archive` removes the worktree and deletes the branch only
+  when it received nothing, with the same `--force` way out of a dirty refusal).
+
+  Two things changed to make room for it. A worktree directory is now named by
+  its **owner**, not by a bare id — `{root}/{task_id}` for a task, unchanged, and
+  `{root}/chat-{chat_id}` for a chat — because both live under one root and
+  `{root}/7` would otherwise be claimed by task 7 and chat 7 at once. And chats
+  join **gc's claim namespace**: `vincent gc` builds its claim sets from *both*
+  tables, so a chat's worktree and its transcripts are not strays and do not
+  inflate `GET /v1/info`'s orphan count. The directory name stays informational —
+  the rule is still that the claim decides, not the name — but two owners
+  resolving to one path is a collision, not a naming preference.
+
+  Keeping chat directories in a root the reclaimer does not scan was considered
+  and rejected: it trades a false positive for no gc coverage at all.
 - **Isolation caveat (documented, not solved):** git worktrees isolate the working
   tree and index, but share the object store and refs — and **do not** isolate
   process-level resources (global caches, package stores, ports, docker). True
@@ -2938,6 +3074,32 @@ error, immediately, when the caller is itself a running step and the target
 cannot be admitted while the caller holds its slot. A silent hang becomes an
 error the agent can act on, no new state is introduced, and these caps keep
 their current meaning.
+
+### Chats (task 063, added 2026-08-30)
+
+Chat turns are bounded by their **own** cap, `max_parallel_chats` (default 3),
+which counts chats in `running` or `awaiting_input` — the §5.5 states that own a
+live agent process, for the same reason `awaiting_input` counts above.
+
+A chat turn is **never queued**. It is not admitted, it does not go through
+`internal/scheduler`, and a `send` over the cap is refused with `409`
+immediately rather than parked. That preserves the foreground property chats
+exist for — a reply never waits behind batch work — and it leaves the "only
+`internal/scheduler` performs `queued → running`" invariant exactly as it was,
+because a chat turn is never `queued` in the first place.
+
+This is the 2026-08-29 amendment above **extended, not excepted**. That
+amendment's cost was named verbatim — live-but-uncounted agent CLIs
+accumulating — and that reasoning does not stop applying because the noun
+changed from step to turn. So a chat turn is counted; what differs is only that
+the response to a full cap is a refusal a human sees rather than a queue a
+human waits in.
+
+The two caps are independent by design: a running chat consumes no
+`max_parallel_tasks` or per-project slot, and does not delay an admissible task.
+The combined ceiling on live agent processes is therefore
+`max_parallel_tasks + max_parallel_chats`, which is the honest number and is
+documented as such in §12.3.
 
 ## 12. The daemon
 
@@ -3313,6 +3475,7 @@ position the file has reached.
 ```yaml
 listen: 127.0.0.1:0          # 0 = ephemeral port, published via daemon.json; may be pinned
 max_parallel_tasks: 3        # global cap
+max_parallel_chats: 3        # chats holding a live agent process (§11, §5.5); over it a send is 409, never queued
 defaults:
   agent_timeout: 60m
   command_timeout: 15m
@@ -3343,6 +3506,14 @@ github:
 update:                        # check for a newer vincent release (task 055)
   check: true                  # opt-out; false = the daemon makes no such request at all
   poll_interval: 24h           # 0 = off, same as check: false; negative is refused
+# `notify:` is silent on chats (task 063, added 2026-08-30). It exists for
+# unattended work that finishes hours after the human left; a chat turn ends
+# while its human is looking at it, and a hook that fired on every turn would be
+# noise on the one signal that is meant to be rare. `internal/config` therefore
+# gains no import of the chat state package, and task 046 decision 4's
+# arrangement — config imports `taskstate` and only `taskstate` — is untouched.
+# If `awaiting_input` on a long-open chat proves to need one, the named trigger
+# is a separate `notify.chat_on` key, not a widening of `notify.on`.
 notify:                        # run a command when a task enters one of these states (task 046)
   on: []                       # §6 state names; [] (the default) fires nothing
   command: []                  # argv, never a shell string; the envelope arrives on stdin
@@ -3787,6 +3958,22 @@ what the daemon executes or exposes — `notify.command`, `environment`,
   `GET /v1/info`, and it deletes nothing — `vincent gc` does that, with a human behind
   it.
 
+*Amended 2026-08-30 (task 063) — chat turns are the exception to the rule
+above.* A chat turn (§5.5) found `running` on startup is finalized
+`interrupted` and is **not re-run**, and its chat returns to `idle`. The
+bullet's justification is what stops applying: re-running a step is safe by
+construction because the step is a *fresh session over a surviving worktree*,
+and a chat turn is neither half of that. Re-running one would re-send the
+human's message without their asking, into a session that died with the
+process — so the outcome would be a message they did not send answered without
+the context they expected.
+
+Everything else carries over verbatim: the same `procx.Identity` PID-reuse
+guard before killing a verified orphan, the same fail-closed atomic transaction
+shape as `store.InterruptTask`, and the same "rows and processes, not
+directories" rule. The human sees the interrupted turn against the
+conversation and decides whether to say it again.
+
 *Amended 2026-08-25 (issue #142).* Recovery is **fail-closed and atomic per
 task**. Finalizing a task's `running` StepRuns and re-queueing the task are one
 store transaction (`store.InterruptTask`), so the order above can never come
@@ -4180,6 +4367,31 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         task 019, added 2026-08-19). Whether those names resolve
                                         is not answered here: it depends on the project's
                                         resolved view and becomes a 400 at task creation
+GET    /v1/chats                        *Added 2026-08-30 (task 063).* Chats, newest first.
+       ?project_id=&state=              `state` may repeat. Chats appear here and nowhere else:
+                                        never in GET /v1/tasks and never on the board
+POST   /v1/chats                        { project_id, title, agent?, model?, effort?,
+                                          base_branch? } → 201 with the chat, its
+                                        `vincent/{id}-{slug}` branch and its worktree (§10).
+                                        An omitted `agent` resolves to the first registered
+                                        adapter that can resume — there is no `defaults.agent`
+                                        key, and a chat's premise is continuity. An adapter that
+                                        cannot resume is refused `400 agent_cannot_resume`
+                                        (§9.3, §9.7): vincent will not replay the log as prompt
+                                        context in its place
+GET    /v1/chats/{id}                   { chat, turns[] } — the whole conversation, oldest turn
+                                        first, each with its accounting (§5.5)
+POST   /v1/chats/{id}/send              { message } → 202 with the new turn. `409` outside
+                                        `idle` (§5.5), and `409 chat_cap_reached` when
+                                        `max_parallel_chats` chats already hold a live process
+                                        — **refused, never queued** (§11)
+POST   /v1/chats/{id}/answer            the §7.4 answer flow verbatim: same normalized request,
+                                        same `Respond()`, same `input_timeout`. `409` outside
+                                        `awaiting_input`
+POST   /v1/chats/{id}/cancel            stops the live turn and kills its process tree
+POST   /v1/chats/{id}/archive           removes the worktree and deletes the branch when it
+                                        received nothing (§10, task 008 semantics), `?force=`
+                                        for the dirty-worktree refusal. Terminal
 GET    /v1/workflows/definition         one workflow's whole recursive structure, selected with
        ?name=&project_id=               the same §5.2 shadowing the list applies (task 017,
                                         added 2026-08-18):
@@ -4585,6 +4797,15 @@ Two kinds of streams:
    every attempt's file, so a step advance or a retry mid-stream would otherwise have
    its output compared against a position in a different file.
 
+**Chat events (added 2026-08-30, task 063).** Chats ride the one durable event
+table and the one broker; there is no second stream. The durable kinds are
+`chat.created`, `chat.state_changed`, `chat.turn_changed` and `chat.archived`,
+carrying the chat id and — for turn changes — the turn id, seq and state. A
+turn's live output is published exactly as a step's is, with the same ~10 Hz
+coalescing and the same drop-the-slow-subscriber rule, because the turn's
+transcript file is the durable copy. `Last-Event-ID` resumes the durable chat
+events and not the output, for the reason it does not resume a step's.
+
 ### 13.4 Model Context Protocol (task 057)
 
 *Added 2026-08-29 (task 057, issue #243).*
@@ -4644,7 +4865,29 @@ So the MCP rendering masks those two fields — values only; the variable names
 survive, which is the same line §12.3 draws for the log — and nothing else. A
 test asserts the two bodies differ in exactly those fields and nowhere else.
 
-Everything else in §13.2 is a tool, including the three the
+*Amended 2026-08-30 (task 063, issue #255).* The **whole chat family** (§13.2)
+is excluded too, on the same kind of line:
+
+    GET    /v1/chats
+    POST   /v1/chats
+    GET    /v1/chats/{id}
+    POST   /v1/chats/{id}/send
+    POST   /v1/chats/{id}/answer
+    POST   /v1/chats/{id}/cancel
+    POST   /v1/chats/{id}/archive
+
+Two reasons, either sufficient. A chat turn starts an agent CLI **without going
+through admission** (§11), so a tool that could send one would let an agent
+start unqueued agent processes — the exact thing `mcp.max_tasks` exists to
+bound. And the recursion bounds walk `created_by_task_id`: a chat is not in that
+chain, so making chats reachable would mean inventing depth semantics for a
+non-task rather than reusing the ones that exist. An agent that needs a
+conversation already has its own session; it does not need vincent to hold one
+for it.
+
+The task 057 property that the tool surface **equals** `Routes()` minus the
+exclusions is unchanged, and is still asserted by a test — the exclusion list it
+compares against is what grew. Everything else in §13.2 is a tool, including the three the
 proposal left unclassified: `POST`/`DELETE /v1/tasks/{id}/github/pull`,
 `POST /v1/tasks/{id}/steps/{step_id}/status`, and `POST /v1/tasks/{id}/archive`
 despite its worktree removal and its possible empty-branch delete. The unlink
@@ -4878,6 +5121,53 @@ CREATE TABLE idempotency_keys (       -- §13.1 replay protection (task 040)
 );
 CREATE INDEX idx_idempotency_keys_created_at ON idempotency_keys(created_at);
 
+-- Chats and their turns (task 063, added 2026-08-30; migration 0022). Two new
+-- tables rather than a `kind` column on `tasks`: a chat has no workflow
+-- snapshot, no step ledger and no §6 lifecycle, so a chat row in `tasks` would
+-- force the board, admission and every §17 aggregate to decide whether they
+-- mean chats too. For the same reason `chat_turns` is not `step_runs` with a
+-- nullable `task_id` — `step_runs.task_id` stays NOT NULL and every query over
+-- it keeps exactly its current meaning.
+CREATE TABLE chats (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id      INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title           TEXT    NOT NULL,
+    state           TEXT    NOT NULL, -- §5.5: idle | running | awaiting_input | archived
+    agent           TEXT    NOT NULL, -- must be an adapter that can resume (§9.1)
+    model           TEXT,
+    effort          TEXT,
+    permission_mode TEXT    NOT NULL DEFAULT 'full_auto',
+    branch          TEXT    NOT NULL, -- vincent/{id}-{slug}, as a task's (§10)
+    base_branch     TEXT    NOT NULL,
+    base_sha        TEXT,
+    worktree_path   TEXT,             -- the §10 claim; NULL once archived
+    session_id      TEXT,             -- the agent CLI's own session (§7.3 amended)
+    pending_input   TEXT,             -- the §7.4 request being awaited, as JSON
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+
+CREATE TABLE chat_turns (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id       INTEGER NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    seq           INTEGER NOT NULL, -- 1-based position in the conversation
+    prompt        TEXT    NOT NULL,
+    state         TEXT    NOT NULL, -- running | done | failed | interrupted
+    fail_reason   TEXT,             -- the shared snake_case vocabulary; `session_lost` lives here
+    error_message TEXT,
+    result_text   TEXT,
+    session_id    TEXT,             -- the session this turn actually ran in
+    input_tokens  INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd      REAL,             -- NULL = the adapter reports none (§9.3, §9.7)
+    exit_code     INTEGER,
+    pid           INTEGER,          -- while running, for §12.4's orphan kill
+    proc_identity TEXT,             -- the same PID-reuse guard step_runs carries
+    started_at    TEXT    NOT NULL,
+    ended_at      TEXT,
+    duration_ms   INTEGER
+);
+
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 ```
 
@@ -4943,6 +5233,14 @@ together or not at all; a concurrent duplicate loses on the primary key, rolls
 its task insert back, and replays the winner's.
 
 ## 15. TUI
+
+> **Chats in the TUI are not in the first cut (task 063, 2026-08-30).** The
+> entity, its API, its CLI (`vincent chat`) and its runner landed together;
+> the chats view did not, and this section is unchanged until it does. A chat
+> is driven from `vincent chat` and from curl in the meantime. The view, when
+> it lands, is a sibling of the existing six routed by `viewID` and gets its
+> screenshots from `scripts/screenshots.sh` like every other panel — never a
+> drawing.
 
 Built with Bubble Tea. The TUI is a pure API client — it holds no *task* state
 the daemon doesn't have, and killing it never affects work. What it does own is
@@ -5100,7 +5398,7 @@ stream for the live tail.
    auto-opening under a keystroke is how an answer gets lost, so it announces
    itself with a badge on the row and a footer hint, and the human opens it.
 
-   **The popup's own tab strip (task 059, added 2026-08-30).** All three form
+   **The popup's own tab strip (task 063, added 2026-08-30).** All three form
    popups below — answer, repair and follow-up — carry a two-tab strip of their
    own as their first body line: the form (**Question** / **Repair** /
    **Follow-up**) and **Task details**. `ctrl+t` cycles them while the popup
@@ -5130,7 +5428,7 @@ stream for the live tail.
    `$EDITOR`) and optional agent/model/effort rows fed by the same
    `GET /v1/agents` pickers the new-task flow uses (§8.6, with the request
    standing in for the step level). `ctrl+s` starts the repair, `esc` closes it
-   and discards the draft — which is why `ctrl+t` (above, task 059) rather than
+   and discards the draft — which is why `ctrl+t` (above, task 063) rather than
    `esc` is the way out to the task's details. It is a popup and not an action
    key because a repair needs prose written for this one task — which is also
    why it is excluded from bulk actions.
@@ -5150,7 +5448,7 @@ stream for the live tail.
    decides what the row under it means — a prompt, a command, or a workflow
    picked from `GET /v1/workflows` — and the same agent/model/effort pickers
    follow. `ctrl+s` starts the run, `esc` closes and discards the draft; as with
-   repair, `ctrl+t` (above, task 059) is the way to read the task's details
+   repair, `ctrl+t` (above, task 063) is the way to read the task's details
    without paying that. Like repair it is excluded from bulk actions (task 011):
    the input is written for one task, and the batch case is
    `vincent task follow-up` (§12.1).
@@ -5585,7 +5883,7 @@ Views 3–7 stay full-screen because they are forms and lists, not observations:
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
 serves neither. Takeovers are for surfaces you visit deliberately; popups are
 for what interrupts you — the palette, confirmations, and the three form popups.
-*(Amended 2026-08-30, task 059: the dividing line is the interruption, not the
+*(Amended 2026-08-30, task 063: the dividing line is the interruption, not the
 size. A form popup with a tab strip takes the whole height budget and carries
 the task inspector inside it, and is no longer a small thing.)*
 
@@ -5775,7 +6073,7 @@ human, surfaced in the footer only when that count is non-zero — the board has
 always pinned and belled those tasks without offering any way to *go* to one.
 
 **`esc` cancels one layer per press**, by a fixed stack: *(amended 2026-08-30,
-task 059)* a form popup's Task details tab → popup (palette, confirmation,
+task 063)* a form popup's Task details tab → popup (palette, confirmation,
 answer form) → takeover screen → bulk selection → active filter →
 nothing. The innermost layer is the newest: on a form popup's details tab `esc`
 returns to the form tab with the draft untouched and the popup still open, and
@@ -6335,6 +6633,18 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
   three OS backends and the packaging that comes with them — stays deferred,
   and the exec hook is why that is now cheap: `terminal-notifier`,
   `notify-send` and `msg` are all one `command:` line away.
+- ~~Free chat: conversational agent sessions beside tasks~~ — **promoted out of
+  future work on landing, 2026-08-30** (§5.5, task 063, issue #255). Like the
+  MCP entry above it was never listed here, so it is recorded as promoted rather
+  than struck through. Named here so the next person does not rediscover them,
+  the pieces deliberately left out of the first cut: **codex `exec resume
+  <thread_id>` and cursor `--resume`**, each of which lands with a fixture
+  captured against a named CLI version the way every other adapter capability
+  has — until then those adapters are *refused* at chat creation, never
+  emulated by replaying a log as prompt context; a **`notify.chat_on` key**, if
+  `awaiting_input` on a long-open chat proves to need an outward signal (§12.3);
+  and **chat routes as MCP tools**, which stays refused on the design line in
+  §13.4 rather than merely deferred.
 - ~~More adapters~~ — **Cursor promoted out of future work to M5, 2026-08-11**
   (§9.7). Gemini CLI, opencode, and adapter capability flags remain here.
 - ~~parallel steps and step fan-out~~ — **promoted out of future work,

--- a/docs/tasks/063-free-chat.md
+++ b/docs/tasks/063-free-chat.md
@@ -1,0 +1,146 @@
+# 063 — Free chat: conversational agent sessions beside tasks
+
+**Issue:** #255
+**Status:** 🔄 in progress (1/2)
+
+## Why
+
+Every agent run vincent owns today is a *task*: a workflow, a step ledger, a
+verdict. There is no way to simply talk to an agent inside a project and keep
+the result. People do it anyway, in a terminal beside vincent — and that
+conversation has no worktree isolation, no transcript, no token or cost record,
+and nothing to come back to.
+
+A chat closes that: a titled conversation, scoped to a project, isolated in its
+own worktree and branch, with every turn recorded the way a step run is.
+
+## What it is
+
+A **first-class entity beside Task**, never a task with a `kind` column. The
+alternative was considered and rejected in the issue: a chat row in `tasks`
+would force the board, admission and every §17 aggregate to decide whether they
+mean chats too, and a chat carrying a `current_step` would be a lie to every
+reader of the snapshot. Same reasoning keeps `chat_turns` out of `step_runs`:
+`step_runs.task_id` stays `NOT NULL` and every query over it keeps its meaning.
+
+Spec: §5.5 (the entity and its lifecycle), §7.3 (the chat-only amendment), §9.1
+/ §9.2 / §9.3 / §9.7 (resume), §10 (worktrees and gc), §11 (the cap), §12.3,
+§12.4 (interrupted turns), §13.2–§13.4, §14, §15, §20, decision record row 29.
+
+## Decisions
+
+1. **A chat turn is bounded by its own cap, and refused rather than queued.**
+   `max_parallel_chats` (default 3) counts chats in `running` or
+   `awaiting_input`. Over it, a send is `409` immediately — never queued, never
+   through `internal/scheduler`. The issue asked for "no admission at all";
+   that collides with §11's 2026-08-29 amendment (task 057, row 28), which
+   rejected releasing a slot while an agent process is live and named the cost
+   verbatim — *live-but-uncounted agent CLIs accumulating*. That reasoning does
+   not stop applying because the noun changed. So the 057 amendment is
+   **extended, not excepted**, and the foreground property the issue wanted is
+   preserved anyway: a chat turn never waits behind batch work, it is refused
+   in front of it. The scheduler invariant is untouched because a chat turn is
+   never `queued`.
+
+2. **No chat route is an MCP tool.** §13.4's exclusion list grows from five
+   routes to five plus the chat family. An agent must not be able to start
+   unqueued agent processes, and `mcp.max_depth`/`mcp.max_tasks` bound tasks by
+   walking `created_by_task_id` — a chain a chat is not in, so adding chats
+   would mean inventing depth semantics for a non-task. An agent that needs a
+   conversation already has its own session. Task 057's assertion that the tool
+   surface equals `Routes()` minus the exclusions is **extended**, not weakened.
+
+3. **claude only in the first cut; codex and cursor are refused, not emulated.**
+   `agent.Resumer` is an optional capability so a new adapter is still one
+   implementation with zero core changes; all three shipped adapters implement
+   it anyway, because §9.x states a missing capability positively. Chat creation
+   refuses a non-resuming adapter with `400 agent_cannot_resume` — the same
+   shape as `agent.ErrRestrictedUnsupported`. Replaying the log as prompt
+   context stays rejected. codex `exec resume <thread_id>` and cursor
+   `--resume` are follow-up work, each landing with a fixture captured against
+   a named CLI version, the way every other adapter capability has.
+
+4. **A turn whose stored session is gone fails.** Reason `session_lost`,
+   rendered against the turn; the chat stays usable and keeps its id, and the
+   human decides whether to start fresh. A silent fresh session answers as if it
+   had context it does not have, and a reader cannot tell that apart from a
+   working one. The classifier only ever runs for a run that actually passed
+   `--resume`, so no workflow step can be misdiagnosed.
+
+5. **A turn interrupted by a daemon restart is finalized `interrupted` and is
+   not re-run.** §12.4's auto-resume rule holds for steps because a fresh
+   session over a surviving worktree is safe by construction; a chat turn is
+   neither half of that. Re-running would re-send the human's message into a
+   session that died with the process. The orphan kill is unchanged: same
+   `procx.Identity` PID-reuse guard, same fail-closed atomic shape as
+   `store.InterruptTask`. The chat returns to `idle`.
+
+6. **Turns get their own `chat_turns` table** with `step_runs`' accounting
+   columns and a transcript file per turn.
+
+7. **`notify:` does nothing for chats in this cut.** It exists for unattended
+   work finishing hours after the human left; a chat turn ends while its human
+   is looking at it. `internal/config` gains no import of the chat state
+   package, so task 046 decision 4's arrangement is untouched. `notify.chat_on`
+   is the named trigger if `awaiting_input` on a long-open chat needs one.
+
+8. **Mid-run input reuses the §7.4 flow.** A chat enters `awaiting_input`
+   holding its process, `pending_input` on the chat row, answered through a chat
+   answer route calling the same adapter `Respond()`. The structured options,
+   multi-select and the permission allow/deny distinction are the reason not to
+   degrade this into "the next message is the answer".
+
+9. **Chat worktrees join the gc claim namespace** (found during review, not in
+   the issue). `internal/taskrun/reclaim.go` builds its claim sets from *task*
+   rows and treats anything unclaimed under the worktree root or
+   `{data_dir}/transcripts` as an orphan, so a chat worktree would be deleted by
+   `vincent gc` and inflate `GET /v1/info`'s orphan count meanwhile. Chats
+   extend both claim sets, and `worktree.Manager` takes an `Owner` rather than a
+   `taskID int64` so chat 7 and task 7 cannot collide on `{root}/7`. Keeping
+   chat directories in a root the reclaimer does not scan was rejected: it
+   trades a false positive for no gc coverage at all.
+
+Unchanged and worth stating: §16 is untouched. Chats are full-auto by default
+like tasks, the worktree isolates collisions and not privileges, and the
+existing first-run acknowledgement already covers it. §6's task FSM,
+`internal/taskstate` and the task board gain nothing.
+
+## Sub-tasks
+
+| ID | What | Status |
+|---|---|---|
+| 063.1 | The entity end to end: `internal/chatstate`, `internal/chatrun`, migration 0022, store CRUD + claims, `internal/agent` resume capability + claude `--resume`, the `/v1/chats` route family, `internal/apiclient`, `vincent chat`, daemon wiring, `max_parallel_chats`, gc claim sets, owner-named worktree directories, spec and docs | ✅ done |
+| 063.2 | The chats view in the TUI, and `scripts/m13-gate.sh` wired into `ci.yml`'s `gates` job on all three platforms | [ ] |
+
+### Why 063.2 is separate
+
+063.1 is the entity, and it is complete and usable — CLI, API, runner,
+recovery, gc, docs. The TUI view and the end-to-end gate are the client and the
+acceptance walk over it; neither changes a decision above, and both are held to
+bars this repository takes seriously and does not want rushed: a view whose
+screenshots come from `scripts/screenshots.sh` rather than a drawing, and a gate
+written in the sh∩pwsh intersection that has actually been run on all three
+platforms before it is claimed to pass on them. §15 carries a note saying the
+view is not there yet, so the spec does not describe a screen that does not
+exist.
+
+## What the tests prove
+
+- **Continuity** — `internal/chatrun`: turn 2 answers with what only turn 1
+  supplied, against `cmd/fakeagent`, which was given a real session store of its
+  own so the resume is the agent remembering rather than vincent staging it.
+- **Refusal, not emulation** — codex and cursor are refused at creation with the
+  typed reason, over the real handlers.
+- **`session_lost`** — a stored id the CLI no longer knows fails the turn,
+  leaves the chat idle and usable, keeps the id, and starts no fresh session
+  (asserted against the fake CLI's own store being untouched).
+- **Caps** — the `max_parallel_chats + 1`-th send is `409` and leaves no turn
+  row behind: refused, not parked.
+- **Recovery** — a turn journaled `running` by a dead daemon is `interrupted`,
+  the chat is `idle`, no second turn exists and the message is not re-sent.
+- **MCP** — the tool surface equals `Routes()` minus the five admin routes *and*
+  the chat family.
+- **gc** — a chat's worktree and transcripts are not strays.
+- **Separation** — chats never appear in `ListTasks` or `GET /v1/tasks`.
+- **FSM** — `internal/chatstate` over every action from every state, including
+  the illegal ones.

--- a/docs/tasks/063-free-chat.md
+++ b/docs/tasks/063-free-chat.md
@@ -111,6 +111,7 @@ existing first-run acknowledgement already covers it. §6's task FSM,
 |---|---|---|
 | 063.1 | The entity end to end: `internal/chatstate`, `internal/chatrun`, migration 0022, store CRUD + claims, `internal/agent` resume capability + claude `--resume`, the `/v1/chats` route family, `internal/apiclient`, `vincent chat`, daemon wiring, `max_parallel_chats`, gc claim sets, owner-named worktree directories, spec and docs | ✅ done |
 | 063.2 | The chats view in the TUI, and `scripts/m13-gate.sh` wired into `ci.yml`'s `gates` job on all three platforms | [ ] |
+| 063.3 | The three gaps the 063.1 documentation audit found, none of which changes a decision above: a chat turn is bounded by **no clock at all** — `internal/chatrun` applies neither `input_timeout` nor `agent_timeout`, so a turn (and the `max_parallel_chats` slot it holds) runs until it is answered or cancelled, and §13.2 carries a dated correction saying so; `vincent chat` has **no `answer` and no `cancel`**, so a chat that enters `awaiting_input` can only be moved on over the API, and `vincent chat send` blocks meanwhile; and the transcript plumbing is task-scoped at both ends — `internal/taskrun`'s pruner walks archived *tasks*, so an **archived chat's transcripts are never reclaimed** by `transcript_retention_days`, and only `internal/taskrun/engine.go` calls `Writer.SetMax`, so a chat turn's transcript is written with **no `transcript_max_bytes` cap**. `vincent chat` also has no `--json`, which is why the blanket claim in the scripting guide was narrowed | [ ] |
 
 ### Why 063.2 is separate
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -76,6 +76,7 @@ the living engineering specification records implementation contracts.
 | [060](060-daemon-configuration-editing.md) | Edit the daemon configuration from the TUI | ✅ done (8/8) |
 | [061](061-container-step-execution.md) | Run a task's steps inside a container: the exec seam | ✅ done (1/1) |
 | [062](062-agent-steps-in-containers.md) | Agent steps inside the task's container | 📋 planned (0/1) |
+| [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | 🔄 in progress (1/2) |
 
 ## How to add and update a task document
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -76,7 +76,7 @@ the living engineering specification records implementation contracts.
 | [060](060-daemon-configuration-editing.md) | Edit the daemon configuration from the TUI | ✅ done (8/8) |
 | [061](061-container-step-execution.md) | Run a task's steps inside a container: the exec seam | ✅ done (1/1) |
 | [062](062-agent-steps-in-containers.md) | Agent steps inside the task's container | 📋 planned (0/1) |
-| [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | 🔄 in progress (1/2) |
+| [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | 🔄 in progress (1/3) |
 
 ## How to add and update a task document
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -78,6 +78,39 @@ var ErrRestrictedUnsupported = errors.New("restricted permission mode is unsuppo
 // run.
 var ErrMCPUnsupported = errors.New("this agent CLI cannot be given an MCP server for a single run")
 
+// ErrResumeUnsupported is returned by Start when the adapter cannot resume a
+// prior session of its CLI (spec §9.1, §9.3, §9.7, task 063). It is the third
+// sentinel of the ErrRestrictedUnsupported shape, and it exists for the same
+// reason: a chat that silently started a *fresh* session would answer as if it
+// had context it does not have, and no reader could tell that apart from a
+// working conversation.
+//
+// The refusal is normally made long before Start — chat creation consults
+// CanResume and refuses the adapter outright (§5.5) — so this is the
+// belt-and-braces half, for a caller that built a RunSpec by hand.
+var ErrResumeUnsupported = errors.New("this agent CLI cannot resume a previous session")
+
+// Resumer is the optional capability an adapter implements when its CLI can
+// resume its own prior session (spec §9.1, task 063 / §7.3 amended).
+//
+// It is an optional interface rather than an Adapter method so that "adding an
+// agent CLI is one new implementation with zero core changes" stays true: an
+// adapter that says nothing cannot resume. All three shipped adapters
+// implement it anyway, because §9.x states a missing capability positively —
+// codex and cursor return false with the reason in their doc comment rather
+// than leaving a reader to infer it from an absence.
+type Resumer interface {
+	// SupportsResume reports whether Start honors RunSpec.ResumeSessionID.
+	SupportsResume() bool
+}
+
+// CanResume reports whether a can resume a prior session. It is what the API
+// consults before creating a chat on an adapter (§5.5).
+func CanResume(a Adapter) bool {
+	r, ok := a.(Resumer)
+	return ok && r.SupportsResume()
+}
+
 // MCPServer is the vincent MCP endpoint a step's agent is wired to (spec
 // §9.1, §13.4). Nil — the zero value of RunSpec.MCP — is a run with no
 // vincent tools, which is every run before task 057 and every run under
@@ -163,6 +196,14 @@ type RunSpec struct {
 	// nil is a run with no vincent tools. An adapter that cannot carry one
 	// returns ErrMCPUnsupported from Start rather than starting without it.
 	MCP *MCPServer
+	// ResumeSessionID resumes the agent CLI's own prior session instead of
+	// starting a fresh one (§7.3, amended for chats only — task 063). Empty
+	// is the fresh session every workflow step gets and always got.
+	//
+	// Only a chat turn ever sets it. An adapter that cannot resume returns
+	// ErrResumeUnsupported from Start rather than starting a fresh session
+	// under a spec that promised continuity.
+	ResumeSessionID string
 	// Env is the child's environment, resolved from §12.3 `environment:`
 	// (T4.23). nil still means "inherit the daemon's", which is what tests
 	// and any other caller get; the engine always populates it, so a running
@@ -329,7 +370,15 @@ type RunResult struct {
 	IsError      bool   // the stream's terminal result was an error, or none arrived
 	ErrorMessage string // set when IsError
 	ResultText   string // agent's final answer/summary
-	InputTokens  int64  // 0 if unreported
+	// SessionID is the CLI's own identifier for the conversation this run
+	// belongs to (§9.1, task 063): claude's `session_id`, codex's
+	// `thread_id`, cursor's `session_id`. Empty when the dialect reported
+	// none, which is every adapter that has not been taught to read it.
+	//
+	// A chat stores it and hands it back as RunSpec.ResumeSessionID on the
+	// next turn. Nothing in the task path reads it.
+	SessionID    string
+	InputTokens  int64 // 0 if unreported
 	OutputTokens int64
 	CostUSD      *float64 // nil if unreported (e.g. codex)
 	// Failure is the adapter's verdict about *why* the run stopped, when it
@@ -373,6 +422,16 @@ const (
 	// perfectly, and sending a user to look at it wastes their time. The
 	// engine maps it to `agent_protocol_error` (§18).
 	FailureStreamError FailureKind = "stream_error"
+	// FailureSessionLost is a resume the CLI refused because the session id
+	// it was given is gone or expired (task 063 decision 4). Only a chat
+	// turn can produce it — nothing else sets RunSpec.ResumeSessionID.
+	//
+	// The engine fails the turn with `session_lost` rather than falling back
+	// to a fresh session: the human asked to continue a conversation, and an
+	// agent answering with none of it in context reads exactly like one that
+	// has it. The chat stays usable; starting over is a decision a person
+	// makes explicitly.
+	FailureSessionLost FailureKind = "session_lost"
 )
 
 // Failure is an adapter's verdict about a stopped run (task 003, §9.1).

--- a/internal/agent/claude/claude.go
+++ b/internal/agent/claude/claude.go
@@ -142,6 +142,13 @@ func buildArgs(spec agent.RunSpec, inputMode bool) ([]string, error) {
 	if inputMode {
 		args = append(args, "--input-format", "stream-json", "--permission-prompt-tool", "stdio")
 	}
+	// --resume takes the session id claude itself reported on a previous run
+	// (§9.2, task 063). It is the whole of chat continuity: the CLI reloads
+	// its own conversation, so turn N sees turns 1..N-1 without vincent
+	// replaying anything as prompt context.
+	if spec.ResumeSessionID != "" {
+		args = append(args, "--resume", spec.ResumeSessionID)
+	}
 	if spec.Model != "" {
 		args = append(args, "--model", spec.Model)
 	}
@@ -241,6 +248,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 	}
 	r := &run{
 		cmd:        cmd,
+		resuming:   spec.ResumeSessionID != "",
 		proc:       proc,
 		stderr:     stderr,
 		stdin:      stdin,
@@ -293,8 +301,18 @@ type run struct {
 	raw     chan agent.Event
 	promote chan agent.Event
 
+	// resuming records that this run was started with a session id, so Wait
+	// can tell a session claude refused to load from any other failure
+	// (task 063 decision 4).
+	resuming bool
+
 	mu       sync.Mutex
 	terminal *agent.RunResult // parsed result event, if any
+	// sessionID is the last `session_id` claude stamped on a stream line.
+	// Every line carries it, so the last one seen is the session the run
+	// actually ran in — which is what a resumed run must store, since
+	// claude may hand a resumed conversation a new id.
+	sessionID string
 	// streamErr is readLoop's own reader failing, latched for Wait. It is
 	// vincent losing the stream, not the CLI failing, and Wait says so with
 	// agent.FailureStreamError rather than letting the exit code speak for a
@@ -358,6 +376,11 @@ func (r *run) readLoop(rd io.Reader) {
 		copy(line, sc.Bytes())
 		if len(strings.TrimSpace(string(line))) == 0 {
 			continue
+		}
+		if sid := sessionIDOf(line); sid != "" {
+			r.mu.Lock()
+			r.sessionID = sid
+			r.mu.Unlock()
 		}
 		ev := r.parseStreamLine(line)
 		if ev.Type == agent.EventResult && ev.Result != nil {
@@ -507,8 +530,9 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal, streamErr := r.terminal, r.streamErr
+		terminal, streamErr, sessionID := r.terminal, r.streamErr, r.sessionID
 		r.mu.Unlock()
+		res.SessionID = sessionID
 		if terminal != nil {
 			res.IsError = terminal.IsError
 			res.ErrorMessage = terminal.ErrorMessage
@@ -527,6 +551,12 @@ func (r *run) Wait() (agent.RunResult, error) {
 		// It happens here because this is the one place that holds both the
 		// terminal result and the stderr tail; the engine sees neither.
 		res.Failure = classify(res, r.stderr.String())
+		// A resume claude refused outranks the generic verdict: the id is
+		// gone, and no amount of retrying this run will bring it back
+		// (task 063 decision 4).
+		if f := classifyResume(res, r.stderr.String(), r.resuming); f != nil {
+			res.Failure = f
+		}
 		// A stream vincent could not read to the end outranks whatever the
 		// exit code says: the run may well have finished cleanly, but the
 		// record of it is missing lines, and §7.1 success is a claim about
@@ -569,3 +599,8 @@ func (w *tailWriter) String() string {
 
 // Argv implements agent.RunHandle: the command line actually spawned.
 func (r *run) Argv() []string { return r.cmd.Args }
+
+// SupportsResume implements agent.Resumer: claude can reload one of its own
+// conversations with `--resume <session_id>` (§9.2), which is what makes a
+// chat's second turn see the first (task 063 decision 3).
+func (a *Adapter) SupportsResume() bool { return true }

--- a/internal/agent/claude/failure.go
+++ b/internal/agent/claude/failure.go
@@ -44,6 +44,18 @@ var unauthenticatedMarkers = []string{
 	"authentication_error",
 }
 
+// sessionLostMarkers are the phrasings that mean "the session id you asked me
+// to resume is not one I know". Same conservative rule as the markers above:
+// recognize documented shapes, fall through to the generic verdict otherwise.
+// They are only ever consulted for a run that actually passed --resume, so a
+// task step can never be misdiagnosed as a lost session.
+var sessionLostMarkers = []string{
+	"no conversation found with session id",
+	"no conversation found",
+	"session not found",
+	"could not resume",
+}
+
 // resetEpochRe matches the reset time claude appends to its usage-limit
 // message as unix seconds: `Claude AI usage limit reached|1755100000`.
 var resetEpochRe = regexp.MustCompile(`limit reached\|(\d{9,11})`)
@@ -69,6 +81,26 @@ func classify(res agent.RunResult, stderr string) *agent.Failure {
 	default:
 		return nil
 	}
+}
+
+// classifyResume names a resume the CLI refused (task 063 decision 4). It
+// returns nil for a run that did not resume at all, and for a resumed run that
+// succeeded — a chat turn's ordinary case.
+//
+// It is a second pass rather than a branch inside classify because it needs
+// something classify has no business knowing: whether this run was a resume.
+// A quota stop or a logged-out CLI still wins nothing here; the caller applies
+// this one last, since a lost session is the actionable verdict and the only
+// one that says "this conversation cannot continue".
+func classifyResume(res agent.RunResult, stderr string, resuming bool) *agent.Failure {
+	if !resuming || !res.IsError {
+		return nil
+	}
+	text := strings.ToLower(strings.Join([]string{res.ErrorMessage, res.ResultText, stderr}, "\n"))
+	if containsAny(text, sessionLostMarkers) {
+		return &agent.Failure{Kind: agent.FailureSessionLost}
+	}
+	return nil
 }
 
 func containsAny(text string, markers []string) bool {

--- a/internal/agent/claude/stream.go
+++ b/internal/agent/claude/stream.go
@@ -11,7 +11,12 @@ import (
 // against claude 2.1.x). Parsing is tolerant: unknown event types become
 // EventUnknown, transcripted verbatim but not normalized (phase 1 decision).
 type streamLine struct {
-	Type         string         `json:"type"`
+	Type string `json:"type"`
+	// SessionID is claude's own identifier for the conversation. Every line
+	// carries it, including the `system`/`init` line that precedes any
+	// assistant output, which is why sessionIDOf reads it off the raw line
+	// rather than off a normalized event (task 063).
+	SessionID    string         `json:"session_id"`
 	Subtype      string         `json:"subtype"`
 	Message      *streamMessage `json:"message"`
 	IsError      bool           `json:"is_error"`
@@ -49,6 +54,20 @@ type streamBlock struct {
 type streamUsage struct {
 	InputTokens  int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
+}
+
+// sessionIDOf reads claude's `session_id` off one verbatim stream line, or ""
+// when the line has none or does not parse. It is deliberately separate from
+// parseLine: a session id is not an event — it is a property of the run, and
+// the run records it (§9.1, §9.2).
+func sessionIDOf(raw []byte) string {
+	var line struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return ""
+	}
+	return line.SessionID
 }
 
 // NewLineParser returns a parser for claude transcript lines (§13.2

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -400,3 +400,12 @@ func (w *tailWriter) String() string {
 
 // Argv implements agent.RunHandle: the command line actually spawned.
 func (r *run) Argv() []string { return r.cmd.Args }
+
+// SupportsResume implements agent.Resumer, in the negative (§9.3, task 063
+// decision 3). codex does have `exec resume <thread_id>`, and its stream does
+// carry a `thread_id` — but neither is read here yet, and no fixture captured
+// against a named codex build proves the argv. Saying false is the positive
+// statement the project's rule asks for: a capability an adapter lacks is
+// stated, never emulated. Replaying the conversation as prompt context would
+// be exactly that emulation, so chat creation refuses codex instead.
+func (a *Adapter) SupportsResume() bool { return false }

--- a/internal/agent/cursor/cursor.go
+++ b/internal/agent/cursor/cursor.go
@@ -460,3 +460,10 @@ func (w *tailWriter) String() string {
 
 // Argv implements agent.RunHandle: the command line actually spawned.
 func (r *run) Argv() []string { return r.cmd.Args }
+
+// SupportsResume implements agent.Resumer, in the negative (§9.7, task 063
+// decision 3). cursor-agent has a `--resume` of its own and emits a
+// `session_id`, but as with codex neither is wired here and no captured
+// fixture pins the flag against a named cursor-agent build. Chat creation
+// refuses cursor rather than replaying the log as prompt context.
+func (a *Adapter) SupportsResume() bool { return false }

--- a/internal/api/actions_test.go
+++ b/internal/api/actions_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // actionHarness is the task harness with no runner: tasks stay queued, so a
@@ -251,7 +252,7 @@ func TestArchiveDirtyWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
-	path, err := h.wt.Create(t.Context(), h.repo, task.ID, stored.BranchName, stored.BaseBranch, false)
+	path, err := h.wt.Create(t.Context(), h.repo, worktree.TaskOwner(task.ID), stored.BranchName, stored.BaseBranch, false)
 	if err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}
@@ -307,7 +308,7 @@ func archivableTask(t *testing.T, h *taskHarness) *store.Task {
 	if err != nil {
 		t.Fatalf("GetTask: %v", err)
 	}
-	path, err := h.wt.Create(t.Context(), h.repo, task.ID, stored.BranchName, stored.BaseBranch, false)
+	path, err := h.wt.Create(t.Context(), h.repo, worktree.TaskOwner(task.ID), stored.BranchName, stored.BaseBranch, false)
 	if err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -1,0 +1,379 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/chatrun"
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// CodeAgentCannotResume is the typed refusal a chat on an adapter that cannot
+// resume its own session gets (§9.1, §9.3, §9.7; task 063 decision 3). It is
+// its own code rather than a generic validation failure because the client's
+// remedy is specific and nameable: pick an adapter that can, and do not expect
+// the conversation to be reconstructed some other way.
+const CodeAgentCannotResume = "agent_cannot_resume"
+
+// CodeChatCapReached is a turn refused because `max_parallel_chats` chats are
+// already running (§11, decision 1). It is a 409 and never a queue.
+const CodeChatCapReached = "chat_cap_reached"
+
+// chatBody is a chat as the API renders it (§5.5, §13.2).
+type chatBody struct {
+	ID           int64           `json:"id"`
+	ProjectID    int64           `json:"project_id"`
+	Title        string          `json:"title"`
+	State        string          `json:"state"`
+	Agent        string          `json:"agent"`
+	Model        string          `json:"model,omitempty"`
+	Effort       string          `json:"effort,omitempty"`
+	Branch       string          `json:"branch"`
+	BaseBranch   string          `json:"base_branch"`
+	BaseSHA      string          `json:"base_sha,omitempty"`
+	WorktreePath string          `json:"worktree_path,omitempty"`
+	SessionID    string          `json:"session_id,omitempty"`
+	PendingInput json.RawMessage `json:"pending_input,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// chatTurnBody is one turn as the API renders it.
+type chatTurnBody struct {
+	ID           int64      `json:"id"`
+	ChatID       int64      `json:"chat_id"`
+	Seq          int        `json:"seq"`
+	Prompt       string     `json:"prompt"`
+	State        string     `json:"state"`
+	FailReason   string     `json:"fail_reason,omitempty"`
+	ErrorMessage string     `json:"error_message,omitempty"`
+	ResultText   string     `json:"result_text,omitempty"`
+	SessionID    string     `json:"session_id,omitempty"`
+	InputTokens  int64      `json:"input_tokens"`
+	OutputTokens int64      `json:"output_tokens"`
+	CostUSD      *float64   `json:"cost_usd"`
+	ExitCode     *int       `json:"exit_code,omitempty"`
+	StartedAt    time.Time  `json:"started_at"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	DurationMS   *int64     `json:"duration_ms,omitempty"`
+}
+
+func renderChat(c *store.Chat) chatBody {
+	return chatBody{
+		ID: c.ID, ProjectID: c.ProjectID, Title: c.Title, State: string(c.State),
+		Agent: c.Agent, Model: c.Model, Effort: c.Effort, Branch: c.Branch,
+		BaseBranch: c.BaseBranch, BaseSHA: c.BaseSHA, WorktreePath: c.WorktreePath,
+		SessionID: c.SessionID, PendingInput: c.PendingInput,
+		CreatedAt: c.CreatedAt, UpdatedAt: c.UpdatedAt,
+	}
+}
+
+func renderChatTurn(t *store.ChatTurn) chatTurnBody {
+	return chatTurnBody{
+		ID: t.ID, ChatID: t.ChatID, Seq: t.Seq, Prompt: t.Prompt, State: string(t.State),
+		FailReason: t.FailReason, ErrorMessage: t.ErrorMessage, ResultText: t.ResultText,
+		SessionID: t.SessionID, InputTokens: t.InputTokens, OutputTokens: t.OutputTokens,
+		CostUSD: t.CostUSD, ExitCode: t.ExitCode, StartedAt: t.StartedAt,
+		EndedAt: t.EndedAt, DurationMS: t.DurationMS,
+	}
+}
+
+type createChatRequest struct {
+	ProjectID  int64  `json:"project_id"`
+	Title      string `json:"title"`
+	Agent      string `json:"agent"`
+	Model      string `json:"model"`
+	Effort     string `json:"effort"`
+	BaseBranch string `json:"base_branch"`
+}
+
+// handleChatCreate creates a chat, allocating its worktree and
+// `vincent/{id}-{slug}` branch exactly as a task's is (§10).
+//
+// The adapter is checked for resume support *before* anything is written: a
+// chat on an adapter that cannot resume would be a conversation that silently
+// forgets itself, and refusing it here is the same shape as §9.4's restricted
+// refusal (decision 3).
+func (s *Server) handleChatCreate(w http.ResponseWriter, r *http.Request) {
+	var req createChatRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.Title == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "title is required")
+		return
+	}
+	project, err := s.deps.Store.GetProject(r.Context(), req.ProjectID)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, fmt.Sprintf("project %d not found", req.ProjectID))
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	// An omitted agent resolves to the first registered adapter that can
+	// resume, rather than to a configured default: there is no
+	// `defaults.agent` key — a task's agent comes from its workflow — and a
+	// chat's whole premise is continuity, so "any adapter that can hold a
+	// conversation" is the only default that is not a trap.
+	name := req.Agent
+	if name == "" {
+		for _, a := range s.deps.Agents.All() {
+			if agent.CanResume(a) {
+				name = a.Name()
+				break
+			}
+		}
+	}
+	adapter, ok := s.deps.Agents.Get(name)
+	if !ok {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, fmt.Sprintf("unknown agent %q", name))
+		return
+	}
+	if !agent.CanResume(adapter) {
+		writeError(w, http.StatusBadRequest, CodeAgentCannotResume, fmt.Sprintf(
+			"agent %q cannot resume its own session, so it cannot hold a conversation; "+
+				"vincent refuses this rather than replaying the log as prompt context", name))
+		return
+	}
+	base := req.BaseBranch
+	if base == "" {
+		base = project.DefaultBranch
+	}
+	chat := &store.Chat{
+		ProjectID: project.ID, Title: req.Title, State: chatstate.Idle, Agent: name,
+		Model: req.Model, Effort: req.Effort, PermissionMode: string(agent.FullAuto),
+		BaseBranch: base,
+	}
+	if err := s.deps.Store.CreateChat(r.Context(), chat); err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	// The branch name needs the id, and the id needs the row: the chat is
+	// written first and named second, exactly as a task is.
+	chat.Branch = worktree.BranchName(chat.ID, chat.Title)
+	if err := s.deps.Store.SetChatBranch(r.Context(), chat.ID, chat.Branch); err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	created, err := s.deps.Worktrees.CreateAndClaim(
+		r.Context(), project.Path, worktree.ChatOwner(chat.ID), chat.Branch, base, true,
+		func(c worktree.Created) error {
+			_, err := s.deps.Store.SetChatWorktree(r.Context(), chat.ID, c.Path, c.BaseSHA)
+			return err
+		})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	chat.WorktreePath, chat.BaseSHA = created.Path, created.BaseSHA
+	writeJSON(w, http.StatusCreated, renderChat(chat))
+}
+
+// handleChatList lists chats. They are here and nowhere else: chats never
+// appear in GET /v1/tasks, which is the whole point of the separate entity.
+func (s *Server) handleChatList(w http.ResponseWriter, r *http.Request) {
+	var f store.ChatFilter
+	if v := r.URL.Query().Get("project_id"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, "project_id must be an integer")
+			return
+		}
+		f.ProjectID = &id
+	}
+	for _, st := range r.URL.Query()["state"] {
+		if !chatstate.Valid(chatstate.State(st)) {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, fmt.Sprintf("unknown chat state %q", st))
+			return
+		}
+		f.States = append(f.States, chatstate.State(st))
+	}
+	chats, err := s.deps.Store.ListChats(r.Context(), f)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	out := make([]chatBody, 0, len(chats))
+	for i := range chats {
+		out = append(out, renderChat(&chats[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"chats": out})
+}
+
+// handleChatGet returns one chat with its turns — the whole conversation, in
+// order, which is what a pane renders.
+func (s *Server) handleChatGet(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	turns, err := s.deps.Store.ListChatTurns(r.Context(), chat.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	body := make([]chatTurnBody, 0, len(turns))
+	for i := range turns {
+		body = append(body, renderChatTurn(&turns[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"chat": renderChat(chat), "turns": body})
+}
+
+type sendChatRequest struct {
+	Message string `json:"message"`
+}
+
+// handleChatSend starts a turn. Over the cap it is refused with 409 and never
+// queued: a chat turn is a foreground reply and must not wait behind batch
+// work (decision 1).
+func (s *Server) handleChatSend(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	var req sendChatRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.Message == "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "message is required")
+		return
+	}
+	if s.deps.Chats == nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, "no chat runner is wired")
+		return
+	}
+	turn, err := s.deps.Chats.Send(r.Context(), chat.ID, req.Message)
+	switch {
+	case errors.Is(err, chatrun.ErrChatCapReached):
+		writeJSON(w, http.StatusConflict, errorBody{Error: errorDetail{
+			Code: CodeChatCapReached, Message: err.Error(),
+			Details: map[string]string{"state": string(chat.State)},
+		}})
+		return
+	case errors.Is(err, store.ErrInvalidChatAction):
+		writeConflict(w, err.Error(), map[string]string{"state": string(chat.State), "action": "send"})
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, renderChatTurn(turn))
+}
+
+// handleChatAnswer answers the chat's pending §7.4 request. It is the same
+// flow a task's answer takes, down to the adapter's Respond (decision 8).
+func (s *Server) handleChatAnswer(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	if chat.State != chatstate.AwaitingInput {
+		writeConflict(w, "this chat is not waiting for an answer", map[string]string{"state": string(chat.State), "action": "answer"})
+		return
+	}
+	var resp agent.InputResponse
+	if !decodeJSON(w, r, &resp) {
+		return
+	}
+	if s.deps.Chats == nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, "no chat runner is wired")
+		return
+	}
+	if err := s.deps.Chats.Answer(r.Context(), chat.ID, resp); err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleChatCancel stops a live turn.
+func (s *Server) handleChatCancel(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !chatstate.Allowed(chat.State, chatstate.Cancel) {
+		writeConflict(w, "this chat has no live turn", map[string]string{"state": string(chat.State), "action": "cancel"})
+		return
+	}
+	if s.deps.Chats == nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, "no chat runner is wired")
+		return
+	}
+	if err := s.deps.Chats.Cancel(r.Context(), chat.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleChatArchive archives a chat: the worktree goes and the branch may go
+// with it, exactly as task 008 archives a task (§10). A dirty worktree is
+// refused unless `force` is set — the same refusal, and the same way out.
+func (s *Server) handleChatArchive(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	if !chatstate.Allowed(chat.State, chatstate.Archive) {
+		writeConflict(w, "a chat with a live turn cannot be archived", map[string]string{"state": string(chat.State), "action": "archive"})
+		return
+	}
+	force := r.URL.Query().Get("force") == "true"
+	project, err := s.deps.Store.GetProject(r.Context(), chat.ProjectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	if chat.WorktreePath != "" {
+		err = s.deps.Worktrees.RemoveAndRelease(r.Context(), project.Path, chat.WorktreePath, force,
+			func() error {
+				_, err := s.deps.Store.SetChatWorktree(r.Context(), chat.ID, "", "")
+				return err
+			})
+		var wtErr *worktree.Error
+		if errors.As(err, &wtErr) {
+			writeConflict(w, wtErr.Error(), map[string]string{"state": string(chat.State), "action": "archive"})
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+			return
+		}
+	}
+	updated, err := s.deps.Store.SetChatState(r.Context(), chat.ID, chatstate.Archived)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, renderChat(updated))
+}
+
+// chatFromPath resolves {id}, answering 400 or 404 itself.
+func (s *Server) chatFromPath(w http.ResponseWriter, r *http.Request) (*store.Chat, bool) {
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "chat id must be an integer")
+		return nil, false
+	}
+	chat, err := s.deps.Store.GetChat(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, fmt.Sprintf("chat %d not found", id))
+		return nil, false
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+		return nil, false
+	}
+	return chat, true
+}

--- a/internal/api/chats_test.go
+++ b/internal/api/chats_test.go
@@ -1,0 +1,306 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/agent/codex"
+	"github.com/lezli01/vincent/internal/agent/cursor"
+	"github.com/lezli01/vincent/internal/chatrun"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// chatHarness is the chat spine over the *real* handlers: server + store +
+// worktrees + a chat runner, with all three adapters pointed at fakeagent so
+// the refusal of codex and cursor is decided by the adapters themselves rather
+// than by a test double.
+type chatHarness struct {
+	*projectHarness
+	runner    *chatrun.Runner
+	repo      string
+	projectID int64
+	cfg       config.Config
+}
+
+func newChatHarness(t *testing.T) *chatHarness {
+	t.Helper()
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "chats.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	git := gitx.New()
+	wt := worktree.NewManager(git, dataDir)
+	bin := func() string { return fake }
+	reg := agent.NewRegistry(claude.New(bin), codex.New(bin), cursor.New(bin))
+	h := &chatHarness{cfg: config.Default()}
+	cfg := func() config.Config { return h.cfg }
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Setenv("FAKEAGENT_SESSION_DIR", t.TempDir())
+
+	runner := chatrun.New(chatrun.Deps{
+		Store: st, Config: cfg, Worktrees: wt, Agents: reg,
+		DataDir: dataDir, Logger: log,
+	})
+	runner.Start(t.Context())
+	t.Cleanup(runner.Stop)
+
+	s := New(Deps{
+		Token:       testToken,
+		Config:      cfg,
+		StartedAt:   time.Now(),
+		ListenAddr:  "127.0.0.1:0",
+		RequestStop: func() {},
+		Logger:      log,
+		Store:       st,
+		Git:         git,
+		Worktrees:   wt,
+		Agents:      reg,
+		Catalog:     agent.NewCatalogCache(reg),
+		Chats:       runner,
+	})
+	ts := httptest.NewServer(s.Handler())
+	t.Cleanup(ts.Close)
+	h.projectHarness = &projectHarness{ts: ts, store: st, wt: wt}
+	h.runner = runner
+
+	h.repo = testrepo.Init(t, "main")
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/projects", map[string]any{"path": h.repo})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("register project: %d %s", resp.StatusCode, body)
+	}
+	var p struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(body, &p); err != nil {
+		t.Fatalf("project body: %v", err)
+	}
+	h.projectID = p.ID
+	return h
+}
+
+// create posts a chat and returns the status and the decoded body.
+func (h *chatHarness) create(t *testing.T, agentName string) (int, map[string]any) {
+	t.Helper()
+	req := map[string]any{"project_id": h.projectID, "title": "a talk"}
+	if agentName != "" {
+		req["agent"] = agentName
+	}
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/chats", req)
+	var out map[string]any
+	_ = json.Unmarshal(body, &out)
+	return resp.StatusCode, out
+}
+
+// TestChatCreateRefusesAdaptersThatCannotResume is decision 3: the capability
+// is stated, never emulated. The refusal happens at creation, so a human never
+// gets a chat that cannot hold a conversation.
+func TestChatCreateRefusesAdaptersThatCannotResume(t *testing.T) {
+	h := newChatHarness(t)
+	for _, name := range []string{"codex", "cursor"} {
+		code, body := h.create(t, name)
+		if code != http.StatusBadRequest {
+			t.Fatalf("create on %s = %d, want 400 (%v)", name, code, body)
+		}
+		errObj, _ := body["error"].(map[string]any)
+		if got := errObj["code"]; got != CodeAgentCannotResume {
+			t.Fatalf("create on %s error code = %v, want %q", name, got, CodeAgentCannotResume)
+		}
+	}
+	if code, body := h.create(t, "claude"); code != http.StatusCreated {
+		t.Fatalf("create on claude = %d, want 201 (%v)", code, body)
+	}
+}
+
+// TestChatsAreNotTasks: the two families never mix. A chat on the board would
+// undo the whole reason it is a separate entity.
+func TestChatsAreNotTasks(t *testing.T) {
+	h := newChatHarness(t)
+	if code, body := h.create(t, "claude"); code != http.StatusCreated {
+		t.Fatalf("create = %d (%v)", code, body)
+	}
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/tasks = %d", resp.StatusCode)
+	}
+	var tasks []json.RawMessage
+	if err := json.Unmarshal(body, &tasks); err != nil {
+		t.Fatalf("tasks body: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("GET /v1/tasks returned %d rows with only a chat in the store", len(tasks))
+	}
+	resp, body = h.doJSON(t, http.MethodGet, "/v1/chats", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/chats = %d", resp.StatusCode)
+	}
+	var chats struct {
+		Chats []json.RawMessage `json:"chats"`
+	}
+	if err := json.Unmarshal(body, &chats); err != nil {
+		t.Fatalf("chats body: %v", err)
+	}
+	if len(chats.Chats) != 1 {
+		t.Fatalf("GET /v1/chats = %d rows, want 1", len(chats.Chats))
+	}
+}
+
+// TestChatSendOverTheCapIs409 is decision 1's wire half: refused immediately,
+// with the §11 vocabulary, and never queued.
+func TestChatSendOverTheCapIs409(t *testing.T) {
+	h := newChatHarness(t)
+	h.cfg.MaxParallelChats = 1
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+
+	_, busy := h.create(t, "claude")
+	_, other := h.create(t, "claude")
+	busyID, otherID := int64(busy["id"].(float64)), int64(other["id"].(float64))
+
+	resp, body := h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/send", busyID), map[string]any{"message": "hold the line"})
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("first send = %d %s", resp.StatusCode, body)
+	}
+	waitUntil(t, func() bool { return h.runner.Running(busyID) })
+
+	resp, body = h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/send", otherID), map[string]any{"message": "me too"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("send over the cap = %d %s, want 409", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), CodeChatCapReached) {
+		t.Fatalf("409 body %s does not carry %q", body, CodeChatCapReached)
+	}
+	// Refused, not parked: the chat is still idle and owns no turn.
+	resp, body = h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/chats/%d", otherID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET chat = %d", resp.StatusCode)
+	}
+	var got struct {
+		Chat struct {
+			State string `json:"state"`
+		} `json:"chat"`
+		Turns []json.RawMessage `json:"turns"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("chat body: %v", err)
+	}
+	if got.Chat.State != "idle" {
+		t.Fatalf("refused chat state = %q, want idle", got.Chat.State)
+	}
+	if len(got.Turns) != 0 {
+		t.Fatalf("refused send left %d turns behind", len(got.Turns))
+	}
+	h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/chats/%d/cancel", busyID), nil)
+}
+
+// TestChatTurnRendersThroughTheWire walks one turn end to end over the real
+// handlers and checks the turn is readable afterwards — the result text, the
+// accounting columns and the session the turn ran in.
+func TestChatTurnRendersThroughTheWire(t *testing.T) {
+	h := newChatHarness(t)
+	_, created := h.create(t, "claude")
+	id := int64(created["id"].(float64))
+
+	resp, body := h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/send", id), map[string]any{"message": "hello there"})
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("send = %d %s", resp.StatusCode, body)
+	}
+	var turns struct {
+		Turns []struct {
+			State        string  `json:"state"`
+			Prompt       string  `json:"prompt"`
+			ResultText   string  `json:"result_text"`
+			SessionID    string  `json:"session_id"`
+			InputTokens  int64   `json:"input_tokens"`
+			OutputTokens int64   `json:"output_tokens"`
+			CostUSD      float64 `json:"cost_usd"`
+		} `json:"turns"`
+	}
+	waitUntil(t, func() bool {
+		resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/chats/%d", id), nil)
+		if resp.StatusCode != http.StatusOK {
+			return false
+		}
+		turns.Turns = turns.Turns[:0]
+		if json.Unmarshal(body, &turns) != nil || len(turns.Turns) == 0 {
+			return false
+		}
+		return turns.Turns[0].State != "running"
+	})
+	got := turns.Turns[0]
+	if got.State != "done" {
+		t.Fatalf("turn state = %q, want done", got.State)
+	}
+	if got.Prompt != "hello there" {
+		t.Fatalf("prompt = %q", got.Prompt)
+	}
+	if !strings.Contains(got.ResultText, "hello there") {
+		t.Fatalf("result text %q did not round-trip the prompt", got.ResultText)
+	}
+	if got.SessionID == "" {
+		t.Fatal("turn recorded no session id, so the next turn has nothing to resume")
+	}
+	// The accounting half of the gap the issue named: a conversation outside
+	// vincent has no token or cost record at all.
+	if got.InputTokens == 0 || got.OutputTokens == 0 {
+		t.Fatalf("turn recorded no tokens: in=%d out=%d", got.InputTokens, got.OutputTokens)
+	}
+	if got.CostUSD == 0 {
+		t.Fatal("turn recorded no cost")
+	}
+}
+
+// TestChatActionsIn409WhenTheFSMSaysNo: the API and the runner consult one
+// definition of what may happen next (§5.5), the way §6's is consulted.
+func TestChatActionsIn409WhenTheFSMSaysNo(t *testing.T) {
+	h := newChatHarness(t)
+	_, created := h.create(t, "claude")
+	id := int64(created["id"].(float64))
+	for _, path := range []string{"answer", "cancel"} {
+		resp, body := h.doJSON(t, http.MethodPost,
+			fmt.Sprintf("/v1/chats/%d/%s", id, path), map[string]any{"value": "x"})
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("%s on an idle chat = %d %s, want 409", path, resp.StatusCode, body)
+		}
+	}
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/chats/%d/archive", id), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive = %d %s", resp.StatusCode, body)
+	}
+	resp, body = h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/send", id), map[string]any{"message": "hello?"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("send to an archived chat = %d %s, want 409", resp.StatusCode, body)
+	}
+}
+
+func waitUntil(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("condition never became true")
+}

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -36,6 +36,10 @@ import (
 type configResponse struct {
 	Listen           string `json:"listen"`
 	MaxParallelTasks int    `json:"max_parallel_tasks"`
+	// MaxParallelChats is a separate dimension from MaxParallelTasks (§11,
+	// task 063 decision 1): a chat turn is refused over the cap rather than
+	// queued, and holds no task slot.
+	MaxParallelChats int `json:"max_parallel_chats"`
 	// BranchTemplate is empty when the file pins none, which is not the same
 	// as the built-in: a project may override it, and the fallback lives in
 	// internal/worktree rather than in a default here.
@@ -222,6 +226,7 @@ func configBody(cfg config.Config) configResponse {
 	return configResponse{
 		Listen:           cfg.Listen,
 		MaxParallelTasks: cfg.MaxParallelTasks,
+		MaxParallelChats: cfg.MaxParallelChats,
 		BranchTemplate:   cfg.BranchTemplate,
 		Defaults: configDefaults{
 			AgentTimeout:   cfg.Defaults.AgentTimeout.String(),
@@ -336,6 +341,7 @@ func inheritBody(i config.Inherit) configInherit {
 type configPatch struct {
 	Listen                      *string            `json:"listen"`
 	MaxParallelTasks            *int               `json:"max_parallel_tasks"`
+	MaxParallelChats            *int               `json:"max_parallel_chats"`
 	BranchTemplate              *string            `json:"branch_template"`
 	Defaults                    *defaultsPatch     `json:"defaults"`
 	DeleteEmptyBranchOnArchive  *bool              `json:"delete_empty_branch_on_archive"`
@@ -450,6 +456,9 @@ func (p configPatch) sets() []config.Set {
 	}
 	if p.MaxParallelTasks != nil {
 		add("max_parallel_tasks", strconv.Itoa(*p.MaxParallelTasks))
+	}
+	if p.MaxParallelChats != nil {
+		add("max_parallel_chats", strconv.Itoa(*p.MaxParallelChats))
 	}
 	if p.BranchTemplate != nil {
 		add("branch_template", config.RenderString(*p.BranchTemplate))

--- a/internal/api/doctor_test.go
+++ b/internal/api/doctor_test.go
@@ -304,7 +304,7 @@ func TestDoctorRequiresAuthAndTheRightMethod(t *testing.T) {
 func (h *doctorHarness) makeOrphan(t *testing.T, projectID int64, repo string, id int64) string {
 	t.Helper()
 	branch := "vincent/orphan-" + strconv.FormatInt(id, 10)
-	path, err := h.wt.Create(t.Context(), repo, id, branch, "main", false)
+	path, err := h.wt.Create(t.Context(), repo, worktree.TaskOwner(id), branch, "main", false)
 	if err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestDoctorLiveWorktreeIsNotAnOrphan(t *testing.T) {
 	h := newDoctorHarness(t)
 	projectID, repo := h.seedProject(t)
 	task := h.seedTask(t, projectID, store.TaskQueued, "live")
-	path, err := h.wt.Create(t.Context(), repo, task.ID, "vincent/live-one", "main", false)
+	path, err := h.wt.Create(t.Context(), repo, worktree.TaskOwner(task.ID), "vincent/live-one", "main", false)
 	if err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}

--- a/internal/api/mcp_parity_test.go
+++ b/internal/api/mcp_parity_test.go
@@ -58,9 +58,16 @@ func TestMCPToolSurfaceMatchesRouteTable(t *testing.T) {
 	}
 }
 
-// TestMCPExcludesDestructiveAdminByName asserts the six exclusions by name,
-// so removing one from Excluded is a test failure rather than a quiet
-// widening of what an agent may do to the daemon supervising it.
+// TestMCPExcludesDestructiveAdminByName asserts the exclusions by name, so
+// removing one from Excluded is a test failure rather than a quiet widening of
+// what an agent may do to the daemon supervising it.
+//
+// It covers two families: the six destructive-admin routes (task 057's five,
+// plus `PATCH /v1/config` from task 060), and task 063's chat routes. The chat
+// family is excluded for a different reason — starting an agent process that
+// no §11 cap admitted and no scheduler ordered — and the list is asserted
+// whole so a new chat route added without a decision about it fails here
+// rather than appearing as a tool.
 func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 	t.Parallel()
 	want := []struct{ method, path string }{
@@ -73,6 +80,13 @@ func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 		{http.MethodDelete, "/v1/projects/{id}"},
 		{http.MethodPost, "/v1/maintenance/gc"},
 		{http.MethodPost, "/v1/doctor/fix"},
+		{http.MethodGet, "/v1/chats"},
+		{http.MethodPost, "/v1/chats"},
+		{http.MethodGet, "/v1/chats/{id}"},
+		{http.MethodPost, "/v1/chats/{id}/send"},
+		{http.MethodPost, "/v1/chats/{id}/answer"},
+		{http.MethodPost, "/v1/chats/{id}/cancel"},
+		{http.MethodPost, "/v1/chats/{id}/archive"},
 	}
 	if len(mcp.Excluded) != len(want) {
 		t.Fatalf("mcp.Excluded has %d entries, want %d", len(mcp.Excluded), len(want))

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -431,7 +431,7 @@ func TestProjectDelete(t *testing.T) {
 		p := h.mustCreate(t, map[string]any{"path": repo, "name": "forced"})
 		id := int64(p["id"].(float64))
 		taskID := insertTask(t, h.store, id, store.TaskQueued)
-		wtPath, err := h.wt.Create(ctx, repo, taskID, "vincent/"+itoa(taskID)+"-x", "main", false)
+		wtPath, err := h.wt.Create(ctx, repo, worktree.TaskOwner(taskID), "vincent/"+itoa(taskID)+"-x", "main", false)
 		if err != nil {
 			t.Fatalf("worktree create: %v", err)
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/chatrun"
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/events"
@@ -74,6 +75,12 @@ type Deps struct {
 	// owns the live runs they reach and the step_run rows they close; this
 	// package only maps them onto HTTP.
 	Runner *taskrun.Runner
+	// Chats runs chat turns (§5.5, task 063). It is a second runner rather
+	// than a mode of the first because a chat turn is never queued and never
+	// goes through internal/scheduler (decision 1). Nil is tolerated (tests
+	// without one) — the chat action routes then answer 500, the way the
+	// task actions do without a Runner.
+	Chats *chatrun.Runner
 	// Catalog serves /v1/agents and /v1/info agent availability from the
 	// §9.6 binary-identity cache: fresh by construction, stat-cheap per
 	// request. Nil is tolerated (tests without adapters) — /v1/info then
@@ -289,6 +296,15 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/github/pull", s.handleTaskGitHubPull)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/github/pull", s.handleTaskGitHubPullLink)
 	rt.handle(http.MethodDelete, "/v1/tasks/{id}/github/pull", s.handleTaskGitHubPullUnlink)
+	// Chats (§5.5, §13.2). They are their own family: nothing here touches
+	// the tasks table, and no chat route is an MCP tool (§13.4, decision 2).
+	rt.handle(http.MethodGet, "/v1/chats", s.handleChatList)
+	rt.handle(http.MethodPost, "/v1/chats", s.handleChatCreate)
+	rt.handle(http.MethodGet, "/v1/chats/{id}", s.handleChatGet)
+	rt.handle(http.MethodPost, "/v1/chats/{id}/send", s.handleChatSend)
+	rt.handle(http.MethodPost, "/v1/chats/{id}/answer", s.handleChatAnswer)
+	rt.handle(http.MethodPost, "/v1/chats/{id}/cancel", s.handleChatCancel)
+	rt.handle(http.MethodPost, "/v1/chats/{id}/archive", s.handleChatArchive)
 	rt.handle(http.MethodGet, "/v1/events", s.handleEvents)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/events", s.handleTaskEvents)
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/tasks_test.go
+++ b/internal/api/tasks_test.go
@@ -539,7 +539,7 @@ func TestTaskDiffUsesTheRecordedBaseSHA(t *testing.T) {
 	}
 	advanceRemoteBase(t, h.repo, stored.BaseBranch)
 
-	created, err := h.wt.CreateAndClaim(t.Context(), h.repo, task.ID,
+	created, err := h.wt.CreateAndClaim(t.Context(), h.repo, worktree.TaskOwner(task.ID),
 		stored.BranchName, stored.BaseBranch, true, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)

--- a/internal/apiclient/chats.go
+++ b/internal/apiclient/chats.go
@@ -1,0 +1,135 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Chat is one conversation (spec §5.5, §13.2). The wire types live here, in
+// the one client both the TUI and the CLI consume, so client and server
+// cannot drift without a *live_test.go noticing.
+type Chat struct {
+	ID           int64           `json:"id"`
+	ProjectID    int64           `json:"project_id"`
+	Title        string          `json:"title"`
+	State        string          `json:"state"`
+	Agent        string          `json:"agent"`
+	Model        string          `json:"model,omitempty"`
+	Effort       string          `json:"effort,omitempty"`
+	Branch       string          `json:"branch"`
+	BaseBranch   string          `json:"base_branch"`
+	BaseSHA      string          `json:"base_sha,omitempty"`
+	WorktreePath string          `json:"worktree_path,omitempty"`
+	SessionID    string          `json:"session_id,omitempty"`
+	PendingInput json.RawMessage `json:"pending_input,omitempty"`
+	CreatedAt    time.Time       `json:"created_at"`
+	UpdatedAt    time.Time       `json:"updated_at"`
+}
+
+// ChatTurn is one exchange in a chat.
+type ChatTurn struct {
+	ID           int64      `json:"id"`
+	ChatID       int64      `json:"chat_id"`
+	Seq          int        `json:"seq"`
+	Prompt       string     `json:"prompt"`
+	State        string     `json:"state"`
+	FailReason   string     `json:"fail_reason,omitempty"`
+	ErrorMessage string     `json:"error_message,omitempty"`
+	ResultText   string     `json:"result_text,omitempty"`
+	SessionID    string     `json:"session_id,omitempty"`
+	InputTokens  int64      `json:"input_tokens"`
+	OutputTokens int64      `json:"output_tokens"`
+	CostUSD      *float64   `json:"cost_usd"`
+	ExitCode     *int       `json:"exit_code,omitempty"`
+	StartedAt    time.Time  `json:"started_at"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	DurationMS   *int64     `json:"duration_ms,omitempty"`
+}
+
+// CreateChatRequest is the POST /v1/chats body. An omitted agent resolves
+// server-side to one that can resume a session (§9.1); an omitted base_branch
+// to the project's default.
+type CreateChatRequest struct {
+	ProjectID  int64  `json:"project_id"`
+	Title      string `json:"title"`
+	Agent      string `json:"agent,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Effort     string `json:"effort,omitempty"`
+	BaseBranch string `json:"base_branch,omitempty"`
+}
+
+// CreateChat starts a chat: a title, a project, an agent, and a worktree and
+// branch of its own.
+func (c *Client) CreateChat(ctx context.Context, req CreateChatRequest) (*Chat, error) {
+	var out Chat
+	if err := c.post(ctx, "/v1/chats", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListChats fetches chats, optionally narrowed to one project. Tasks never
+// appear here, and chats never appear in ListTasks.
+func (c *Client) ListChats(ctx context.Context, projectID int64) ([]Chat, error) {
+	path := "/v1/chats"
+	if projectID > 0 {
+		path += fmt.Sprintf("?project_id=%d", projectID)
+	}
+	var out struct {
+		Chats []Chat `json:"chats"`
+	}
+	if err := c.get(ctx, path, &out); err != nil {
+		return nil, err
+	}
+	return out.Chats, nil
+}
+
+// GetChat fetches one chat with its whole conversation, in order.
+func (c *Client) GetChat(ctx context.Context, id int64) (*Chat, []ChatTurn, error) {
+	var out struct {
+		Chat  Chat       `json:"chat"`
+		Turns []ChatTurn `json:"turns"`
+	}
+	if err := c.get(ctx, fmt.Sprintf("/v1/chats/%d", id), &out); err != nil {
+		return nil, nil, err
+	}
+	return &out.Chat, out.Turns, nil
+}
+
+// SendChat starts a turn. A 409 with code `chat_cap_reached` means
+// `max_parallel_chats` chats are already running — the send is refused, not
+// queued (§11).
+func (c *Client) SendChat(ctx context.Context, id int64, message string) (*ChatTurn, error) {
+	var out ChatTurn
+	body := map[string]string{"message": message}
+	if err := c.post(ctx, fmt.Sprintf("/v1/chats/%d/send", id), body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AnswerChat answers a chat's pending §7.4 input request.
+func (c *Client) AnswerChat(ctx context.Context, id int64, resp InputResponse) error {
+	return c.post(ctx, fmt.Sprintf("/v1/chats/%d/answer", id), resp, nil)
+}
+
+// CancelChat stops a chat's live turn.
+func (c *Client) CancelChat(ctx context.Context, id int64) error {
+	return c.post(ctx, fmt.Sprintf("/v1/chats/%d/cancel", id), nil, nil)
+}
+
+// ArchiveChat archives a chat, removing its worktree and taking an empty
+// branch with it. force is the way past a dirty worktree, as on a task.
+func (c *Client) ArchiveChat(ctx context.Context, id int64, force bool) (*Chat, error) {
+	path := fmt.Sprintf("/v1/chats/%d/archive", id)
+	if force {
+		path += "?force=true"
+	}
+	var out Chat
+	if err := c.post(ctx, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -111,6 +111,9 @@ func (c *Client) Info(ctx context.Context) (Info, error) {
 type Config struct {
 	Listen           string `json:"listen"`
 	MaxParallelTasks int    `json:"max_parallel_tasks"`
+	// MaxParallelChats bounds chats holding a live agent process, counted
+	// separately from MaxParallelTasks (§11, task 063 decision 1).
+	MaxParallelChats int `json:"max_parallel_chats"`
 	// BranchTemplate is empty when the file pins none; the built-in fallback
 	// lives in the daemon, and a project may override it either way.
 	BranchTemplate string         `json:"branch_template"`
@@ -336,6 +339,7 @@ func (c *Client) PatchConfig(ctx context.Context, req ConfigPatch) (Config, erro
 type ConfigPatch struct {
 	Listen                      *string                 `json:"listen,omitempty"`
 	MaxParallelTasks            *int                    `json:"max_parallel_tasks,omitempty"`
+	MaxParallelChats            *int                    `json:"max_parallel_chats,omitempty"`
 	BranchTemplate              *string                 `json:"branch_template,omitempty"`
 	Defaults                    *ConfigDefaultsPatch    `json:"defaults,omitempty"`
 	DeleteEmptyBranchOnArchive  *bool                   `json:"delete_empty_branch_on_archive,omitempty"`

--- a/internal/chatrun/doc.go
+++ b/internal/chatrun/doc.go
@@ -1,0 +1,24 @@
+// Package chatrun runs chat turns (spec §5.5, task 063). It is to a chat what
+// internal/taskrun is to a task, and it holds the same actor invariant: one
+// goroutine per running turn, and that goroutine is the sole writer of the
+// chat's §5.5 state and of its `chat_turns` row.
+//
+// Three things make it a separate package rather than a mode of the engine:
+//
+//   - Admission. A turn never goes through internal/scheduler and is never
+//     `queued`. It starts when the human sends it, or it is refused with 409
+//     because `max_parallel_chats` is reached (§11, decision 1). The
+//     scheduler's "the only place queued → running happens" invariant is
+//     untouched because a chat turn is never in that state.
+//   - Continuity. A turn resumes the agent CLI's own session (§7.3, amended
+//     for chats), which is the one place in vincent that does not start a
+//     fresh one. That is a per-adapter capability, and an adapter without it
+//     is refused at chat creation rather than emulated (§9.3, §9.7).
+//   - Recovery. A turn the daemon died under is finalized `interrupted` and
+//     is **not** re-run (§12.4, decision 5): re-running would re-send the
+//     human's message, and the session it was resuming died with the process.
+//
+// What it does share is extracted, not copied: the transcript writer is
+// internal/transcript, and rendering goes through the same normalized event
+// stream every adapter already emits.
+package chatrun

--- a/internal/chatrun/recover.go
+++ b/internal/chatrun/recover.go
@@ -1,0 +1,82 @@
+package chatrun
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/procx"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// identityOf is procx.Identity, indirected so a test can make the read fail —
+// the same arrangement, for the same reason, as internal/taskrun's.
+var identityOf = procx.Identity
+
+// Recover finalizes the turns a previous daemon died under (spec §12.4, task
+// 063 decision 5).
+//
+// §12.4's rule for a task is to re-run the interrupted step as an attempt that
+// does not consume a retry, and that rule is safe because a fresh session over
+// a surviving worktree is safe by construction. A chat turn is the case where
+// that stops being true, on both halves: re-running would **re-send the
+// human's message**, and the session it was resuming died with the process, so
+// the "same run again" a retry promises is not available at any price.
+//
+// So a chat turn is finalized `interrupted` and the chat returns to idle. The
+// human sees the turn that did not finish and decides whether to send it
+// again — which is the one thing that cannot be wrong.
+//
+// The orphan kill is unchanged: the same PID-reuse guard, proving the pid
+// still holds the process the row journaled before killing anything.
+func (r *Runner) Recover(ctx context.Context) error {
+	turns, err := r.deps.Store.ListRunningChatTurns(ctx)
+	if err != nil {
+		return err
+	}
+	for i := range turns {
+		t := &turns[i]
+		killOrphan(t, r.deps.Logger)
+		now := r.deps.Now()
+		ms := now.Sub(t.StartedAt).Milliseconds()
+		t.State, t.EndedAt, t.DurationMS, t.PID = chatstate.TurnInterruptedState, &now, &ms, nil
+		if err := r.deps.Store.UpdateChatTurn(ctx, t); err != nil {
+			return fmt.Errorf("recover chat turn %d: %w", t.ID, err)
+		}
+		chat, err := r.deps.Store.GetChat(ctx, t.ChatID)
+		if err != nil {
+			return err
+		}
+		if chatstate.HoldsProcess(chat.State) {
+			if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.Idle); err != nil {
+				return fmt.Errorf("recover chat %d: %w", chat.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+// killOrphan kills the process a recovered turn journaled, but only once the
+// pid is proved to still hold it.
+func killOrphan(t *store.ChatTurn, log *slog.Logger) {
+	if t.PID == nil {
+		return
+	}
+	pid := *t.PID
+	if t.ProcIdentity == nil {
+		// Nothing to compare: the turn crashed before the journal write, or
+		// the identity read failed at spawn. "Cannot prove, do not kill" —
+		// the cost of a wrong yes is killing a stranger's process.
+		return
+	}
+	id, err := identityOf(pid)
+	if err != nil || id != *t.ProcIdentity {
+		return
+	}
+	if err := procx.KillPID(pid); err != nil {
+		log.Error("recovery: kill orphaned chat process", "pid", pid, "error", err)
+		return
+	}
+	log.Warn("recovery: killed orphaned chat process from a previous run", "pid", pid)
+}

--- a/internal/chatrun/runner.go
+++ b/internal/chatrun/runner.go
@@ -1,0 +1,391 @@
+package chatrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/procx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/transcript"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// Turn failure reasons. They are the shared snake_case vocabulary
+// internal/taskrun and internal/worktree own — a `session_lost` means the same
+// thing wherever it originated — with one addition that only a chat can
+// produce.
+const (
+	// ReasonSessionLost is a turn whose stored session id the CLI no longer
+	// knows (decision 4). The chat stays usable; whether to start a fresh
+	// conversation is a human decision, because an agent answering with none
+	// of the thread in context reads exactly like one that has it.
+	ReasonSessionLost = "session_lost"
+	// ReasonAgentError is the generic "the run failed" reason, spelled the
+	// same as the engine's.
+	ReasonAgentError = "agent_error"
+	// ReasonAgentUnavailable is an adapter whose CLI is not installed.
+	ReasonAgentUnavailable = "agent_unavailable"
+	// ReasonCanceled is a turn a human stopped.
+	ReasonCanceled = "canceled"
+	// ReasonTranscriptIOError is a turn whose transcript could not be
+	// written. As on the task path, a run that cannot record what happened
+	// does not get to claim success.
+	ReasonTranscriptIOError = "transcript_io_error"
+)
+
+// ErrChatCapReached is a send refused because `max_parallel_chats` chats
+// already hold a live agent process (§11, decision 1). It is a refusal, never
+// a queue: a chat turn is a foreground reply, and parking it behind other
+// people's conversations would be exactly the wait chats exist to avoid.
+var ErrChatCapReached = errors.New("too many chats are running")
+
+// ErrNoLiveTurn is an answer or a cancel for a chat with nothing running.
+var ErrNoLiveTurn = errors.New("this chat has no live turn")
+
+// Deps is what a Runner needs. It is the taskrun Deps minus everything only a
+// workflow has — no Shells, no Catalog, no MCP: a chat runs one agent, and
+// §13.4 keeps chat routes off the tool surface anyway (decision 2).
+type Deps struct {
+	Store     *store.Store
+	Config    func() config.Config
+	Worktrees *worktree.Manager
+	Agents    *agent.Registry
+	DataDir   string
+	Logger    *slog.Logger
+	// Events receives live output chunks for the per-chat SSE stream
+	// (§13.3). Nil is tolerated; the transcript stays the durable copy.
+	Events *events.Broker
+	// Now is the clock, nil meaning time.Now. Injected by tests.
+	Now func() time.Time
+}
+
+// Runner owns every live chat turn.
+type Runner struct {
+	deps   Deps
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	base   context.Context //nolint:containedctx // the runner's own lifetime
+	// persist is detached from shutdown, so a turn's final state still
+	// reaches the database after the run context is canceled.
+	persist context.Context //nolint:containedctx // deliberately outlives the run
+
+	mu   sync.Mutex
+	live map[int64]*liveTurn
+}
+
+// liveTurn is one running turn: the handle to stop it and the id of the row
+// it is writing.
+type liveTurn struct {
+	turnID int64
+	handle agent.RunHandle
+	cancel context.CancelFunc
+}
+
+// New returns a runner over deps.
+func New(deps Deps) *Runner {
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	return &Runner{deps: deps, live: map[int64]*liveTurn{}}
+}
+
+// Start makes the runner able to accept sends. It starts no goroutine of its
+// own: unlike the task runner there is no admission loop to run, because a
+// turn begins when a human sends it and never before.
+func (r *Runner) Start(ctx context.Context) {
+	r.base, r.cancel = context.WithCancel(ctx)
+	r.persist = context.WithoutCancel(ctx)
+}
+
+// Stop cancels every live turn and waits for their goroutines. A turn stopped
+// this way is `interrupted`, not `failed`: the daemon went away, the agent did
+// not misbehave (§12.4, decision 5).
+func (r *Runner) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// Send starts a turn on chat id with the human's message. It refuses rather
+// than queues when the cap is reached, and it is the only producer of
+// `idle → running` (§5.5).
+func (r *Runner) Send(ctx context.Context, chatID int64, prompt string) (*store.ChatTurn, error) {
+	chat, err := r.deps.Store.GetChat(ctx, chatID)
+	if err != nil {
+		return nil, err
+	}
+	if !chatstate.Allowed(chat.State, chatstate.Send) {
+		return nil, store.ErrInvalidChatAction
+	}
+	// The cap is checked before the row is written, and it counts chats
+	// rather than turns because a chat holds exactly one process at a time.
+	// It is racy only against another send in the same instant; the store is
+	// a single writer, so the window is one statement wide and the worst
+	// outcome is one extra process — the same tolerance §11's own tally has.
+	n, err := r.deps.Store.CountChatsHoldingProcess(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if limit := r.maxParallelChats(); n >= limit {
+		return nil, fmt.Errorf("%w: %d of %d chats are already running", ErrChatCapReached, n, limit)
+	}
+	turn, err := r.deps.Store.CreateChatTurn(ctx, chatID, prompt)
+	if err != nil {
+		return nil, err
+	}
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.runTurn(chat, turn)
+	}()
+	return turn, nil
+}
+
+func (r *Runner) maxParallelChats() int {
+	if r.deps.Config == nil {
+		return 1
+	}
+	if n := r.deps.Config().MaxParallelChats; n > 0 {
+		return n
+	}
+	return 1
+}
+
+// Answer answers the chat's pending §7.4 request through the adapter's own
+// Respond — the same flow, the same normalization and the same adapter-side
+// queueing the task path uses (decision 8).
+func (r *Runner) Answer(ctx context.Context, chatID int64, resp agent.InputResponse) error {
+	r.mu.Lock()
+	live := r.live[chatID]
+	r.mu.Unlock()
+	if live == nil {
+		return ErrNoLiveTurn
+	}
+	if err := live.handle.Respond(resp); err != nil {
+		return fmt.Errorf("answer chat %d: %w", chatID, err)
+	}
+	if _, err := r.deps.Store.SetChatState(ctx, chatID, chatstate.Running); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Cancel stops a chat's live turn and kills its process tree.
+func (r *Runner) Cancel(_ context.Context, chatID int64) error {
+	r.mu.Lock()
+	live := r.live[chatID]
+	r.mu.Unlock()
+	if live == nil {
+		return ErrNoLiveTurn
+	}
+	live.cancel()
+	return nil
+}
+
+// Running reports whether this runner owns a live turn for the chat. The API
+// uses it to tell "no live turn here" from "no live turn anywhere".
+func (r *Runner) Running(chatID int64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.live[chatID] != nil
+}
+
+// runTurn is the actor: one goroutine, sole writer of this chat's state and
+// this turn's row, living for exactly one turn.
+func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
+	ctx, cancel := context.WithCancel(r.base)
+	defer cancel()
+	adapter, ok := r.deps.Agents.Get(chat.Agent)
+	if !ok {
+		r.finish(turn, chatstate.TurnFailed, ReasonAgentUnavailable,
+			fmt.Sprintf("no adapter named %q", chat.Agent), nil)
+		return
+	}
+	tr, err := transcript.Open(r.transcriptDir(chat.ID), fmt.Sprintf("%d.jsonl", turn.Seq))
+	if err != nil {
+		r.finish(turn, chatstate.TurnFailed, ReasonTranscriptIOError, err.Error(), nil)
+		return
+	}
+	defer tr.Close()
+
+	spec := agent.RunSpec{
+		Prompt:          turn.Prompt,
+		WorkDir:         chat.WorktreePath,
+		Model:           chat.Model,
+		Effort:          chat.Effort,
+		PermissionMode:  agent.PermissionMode(chat.PermissionMode),
+		OnInput:         agent.InputWait,
+		ResumeSessionID: chat.SessionID,
+	}
+	handle, err := adapter.Start(ctx, spec)
+	if err != nil {
+		reason := ReasonAgentError
+		if errors.Is(err, agent.ErrResumeUnsupported) {
+			reason = ReasonSessionLost
+		}
+		r.finish(turn, chatstate.TurnFailed, reason, err.Error(), nil)
+		return
+	}
+	r.track(chat.ID, &liveTurn{turnID: turn.ID, handle: handle, cancel: cancel})
+	defer r.untrack(chat.ID)
+	r.journal(turn, handle)
+
+	r.consume(ctx, chat, turn, handle, tr)
+
+	res, waitErr := handle.Wait()
+	turn.ExitCode = &res.ExitCode
+	turn.InputTokens, turn.OutputTokens, turn.CostUSD = res.InputTokens, res.OutputTokens, res.CostUSD
+	turn.ResultText = res.ResultText
+	if res.SessionID != "" {
+		turn.SessionID = res.SessionID
+	}
+	switch {
+	case ctx.Err() != nil && r.base.Err() != nil:
+		// The daemon is going away under a live turn. It is interrupted, not
+		// failed, and it is never re-run (decision 5).
+		r.finish(turn, chatstate.TurnInterruptedState, "", "", chat)
+	case ctx.Err() != nil:
+		r.finish(turn, chatstate.TurnFailed, ReasonCanceled, "canceled", chat)
+	case waitErr != nil:
+		r.finish(turn, chatstate.TurnFailed, ReasonAgentError, waitErr.Error(), chat)
+	case res.Failure != nil && res.Failure.Kind == agent.FailureSessionLost:
+		// The stored session is gone. The chat stays usable and keeps its
+		// id: clearing it here would silently convert the next turn into a
+		// fresh conversation, which is the behaviour decision 4 rejects.
+		r.finish(turn, chatstate.TurnFailed, ReasonSessionLost, res.ErrorMessage, chat)
+	case res.IsError:
+		r.finish(turn, chatstate.TurnFailed, ReasonAgentError, res.ErrorMessage, chat)
+	default:
+		r.finish(turn, chatstate.TurnDone, "", "", chat)
+	}
+}
+
+// consume drains the run's normalized events into the transcript and the live
+// output stream, and applies the §7.4 states as they arrive.
+func (r *Runner) consume(
+	ctx context.Context, chat *store.Chat, turn *store.ChatTurn,
+	handle agent.RunHandle, tr *transcript.Writer,
+) {
+	for ev := range handle.Events() {
+		if len(ev.Raw) > 0 {
+			at := tr.Raw(ev.Raw)
+			if r.deps.Events != nil {
+				r.deps.Events.PublishOutput(chatOutputKey(chat.ID), events.Chunk{
+					Type: "output",
+					Payload: map[string]any{
+						"chat_id": chat.ID, "turn_id": turn.ID,
+						"raw": string(ev.Raw), "offset": at,
+					},
+				})
+			}
+		}
+		switch ev.Type {
+		case agent.EventInputRequest:
+			req, err := json.Marshal(ev.Request)
+			if err != nil {
+				continue
+			}
+			if _, err := r.deps.Store.SetChatPendingInput(ctx, chat.ID, req); err != nil {
+				r.deps.Logger.Warn("store chat pending input", "chat", chat.ID, "error", err)
+				continue
+			}
+			if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.AwaitingInput); err != nil {
+				r.deps.Logger.Warn("chat awaiting input", "chat", chat.ID, "error", err)
+			}
+		case agent.EventInputCanceled:
+			if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.Running); err != nil {
+				r.deps.Logger.Warn("chat input closed", "chat", chat.ID, "error", err)
+			}
+		case agent.EventUsage, agent.EventResult, agent.EventOutput, agent.EventToolUse,
+			agent.EventToolResult, agent.EventThinking, agent.EventError, agent.EventUnknown:
+			// Rendering is the client's job: every one of these is already
+			// in the transcript and on the stream, and internal/tui's
+			// outputlines.go decides what a verbosity level shows.
+		}
+	}
+}
+
+// journal records the process identity beside the pid, so §12.4 recovery can
+// prove a surviving pid is still the process this row started before killing
+// it — the same PID-reuse guard `step_runs` carries (migration 0013).
+func (r *Runner) journal(turn *store.ChatTurn, handle agent.RunHandle) {
+	pid := handle.PID()
+	if pid <= 0 {
+		return
+	}
+	turn.PID = &pid
+	if id, err := procx.Identity(pid); err == nil && id != "" {
+		turn.ProcIdentity = &id
+	}
+	if err := r.deps.Store.UpdateChatTurn(r.persist, turn); err != nil {
+		r.deps.Logger.Warn("journal chat turn", "turn", turn.ID, "error", err)
+	}
+}
+
+// finish writes the turn's ending and returns the chat to idle, in that
+// order: a reader must never see an idle chat with a turn still running.
+func (r *Runner) finish(
+	turn *store.ChatTurn, state chatstate.TurnState, reason, msg string, chat *store.Chat,
+) {
+	ctx := r.persist
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	now := r.deps.Now()
+	turn.State, turn.FailReason, turn.ErrorMessage = state, reason, msg
+	turn.EndedAt = &now
+	ms := now.Sub(turn.StartedAt).Milliseconds()
+	turn.DurationMS = &ms
+	turn.PID = nil
+	if err := r.deps.Store.UpdateChatTurn(ctx, turn); err != nil {
+		r.deps.Logger.Error("finish chat turn", "turn", turn.ID, "error", err)
+	}
+	if chat == nil {
+		return
+	}
+	if turn.SessionID != "" && turn.SessionID != chat.SessionID {
+		if _, err := r.deps.Store.SetChatSession(ctx, chat.ID, turn.SessionID); err != nil {
+			r.deps.Logger.Error("store chat session", "chat", chat.ID, "error", err)
+		}
+	}
+	if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.Idle); err != nil {
+		r.deps.Logger.Error("chat back to idle", "chat", chat.ID, "error", err)
+	}
+}
+
+func (r *Runner) track(chatID int64, lt *liveTurn) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.live[chatID] = lt
+}
+
+func (r *Runner) untrack(chatID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.live, chatID)
+}
+
+func (r *Runner) transcriptDir(chatID int64) string {
+	return filepath.Join(r.deps.DataDir, "transcripts", worktree.ChatOwner(chatID).Dir())
+}
+
+// chatOutputKey is the broker key a chat's live output rides on. The broker is
+// keyed by int64 because tasks are, so chats take the negative half of the
+// space: a chat can never collide with a task, and a task subscriber can never
+// be handed a chat's bytes.
+func chatOutputKey(chatID int64) int64 { return -chatID }
+
+// ChatOutputKey exposes the mapping to the API, which subscribes on behalf of
+// an SSE client.
+func ChatOutputKey(chatID int64) int64 { return chatOutputKey(chatID) }

--- a/internal/chatrun/runner_test.go
+++ b/internal/chatrun/runner_test.go
@@ -1,0 +1,381 @@
+package chatrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
+	"github.com/lezli01/vincent/internal/agent/codex"
+	"github.com/lezli01/vincent/internal/agent/cursor"
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/gitx"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+type harness struct {
+	store   *store.Store
+	runner  *Runner
+	repo    string
+	project *store.Project
+	dataDir string
+	// sessionDir is the fake CLI's own conversation store. It lives outside
+	// vincent's data directory on purpose: continuity has to come from the
+	// agent remembering, not from anything vincent kept.
+	sessionDir string
+	cfg        config.Config
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir := t.TempDir()
+	st, err := store.Open(filepath.Join(dataDir, "chat.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	repo := testrepo.Init(t, "main")
+	project := &store.Project{Name: "proj", Path: repo, DefaultBranch: "main"}
+	if err := st.CreateProject(t.Context(), project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	h := &harness{
+		store: st, repo: repo, project: project, dataDir: dataDir,
+		sessionDir: t.TempDir(), cfg: config.Default(),
+	}
+	t.Setenv("FAKEAGENT_SESSION_DIR", h.sessionDir)
+	h.runner = New(Deps{
+		Store:     st,
+		Config:    func() config.Config { return h.cfg },
+		Worktrees: worktree.NewManager(gitx.New(), dataDir),
+		Agents: agent.NewRegistry(
+			claude.New(func() string { return fake }),
+			codex.New(func() string { return fake }),
+			cursor.New(func() string { return fake }),
+		),
+		DataDir: dataDir,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	h.runner.Start(t.Context())
+	t.Cleanup(h.runner.Stop)
+	return h
+}
+
+// chat creates a chat with a real worktree, the way the API does. It is always
+// on claude: the other two adapters cannot resume, so a chat on one never gets
+// past creation — which is asserted at the adapter level in
+// TestAdaptersThatCannotResume and over the wire in internal/api.
+func (h *harness) chat(t *testing.T) *store.Chat {
+	t.Helper()
+	c := &store.Chat{
+		ProjectID: h.project.ID, Title: "a talk", State: chatstate.Idle,
+		Agent: "claude", PermissionMode: string(agent.FullAuto), BaseBranch: "main",
+	}
+	if err := h.store.CreateChat(t.Context(), c); err != nil {
+		t.Fatalf("CreateChat: %v", err)
+	}
+	c.Branch = worktree.BranchName(c.ID, c.Title)
+	if err := h.store.SetChatBranch(t.Context(), c.ID, c.Branch); err != nil {
+		t.Fatalf("SetChatBranch: %v", err)
+	}
+	created, err := worktree.NewManager(gitx.New(), h.dataDir).CreateAndClaim(
+		t.Context(), h.repo, worktree.ChatOwner(c.ID), c.Branch, "main", false,
+		func(w worktree.Created) error {
+			_, err := h.store.SetChatWorktree(t.Context(), c.ID, w.Path, w.BaseSHA)
+			return err
+		})
+	if err != nil {
+		t.Fatalf("CreateAndClaim: %v", err)
+	}
+	c.WorktreePath = created.Path
+	return c
+}
+
+// sendAndWait runs one turn to completion and returns the finished row.
+func (h *harness) sendAndWait(t *testing.T, chatID int64, prompt string) *store.ChatTurn {
+	t.Helper()
+	turn, err := h.runner.Send(t.Context(), chatID, prompt)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	return h.waitTurn(t, turn.ID)
+}
+
+// waitIdle waits for the chat itself to come to rest. finish writes the turn's
+// ending *before* it returns the chat to idle — deliberately, so a reader never
+// sees an idle chat with a turn still running — so a terminal turn row is not
+// yet proof that the chat is done.
+func (h *harness) waitIdle(t *testing.T, chatID int64) *store.Chat {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := h.store.GetChat(t.Context(), chatID)
+		if err != nil {
+			t.Fatalf("GetChat: %v", err)
+		}
+		if got.State == chatstate.Idle {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("chat %d never returned to idle", chatID)
+	return nil
+}
+
+func (h *harness) waitTurn(t *testing.T, turnID int64) *store.ChatTurn {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := h.store.GetChatTurn(t.Context(), turnID)
+		if err != nil {
+			t.Fatalf("GetChatTurn: %v", err)
+		}
+		if chatstate.TurnTerminal(got.State) {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("turn %d never finished", turnID)
+	return nil
+}
+
+// TestTurnTwoSeesTurnOne is the acceptance criterion of task 063 and the
+// reason the feature exists: the second turn answers with something only the
+// first supplies. Nothing here replays a log — the fake CLI is asked to resume
+// its own session, and it says what it remembers.
+func TestTurnTwoSeesTurnOne(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t)
+
+	first := h.sendAndWait(t, c.ID, "my favourite colour is heliotrope")
+	if first.State != chatstate.TurnDone {
+		t.Fatalf("turn 1 = %s (%s: %s)", first.State, first.FailReason, first.ErrorMessage)
+	}
+	if first.SessionID == "" {
+		t.Fatal("turn 1 recorded no session id, so there is nothing to resume")
+	}
+	// The chat, not the turn, is what the next turn resumes.
+	after := h.waitIdle(t, c.ID)
+	if after.SessionID != first.SessionID {
+		t.Fatalf("chat session id = %q, want the turn's %q", after.SessionID, first.SessionID)
+	}
+
+	second := h.sendAndWait(t, c.ID, "what is it again?")
+	if second.State != chatstate.TurnDone {
+		t.Fatalf("turn 2 = %s (%s: %s)", second.State, second.FailReason, second.ErrorMessage)
+	}
+	// The recall line is only ever emitted by a run that was handed a
+	// session the store already held, so its presence is the proof.
+	body := h.transcript(t, c.ID, second.Seq)
+	if !strings.Contains(body, "heliotrope") {
+		t.Fatalf("turn 2 does not recall turn 1; transcript:\n%s", body)
+	}
+	if !strings.Contains(body, "recalled:") {
+		t.Fatalf("turn 2 ran a fresh session, not a resume; transcript:\n%s", body)
+	}
+	if second.Seq != 2 {
+		t.Fatalf("turn 2 seq = %d, want 2", second.Seq)
+	}
+}
+
+// transcript reads one turn's durable record — the file, not the broker, since
+// that is what a reader gets after the fact.
+func (h *harness) transcript(t *testing.T, chatID int64, seq int) string {
+	t.Helper()
+	path := filepath.Join(h.runner.transcriptDir(chatID), fmt.Sprintf("%d.jsonl", seq))
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	return string(b)
+}
+
+// TestSessionLostFailsTheTurnAndLeavesTheChatUsable is decision 4. A silently
+// fresh session would answer as if it had context it does not have, and a
+// reader could not tell that apart from a working conversation.
+func TestSessionLostFailsTheTurnAndLeavesTheChatUsable(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t)
+	if _, err := h.store.SetChatSession(t.Context(), c.ID, "fake-session-gone"); err != nil {
+		t.Fatalf("SetChatSession: %v", err)
+	}
+
+	turn := h.sendAndWait(t, c.ID, "still there?")
+	if turn.State != chatstate.TurnFailed {
+		t.Fatalf("turn state = %s, want failed", turn.State)
+	}
+	if turn.FailReason != ReasonSessionLost {
+		t.Fatalf("fail reason = %q, want %q", turn.FailReason, ReasonSessionLost)
+	}
+	after := h.waitIdle(t, c.ID)
+	if after.SessionID != "fake-session-gone" {
+		t.Fatalf("session id = %q; a lost session is not silently cleared", after.SessionID)
+	}
+	// And nothing was fabricated: no fresh conversation was written.
+	entries, err := os.ReadDir(h.sessionDir)
+	if err != nil {
+		t.Fatalf("read session dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("a fresh session was started behind the human's back: %v", entries)
+	}
+}
+
+// TestCapRefusesRatherThanQueues is decision 1. The refusal is immediate and
+// the turn never becomes a row waiting for a slot: a chat that queued would be
+// exactly the wait chats exist to avoid.
+func TestCapRefusesRatherThanQueues(t *testing.T) {
+	h := newHarness(t)
+	h.cfg.MaxParallelChats = 1
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+
+	busy := h.chat(t)
+	if _, err := h.runner.Send(t.Context(), busy.ID, "hold the line"); err != nil {
+		t.Fatalf("first Send: %v", err)
+	}
+	waitFor(t, func() bool { return h.runner.Running(busy.ID) })
+
+	other := h.chat(t)
+	_, err := h.runner.Send(t.Context(), other.ID, "me too")
+	if !errors.Is(err, ErrChatCapReached) {
+		t.Fatalf("second Send err = %v, want ErrChatCapReached", err)
+	}
+	turns, err := h.store.ListChatTurns(t.Context(), other.ID)
+	if err != nil {
+		t.Fatalf("ListChatTurns: %v", err)
+	}
+	if len(turns) != 0 {
+		t.Fatalf("a refused send wrote %d turn rows; it must queue nothing", len(turns))
+	}
+	if err := h.runner.Cancel(t.Context(), busy.ID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+}
+
+// TestChatsNeverAppearAsTasks: the separate entity is the whole design, and a
+// chat leaking onto the board would undo it.
+func TestChatsNeverAppearAsTasks(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t)
+	h.sendAndWait(t, c.ID, "hello")
+
+	tasks, err := h.store.ListTasks(t.Context(), store.TaskFilter{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("ListTasks returned %d rows for a store holding only chats", len(tasks))
+	}
+	chats, err := h.store.ListChats(t.Context(), store.ChatFilter{})
+	if err != nil {
+		t.Fatalf("ListChats: %v", err)
+	}
+	if len(chats) != 1 {
+		t.Fatalf("ListChats = %d, want 1", len(chats))
+	}
+}
+
+// TestRecoverFinalizesInterruptedAndDoesNotResend is decision 5. §12.4's
+// auto-resume rule stops applying here: re-running would re-send the human's
+// message, and the session being resumed died with the process.
+func TestRecoverFinalizesInterruptedAndDoesNotResend(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t)
+	// A turn journaled as running by a daemon that is now gone. The pid is
+	// this process's, which is alive but carries no matching identity, so
+	// the PID-reuse guard must refuse to kill it.
+	turn, err := h.store.CreateChatTurn(t.Context(), c.ID, "the message that must not be re-sent")
+	if err != nil {
+		t.Fatalf("CreateChatTurn: %v", err)
+	}
+	pid := os.Getpid()
+	identity := "not-the-identity-this-pid-has"
+	turn.PID = &pid
+	turn.ProcIdentity = &identity
+	if err := h.store.UpdateChatTurn(t.Context(), turn); err != nil {
+		t.Fatalf("UpdateChatTurn: %v", err)
+	}
+	if _, err := h.store.SetChatState(t.Context(), c.ID, chatstate.Running); err != nil {
+		t.Fatalf("SetChatState: %v", err)
+	}
+
+	if err := h.runner.Recover(context.Background()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+
+	got, err := h.store.GetChatTurn(t.Context(), turn.ID)
+	if err != nil {
+		t.Fatalf("GetChatTurn: %v", err)
+	}
+	if got.State != chatstate.TurnInterruptedState {
+		t.Fatalf("turn state = %s, want interrupted", got.State)
+	}
+	after, err := h.store.GetChat(t.Context(), c.ID)
+	if err != nil {
+		t.Fatalf("GetChat: %v", err)
+	}
+	if after.State != chatstate.Idle {
+		t.Fatalf("chat state = %s, want idle", after.State)
+	}
+	// Nothing re-ran: the conversation store is still empty, so the human's
+	// message was not sent to any agent.
+	entries, err := os.ReadDir(h.sessionDir)
+	if err != nil {
+		t.Fatalf("read session dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("an interrupted turn was re-sent: %v", entries)
+	}
+	turns, err := h.store.ListChatTurns(t.Context(), c.ID)
+	if err != nil {
+		t.Fatalf("ListChatTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("recovery created %d turns, want the original 1", len(turns))
+	}
+}
+
+// TestAdaptersThatCannotResume states the capability positively, in both
+// directions (decision 3). No adapter ever replays a log as prompt context.
+func TestAdaptersThatCannotResume(t *testing.T) {
+	fake := agenttest.BuildFakeAgent(t)
+	bin := func() string { return fake }
+	for _, tc := range []struct {
+		name string
+		a    agent.Adapter
+		want bool
+	}{
+		{"claude", claude.New(bin), true},
+		{"codex", codex.New(bin), false},
+		{"cursor", cursor.New(bin), false},
+	} {
+		if got := agent.CanResume(tc.a); got != tc.want {
+			t.Errorf("CanResume(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition never became true")
+}

--- a/internal/chatstate/chatstate.go
+++ b/internal/chatstate/chatstate.go
@@ -1,0 +1,171 @@
+// Package chatstate is the chat lifecycle state machine of spec §5.5. It is
+// pure: no persistence, no I/O. Both the API (which rejects an invalid action
+// with 409) and internal/chatrun consult it, so there is exactly one
+// definition of what may happen next — the arrangement internal/taskstate has
+// for §6's task FSM.
+//
+// It is a second, deliberately separate vocabulary rather than a reuse of
+// taskstate (task 063, §6). A chat has no steps, no gates and no verdict: it
+// never "completes", a failed turn is rendered against that turn rather than
+// parking the whole chat, and the only end is `archived`. Folding those four
+// states into §6 would mean every existing task query and every board legend
+// deciding whether it means chats too — the same objection that kept a `kind`
+// column off the tasks table.
+package chatstate
+
+import "sort"
+
+// State is a chat lifecycle state (spec §5.5).
+type State string
+
+// Chat lifecycle states (spec §5.5).
+const (
+	// Idle is a chat with no live turn: the one a human can send to. It is
+	// the state a chat is created in and the one every finished turn —
+	// succeeded, failed or interrupted — returns it to.
+	Idle State = "idle"
+	// Running is a live turn: an agent process is up, owned by the chat's
+	// runner goroutine.
+	Running State = "running"
+	// AwaitingInput is a turn holding its process while the agent waits on
+	// a §7.4 mid-run request. As in §6 it holds its slot, because the
+	// process is alive and idle on its stdin (task 063 decision 8).
+	AwaitingInput State = "awaiting_input"
+	// Archived is the only terminal state. Its worktree is gone and its
+	// branch may have been deleted, so nothing further can run in it.
+	Archived State = "archived"
+)
+
+// All lists every state, in the order §5.5 documents them.
+var All = []State{Idle, Running, AwaitingInput, Archived}
+
+// Valid reports whether s is a known state.
+func Valid(s State) bool {
+	for _, v := range All {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// HoldsProcess reports whether a chat in this state owns a live agent process,
+// and so counts against `max_parallel_chats` (§11, task 063 decision 1).
+//
+// This is the chat analogue of taskstate.HoldsSlot and counts the same two
+// states for the same reason: `awaiting_input` has a process alive on its
+// stdin, and a cap that did not count it would be a cap on nothing.
+func HoldsProcess(s State) bool { return s == Running || s == AwaitingInput }
+
+// Terminal reports whether no further transition is possible.
+func Terminal(s State) bool { return s == Archived }
+
+// Action is something that moves a chat between states: a human action or a
+// runner event.
+type Action string
+
+// Human actions (spec §5.5). Every one is rejected with 409 outside its valid
+// states, exactly as §6's are.
+const (
+	// Send is a human message, and the only thing that starts a turn. It is
+	// refused rather than queued when `max_parallel_chats` is reached
+	// (decision 1) — a refusal the FSM does not model, because the cap is
+	// about how many chats are running, not about what this chat may do.
+	Send Action = "send"
+	// Answer answers a pending §7.4 input request, through the same adapter
+	// Respond the task path uses (decision 8).
+	Answer Action = "answer"
+	// Cancel stops a live turn and kills its process tree. There is no
+	// pause: a chat is a foreground conversation, and a paused one is just
+	// an idle one nobody has sent to.
+	Cancel Action = "cancel"
+	// Archive removes the worktree and may delete the empty branch, the way
+	// task 008 archives a task (§10).
+	Archive Action = "archive"
+)
+
+// Runner events. They are transitions the daemon performs while running a
+// turn, and go through the same table so no state change bypasses §5.5.
+const (
+	// TurnStarted is the runner picking up an accepted send.
+	TurnStarted Action = "turn_started"
+	// InputRequested is the agent asking mid-run (§7.4).
+	InputRequested Action = "input_requested"
+	// InputClosed is the agent withdrawing its request (§7.4).
+	InputClosed Action = "input_closed"
+	// TurnFinished ends a turn, whatever its outcome. A chat has no
+	// `blocked`: a failed turn is a property of the turn, and the chat is
+	// idle and usable the instant the process is gone (task 063).
+	TurnFinished Action = "turn_finished"
+	// TurnInterrupted is recovery finalizing a turn whose daemon died under
+	// it (decision 5). It is a separate action from TurnFinished only so a
+	// reader of this table can see that the case exists; both land on Idle.
+	TurnInterrupted Action = "turn_interrupted"
+)
+
+// transitions is the whole of §5.5: state → action → next state. Anything not
+// in it is invalid, which is what the API turns into a 409.
+var transitions = map[State]map[Action]State{
+	Idle: {
+		Send:    Running,
+		Archive: Archived,
+	},
+	Running: {
+		InputRequested:  AwaitingInput,
+		TurnFinished:    Idle,
+		TurnInterrupted: Idle,
+		Cancel:          Idle,
+		TurnStarted:     Running,
+	},
+	AwaitingInput: {
+		Answer:          Running,
+		InputClosed:     Running,
+		TurnFinished:    Idle,
+		TurnInterrupted: Idle,
+		Cancel:          Idle,
+	},
+	Archived: {},
+}
+
+// Next returns the state a reaches from s, and whether the pair is legal.
+func Next(s State, a Action) (State, bool) {
+	next, ok := transitions[s][a]
+	return next, ok
+}
+
+// Allowed reports whether a is legal from s.
+func Allowed(s State, a Action) bool {
+	_, ok := transitions[s][a]
+	return ok
+}
+
+// Actions lists the actions legal from s, sorted, so a client can render the
+// affordances without a second copy of the table.
+func Actions(s State) []Action {
+	out := make([]Action, 0, len(transitions[s]))
+	for a := range transitions[s] {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// TurnState is the outcome recorded against one turn (spec §5.5, §14). Unlike
+// State it is not a lifecycle: a turn is running, then it is one of the three
+// endings, forever.
+type TurnState string
+
+// Turn outcomes.
+const (
+	TurnRunning TurnState = "running"
+	TurnDone    TurnState = "done"
+	TurnFailed  TurnState = "failed"
+	// TurnInterruptedState is a turn whose daemon restarted under it
+	// (decision 5). It is never re-run: re-running would re-send the
+	// human's message, and the session it was resuming died with the
+	// process, so §12.4's auto-resume rule does not carry over.
+	TurnInterruptedState TurnState = "interrupted"
+)
+
+// TurnTerminal reports whether a turn in this state has finished.
+func TurnTerminal(s TurnState) bool { return s != TurnRunning }

--- a/internal/chatstate/chatstate_test.go
+++ b/internal/chatstate/chatstate_test.go
@@ -1,0 +1,150 @@
+package chatstate
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestTransitionTable walks every (state, action) pair — the whole product,
+// not just the legal half — so a transition added to the table without a
+// decision behind it shows up as a failing case here rather than as a chat
+// that quietly does something §5.5 does not describe.
+func TestTransitionTable(t *testing.T) {
+	allActions := []Action{
+		Send, Answer, Cancel, Archive,
+		TurnStarted, InputRequested, InputClosed, TurnFinished, TurnInterrupted,
+	}
+	// want[state][action] is the state the pair reaches; a missing entry
+	// means the pair is illegal and must be a 409.
+	want := map[State]map[Action]State{
+		Idle: {
+			Send:    Running,
+			Archive: Archived,
+		},
+		Running: {
+			TurnStarted:     Running,
+			InputRequested:  AwaitingInput,
+			TurnFinished:    Idle,
+			TurnInterrupted: Idle,
+			Cancel:          Idle,
+		},
+		AwaitingInput: {
+			Answer:          Running,
+			InputClosed:     Running,
+			TurnFinished:    Idle,
+			TurnInterrupted: Idle,
+			Cancel:          Idle,
+		},
+		Archived: {},
+	}
+	for _, s := range All {
+		for _, a := range allActions {
+			next, ok := Next(s, a)
+			wantNext, wantOK := want[s][a]
+			if ok != wantOK {
+				t.Errorf("Next(%s, %s) legal = %v, want %v", s, a, ok, wantOK)
+				continue
+			}
+			if ok && next != wantNext {
+				t.Errorf("Next(%s, %s) = %s, want %s", s, a, next, wantNext)
+			}
+			if got := Allowed(s, a); got != wantOK {
+				t.Errorf("Allowed(%s, %s) = %v, want %v", s, a, got, wantOK)
+			}
+		}
+	}
+}
+
+// TestArchivedIsTheOnlyTerminal pins the shape of the lifecycle: a chat is
+// never parked. A failed turn leaves the chat idle and usable, which is the
+// difference from §6 that made a separate FSM worth having.
+func TestArchivedIsTheOnlyTerminal(t *testing.T) {
+	for _, s := range All {
+		if got, want := Terminal(s), s == Archived; got != want {
+			t.Errorf("Terminal(%s) = %v, want %v", s, got, want)
+		}
+		if len(Actions(s)) == 0 && s != Archived {
+			t.Errorf("state %s is a dead end but is not archived", s)
+		}
+	}
+}
+
+// TestHoldsProcess is the cap's definition (§11, decision 1). awaiting_input
+// counts because the process is alive on its stdin — a cap that did not count
+// it would be a cap on nothing.
+func TestHoldsProcess(t *testing.T) {
+	for _, tc := range []struct {
+		state State
+		want  bool
+	}{
+		{Idle, false},
+		{Running, true},
+		{AwaitingInput, true},
+		{Archived, false},
+	} {
+		if got := HoldsProcess(tc.state); got != tc.want {
+			t.Errorf("HoldsProcess(%s) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+}
+
+func TestValid(t *testing.T) {
+	for _, s := range All {
+		if !Valid(s) {
+			t.Errorf("Valid(%s) = false", s)
+		}
+	}
+	for _, s := range []State{"", "queued", "blocked", "completed", "IDLE"} {
+		if Valid(s) {
+			t.Errorf("Valid(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestActionsSorted keeps the affordance list stable, since a client renders
+// it directly.
+func TestActionsSorted(t *testing.T) {
+	if got, want := Actions(Idle), []Action{Archive, Send}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Actions(idle) = %v, want %v", got, want)
+	}
+	if got := Actions(Archived); len(got) != 0 {
+		t.Errorf("Actions(archived) = %v, want none", got)
+	}
+}
+
+// TestTurnStates: a turn is running, then it is one of three endings, forever.
+func TestTurnStates(t *testing.T) {
+	if TurnTerminal(TurnRunning) {
+		t.Error("a running turn is terminal")
+	}
+	for _, s := range []TurnState{TurnDone, TurnFailed, TurnInterruptedState} {
+		if !TurnTerminal(s) {
+			t.Errorf("TurnTerminal(%s) = false", s)
+		}
+	}
+}
+
+// TestNoStateCollidesWithATaskState is the point of decision 6 and of §6
+// staying unchanged: the two vocabularies are separate on purpose, so a reader
+// who sees `blocked` knows it is a task and one who sees `idle` knows it is a
+// chat. Only the words are checked — taskstate is deliberately not imported,
+// because chatstate is a leaf and importing it would be the coupling this
+// package exists to avoid.
+func TestNoStateCollidesWithATaskState(t *testing.T) {
+	taskStates := map[State]bool{
+		"queued": true, "running": true, "blocked": true, "paused": true,
+		"completed": true, "failed": true, "canceled": true, "archived": true,
+	}
+	var shared []State
+	for _, s := range All {
+		if taskStates[s] {
+			shared = append(shared, s)
+		}
+	}
+	// `running` and `archived` are shared words by design — they mean the
+	// same thing in both. Anything else would be a collision worth arguing.
+	want := []State{Running, Archived}
+	if !reflect.DeepEqual(shared, want) {
+		t.Errorf("states shared with §6 = %v, want exactly %v", shared, want)
+	}
+}

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// newChatCmd is `vincent chat` (spec §5.5, §12.1, task 063): the CLI half of
+// free chat, so the feature is not TUI-only.
+//
+// The verbs are the four §5.5 actions plus a read: start, send, list, show,
+// archive. `send` blocks until the turn ends and prints the answer, which is
+// what a conversation in a terminal has to do — a fire-and-forget send would
+// leave the human polling `show`.
+func newChatCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "chat",
+		Short: "Talk to an agent in its own worktree",
+		Long: "Chats are conversations with an agent, each in its own git worktree and " +
+			"vincent/{id}-{slug} branch. Every turn resumes the agent's own session, so " +
+			"turn N sees turns 1..N-1 (spec §7.3, amended for chats).\n\n" +
+			"Chats are not tasks: they never appear on the board, they run no workflow, " +
+			"and a chat turn never waits for a scheduler slot.",
+	}
+	cmd.AddCommand(newChatStartCmd(), newChatSendCmd(), newChatListCmd(),
+		newChatShowCmd(), newChatArchiveCmd())
+	return cmd
+}
+
+func newChatStartCmd() *cobra.Command {
+	var (
+		projectID  int64
+		agentName  string
+		model      string
+		effort     string
+		baseBranch string
+		message    string
+	)
+	cmd := &cobra.Command{
+		Use:   "start <title>",
+		Short: "Start a chat",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				chat, err := c.CreateChat(ctx, apiclient.CreateChatRequest{
+					ProjectID: projectID, Title: args[0], Agent: agentName,
+					Model: model, Effort: effort, BaseBranch: baseBranch,
+				})
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d  %s  [%s]  %s\n",
+					chat.ID, chat.Title, chat.Agent, chat.Branch)
+				if message == "" {
+					return nil
+				}
+				return runChatTurn(ctx, cmd, c, chat.ID, message)
+			})
+		},
+	}
+	cmd.Flags().Int64Var(&projectID, "project", 0, "project id (required)")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent adapter; default is one that can resume a session")
+	cmd.Flags().StringVar(&model, "model", "", "model override")
+	cmd.Flags().StringVar(&effort, "effort", "", "effort override")
+	cmd.Flags().StringVar(&baseBranch, "base", "", "base branch; default is the project's")
+	cmd.Flags().StringVar(&message, "message", "", "send this first message straight away")
+	_ = cmd.MarkFlagRequired("project")
+	return cmd
+}
+
+func newChatSendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send <chat-id> <message>",
+		Short: "Send a message and wait for the answer",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				return runChatTurn(ctx, cmd, c, id, args[1])
+			})
+		},
+	}
+	return cmd
+}
+
+// runChatTurn sends a message and polls the chat until the turn ends, then
+// prints the agent's answer or the reason the turn failed.
+//
+// Polling rather than the SSE stream is deliberate for the CLI: `vincent chat
+// send` is one round trip a human waits on, and a poll has no reconnect
+// semantics to get wrong. The TUI, which renders the turn as it arrives, uses
+// the stream.
+func runChatTurn(ctx context.Context, cmd *cobra.Command, c *apiclient.Client, id int64, message string) error {
+	turn, err := c.SendChat(ctx, id, message)
+	if err != nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+		return exitError{code: 1}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		_, turns, err := c.GetChat(ctx, id)
+		if err != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+			return exitError{code: 1}
+		}
+		for i := range turns {
+			t := &turns[i]
+			if t.ID != turn.ID || t.State == "running" {
+				continue
+			}
+			if t.State != "done" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "turn %d %s: %s %s\n",
+					t.Seq, t.State, t.FailReason, t.ErrorMessage)
+				return exitError{code: 1}
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), strings.TrimRight(t.ResultText, "\n"))
+			return nil
+		}
+	}
+}
+
+func newChatListCmd() *cobra.Command {
+	var projectID int64
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List chats",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				chats, err := c.ListChats(ctx, projectID)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if len(chats) == 0 {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No chats.")
+					return nil
+				}
+				for i := range chats {
+					ch := &chats[i]
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-5d %-14s %-10s %s\n",
+						ch.ID, ch.State, ch.Agent, ch.Title)
+				}
+				return nil
+			})
+		},
+	}
+	cmd.Flags().Int64Var(&projectID, "project", 0, "only this project's chats")
+	return cmd
+}
+
+func newChatShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <chat-id>",
+		Short: "Show a chat and its turns",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				chat, turns, err := c.GetChat(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				out := cmd.OutOrStdout()
+				_, _ = fmt.Fprintf(out, "chat %d  %s\nstate: %s  agent: %s  branch: %s\n",
+					chat.ID, chat.Title, chat.State, chat.Agent, chat.Branch)
+				for i := range turns {
+					t := &turns[i]
+					_, _ = fmt.Fprintf(out, "\n--- turn %d (%s) ---\n> %s\n", t.Seq, t.State, t.Prompt)
+					if t.ResultText != "" {
+						_, _ = fmt.Fprintln(out, strings.TrimRight(t.ResultText, "\n"))
+					}
+					if t.FailReason != "" {
+						_, _ = fmt.Fprintf(out, "failed: %s %s\n", t.FailReason, t.ErrorMessage)
+					}
+				}
+				return nil
+			})
+		},
+	}
+	return cmd
+}
+
+func newChatArchiveCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "archive <chat-id>",
+		Short: "Archive a chat, removing its worktree",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				chat, err := c.ArchiveChat(ctx, id, force)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d archived\n", chat.ID)
+				return nil
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "archive even if the worktree has local changes")
+	return cmd
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -40,7 +40,7 @@ func newRootCmd() *cobra.Command {
 	}
 	root.AddCommand(
 		newDaemonCmd(), newVersionCmd(), newDoctorCmd(),
-		newProjectCmd(), newTaskCmd(), newWorkflowCmd(), newServiceCmd(),
+		newProjectCmd(), newTaskCmd(), newChatCmd(), newWorkflowCmd(), newServiceCmd(),
 		newGCCmd(), newGitHubCmd(), newStatusCmd(), newUpdateCmd(),
 		newConfigCmd(),
 	)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -157,6 +157,9 @@ func configFields() map[string]configField {
 		"max_parallel_tasks": intField(
 			func(c apiclient.Config) int { return c.MaxParallelTasks },
 			func(n *int) apiclient.ConfigPatch { return apiclient.ConfigPatch{MaxParallelTasks: n} }),
+		"max_parallel_chats": intField(
+			func(c apiclient.Config) int { return c.MaxParallelChats },
+			func(n *int) apiclient.ConfigPatch { return apiclient.ConfigPatch{MaxParallelChats: n} }),
 		"branch_template": {
 			read: func(c apiclient.Config) string { return c.BranchTemplate },
 			// Not trimmed: a template is written verbatim into a branch name,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,18 @@ func ParseByteSize(s string) (ByteSize, error) {
 type Config struct {
 	Listen           string `yaml:"listen"`
 	MaxParallelTasks int    `yaml:"max_parallel_tasks"`
+	// MaxParallelChats bounds how many chats may hold a live agent process
+	// at once (§11, task 063 decision 1). It is a *separate* cap, not a
+	// share of MaxParallelTasks: a chat turn is a foreground reply to a
+	// person and must never wait behind batch work.
+	//
+	// It exists because the §11 amendment of 2026-08-29 (task 057) named the
+	// cost of an uncapped agent process verbatim — live-but-uncounted agent
+	// CLIs accumulating — and that reasoning does not stop applying because
+	// the noun changed. A turn over the cap is refused with 409 immediately;
+	// it is never queued, so internal/scheduler's "the only place
+	// queued → running happens" invariant is untouched.
+	MaxParallelChats int `yaml:"max_parallel_chats"`
 	// BranchTemplate is the global branch-naming convention, the level between
 	// the built-in `vincent/{id}-{slug}` and a project's own template (task 001,
 	// §5.3). Empty means the built-in name.
@@ -613,6 +625,7 @@ func Default() Config {
 	return Config{
 		Listen:           "127.0.0.1:0",
 		MaxParallelTasks: 3,
+		MaxParallelChats: 3,
 		Defaults: Defaults{
 			AgentTimeout:   Duration(60 * time.Minute),
 			CommandTimeout: Duration(15 * time.Minute),
@@ -718,6 +731,9 @@ func (c Config) validate() error {
 	}
 	if c.MaxParallelTasks < 1 {
 		return fmt.Errorf("max_parallel_tasks must be at least 1, got %d", c.MaxParallelTasks)
+	}
+	if c.MaxParallelChats < 1 {
+		return fmt.Errorf("max_parallel_chats must be at least 1, got %d", c.MaxParallelChats)
 	}
 	if c.Defaults.AgentTimeout <= 0 {
 		return fmt.Errorf("defaults.agent_timeout must be positive, got %s", c.Defaults.AgentTimeout)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,7 @@ agents:
 	want := Config{
 		Listen:           "localhost:7777",
 		MaxParallelTasks: 9,
+		MaxParallelChats: 3,
 		Defaults: Defaults{
 			AgentTimeout:   Duration(90 * time.Minute),
 			CommandTimeout: Duration(90 * time.Second),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lezli01/vincent/internal/agent/codex"
 	"github.com/lezli01/vincent/internal/agent/cursor"
 	"github.com/lezli01/vincent/internal/api"
+	"github.com/lezli01/vincent/internal/chatrun"
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/container"
 	"github.com/lezli01/vincent/internal/events"
@@ -334,6 +335,18 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		},
 	}
 	runner := taskrun.New(runnerDeps)
+	// The chat runner (§5.5, task 063). It is wired beside the task runner
+	// and shares nothing with the scheduler: a chat turn is never queued, so
+	// there is no admission loop to join.
+	chats := chatrun.New(chatrun.Deps{
+		Store:     st,
+		Config:    currentConfig,
+		Worktrees: worktrees,
+		Agents:    agents,
+		DataDir:   dirs.Data,
+		Logger:    logger,
+		Events:    broker,
+	})
 	// Transcript retention (§17): once at startup and every 24 h after. The
 	// ticker is what makes retention work on a daemon that survives reboots
 	// (T4.1) rather than only on the restarts it no longer has.
@@ -500,6 +513,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		Catalog:      catalog,
 		Workflows:    workflows,
 		Runner:       runner,
+		Chats:        chats,
 		WakeRunner:   sched.Wake,
 		Broker:       broker,
 		Reclaimer:    reclaimer,
@@ -530,6 +544,14 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	defer func() { _ = RemoveRuntimeInfo(dirs.Data) }()
 
 	runner.Start(ctx)
+	chats.Start(ctx)
+	// A turn the previous daemon died under is finalized `interrupted` and
+	// never re-run (§12.4, task 063 decision 5): re-running would re-send the
+	// human's message, and the session it was resuming died with the process.
+	if err := chats.Recover(ctx); err != nil {
+		logger.Error("startup failed: chat recovery", "error", err)
+		return err
+	}
 	sched.Start(ctx)
 
 	serveErr := make(chan error, 1)
@@ -545,6 +567,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 		logger.Error("http server failed", "error", err)
 		sched.Stop()
 		runner.Stop()
+		chats.Stop()
 		notifier.Stop()
 		broker.Close()
 		return fmt.Errorf("http server: %w", err)
@@ -560,6 +583,7 @@ func runWithAgents(ctx context.Context, opts Options, agents *agent.Registry) er
 	}
 	sched.Stop()
 	runner.StopGraceful(processGrace)
+	chats.Stop()
 	// Before broker.Close(): the broker is what feeds the notifier's hook, and
 	// a notification for a shutdown-time transition is one a person wants.
 	notifier.Stop()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -46,6 +46,25 @@ var Excluded = []Route{
 	{Method: http.MethodDelete, Path: "/v1/projects/{id}"},
 	{Method: http.MethodPost, Path: "/v1/maintenance/gc"},
 	{Method: http.MethodPost, Path: "/v1/doctor/fix"},
+	// The chat family (task 063 decision 2). An agent must not be able to
+	// start agent processes that no §11 cap admitted and no scheduler
+	// ordered — a chat turn is deliberately unqueued, and that property is
+	// safe only while a *human* is the one starting it.
+	//
+	// The depth bound cannot help here either: mcp.max_depth and
+	// mcp.max_tasks bound a tree by walking `created_by_task_id`, and a chat
+	// is not in that chain. Giving chats a depth would mean inventing depth
+	// semantics for a non-task, and getting it wrong means an agent that can
+	// fork conversations without limit.
+	//
+	// Nothing is lost: an agent calling these tools already *has* a session.
+	{Method: http.MethodGet, Path: "/v1/chats"},
+	{Method: http.MethodPost, Path: "/v1/chats"},
+	{Method: http.MethodGet, Path: "/v1/chats/{id}"},
+	{Method: http.MethodPost, Path: "/v1/chats/{id}/send"},
+	{Method: http.MethodPost, Path: "/v1/chats/{id}/answer"},
+	{Method: http.MethodPost, Path: "/v1/chats/{id}/cancel"},
+	{Method: http.MethodPost, Path: "/v1/chats/{id}/archive"},
 }
 
 // Streaming lists the §13.3 SSE routes. They are not tools because a tool call

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -1,0 +1,521 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+// Chat event types (spec §13.3, task 063). They ride the one durable event
+// table and the one broker: a client that already follows `GET /v1/events`
+// sees chats without a second stream.
+const (
+	EventChatCreated  = "chat.created"
+	EventChatState    = "chat.state_changed"
+	EventChatTurn     = "chat.turn_changed"
+	EventChatArchived = "chat.archived"
+)
+
+const chatColumns = `id, project_id, title, state, agent, model, effort, permission_mode,
+	branch, base_branch, base_sha, worktree_path, session_id, pending_input, created_at, updated_at`
+
+const chatTurnColumns = `id, chat_id, seq, prompt, state, fail_reason, error_message, result_text,
+	session_id, input_tokens, output_tokens, cost_usd, exit_code, pid, proc_identity,
+	started_at, ended_at, duration_ms`
+
+// CreateChat inserts c, assigning its ID and timestamps, and writes the
+// durable chat.created event in the same transaction (§13.3).
+//
+// The chat is created before its worktree exists, exactly as a task is: the id
+// is what names the branch and the directory, so it has to be allocated first.
+// The worktree claim lands in the same CreateAndClaim window tasks use (§10).
+func (s *Store) CreateChat(ctx context.Context, c *Chat) error {
+	now := time.Now()
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.UpdatedAt = now
+	if c.State == "" {
+		c.State = chatstate.Idle
+	}
+	var ev *Event
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO chats (project_id, title, state, agent, model, effort, permission_mode,
+				branch, base_branch, base_sha, worktree_path, session_id, pending_input, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			c.ProjectID, c.Title, string(c.State), c.Agent, nullString(c.Model), nullString(c.Effort),
+			c.PermissionMode, c.Branch, c.BaseBranch, nullString(c.BaseSHA), nullString(c.WorktreePath),
+			nullString(c.SessionID), nullString(string(c.PendingInput)),
+			formatTime(c.CreatedAt), formatTime(c.UpdatedAt))
+		if err != nil {
+			return fmt.Errorf("insert chat: %w", err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("insert chat: %w", err)
+		}
+		c.ID = id
+		ev, err = chatEvent(EventChatCreated, c, nil)
+		if err != nil {
+			return err
+		}
+		return appendEventTx(ctx, tx, ev)
+	})
+	if err != nil {
+		return err
+	}
+	s.notify(ev)
+	return nil
+}
+
+// chatEvent builds a chat.* event. It carries the chat's id, title and state
+// so a list can be re-rendered without a fetch, and nothing more — the same
+// shape, and the same reasoning, as the task events beside it (§13.3).
+//
+// TaskID stays nil: a chat is not a task, and a per-task stream must never
+// deliver one. Clients filter chat events by type, and `GET /v1/chats/{id}/events`
+// filters by the payload's id.
+func chatEvent(evType string, c *Chat, turn *ChatTurn) (*Event, error) {
+	body := map[string]any{"id": c.ID, "title": c.Title, "state": string(c.State)}
+	if turn != nil {
+		body["turn_id"] = turn.ID
+		body["turn_seq"] = turn.Seq
+		body["turn_state"] = string(turn.State)
+		if turn.FailReason != "" {
+			body["fail_reason"] = turn.FailReason
+		}
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s event: %w", evType, err)
+	}
+	pid := c.ProjectID
+	return &Event{Type: evType, ProjectID: &pid, Payload: payload}, nil
+}
+
+// GetChat returns the chat with the given id, or ErrNotFound.
+func (s *Store) GetChat(ctx context.Context, id int64) (*Chat, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+chatColumns+` FROM chats WHERE id = ?`, id)
+	c, err := scanChat(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("chat %d: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get chat %d: %w", id, err)
+	}
+	return c, nil
+}
+
+// ChatFilter narrows ListChats. The zero value lists every chat, archived
+// ones included — the caller decides, since a chat list that silently hid
+// archived rows would make `vincent chat list --all` a lie.
+type ChatFilter struct {
+	ProjectID *int64
+	States    []chatstate.State
+}
+
+// ListChats returns chats newest first, which is the order a conversation
+// list is read in.
+func (s *Store) ListChats(ctx context.Context, f ChatFilter) ([]Chat, error) {
+	q := `SELECT ` + chatColumns + ` FROM chats WHERE 1=1`
+	var args []any
+	if f.ProjectID != nil {
+		q += ` AND project_id = ?`
+		args = append(args, *f.ProjectID)
+	}
+	if len(f.States) > 0 {
+		//nolint:gosec // G202: placeholders renders bind markers only, never values.
+		q += ` AND state IN ` + placeholders(len(f.States))
+		for _, st := range f.States {
+			args = append(args, string(st))
+		}
+	}
+	q += ` ORDER BY id DESC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list chats: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Chat
+	for rows.Next() {
+		c, err := scanChat(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan chat: %w", err)
+		}
+		out = append(out, *c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chats: %w", err)
+	}
+	return out, nil
+}
+
+// SetChatState moves a chat to state and publishes chat.state_changed. It is
+// the one write that changes §5.5 state; internal/chatrun is its only caller
+// besides the API's archive and cancel handlers, which mirrors the task path's
+// single-writer arrangement.
+func (s *Store) SetChatState(ctx context.Context, id int64, st chatstate.State) (*Chat, error) {
+	return s.updateChat(ctx, id, EventChatState, func(c *Chat) {
+		c.State = st
+		if st != chatstate.AwaitingInput {
+			// Leaving awaiting_input for any reason retires the request: a
+			// pending question outliving the process that asked it is an
+			// answer route with nothing to answer (§7.4).
+			c.PendingInput = nil
+		}
+	})
+}
+
+// SetChatSession records the agent CLI's own session id for the chat (§7.3,
+// amended). It is written after every turn, not just the first: claude may
+// hand a resumed conversation a new id, and the next turn must resume the one
+// that actually ran.
+func (s *Store) SetChatSession(ctx context.Context, id int64, sessionID string) (*Chat, error) {
+	return s.updateChat(ctx, id, "", func(c *Chat) { c.SessionID = sessionID })
+}
+
+// SetChatPendingInput stores or clears the §7.4 request a chat is waiting on.
+func (s *Store) SetChatPendingInput(ctx context.Context, id int64, req json.RawMessage) (*Chat, error) {
+	return s.updateChat(ctx, id, "", func(c *Chat) { c.PendingInput = req })
+}
+
+// SetChatBranch records the branch name, which is only knowable once the row
+// has an id (§10). It is a separate write for the same reason a task's is.
+func (s *Store) SetChatBranch(ctx context.Context, id int64, branch string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE chats SET branch = ?, updated_at = ? WHERE id = ?`,
+		branch, formatTime(time.Now()), id); err != nil {
+		return fmt.Errorf("set chat %d branch: %w", id, err)
+	}
+	return nil
+}
+
+// SetChatWorktree records or clears the §10 claim. Clearing it is archive's
+// half of the claim window: the directory is gone, so the row must stop
+// naming it before the lock is released (task 005).
+func (s *Store) SetChatWorktree(ctx context.Context, id int64, path, baseSHA string) (*Chat, error) {
+	return s.updateChat(ctx, id, "", func(c *Chat) {
+		c.WorktreePath = path
+		if baseSHA != "" {
+			c.BaseSHA = baseSHA
+		}
+	})
+}
+
+// updateChat applies mutate to the row and writes it back, publishing evType
+// when it is non-empty. Read-modify-write under the store's single connection
+// is safe for the same reason the task path's is: one writer, serialized.
+func (s *Store) updateChat(ctx context.Context, id int64, evType string, mutate func(*Chat)) (*Chat, error) {
+	var out *Chat
+	var ev *Event
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `SELECT `+chatColumns+` FROM chats WHERE id = ?`, id)
+		c, err := scanChat(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("chat %d: %w", id, ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get chat %d: %w", id, err)
+		}
+		mutate(c)
+		c.UpdatedAt = time.Now()
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE chats SET title = ?, state = ?, model = ?, effort = ?, base_sha = ?,
+				worktree_path = ?, session_id = ?, pending_input = ?, updated_at = ?
+			WHERE id = ?`,
+			c.Title, string(c.State), nullString(c.Model), nullString(c.Effort), nullString(c.BaseSHA),
+			nullString(c.WorktreePath), nullString(c.SessionID), nullString(string(c.PendingInput)),
+			formatTime(c.UpdatedAt), c.ID); err != nil {
+			return fmt.Errorf("update chat %d: %w", id, err)
+		}
+		out = c
+		if evType == "" {
+			return nil
+		}
+		ev, err = chatEvent(evType, c, nil)
+		if err != nil {
+			return err
+		}
+		return appendEventTx(ctx, tx, ev)
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.notify(ev)
+	return out, nil
+}
+
+// CreateChatTurn inserts a running turn, assigning its seq, and moves the chat
+// to `running` in the same transaction. Both halves are one write because a
+// chat that is running with no turn row — or the reverse — is the state
+// recovery cannot tell from a crash (§12.4).
+func (s *Store) CreateChatTurn(ctx context.Context, chatID int64, prompt string) (*ChatTurn, error) {
+	var turn *ChatTurn
+	var ev *Event
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `SELECT `+chatColumns+` FROM chats WHERE id = ?`, chatID)
+		c, err := scanChat(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("chat %d: %w", chatID, ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get chat %d: %w", chatID, err)
+		}
+		next, ok := chatstate.Next(c.State, chatstate.Send)
+		if !ok {
+			return fmt.Errorf("chat %d: %w", chatID, ErrInvalidChatAction)
+		}
+		var seq int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COALESCE(MAX(seq), 0) + 1 FROM chat_turns WHERE chat_id = ?`, chatID).Scan(&seq); err != nil {
+			return fmt.Errorf("next chat turn seq: %w", err)
+		}
+		t := &ChatTurn{
+			ChatID: chatID, Seq: seq, Prompt: prompt,
+			State: chatstate.TurnRunning, SessionID: c.SessionID, StartedAt: time.Now(),
+		}
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO chat_turns (chat_id, seq, prompt, state, session_id, started_at)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			t.ChatID, t.Seq, t.Prompt, string(t.State), nullString(t.SessionID), formatTime(t.StartedAt))
+		if err != nil {
+			return fmt.Errorf("insert chat turn: %w", err)
+		}
+		if t.ID, err = res.LastInsertId(); err != nil {
+			return fmt.Errorf("insert chat turn: %w", err)
+		}
+		c.State = next
+		c.UpdatedAt = time.Now()
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE chats SET state = ?, updated_at = ? WHERE id = ?`,
+			string(c.State), formatTime(c.UpdatedAt), c.ID); err != nil {
+			return fmt.Errorf("update chat %d: %w", chatID, err)
+		}
+		turn = t
+		ev, err = chatEvent(EventChatTurn, c, t)
+		if err != nil {
+			return err
+		}
+		return appendEventTx(ctx, tx, ev)
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.notify(ev)
+	return turn, nil
+}
+
+// ErrInvalidChatAction is a §5.5 transition the FSM does not allow. The API
+// turns it into a 409, the way an invalid §6 action becomes one.
+var ErrInvalidChatAction = errors.New("action not allowed in this chat state")
+
+// UpdateChatTurn writes the whole turn row back and publishes
+// chat.turn_changed. The chat's own state is not touched here: a turn ending
+// and the chat returning to idle are separate transitions, and chatrun does
+// them in that order so a reader never sees an idle chat with a running turn.
+func (s *Store) UpdateChatTurn(ctx context.Context, t *ChatTurn) error {
+	var ev *Event
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE chat_turns SET state = ?, fail_reason = ?, error_message = ?, result_text = ?,
+				session_id = ?, input_tokens = ?, output_tokens = ?, cost_usd = ?, exit_code = ?,
+				pid = ?, proc_identity = ?, ended_at = ?, duration_ms = ?
+			WHERE id = ?`,
+			string(t.State), nullString(t.FailReason), nullString(t.ErrorMessage), nullString(t.ResultText),
+			nullString(t.SessionID), t.InputTokens, t.OutputTokens, t.CostUSD, t.ExitCode,
+			t.PID, t.ProcIdentity, formatTimePtr(t.EndedAt), t.DurationMS, t.ID); err != nil {
+			return fmt.Errorf("update chat turn %d: %w", t.ID, err)
+		}
+		row := tx.QueryRowContext(ctx, `SELECT `+chatColumns+` FROM chats WHERE id = ?`, t.ChatID)
+		c, err := scanChat(row)
+		if err != nil {
+			return fmt.Errorf("get chat %d: %w", t.ChatID, err)
+		}
+		ev, err = chatEvent(EventChatTurn, c, t)
+		if err != nil {
+			return err
+		}
+		return appendEventTx(ctx, tx, ev)
+	})
+	if err != nil {
+		return err
+	}
+	s.notify(ev)
+	return nil
+}
+
+// ListChatTurns returns a chat's turns in conversation order.
+func (s *Store) ListChatTurns(ctx context.Context, chatID int64) ([]ChatTurn, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+chatTurnColumns+` FROM chat_turns WHERE chat_id = ? ORDER BY seq`, chatID)
+	if err != nil {
+		return nil, fmt.Errorf("list chat turns: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ChatTurn
+	for rows.Next() {
+		t, err := scanChatTurn(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan chat turn: %w", err)
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chat turns: %w", err)
+	}
+	return out, nil
+}
+
+// GetChatTurn returns one turn by id, or ErrNotFound.
+func (s *Store) GetChatTurn(ctx context.Context, id int64) (*ChatTurn, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+chatTurnColumns+` FROM chat_turns WHERE id = ?`, id)
+	t, err := scanChatTurn(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("chat turn %d: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get chat turn %d: %w", id, err)
+	}
+	return t, nil
+}
+
+// ListRunningChatTurns returns every turn still marked running — what §12.4
+// recovery finalizes as `interrupted` at startup (task 063 decision 5).
+func (s *Store) ListRunningChatTurns(ctx context.Context) ([]ChatTurn, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+chatTurnColumns+` FROM chat_turns WHERE state = ? ORDER BY id`,
+		string(chatstate.TurnRunning))
+	if err != nil {
+		return nil, fmt.Errorf("list running chat turns: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ChatTurn
+	for rows.Next() {
+		t, err := scanChatTurn(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan chat turn: %w", err)
+		}
+		out = append(out, *t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chat turns: %w", err)
+	}
+	return out, nil
+}
+
+// CountChatsHoldingProcess returns how many chats currently own a live agent
+// process — the tally `max_parallel_chats` is checked against (§11, task 063
+// decision 1).
+func (s *Store) CountChatsHoldingProcess(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM chats WHERE state IN (?, ?)`,
+		string(chatstate.Running), string(chatstate.AwaitingInput)).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count running chats: %w", err)
+	}
+	return n, nil
+}
+
+// ListChatWorktreeClaims is the chat half of gc's claim set (§10, task 063
+// decision 9). A chat's worktree lives under the same root a task's does, and
+// the reclaimer's rule is that the claim decides — so a chat that claims a
+// directory keeps it, and a chat row that has been archived (worktree_path
+// cleared) claims nothing, exactly like an archived task.
+func (s *Store) ListChatWorktreeClaims(ctx context.Context) ([]ChatWorktreeClaim, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, COALESCE(worktree_path, ''), state FROM chats ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list chat worktree claims: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ChatWorktreeClaim
+	for rows.Next() {
+		var c ChatWorktreeClaim
+		if err := rows.Scan(&c.ChatID, &c.Path, (*string)(&c.State)); err != nil {
+			return nil, fmt.Errorf("scan chat worktree claim: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chat worktree claims: %w", err)
+	}
+	return out, nil
+}
+
+// ListChatIDs returns every chat id, archived rows included — the transcript
+// root's claim set, on the same terms ListTaskIDs sets.
+func (s *Store) ListChatIDs(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id FROM chats ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list chat ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan chat id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chat ids: %w", err)
+	}
+	return ids, nil
+}
+
+func scanChat(r rowScanner) (*Chat, error) {
+	var c Chat
+	var model, effort, baseSHA, worktreePath, sessionID, pending sql.NullString
+	var createdAt, updatedAt string
+	if err := r.Scan(&c.ID, &c.ProjectID, &c.Title, (*string)(&c.State), &c.Agent, &model, &effort,
+		&c.PermissionMode, &c.Branch, &c.BaseBranch, &baseSHA, &worktreePath, &sessionID, &pending,
+		&createdAt, &updatedAt); err != nil {
+		return nil, err
+	}
+	c.Model, c.Effort = model.String, effort.String
+	c.BaseSHA, c.WorktreePath, c.SessionID = baseSHA.String, worktreePath.String, sessionID.String
+	if pending.Valid && pending.String != "" {
+		c.PendingInput = json.RawMessage(pending.String)
+	}
+	var err error
+	if c.CreatedAt, err = parseTime(createdAt); err != nil {
+		return nil, err
+	}
+	if c.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func scanChatTurn(r rowScanner) (*ChatTurn, error) {
+	var t ChatTurn
+	var failReason, errMsg, resultText, sessionID, procIdentity sql.NullString
+	var startedAt string
+	var endedAt sql.NullString
+	if err := r.Scan(&t.ID, &t.ChatID, &t.Seq, &t.Prompt, (*string)(&t.State), &failReason, &errMsg,
+		&resultText, &sessionID, &t.InputTokens, &t.OutputTokens, &t.CostUSD, &t.ExitCode,
+		&t.PID, &procIdentity, &startedAt, &endedAt, &t.DurationMS); err != nil {
+		return nil, err
+	}
+	t.FailReason, t.ErrorMessage = failReason.String, errMsg.String
+	t.ResultText, t.SessionID = resultText.String, sessionID.String
+	if procIdentity.Valid {
+		id := procIdentity.String
+		t.ProcIdentity = &id
+	}
+	var err error
+	if t.StartedAt, err = parseTime(startedAt); err != nil {
+		return nil, err
+	}
+	if t.EndedAt, err = parseTimePtr(endedAt); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 21
+const latestSchemaVersion = 22
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0022_chats.sql
+++ b/internal/store/migrations/0022_chats.sql
@@ -1,0 +1,69 @@
+-- 0022_chats: chats and their turns (task 063, spec §5.5, §14).
+--
+-- Two new tables rather than a `kind` column on `tasks`. The alternative was
+-- considered and rejected in the issue and again in the brief: a chat has no
+-- workflow snapshot, no step ledger and no §6 lifecycle, so a chat row in
+-- `tasks` would force every existing query — the board, admission, the §17
+-- aggregates — to decide whether it means chats too, and a chat carrying a
+-- `current_step` would be a lie to every reader of the snapshot.
+--
+-- `chat_turns` is deliberately not `step_runs` with a nullable `task_id`, for
+-- the same reason: `step_runs.task_id` stays NOT NULL, so every query and
+-- every §17 aggregate over it keeps exactly its current meaning. The columns
+-- are the accounting half of `step_runs` (tokens, cost, duration, pid, exit
+-- code, proc identity) because that is the gap the issue named — talking to an
+-- agent outside vincent has no transcript and no cost record.
+--
+-- `session_id` on `chats` is the whole of §7.3's chat-only amendment: the
+-- agent CLI's own conversation id, handed back as `--resume` on the next turn.
+-- It also rides on each turn row, so a reader can see which session a given
+-- turn actually ran in — claude may hand a resumed conversation a new id, and
+-- a turn that failed `session_lost` names the id that was refused.
+--
+-- ON DELETE CASCADE mirrors tasks': `DELETE /v1/projects/{id}` drops a
+-- project's chats, and gc reconciles the directories that leaves behind (§10).
+CREATE TABLE chats (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id      INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title           TEXT    NOT NULL,
+    state           TEXT    NOT NULL, -- §5.5: idle | running | awaiting_input | archived
+    agent           TEXT    NOT NULL, -- adapter name; must be one that can resume (§9.1)
+    model           TEXT,             -- NULL/'' = CLI default (§8.6)
+    effort          TEXT,
+    permission_mode TEXT    NOT NULL DEFAULT 'full_auto',
+    branch          TEXT    NOT NULL, -- vincent/{id}-{slug}, as a task's (§10)
+    base_branch     TEXT    NOT NULL,
+    base_sha        TEXT,             -- the fetched commit the branch starts at, when one resolved
+    worktree_path   TEXT,             -- the §10 claim; NULL once archived
+    session_id      TEXT,             -- the agent CLI's own session; NULL before the first turn
+    pending_input   TEXT,             -- the §7.4 request awaiting an answer, as JSON; NULL otherwise
+    created_at      TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL
+);
+
+CREATE INDEX chats_project_idx ON chats (project_id);
+CREATE INDEX chats_state_idx ON chats (state, id);
+
+CREATE TABLE chat_turns (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id       INTEGER NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    seq           INTEGER NOT NULL, -- 1-based position in the conversation
+    prompt        TEXT    NOT NULL, -- the human's message
+    state         TEXT    NOT NULL, -- running | done | failed | interrupted
+    fail_reason   TEXT,             -- the shared snake_case vocabulary; session_lost lives here
+    error_message TEXT,
+    result_text   TEXT,             -- the agent's final answer
+    session_id    TEXT,             -- the session this turn ran in
+    input_tokens  INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd      REAL,             -- NULL = the adapter reports none (§9.3, §9.7)
+    exit_code     INTEGER,
+    pid           INTEGER,          -- while running, for §12.4's orphan kill
+    proc_identity TEXT,             -- the 0013 PID-reuse guard, same contract
+    started_at    TEXT    NOT NULL,
+    ended_at      TEXT,
+    duration_ms   INTEGER
+);
+
+CREATE UNIQUE INDEX chat_turns_seq_idx ON chat_turns (chat_id, seq);
+CREATE INDEX chat_turns_state_idx ON chat_turns (state);

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/lezli01/vincent/internal/chatstate"
 	"github.com/lezli01/vincent/internal/github"
 	"github.com/lezli01/vincent/internal/taskstate"
 )
@@ -471,4 +472,77 @@ type Event struct {
 	TaskID    *int64
 	ProjectID *int64
 	Payload   json.RawMessage
+}
+
+// Chat is a titled conversation with an agent, scoped to a project and
+// running in its own git worktree and `vincent/{id}-{slug}` branch (spec
+// §5.5, task 063). It is a first-class entity beside Task, not a task with a
+// different shape: it has no workflow snapshot, no step ledger and no §6
+// lifecycle, and it never appears on the task board.
+type Chat struct {
+	ID        int64
+	ProjectID int64
+	Title     string
+	State     chatstate.State
+	// Agent is the adapter this chat talks to. It is fixed at creation and
+	// must be one that can resume its own session (§9.1): a chat whose
+	// adapter changed mid-conversation would resume an id another CLI never
+	// issued.
+	Agent          string
+	Model          string
+	Effort         string
+	PermissionMode string
+	Branch         string
+	BaseBranch     string
+	BaseSHA        string
+	// WorktreePath is the §10 claim. Empty once archived, which is what
+	// takes the directory out of gc's claim set.
+	WorktreePath string
+	// SessionID is the agent CLI's own conversation id, resumed on the next
+	// turn (§7.3, amended for chats). Empty before the first turn finishes.
+	SessionID string
+	// PendingInput is the §7.4 request this chat is waiting on, verbatim as
+	// the API renders it. Non-nil exactly in `awaiting_input`.
+	PendingInput json.RawMessage
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// ChatTurn is one exchange: a human message and the agent run it produced
+// (spec §5.5, §14). Its accounting columns are step_runs' — tokens, cost,
+// duration, pid, exit code, proc identity — because closing the accounting
+// gap is half of what chats are for; `step_runs` itself is untouched, and
+// `step_runs.task_id` stays NOT NULL.
+type ChatTurn struct {
+	ID     int64
+	ChatID int64
+	// Seq is 1-based position in the conversation, unique per chat.
+	Seq    int
+	Prompt string
+	State  chatstate.TurnState
+	// FailReason is the shared snake_case vocabulary internal/taskrun and
+	// internal/worktree own — `session_lost`, `timeout`, `agent_error`. A
+	// reason means the same thing wherever it originated.
+	FailReason   string
+	ErrorMessage string
+	ResultText   string
+	SessionID    string
+	InputTokens  int64
+	OutputTokens int64
+	CostUSD      *float64
+	ExitCode     *int
+	PID          *int
+	ProcIdentity *string
+	StartedAt    time.Time
+	EndedAt      *time.Time
+	DurationMS   *int64
+}
+
+// ChatWorktreeClaim is one chat's claim on a data-root directory (§10). It
+// mirrors WorktreeClaim, and gc unions the two sets: the roots are shared, so
+// a chat's worktree that no set named would be deleted as a stray.
+type ChatWorktreeClaim struct {
+	ChatID int64
+	Path   string
+	State  chatstate.State
 }

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -722,7 +722,7 @@ func (h *actionHarness) runs(t *testing.T, taskID int64) []store.StepRun {
 func (h *actionHarness) worktree(t *testing.T, task *store.Task) string {
 	t.Helper()
 	path, err := h.runner.deps.Worktrees.Create(
-		t.Context(), h.repo, task.ID, task.BranchName, task.BaseBranch, false)
+		t.Context(), h.repo, worktree.TaskOwner(task.ID), task.BranchName, task.BaseBranch, false)
 	if err != nil {
 		t.Fatalf("create worktree: %v", err)
 	}

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -682,7 +682,7 @@ func (r *Runner) ensureWorktree(ctx context.Context, task *store.Task, project *
 	// Read per admission, not cached: a hot reload then reaches the next task
 	// admitted, the way usage_limit_recheck_interval reaches the next hold.
 	fetch := r.deps.Config().FetchBaseBranch
-	created, err := r.deps.Worktrees.CreateAndClaim(ctx, project.Path, task.ID,
+	created, err := r.deps.Worktrees.CreateAndClaim(ctx, project.Path, worktree.TaskOwner(task.ID),
 		task.BranchName, task.BaseBranch, fetch, func(c worktree.Created) error {
 			// A failed persist is logged and the run continues, as it always
 			// has: the worktree is real and the step can use it. What it

--- a/internal/taskrun/reclaim.go
+++ b/internal/taskrun/reclaim.go
@@ -180,18 +180,14 @@ func (rc *Reclaimer) remove(o Orphan) error {
 // classify diffs both roots against the claim set and decides what each
 // entry is. It is the whole definition of an orphan in one place.
 func (rc *Reclaimer) classify(ctx context.Context, force, dryRun bool) (Report, error) {
-	claims, err := rc.deps.Store.ListWorktreeClaims(ctx)
-	if err != nil {
-		return Report{}, err
-	}
-	ids, err := rc.deps.Store.ListTaskIDs(ctx)
+	claimed, transcripts, err := rc.claimSets(ctx)
 	if err != nil {
 		return Report{}, err
 	}
 	rep := Report{DryRun: dryRun, Force: force}
 
 	wtRoot := rc.worktreeRoot()
-	for _, e := range rc.strays(wtRoot, claimedPaths(claims)) {
+	for _, e := range rc.strays(wtRoot, claimed) {
 		o := rc.measure(e, wtRoot, KindWorktree)
 		if o.Skip == "" && !force {
 			o.Skip = rc.dirtiness(ctx, o.Path)
@@ -199,7 +195,7 @@ func (rc *Reclaimer) classify(ctx context.Context, force, dryRun bool) (Report, 
 		rep.Orphans = append(rep.Orphans, o)
 	}
 	tsRoot := rc.transcriptRoot()
-	for _, e := range rc.strays(tsRoot, claimedTranscripts(tsRoot, ids)) {
+	for _, e := range rc.strays(tsRoot, transcripts) {
 		// No dirty check: a transcript directory is vincent's own output,
 		// not a working tree, so there is nothing for git to have an opinion
 		// about.
@@ -207,6 +203,16 @@ func (rc *Reclaimer) classify(ctx context.Context, force, dryRun bool) (Report, 
 	}
 	sortOrphans(rep.Orphans)
 
+	// The mismatch pass is tasks-only, deliberately. A Mismatch is §18's
+	// `worktree_missing` shape — a task row pointing at a directory that is
+	// gone — and it is keyed by TaskID. A chat with the same problem is
+	// reported the same way once it has a shape to be reported in; adding a
+	// chat id to a task-shaped record would make every consumer sniff which
+	// it got.
+	claims, err := rc.deps.Store.ListWorktreeClaims(ctx)
+	if err != nil {
+		return Report{}, err
+	}
 	for _, c := range claims {
 		if c.Path == "" {
 			continue
@@ -265,7 +271,15 @@ func (rc *Reclaimer) dirtiness(ctx context.Context, path string) string {
 	}
 }
 
-// claimSets builds both roots' claim sets in one pair of queries.
+// claimSets builds both roots' claim sets in one pass over the tables that
+// own directories under them.
+//
+// Chats are in both sets (task 063 decision 9). They live under the same two
+// roots, and `strays` treats anything no set names as an orphan — so a chat
+// whose worktree was not claimed here would be deleted by `vincent gc` and
+// would inflate `GET /v1/info`'s orphan count in the meantime. Keeping chat
+// directories in a root the reclaimer does not scan was rejected: it trades a
+// false positive for no gc coverage at all.
 func (rc *Reclaimer) claimSets(ctx context.Context) (worktrees, transcripts map[string]bool, err error) {
 	claims, err := rc.deps.Store.ListWorktreeClaims(ctx)
 	if err != nil {
@@ -275,7 +289,27 @@ func (rc *Reclaimer) claimSets(ctx context.Context) (worktrees, transcripts map[
 	if err != nil {
 		return nil, nil, err
 	}
-	return claimedPaths(claims), claimedTranscripts(rc.transcriptRoot(), ids), nil
+	chatClaims, err := rc.deps.Store.ListChatWorktreeClaims(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	chatIDs, err := rc.deps.Store.ListChatIDs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	wt := claimedPaths(claims)
+	for _, c := range chatClaims {
+		if c.Path == "" {
+			continue
+		}
+		wt[filepath.Clean(c.Path)] = true
+	}
+	tsRoot := rc.transcriptRoot()
+	ts := claimedTranscripts(tsRoot, ids)
+	for _, id := range chatIDs {
+		ts[filepath.Clean(filepath.Join(tsRoot, worktree.ChatOwner(id).Dir()))] = true
+	}
+	return wt, ts, nil
 }
 
 // strays lists the entries directly under root that claimed does not name. A

--- a/internal/taskrun/reclaim_test.go
+++ b/internal/taskrun/reclaim_test.go
@@ -100,7 +100,7 @@ func (h *reclaimHarness) realWorktree(t *testing.T, title string) *store.Task {
 	t.Helper()
 	task := h.task(t, title)
 	branch := worktree.BranchName(task.ID, title)
-	created, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, task.ID, branch, "main", false,
+	created, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, worktree.TaskOwner(task.ID), branch, "main", false,
 		func(c worktree.Created) error {
 			return h.store.SetTaskProgress(t.Context(), task.ID, nil, &c.Path, nil)
 		})
@@ -484,7 +484,7 @@ func TestScanCannotDeleteAWorktreeBeingCreated(t *testing.T) {
 	}()
 
 	branch := worktree.BranchName(task.ID, "racing")
-	created, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, task.ID, branch, "main", false,
+	created, err := h.worktrees.CreateAndClaim(t.Context(), h.repo, worktree.TaskOwner(task.ID), branch, "main", false,
 		func(c worktree.Created) error {
 			close(inClaim)
 			return h.store.SetTaskProgress(t.Context(), task.ID, nil, &c.Path, nil)

--- a/internal/taskrun/transcript.go
+++ b/internal/taskrun/transcript.go
@@ -1,47 +1,23 @@
 package taskrun
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 	"unicode/utf8"
+
+	txn "github.com/lezli01/vincent/internal/transcript"
 )
 
-// transcript is one attempt's transcript file (spec §12.2:
+// transcript is the shared writer (internal/transcript), aliased so this
+// package's existing callers read as they did before the extraction (task
+// 063). The naming convention below is the part that is genuinely taskrun's.
+type transcript = txn.Writer
+
+// openTranscript creates the transcript file for one attempt (spec §12.2:
 // {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl, with a
 // sub-step of a `parallel` group taking {step_index}-{step_id}-{attempt}).
-// Agent
-// stream lines are written verbatim so the file stays replayable; vincent's
-// own annotations are namespaced `vincent.*` (phase 1 decision).
-type transcript struct {
-	path string
-	mu   sync.Mutex
-	f    *os.File
-	// size is the byte length written so far. Every append returns the
-	// position after it, which live-output chunks carry so a client can tell
-	// exactly which lines its transcript fetch already covered (§13.3).
-	size int64
-	// max is the §12.3 per-attempt cap; 0 disables it. Past the cap writes
-	// are dropped and exceeded latches, which the step executors poll to fail
-	// the attempt (§18 transcript_limit).
-	max      int64
-	exceeded bool
-	// err is the first write, encode or close failure. A transcript that
-	// could not record what happened is not the lossless record §12.2
-	// promises, and the step executors turn it into transcript_io_error
-	// rather than let an attempt claim success over evidence that is not
-	// there (§7.1, §18).
-	err    error
-	closed bool
-}
-
-// openTranscript creates the transcript file for one attempt.
 //
 // subStepID is empty for an ordinary step, whose index owns its name. A
 // member of a `parallel` group shares its group's index with its siblings, so
@@ -56,11 +32,14 @@ type transcript struct {
 // would rename every transcript vincent has ever written to make a directory
 // listing consistent with itself; nothing parses these names, because
 // `transcript_path` is stored on the row.
+// outputFields renders a `vincent.output` note's fields. It stays an alias
+// here so the step executors read unchanged after the extraction.
+func outputFields(phase, stream, text string, partial bool) map[string]any {
+	return txn.OutputFields(phase, stream, text, partial)
+}
+
 func openTranscript(dataDir string, taskID int64, stepIndex, iteration, attempt int, subStepID string) (*transcript, error) {
 	dir := filepath.Join(dataDir, "transcripts", strconv.FormatInt(taskID, 10))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("create transcript dir: %w", err)
-	}
 	name := fmt.Sprintf("%d-%d.jsonl", stepIndex, attempt)
 	switch {
 	case iteration > 0:
@@ -68,153 +47,7 @@ func openTranscript(dataDir string, taskID int64, stepIndex, iteration, attempt 
 	case subStepID != "":
 		name = fmt.Sprintf("%d-%s-%d.jsonl", stepIndex, subStepID, attempt)
 	}
-	path := filepath.Join(dir, name)
-	//nolint:gosec // G304: path is built here from the daemon's transcript dir and the step's own indices
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return nil, fmt.Errorf("create transcript: %w", err)
-	}
-	return &transcript{path: path, f: f}, nil
-}
-
-// Path is the transcript's location, recorded on the StepRun.
-func (t *transcript) Path() string { return t.path }
-
-// SetMax installs the per-attempt cap (§12.3). Zero or negative disables it.
-func (t *transcript) SetMax(limit int64) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.max = limit
-}
-
-// Exceeded reports that the cap was passed. It latches: once a transcript is
-// over the limit the attempt is doomed, and un-latching on a later smaller
-// write would let a run creep past the cap indefinitely.
-func (t *transcript) Exceeded() bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.exceeded
-}
-
-// Err reports the first write, encode or close failure, or nil.
-//
-// Like Exceeded it latches, and for a stronger reason: a line that failed to
-// land is gone, and a later successful write does not put it back. Disk-full,
-// permission and short-write faults all arrive here, and ENOSPC on a buffered
-// filesystem usually arrives at Close and nowhere else — which is why Close
-// feeds this latch too.
-func (t *transcript) Err() error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.err
-}
-
-// fail latches the first error. The caller holds t.mu.
-func (t *transcript) fail(err error) {
-	if t.err == nil {
-		t.err = err
-	}
-}
-
-// Raw appends a verbatim stream line and reports the file offset just past
-// it. A short or failed write still advances by what landed, so the offset
-// never claims more of the file than exists.
-//
-// The line that trips the cap is written whole rather than truncated: a
-// transcript is replayed by a JSONL parser (§13.2), and half a line would
-// turn a size failure into a parse failure for every reader afterwards. The
-// overshoot is bounded by one line.
-func (t *transcript) Raw(line []byte) int64 { return t.write(line, false) }
-
-// write appends a line. force bypasses the cap, which exactly one caller
-// needs: the annotation recording *why* the transcript stopped. Suppressing
-// that line would leave a reader with a file that simply ends.
-func (t *transcript) write(line []byte, force bool) int64 {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.exceeded && !force {
-		return t.size
-	}
-	want := len(line) + 1
-	n, err := t.f.Write(append(line, '\n'))
-	t.size += int64(n)
-	switch {
-	case err != nil:
-		t.fail(err)
-	case n < want:
-		// io.Writer's contract says a short write reports an error, and
-		// os.File honours it; checking anyway costs a comparison and is the
-		// difference between trusting the contract and having checked.
-		t.fail(io.ErrShortWrite)
-	}
-	if t.max > 0 && t.size > t.max {
-		t.exceeded = true
-	}
-	return t.size
-}
-
-// Note appends a namespaced vincent annotation and reports the offset past
-// it.
-func (t *transcript) Note(kind string, fields map[string]any) int64 {
-	return t.note(kind, fields, false)
-}
-
-// NoteOverLimit is Note for the one annotation the cap must not suppress:
-// the record of why the transcript stops.
-func (t *transcript) NoteOverLimit(kind string, fields map[string]any) int64 {
-	return t.note(kind, fields, true)
-}
-
-func (t *transcript) note(kind string, fields map[string]any, force bool) int64 {
-	entry := make(map[string]any, len(fields)+2)
-	for k, v := range fields {
-		entry[k] = v
-	}
-	entry["type"] = "vincent." + kind
-	entry["ts"] = time.Now().UTC().Format(time.RFC3339)
-	b, err := json.Marshal(entry)
-	if err != nil {
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		t.fail(err)
-		return t.size
-	}
-	return t.write(b, force)
-}
-
-// outputFields is one record of process output, tagged with its stream and
-// the phase that produced it (the step's own command, or its check).
-//
-// partial marks a piece of a line too long to record whole: the next output
-// record on the same phase and stream continues it (#139, §12.2). It is
-// absent rather than false on an ordinary line, so the common record keeps
-// the shape every reader already knows.
-//
-// One map serves the transcript record and the §13.3 live chunk, which is
-// what keeps the durable and live shapes from drifting.
-func outputFields(phase, stream, text string, partial bool) map[string]any {
-	f := map[string]any{"phase": phase, "stream": stream, "text": text}
-	if partial {
-		f["partial"] = true
-	}
-	return f
-}
-
-// Close closes the file, latching a close failure into Err.
-//
-// It is idempotent, because runAttempt closes explicitly — before it judges
-// the attempt, so a close-time ENOSPC still reaches the outcome — while the
-// deferred close stays as the guard for every early return.
-func (t *transcript) Close() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.closed {
-		return
-	}
-	t.closed = true
-	if err := t.f.Close(); err != nil {
-		t.fail(err)
-	}
+	return txn.Open(dir, name)
 }
 
 // outputTailBytes bounds the tail by size as well as by line count.

--- a/internal/taskrun/transcript_test.go
+++ b/internal/taskrun/transcript_test.go
@@ -31,13 +31,13 @@ func TestTranscriptCapLatches(t *testing.T) {
 	if !tr.Exceeded() {
 		t.Fatal("Exceeded is false after passing the cap")
 	}
-	before := tr.size
+	before := tr.Size()
 	tr.Raw([]byte("y"))
 	if !tr.Exceeded() {
 		t.Error("Exceeded un-latched on a later write")
 	}
-	if tr.size != before {
-		t.Errorf("size advanced from %d to %d after the cap; writes must be dropped", before, tr.size)
+	if tr.Size() != before {
+		t.Errorf("size advanced from %d to %d after the cap; writes must be dropped", before, tr.Size())
 	}
 }
 
@@ -78,8 +78,8 @@ func TestTranscriptCapDisabledByZero(t *testing.T) {
 	if tr.Exceeded() {
 		t.Error("Exceeded with the cap disabled")
 	}
-	if tr.size < 100_000 {
-		t.Errorf("size = %d; writes were dropped with the cap disabled", tr.size)
+	if tr.Size() < 100_000 {
+		t.Errorf("size = %d; writes were dropped with the cap disabled", tr.Size())
 	}
 }
 
@@ -94,12 +94,12 @@ func TestNoteOverLimitSurvivesTheCap(t *testing.T) {
 	}
 
 	tr.Note("ignored", map[string]any{"k": "v"})
-	sizeAfterNormalNote := tr.size
+	sizeAfterNormalNote := tr.Size()
 
 	tr.NoteOverLimit("transcript_limit", map[string]any{"max_bytes": 16})
 	tr.Close()
 
-	if tr.size <= sizeAfterNormalNote {
+	if tr.Size() <= sizeAfterNormalNote {
 		t.Error("NoteOverLimit was dropped by the cap")
 	}
 	body, err := os.ReadFile(tr.Path())

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -1,0 +1,216 @@
+// Package transcript is the one transcript writer (spec §12.2): a JSONL file
+// holding an agent run's verbatim stream lines, plus vincent's own
+// `vincent.*` annotations.
+//
+// It was extracted from internal/taskrun when chats arrived (task 063): a
+// chat turn produces exactly the same artifact as a step attempt, and a
+// second copy of the size cap, the latching error and the append-and-report-
+// position contract would have been two files that had to agree forever.
+// internal/taskrun keeps its own filename convention and calls Open with the
+// name it builds; internal/chatrun does the same with its own.
+package transcript
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Writer is one attempt's transcript file (spec §12.2:
+// {data_dir}/transcripts/{task_id}/{step_index}-{attempt}.jsonl, with a
+// sub-step of a `parallel` group taking {step_index}-{step_id}-{attempt}).
+// Agent
+// stream lines are written verbatim so the file stays replayable; vincent's
+// own annotations are namespaced `vincent.*` (phase 1 decision).
+type Writer struct {
+	path string
+	mu   sync.Mutex
+	f    *os.File
+	// size is the byte length written so far. Every append returns the
+	// position after it, which live-output chunks carry so a client can tell
+	// exactly which lines its transcript fetch already covered (§13.3).
+	size int64
+	// max is the §12.3 per-attempt cap; 0 disables it. Past the cap writes
+	// are dropped and exceeded latches, which the step executors poll to fail
+	// the attempt (§18 transcript_limit).
+	max      int64
+	exceeded bool
+	// err is the first write, encode or close failure. A transcript that
+	// could not record what happened is not the lossless record §12.2
+	// promises, and the step executors turn it into transcript_io_error
+	// rather than let an attempt claim success over evidence that is not
+	// there (§7.1, §18).
+	err    error
+	closed bool
+}
+
+// Open creates (truncating) the transcript file called name inside dir,
+// making dir if it is missing. Callers own the naming convention: a step
+// attempt's name encodes its index, iteration and attempt (§12.2), a chat
+// turn's its sequence number (§5.5), and nothing parses either — the path is
+// stored on the row.
+func Open(dir, name string) (*Writer, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create transcript dir: %w", err)
+	}
+	path := filepath.Join(dir, name)
+	//nolint:gosec // G304: path is built by the daemon from its own data dir and a caller-owned name
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("create transcript: %w", err)
+	}
+	return &Writer{path: path, f: f}, nil
+}
+
+// Size is the byte length written so far. It is what a caller compares
+// across a write to tell an accepted append from one the cap dropped.
+func (t *Writer) Size() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.size
+}
+
+// Path is the transcript's location, recorded on the StepRun.
+func (t *Writer) Path() string { return t.path }
+
+// SetMax installs the per-attempt cap (§12.3). Zero or negative disables it.
+func (t *Writer) SetMax(limit int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.max = limit
+}
+
+// Exceeded reports that the cap was passed. It latches: once a transcript is
+// over the limit the attempt is doomed, and un-latching on a later smaller
+// write would let a run creep past the cap indefinitely.
+func (t *Writer) Exceeded() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.exceeded
+}
+
+// Err reports the first write, encode or close failure, or nil.
+//
+// Like Exceeded it latches, and for a stronger reason: a line that failed to
+// land is gone, and a later successful write does not put it back. Disk-full,
+// permission and short-write faults all arrive here, and ENOSPC on a buffered
+// filesystem usually arrives at Close and nowhere else — which is why Close
+// feeds this latch too.
+func (t *Writer) Err() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+// fail latches the first error. The caller holds t.mu.
+func (t *Writer) fail(err error) {
+	if t.err == nil {
+		t.err = err
+	}
+}
+
+// Raw appends a verbatim stream line and reports the file offset just past
+// it. A short or failed write still advances by what landed, so the offset
+// never claims more of the file than exists.
+//
+// The line that trips the cap is written whole rather than truncated: a
+// transcript is replayed by a JSONL parser (§13.2), and half a line would
+// turn a size failure into a parse failure for every reader afterwards. The
+// overshoot is bounded by one line.
+func (t *Writer) Raw(line []byte) int64 { return t.write(line, false) }
+
+// write appends a line. force bypasses the cap, which exactly one caller
+// needs: the annotation recording *why* the transcript stopped. Suppressing
+// that line would leave a reader with a file that simply ends.
+func (t *Writer) write(line []byte, force bool) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.exceeded && !force {
+		return t.size
+	}
+	want := len(line) + 1
+	n, err := t.f.Write(append(line, '\n'))
+	t.size += int64(n)
+	switch {
+	case err != nil:
+		t.fail(err)
+	case n < want:
+		// io.Writer's contract says a short write reports an error, and
+		// os.File honours it; checking anyway costs a comparison and is the
+		// difference between trusting the contract and having checked.
+		t.fail(io.ErrShortWrite)
+	}
+	if t.max > 0 && t.size > t.max {
+		t.exceeded = true
+	}
+	return t.size
+}
+
+// Note appends a namespaced vincent annotation and reports the offset past
+// it.
+func (t *Writer) Note(kind string, fields map[string]any) int64 {
+	return t.note(kind, fields, false)
+}
+
+// NoteOverLimit is Note for the one annotation the cap must not suppress:
+// the record of why the transcript stops.
+func (t *Writer) NoteOverLimit(kind string, fields map[string]any) int64 {
+	return t.note(kind, fields, true)
+}
+
+func (t *Writer) note(kind string, fields map[string]any, force bool) int64 {
+	entry := make(map[string]any, len(fields)+2)
+	for k, v := range fields {
+		entry[k] = v
+	}
+	entry["type"] = "vincent." + kind
+	entry["ts"] = time.Now().UTC().Format(time.RFC3339)
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		t.fail(err)
+		return t.size
+	}
+	return t.write(b, force)
+}
+
+// OutputFields is one record of process output, tagged with its stream and
+// the phase that produced it (the step's own command, or its check).
+//
+// partial marks a piece of a line too long to record whole: the next output
+// record on the same phase and stream continues it (#139, §12.2). It is
+// absent rather than false on an ordinary line, so the common record keeps
+// the shape every reader already knows.
+//
+// One map serves the transcript record and the §13.3 live chunk, which is
+// what keeps the durable and live shapes from drifting.
+// OutputFields renders the fields of a `vincent.output` note.
+func OutputFields(phase, stream, text string, partial bool) map[string]any {
+	f := map[string]any{"phase": phase, "stream": stream, "text": text}
+	if partial {
+		f["partial"] = true
+	}
+	return f
+}
+
+// Close closes the file, latching a close failure into Err.
+//
+// It is idempotent, because runAttempt closes explicitly — before it judges
+// the attempt, so a close-time ENOSPC still reaches the outcome — while the
+// deferred close stays as the guard for every early return.
+func (t *Writer) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	t.closed = true
+	if err := t.f.Close(); err != nil {
+		t.fail(err)
+	}
+}

--- a/internal/tui/configkeys.go
+++ b/internal/tui/configkeys.go
@@ -125,6 +125,15 @@ func configKeys() []configKey {
 			},
 		},
 		{
+			path: "max_parallel_chats", label: "max parallel chats", kind: kindInt,
+			help: "cap on chats holding a live agent process; separate from the task cap",
+			read: func(c apiclient.Config) string { return strconv.Itoa(c.MaxParallelChats) },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				n, err := parseInt(s)
+				return apiclient.ConfigPatch{MaxParallelChats: &n}, err
+			},
+		},
+		{
 			path: "branch_template", label: "branch template", kind: kindText,
 			help: "Go template for a task's branch name; empty uses the built-in",
 			read: func(c apiclient.Config) string { return c.BranchTemplate },

--- a/internal/worktree/branch_delete_test.go
+++ b/internal/worktree/branch_delete_test.go
@@ -44,10 +44,10 @@ func TestDeleteEmptyBranch(t *testing.T) {
 		{
 			name: "no commits past base is deleted",
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
-				if _, err := m.Create(t.Context(), repo, 1, "vincent/1-empty", "main", false); err != nil {
+				if _, err := m.Create(t.Context(), repo, TaskOwner(1), "vincent/1-empty", "main", false); err != nil {
 					t.Fatalf("create: %v", err)
 				}
-				if err := m.Remove(t.Context(), repo, m.Path(1), false); err != nil {
+				if err := m.Remove(t.Context(), repo, m.Path(TaskOwner(1)), false); err != nil {
 					t.Fatalf("remove: %v", err)
 				}
 				return "main", "vincent/1-empty"
@@ -58,7 +58,7 @@ func TestDeleteEmptyBranch(t *testing.T) {
 		{
 			name: "one commit past base survives",
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
-				path, err := m.Create(t.Context(), repo, 2, "vincent/2-work", "main", false)
+				path, err := m.Create(t.Context(), repo, TaskOwner(2), "vincent/2-work", "main", false)
 				if err != nil {
 					t.Fatalf("create: %v", err)
 				}
@@ -75,10 +75,10 @@ func TestDeleteEmptyBranch(t *testing.T) {
 		{
 			name: "base moving forward afterwards still reads as empty",
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
-				if _, err := m.Create(t.Context(), repo, 3, "vincent/3-empty", "main", false); err != nil {
+				if _, err := m.Create(t.Context(), repo, TaskOwner(3), "vincent/3-empty", "main", false); err != nil {
 					t.Fatalf("create: %v", err)
 				}
-				if err := m.Remove(t.Context(), repo, m.Path(3), false); err != nil {
+				if err := m.Remove(t.Context(), repo, m.Path(TaskOwner(3)), false); err != nil {
 					t.Fatalf("remove: %v", err)
 				}
 				// main gains work the task never saw. The tip is still an
@@ -93,10 +93,10 @@ func TestDeleteEmptyBranch(t *testing.T) {
 		{
 			name: "base branch that no longer resolves cannot be judged",
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
-				if _, err := m.Create(t.Context(), repo, 4, "vincent/4-empty", "main", false); err != nil {
+				if _, err := m.Create(t.Context(), repo, TaskOwner(4), "vincent/4-empty", "main", false); err != nil {
 					t.Fatalf("create: %v", err)
 				}
-				if err := m.Remove(t.Context(), repo, m.Path(4), false); err != nil {
+				if err := m.Remove(t.Context(), repo, m.Path(TaskOwner(4)), false); err != nil {
 					t.Fatalf("remove: %v", err)
 				}
 				return "gone-forever", "vincent/4-empty"
@@ -109,7 +109,7 @@ func TestDeleteEmptyBranch(t *testing.T) {
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
 				// The worktree is deliberately *not* removed: `git branch -d`
 				// is the belt that covers this, and it must refuse.
-				if _, err := m.Create(t.Context(), repo, 5, "vincent/5-live", "main", false); err != nil {
+				if _, err := m.Create(t.Context(), repo, TaskOwner(5), "vincent/5-live", "main", false); err != nil {
 					t.Fatalf("create: %v", err)
 				}
 				return "main", "vincent/5-live"
@@ -126,10 +126,10 @@ func TestDeleteEmptyBranch(t *testing.T) {
 			name: "a ref hierarchy neighbour is not collaterally removed",
 			setup: func(t *testing.T, m *Manager, repo string) (string, string) {
 				for id, name := range map[int64]string{6: "feat/foo/bar", 7: "feat/foo/baz"} {
-					if _, err := m.Create(t.Context(), repo, id, name, "main", false); err != nil {
+					if _, err := m.Create(t.Context(), repo, TaskOwner(id), name, "main", false); err != nil {
 						t.Fatalf("create %s: %v", name, err)
 					}
-					if err := m.Remove(t.Context(), repo, m.Path(id), false); err != nil {
+					if err := m.Remove(t.Context(), repo, m.Path(TaskOwner(id)), false); err != nil {
 						t.Fatalf("remove %s: %v", name, err)
 					}
 				}
@@ -183,7 +183,7 @@ func TestDeleteEmptyBranch(t *testing.T) {
 func TestDeleteEmptyBranchKeepsTheCommitObject(t *testing.T) {
 	repo := testrepo.Init(t, "main")
 	m := newManager(t)
-	path, err := m.Create(t.Context(), repo, 1, "vincent/1-work", "main", false)
+	path, err := m.Create(t.Context(), repo, TaskOwner(1), "vincent/1-work", "main", false)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -245,7 +245,7 @@ func pushedRepo(t *testing.T, m *Manager, branch string) (repo, remote string) {
 	remote = testrepo.InitBare(t)
 	testrepo.Run(t, repo, "remote", "add", "origin", remote)
 	testrepo.Run(t, repo, "push", "-q", "-u", "origin", "main")
-	path, err := m.Create(t.Context(), repo, 1, branch, "main", false)
+	path, err := m.Create(t.Context(), repo, TaskOwner(1), branch, "main", false)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -291,10 +291,10 @@ func TestDeleteEmptyBranchRemoteNoUpstream(t *testing.T) {
 	testrepo.Run(t, repo, "remote", "add", "origin", remote)
 	testrepo.Run(t, repo, "push", "-q", "origin", "main")
 	m := newManager(t)
-	if _, err := m.Create(t.Context(), repo, 1, "vincent/1-local", "main", false); err != nil {
+	if _, err := m.Create(t.Context(), repo, TaskOwner(1), "vincent/1-local", "main", false); err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if err := m.Remove(t.Context(), repo, m.Path(1), false); err != nil {
+	if err := m.Remove(t.Context(), repo, m.Path(TaskOwner(1)), false); err != nil {
 		t.Fatalf("remove: %v", err)
 	}
 	// A branch with the same name on the remote, put there by something other

--- a/internal/worktree/concurrency_test.go
+++ b/internal/worktree/concurrency_test.go
@@ -51,7 +51,7 @@ func TestConcurrentCreateInOneProject(t *testing.T) {
 				defer wg.Done()
 				<-gate
 				id := int64(round*100 + i + 1)
-				_, errs[i] = m.CreateAndClaim(t.Context(), repo, id,
+				_, errs[i] = m.CreateAndClaim(t.Context(), repo, TaskOwner(id),
 					fmt.Sprintf("vincent/%d-lane", id), "main", false, nil)
 			}()
 		}

--- a/internal/worktree/fetch_test.go
+++ b/internal/worktree/fetch_test.go
@@ -46,7 +46,7 @@ func TestCreateFetchesTheBaseBranch(t *testing.T) {
 		t.Fatal("fixture is wrong: the remote is not ahead")
 	}
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, "vincent/1-fresh", "main", true, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), "vincent/1-fresh", "main", true, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestCreateFetchLeavesTheLocalBaseAlone(t *testing.T) {
 		t.Fatal("fixture is wrong: the working tree should be dirty")
 	}
 	m := newManager(t)
-	if _, err := m.Create(t.Context(), repo, 1, "vincent/1-fresh", "main", true); err != nil {
+	if _, err := m.Create(t.Context(), repo, TaskOwner(1), "vincent/1-fresh", "main", true); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	wantTip(t, repo, "refs/heads/main", localTip, "local base after the fetch")
@@ -103,7 +103,7 @@ func TestCreateSetsNoUpstreamOnTheTaskBranch(t *testing.T) {
 			testrepo.Run(t, repo, "config", "branch.autoSetupMerge", "always")
 			m := newManager(t)
 			const branch = "vincent/1-fresh"
-			if _, err := m.Create(t.Context(), repo, 1, branch, "main", fetch); err != nil {
+			if _, err := m.Create(t.Context(), repo, TaskOwner(1), branch, "main", fetch); err != nil {
 				t.Fatalf("Create: %v", err)
 			}
 			for _, key := range []string{"branch." + branch + ".remote", "branch." + branch + ".merge"} {
@@ -126,7 +126,7 @@ func TestCreateFetchWithNoRemote(t *testing.T) {
 	repo := testrepo.Init(t, "main")
 	localTip := testrepo.Run(t, repo, "rev-parse", "main")
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, "vincent/1-local", "main", true, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), "vincent/1-local", "main", true, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestCreateFetchWithBaseThatHasNoUpstream(t *testing.T) {
 	repo, _, _ := remoteAhead(t)
 	m := newManager(t)
 	// The parent lane's branch, cut from a fetched main.
-	parent, err := m.CreateAndClaim(t.Context(), repo, 1, "vincent/1-parent", "main", true, nil)
+	parent, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), "vincent/1-parent", "main", true, nil)
 	if err != nil {
 		t.Fatalf("create parent: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestCreateFetchWithBaseThatHasNoUpstream(t *testing.T) {
 	testrepo.Run(t, parent.Path, "commit", "-q", "-m", "parent work")
 	parentTip := testrepo.Run(t, parent.Path, "rev-parse", "HEAD")
 
-	child, err := m.CreateAndClaim(t.Context(), repo, 2, "vincent/2-lane", "vincent/1-parent", true, nil)
+	child, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(2), "vincent/2-lane", "vincent/1-parent", true, nil)
 	if err != nil {
 		t.Fatalf("create lane: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestCreateFetchFailureFallsBack(t *testing.T) {
 		testrepo.Run(t, repo, "rev-parse", "--show-toplevel")+"-gone.git")
 	m := newManager(t)
 	start := time.Now()
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, "vincent/1-fresh", "main", true, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), "vincent/1-fresh", "main", true, nil)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("an unreachable remote must not fail the creation: %v", err)
@@ -201,7 +201,7 @@ func TestCreateFetchFailureFallsBack(t *testing.T) {
 func TestCreateFetchDisabled(t *testing.T) {
 	repo, localTip, remoteTip := remoteAhead(t)
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, "vincent/1-stale", "main", false, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), "vincent/1-stale", "main", false, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestDeleteEmptyBranchUsesTheRecordedBaseSHA(t *testing.T) {
 	const branch = "vincent/1-nothing"
 	repo, _, _ := remoteAhead(t)
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, branch, "main", true, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), branch, "main", true, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestDeleteEmptyBranchFallsBackToTheBranchName(t *testing.T) {
 	const branch = "vincent/1-nothing"
 	repo, _, _ := remoteAhead(t)
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, branch, "main", false, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), branch, "main", false, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestDeleteEmptyBranchRefusesACheckedOutBranch(t *testing.T) {
 	const branch = "vincent/1-live"
 	repo, _, _ := remoteAhead(t)
 	m := newManager(t)
-	c, err := m.CreateAndClaim(t.Context(), repo, 1, branch, "main", true, nil)
+	c, err := m.CreateAndClaim(t.Context(), repo, TaskOwner(1), branch, "main", true, nil)
 	if err != nil {
 		t.Fatalf("CreateAndClaim: %v", err)
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -102,8 +102,45 @@ func BranchName(taskID int64, title string) string {
 	return fmt.Sprintf("vincent/%d-%s", taskID, s)
 }
 
-// Manager creates and removes per-task worktrees under
-// {data_dir}/worktrees/{task_id} (spec §10).
+// OwnerKind says which entity a worktree belongs to (spec §10, task 063).
+type OwnerKind string
+
+// Worktree owner kinds.
+const (
+	OwnerTask OwnerKind = "task"
+	OwnerChat OwnerKind = "chat"
+)
+
+// Owner identifies the entity a worktree and its directory belong to. It
+// replaced a bare `taskID int64` when chats arrived (task 063 decision 9):
+// chats live under the same root, so `{root}/{id}` would have put chat 7 and
+// task 7 in one directory.
+//
+// The directory name stays informational — gc's rule is that the claim
+// decides, not the name — but two owners resolving to one path is not a
+// naming preference, it is a collision.
+type Owner struct {
+	Kind OwnerKind
+	ID   int64
+}
+
+// TaskOwner is the worktree owner for a task. Its directory name is the bare
+// id, unchanged from before Owner existed, so no installed worktree moves.
+func TaskOwner(id int64) Owner { return Owner{Kind: OwnerTask, ID: id} }
+
+// ChatOwner is the worktree owner for a chat (§5.5).
+func ChatOwner(id int64) Owner { return Owner{Kind: OwnerChat, ID: id} }
+
+// Dir is the owner's directory name directly under the worktree root.
+func (o Owner) Dir() string {
+	if o.Kind == OwnerChat {
+		return "chat-" + strconv.FormatInt(o.ID, 10)
+	}
+	return strconv.FormatInt(o.ID, 10)
+}
+
+// Manager creates and removes per-owner worktrees under
+// {data_dir}/worktrees/{owner} (spec §10).
 type Manager struct {
 	git  *gitx.Git
 	root string
@@ -170,9 +207,9 @@ func (m *Manager) lockRepo(projectPath string) func() {
 // Reclaim will delete inside (spec §10).
 func (m *Manager) Root() string { return m.root }
 
-// Path returns the worktree location for a task.
-func (m *Manager) Path(taskID int64) string {
-	return filepath.Join(m.root, strconv.FormatInt(taskID, 10))
+// Path returns the worktree location for an owner.
+func (m *Manager) Path(o Owner) string {
+	return filepath.Join(m.root, o.Dir())
 }
 
 // Created is what one worktree creation produced.
@@ -202,11 +239,11 @@ type Created struct {
 // are things only a caller that records the creation has any use for. This
 // one deliberately drops both.
 func (m *Manager) Create(
-	ctx context.Context, projectPath string, taskID int64, branch, base string, fetch bool,
+	ctx context.Context, projectPath string, owner Owner, branch, base string, fetch bool,
 ) (string, error) {
 	m.claims.RLock()
 	defer m.claims.RUnlock()
-	c, err := m.create(ctx, projectPath, taskID, branch, base, fetch)
+	c, err := m.create(ctx, projectPath, owner, branch, base, fetch)
 	return c.Path, err
 }
 
@@ -219,12 +256,12 @@ func (m *Manager) Create(
 // engine's own error path decides what happens to the task. The next scan
 // will see it as an orphan, which is precisely the crash case gc exists for.
 func (m *Manager) CreateAndClaim(
-	ctx context.Context, projectPath string, taskID int64, branch, base string, fetch bool,
+	ctx context.Context, projectPath string, owner Owner, branch, base string, fetch bool,
 	claim func(c Created) error,
 ) (Created, error) {
 	m.claims.RLock()
 	defer m.claims.RUnlock()
-	c, err := m.create(ctx, projectPath, taskID, branch, base, fetch)
+	c, err := m.create(ctx, projectPath, owner, branch, base, fetch)
 	if err != nil {
 		return c, err
 	}
@@ -261,7 +298,7 @@ func (m *Manager) WithReclaimLock(fn func() error) error {
 }
 
 func (m *Manager) create(
-	ctx context.Context, projectPath string, taskID int64, branch, base string, fetch bool,
+	ctx context.Context, projectPath string, owner Owner, branch, base string, fetch bool,
 ) (Created, error) {
 	// Whole of create, not just the prune: the add is as unsafe against a
 	// peer add as it is against a peer prune (#126, see Manager.repos). The
@@ -294,7 +331,7 @@ func (m *Manager) create(
 	if err := m.prune(ctx, projectPath); err != nil {
 		return Created{}, err
 	}
-	target := m.Path(taskID)
+	target := m.Path(owner)
 	if entries, err := os.ReadDir(target); err == nil && len(entries) > 0 {
 		return Created{}, &Error{
 			Reason:  ReasonWorktreePathOccupied,

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -60,12 +60,12 @@ func TestCreateRemoveLifecycle(t *testing.T) {
 	m := newManager(t)
 	ctx := context.Background()
 
-	path, err := m.Create(ctx, repo, 7, "vincent/7-test", "main", false)
+	path, err := m.Create(ctx, repo, TaskOwner(7), "vincent/7-test", "main", false)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if path != m.Path(7) {
-		t.Errorf("path = %q, want %q", path, m.Path(7))
+	if path != m.Path(TaskOwner(7)) {
+		t.Errorf("path = %q, want %q", path, m.Path(TaskOwner(7)))
 	}
 	if _, err := os.Stat(filepath.Join(path, "README.md")); err != nil {
 		t.Errorf("worktree not checked out: %v", err)
@@ -91,25 +91,25 @@ func TestCreateErrors(t *testing.T) {
 	m := newManager(t)
 	ctx := context.Background()
 
-	_, err := m.Create(ctx, filepath.Join(t.TempDir(), "gone"), 1, "vincent/1", "main", false)
+	_, err := m.Create(ctx, filepath.Join(t.TempDir(), "gone"), TaskOwner(1), "vincent/1", "main", false)
 	wantReason(t, err, ReasonProjectPathMissing)
 
-	_, err = m.Create(ctx, repo, 2, "vincent/2", "nope", false)
+	_, err = m.Create(ctx, repo, TaskOwner(2), "vincent/2", "nope", false)
 	wantReason(t, err, ReasonBaseBranchMissing)
 
 	testrepo.Run(t, repo, "branch", "vincent/3-taken")
-	_, err = m.Create(ctx, repo, 3, "vincent/3-taken", "main", false)
+	_, err = m.Create(ctx, repo, TaskOwner(3), "vincent/3-taken", "main", false)
 	wantReason(t, err, ReasonBranchExists)
 
 	// Pre-existing non-empty target dir: prune-then-fail decision.
-	target := m.Path(4)
+	target := m.Path(TaskOwner(4))
 	if err := os.MkdirAll(target, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(target, "leftover"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err = m.Create(ctx, repo, 4, "vincent/4", "main", false)
+	_, err = m.Create(ctx, repo, TaskOwner(4), "vincent/4", "main", false)
 	wantReason(t, err, ReasonWorktreePathOccupied)
 }
 
@@ -118,7 +118,7 @@ func TestRemoveDirty(t *testing.T) {
 	m := newManager(t)
 	ctx := context.Background()
 
-	path, err := m.Create(ctx, repo, 5, "vincent/5-dirty", "main", false)
+	path, err := m.Create(ctx, repo, TaskOwner(5), "vincent/5-dirty", "main", false)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestRemoveDirtyTracked(t *testing.T) {
 	m := newManager(t)
 	ctx := context.Background()
 
-	path, err := m.Create(ctx, repo, 6, "vincent/6", "main", false)
+	path, err := m.Create(ctx, repo, TaskOwner(6), "vincent/6", "main", false)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestRemoveProjectGone(t *testing.T) {
 	m := newManager(t)
 	ctx := context.Background()
 
-	path, err := m.Create(ctx, repo, 8, "vincent/8", "main", false)
+	path, err := m.Create(ctx, repo, TaskOwner(8), "vincent/8", "main", false)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds `chat`: a titled conversation with an agent, scoped to a project, running
in its own git worktree and `vincent/{id}-{slug}` branch. Each turn spawns the
agent CLI resuming the agent's **own** session, so turn N has turns 1..N-1 in
context — nothing is replayed as prompt context.

A chat is a first-class entity beside `Task`, never a task with a `kind` column:
its own `chats`/`chat_turns` tables (migration 0021), its own four-state
lifecycle (`idle` / `running` / `awaiting_input` / `archived`) in the pure
`internal/chatstate` FSM, its own actor package `internal/chatrun`, its own
`/v1/chats` route family, and no presence at all in `GET /v1/tasks` or on the
board. `step_runs.task_id` stays `NOT NULL`, so every existing query and every
§17 aggregate keeps its current meaning.

Turns carry a step run's accounting — tokens, cost, duration, exit code — and
each gets its own transcript. That closes the accounting half of the gap the
issue named: a conversation held outside vincent leaves no record at all.

Decisions worth reviewing (all argued in `docs/tasks/059-free-chat.md` and
spec decision-record row 29):

- **`max_parallel_chats` (default 3), refused rather than queued.** The issue
  asked for no admission at all; that collides with §11's 2026-08-29 amendment
  (task 057, row 28), which rejected releasing a slot while an agent process is
  live and named the cost verbatim — *live-but-uncounted agent CLIs
  accumulating*. That reasoning does not stop applying because the noun changed,
  so the amendment is **extended, not excepted**: a chat turn is counted, but
  over the cap a `send` is `409` immediately and never queued. `internal/scheduler`
  stays the only place `queued → running` happens, because a chat turn is never
  `queued`. The foreground property the issue wanted survives — a reply is
  refused in front of batch work rather than parked behind it.
- **No chat route is an MCP tool.** §13.4's exclusion list grows by the whole
  chat family. An agent must not start unqueued agent processes, and
  `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id` —
  a chain a chat is not in.
- **claude only; codex and cursor are refused, not emulated.** `400
  agent_cannot_resume` at creation. Both CLIs have a resume of some shape;
  vincent reads neither yet and no fixture pins the argv, so the capability is
  stated as absent (§9.3, §9.7) rather than approximated. Replaying the log into
  the prompt is exactly what the refusal prevents.
- **`session_lost` fails the turn and leaves the chat usable**, keeping the id.
  A silently fresh session answers as if it had context it does not have.
- **An interrupted turn is not re-run.** §12.4's auto-resume rule holds for
  steps because a fresh session over a surviving worktree is safe by
  construction; a chat turn is neither half of that.
- **Chat worktrees join gc's claim namespace**, and worktree directories are
  named by owner (`{root}/{task_id}` unchanged, `{root}/chat-{chat_id}` new), so
  chat 7 and task 7 cannot collide. Found during review, not in the issue.

`cmd/fakeagent` gained a session store of its own (`FAKEAGENT_SESSION_DIR`), so
continuity is the fake CLI actually remembering rather than the test staging it:
a vincent that dropped `--resume` fails `TestTurnTwoSeesTurnOne` by omission.

### Not in this PR

`docs/tasks/059-free-chat.md` splits the work: **059.1 (this PR) is done**;
**059.2 is open** and covers the **chats view in the TUI** and
**`scripts/m11-gate.sh`** wired into `ci.yml`'s `gates` job. The entity is
complete and usable without them — CLI, API, runner, recovery, gc — and neither
changes a decision above. They are held out rather than rushed because this
repository holds both to bars worth respecting: a view whose screenshots come
from `scripts/screenshots.sh` rather than a drawing, and a gate that has
actually been run on all three platforms before it is claimed to pass on them.
§15 carries a dated note saying the view is not there yet, so the spec does not
describe a screen that does not exist, and the `CHANGELOG.md` entry says so in
the feature's own bullet.

### Found by the documentation audit, not fixed here

Three gaps in the implementation, recorded as open task **059.3** in
`docs/tasks/059-free-chat.md` and written into the pages they affect. None
changes a decision above; all three are ordinary follow-up work.

1. **A chat turn is bounded by no clock at all.** `internal/chatrun` applies
   neither `input_timeout` nor `agent_timeout`, so a turn — and the
   `max_parallel_chats` slot it holds — runs until it is answered or cancelled.
   §13.2 said the answer flow used "the same `input_timeout`" as §7.4; it now
   carries a dated correction saying it does not.
2. **`vincent chat` has no `answer` and no `cancel`.** `POST
   /v1/chats/{id}/answer` and `/cancel` exist as routes with no CLI
   counterpart, so a chat that enters `awaiting_input` can only be moved on
   over the API — and `vincent chat send`, which polls until the turn ends,
   blocks on it meanwhile with (per 1) nothing to time it out. `cli.md` says
   this plainly rather than leaving a reader to discover it.
3. **Chat transcripts are neither capped nor pruned.** Only
   `internal/taskrun/engine.go` calls `transcript.Writer.SetMax`, and the
   pruner walks archived *tasks*, so `transcript_max_bytes` and
   `transcript_retention_days` both miss `transcripts/chat-{id}/`.
   `configuration.md` and `files.md` state the omission.

Two smaller things the audit corrected rather than reported:

- `configuration.md` had gained `max_parallel_chats` inside the block it calls
  the generated default file **verbatim**, but `internal/config/bootstrap.go`
  does not write that key. The block is verbatim again; the key stays
  documented under Keys, alongside the other keys the generated file also
  omits (`branch_template`, `mcp`, `notify`, …). If it *should* ship in the
  generated file, that is a `bootstrap.go` change, not a docs one.
- The new `CHANGELOG.md` entry introduced a `### Changed` and a `### Not
  included` heading ahead of the existing `## [Unreleased]` list, which left
  every pre-existing `### Added` entry — enum task fields, the pull-requests
  screen, the update checker, the MCP server — sitting under **Not included**.
  Unreleased is back to Added / Changed / Fixed, with the worktree-naming
  entry moved into the real `### Changed`. The entry also advertised
  `vincent chat new` and `vincent chat answer`, neither of which exists; it
  now names the five subcommands the cobra tree actually has.

No `docs/assets/tui-*.png` is stale: this cut adds no TUI view and changes no
existing panel, so no screenshot needs re-capturing.

## Related

Closes #255

Task **059.1** (`docs/tasks/059-free-chat.md`); 059.2 stays open.

This **extends** decision-record row 28 (task 057) rather than revisiting it:
§11's 2026-08-29 amendment about live-but-uncounted agent CLIs is applied to
chat turns, and row 28's MCP exclusion list is grown, not weakened — the task
057 assertion that the tool surface equals `Routes()` minus the exclusions is
extended and still passes. §7.3's fresh-session rule is amended **for chats
only**; no workflow step's behaviour changed. §6, `internal/taskstate` and §16
are untouched.

Spec amended in this branch with dated notes: §3 (row 29), §5.5 (new), §6
(pointer), §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3,
§13.4, §14, §15, §20. §13.2 additionally carries a *correction* dated the same
day, from the documentation audit: the chat answer flow is not bounded by
`input_timeout`, because `internal/chatrun` applies no clock at all.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Notes on the last two boxes, so they mean something:

- **Tests.** `internal/chatstate` table tests over every action from every state
  (the illegal pairs too); `internal/chatrun` covers continuity, `session_lost`,
  the cap refusing rather than queueing, recovery finalizing `interrupted`
  without re-sending, and chats never appearing in `ListTasks`; `internal/api`
  covers the adapter refusal, the `409`s, and a turn end-to-end over the real
  handlers. The pre-existing MCP-parity, reclaim, config, migration and worktree
  tests were extended rather than replaced.
- **Docs.** In the feature commit: `docs/reference/api.md` (the route family +
  the MCP exclusion row), `docs/reference/configuration.md`
  (`max_parallel_chats`), `docs/reference/cli.md` (`vincent chat`),
  `docs/tasks/059-free-chat.md` plus its index row, and the spec sections
  listed above. In the follow-up docs commit, after auditing each derivation
  against its source: `docs/features.md` (the product surface had no chats at
  all), `docs/guides/agents.md` (the resume row in the capability matrix, and
  the positive per-adapter statement the "stated, never emulated" rule asks
  for), `docs/guides/mcp.md` ("five things are not tools" is now five admin
  routes plus the chat family), `docs/reference/files.md` (the chat worktree
  and transcript paths), `docs/guides/scripting.md` and `README.md` (`--json`
  is not on `vincent chat`), the two missing reference indexes, the `chat.*`
  durable events, a chats pointer on `docs/reference/task-lifecycle.md`, and
  `docs/security-model.md`'s concurrency advice. **No TUI key table changed**
  and **no new `Reason*` block-reason constant is user-facing on a task** — the
  chat failure reasons live on `chat_turns`, and `docs/spec.md` §15 says
  explicitly that the chats view is not in this cut.
  `skills/vincent-workflows/SKILL.md` is untouched on purpose: this change
  alters no step type, field, validation rule or template variable.
