### PR TITLE
Surface more of claude's stream-json in the output view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,32 @@ list with the user-facing context a commit subject cannot carry.
   a fresh install has nothing folded. See
   [Using the TUI](docs/guides/tui.md#folding-groups).
 
+- **The output pane shows much more of what a Claude Code run reported about
+  itself.** Claude's `stream-json` carries far more than vincent read, and the
+  discarded part was exactly what a reader watching a run wants: a run now opens
+  with a `#` header naming the working directory the CLI reported and the tools
+  it was given — the only place *"what could this agent actually reach"* is
+  written down — and closes with a line carrying its duration, turn count,
+  refused tool calls and, when it is not the ordinary one, why it stopped.
+  `stop: max_tokens` on that line is the difference between a model that
+  finished and a model that ran out; both read as a bare success before. At
+  `verbose` the line also splits API time out of wall clock, splits cache reads
+  from cache writes, and breaks the spend down per model. A tool call a
+  permission rule **refused** is now marked `⊘` rather than `✗`, because that is
+  the step's permission mode rather than the agent's problem, and an outcome the
+  dialect described structurally leads with its verb (`✓ created · …`).
+
+  `compact` is unchanged — that level means "what the agent said and did,
+  nothing else", and the run's own account of itself is neither. The same
+  material is on the API: `GET …/transcript?format=normalized` gains an
+  `agent.run_header` record and a richer `agent.result`, `agent.tool_result`
+  entries gain `verb` and `blocked`, and any record may carry `parent_call_id`.
+  Every new key is omitted when unreported, so "absent" stays distinguishable
+  from "zero". Because transcripts are normalized **on read**, this improves
+  runs already on disk — a claude run recorded last week renders with all of it
+  today. Codex and cursor report none of it and nothing is synthesised for them.
+  See [Using the TUI](docs/guides/tui.md#what-v-adds).
+
 ### Changed
 
 - **Archiving never deletes a branch vincent did not cut.**

--- a/docs/features.md
+++ b/docs/features.md
@@ -227,7 +227,7 @@ API keys or login credentials.
 
 | Agent | What vincent integrates |
 |---|---|
-| Claude Code | Model and effort discovery, usage and cost reporting, restricted mode, and mid-run questions |
+| Claude Code | Model and effort discovery, usage and cost reporting, restricted mode, mid-run questions, and the fullest account of its own run — the working directory and tool set it was given, its duration, turns, cache split and refused tool calls |
 | Codex | Headless execution and restricted mode; no mid-run input or cost reported by the CLI |
 | Cursor | Headless execution and model discovery; reasoning effort is part of the model id, and restricted mode is unavailable on Windows |
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -72,6 +72,12 @@ The most capable adapter, and the only one that can be interrupted mid-step.
   Options are discovered by parsing `claude --help` and merged with a curated
   catalog, so a CLI upgrade that adds an effort level makes it selectable without
   a vincent release.
+- **Reports the most about its own run.** The output pane's `#` header line —
+  the working directory and the tool set a run was given — and the closing
+  line's duration, turn count, cache-token split, per-model breakdown, refused
+  tool calls and stop reason all come from claude's stream and from no other
+  adapter's. A tool call a permission rule refused is marked apart from one that
+  ran and failed. See [the output pane](tui.md#what-v-adds).
 - **Reports token usage and cost.** The board's cost column sums every attempt,
   retries included. The other two adapters report no cost at all — which also
   means [`max_task_cost_usd`](../reference/configuration.md#max_task_cost_usd)

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -316,10 +316,38 @@ output. It is the sentence that decides whether to open the transcript.
 | `enter` | From Steps & Attempts, open the selected attempt in Output |
 | `←`/`→` or `h`/`l` | On Output, select which attempt's output to show |
 | `f` or `G` | Follow the live output again |
-| `v` | More or less detail: compact → normal → verbose (reasoning, then unrecognized lines) |
+| `v` | More or less detail: compact → normal → verbose (reasoning, the run's own metadata, then unrecognized lines) |
 | `e` | Open this attempt's **whole** transcript in `$EDITOR` |
 | `↑`/`↓` | Select an attempt or Task Details section, scroll Output, or move between diff files — according to the active tab |
 | `pgup`/`pgdn` | Scroll the selected Task Details section |
+
+### What `v` adds
+
+`compact` is what the agent **said and did**, and nothing else. Reasoning is
+hidden, and so is everything about the run itself.
+
+`normal` adds reasoning, truncated to its first lines — and, for an agent whose
+CLI reports them, two records that answer questions the pane could not answer at
+all before. A `#` line at the top of the run names the directory the agent said
+it was working in and the tools it was given, which is the only place *"what
+could this agent actually reach"* is written down. And the closing `✓` line
+carries the run's own account of itself: how long it took, how many turns it
+burned, how many tool calls a permission rule refused, and — when it is not the
+ordinary one — why it stopped. `stop: max_tokens` on that line is the difference
+between a model that finished and a model that ran out, which both read as a
+bare success before.
+
+`verbose` adds the API-time split, the cache read/write token split, a per-model
+breakdown for a run that used more than one, and the lines vincent's parsers do
+not model, expanded out from behind their count.
+
+A tool call that a permission rule **refused** is marked `⊘` rather than `✗`, at
+every level. The distinction is worth a glyph: `✗` is the agent's problem, and
+`⊘` is the step's [permission mode](agents.md).
+
+Only [Claude Code](agents.md#claude-code) reports the run header and the run
+metadata today. On codex and cursor those lines simply do not appear — vincent
+does not synthesise one from what it happens to know.
 
 ### Reading the whole transcript
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1423,6 +1423,15 @@ The transcript is the attempt's JSONL file, ranged:
   the live-output shapes plus `agent.result`, `agent.error`, the `vincent.*`
   kinds, and `agent.raw` for anything unrecognized. That is one render path for
   live tail and scrollback alike. Absent, you get the raw file byte for byte.
+- `agent.run_header` carries `work_dir` and `available_tools` — what the CLI
+  announced about the run before starting it. `agent.result` additionally
+  carries `duration_ms`, `api_duration_ms`, `num_turns`, `stop_reason`,
+  `terminal_reason`, `cache_read_tokens`, `cache_write_tokens`, `model_usage`
+  and `permission_denials` where the adapter reports them; `agent.tool_result`
+  entries carry `verb` and `blocked`; and any record may carry `parent_call_id`,
+  the tool call a subagent's line belongs to. **Every one of those keys is
+  omitted when unreported**, so absent and zero are distinguishable — only
+  [Claude Code](../guides/agents.md#claude-code) fills them today.
 
 Because normalization runs **on read**, enriching a parser improves transcripts
 already on disk.
@@ -1504,7 +1513,8 @@ they need.
 ### Live output — ephemeral
 
 `agent.output`, `agent.tool_use`, `agent.tool_result`, `agent.thinking`,
-`agent.usage` and `command.output` chunks stream on the **per-task** stream only
+`agent.run_header`, `agent.usage` and `command.output` chunks stream on the
+**per-task** stream only
 and are **not** written to the events table. Their durable copy is the transcript
 file.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1514,9 +1514,8 @@ they need.
 
 `agent.output`, `agent.tool_use`, `agent.tool_result`, `agent.thinking`,
 `agent.run_header`, `agent.usage` and `command.output` chunks stream on the
-**per-task** stream only
-and are **not** written to the events table. Their durable copy is the transcript
-file.
+**per-task** stream only and are **not** written to the events table. Their
+durable copy is the transcript file.
 
 Each chunk is one SSE event, flushed on a ~100 ms coalescing timer, and carries:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2065,9 +2065,18 @@ type ToolUse struct {                // T4.14
 type ToolResult struct {             // T4.16
     CallID  string // the ToolUse this reports on
     Name    string // when the dialect repeats it; "" is normal
-    Summary string // the outcome in a few words: "exit 0", "+1 −0" — never the
-                   // tool's output body, which stays in the transcript
+    Summary string // the outcome in a few words: "exit 0" — never the tool's
+                   // output body, which stays in the transcript
+    Verb    string // task 066: the dialect's structured outcome ("created"); ""
+                   // when it reported none, or named a type no capture has shown
+    Blocked bool   // task 066: a permission rule refused the call, as distinct
+                   // from one that ran and failed
     IsError bool   // "known to have failed", never "assumed fine"
+}
+
+type RunHeader struct {              // task 066, added 2026-08-31
+    WorkDir string   // where the CLI said it was running
+    Tools   []string // the tool set the run was given, in the CLI's order
 }
 
 type RunResult struct {
@@ -2077,6 +2086,19 @@ type RunResult struct {
     OutputTokens int64
     CostUSD      *float64 // nil if unreported (e.g. codex)
     Failure      *Failure // task 003: the adapter's verdict, nil = nothing recognized
+    // task 066, added 2026-08-31: the run's own account of itself, as its
+    // terminal result reported it. Zero/nil throughout for an adapter that
+    // reports none of it, which is codex and cursor for every member. None of
+    // it is persisted — it reaches a reader through the transcript (§13.2).
+    Duration            time.Duration      // the CLI's own wall clock, not vincent's
+    APIDuration         time.Duration      // of which was spent in API calls
+    NumTurns            int
+    StopReason          string             // why the model stopped ("end_turn")
+    TerminalReason      string             // why the run stopped ("completed")
+    CacheReadTokens     int64
+    CacheCreationTokens int64
+    ModelUsage          []ModelUsage       // per-model share; nil = unreported
+    PermissionDenials   []PermissionDenial // refused calls; nil = unreported and none
 }
 
 type Failure struct {                // task 003, added 2026-08-14
@@ -2126,6 +2148,26 @@ recording and discarding:
   **whole blocks**; a dialect that streams token-level deltas coalesces them
   itself and emits when the block closes. See the §9.7 amendment for why that
   constraint is the part of the original decision worth keeping.
+
+**The run header, the run's account of itself, and subagent attribution (task
+066, added 2026-08-31).** A third event type joins the normalized stream —
+`EventRunHeader`, carrying a `RunHeader` — and it is the one event that
+describes the *run* rather than something that happened inside it: where the CLI
+said it was working, and what tools it was given. "What could this agent
+actually reach" had no answer in a transcript at any level.
+
+`Event` also gains `ParentCallID`: the tool call a subagent's lines belong to.
+It is read, carried on the wire and on the live chunk, and **not rendered** —
+§15's pane is a flat two-column gutter, and every captured run has the field
+`null`, so there is nothing to test a tree against. Nesting is its own work with
+its own capture; because §13.2 re-normalizes on read, transcripts recorded now
+will render under it when it lands.
+
+Both are stated positively where an adapter lacks them (§9.3, §9.7) and neither
+is ever emulated. Nothing is persisted: `step_runs` keeps vincent's own timing
+and token columns, and a claude-only duration there would be a second duration
+disagreeing with vincent's own, since claude's excludes what a §7.4 input wait
+adds to ours.
 
 **The adapter's failure verdict (task 003, added 2026-08-14).** `RunResult`
 carries an optional `Failure`: the adapter's reading of *why* its CLI stopped,
@@ -2275,6 +2317,44 @@ on a current CLI and **changes no behaviour whatsoever**. The separate
 capability and degrades the invocation visibly, which is a different question
 from whether vincent has ever seen this build.
 
+*Amended 2026-08-31 (task 066).* The parser reads more of the dialect it was
+already recording. Four groups, all of them present in the `2.1.226` fixtures
+since they were captured:
+
+- **The `system`/`init` line** normalizes to the §9.1 run header — `cwd` and
+  `tools` — instead of falling through to `EventUnknown`. Any other `system`
+  subtype still does fall through, which is the phase 1 tolerant-parsing rule
+  and is asserted rather than assumed.
+- **The `result` line's metadata:** `duration_ms`, `duration_api_ms`,
+  `num_turns`, `stop_reason`, `terminal_reason`, `permission_denials[]`,
+  `usage.cache_read_input_tokens` / `usage.cache_creation_input_tokens`, and the
+  `modelUsage` map flattened into a per-model slice with its keys **sorted** —
+  Go randomizes map iteration, and a pane whose per-model lines reorder between
+  two reads of one transcript is a bug a reader would blame on the run.
+  `modelUsage`'s `contextWindow`, `maxOutputTokens`, `canonicalModel` and
+  `provider` are deliberately **not** read: they describe the model rather than
+  the run, and §9.6's catalog is where a fact about a model belongs.
+- **The structured tool outcome.** `tool_use_result` and `tool_result_meta` ride
+  on a `user` line *beside* `message`, not inside it. `tool_use_result` decodes
+  as either an object or a bare string — the deny fixture's is
+  `"Error: no user is available; permission denied"` — so it is held as
+  `json.RawMessage` and probed, the way `resultSummary` already handles claude's
+  two content shapes. Its `type` becomes `ToolResult.Verb` through a table
+  holding exactly the values a capture has shown (`create` → `created`); an
+  unobserved type yields **no verb** rather than a guessed past tense, because a
+  wrong verb is indistinguishable from a tool that reported none (the T4.17
+  rule). A `tool_result_meta[].non_execution_kind` of `permission-rule` sets
+  `ToolResult.Blocked` — the call never ran, which a reader acts on differently
+  from one that ran and failed. `Blocked` does not clear `IsError`: the dialect
+  flags a refused call as an error too, and that is true as far as the model is
+  concerned.
+- **`parent_tool_use_id`** is read onto `Event.ParentCallID`. It is `null` on
+  every line of all three captures.
+
+The tool's output **body** still never enters the normalized stream (T4.16), and
+the transcript remains the durable copy. Nothing is persisted (task 066
+decision 4).
+
 *Added 2026-08-29 (task 057).* The §13.4 MCP server rides on
 `--mcp-config <inline JSON>` with `--strict-mcp-config` beside it, so the
 user's own `.mcp.json` and global servers never leak into a vincent step.
@@ -2296,6 +2376,19 @@ transcript is something people paste into issues.
   worktree the real git dir lives under the main repo, so a `git commit` from
   a restricted codex step may be denied; vincent itself never needs commits
   (the diff reads the working tree).
+- **Reports no run header and no run metadata (stated positively, 2026-08-31,
+  task 066).** Codex's stream opens with `thread.started`, which carries a
+  thread id and nothing else — no working directory, no tool list — so there is
+  no run header to normalize and this adapter emits no `EventRunHeader`.
+  `item.completed` reports an outcome in prose with no structured type and no
+  non-execution kind, so `ToolResult.Verb` and `.Blocked` stay empty. The one
+  field codex's dialect *does* carry that claude's new ones parallel is
+  `turn.completed.usage.cached_input_tokens`; it is **not** read, and that is
+  scope rather than absence — this task widened one adapter, the dialects
+  diverge, and each deserves its own fixtures (task 066). Until then every one
+  of the fields stays zero here and **nothing emulates a value**, which is the
+  standing §9.x rule and is asserted over every codex fixture by
+  `TestNoRunHeaderOrResultMetadata`.
 - **Cannot resume (stated positively, 2026-08-30, task 063).** `agent.CanResume`
   is false for codex, so a chat on it is refused at creation (§13.2,
   `agent_cannot_resume`). codex does have `exec resume <thread_id>` and its
@@ -2648,6 +2741,17 @@ would invalidate every one of them.
   launcher and would open a GUI; the adapter resolves `cursor-agent` only. The
   adapter's `Name()` — and therefore the workflow `agent:` value and the
   `agents.cursor.path` config key — is `cursor`.
+- **Reports no run header and no run metadata *yet* (stated positively,
+  2026-08-31, task 066).** Cursor's `tool_call/completed` carries no outcome
+  type and no non-execution kind, so `ToolResult.Verb` and `.Blocked` stay
+  empty. The rest is scope, not absence, and saying so is the point of stating
+  it here: cursor's `system`/`init` line **does** carry `cwd` (though no tool
+  list), and its `result` line **does** carry `duration_ms`, `duration_api_ms`
+  and `usage.cacheReadTokens`/`cacheWriteTokens`. None of it is read. Task 066
+  widened claude's parser only — the dialects diverge and each deserves its own
+  fixtures — and the shared vocabulary was designed so cursor can fill these
+  later without another wire change. Until it does, all of them stay zero and
+  none of them is emulated, asserted over every cursor fixture.
 - **Cannot resume (stated positively, 2026-08-30, task 063).** As with codex,
   `agent.CanResume` is false and a chat on cursor is refused at creation.
   cursor-agent has a `--resume`, and its stream carries `session_id`, but the
@@ -4837,6 +4941,27 @@ GET    /v1/tasks/{id}/steps/{run_id}/transcript?offset=&tail=&format=
                                         Because normalization is re-run on read, enriching a
                                         parser improves transcripts **already on disk** — the
                                         reasoning in a run recorded last week renders today.
+                                        **v0 wire change (task 066, 2026-08-31):** a third
+                                        record type, `agent.run_header`
+                                        (`work_dir`, `available_tools: []string` — the tool
+                                        list cannot ride on `tools`, which is
+                                        `agent.tool_use`'s objects); `agent.result` gains
+                                        `duration_ms`, `api_duration_ms`, `num_turns`,
+                                        `stop_reason`, `terminal_reason`,
+                                        `cache_read_tokens`, `cache_write_tokens`,
+                                        `model_usage: [{model, input_tokens, output_tokens,
+                                        cache_read_tokens, cache_write_tokens, cost_usd}]` and
+                                        `permission_denials: [{tool_name, call_id}]`;
+                                        `agent.tool_result`'s entries gain `verb` and
+                                        `blocked`; and **any** record may carry
+                                        `parent_call_id`. Every one is omitted when
+                                        unreported, so a client tells "unreported" from
+                                        "zero". Same reasoning as T4.14's and T4.16's: records
+                                        are recomputed from the raw file on every read and
+                                        never stored, and live chunks are ephemeral, so the
+                                        handler, the §13.3 live publisher and the in-tree
+                                        clients moved in one commit rather than carrying two
+                                        shapes.
 GET    /v1/tasks/{id}/diff              unified diff of worktree vs merge-base with base branch
                                         (includes uncommitted changes)
 
@@ -4939,7 +5064,10 @@ Two kinds of streams:
    history unasked; state catch-up is a REST snapshot, then the stream.
 
 2. **Live output** — ephemeral, high-volume. `agent.output`, `agent.tool_use`,
-   `agent.tool_result`, `agent.thinking` (T4.16),
+   `agent.tool_result`, `agent.thinking` (T4.16), `agent.run_header` (task 066 —
+   it is the *first* line of the stream, so a reader who opens the pane on a
+   running step sees the run's frame before its first word rather than only once
+   the step has finished),
    `agent.usage`, `command.output` chunks are streamed on the **per-task** stream only
    and are *not* written to the events table (they are durable in transcript files;
    catch-up = fetch the transcript, then follow live). Chunks are one SSE event each,
@@ -6082,6 +6210,38 @@ dialect's result text repeats assistant messages already on screen, and
 cursor's is the entire turn concatenated. The text is kept when the attempt
 rendered no output at all — a codex turn with no `agent_message` — and always
 on an error, where it is the error and may be the only content there is.
+
+*Amended 2026-08-31 (task 066).* Two lines join the scheme, and one gutter mark:
+
+- **`# ` — the run header.** `agent.run_header` renders the working directory
+  the CLI reported and the tools it was given, dim throughout, gutter included:
+  it is context for everything below it rather than a thing that happened, and
+  it must not compete with the first assistant line for a reader's eye. Its tool
+  list wraps to the hanging indent like any other record. It appears at
+  **`normal` and `verbose`**, never at `compact` — that level's stated meaning
+  is "what the agent said and did, nothing else", and the run's frame is
+  neither.
+- **`⊘ ` — a blocked tool call.** A call a permission rule refused never ran,
+  and that sends a reader somewhere different from a call that ran and failed:
+  one is the agent's problem, the other is the step's permission mode. It is
+  marked apart from `✗ ` at every level, which is a correction to what the
+  record *means* rather than growth in what compact shows. A structured outcome
+  verb, where the dialect reports one, leads the tool's own prose about it:
+  `✓ created · File created successfully at: hello.txt`.
+- **The result line grows by level.** `compact` is byte for byte what it always
+  rendered (`done`, or `done · $0.02`). From `normal` up it adds the run's own
+  account of itself — elapsed, turns, an *unusual* stop or terminal reason, and
+  a count of permission denials. The ordinary reasons are never printed: every
+  successful claude run ends `end_turn`/`completed`, so naming them would spend
+  columns saying nothing, and the whole point of the field is to distinguish
+  "the model finished" from "it hit a limit". `verbose` adds the API-time split
+  and, on wrapped continuation lines of the same record, the cache read/write
+  split and the per-model breakdown.
+
+Still **no timestamps**, and `parent_call_id` — which every record may now carry
+— is deliberately **not rendered**: the gutter is two columns and flat, and
+nesting subagent work under its parent is its own design problem with its own
+capture (task 066 decision 2).
 
 Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail

--- a/docs/tasks/066-claude-stream-json-surface.md
+++ b/docs/tasks/066-claude-stream-json-surface.md
@@ -1,0 +1,176 @@
+# 066 — Surface more of claude's stream-json in the output view
+
+**Status:** 🔄 in progress (4/5) · **Issue:**
+[#267](https://github.com/lezli01/vincent/issues/267)
+· **Spec:** §9.2, §9.3, §9.7, §13.2, §13.3, §15
+
+`internal/agent/claude/stream.go` read a deliberately narrow subset of claude's
+`stream-json`. `parseLine` recognized three line types; the `system`/`init` line
+fell through to `EventUnknown`; `parseResult` read five of the result line's ~20
+fields; and `parseToolResults` read the `tool_result` blocks inside
+`message.content` and never touched the sibling `tool_use_result` /
+`tool_result_meta` objects.
+
+The consequence was visible in the detail view's output pane. A reader watching
+a run could not see how long it took, how many turns it burned, why it stopped,
+what it was refused permission to do, or how much of the token spend was cache
+reads. At `verbose` those lines existed only as raw JSON behind `agent.raw`,
+which is a debugging affordance rather than a rendering.
+
+Everything the issue said was thrown away was in fact thrown away, and the
+fixtures already carried it. Each of the three
+`internal/agent/claude/testdata/stream_*_2.1.226.jsonl` files is one
+`system/init`, four `assistant`, one `control_request`, one `user` and one
+`result/success`. `stream_permission_deny_2.1.226.jsonl` additionally carries a
+one-element `permission_denials[]` and a `tool_result_meta` of
+`[{"id":…,"non_execution_kind":"permission-rule"}]`.
+
+Nothing here contradicts a recorded decision. It is the deliberate
+*continuation* of two of them: T4.14's tool subjects and T4.16's
+outcomes-not-bodies rule, both of which are respected — the tool's output body
+stays out of the normalized stream, and the transcript remains the durable copy.
+
+## Decisions (2026-08-31)
+
+**1. The new records appear at `normal` and `verbose`; `compact` does not
+grow.** The issue said the run header and result metadata "belong at `normal` or
+below" and *also* that "`compact` does not grow" — and compact *is* below
+normal. The acceptance criterion wins. `levelCompact` keeps its stated meaning
+("what the agent said and did, nothing else"), the run header and a condensed
+result line render from `levelNormal` up, and the per-model and cache-token
+breakdown is `levelVerbose` only. `TestResultMetadataByLevel` asserts the
+compact line byte for byte against what it rendered before this task.
+
+The alternative — one more level, or a fourth record class — was rejected: `v`
+cycles three levels and "show me more" is one intention (T4.16).
+
+**2. `parent_tool_use_id` is carried on the wire; subagent nesting is not built
+here.** The field is `null` on all eight lines of all three captured fixtures,
+so there is no evidence to test a nesting renderer against, and nesting would
+amend §15's flat two-column gutter model — the one thing T4.16 built the pane
+around. The parser reads the field, it reaches the normalized record and the
+live chunk, and the pane keeps rendering flat. Capturing a `Task` run and
+designing the tree is follow-up work in its own document; because §13.2
+re-normalizes on every read, transcripts recorded before that lands will render
+under it.
+
+**3. Tool outcomes get a verb, not a diff delta.** `ToolResult.Summary`'s doc
+comment promised "created (+1 −0)", but the only fixture with a structured
+`tool_use_result` is a *create* whose `structuredPatch` is `[]`; no capture in
+the repo contains an edit with hunks. Implementing `+N −M` against the
+documented shape is precisely what T4.17 rejected — a wrong guess fails
+silently, the delta simply never appears, and nothing distinguishes that from a
+file that did not change.
+
+So the verb comes from `tool_use_result.type`, through a table holding exactly
+the types a capture has shown (`create` → `created`); an unobserved type yields
+no verb rather than a guessed past tense. A
+`tool_result_meta[].non_execution_kind` of `permission-rule` renders as a
+blocked call (`⊘`) rather than as an error string (`✗`). Deltas wait for a
+fixture that has one. The doc comment that made the unkept promise was corrected
+in the same change, in `internal/agent/agent.go` and in §9.1's type listing.
+
+**4. No migration; nothing is persisted on `step_runs`.** The durable half is
+split out, to be opened when a consumer asks for it. Three reasons, and the
+first decides it:
+
+- Migrations are append-only by convention, so a speculative column is expensive
+  to take back.
+- `step_runs` already carries `started_at`/`finished_at`, so a persisted
+  `duration_ms` would be a *second* duration that disagrees with vincent's own
+  (claude's excludes what §7.4 input waits add to ours).
+- The columns would be claude-only in a table that is otherwise adapter-neutral,
+  read by no named client — the pane reads the transcript, which §13.2
+  normalizes on read.
+
+This task is parser, wire and pane. There is consequently **no §14 amendment**.
+
+**5. Both mappings move together.** The issue listed `internal/api/transcript.go`
+and the TUI. There is a second mapping: `Runner.publishAgentEvent`
+(`internal/taskrun/steps.go`) produces the §13.3 live chunks, and the spec
+records that the two are kept in agreement deliberately — a difference shows up
+as output that changes when a step finishes. The run header is published there
+too, and `toolChunks`/`resultChunks` gained the same fields `toolLines`/
+`resultLines` did.
+
+`publishAgentEvent` deliberately drops `EventResult` (results surface as step
+outcomes), so the enriched result metadata reaches the pane on scrollback only.
+That asymmetry is pre-existing and this task does not change it.
+
+**6. `modelUsage` carries what the run spent, not what the model is.** Claude's
+payload also names `contextWindow`, `maxOutputTokens`, `canonicalModel` and
+`provider`. Those describe the model rather than this run, and §9.6's option
+catalog is where a fact about a model belongs, so they are read by nothing. A
+field on the wire that no client can use is a field that will be wrong later.
+
+## Task list
+
+- [x] **066.1** `internal/agent`: `EventRunHeader` and `RunHeader`;
+  `Event.ParentCallID`; `ToolResult.Verb`/`.Blocked`; `RunResult`'s durations,
+  turns, stop/terminal reason, cache counts, `ModelUsage` and
+  `PermissionDenials`. Every one documented as empty-for-adapters-that-do-not-
+  report-it, in the shape `RunResult.SessionID` and `.Failure` already use.
+- [x] **066.2** `internal/agent/claude/stream.go`: the `system`/`init` arm, the
+  result line's metadata, the structured tool outcome (probed as object *or*
+  string — the deny fixture's is the bare string `"Error: no user is available;
+  permission denied"`), and `parent_tool_use_id`. Codex and cursor untouched.
+- [x] **066.3** The wire, in one commit: `internal/api/transcript.go`'s
+  `agent.run_header` record and enriched `agent.result`,
+  `internal/taskrun/steps.go`'s matching live chunks, and
+  `internal/apiclient/transcript.go` so `vincent task transcript` renders them.
+- [x] **066.4** `internal/tui`: the run-header line, the level-aware
+  `resultOutcome`, the `⊘` blocked mark, and the verbose-only breakdown — all
+  inside §15's two-column gutter scheme, with no timestamps.
+- [ ] **066.5** Owner walkthrough against a real claude run, recorded below.
+
+## What the tests prove
+
+- `internal/agent/claude/stream_test.go`, off the existing `2.1.226` fixtures:
+  the result line's duration, API duration, turns, stop and terminal reason,
+  cache counts, per-model usage and the deny fixture's single
+  `permission_denials` entry; the init line normalizing to a run header carrying
+  `cwd` and its five tools, exactly once per run; the allow fixture's
+  `tool_use_result` yielding the `created` verb; the deny fixture's
+  `non_execution_kind: permission-rule` yielding a blocked outcome rather than
+  an error string, *and* its string-shaped `tool_use_result` not derailing the
+  object decode; an unobserved `tool_use_result.type` yielding no verb;
+  `parent_tool_use_id` read as empty across all three captures, which is what
+  they contain, and read correctly on a synthetic line that has one.
+- A `system` line with an unknown `subtype` and a line with an unmodelled
+  `type`, both still `EventUnknown` with `Raw` intact — the phase 1
+  tolerant-parsing decision, asserted rather than assumed.
+- `internal/taskrun/chunks_test.go` — the header chunk's shape and the result
+  chunk's new keys, extending the parity test T4.16 wrote for exactly this.
+- `internal/api/transcript_test.go` — the new wire names round-trip, *and* an
+  adapter that reports none of them emits none of the keys, so a client can
+  tell "unreported" from "zero".
+- `internal/tui/outputlines_test.go` — the new records at all three levels,
+  including that `levelCompact`'s result line is byte-identical to what it was,
+  and that a header whose tool list overflows 80 columns wraps to the hanging
+  indent rather than clipping.
+- `internal/agent/codex` and `internal/agent/cursor` —
+  `TestNoRunHeaderOrResultMetadata` states positively, over every existing
+  fixture, that neither adapter produces a run header or fills any new field.
+
+The unit tests are necessary and **not sufficient.** T4.16's own record is
+explicit that every test it wrote proves a *parser* and none of them proves a
+*pane*, and its acceptance was the owner walking the TUI against a real claude
+run — the same reason `scripts/m3-gate.sh` seeds instead of asserting. This
+change adds two record shapes to that pane, so 066.5 is the leg that closes it.
+
+## Walkthrough record
+
+| Date | By | Result |
+|---|---|---|
+| — | — | not yet walked |
+
+## Follow-up work this task creates
+
+1. **Subagent nesting.** Capture a claude run that uses the `Task` tool, design
+   the pane's tree within §15's model, amend §15. The wire field is already
+   there and already recorded.
+2. **Edit deltas.** Capture a run containing an `Edit` with a non-empty
+   `structuredPatch`, then make `ToolResult.Summary` keep the promise its doc
+   comment made from T4.14 until this task removed it.
+3. **Durable result metadata on `step_runs`**, if and when a client needs it off
+   `/v1/tasks` rather than off a transcript (decision 4).

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -79,6 +79,7 @@ the living engineering specification records implementation contracts.
 | [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | 🔄 in progress (1/3) |
 | [064](064-task-from-pull-request.md) | Create a task from a pull request, on the PR's head branch | 🔄 in progress (8/9) |
 | [065](065-workflow-editor-in-the-tui.md) | A workflow editor in the TUI: create, edit and fork through structured forms | ✅ done (13/13) |
+| [066](066-claude-stream-json-surface.md) | Surface more of claude's stream-json in the output view | 🔄 in progress (4/5) |
 
 ## How to add and update a task document
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -256,6 +256,15 @@ const (
 	// (spec §9.7, amended).
 	EventThinking EventType = "thinking"
 	EventUsage    EventType = "usage"
+	// EventRunHeader is what the CLI announced about the run *before* any
+	// work happened — its working directory and the tool set it was given
+	// (task 066). It is emitted at most once, from the first line of the
+	// stream, and it is the one event that describes the run rather than
+	// something that occurred inside it.
+	//
+	// Only claude reports one today (§9.2); codex and cursor emit no
+	// equivalent line and never produce this event (§9.3, §9.7).
+	EventRunHeader EventType = "run_header"
 	// EventInputRequest carries a mid-run input request (spec §7.4). A nil
 	// Request means the adapter received a control message it could not
 	// parse or that violates the serial-request contract — the engine fails
@@ -286,7 +295,16 @@ type Event struct {
 	Results []ToolResult  // EventToolResult: outcomes reported by this line
 	Request *InputRequest // EventInputRequest
 	Result  *RunResult    // EventResult
+	Header  *RunHeader    // EventRunHeader
 	Message string        // EventError: what went wrong
+	// ParentCallID attributes this event to the tool call that spawned the
+	// sub-run it came from — claude's `parent_tool_use_id`, which is stamped
+	// on every line a `Task` subagent produces (task 066). Empty is the main
+	// loop, and is also every adapter that does not report the field.
+	//
+	// It is carried but not yet rendered: §15's pane is a flat two-column
+	// gutter, and nesting is its own piece of work with its own capture.
+	ParentCallID string
 	// Raw is the verbatim stream line, which transcripts write. The one
 	// exception is a coalesced EventThinking: its Text was accumulated
 	// across earlier delta lines, so Raw is the line that closed the block
@@ -294,6 +312,21 @@ type Event struct {
 	// pairs Text with Raw, and offsets stay correct because the closing line
 	// is the one that had just been written.
 	Raw []byte
+}
+
+// RunHeader is what an agent CLI announced about the run before starting it
+// (task 066, §9.2): where it is running and what it was allowed to reach.
+// Both fields are empty for an adapter whose dialect has no such line — the
+// header simply never arrives, and nothing synthesizes one.
+type RunHeader struct {
+	// WorkDir is the directory the CLI reported working in. It is the
+	// adapter's own report, not vincent's RunSpec.WorkDir: the point of
+	// showing it is that the two could disagree.
+	WorkDir string
+	// Tools is the tool set the run was given, in the order the CLI listed
+	// it. "What could this agent actually reach" has no other answer in a
+	// transcript.
+	Tools []string
 }
 
 // ToolUse is one tool invocation surfaced by the agent.
@@ -321,9 +354,24 @@ type ToolResult struct {
 	// Name is the tool, when the dialect repeats it on the result. Empty is
 	// normal — claude names the tool only on the call.
 	Name string
-	// Summary is the outcome in a few words: "exit 0", "created (+1 −0)",
-	// the first line of the result text.
+	// Summary is the outcome in a few words: "exit 0", the first line of the
+	// result text. Never the tool's output body.
 	Summary string
+	// Verb is what the invocation *did*, taken from the dialect's own
+	// structured outcome rather than from its prose — claude's
+	// `tool_use_result.type` (task 066). Empty is the normal case: most
+	// tools report no structured outcome, and a type vincent has not seen in
+	// a capture is left unnamed rather than guessed at a past tense for.
+	Verb string
+	// Blocked reports an invocation that never ran because a permission rule
+	// refused it, as opposed to one that ran and failed. Claude says so with
+	// `tool_result_meta[].non_execution_kind: "permission-rule"` (task 066).
+	//
+	// It does not clear IsError — the dialect flags a blocked call as an
+	// error too, and that is true as far as the model is concerned. It is
+	// the finer verdict, and a client that renders it says "blocked" where
+	// it would otherwise say "failed".
+	Blocked bool
 	// IsError reports a failed invocation. A dialect that says nothing about
 	// success reports false — the flag means "known to have failed", never
 	// "assumed fine".
@@ -381,6 +429,36 @@ type RunResult struct {
 	InputTokens  int64 // 0 if unreported
 	OutputTokens int64
 	CostUSD      *float64 // nil if unreported (e.g. codex)
+	// The fields below are the run's own account of itself, as the terminal
+	// result line reported it (task 066, §9.2). Every one is zero or empty
+	// for an adapter that does not report it, which is codex and cursor for
+	// all of them — a missing capability is stated in §9.x and never
+	// emulated. None of them is persisted: `step_runs` keeps vincent's own
+	// timing and token columns, and these reach a reader through the
+	// transcript, which §13.2 re-normalizes on every read.
+	//
+	// Duration is claude's, not vincent's, and the two legitimately
+	// disagree: claude's excludes the time a §7.4 input wait adds to ours.
+	Duration    time.Duration // wall clock the CLI measured; 0 if unreported
+	APIDuration time.Duration // of which was spent in API calls
+	NumTurns    int           // model turns the run burned; 0 if unreported
+	// StopReason is why the model stopped ("end_turn", "max_tokens"), and
+	// TerminalReason why the *run* stopped ("completed"). They are what
+	// distinguishes "the model finished" from "it hit a limit", which
+	// otherwise both read as a bare success.
+	StopReason     string
+	TerminalReason string
+	// CacheReadTokens and CacheCreationTokens split the token spend the two
+	// plain counts above do not account for.
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	// ModelUsage is the per-model breakdown of a run that used more than one
+	// model, in the order the adapter reported it. nil is unreported.
+	ModelUsage []ModelUsage
+	// PermissionDenials lists the tool calls a permission rule refused over
+	// the whole run — the run-level counterpart of ToolResult.Blocked. nil
+	// is unreported *and* none, which are the same thing to a reader.
+	PermissionDenials []PermissionDenial
 	// Failure is the adapter's verdict about *why* the run stopped, when it
 	// recognized the reason in its own CLI's output (task 003, §9.1). nil —
 	// "nothing recognized" — is every run that behaves as it did before this
@@ -391,6 +469,31 @@ type RunResult struct {
 	// where the material already is: the terminal result and the stderr tail
 	// live inside the handle, and the engine never sees either.
 	Failure *Failure
+}
+
+// ModelUsage is one model's share of a run (task 066, §9.2). A run that used
+// a single model still reports one entry.
+//
+// It carries what the *run* spent, not what the model *is*: claude's payload
+// also names the model's context window, its max output tokens and its
+// provider, and those describe the model rather than this run — §9.6's option
+// catalog is where a fact about a model belongs.
+type ModelUsage struct {
+	Model               string
+	InputTokens         int64
+	OutputTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	CostUSD             *float64 // nil if unreported
+}
+
+// PermissionDenial is one tool call a permission rule refused, as the
+// terminal result reported it (task 066).
+type PermissionDenial struct {
+	ToolName string
+	// CallID is the refused invocation's id, so a client can correlate the
+	// run-level list with the ToolResult that carried Blocked.
+	CallID string
 }
 
 // FailureKind names a condition an adapter recognized in its CLI's output

--- a/internal/agent/claude/claude_test.go
+++ b/internal/agent/claude/claude_test.go
@@ -158,9 +158,12 @@ func TestRunSuccess(t *testing.T) {
 	for _, ev := range events {
 		counts[ev.Type]++
 	}
+	// The `system`/`init` line normalizes to a run header since task 066;
+	// fake_marker is the one line left over for EventUnknown.
 	if counts[agent.EventOutput] == 0 || counts[agent.EventToolUse] == 0 ||
-		counts[agent.EventResult] != 1 || counts[agent.EventUnknown] < 2 {
-		t.Errorf("event mix %v, want output+tool_use+1 result+2 unknown (init, fake_marker)", counts)
+		counts[agent.EventResult] != 1 || counts[agent.EventRunHeader] != 1 ||
+		counts[agent.EventUnknown] < 1 {
+		t.Errorf("event mix %v, want output+tool_use+1 result+1 run_header+1 unknown (fake_marker)", counts)
 	}
 }
 

--- a/internal/agent/claude/stream.go
+++ b/internal/agent/claude/stream.go
@@ -2,7 +2,9 @@ package claude
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
 )
@@ -23,6 +25,69 @@ type streamLine struct {
 	Result       string         `json:"result"`
 	TotalCostUSD *float64       `json:"total_cost_usd"`
 	Usage        *streamUsage   `json:"usage"`
+	// ParentToolUseID is the `Task` call a subagent's lines belong to, and
+	// is `null` on every line of the main loop — which is every line of
+	// every fixture captured so far (task 066). It is read and carried, and
+	// nothing renders it yet: §15's pane is flat.
+	ParentToolUseID string `json:"parent_tool_use_id"`
+	// CWD and Tools are the `system`/`init` line's payload — the run header
+	// (task 066). They appear on no other line type.
+	CWD   string   `json:"cwd"`
+	Tools []string `json:"tools"`
+	// The rest are the `result` line's account of the run. claude sends ~20
+	// fields there; these are the ones that answer a question the pane could
+	// not previously answer at any level.
+	DurationMS        int64                       `json:"duration_ms"`
+	DurationAPIMS     int64                       `json:"duration_api_ms"`
+	NumTurns          int                         `json:"num_turns"`
+	StopReason        string                      `json:"stop_reason"`
+	TerminalReason    string                      `json:"terminal_reason"`
+	ModelUsage        map[string]streamModelUsage `json:"modelUsage"`
+	PermissionDenials []streamPermissionDenial    `json:"permission_denials"`
+	// ToolUseResult and ToolResultMeta ride on a `user` line beside the
+	// message, not inside it (task 066). ToolUseResult is raw because claude
+	// sends either the structured object or a bare error string — the deny
+	// fixture's is `"Error: no user is available; permission denied"` — the
+	// same two-shapes problem resultSummary already has.
+	ToolUseResult  json.RawMessage        `json:"tool_use_result"`
+	ToolResultMeta []streamToolResultMeta `json:"tool_result_meta"`
+}
+
+// streamModelUsage is one entry of the result line's `modelUsage` map, whose
+// key is the model id. The model-describing members claude also sends there
+// (`contextWindow`, `maxOutputTokens`, `canonicalModel`, `provider`) are
+// deliberately not read: they are facts about the model, and §9.6's option
+// catalog is where those belong.
+type streamModelUsage struct {
+	InputTokens              int64    `json:"inputTokens"`
+	OutputTokens             int64    `json:"outputTokens"`
+	CacheReadInputTokens     int64    `json:"cacheReadInputTokens"`
+	CacheCreationInputTokens int64    `json:"cacheCreationInputTokens"`
+	CostUSD                  *float64 `json:"costUSD"`
+}
+
+// streamPermissionDenial is one entry of the result line's
+// `permission_denials`. The refused `tool_input` is not read — it is the
+// tool's arguments, and an outcome record carries no bodies (T4.16).
+type streamPermissionDenial struct {
+	ToolName  string `json:"tool_name"`
+	ToolUseID string `json:"tool_use_id"`
+}
+
+// streamToolResultMeta annotates one tool result on a `user` line.
+// `non_execution_kind` is how a call that never ran announces itself; the one
+// value captured so far is `permission-rule`.
+type streamToolResultMeta struct {
+	ID               string `json:"id"`
+	NonExecutionKind string `json:"non_execution_kind"`
+}
+
+// streamToolUseResult is the object shape of a `user` line's
+// `tool_use_result`. Only `type` is read: it is the verb, and everything else
+// in the payload is the tool's body, which never enters the normalized stream
+// (T4.16).
+type streamToolUseResult struct {
+	Type string `json:"type"`
 }
 
 type streamMessage struct {
@@ -54,6 +119,11 @@ type streamBlock struct {
 type streamUsage struct {
 	InputTokens  int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
+	// The cache counts are not included in InputTokens: a run whose prompt
+	// was almost entirely a cache hit reports a handful of input tokens and
+	// tens of thousands of cache reads (task 066).
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
 }
 
 // sessionIDOf reads claude's `session_id` off one verbatim stream line, or ""
@@ -82,18 +152,47 @@ func parseLine(raw []byte) agent.Event {
 	if err := json.Unmarshal(raw, &line); err != nil {
 		return agent.Event{Type: agent.EventUnknown, Raw: raw}
 	}
+	ev := parseTyped(&line, raw)
+	// Every line carries it, so it is attached once here rather than in each
+	// of the four arms (task 066).
+	ev.ParentCallID = line.ParentToolUseID
+	return ev
+}
+
+func parseTyped(line *streamLine, raw []byte) agent.Event {
 	switch line.Type {
 	case "assistant":
-		return parseAssistant(&line, raw)
+		return parseAssistant(line, raw)
 	case "user":
 		// A `user` line is claude replaying tool results back to the model.
 		// It is the only place an invocation's outcome is reported, so it is
 		// normalized rather than left to fall through as raw (T4.16).
-		return parseToolResults(&line, raw)
+		return parseToolResults(line, raw)
 	case "result":
-		return parseResult(&line, raw)
+		return parseResult(line, raw)
+	case "system":
+		// `init` is the run header; claude sends other subtypes here
+		// (compact boundaries among them) and an unmodelled one stays raw,
+		// which is the phase 1 tolerant-parsing rule (task 066).
+		if line.Subtype == "init" {
+			return parseInit(line, raw)
+		}
+		return agent.Event{Type: agent.EventUnknown, Raw: raw}
 	default:
 		return agent.Event{Type: agent.EventUnknown, Raw: raw}
+	}
+}
+
+// parseInit normalizes the `system`/`init` line claude opens every stream
+// with: the directory it is working in and the tools it was given (task 066).
+func parseInit(line *streamLine, raw []byte) agent.Event {
+	return agent.Event{
+		Type: agent.EventRunHeader,
+		Header: &agent.RunHeader{
+			WorkDir: line.CWD,
+			Tools:   line.Tools,
+		},
+		Raw: raw,
 	}
 }
 
@@ -148,6 +247,7 @@ func parseToolResults(line *streamLine, raw []byte) agent.Event {
 	if line.Message == nil {
 		return ev
 	}
+	verb := resultVerb(line.ToolUseResult)
 	for _, b := range line.Message.Content {
 		if b.Type != "tool_result" {
 			continue
@@ -155,6 +255,8 @@ func parseToolResults(line *streamLine, raw []byte) agent.Event {
 		ev.Results = append(ev.Results, agent.ToolResult{
 			CallID:  b.ToolUseID,
 			Summary: resultSummary(b.Content),
+			Verb:    verb,
+			Blocked: blockedByRule(line.ToolResultMeta, b.ToolUseID),
 			IsError: b.IsError,
 		})
 	}
@@ -162,6 +264,43 @@ func parseToolResults(line *streamLine, raw []byte) agent.Event {
 		ev.Type = agent.EventToolResult
 	}
 	return ev
+}
+
+// resultVerbs maps claude's structured `tool_use_result.type` onto the verb a
+// reader sees. It holds exactly the types a captured run has shown, and an
+// unmapped one yields no verb rather than a guessed past tense: a wrong guess
+// fails silently — the verb is simply wrong, and nothing distinguishes that
+// from a tool that reported no type at all (the T4.17 rule).
+var resultVerbs = map[string]string{
+	"create": "created",
+}
+
+// resultVerb reads the verb off a `user` line's `tool_use_result`. The
+// payload is either the structured object or a bare string, so the object
+// decode is *probed* — a string there is not an error, it is claude's other
+// shape, and it simply carries no verb.
+func resultVerb(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var res streamToolUseResult
+	if err := json.Unmarshal(payload, &res); err != nil {
+		return ""
+	}
+	return resultVerbs[res.Type]
+}
+
+// blockedByRule reports whether a permission rule refused this call, from the
+// line's `tool_result_meta`. A meta entry with any other
+// `non_execution_kind` is not treated as blocked: only `permission-rule` has
+// been captured, and the others are unknown conditions rather than known ones.
+func blockedByRule(meta []streamToolResultMeta, callID string) bool {
+	for _, m := range meta {
+		if m.ID == callID && m.NonExecutionKind == "permission-rule" {
+			return true
+		}
+	}
+	return false
 }
 
 // resultSummaryMax caps a tool result at roughly one pane line. The outcome
@@ -208,6 +347,46 @@ func parseResult(line *streamLine, raw []byte) agent.Event {
 	if line.Usage != nil {
 		res.InputTokens = line.Usage.InputTokens
 		res.OutputTokens = line.Usage.OutputTokens
+		res.CacheReadTokens = line.Usage.CacheReadInputTokens
+		res.CacheCreationTokens = line.Usage.CacheCreationInputTokens
+	}
+	res.Duration = time.Duration(line.DurationMS) * time.Millisecond
+	res.APIDuration = time.Duration(line.DurationAPIMS) * time.Millisecond
+	res.NumTurns = line.NumTurns
+	res.StopReason = line.StopReason
+	res.TerminalReason = line.TerminalReason
+	res.ModelUsage = modelUsage(line.ModelUsage)
+	for _, d := range line.PermissionDenials {
+		res.PermissionDenials = append(res.PermissionDenials,
+			agent.PermissionDenial{ToolName: d.ToolName, CallID: d.ToolUseID})
 	}
 	return agent.Event{Type: agent.EventResult, Result: &res, Raw: raw}
+}
+
+// modelUsage flattens claude's `modelUsage` map into the normalized slice.
+// The keys are sorted rather than ranged over: Go randomizes map iteration,
+// and a pane whose per-model lines reorder between two reads of the same
+// transcript is a bug a reader would blame on the run.
+func modelUsage(m map[string]streamModelUsage) []agent.ModelUsage {
+	if len(m) == 0 {
+		return nil
+	}
+	models := make([]string, 0, len(m))
+	for name := range m {
+		models = append(models, name)
+	}
+	slices.Sort(models)
+	out := make([]agent.ModelUsage, 0, len(models))
+	for _, name := range models {
+		u := m[name]
+		out = append(out, agent.ModelUsage{
+			Model:               name,
+			InputTokens:         u.InputTokens,
+			OutputTokens:        u.OutputTokens,
+			CacheReadTokens:     u.CacheReadInputTokens,
+			CacheCreationTokens: u.CacheCreationInputTokens,
+			CostUSD:             u.CostUSD,
+		})
+	}
+	return out
 }

--- a/internal/agent/claude/stream_test.go
+++ b/internal/agent/claude/stream_test.go
@@ -1,8 +1,10 @@
 package claude
 
 import (
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
 )
@@ -103,11 +105,40 @@ func TestParseLine(t *testing.T) {
 			},
 		},
 		{
-			name: "unknown type is tolerated",
-			line: `{"type":"system","subtype":"init","model":"x"}`,
+			// A `system` line is only normalized for the one subtype vincent
+			// models. Anything else — compact boundaries among them — stays
+			// raw, which is the phase 1 tolerant-parsing rule asserted
+			// rather than assumed (task 066).
+			name: "unknown system subtype is tolerated",
+			line: `{"type":"system","subtype":"compact_boundary","model":"x"}`,
 			want: func(t *testing.T, ev agent.Event) {
 				if ev.Type != agent.EventUnknown {
 					t.Errorf("got %q, want unknown", ev.Type)
+				}
+			},
+		},
+		{
+			name: "unmodelled type is tolerated",
+			line: `{"type":"control_response","request_id":"r1"}`,
+			want: func(t *testing.T, ev agent.Event) {
+				if ev.Type != agent.EventUnknown {
+					t.Errorf("got %q, want unknown", ev.Type)
+				}
+			},
+		},
+		{
+			name: "system init becomes the run header",
+			line: `{"type":"system","subtype":"init","cwd":"C:\\work\\repo",` +
+				`"tools":["Task","Bash"]}`,
+			want: func(t *testing.T, ev agent.Event) {
+				if ev.Type != agent.EventRunHeader || ev.Header == nil {
+					t.Fatalf("got %q header=%v, want a run header", ev.Type, ev.Header)
+				}
+				if ev.Header.WorkDir != `C:\work\repo` {
+					t.Errorf("cwd = %q", ev.Header.WorkDir)
+				}
+				if len(ev.Header.Tools) != 2 || ev.Header.Tools[0] != "Task" {
+					t.Errorf("tools = %v, want the list claude was given", ev.Header.Tools)
 				}
 			},
 		},
@@ -252,4 +283,191 @@ func TestErrorToolResultIsFlagged(t *testing.T) {
 	if !ev.Results[0].IsError {
 		t.Errorf("result = %+v, want IsError", ev.Results[0])
 	}
+}
+
+// TestParseResultMetadataFixture reads the result line every captured run
+// ends with. Each field was in the stream the whole time and was discarded
+// (task 066): a reader could not see how long a run took, how many turns it
+// burned, why it stopped, or how much of the spend was cache reads.
+func TestParseResultMetadataFixture(t *testing.T) {
+	events, _ := fixtureEvents(t, "stream_permission_deny_2.1.226.jsonl")
+	res := lastResult(t, events)
+
+	if res.Duration != 7324*time.Millisecond {
+		t.Errorf("duration = %s, want the run's own 7324ms", res.Duration)
+	}
+	if res.APIDuration != 5706*time.Millisecond {
+		t.Errorf("api duration = %s, want 5706ms", res.APIDuration)
+	}
+	if res.NumTurns != 2 {
+		t.Errorf("turns = %d, want 2", res.NumTurns)
+	}
+	if res.StopReason != "end_turn" || res.TerminalReason != "completed" {
+		t.Errorf("stop/terminal = %q/%q, want end_turn/completed",
+			res.StopReason, res.TerminalReason)
+	}
+	// The cache counts are not part of input_tokens: this run reported 18
+	// input tokens against 60280 cache reads, and reporting only the former
+	// makes a real spend look like nothing happened.
+	if res.InputTokens != 18 || res.CacheReadTokens != 60280 ||
+		res.CacheCreationTokens != 6835 {
+		t.Errorf("tokens = %d in / %d cache-read / %d cache-write",
+			res.InputTokens, res.CacheReadTokens, res.CacheCreationTokens)
+	}
+
+	if len(res.ModelUsage) != 1 {
+		t.Fatalf("model usage = %+v, want one model", res.ModelUsage)
+	}
+	u := res.ModelUsage[0]
+	if u.Model != "claude-haiku-4-5-20251001" || u.InputTokens != 18 ||
+		u.OutputTokens != 536 || u.CacheReadTokens != 60280 ||
+		u.CacheCreationTokens != 6835 || u.CostUSD == nil {
+		t.Errorf("model usage = %+v", u)
+	}
+
+	// The denial the fixture was captured for: full-auto with no user to
+	// approve a Write.
+	if len(res.PermissionDenials) != 1 {
+		t.Fatalf("denials = %+v, want the one this run recorded", res.PermissionDenials)
+	}
+	if d := res.PermissionDenials[0]; d.ToolName != "Write" ||
+		d.CallID != "toolu_01NfZSDqXQKXwt59MWGhoqgw" {
+		t.Errorf("denial = %+v, want the refused Write and its call id", d)
+	}
+}
+
+// TestParseRunHeaderFixture covers the `system`/`init` line each capture
+// opens with — the one that fell through to EventUnknown entirely.
+func TestParseRunHeaderFixture(t *testing.T) {
+	events, _ := fixtureEvents(t, "stream_permission_allow_2.1.226.jsonl")
+	if events[0].Type != agent.EventRunHeader || events[0].Header == nil {
+		t.Fatalf("first event = %q, want the run header", events[0].Type)
+	}
+	h := events[0].Header
+	if h.WorkDir != `C:\work\repo` {
+		t.Errorf("cwd = %q, want the directory claude reported", h.WorkDir)
+	}
+	want := []string{"Task", "AskUserQuestion", "Bash", "Read", "Write"}
+	if !slices.Equal(h.Tools, want) {
+		t.Errorf("tools = %v, want %v in the order claude listed them", h.Tools, want)
+	}
+	// Exactly one: a header per run, not per line.
+	var headers int
+	for _, ev := range events {
+		if ev.Type == agent.EventRunHeader {
+			headers++
+		}
+	}
+	if headers != 1 {
+		t.Errorf("got %d run headers, want exactly one", headers)
+	}
+}
+
+// TestParseToolUseResultVerb covers the structured outcome that rides beside
+// a `user` line's message rather than inside it (task 066).
+func TestParseToolUseResultVerb(t *testing.T) {
+	events, _ := fixtureEvents(t, "stream_permission_allow_2.1.226.jsonl")
+	var found bool
+	for _, ev := range events {
+		for _, r := range ev.Results {
+			if r.CallID != "toolu_01PSqBeA6sKydYaELf8NTXHH" {
+				continue
+			}
+			found = true
+			if r.Verb != "created" {
+				t.Errorf("verb = %q, want created from tool_use_result.type", r.Verb)
+			}
+			if r.Blocked {
+				t.Errorf("allowed Write marked blocked: %+v", r)
+			}
+		}
+	}
+	if !found {
+		t.Error("no result correlated to the captured Write call")
+	}
+}
+
+// TestParseBlockedToolResult covers the deny capture's two halves at once: a
+// permission-blocked call is reported as blocked rather than as an ordinary
+// error string, and the *string*-shaped `tool_use_result` on that same line
+// does not derail the object decode the verb comes from.
+func TestParseBlockedToolResult(t *testing.T) {
+	events, _ := fixtureEvents(t, "stream_permission_deny_2.1.226.jsonl")
+	var results []agent.ToolResult
+	for _, ev := range events {
+		results = append(results, ev.Results...)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %+v, want the one refused Write", results)
+	}
+	r := results[0]
+	if !r.Blocked {
+		t.Errorf("result = %+v, want Blocked from non_execution_kind permission-rule", r)
+	}
+	if !r.IsError {
+		t.Errorf("result = %+v: a blocked call is still an error to the model", r)
+	}
+	// `tool_use_result` here is the bare string
+	// "Error: no user is available; permission denied" — the object probe
+	// must decline it rather than fail the line.
+	if r.Verb != "" {
+		t.Errorf("verb = %q, want none: a string payload carries no type", r.Verb)
+	}
+	if !strings.Contains(r.Summary, "permission denied") {
+		t.Errorf("summary = %q, want the tool's reported outcome", r.Summary)
+	}
+}
+
+// TestUnobservedToolUseResultTypeHasNoVerb is the T4.17 rule asserted: a
+// structured outcome whose type no capture has shown yields no verb rather
+// than a guessed past tense, because a wrong verb is indistinguishable from
+// a tool that reported nothing.
+func TestUnobservedToolUseResultTypeHasNoVerb(t *testing.T) {
+	line := `{"type":"user","message":{"content":[{"type":"tool_result",` +
+		`"tool_use_id":"t1","content":"ok"}]},` +
+		`"tool_use_result":{"type":"some_future_shape"}}`
+	ev := parseLine([]byte(line))
+	if len(ev.Results) != 1 || ev.Results[0].Verb != "" {
+		t.Errorf("results = %+v, want no verb for an unobserved type", ev.Results)
+	}
+}
+
+// TestParentToolUseIDIsEmptyInCaptures pins what the fixtures actually
+// contain: `parent_tool_use_id` is null on every line of all three, so the
+// field is carried and there is nothing here to nest. A capture of a `Task`
+// run is what unblocks the renderer, and it is follow-up work.
+func TestParentToolUseIDIsEmptyInCaptures(t *testing.T) {
+	for _, name := range []string{
+		"stream_permission_allow_2.1.226.jsonl",
+		"stream_permission_deny_2.1.226.jsonl",
+		"stream_question_2.1.226.jsonl",
+	} {
+		events, _ := fixtureEvents(t, name)
+		for i, ev := range events {
+			if ev.ParentCallID != "" {
+				t.Errorf("%s line %d: parent = %q, want empty", name, i, ev.ParentCallID)
+			}
+		}
+	}
+}
+
+// TestParentToolUseIDIsRead is the other half: the field is read when it is
+// there. It has to be asserted synthetically because no captured run has one.
+func TestParentToolUseIDIsRead(t *testing.T) {
+	line := `{"type":"assistant","parent_tool_use_id":"toolu_parent",` +
+		`"message":{"content":[{"type":"text","text":"from a subagent"}]}}`
+	if ev := parseLine([]byte(line)); ev.ParentCallID != "toolu_parent" {
+		t.Errorf("parent = %q, want the spawning call id", ev.ParentCallID)
+	}
+}
+
+func lastResult(t *testing.T, events []agent.Event) *agent.RunResult {
+	t.Helper()
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Type == agent.EventResult && events[i].Result != nil {
+			return events[i].Result
+		}
+	}
+	t.Fatal("no result event in the capture")
+	return nil
 }

--- a/internal/agent/codex/stream_test.go
+++ b/internal/agent/codex/stream_test.go
@@ -279,3 +279,37 @@ func TestParseReasoningWithoutText(t *testing.T) {
 		t.Errorf("empty reasoning normalized to %v, want unknown", ev.Type)
 	}
 }
+
+// TestNoRunHeaderOrResultMetadata states positively what task 066 did *not*
+// do to this adapter. The shared vocabulary grew a run header, a structured
+// tool verb and the result's own account of a run; codex reports no run header
+// at all (`thread.started` is a thread id and nothing else) and no structured
+// tool outcome, and the one field it does carry that parallels the new ones —
+// `turn.completed.usage.cached_input_tokens` — is deliberately not read: task
+// 066 widened one adapter, and each dialect deserves its own fixtures. Every
+// new field therefore stays zero here, and nothing emulates a value (§9.3).
+func TestNoRunHeaderOrResultMetadata(t *testing.T) {
+	for _, name := range []string{"success.jsonl", "tooluse.jsonl", "failure.jsonl", "reasoning_0.147.0.jsonl"} {
+		for i, ev := range parseFixture(t, name) {
+			if ev.Type == agent.EventRunHeader || ev.Header != nil {
+				t.Errorf("%s line %d: produced a run header", name, i)
+			}
+			if ev.ParentCallID != "" {
+				t.Errorf("%s line %d: parent = %q", name, i, ev.ParentCallID)
+			}
+			for _, r := range ev.Results {
+				if r.Verb != "" || r.Blocked {
+					t.Errorf("%s line %d: result = %+v, want no verb and no block", name, i, r)
+				}
+			}
+			if res := ev.Result; res != nil {
+				if res.Duration != 0 || res.APIDuration != 0 || res.NumTurns != 0 ||
+					res.StopReason != "" || res.TerminalReason != "" ||
+					res.CacheReadTokens != 0 || res.CacheCreationTokens != 0 ||
+					res.ModelUsage != nil || res.PermissionDenials != nil {
+					t.Errorf("%s line %d: result carries claude-only metadata: %+v", name, i, res)
+				}
+			}
+		}
+	}
+}

--- a/internal/agent/cursor/stream_test.go
+++ b/internal/agent/cursor/stream_test.go
@@ -337,3 +337,37 @@ func TestCoalescedThinkingRawIsTheClosingLine(t *testing.T) {
 		t.Errorf("Raw = %s, want the closing line verbatim", ev.Raw)
 	}
 }
+
+// TestNoRunHeaderOrResultMetadata states positively what task 066 did *not*
+// do to this adapter. The shared vocabulary grew a run header, a structured
+// tool verb and the result's own account of a run; cursor reports no structured
+// tool outcome, and the equivalents its dialect *does* carry — `cwd` on the
+// init line, `duration_ms`/`duration_api_ms` and the cache token split on the
+// result — are deliberately not read: task 066 widened one adapter, and each
+// dialect deserves its own fixtures. Every new field therefore stays zero here,
+// and nothing emulates a value (§9.7).
+func TestNoRunHeaderOrResultMetadata(t *testing.T) {
+	for _, name := range []string{"success_2026.08.04.jsonl", "tools_2026.08.11.jsonl"} {
+		for i, ev := range parseFixture(t, name) {
+			if ev.Type == agent.EventRunHeader || ev.Header != nil {
+				t.Errorf("%s line %d: produced a run header", name, i)
+			}
+			if ev.ParentCallID != "" {
+				t.Errorf("%s line %d: parent = %q", name, i, ev.ParentCallID)
+			}
+			for _, r := range ev.Results {
+				if r.Verb != "" || r.Blocked {
+					t.Errorf("%s line %d: result = %+v, want no verb and no block", name, i, r)
+				}
+			}
+			if res := ev.Result; res != nil {
+				if res.Duration != 0 || res.APIDuration != 0 || res.NumTurns != 0 ||
+					res.StopReason != "" || res.TerminalReason != "" ||
+					res.CacheReadTokens != 0 || res.CacheCreationTokens != 0 ||
+					res.ModelUsage != nil || res.PermissionDenials != nil {
+					t.Errorf("%s line %d: result carries claude-only metadata: %+v", name, i, res)
+				}
+			}
+		}
+	}
+}

--- a/internal/api/transcript.go
+++ b/internal/api/transcript.go
@@ -99,6 +99,47 @@ type normalizedLine struct {
 	InputTokens  int64        `json:"input_tokens,omitempty"`
 	OutputTokens int64        `json:"output_tokens,omitempty"`
 	CostUSD      *float64     `json:"cost_usd,omitempty"`
+	// ParentCallID rides on any record produced inside a subagent call
+	// (task 066). It is carried on the wire ahead of any renderer: the pane
+	// is flat today, and a transcript recorded now renders under whatever
+	// nesting lands later, because §13.2 re-normalizes on every read.
+	ParentCallID string `json:"parent_call_id,omitempty"`
+	// WorkDir and AvailableTools are the agent.run_header record (task 066):
+	// where the CLI said it was running and what it said it could reach.
+	// The tool list cannot ride on `tools` — that is agent.tool_use's
+	// objects, and a bare name list is a different shape.
+	WorkDir        string   `json:"work_dir,omitempty"`
+	AvailableTools []string `json:"available_tools,omitempty"`
+	// The rest enrich agent.result with the run's own account of itself
+	// (task 066). Durations are milliseconds, matching the dialect they came
+	// from and needing no unit in the name a reader has to remember.
+	DurationMS        int64                `json:"duration_ms,omitempty"`
+	APIDurationMS     int64                `json:"api_duration_ms,omitempty"`
+	NumTurns          int                  `json:"num_turns,omitempty"`
+	StopReason        string               `json:"stop_reason,omitempty"`
+	TerminalReason    string               `json:"terminal_reason,omitempty"`
+	CacheReadTokens   int64                `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens  int64                `json:"cache_write_tokens,omitempty"`
+	ModelUsage        []modelUsageLine     `json:"model_usage,omitempty"`
+	PermissionDenials []permissionDenyLine `json:"permission_denials,omitempty"`
+}
+
+// modelUsageLine is one model's share of a run. It carries what the run
+// spent, never what the model is — §9.6's catalog answers that (§13.2).
+type modelUsageLine struct {
+	Model            string   `json:"model"`
+	InputTokens      int64    `json:"input_tokens,omitempty"`
+	OutputTokens     int64    `json:"output_tokens,omitempty"`
+	CacheReadTokens  int64    `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int64    `json:"cache_write_tokens,omitempty"`
+	CostUSD          *float64 `json:"cost_usd,omitempty"`
+}
+
+// permissionDenyLine is one tool call a permission rule refused over the
+// whole run — the run-level counterpart of a result's `blocked` (§13.2).
+type permissionDenyLine struct {
+	ToolName string `json:"tool_name,omitempty"`
+	CallID   string `json:"call_id,omitempty"`
 }
 
 // resultLine reports one tool invocation's outcome. It never carries the
@@ -108,6 +149,11 @@ type resultLine struct {
 	CallID  string `json:"call_id,omitempty"`
 	Name    string `json:"name,omitempty"`
 	Summary string `json:"summary,omitempty"`
+	// Verb is the dialect's structured outcome ("created"), absent when it
+	// reported none; Blocked marks a call a permission rule refused, which
+	// is a different thing from one that ran and failed (task 066).
+	Verb    string `json:"verb,omitempty"`
+	Blocked bool   `json:"blocked,omitempty"`
 	IsError bool   `json:"is_error,omitempty"`
 }
 
@@ -135,8 +181,40 @@ func resultLines(results []agent.ToolResult) []resultLine {
 	out := make([]resultLine, 0, len(results))
 	for _, r := range results {
 		out = append(out, resultLine{
-			CallID: r.CallID, Name: r.Name, Summary: r.Summary, IsError: r.IsError,
+			CallID: r.CallID, Name: r.Name, Summary: r.Summary,
+			Verb: r.Verb, Blocked: r.Blocked, IsError: r.IsError,
 		})
+	}
+	return out
+}
+
+// modelUsageLines maps a run's per-model breakdown onto its wire shape.
+func modelUsageLines(usage []agent.ModelUsage) []modelUsageLine {
+	if len(usage) == 0 {
+		return nil
+	}
+	out := make([]modelUsageLine, 0, len(usage))
+	for _, u := range usage {
+		out = append(out, modelUsageLine{
+			Model:            u.Model,
+			InputTokens:      u.InputTokens,
+			OutputTokens:     u.OutputTokens,
+			CacheReadTokens:  u.CacheReadTokens,
+			CacheWriteTokens: u.CacheCreationTokens,
+			CostUSD:          u.CostUSD,
+		})
+	}
+	return out
+}
+
+// permissionDenyLines maps the run-level denial list onto its wire shape.
+func permissionDenyLines(denials []agent.PermissionDenial) []permissionDenyLine {
+	if len(denials) == 0 {
+		return nil
+	}
+	out := make([]permissionDenyLine, 0, len(denials))
+	for _, d := range denials {
+		out = append(out, permissionDenyLine{ToolName: d.ToolName, CallID: d.CallID})
 	}
 	return out
 }
@@ -166,7 +244,19 @@ func normalizeLine(raw []byte, parse agent.LineParser) any {
 		// so anything else is surfaced verbatim rather than guessed at.
 		return normalizedLine{Type: "agent.raw", Line: string(raw)}
 	}
-	ev := parse(raw)
+	return normalizedEvent(parse(raw), raw)
+}
+
+// normalizedEvent maps one parsed event onto its wire record. It is split
+// from normalizeLine so that ParentCallID — which rides on any record, of any
+// type — is attached in one place rather than in each arm (task 066).
+func normalizedEvent(ev agent.Event, raw []byte) normalizedLine {
+	out := normalizedRecord(ev, raw)
+	out.ParentCallID = ev.ParentCallID
+	return out
+}
+
+func normalizedRecord(ev agent.Event, raw []byte) normalizedLine {
 	switch ev.Type {
 	case agent.EventOutput:
 		return normalizedLine{Type: "agent.output", Text: ev.Text}
@@ -178,6 +268,13 @@ func normalizeLine(raw []byte, parse agent.LineParser) any {
 		return normalizedLine{Type: "agent.thinking", Text: ev.Text}
 	case agent.EventUsage:
 		return normalizedLine{Type: "agent.usage", Raw: string(ev.Raw)}
+	case agent.EventRunHeader:
+		out := normalizedLine{Type: "agent.run_header"}
+		if ev.Header != nil {
+			out.WorkDir = ev.Header.WorkDir
+			out.AvailableTools = ev.Header.Tools
+		}
+		return out
 	case agent.EventError:
 		return normalizedLine{Type: "agent.error", Message: ev.Message}
 	case agent.EventResult:
@@ -189,6 +286,15 @@ func normalizeLine(raw []byte, parse agent.LineParser) any {
 			out.InputTokens = ev.Result.InputTokens
 			out.OutputTokens = ev.Result.OutputTokens
 			out.CostUSD = ev.Result.CostUSD
+			out.DurationMS = ev.Result.Duration.Milliseconds()
+			out.APIDurationMS = ev.Result.APIDuration.Milliseconds()
+			out.NumTurns = ev.Result.NumTurns
+			out.StopReason = ev.Result.StopReason
+			out.TerminalReason = ev.Result.TerminalReason
+			out.CacheReadTokens = ev.Result.CacheReadTokens
+			out.CacheWriteTokens = ev.Result.CacheCreationTokens
+			out.ModelUsage = modelUsageLines(ev.Result.ModelUsage)
+			out.PermissionDenials = permissionDenyLines(ev.Result.PermissionDenials)
 		}
 		return out
 	case agent.EventInputRequest, agent.EventInputCanceled, agent.EventUnknown:

--- a/internal/api/transcript_test.go
+++ b/internal/api/transcript_test.go
@@ -83,7 +83,7 @@ func TestNormalizeTranscript(t *testing.T) {
 		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","id":"toolu_01",` +
 			`"input":{"file_path":"internal/auth/token.go"}}]}}`,
 		`{"type":"vincent.output","phase":"run","stream":"stdout","text":"building"}`,
-		`{"type":"system","subtype":"init"}`,
+		`{"type":"system","subtype":"compact_boundary"}`,
 		`{"type":"result","subtype":"success","result":"done","total_cost_usd":0.5,` +
 			`"usage":{"input_tokens":10,"output_tokens":3}}`,
 	}, "\n") + "\n"
@@ -127,8 +127,10 @@ func TestNormalizeTranscript(t *testing.T) {
 	if !strings.Contains(lines[2], `"phase":"run"`) || !strings.Contains(lines[2], `"text":"building"`) {
 		t.Errorf("vincent annotation not passed through: %s", lines[2])
 	}
-	// The unrecognized line survives verbatim inside agent.raw.
-	if !strings.Contains(lines[3], `\"subtype\":\"init\"`) {
+	// The unrecognized line survives verbatim inside agent.raw. `init` is
+	// normalized since task 066, so the unmodelled subtype beside it is what
+	// stands in for "a line this dialect does not model".
+	if !strings.Contains(lines[3], `\"subtype\":\"compact_boundary\"`) {
 		t.Errorf("unknown line not preserved: %s", lines[3])
 	}
 	if !strings.Contains(lines[4], `"result_text":"done"`) ||
@@ -358,5 +360,109 @@ func TestNormalizeThinkingAndToolResults(t *testing.T) {
 	}
 	if !strings.Contains(out[3], `"is_error":true`) {
 		t.Errorf("failed tool result not flagged: %s", out[3])
+	}
+}
+
+// TestNormalizeRunHeaderAndResultMetadata covers the wire names task 066
+// added (§13.2): the new agent.run_header record, and the result line's own
+// account of the run. Both come off the shapes a captured claude run
+// actually sends.
+//
+// The key names here are the *contract* with internal/taskrun's live chunks:
+// a client renders the live tail and the fetched scrollback through one path,
+// so a name that differs by one character shows up as output that changes the
+// moment a step finishes. taskrun/chunks_test.go pins the other side.
+func TestNormalizeRunHeaderAndResultMetadata(t *testing.T) {
+	lines := []string{
+		`{"type":"system","subtype":"init","session_id":"s1","cwd":"C:\\work\\repo",` +
+			`"tools":["Task","Bash","Write"]}`,
+		`{"type":"user","parent_tool_use_id":"toolu_parent","message":{"content":[` +
+			`{"type":"tool_result","tool_use_id":"toolu_01","content":"File created"}]},` +
+			`"tool_use_result":{"type":"create","filePath":"hello.txt"}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_02",` +
+			`"content":"no user is available; permission denied","is_error":true}]},` +
+			`"tool_use_result":"Error: no user is available; permission denied",` +
+			`"tool_result_meta":[{"id":"toolu_02","non_execution_kind":"permission-rule"}]}`,
+		`{"type":"result","subtype":"success","is_error":false,"result":"done",` +
+			`"duration_ms":7324,"duration_api_ms":5706,"num_turns":2,` +
+			`"stop_reason":"end_turn","terminal_reason":"completed",` +
+			`"total_cost_usd":0.02206225,` +
+			`"usage":{"input_tokens":18,"output_tokens":536,` +
+			`"cache_read_input_tokens":60280,"cache_creation_input_tokens":6835},` +
+			`"modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":18,"outputTokens":536,` +
+			`"cacheReadInputTokens":60280,"cacheCreationInputTokens":6835,"costUSD":0.02206225}},` +
+			`"permission_denials":[{"tool_name":"Write","tool_use_id":"toolu_02"}]}`,
+	}
+	var buf bytes.Buffer
+	parser := claude.New(func() string { return "" }).NewLineParser()
+	if err := normalizeTranscript(&buf, strings.NewReader(strings.Join(lines, "\n")+"\n"), parser); err != nil {
+		t.Fatalf("normalizeTranscript: %v", err)
+	}
+	out := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
+	if len(out) != len(lines) {
+		t.Fatalf("got %d normalized lines, want %d:\n%s", len(out), len(lines), buf.String())
+	}
+
+	for _, want := range []string{
+		`"type":"agent.run_header"`,
+		`"work_dir":"C:\\work\\repo"`,
+		`"available_tools":["Task","Bash","Write"]`,
+	} {
+		if !strings.Contains(out[0], want) {
+			t.Errorf("run header missing %s: %s", want, out[0])
+		}
+	}
+
+	// The verb rides beside the summary, and the subagent attribution rides
+	// on the record rather than on one of its results.
+	if !strings.Contains(out[1], `"verb":"created"`) ||
+		!strings.Contains(out[1], `"parent_call_id":"toolu_parent"`) {
+		t.Errorf("structured outcome lost: %s", out[1])
+	}
+	// A blocked call is flagged apart from an ordinary failure, and keeps
+	// its error flag: it is both, and the finer verdict is the new one.
+	if !strings.Contains(out[2], `"blocked":true`) || !strings.Contains(out[2], `"is_error":true`) {
+		t.Errorf("blocked call not flagged: %s", out[2])
+	}
+
+	for _, want := range []string{
+		`"duration_ms":7324`,
+		`"api_duration_ms":5706`,
+		`"num_turns":2`,
+		`"cache_read_tokens":60280`,
+		`"cache_write_tokens":6835`,
+		`"model_usage":[{"model":"claude-haiku-4-5-20251001"`,
+		`"permission_denials":[{"tool_name":"Write","call_id":"toolu_02"}]`,
+	} {
+		if !strings.Contains(out[3], want) {
+			t.Errorf("result missing %s: %s", want, out[3])
+		}
+	}
+	// The ordinary reasons are on the wire even though the pane does not
+	// print them: a client other than the TUI may well want them.
+	if !strings.Contains(out[3], `"stop_reason":"end_turn"`) ||
+		!strings.Contains(out[3], `"terminal_reason":"completed"`) {
+		t.Errorf("stop reasons lost: %s", out[3])
+	}
+}
+
+// TestNormalizeOmitsUnreportedResultMetadata is the other half of the wire
+// contract: an adapter that reports none of task 066's fields sends none of
+// their keys, so a client can tell "unreported" from "zero".
+func TestNormalizeOmitsUnreportedResultMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	parser := claude.New(func() string { return "" }).NewLineParser()
+	line := `{"type":"result","subtype":"success","result":"done"}` + "\n"
+	if err := normalizeTranscript(&buf, strings.NewReader(line), parser); err != nil {
+		t.Fatalf("normalizeTranscript: %v", err)
+	}
+	for _, absent := range []string{
+		"duration_ms", "api_duration_ms", "num_turns", "stop_reason",
+		"terminal_reason", "cache_read_tokens", "cache_write_tokens",
+		"model_usage", "permission_denials", "parent_call_id",
+	} {
+		if strings.Contains(buf.String(), absent) {
+			t.Errorf("unreported %s reached the wire: %s", absent, buf.String())
+		}
 	}
 }

--- a/internal/apiclient/transcript.go
+++ b/internal/apiclient/transcript.go
@@ -50,9 +50,48 @@ type TranscriptRecord struct {
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
 	CostUSD      *float64 `json:"cost_usd"`
+	// ParentCallID names the subagent call a record was produced inside,
+	// empty for the main loop and for every adapter that does not report it.
+	// It is on the wire ahead of any renderer for it.
+	ParentCallID string `json:"parent_call_id"`
+	// WorkDir and AvailableTools are the agent.run_header record: what the
+	// CLI announced about the run before starting it.
+	WorkDir        string   `json:"work_dir"`
+	AvailableTools []string `json:"available_tools"`
+	// The rest is the run's own account of itself, on the terminal
+	// agent.result. Zero means unreported, which is every adapter but
+	// claude. Durations are milliseconds; the duration is the CLI's own and
+	// is not vincent's — claude's excludes the time an input wait adds.
+	DurationMS        int64                        `json:"duration_ms"`
+	APIDurationMS     int64                        `json:"api_duration_ms"`
+	NumTurns          int                          `json:"num_turns"`
+	StopReason        string                       `json:"stop_reason"`
+	TerminalReason    string                       `json:"terminal_reason"`
+	CacheReadTokens   int64                        `json:"cache_read_tokens"`
+	CacheWriteTokens  int64                        `json:"cache_write_tokens"`
+	ModelUsage        []TranscriptModelUsage       `json:"model_usage"`
+	PermissionDenials []TranscriptPermissionDenial `json:"permission_denials"`
 	// Raw is the whole record, for the annotation fields this struct does not
 	// name.
 	Raw json.RawMessage `json:"-"`
+}
+
+// TranscriptModelUsage is one model's share of a run. It says what the run
+// spent, not what the model is — `GET /v1/agents` answers the latter.
+type TranscriptModelUsage struct {
+	Model            string   `json:"model"`
+	InputTokens      int64    `json:"input_tokens"`
+	OutputTokens     int64    `json:"output_tokens"`
+	CacheReadTokens  int64    `json:"cache_read_tokens"`
+	CacheWriteTokens int64    `json:"cache_write_tokens"`
+	CostUSD          *float64 `json:"cost_usd"`
+}
+
+// TranscriptPermissionDenial is one tool call a permission rule refused over
+// the whole run — the run-level counterpart of a result's Blocked.
+type TranscriptPermissionDenial struct {
+	ToolName string `json:"tool_name"`
+	CallID   string `json:"call_id"`
 }
 
 // TranscriptTool is one tool invocation inside an agent.tool_use record.
@@ -73,6 +112,11 @@ type TranscriptToolResult struct {
 	CallID  string `json:"call_id"`
 	Name    string `json:"name"`
 	Summary string `json:"summary"`
+	// Verb is the dialect's own structured outcome ("created"), empty when
+	// it reported none. Blocked is a call a permission rule refused, which a
+	// reader wants told apart from one that ran and failed.
+	Verb    string `json:"verb"`
+	Blocked bool   `json:"blocked"`
 	IsError bool   `json:"is_error"`
 }
 

--- a/internal/chatrun/runner.go
+++ b/internal/chatrun/runner.go
@@ -308,7 +308,8 @@ func (r *Runner) consume(
 				r.deps.Logger.Warn("chat input closed", "chat", chat.ID, "error", err)
 			}
 		case agent.EventUsage, agent.EventResult, agent.EventOutput, agent.EventToolUse,
-			agent.EventToolResult, agent.EventThinking, agent.EventError, agent.EventUnknown:
+			agent.EventToolResult, agent.EventThinking, agent.EventRunHeader,
+			agent.EventError, agent.EventUnknown:
 			// Rendering is the client's job: every one of these is already
 			// in the transcript and on the stream, and internal/tui's
 			// outputlines.go decides what a verbosity level shows.

--- a/internal/taskrun/chunks_test.go
+++ b/internal/taskrun/chunks_test.go
@@ -44,6 +44,41 @@ func TestResultChunkShape(t *testing.T) {
 	}
 }
 
+// TestResultChunkCarriesVerbAndBlock extends the parity above onto the two
+// fields task 066 added: the dialect's structured verb, and a call a
+// permission rule refused — which is a different verdict from one that ran
+// and failed, and renders with its own mark.
+func TestResultChunkCarriesVerbAndBlock(t *testing.T) {
+	got := marshal(t, resultChunks([]agent.ToolResult{
+		{CallID: "toolu_01", Summary: "File created successfully", Verb: "created"},
+		{CallID: "toolu_02", Summary: "permission denied", Blocked: true, IsError: true},
+	}))
+	want := `[{"call_id":"toolu_01","summary":"File created successfully","verb":"created"},` +
+		`{"blocked":true,"call_id":"toolu_02","is_error":true,"summary":"permission denied"}]`
+	if got != want {
+		t.Errorf("result chunks =\n%s\nwant\n%s", got, want)
+	}
+}
+
+// TestHeaderChunkShape pins the run header's live shape (task 066). The tool
+// list rides on `available_tools` rather than `tools`, which is
+// agent.tool_use's objects — one key cannot mean two shapes.
+func TestHeaderChunkShape(t *testing.T) {
+	got := marshal(t, headerChunk(&agent.RunHeader{
+		WorkDir: `C:\work\repo`,
+		Tools:   []string{"Task", "Bash"},
+	}))
+	want := `{"available_tools":["Task","Bash"],"work_dir":"C:\\work\\repo"}`
+	if got != want {
+		t.Errorf("header chunk =\n%s\nwant\n%s", got, want)
+	}
+	// A header with neither half still publishes: the record itself is the
+	// statement that the run began.
+	if got := marshal(t, headerChunk(&agent.RunHeader{})); got != "{}" {
+		t.Errorf("empty header chunk = %s, want {}", got)
+	}
+}
+
 func marshal(t *testing.T, v any) string {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/internal/taskrun/steps.go
+++ b/internal/taskrun/steps.go
@@ -718,18 +718,34 @@ func exitCodeOf(err error) int {
 // live-output chunk types. Events that carry nothing a client renders
 // (results, errors — those surface as step outcomes) are skipped.
 func (r *Runner) publishAgentEvent(taskID, runID, offset int64, ev agent.Event) {
+	publish := func(kind string, payload map[string]any) {
+		// Carried on every chunk it is set on, matching the normalized
+		// record, which attaches it in one place for the same reason
+		// (task 066).
+		if ev.ParentCallID != "" {
+			payload["parent_call_id"] = ev.ParentCallID
+		}
+		r.publishOutput(taskID, runID, offset, kind, payload)
+	}
 	switch ev.Type {
 	case agent.EventOutput:
 		if ev.Text == "" {
 			return
 		}
-		r.publishOutput(taskID, runID, offset, "agent.output", map[string]any{"text": ev.Text})
+		publish("agent.output", map[string]any{"text": ev.Text})
+	case agent.EventRunHeader:
+		// The run header goes live like the rest (task 066): it is the first
+		// line of the stream, so a reader who opens the pane on a running
+		// step sees the run's frame before its first word, and does not have
+		// to wait for the step to finish to learn what the agent could reach.
+		if ev.Header == nil {
+			return
+		}
+		publish("agent.run_header", headerChunk(ev.Header))
 	case agent.EventToolUse:
-		r.publishOutput(taskID, runID, offset, "agent.tool_use",
-			map[string]any{"tools": toolChunks(ev.Tools)})
+		publish("agent.tool_use", map[string]any{"tools": toolChunks(ev.Tools)})
 	case agent.EventToolResult:
-		r.publishOutput(taskID, runID, offset, "agent.tool_result",
-			map[string]any{"results": resultChunks(ev.Results)})
+		publish("agent.tool_result", map[string]any{"results": resultChunks(ev.Results)})
 	case agent.EventThinking:
 		// Thinking goes live like everything else (T4.16). §9.7 held it back
 		// when it meant one chunk per token; coalescing removed that, and a
@@ -738,15 +754,29 @@ func (r *Runner) publishAgentEvent(taskID, runID, offset int64, ev agent.Event) 
 		if ev.Text == "" {
 			return
 		}
-		r.publishOutput(taskID, runID, offset, "agent.thinking", map[string]any{"text": ev.Text})
+		publish("agent.thinking", map[string]any{"text": ev.Text})
 	case agent.EventUsage:
 		// Usage payloads are adapter-native; the raw line is the honest shape.
-		r.publishOutput(taskID, runID, offset, "agent.usage", map[string]any{"raw": string(ev.Raw)})
+		publish("agent.usage", map[string]any{"raw": string(ev.Raw)})
 	case agent.EventInputRequest, agent.EventInputCanceled,
 		agent.EventResult, agent.EventError, agent.EventUnknown:
 		// Input requests surface via the state change (§13.3); results and
 		// errors surface as step outcomes.
 	}
+}
+
+// headerChunk maps a run header onto the §13.3 live-chunk shape, matching
+// what api.normalizeLine writes for the same event. The tool list cannot ride
+// on `tools`: that key is agent.tool_use's objects.
+func headerChunk(h *agent.RunHeader) map[string]any {
+	chunk := map[string]any{}
+	if h.WorkDir != "" {
+		chunk["work_dir"] = h.WorkDir
+	}
+	if len(h.Tools) > 0 {
+		chunk["available_tools"] = h.Tools
+	}
+	return chunk
 }
 
 // toolChunks maps tool uses onto the §13.3 live-chunk shape. It must match
@@ -775,11 +805,14 @@ func resultChunks(results []agent.ToolResult) []map[string]any {
 	for _, r := range results {
 		chunk := map[string]any{}
 		for k, v := range map[string]string{
-			"call_id": r.CallID, "name": r.Name, "summary": r.Summary,
+			"call_id": r.CallID, "name": r.Name, "summary": r.Summary, "verb": r.Verb,
 		} {
 			if v != "" {
 				chunk[k] = v
 			}
+		}
+		if r.Blocked {
+			chunk["blocked"] = true
 		}
 		if r.IsError {
 			chunk["is_error"] = true

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -1065,6 +1065,13 @@ func (d *detail) renderRecord(rec apiclient.TranscriptRecord, sawOutput bool) (p
 		// One record can report several outcomes; the first owns the line
 		// and the rest are rare enough to share it rather than earn rows.
 		return toolResultLine(rec.Results[0]), true
+	case "agent.run_header":
+		// levelCompact is "what the agent said and did, nothing else"; the
+		// run header is neither, so it appears from normal up (task 066).
+		if d.level == levelCompact {
+			return paneLine{}, false
+		}
+		return runHeaderLine(rec), true
 	case "agent.usage":
 		if d.level != levelVerbose {
 			return paneLine{}, false
@@ -1073,7 +1080,7 @@ func (d *detail) renderRecord(rec apiclient.TranscriptRecord, sawOutput bool) (p
 	case "agent.error":
 		return marked("✗ ", rec.Message, styleBad), true
 	case "agent.result":
-		return renderResult(rec, sawOutput), true
+		return renderResult(rec, sawOutput, d.level), true
 	case "command.output", "vincent.output":
 		if rec.Stream == "stderr" {
 			return plain(rec.Text, styleStderr, false), true
@@ -1150,25 +1157,89 @@ func toolUsePane(tools []apiclient.TranscriptTool) paneLine {
 // it again is the same words twice. The text is kept when nothing else
 // rendered, which is what a codex turn with no agent_message looks like, and
 // always on error, where it is the error and may be the only content there is.
-func renderResult(rec apiclient.TranscriptRecord, sawOutput bool) paneLine {
+func renderResult(rec apiclient.TranscriptRecord, sawOutput bool, level outputLevel) paneLine {
 	if rec.IsError {
 		return marked("✗ ", firstNonEmpty(rec.Message, rec.ResultText, "run failed"), styleBad)
 	}
 	if !sawOutput {
 		return marked("✓ ", firstNonEmpty(rec.ResultText, "run finished"), styleOK)
 	}
-	return marked("✓ ", resultOutcome(rec), styleOK)
+	return marked("✓ ", resultOutcome(rec, level), styleOK)
 }
 
 // resultOutcome is the one-line summary that replaces a repeated result text.
-// Tokens are deliberately absent — the attempt's own timeline row already
-// carries them, and the point of this line is to stop saying things twice.
-// Cost is here because it is reported nowhere else in this view.
-func resultOutcome(rec apiclient.TranscriptRecord) string {
-	if rec.CostUSD != nil {
-		return fmt.Sprintf("done · %s", formatCost(rec.CostUSD))
+// Plain token counts are deliberately absent — the attempt's own timeline row
+// already carries them, and the point of this line is to stop saying things
+// twice. Cost is here because it is reported nowhere else in this view.
+//
+// Task 066 widened it by level rather than unconditionally. levelCompact is
+// byte-for-byte what it always rendered: that level means "what the agent
+// said and did, nothing else", and how long a run took is neither. From
+// normal up it carries what the run said about itself, and the per-model and
+// cache breakdown — the part that is several lines, not several words — is
+// verbose only.
+func resultOutcome(rec apiclient.TranscriptRecord, level outputLevel) string {
+	if level == levelCompact {
+		if rec.CostUSD != nil {
+			return fmt.Sprintf("done · %s", formatCost(rec.CostUSD))
+		}
+		return "done"
 	}
-	return "done"
+	parts := []string{"done"}
+	if rec.DurationMS > 0 {
+		elapsed := formatAgentDuration(rec.DurationMS)
+		if level == levelVerbose && rec.APIDurationMS > 0 {
+			elapsed += fmt.Sprintf(" (%s api)", formatAgentDuration(rec.APIDurationMS))
+		}
+		parts = append(parts, elapsed)
+	}
+	if rec.NumTurns > 0 {
+		parts = append(parts, plural(rec.NumTurns, "turn", "turns"))
+	}
+	// The ordinary reasons are not printed: every successful claude run ends
+	// `end_turn`/`completed`, so naming them on every line would spend two
+	// columns saying nothing. An unusual one is exactly what distinguishes
+	// "the model finished" from "it hit a limit".
+	if rec.StopReason != "" && rec.StopReason != "end_turn" {
+		parts = append(parts, "stop: "+rec.StopReason)
+	}
+	if rec.TerminalReason != "" && rec.TerminalReason != "completed" {
+		parts = append(parts, rec.TerminalReason)
+	}
+	if n := len(rec.PermissionDenials); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d denied", n))
+	}
+	if rec.CostUSD != nil {
+		parts = append(parts, formatCost(rec.CostUSD))
+	}
+	line := strings.Join(parts, " · ")
+	if level != levelVerbose {
+		return line
+	}
+	return line + resultBreakdown(rec)
+}
+
+// resultBreakdown is the verbose-only tail of the result line: the cache
+// split the two plain token counts do not account for, and the per-model
+// share of a run. They ride as newline-separated segments of the same record
+// rather than as records of their own, so the pane's own wrapping gives them
+// the hanging indent under the ✓ for free.
+func resultBreakdown(rec apiclient.TranscriptRecord) string {
+	var b strings.Builder
+	if rec.CacheReadTokens > 0 || rec.CacheWriteTokens > 0 {
+		fmt.Fprintf(&b, "\ncache %d read / %d written",
+			rec.CacheReadTokens, rec.CacheWriteTokens)
+	}
+	for _, u := range rec.ModelUsage {
+		fmt.Fprintf(&b, "\n%s · %d in / %d out", u.Model, u.InputTokens, u.OutputTokens)
+		if u.CacheReadTokens > 0 {
+			fmt.Fprintf(&b, " · %d cached", u.CacheReadTokens)
+		}
+		if u.CostUSD != nil {
+			fmt.Fprintf(&b, " · %s", formatCost(u.CostUSD))
+		}
+	}
+	return b.String()
 }
 
 // fieldOf reads one string field out of a record's raw JSON — the annotation

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
@@ -107,6 +108,9 @@ const (
 	gutterNone     = "  "
 	gutterThinking = "· "
 	gutterTool     = "▸ "
+	// gutterHeader marks the run header — the frame of the run rather than
+	// anything that happened inside it (task 066).
+	gutterHeader = "# "
 	// gutterResult is four columns: a result is indented under its call, so
 	// a run of calls and outcomes reads as a tree rather than a list.
 	gutterResult = "    "
@@ -255,19 +259,63 @@ func splitWords(para string, avail int) []string {
 	return out
 }
 
+// runHeaderLine renders what the CLI announced about the run before it
+// started: where it ran and what it was allowed to reach (task 066). It is
+// the answer to "what could this agent actually do", which the pane could not
+// give at any level before.
+//
+// It is dim throughout, gutter included: it is context for everything below
+// it rather than a thing that happened, and it must not compete with the
+// first assistant line for a reader's eye.
+func runHeaderLine(rec apiclient.TranscriptRecord) paneLine {
+	dir := rec.WorkDir
+	if dir == "" {
+		// A header with no cwd still says the run began and lists its tools,
+		// which is the half a reader cannot get anywhere else.
+		dir = "run started"
+	}
+	segs := []segment{{text: dir, style: styleDim}}
+	if len(rec.AvailableTools) > 0 {
+		segs = append(segs, segment{
+			text:  " · " + plural(len(rec.AvailableTools), "tool", "tools") + ": " + strings.Join(rec.AvailableTools, ", "),
+			style: styleDim,
+		})
+	}
+	return paneLine{gutter: gutterHeader, gutterStyle: styleDim, segs: segs}
+}
+
 // toolResultLine renders one outcome under its call.
 func toolResultLine(r apiclient.TranscriptToolResult) paneLine {
 	mark, style := "✓ ", styleOKDim
-	if r.IsError {
+	switch {
+	case r.Blocked:
+		// A call a permission rule refused never ran at all. It gets its own
+		// mark because "the tool failed" and "the tool was not allowed" send
+		// a reader to two different places — one is the agent's problem, the
+		// other is the step's permission mode (task 066).
+		mark, style = "⊘ ", styleErrDim
+	case r.IsError:
 		mark, style = "✗ ", styleErrDim
 	}
 	text := r.Summary
+	if r.Verb != "" {
+		// The verb leads: it is the dialect's own structured account of what
+		// happened, where the summary is the tool's prose about it.
+		text = r.Verb
+		if r.Summary != "" {
+			text += " · " + r.Summary
+		}
+	}
 	if text == "" {
 		// An outcome with nothing to say still says whether it worked, which
 		// is the question a reader is asking.
-		text = "done"
-		if r.IsError {
+		switch {
+		case r.Blocked:
+			text = "blocked"
+		case r.IsError:
 			text = "failed"
+		default:
+			text = "done"
 		}
 	}
 	return paneLine{
@@ -295,4 +343,16 @@ func thinkingBlock(text string, level outputLevel, width int) []string {
 	hidden := len(lines) - thinkingLines
 	return append(lines[:thinkingLines:thinkingLines],
 		gutterNone+styleDim.Render(fmt.Sprintf("… +%d lines (v)", hidden)))
+}
+
+// formatAgentDuration renders a duration the agent itself reported. Under a
+// minute it keeps a decimal, because most agent runs are seconds long and
+// "0s" for a 400 ms turn is worse than no number at all; above that it hands
+// over to the board's own formatter so one duration does not spell two ways.
+func formatAgentDuration(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return formatElapsed(d)
 }

--- a/internal/tui/outputlines_test.go
+++ b/internal/tui/outputlines_test.go
@@ -352,3 +352,192 @@ func TestOutputTitleNamesNonDefaultLevel(t *testing.T) {
 		t.Errorf("title = %q, want it to name the level", got)
 	}
 }
+
+// TestRunHeaderLevels covers the record task 066 added to the pane. It is the
+// run's frame rather than something the agent said or did, so levelCompact —
+// whose stated meaning is "what the agent said and did, nothing else" — does
+// not grow, and it renders identically at normal and verbose.
+func TestRunHeaderLevels(t *testing.T) {
+	d := newTestDetail(t)
+	d.width = 80
+	d.records = []apiclient.TranscriptRecord{{
+		Type:           "agent.run_header",
+		WorkDir:        "/work/repo",
+		AvailableTools: []string{"Task", "Bash", "Write"},
+	}}
+
+	d.level = levelCompact
+	if got := d.outputLines(); len(got) != 0 {
+		t.Errorf("compact rendered the run header: %q", got)
+	}
+
+	var atNormal string
+	for _, level := range []outputLevel{levelNormal, levelVerbose} {
+		d.level = level
+		got := plainLines(d.outputLines())
+		if len(got) != 1 {
+			t.Fatalf("%s = %q, want one line", level, got)
+		}
+		want := "# /work/repo · 3 tools: Task, Bash, Write"
+		if got[0] != want {
+			t.Errorf("%s = %q, want %q", level, got[0], want)
+		}
+		if level == levelNormal {
+			atNormal = got[0]
+		} else if got[0] != atNormal {
+			t.Errorf("verbose = %q, normal = %q: the header does not grow", got[0], atNormal)
+		}
+	}
+}
+
+// TestRunHeaderWrapsRatherThanClips is the case a real run produces: claude
+// hands a step a dozen tools, and the list is past 80 columns before it is
+// half printed. It must fold to the hanging indent, which is the whole reason
+// this pane wraps its own lines.
+func TestRunHeaderWrapsRatherThanClips(t *testing.T) {
+	tools := []string{
+		"Task", "AskUserQuestion", "Bash", "BashOutput", "Edit", "Glob",
+		"Grep", "KillShell", "NotebookEdit", "Read", "TodoWrite", "WebFetch",
+		"WebSearch", "Write",
+	}
+	d := newTestDetail(t)
+	d.width = 80
+	d.level = levelNormal
+	d.records = []apiclient.TranscriptRecord{{
+		Type:           "agent.run_header",
+		WorkDir:        "/work/repo",
+		AvailableTools: tools,
+	}}
+	got := plainLines(d.outputLines())
+	if len(got) < 2 {
+		t.Fatalf("lines = %q, want the tool list wrapped", got)
+	}
+	for i, line := range got {
+		if cols(line) > 80 {
+			t.Errorf("line %d is %d columns: %q", i, cols(line), line)
+		}
+		if i > 0 && !strings.HasPrefix(line, "  ") {
+			t.Errorf("continuation %d = %q, want the hanging indent", i, line)
+		}
+	}
+	// Nothing was dropped on the way: clipping is what this replaces.
+	joined := strings.Join(got, " ")
+	for _, tool := range tools {
+		if !strings.Contains(joined, tool) {
+			t.Errorf("tool %q clipped out of %q", tool, joined)
+		}
+	}
+}
+
+// TestResultMetadataByLevel is the level contract for the enriched result
+// line (task 066). Compact is byte-identical to what it rendered before —
+// the acceptance criterion that "compact does not grow" — normal carries the
+// run's condensed account of itself, and the per-model and cache breakdown is
+// verbose only.
+func TestResultMetadataByLevel(t *testing.T) {
+	cost := 0.02206225
+	modelCost := 0.02206225
+	rec := apiclient.TranscriptRecord{
+		Type:             "agent.result",
+		ResultText:       "all done",
+		CostUSD:          &cost,
+		DurationMS:       7324,
+		APIDurationMS:    5706,
+		NumTurns:         2,
+		StopReason:       "end_turn",
+		TerminalReason:   "completed",
+		CacheReadTokens:  60280,
+		CacheWriteTokens: 6835,
+		ModelUsage: []apiclient.TranscriptModelUsage{{
+			Model: "claude-haiku-4-5", InputTokens: 18, OutputTokens: 536,
+			CacheReadTokens: 60280, CostUSD: &modelCost,
+		}},
+	}
+	d := newTestDetail(t)
+	d.width = 100
+	// An assistant line first, so the result renders its outcome rather than
+	// repeating its text (T4.16).
+	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: "all done"}, rec}
+
+	d.level = levelCompact
+	compact := plainLines(d.outputLines())
+	if compact[len(compact)-1] != "✓ done · $0.02" {
+		t.Errorf("compact = %q, want exactly what it rendered before task 066",
+			compact[len(compact)-1])
+	}
+
+	d.level = levelNormal
+	normal := plainLines(d.outputLines())
+	if got := normal[len(normal)-1]; got != "✓ done · 7.3s · 2 turns · $0.02" {
+		t.Errorf("normal = %q", got)
+	}
+	// The ordinary stop reasons stay off the line: every successful claude
+	// run ends end_turn/completed, so printing them says nothing.
+	for _, line := range normal {
+		if strings.Contains(line, "end_turn") || strings.Contains(line, "completed") ||
+			strings.Contains(line, "cache") || strings.Contains(line, "claude-haiku") {
+			t.Errorf("normal carries a verbose-only detail: %q", line)
+		}
+	}
+
+	d.level = levelVerbose
+	verbose := strings.Join(plainLines(d.outputLines()), "\n")
+	for _, want := range []string{
+		"✓ done · 7.3s (5.7s api) · 2 turns · $0.02",
+		"cache 60280 read / 6835 written",
+		"claude-haiku-4-5 · 18 in / 536 out · 60280 cached · $0.02",
+	} {
+		if !strings.Contains(verbose, want) {
+			t.Errorf("verbose missing %q:\n%s", want, verbose)
+		}
+	}
+}
+
+// TestResultNamesAnUnusualStop covers what the metadata is *for*: a run that
+// hit a limit and one that finished read identically before task 066.
+func TestResultNamesAnUnusualStop(t *testing.T) {
+	d := newTestDetail(t)
+	d.width = 100
+	d.level = levelNormal
+	d.records = []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "working"},
+		{
+			Type: "agent.result", StopReason: "max_tokens", TerminalReason: "interrupted",
+			NumTurns: 1, PermissionDenials: []apiclient.TranscriptPermissionDenial{
+				{ToolName: "Write", CallID: "toolu_02"},
+			},
+		},
+	}
+	got := plainLines(d.outputLines())
+	last := got[len(got)-1]
+	for _, want := range []string{"stop: max_tokens", "interrupted", "1 denied"} {
+		if !strings.Contains(last, want) {
+			t.Errorf("result = %q, want it to carry %q", last, want)
+		}
+	}
+}
+
+// TestBlockedToolResultHasItsOwnMark separates the two verdicts a reader acts
+// on differently: a tool that ran and failed is the agent's problem, a tool a
+// permission rule refused is the step's permission mode.
+func TestBlockedToolResultHasItsOwnMark(t *testing.T) {
+	blocked := plainLines(wrapLine(toolResultLine(apiclient.TranscriptToolResult{
+		Summary: "permission denied", Blocked: true, IsError: true,
+	}), 60))
+	if strings.TrimSpace(blocked[0]) != "⊘ permission denied" {
+		t.Errorf("blocked = %q, want the ⊘ mark", blocked[0])
+	}
+	bare := plainLines(wrapLine(toolResultLine(apiclient.TranscriptToolResult{
+		Blocked: true, IsError: true,
+	}), 60))
+	if strings.TrimSpace(bare[0]) != "⊘ blocked" {
+		t.Errorf("bare blocked = %q, want it to say so", bare[0])
+	}
+	// The verb leads the tool's own prose about what it did.
+	verb := plainLines(wrapLine(toolResultLine(apiclient.TranscriptToolResult{
+		Verb: "created", Summary: "File created successfully at: hello.txt",
+	}), 80))
+	if strings.TrimSpace(verb[0]) != "✓ created · File created successfully at: hello.txt" {
+		t.Errorf("verb = %q", verb[0])
+	}
+}


### PR DESCRIPTION
## Summary

`internal/agent/claude/stream.go` read a deliberately narrow subset of claude's
`stream-json`, and the discarded part was exactly what a reader watching a run
wants. `parseLine` recognized three line types, so the `system`/`init` line fell
through to `EventUnknown`; `parseResult` read five of the result line's ~20
fields; and `parseToolResults` read the `tool_result` blocks inside
`message.content` and never touched the sibling `tool_use_result` /
`tool_result_meta` objects. All of it was in the `2.1.226` fixtures the whole
time — no capture was needed.

**The parser** now reads the run header (`cwd` plus the tool list), the result
line's `duration_ms` / `duration_api_ms` / `num_turns` / `stop_reason` /
`terminal_reason` / cache token split / `modelUsage` / `permission_denials[]`,
the structured tool outcome, and `parent_tool_use_id`. `tool_use_result` decodes
as *either* an object or a bare string — the deny fixture's is
`"Error: no user is available; permission denied"` — so it is probed the way
`resultSummary` already handles claude's two content shapes.

**The wire** moves in one commit, both mappings together. The issue named
`internal/api/transcript.go`; `Runner.publishAgentEvent` is the second mapping,
and the spec records that the two are kept in agreement deliberately — a
difference shows up as output that changes when a step finishes. `format=
normalized` gains an `agent.run_header` record and a richer `agent.result`,
`agent.tool_result` entries gain `verb` and `blocked`, and any record may carry
`parent_call_id`. Every new key is omitted when unreported, so a client tells
"absent" from "zero". `internal/apiclient` carries the same fields for a Go
client, and `vincent task transcript --json` is a raw passthrough of the
record, so both see all of it — but the CLI's **default text** renderer does
not; see the note under the checklist.

**The pane** respects the level model. `compact` is byte-identical to what it
rendered before — that level means "what the agent said and did, nothing else",
and the run's own account of itself is neither. From `normal` up: a `#` run
header, and a result line carrying elapsed, turns, refused calls and an
*unusual* stop reason (`stop: max_tokens` is the difference between a model that
finished and one that ran out; both read as a bare success before). `verbose`
adds the API-time split, the cache read/write split and the per-model breakdown,
on wrapped continuation lines of the same record. A call a permission rule
refused is marked `⊘` rather than `✗` at every level: that is the step's
permission mode, not the agent's problem.

Three limits are deliberate and recorded, not omissions:

- **`parent_call_id` is carried, not rendered.** It is `null` on all eight lines
  of all three captures, so there is nothing to test a tree against, and nesting
  would amend §15's flat two-column gutter — the one thing T4.16 built the pane
  around. Because §13.2 re-normalizes on read, transcripts recorded now will
  render under the nesting when it lands.
- **A verb, not a diff delta.** `ToolResult.Summary`'s doc comment promised
  `"created (+1 −0)"`, but the only fixture with a structured `tool_use_result`
  is a *create* whose `structuredPatch` is `[]`. Guessing at `+N −M` is what
  T4.17 rejected — the delta just never appears, and that is indistinguishable
  from a file that did not change. The verb comes from a table of the types a
  capture has shown; an unobserved type yields none. The unkept doc comment was
  corrected here, in `agent.go` and in §9.1.
- **No migration.** Nothing is persisted on `step_runs`: migrations are
  append-only so a speculative column is expensive to take back, a claude
  `duration_ms` there would be a *second* duration disagreeing with vincent's
  own (claude's excludes what a §7.4 input wait adds to ours), and the columns
  would be claude-only in an adapter-neutral table read by no named client.

Codex and cursor are untouched and emulate nothing. §9.3 and §9.7 now state
positively what each does and does not report — including, honestly, that
cursor's dialect *does* carry `cwd`, `duration_ms` and a cache split that
vincent does not read yet, and codex's carries `cached_input_tokens`. That is
scope, not absence, and the shared vocabulary was designed so they can fill it
later without another wire change.

## Related

Closes #267. Closes 066.1, 066.2, 066.3, 066.4 in
[`docs/tasks/066-claude-stream-json-surface.md`](docs/tasks/066-claude-stream-json-surface.md).

**066.5 is deliberately left open**: an owner walkthrough against a real claude
run. T4.16's own record is explicit that every test it wrote proves a *parser*
and none of them proves a *pane*, and its acceptance was the owner walking the
TUI — the same reason `scripts/m3-gate.sh` seeds instead of asserting. This
change adds two record shapes to that pane, so the unit tests below are
necessary and not sufficient. The task document carries the walkthrough table.

This **continues** two recorded decisions rather than revisiting any: T4.14's
tool subjects and T4.16's outcomes-not-bodies rule are both respected — the
tool's output body stays out of the normalized stream and the transcript remains
the durable copy. The T4.17 no-guessing rule is applied rather than relitigated.
The one thing corrected is a doc comment that had promised an edit delta since
T4.14 and never delivered one.

Spec amended in place, dated 2026-08-31: §9.1 (the new members and the corrected
`ToolResult.Summary` comment), §9.2, §9.3, §9.7, §13.2, §13.3, §15. No §14
amendment — nothing is persisted.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

### Two things the documentation audit found and did not fix

Both are code, in files a documentation commit must not touch. Neither blocks
the wire or the pane; both are small follow-ups on this branch.

1. **`internal/tui/bindings.go:198` was not updated with the pane.** The `v`
   key's palette label still reads *"compact → normal → verbose (reasoning,
   then unrecognized lines)"*. `normal` now also adds the run header and the
   result metadata, and `docs/guides/tui.md` says so — so the in-app help and
   the documented key table now disagree, on a table that is supposed to be
   derived from that label. The label wants the run's own metadata named in it.

2. **`vincent task transcript`'s default text output renders none of the new
   material.** `internal/cli/transcript.go` was not part of the change:
   `agent.run_header` falls through `renderTranscriptRecord`'s `default:` arm
   and is dropped silently, `renderTranscriptResult` prints no duration, turns,
   stop reason or denial count, and — the one that matters — a **blocked** call
   is rendered with the `!` error mark, which is precisely the conflation `⊘`
   was introduced to end. `--json` is unaffected (it re-emits `rec.Raw`), and
   so is the TUI. `docs/reference/cli.md` needed no correction: it describes
   that output as an explicit enumeration which is still accurate, and
   `agent.thinking` was already dropped there before this change.

### Documentation audit

Every derivation `CLAUDE.md` names was checked against its source. `internal/
config`, the cobra tree, `internal/api/server.go`'s route table, the `Reason*`
constants, `internal/workflow` and the step types are all untouched by this
change, so `configuration.md`, `cli.md`, the route table, the block-reason
tables, `workflow-schema.md`, `task-lifecycle.md` and
`skills/vincent-workflows/SKILL.md` needed nothing — no step type, field,
validation rule or template variable moved, so the skill is not part of this
pull request. §9.1's type listing was verified field for field against
`internal/agent/agent.go`, §15's per-level account against `resultOutcome` /
`resultBreakdown` / `toolResultLine`, §13.3's per-task-only chunk list against
`publishAgentEvent`, and every new wire key in `api.md` name for name against
`normalizedLine`, `resultLine`, `modelUsageLine` and `permissionDenyLine`. No
`docs/assets/tui-*.png` captures the Output tab, so no screenshot went stale.
`docs/gates/m3-gate.md`'s L7 walks the pane for live arrival and `f`/`G`
re-follow, which this change does not touch; the pane's new records are 066.5's
walkthrough.

Two pages moved:

- **`docs/features.md`** — the adapters table's Claude Code row stopped at
  "mid-run questions"; it now names the run reporting that is claude's alone.
- **`docs/reference/api.md`** — rewrapped the sentence this change lengthened
  in "Live output — ephemeral". No claim changed.

### What the tests prove

- `internal/agent/claude/stream_test.go`, off the existing fixtures: the result
  line's duration, API duration, turns, stop and terminal reason, cache counts,
  per-model usage and the deny fixture's single `permission_denials` entry; the
  init line normalizing to a run header carrying `cwd` and its five tools,
  exactly once per run; the allow fixture's `created` verb; the deny fixture's
  `permission-rule` yielding a blocked outcome rather than an error string, *and*
  its string-shaped `tool_use_result` not derailing the object decode; an
  unobserved `tool_use_result.type` yielding no verb; `parent_tool_use_id` empty
  across all three captures and read correctly on a synthetic line that has one.
- A `system` line with an unknown `subtype` and a line with an unmodelled `type`,
  both still `EventUnknown` with `Raw` intact — the phase 1 tolerant-parsing
  decision asserted rather than assumed.
- `internal/taskrun/chunks_test.go` — the header chunk's shape and the result
  chunk's new keys, extending the parity test T4.16 wrote for exactly this.
- `internal/api/transcript_test.go` — the new wire names round-trip, and a result
  reporting none of them emits none of the keys.
- `internal/tui/outputlines_test.go` — the new records at all three levels,
  including that `levelCompact`'s result line is byte-identical to what it was,
  and that a header whose tool list overflows 80 columns wraps to the hanging
  indent rather than clipping.
- `internal/agent/codex` and `internal/agent/cursor` —
  `TestNoRunHeaderOrResultMetadata` asserts over every existing fixture that
  neither adapter produces a run header or fills any new field.

`go run mage.go test` and `go run mage.go lint` are green, and the linter was
run host-built against `GOOS=windows`, `darwin` and `linux` — 0 issues on each.

### One note on the title

`CLAUDE.md` and the `PR title` workflow require a plain-language PR title and
**reject** a Conventional Commit prefix on one, because GitHub copies the title
into the merge commit body and Release Please would then record both the merge
and the matching inner commit. The title above is therefore plain language; the
commit itself is `feat(agent): …`.
