### PR TITLE
fix(tui): re-derive the workflow when the project-scoped catalog arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,19 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **New task fell back to `adhoc` for a project whose `default_workflow` lives in
+  its own `.vincent/workflows/`.** The form loads its workflow catalog before a
+  project is selected, so that first, unscoped listing cannot contain a
+  project-scoped workflow (§5.2); when the form then selected the project itself
+  — from the board's cursor, or because exactly one is registered — the Workflow
+  row settled on `adhoc` and the project-scoped listing that arrived a moment
+  later was ignored, because `adhoc` still resolved. Since the form submits what
+  it displays, a task created without noticing ran `adhoc`. The row now tracks
+  whether it was chosen by hand and re-derives the default when the
+  project-scoped catalog lands; a workflow picked in the picker still survives
+  it. Picking the project by hand, and a global or built-in `default_workflow`,
+  worked before and are unchanged.
+
 - **The footer and `?` described the wrong surface while an answer, repair or
   follow-up popup was open.** The task workspace fell through to the current
   tab's context, so a popup that owned the keyboard was documented as the Steps

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -169,10 +169,17 @@ type newTask struct {
 
 	projectID int64
 	workflow  string
-	titleIn   textinput.Model
-	desc      textarea.Model
-	fields    []kv
-	branch    textinput.Model
+	// workflowPicked records that the Workflow row was chosen by hand, which
+	// is the only thing that distinguishes it from a name the form derived
+	// for itself. The registry is project-scoped (§5.2) and the first listing
+	// is fetched before a project is selected, so a derived name must be
+	// re-derived when the project-scoped catalog lands; a deliberate pick
+	// must survive it.
+	workflowPicked bool
+	titleIn        textinput.Model
+	desc           textarea.Model
+	fields         []kv
+	branch         textinput.Model
 	// branchName is the task's own branch, distinct from branch above, which is
 	// the *base* it forks from. Two adjacent rows about branches need labels that
 	// cannot be misread as one having been renamed (task 001).
@@ -533,7 +540,7 @@ func (n *newTask) reset() {
 	n.priority.SetValue("0")
 	n.fields = nil
 	n.agent, n.model, n.effort = "", "", ""
-	n.workflow = ""
+	n.workflow, n.workflowPicked = "", false
 	n.projectID = 0
 	n.cursor = ntProject
 	n.mode = ntNavigating
@@ -588,7 +595,7 @@ func (n *newTask) setProject(p apiclient.Project) {
 // selectDefaultWorkflow points at the project's default, else adhoc, else
 // the first valid entry — the same fallback handleTaskCreate applies.
 func (n *newTask) selectDefaultWorkflow() {
-	if n.workflow != "" && n.workflowEntry(n.workflow) != nil {
+	if n.workflowPicked && n.workflow != "" && n.workflowEntry(n.workflow) != nil {
 		n.syncWorkflowFields()
 		return
 	}

--- a/internal/tui/newtask_test.go
+++ b/internal/tui/newtask_test.go
@@ -228,6 +228,52 @@ func TestNewTaskFallsBackToAdhocWithoutAProjectDefault(t *testing.T) {
 	}
 }
 
+// TestNewTaskPrefillsAProjectScopedDefaultWorkflow covers the default that
+// only the project-scoped listing carries. The first, unscoped ListWorkflows
+// cannot contain it (loadCmd runs before a project is picked, so it passes
+// project 0), so the preselection §5.1 promises can only be made once the
+// follow-up ntWorkflowsMsg lands.
+func TestNewTaskPrefillsAProjectScopedDefaultWorkflow(t *testing.T) {
+	// unscoped is what GET /v1/workflows answers without a project_id:
+	// builtin and global entries, never a repo's own .vincent/workflows.
+	unscoped := []apiclient.WorkflowEntry{{
+		Name: "adhoc", Scope: "builtin", Description: "One agent step.",
+		Steps: []apiclient.WorkflowEntryStep{{ID: "run", Name: "Run", Type: "agent", Agent: "claude"}},
+	}}
+	scoped := append(append([]apiclient.WorkflowEntry{}, unscoped...), apiclient.WorkflowEntry{
+		Name: "repo-flow", Scope: "project", Description: "Defined in the repo.",
+		Steps: []apiclient.WorkflowEntryStep{{ID: "run", Name: "Run", Type: "agent", Agent: "claude"}},
+	})
+	projects := []apiclient.Project{
+		{ID: 1, Name: "vincent", DefaultBranch: "main"},
+		{ID: 2, Name: "other", DefaultBranch: "trunk", DefaultWorkflow: ptr("repo-flow")},
+	}
+
+	for _, tc := range []struct {
+		name     string
+		hint     int64
+		projects []apiclient.Project
+	}{
+		// The two paths that select a project without the picker: the board's
+		// hint, and the sole registered project.
+		{name: "hinted project", hint: 2, projects: projects},
+		{name: "only project", projects: projects[1:]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := newNewTask()
+			n.hintProject = tc.hint
+			n.update(ntLoadedMsg{projects: tc.projects, workflows: unscoped})
+			if n.projectID != 2 {
+				t.Fatalf("projectID = %d, want the project carrying the default", n.projectID)
+			}
+			n.update(ntWorkflowsMsg{projectID: 2, entries: scoped})
+			if n.workflow != "repo-flow" {
+				t.Errorf("workflow = %q, want the project's project-scoped default", n.workflow)
+			}
+		})
+	}
+}
+
 // resolveField is a resolved §8.6 value with its source, spelled short.
 func resolveField(value, source string) *apiclient.ResolvedField {
 	return &apiclient.ResolvedField{Value: value, Source: source}

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -463,11 +463,13 @@ func (n *newTask) applyPick(row ntRow, value string) tea.Cmd {
 		// GitHub", and an issue from the old project has no meaning here.
 		n.workflows = nil
 		n.setWorkflow("")
+		n.workflowPicked = false
 		n.github, n.githubProject = apiclient.GitHubStatus{}, 0
 		n.issues, n.issuesFor, n.issuesErr, n.issue = nil, issuesKey{}, "", nil
 		return tea.Batch(n.workflowsCmd(id), n.githubCmd(id))
 	case ntWorkflow:
 		n.setWorkflow(value)
+		n.workflowPicked = true
 		// Each listed issue carries the prefill computed for the workflow's
 		// declared fields, so a workflow change makes those prefills stale.
 		return tea.Batch(n.issuesCmd(), n.resolveCmd())


### PR DESCRIPTION
## Summary

The TUI new-task form showed `adhoc` in the Workflow row for a project whose
`default_workflow` names a workflow defined in the repo's own
`.vincent/workflows/`, whenever the form selected the project by itself — from
the board's cursor hint, or because exactly one project is registered. The form
submits the workflow it displays, so a task created without noticing ran
`adhoc` instead of the project's workflow. A global or built-in
`default_workflow` was unaffected, which is why it went unnoticed.

**Root cause.** `open` → `reset` zeroes `projectID`, so `loadCmd` fetches the
workflow catalog with project id 0 — builtin and global entries only. A
project-scoped workflow (§5.2) cannot be in that response. `applyLoaded` then
selects the project *and* runs `selectDefaultWorkflow` against that unscoped
list, so the project's default misses and the fallback lands on `adhoc`. The
project-scoped list does arrive a moment later as `ntWorkflowsMsg`, which
re-runs `selectDefaultWorkflow` — but its guard was

```go
if n.workflow != "" && n.workflowEntry(n.workflow) != nil { … return }
```

and `adhoc` still resolves, so the correct list was never consulted. The guard
exists to protect a workflow the user chose by hand, but "the current name
resolves in the current list" cannot tell a hand-pick apart from a value the
form derived for itself. (`touched` is no substitute: `applyPick` sets it for
*any* pick, including a project.)

**Fix.** The form now records that fact explicitly. `workflowPicked` is set in
`applyPick`'s `ntWorkflow` branch, cleared by `reset` and by `applyPick`'s
`ntProject` branch beside the `setWorkflow("")` that path already did, and the
guard keys on it. A value the form derived is re-derived when the
better-scoped catalog lands; a deliberate pick survives it. `loadCmd` and
`applyLoaded` are untouched — the unscoped listing must still leave a sensible
value on the row while the scoped fetch is in flight, and `ntWorkflowsMsg`
already batches `resolveCmd`/`issuesCmd`, so the §8.6 resolution and the issue
prefills follow the corrected selection.

Three lines of behaviour change plus a field; no call-site guard, no refactor.

**Regression test.** `TestNewTaskPrefillsAProjectScopedDefaultWorkflow` drives
the form with an unscoped catalog that holds only `adhoc`, feeds it
`ntLoadedMsg` and then the project-scoped `ntWorkflowsMsg` carrying
`repo-flow`, and asserts the Workflow row ends on `repo-flow` — for both
auto-selection paths, the board hint and the sole registered project. It is the
shape every existing test misses, because `loadedForm`'s default is
`Scope: "global"` and so is already in the first listing. Verified red at the
test-only commit (`adhoc` for both subtests) and green after the fix. Any
future short-circuit that keeps a form-derived name past the scoped listing
fails it again. The test was not weakened or adjusted in any way.

No `docs/spec.md` amendment: §5.1 ("optional workflow name preselected in task
creation") and the M3 new-task decision in `docs/history/v0-tasks.md:388`
("workflow from that project's `default_workflow` else `adhoc` … all
re-derived each open") both already describe the fixed behaviour. The code was
the side that was wrong. The daemon's own fallback in `handleTaskCreate` was
already correct and is unchanged.

## Related

Closes #260

## Checklist

- [ ] PR title is plain language (no Conventional Commit prefix) — this
      workflow asks for the title in Conventional Commits style, so
      `pr-title.txt` carries `fix(tui): …`. Retitle to plain language
      (e.g. "Re-derive the new-task workflow when the scoped catalog arrives")
      before merging if the `PR title` check is to pass.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — `test(tui):` then `fix(tui):`
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — audited, none needed. No derived source changed: not
      `internal/config`, the cobra tree, the route table in
      `internal/api/server.go`, `internal/tui/bindings.go`, the `Reason*`
      constants, the workflow/step types, or any adapter. The pages that state
      this behaviour already state it correctly, because the code was the side
      that was wrong: spec §5.1 ("optional workflow name preselected in task
      creation"), `docs/reference/configuration.md`'s per-project table
      (`default_workflow` — "Used when a task names none"),
      `docs/reference/cli.md`'s `--workflow` ("Defaults to the project's default
      workflow") and `docs/getting-started/concepts.md`. `docs/guides/tui.md`'s
      New task section documents the form's flow and never claimed a rule for
      the Workflow row's initial value, so no sentence in it became false.
      `skills/vincent-workflows/SKILL.md` and this repo's own
      `.vincent/workflows/*.yaml` are untouched — the workflow schema did not
      change. No `docs/tasks/` document: per `docs/tasks/README.md`, a one-line
      fix's record is its commit message.

**Nothing stale was found and left behind.** `docs/assets/tui-new-task.png` was
checked against the fix rather than assumed: `scripts/screenshots.sh` registers
every seeded project with a **global**-scoped `default_workflow` (`feature-pr`,
`docs-refresh`, `incident-response`, `release-train`, `security-audit`), and the
only project-scoped file it seeds (`api`'s `feature-delivery.yaml`) is not any
project's default — so the shot's Workflow row renders the same value before and
after this change. `docs/gates/m3-gate.md` is likewise unaffected: its L5 picks
the workflow by hand and its seed sets no project default. No defect was found
in the change itself.
