### PR TITLE
Add a chats board and a chat workspace to the TUI, and bound a chat turn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,12 @@ jobs:
       - name: M13 gate (workflow editor)
         shell: bash
         run: ./scripts/m13-gate.sh
+
+      # M14: a chat end to end (task 067, closing 063.2; §5.5, §11, §13.2,
+      # §13.3). The three-OS matrix earns its keep here too: a chat's whole
+      # premise is an agent CLI resuming a session it wrote to disk, and the
+      # per-chat SSE stream and the transcript route are read back with the
+      # platform's own line endings.
+      - name: M14 gate (chats end to end)
+        shell: bash
+        run: ./scripts/m14-gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,7 @@ list with the user-facing context a commit subject cannot carry.
   gap the feature was asked for: a conversation held outside vincent leaves no
   record at all. Drive one with `vincent chat start|send|list|show|archive`, or
   over the API. Mid-run questions use the existing §7.4 flow verbatim; answering
-  one is `POST /v1/chats/{id}/answer`, which has no `vincent chat` subcommand
-  yet.
+  one is `vincent chat answer` or `POST /v1/chats/{id}/answer`.
 
   Two limits worth knowing before you reach for it. **codex and cursor cannot
   hold a chat**: creating one on either is refused with `400
@@ -38,9 +37,7 @@ list with the user-facing context a commit subject cannot carry.
   it. A stored session the CLI no longer knows fails that turn with
   `session_lost` and leaves the chat usable, for the same reason: a silently
   fresh session answers as if it had context it does not have, and you could
-  not tell that apart from a working conversation. And **there is no chats view
-  in the TUI yet** — chats are driven from `vincent chat` and the API in this
-  release.
+  not tell that apart from a working conversation.
 - **`max_parallel_chats` (default 3).** Chats are bounded by their own cap,
   counted independently of `max_parallel_tasks`: a running chat consumes no task
   slot and never delays an admissible task. A `send` over the cap is refused
@@ -50,6 +47,48 @@ list with the user-facing context a commit subject cannot carry.
 - **`--resume` for the claude adapter.** `RunSpec.ResumeSessionID` and
   `RunResult.SessionID`, plus the `agent.Resumer` capability. Only chat turns
   set it; every workflow step still gets a fresh session, unchanged.
+- **Chats in the TUI: a chats board and a chat workspace.** Reached from the
+  command palette. The board lists every conversation grouped by project, with
+  its state, agent, last activity and title; `enter` opens the workspace, `n`
+  starts a chat, `a` archives one, `/` filters and `←`/`→` fold a project group.
+  It is a *second* board rather than rows on the first, because a chat has no
+  workflow, no step `k/n` and none of the task actions — and a chat has never
+  appeared on the task board by design.
+
+  A chat waiting on you is pinned to the top of the chats board and counted in
+  *its* header. `!` and the task board's needs-attention count stay task-only,
+  so nothing about the task board moves.
+
+  The workspace is the conversation: finished turns above, the running turn's
+  live output below, a composer at the bottom. `enter` sends, `ctrl+x` stops the
+  live turn. When the agent asks something mid-turn you get **the same popup a
+  task's question opens** — same options, same multi-select, same allow/deny —
+  and answering it from `vincent chat answer` or the API closes it here too. A
+  send refused because the cap is full says so and creates nothing: it is a
+  refusal, not a queue.
+- **`GET /v1/chats/{id}/events` and `GET /v1/chats/{id}/turns/{seq}/transcript`.**
+  A per-chat SSE stream — that chat's events plus its live output, filtered so a
+  task's never leak onto it and vice versa — and the turn's durable record, with
+  the step transcript's `?offset=`/`?tail=` contract and `X-Next-Offset`. A turn
+  is named by its `seq` because a chat turn is its own run. Neither is an MCP
+  tool: the whole chat family stays off the tool surface.
+- **`vincent chat answer` and `vincent chat cancel`, and `--json` on every
+  `vincent chat` subcommand.** Interrupting `vincent chat send` stops the CLI,
+  not the turn — the turn belongs to the daemon — so `cancel` is what ends one,
+  and `answer` is what moves a parked chat on without curl. `chat show` now
+  prints a parked chat's questions, numbered, which are the numbers
+  `chat answer --answer N=VALUE` reads.
+- **Chat turns are bounded by `agent_timeout` and `input_timeout`.** The same
+  two clocks a workflow step gets, applied verbatim: a turn that runs past
+  `defaults.agent_timeout` fails `timeout`, and a chat left in `awaiting_input`
+  past `defaults.input_timeout` fails `input_timeout`. Either kills the process
+  tree, returns the chat to `idle` and **releases its `max_parallel_chats`
+  slot** — which is what a chat you walked away from used to hold forever, with
+  nothing that would ever make a `409 chat_cap_reached` succeed. There is no
+  chat-specific setting and no per-turn override; the numbers are the ones you
+  already tune. `transcript_max_bytes` applies to a turn's transcript the same
+  way, and `transcript_retention_days` now reclaims an **archived chat's**
+  transcripts, which it previously walked straight past.
 
 - **Run a task's steps inside a container.** A new `container:` block in
   `config.yaml` names an image, and a task's step processes run inside **one**
@@ -430,6 +469,15 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **Writing a chat's session id crashed every open event stream.** The store
+  publishes an event after each write, and the three chat columns no client is
+  told about — session id, worktree path, pending input — handed it a `nil`
+  instead of skipping the publish. Every SSE subscriber dereferences the event
+  it is handed, so finishing the first turn of any chat panicked
+  `GET /v1/events`, and any per-task stream, for everyone connected; the
+  connection dropped with a `500` mid-stream and reconnected into the next
+  crash. A `nil` is now dropped where it is produced rather than guarded in each
+  handler, since "there is no event to announce" is the publisher's business.
 - **New task fell back to `adhoc` for a project whose `default_workflow` lives in
   its own `.vincent/workflows/`.** The form loads its workflow catalog before a
   project is selected, so that first, unscoped listing cannot contain a

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ It is released under the [MIT License](LICENSE) and created by `lezli01` at
 | **Verification and recovery** | Checks decide whether work succeeded, retries receive the real failure, timeouts are enforced, transcripts are durable, and interrupted steps recover after a daemon restart. |
 | **Human control where it matters** | Pause at approval gates, answer supported agents mid-run, inspect file-grouped diffs, edit and retry blocked steps, and decide when publishing happens. |
 | **A TUI built for active workloads** | Use a grouped task board, guided task creation, project and workflow workspaces, bulk actions, live output, cost and duration metrics, and a navigable workflow graph. |
-| **Automation-ready interfaces** | Every operation is available through the localhost REST + SSE API, and all but a chat's answer and cancel have a CLI subcommand too. `--json`, stable exit codes, and offline workflow validation make scripting and CI practical. |
+| **Automation-ready interfaces** | Every operation is available through CLI subcommands and a localhost REST + SSE API. `--json`, stable exit codes, and offline workflow validation make scripting and CI practical. |
 | **Drivable by an agent over MCP** | The daemon serves the Model Context Protocol on the same listener, so any MCP client gets the API as tools with discovery, schemas, typed errors, and one bounded call that waits for a task. Vincent's own agent steps are wired in by default. |
 | **Cross-platform delivery** | Run the same single binary on Windows, macOS, and Linux through Homebrew, WinGet, Scoop, mise, deb/rpm packages, or release archives. |
 
@@ -207,7 +207,7 @@ vincent workflow render .vincent/workflows/feature-pr.yaml
 vincent config get                         # or set max_parallel_tasks 6
 ```
 
-Every subcommand except `vincent chat` takes `--json` for scripting. Exit codes are `0` success,
+Every subcommand takes `--json` for scripting. Exit codes are `0` success,
 `1` the request was rejected — by the daemon, or by a daemon-free command such as
 `workflow validate` on an invalid file — and `2` no daemon answered
 — so a script can tell "start the daemon" from "fix your request" without

--- a/docs/features.md
+++ b/docs/features.md
@@ -61,9 +61,13 @@ starts the moment you send it, bounded only by its own
 that it is refused immediately rather than queued behind batch work, which is
 the wait a chat exists to avoid.
 
-Drive one with [`vincent chat`](reference/cli.md#vincent-chat) or the
-[`/v1/chats` routes](reference/api.md#chats). There is no chats view in the TUI
-yet, and no chat route is exposed as an MCP tool.
+Drive one from the TUI's own **chats board and chat workspace**
+([guide](guides/tui.md#chats)), from
+[`vincent chat`](reference/cli.md#vincent-chat), or over the
+[`/v1/chats` routes](reference/api.md#chats). A chat turn is bounded by the same
+`agent_timeout` and `input_timeout` a workflow step is, so a conversation
+nobody comes back to gives its slot up rather than holding it forever. No chat
+route is exposed as an MCP tool.
 
 ## Express the workflow the work needs
 

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -136,9 +136,10 @@ Two guarantees make it safe to pipe into `jq`:
 vincent task ls --state blocked --json | jq -r '.[] | "\(.id)\t\(.title)"'
 ```
 
-The exception is [`vincent chat`](../reference/cli.md#vincent-chat), which has
-no `--json` on any of its subcommands — it prints for a person. Script chats
-against [`/v1/chats`](../reference/api.md#chats) directly.
+[`vincent chat`](../reference/cli.md#vincent-chat) carries `--json` on every
+subcommand too. `chat send --json` emits the finished turn, so a script reads
+the answer and the accounting off one object and still exits 1 when the turn
+failed.
 
 `vincent task show <id> --json` carries two fields worth knowing about:
 `available_actions`, which is what the daemon will accept right now — read it

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -956,6 +956,13 @@ you straight into the workspace. Only an agent that can resume its own session
 can hold a chat, and picking one that cannot is refused on the form with that
 reason, not with a generic failure.
 
+| Key | Does, in the create form |
+|---|---|
+| `tab` / `shift+tab` | Next / previous field |
+| `←` / `→` | Choose on the project and agent fields |
+| `ctrl+s` | Create the chat and open it |
+| `esc` | Discard the draft |
+
 ### Chat workspace
 
 One conversation: the finished turns above, the running turn's live output below

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -924,6 +924,63 @@ the picture never moves under you while you are reading it.
 select nodes. There is no `e` or `R`: a snapshot has no file to open and no
 registry entry to re-read.
 
+### Chats
+
+A second board, for [chats](../reference/cli.md#vincent-chat) — conversations
+with an agent, each in its own worktree. Chats are not tasks and never appear on
+the task board, so they get a board of their own: one row per conversation, with
+its id, state, agent, last activity and title, grouped by project.
+
+Grouping is by project only: `tui.board.group_by`'s workflow levels mean nothing
+for a chat, which runs no workflow, so `g` is not offered here. Folds persist in
+`{data_dir}/tui.json` separately from the task board's, so folding a project
+here does not fold it there.
+
+A chat waiting on you is sorted to the top and counted in this header's badge —
+**and nowhere else**. `!` and the task board's needs-attention count stay
+task-only.
+
+| Key | Does |
+|---|---|
+| `enter` | Open the chat's workspace |
+| `n` | Start a chat in the project you are looking at |
+| `a` | Archive the chat — asks first, and re-offers with the force when the worktree is dirty |
+| `/` | Filter by title, agent or branch |
+| `←` / `→` | Collapse or expand a project group |
+| `r` | Reload the board |
+
+`n` is the one key whose meaning depends on where you are: on this board it
+starts a chat, everywhere else it opens the new-task form. The create form takes
+project, title, agent, model, effort and base branch; `ctrl+s` creates and drops
+you straight into the workspace. Only an agent that can resume its own session
+can hold a chat, and picking one that cannot is refused on the form with that
+reason, not with a generic failure.
+
+### Chat workspace
+
+One conversation: the finished turns above, the running turn's live output below
+them, and a composer at the bottom.
+
+| Key | Does |
+|---|---|
+| `enter` | Send the message |
+| `ctrl+x` | Stop the running turn — its process tree is killed |
+| `esc` | Back to the chats board |
+
+When the agent asks something mid-turn, the chat enters `awaiting_input` and
+**the same popup a task's question opens** appears here — same options, same
+multi-select, same allow/deny for a permission request. Answering it from
+`vincent chat answer` or over the API closes it here too: the popup follows the
+chat's state rather than its own.
+
+A send refused because `max_parallel_chats` chats are already running says so
+and creates nothing. It is a refusal, not a queue: finish or stop another
+conversation and send again.
+
+A turn that runs past `agent_timeout`, or sits unanswered past `input_timeout`,
+fails and returns the chat to `idle` — the slot comes back rather than being
+held by a conversation nobody came back to.
+
 ### Daemon
 
 Version, uptime, the config in effect, the adapters detected, and a live tail of

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1286,7 +1286,13 @@ POST   /v1/chats/{id}/send            start a turn
 POST   /v1/chats/{id}/answer          answer a mid-run request
 POST   /v1/chats/{id}/cancel          stop the live turn
 POST   /v1/chats/{id}/archive         remove the worktree; terminal
+GET    /v1/chats/{id}/events          SSE: this chat's events plus its live output
+GET    /v1/chats/{id}/turns/{seq}/transcript
+                                      one turn's transcript, with ?offset= / ?tail=
 ```
+
+None of these is an [MCP tool](#the-mcp-endpoint) — the whole family is
+excluded, the stream and the transcript included.
 
 ### Creating one
 
@@ -1335,10 +1341,34 @@ The chat is left exactly as it was: still `idle`, with no turn row behind it.
 Each turn carries the accounting a step run does — `input_tokens`,
 `output_tokens`, `cost_usd`, `exit_code`, `duration_ms` — plus `session_id`, the
 session it actually ran in, and its own transcript at
-`{data_dir}/transcripts/chat-{chat_id}/{seq}.jsonl`. That file is not served by
-any route: [`/v1/tasks/{id}/transcript`](#transcripts-and-diffs) is task-only,
-and a chat's is read from disk. A turn is `running`, then `done`, `failed` or
-`interrupted`, forever.
+`{data_dir}/transcripts/chat-{chat_id}/{seq}.jsonl`. A turn is `running`, then
+`done`, `failed` or `interrupted`, forever.
+
+```bash
+curl -sS "http://127.0.0.1:PORT/v1/chats/3/turns/2/transcript?offset=0" \
+  -H "Authorization: Bearer $TOKEN" -D -
+```
+
+The turn is named by its **`seq`**, not by a run id: a chat turn is its own run.
+`?offset=` and `?tail=` are mutually exclusive, the body always covers whole
+records, and `X-Next-Offset` names where the next fetch resumes — the same
+contract [a step's transcript](#transcripts-and-diffs) has. Add
+`?format=normalized` for vincent's own vocabulary instead of the agent's
+dialect.
+
+### Following one
+
+```bash
+curl -N http://127.0.0.1:PORT/v1/chats/3/events -H "Authorization: Bearer $TOKEN"
+```
+
+This chat's durable `chat.*` events interleaved with its live output — the
+[per-task stream](#events-sse)'s shape for a chat. Another chat's events do not
+arrive on it and neither do a task's. `Last-Event-ID` resumes the durable
+events; live output is ephemeral and is never replayed, so a reconnect catches
+up by re-fetching the running turn's transcript and discarding every chunk whose
+`offset` is at or before the `X-Next-Offset` it reported. Chunks carry
+`chat_id`, `turn_id`, `offset` and the agent's own `raw` line.
 
 Two failure reasons are worth knowing:
 
@@ -1350,6 +1380,12 @@ Two failure reasons are worth knowing:
 - **`interrupted`** — the daemon restarted under a live turn. It is **not**
   re-run, unlike a task's step: re-running would re-send your message into a
   session that died with the process. The chat returns to `idle`.
+- **`timeout` / `input_timeout`** — the turn ran past
+  [`defaults.agent_timeout`](configuration.md#defaults), or the chat sat in
+  `awaiting_input` past `defaults.input_timeout`. The process tree is killed,
+  the chat returns to `idle` and its `max_parallel_chats` slot is released. The
+  two clocks are the ones a workflow step gets, with no chat-specific key and
+  no per-turn override.
 
 ## Step status
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1482,9 +1482,12 @@ are excluded — a documented limitation.
 ```
 GET /v1/events?types=&project_id=
 GET /v1/tasks/{id}/events
+GET /v1/chats/{id}/events
 ```
 
-Two kinds of stream, with deliberately different guarantees.
+Two kinds of stream, with deliberately different guarantees. The per-chat one is
+the per-task one's twin, over a [chat](#chats) instead of a task, and is
+documented there.
 
 ### State events — durable
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1025,6 +1025,7 @@ the log as prompt context.
 
 ```sh
 vincent chat start TITLE --project ID [--agent NAME] [--model M] [--effort E]
+                  [--base BRANCH] [--message TEXT] [--json]
                          [--base BRANCH] [--message TEXT]
 ```
 
@@ -1035,7 +1036,7 @@ turn straight away and waits for it, which is `start` plus `send` in one call.
 ### `vincent chat send`
 
 ```sh
-vincent chat send CHAT_ID MESSAGE
+vincent chat send CHAT_ID MESSAGE [--json]
 ```
 
 Sends a message and blocks until the turn ends, then prints the agent's answer
@@ -1044,38 +1045,68 @@ on stdout. A failed turn prints its reason on stderr and exits 1 — including
 was resuming. The chat stays usable; starting a fresh conversation is a
 decision you make, not one vincent makes silently.
 
-There is **no `vincent chat answer`**. If the agent asks a question mid-turn the
-chat enters `awaiting_input` and the send keeps waiting, because the turn has
-not ended; answering it means calling `POST /v1/chats/{id}/answer`
-[over the API](api.md#chats). Nothing bounds that wait today — a chat turn has
-no timeout of its own — so an unanswered question leaves the turn live in the
-daemon and the send waiting on it. Interrupting `vincent chat send` stops the
-polling, not the turn; `POST /v1/chats/{id}/cancel` is what ends it.
+If the agent asks a question mid-turn the chat enters `awaiting_input` and the
+send keeps waiting, because the turn has not ended. Answer it from another
+terminal with [`vincent chat answer`](#vincent-chat-answer).
+
+A chat turn is bounded by the same two clocks a workflow step is: it fails with
+`timeout` past `defaults.agent_timeout` (60 minutes by default) and with
+`input_timeout` if nobody answers within `defaults.input_timeout` (24 hours).
+Either expiry kills the process, returns the chat to `idle` and releases its
+`max_parallel_chats` slot.
+
+Interrupting `vincent chat send` stops the polling, not the turn: the turn
+belongs to the daemon. [`vincent chat cancel`](#vincent-chat-cancel) is what
+ends it.
 
 Exits 1 with `chat_cap_reached` when `max_parallel_chats` chats already hold a
 live agent process. The send is refused, never queued.
 
+### `vincent chat answer`
+
+```sh
+vincent chat answer CHAT_ID (--answer N=VALUE... | --allow | --deny) [--json]
+```
+
+Answers the request an `awaiting_input` chat is parked on; the turn resumes in
+place. Questions are answered by the number `vincent chat show` prints them
+under — repeat `--answer` for one index to give a multi-select several values —
+and a permission request takes `--allow` or `--deny`. It is `vincent task
+answer` for a chat, flag for flag, because it is the same request.
+
+### `vincent chat cancel`
+
+```sh
+vincent chat cancel CHAT_ID [--json]
+```
+
+Stops the chat's live turn and kills its process tree, returning the chat to
+`idle` and releasing its slot. This is what `send` cannot do by being
+interrupted.
+
 ### `vincent chat list`
 
 ```sh
-vincent chat list [--project ID]
+vincent chat list [--project ID] [--json]
 ```
 
-One line per chat: id, state, agent, title.
+One line per chat: id, state, agent, title. `--json` emits the chat objects.
 
 ### `vincent chat show`
 
 ```sh
-vincent chat show CHAT_ID
+vincent chat show CHAT_ID [--json]
 ```
 
 The chat's header and every turn in order, with each turn's prompt, answer and
-— where it failed — its reason.
+— where it failed — its reason. A chat parked in `awaiting_input` prints the
+request first, with its questions numbered: those are the numbers
+`vincent chat answer --answer N=VALUE` reads.
 
 ### `vincent chat archive`
 
 ```sh
-vincent chat archive CHAT_ID [--force]
+vincent chat archive CHAT_ID [--force] [--json]
 ```
 
 Removes the chat's worktree and, under `delete_empty_branch_on_archive`, an

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1026,7 +1026,6 @@ the log as prompt context.
 ```sh
 vincent chat start TITLE --project ID [--agent NAME] [--model M] [--effort E]
                   [--base BRANCH] [--message TEXT] [--json]
-                         [--base BRANCH] [--message TEXT]
 ```
 
 Starts a chat and prints its id, agent and branch. `--agent` defaults to the

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -55,7 +55,8 @@ max_parallel_tasks: 3
 # branch_template: "vincent/{{.ID}}-{{.Slug}}"
 
 # Fallback step timeouts, used when a workflow step declares none.
-# input_timeout bounds each wait for an answer to an agent's input request
+# input_timeout bounds each wait for an answer to an agent's input request.
+# Both clocks bound a chat turn as well as a workflow step.
 # (awaiting_input, §7.4); on expiry the attempt fails under the retry policy.
 defaults:
   agent_timeout: 60m
@@ -411,15 +412,21 @@ strings (`45m`, `1h30m`, `90s`) and all must be positive.
 
 | Key | Applies to |
 |---|---|
-| `agent_timeout` | One attempt of an agent step |
+| `agent_timeout` | One attempt of an agent step, **and one chat turn** |
 | `command_timeout` | One attempt of a command step, and checks |
-| `input_timeout` | Each wait in `awaiting_input` — measured **per request**, so a new question starts a fresh window |
+| `input_timeout` | Each wait in `awaiting_input` — measured **per request**, so a new question starts a fresh window — on a task **and on a chat** |
 
 A timed-out process is killed and the attempt counts as a failure under the
 normal retry policy. The step clock **pauses** while a task is
 `awaiting_input`: it measures agent work, not human latency.
 
 Workflow `defaults:` and per-step fields override these.
+
+A [chat](cli.md#vincent-chat) turn gets `agent_timeout` and `input_timeout`
+verbatim, with the same pause rule and **no override**: `defaults:` and per-step
+fields are workflow things, and a chat has no workflow. An expiry fails the turn
+with `timeout` or `input_timeout`, kills the process tree, returns the chat to
+`idle` and releases its `max_parallel_chats` slot.
 
 ### `delete_empty_branch_on_archive`
 
@@ -552,10 +559,11 @@ reboots rather than only on the restarts it no longer has.
 
 Task and step rows are **never** deleted — only the transcript files.
 
-**Chats are outside this.** The pruner walks archived *tasks*, so an archived
-[chat](cli.md#vincent-chat)'s turn transcripts under
-`{data_dir}/transcripts/chat-{chat_id}/` are kept until you delete them
-yourself.
+This covers [chats](cli.md#vincent-chat) too: an archived chat's turn
+transcripts under `{data_dir}/transcripts/chat-{chat_id}/` are pruned on the
+same pass, under the same setting, measured from when the chat was archived. A
+chat that was never archived keeps its transcripts however old it is, exactly as
+a task does. Chat and turn rows are never deleted either.
 
 That same pass also drops
 [idempotency keys](api.md#transport-and-auth) older than a fixed 24 hours. This
@@ -572,7 +580,8 @@ Per-attempt transcript cap. Written as a human size (`512MB`, `1GB`, `4096` for
 bare bytes); suffixes are binary multiples.
 
 Past the limit, the transcript latches, later writes are dropped, the process
-tree is killed, and the step fails with `transcript_limit`. The tripping
+tree is killed, and the step — or the [chat](cli.md#vincent-chat) turn, which
+the same cap bounds — fails with `transcript_limit`. The tripping
 annotation is written whole and bypasses the cap, so the file records *why* it
 ends — a half-written line would turn a size failure into a parse failure for
 every later reader.

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -170,9 +170,11 @@ Transcripts are bounded by `transcript_max_bytes` per attempt and pruned for
 **archived** tasks past `transcript_retention_days` — see
 [Configuration](configuration.md).
 
-Both of those are **task-scoped**. A chat's turn transcripts are written with no
-size cap and are not pruned when the chat is archived; they stay until you
-remove them.
+Both of those cover a [chat](cli.md#vincent-chat) too: a turn's transcript is
+capped by `transcript_max_bytes`, and an **archived** chat's directory under
+`transcripts/chat-{chat_id}/` is reclaimed by the same retention pass, measured
+from when the chat was archived. A chat nobody archived keeps its transcripts
+however old they are, exactly as a task does.
 
 **What reclaims a transcript.** Retention, for as long as the task row exists.
 Deleting a project deletes its task rows, and retention walks rows — so those

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3733,6 +3733,16 @@ tui:                           # view preference; the daemon validates and relay
     group_by: [project, workflow]  # task-table grouping, outermost first; [] = flat
 ```
 
+*Amended 2026-08-31 (task 067, issue #269).* Four of these keys reach **chats**
+(§5.5) as well as tasks, and none of them gains a chat-specific twin:
+`defaults.agent_timeout` bounds a running turn and `defaults.input_timeout` an
+`awaiting_input` one, either expiry failing the turn and releasing its
+`max_parallel_chats` slot (§11, §13.2); `transcript_max_bytes` caps a turn's
+transcript and fails it `transcript_limit`; and `transcript_retention_days`
+reclaims an **archived** chat's transcripts on the same pass as an archived
+task's (§17). `notify:` stays the one exception, silent on chats for the reason
+its own comment gives.
+
 **`container:` (task 061, added 2026-08-30).** `image` is the whole switch and
 `""` is the default: no image means every step runs on this host, no runtime is
 consulted, and an existing installation is byte-for-byte unchanged. Set it and
@@ -6768,7 +6778,11 @@ global cursor config is untouched.
   small, and useless once the retry window it covers has passed, so there is no
   operator reason to keep one. The table is counted in
   `GET /v1/doctor`'s `database.table_rows` like every other, by enumeration
-  rather than by name.
+  rather than by name. *Amended 2026-08-31 (task 067, issue #269):* an
+  **archived chat**'s turn transcripts (§5.5) are pruned by the same pass under
+  the same key, measured from when the chat was archived. The pruner walked
+  archived tasks alone until then, so a chat's transcripts outlived every
+  retention window.
 - **Entry point** (*added 2026-08-15, task 005*): `vincent doctor` and
   `GET /v1/doctor`. Everything above answers "what happened to this task"; the
   question that had no surface at all was "why is nothing running?", which took

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,7 +132,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 26 | GitHub issue linking | **Read-only, daemon-side.** A task may be created *from* a GitHub issue when the project's `origin` parses as a github.com repository and `github.enabled` is on. The daemon prefers the `gh` CLI and falls back to `GITHUB_TOKEN`/`GH_TOKEN` from its inherited environment; **vincent stores no credential**, keeping §2's secret-management non-goal intact. The issue is fetched **once at creation**, snapshotted onto the task and never re-fetched, so `.Issue` (§8.4) renders offline and a run stays reproducible. The daemon makes every call — at pick time and create time only, never in the step path — and nothing here writes to GitHub, so row 11 is untouched (§5.3, §8.4, §12.3, §13.2, §14, §15; task 035, added 2026-08-26). *Narrowed 2026-08-29 (task 052):* this row is about **issues**; pull requests are row 27, which stores a pointer rather than a snapshot and reverses nothing here |
 | 27 | GitHub pull requests | **Read-only, daemon-side**, like row 26 and through the same gate and credential. A project's **open** pull requests are listed on demand, and a task is linked to the pull request whose head branch equals its own `branch_name` — by a daemon-side reconciler on a `github.poll_interval` tick, never as a side effect of a GET. Only the *link* is stored (`github_pull_json`: repo, number, source, suppressed) and it is a **pointer, not a snapshot** — the deliberate opposite of row 26, because draft, state and merged status are live by nature and a stored copy of them would read exactly like a current one while being wrong. A human may link or unlink; a human unlink is *sticky* and the reconciler never re-applies it, never overwrites a human link and never un-suppresses one. **Row 11 stands unamended**: vincent pushes nothing, opens nothing and merges nothing, and the “create a PR” affordance is a *constructed* compare URL — no request is made to GitHub when it is built — that a human clicks. `internal/github` gains no write method, no `POST` and no mutating `gh` subcommand. Task 035 decision 5's “repo identity is not stored” was revisited exactly as it predicted: the identity landed on the **task**, beside the number, and no `github_repo` column was added to projects (§5.3, §12.3, §13.2, §13.3, §14, §20; task 052, added 2026-08-29). *Narrowed 2026-08-30 (task 064):* the read-only posture holds in full — no write method, no `POST`, no mutating `gh` subcommand — and a task may now be created **from** a pull request and run on its head branch. That adds a flag to the same envelope (`branch`, `fork`) rather than a snapshot: nothing renderable is stored, so "a pointer, never a snapshot" is unchanged, and there is still no `.Pull` template variable. The consequences live in §10 (a second worktree creation mode, and archive never touching a branch vincent did not cut) and in §5.3's branch-name chain, which gains `pull` above the per-task literal. The listing above is narrowed the same way: it still **defaults** to open, but `?state=` (§13.2) makes a closed or merged pull request reachable, because acting on a merged one and redoing a reverted one are exactly what creating a task from one is for |
 | 28 | MCP from the daemon | **A second protocol on the existing listener, not a second server.** `/mcp` is registered in §13.2's route table inside the same `recover → log → auth` chain, so row 4 is *added to*, not reversed: same loopback listener, same `Authorization: Bearer {token}` from `{data_dir}/token`, same `daemon.json` discovery. The tool surface **is** the route table — a call replays its arguments as an in-process request against the same handler, so the §13.1 bounds, the validation, the `409` + `details.state` envelopes and `Idempotency-Key` hold by construction — **minus five destructive-admin routes** (`daemon/stop`, `daemon/backup`, `DELETE projects/{id}`, `maintenance/gc`, `doctor/fix`), which is a design line: an agent must not be able to stop, garbage-collect or reconfigure the daemon supervising it. §13.3's SSE routes are replaced by a bounded blocking `task_wait` with a hard ceiling, whose result is complete for a client that drops every progress notification. A step parked in that wait **keeps its §11 slot** and a self-blocking wait is *refused*, not released — releasing it would create a §6 state owning a live agent process and holding no slot, which no state does today. The daemon wires its own agent steps to a **per-step endpoint** (`/mcp/step/{run_id}`, per-run secret), which is identity for the refusal and the provenance column and is explicitly **not** a security boundary (§16). Recursion is bounded by `created_by_task_id` + `mcp.max_depth`/`mcp.max_tasks`, deliberately **not** by `parent_task_id`, which the `awaiting_children` join counts (§9.1, §9.2, §9.3, §9.4, §9.7, §11, §12.3, §12.4, §13.4, §14, §16, §20; task 057, issue #243, added 2026-08-29) |
-| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30) |
+| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15) |
 
 ## 4. Architecture
 
@@ -516,7 +516,7 @@ chats too — the same objection that kept a `kind` column off `tasks`.
 |---|---|
 | `idle` | no live turn; the state a chat is created in and the one every finished turn returns it to |
 | `running` | a live turn: an agent process is up, owned by the chat's runner goroutine |
-| `awaiting_input` | a turn holding its process while the agent waits on a §7.4 request. It **holds** its cap slot, for §6's reason: the process is alive on its stdin |
+| `awaiting_input` | a turn holding its process while the agent waits on a §7.4 request. It **holds** its cap slot, for §6's reason: the process is alive on its stdin. *Amended 2026-08-31 (task 067, issue #269): that hold is now **bounded** by `defaults.input_timeout` — the wait expires, the turn fails `input_timeout`, the process tree is killed and the chat returns to `idle`, releasing the slot* |
 | `archived` | the only terminal state. The worktree is gone; nothing further can run in it |
 
 Human actions: `send` (idle → running), `answer` (awaiting_input → running),
@@ -3284,6 +3284,18 @@ changed from step to turn. So a chat turn is counted; what differs is only that
 the response to a full cap is a refusal a human sees rather than a queue a
 human waits in.
 
+*Amended 2026-08-31 (task 067, issue #269).* A chat's slot is now **bounded in
+time as well as counted**. §7.2's `defaults.agent_timeout` bounds a running
+turn and §7.4's `defaults.input_timeout` bounds an `awaiting_input` one;
+either expiry kills the process tree, fails the turn with the matching
+snake_case reason and returns the chat to `idle`, which frees the slot. That
+closes the hole this section named in its own words: before it, a human who
+walked away from a question held one of `max_parallel_chats` slots forever, and
+a `send` refused with `409 chat_cap_reached` had nothing that would ever make it
+succeed. The two clocks are §7.2's and §7.4's numbers verbatim — no
+`defaults.chat_*` key, and no per-turn override, because §8.2's `timeout` and
+`input_timeout` are workflow step fields and a chat has no workflow.
+
 The two caps are independent by design: a running chat consumes no
 `max_parallel_tasks` or per-project slot, and does not delay an admissible task.
 The combined ceiling on live agent processes is therefore
@@ -4597,18 +4609,35 @@ POST   /v1/chats/{id}/send              { message } → 202 with the new turn. `
                                         — **refused, never queued** (§11)
 POST   /v1/chats/{id}/answer            the §7.4 answer flow verbatim: same normalized request,
                                         same `Respond()`. `409` outside `awaiting_input`.
-                                        *Corrected 2026-08-30 (task 063, same PR): the wait is
-                                        **not** bounded by `input_timeout`. `internal/chatrun`
-                                        applies no clock at all — neither `input_timeout` nor
-                                        `agent_timeout` — so a chat turn runs, and an
-                                        `awaiting_input` chat waits, until it is answered or
-                                        cancelled. It holds its `max_parallel_chats` slot for as
-                                        long as it does. Bounding it is open work, recorded in
-                                        `docs/tasks/063-free-chat.md`*
+                                        *Amended 2026-08-31 (task 067, issue #269), replacing the
+                                        2026-08-30 correction: the wait **is** bounded, by
+                                        `defaults.input_timeout` (24h), and a running turn by
+                                        `defaults.agent_timeout` (60m) — §7.2's and §7.4's
+                                        numbers verbatim, with no `defaults.chat_*` key and no
+                                        per-turn override, because §8.2's `timeout`/`input_timeout`
+                                        are workflow step fields and a chat has no workflow.
+                                        Expiry fails the turn `timeout` or `input_timeout`, kills
+                                        the process tree, returns the chat to `idle` and releases
+                                        its `max_parallel_chats` slot. `transcript_max_bytes`
+                                        applies to a turn's transcript the same way, failing it
+                                        `transcript_limit`*
 POST   /v1/chats/{id}/cancel            stops the live turn and kills its process tree
 POST   /v1/chats/{id}/archive           removes the worktree and deletes the branch when it
                                         received nothing (§10, task 008 semantics), `?force=`
                                         for the dirty-worktree refusal. Terminal
+GET    /v1/chats/{id}/events            *Added 2026-08-31 (task 067).* SSE: this chat's durable
+                                        `chat.*` events interleaved with its live output, the
+                                        per-task stream's shape for a chat. The filter is the
+                                        payload's `id` — a chat event carries no `task_id`, by
+                                        design — and the output rides the chat's own broker key,
+                                        so neither stream can be handed the other's bytes.
+                                        `Last-Event-ID` resumes the durable events only (§13.3)
+GET    /v1/chats/{id}/turns/{seq}       *Added 2026-08-31 (task 067).* One turn's transcript,
+       /transcript                      with the step route's range contract: `?offset=` and
+       ?offset=|?tail=&format=          `?tail=` mutually exclusive, whole records at both ends,
+                                        `X-Next-Offset` naming where the next fetch resumes.
+                                        There is no `run_id` analogue — a chat turn **is** its
+                                        run, named by its 1-based `seq`
 GET    /v1/workflows/definition         one workflow's whole recursive structure, selected with
        ?name=&project_id=               the same §5.2 shadowing the list applies (task 017,
                                         added 2026-08-18):
@@ -5091,6 +5120,18 @@ coalescing and the same drop-the-slow-subscriber rule, because the turn's
 transcript file is the durable copy. `Last-Event-ID` resumes the durable chat
 events and not the output, for the reason it does not resume a step's.
 
+*Amended 2026-08-31 (task 067, issue #269).* There is now a **per-chat stream**,
+`GET /v1/chats/{id}/events` (§13.2), the per-task stream's twin. It narrows the
+durable events on the payload's `id` rather than on a column — a chat event
+carries no `task_id`, deliberately, so a per-task stream can never deliver one —
+and subscribes to the chat's own broker key, the negative half of the int64 key
+space, so a task subscriber can never be handed a chat's bytes. Its **catch-up
+seam is now exact rather than approximate**: a chunk carries `turn_id` and
+`offset`, and `GET /v1/chats/{id}/turns/{seq}/transcript` reports
+`X-Next-Offset`; a client fetches, then keeps every chunk whose `offset` is past
+what the fetch reported, for that `turn_id`. That is the same pair a task uses,
+with `turn_id` where `run_id` stands — a chat turn is its own run.
+
 ### 13.4 Model Context Protocol (task 057)
 
 *Added 2026-08-29 (task 057, issue #243).*
@@ -5176,6 +5217,14 @@ config route: an agent must not reconfigure the daemon supervising it, and a
 workflow file is what that daemon runs. Nothing regresses — the
 `create-workflow` built-in writes its deliverable through the filesystem, not
 through this API. `GET /v1/workflows/schema` is an ordinary tool.
+
+*Amended 2026-08-31 (task 067, issue #269).* **Seventeen**, with
+`GET /v1/chats/{id}/events` and `GET /v1/chats/{id}/turns/{seq}/transcript` —
+the chat family stays whole. They are listed as *exclusions* rather than under
+the SSE carve-out below, even though one of them is a stream: the rule that
+keeps chats off the tool surface is "a human drives a chat", not "a stream is
+not a request/response", and one rule for the whole family is what stops a
+later chat route being classified by which sentence it happens to match.
 
 The task 057 property that the tool surface **equals** `Routes()` minus the
 exclusions is unchanged, and is still asserted by a test — the exclusion list it
@@ -5525,14 +5574,6 @@ together or not at all; a concurrent duplicate loses on the primary key, rolls
 its task insert back, and replays the winner's.
 
 ## 15. TUI
-
-> **Chats in the TUI are not in the first cut (task 063, 2026-08-30).** The
-> entity, its API, its CLI (`vincent chat`) and its runner landed together;
-> the chats view did not, and this section is unchanged until it does. A chat
-> is driven from `vincent chat` and from curl in the meantime. The view, when
-> it lands, is a sibling of the existing six routed by `viewID` and gets its
-> screenshots from `scripts/screenshots.sh` like every other panel — never a
-> drawing.
 
 Built with Bubble Tea. The TUI is a pure API client — it holds no *task* state
 the daemon doesn't have, and killing it never affects work. What it does own is
@@ -5948,6 +5989,56 @@ stream for the live tail.
    every view, so a `task.github_pull_changed` tick re-renders it with no
    keypress.
 
+8. **Chats board.** *Added 2026-08-31 (task 067, issue #269, closing 063.2).* A
+   second board, not a filter on the first: every chat from `GET /v1/chats`,
+   grouped by project, one row per conversation carrying id, state, agent, last
+   activity and title. It shares none of view 1's columns because a chat has
+   none of them — no workflow, no step `k/n`, no §6 action set — and decision
+   row 29's "a chat never appears on the task board" is what makes the second
+   board the right answer rather than a `kind` column on the first.
+
+   Grouping is **by project and by nothing else**: `tui.board.group_by`'s
+   workflow levels are meaningless for a chat, so the `g` cycle is not offered
+   here. Folds persist in `{data_dir}/tui.json` under their own key, beside the
+   task board's rather than sharing them — the two boards group by the same
+   project names, and one list would make folding a project on one fold it on
+   the other.
+
+   **Attention is this board's own.** An `awaiting_input` chat is sorted to the
+   top and counted in *this* header's badge. `!` and view 1's needs-attention
+   count stay task-only, which is what keeps row 29 literal in the client. The
+   `notify:` hook (§12.3) is untouched in both directions: it is the daemon's
+   outward signal and this is a client's own ordering.
+
+   **Actions.** `enter` opens view 9. `n` starts a chat — the create form is a
+   layer over this board, taking project, title, agent, model, effort and base
+   branch, and rendering `400 agent_cannot_resume` as the typed refusal it is
+   rather than a generic failure. `a` archives, asking first and re-offering
+   with the force when the worktree is dirty. `/` filters on title, agent or
+   branch; `←`/`→` fold a project group; `r` re-lists. A `chat.*` event
+   re-renders the board with no keypress, and a `task.*` event does not — the
+   separation runs both ways.
+
+9. **Chat workspace.** *Added 2026-08-31 (task 067, closing 063.2 and 063.3).*
+   One conversation: the finished turns above, the running turn's live tail
+   below them, and a composer at the bottom. `enter` sends, `ctrl+x` stops the
+   live turn, `esc` returns to view 8.
+
+   The live tail consumes `GET /v1/chats/{id}/events` and seams onto
+   `GET /v1/chats/{id}/turns/{seq}/transcript` exactly the way the task
+   workspace's output tab seams onto a step's: fetch, then keep every chunk
+   whose `offset` is past the fetch's `X-Next-Offset`, for that `turn_id`. A
+   finished turn renders from its transcript and falls back to `ResultText`
+   when the file has gone to retention (§17).
+
+   The §7.4 popup is **the same popup** view 2 uses, not a fork of it:
+   structured options, multi-select and the permission allow/deny distinction
+   come along because the request is the same request, and only where the
+   answer is POSTed differs. It opens and closes on the chat's own state, so an
+   answer given from `vincent chat answer` or from curl closes it here too. A
+   `409 chat_cap_reached` on send renders as a refusal — never a queued turn,
+   never a spinner — because that is what the daemon did.
+
 ### Layout
 
 The list above is also the screen contract. View 1 is the board-only home
@@ -5956,6 +6047,12 @@ screen. `enter` on its selected row opens view 2, the full-screen task workspace
 task 051, 2026-08-29, added the Workflow tab). Views 3–7 are
 full-screen takeovers reached from the command palette (view 7 added
 2026-08-29 by task 052.6).
+
+*Amended 2026-08-31 (task 067).* Views **8 and 9** join it as a second
+board-and-workspace pair, with the same relationship to each other that views 1
+and 2 have: view 8 is a keyless nav row in the palette, `enter` on a row opens
+view 9, `esc` returns. The chats board keeps `n` for itself — on it, `n` starts
+a chat; everywhere else it still opens the new-task form.
 
 *Amended 2026-08-30 (task 064).* View 7 gains two keys. **`c`** opens the
 new-task form seeded with the selected pull request: the daemon computes the
@@ -6435,6 +6532,19 @@ reasoning and nothing unrecognized. `e` opens `$EDITOR` where a view has a file 
 re-reads a registry or the daemon blocks. One key jumps to the next task needing a
 human, surfaced in the footer only when that count is non-zero — the board has
 always pinned and belled those tasks without offering any way to *go* to one.
+
+*Amended 2026-08-31 (task 067).* The chats board and the chat workspace carry
+their own rows in the registry (`internal/tui/bindings.go`), which is what the
+`?` overlay, the footer and the palette are derived from. On the **chats
+board**: `enter` opens the workspace, `n` starts a chat, `a` archives, `/`
+filters, `←`/`→` fold a project group and `r` re-lists. In the **chat
+workspace**: `enter` sends, `ctrl+x` stops the live turn, `esc` returns to the
+board. In the **new-chat form**: `ctrl+s` creates, `tab`/`shift+tab` move
+between fields, `←`/`→` choose on the project and agent fields, `esc` discards.
+`n` is the one key whose meaning depends on where you are, deliberately: on the
+chats board it makes a chat, and everywhere else it still makes a task. `!` is
+**not** extended to chats — an `awaiting_input` chat is pinned and badged on
+its own board and nowhere else.
 
 **`esc` cancels one layer per press**, by a fixed stack: *(amended 2026-08-30,
 task 063)* a form popup's Task details tab → popup (palette, confirmation,

--- a/docs/tasks/063-free-chat.md
+++ b/docs/tasks/063-free-chat.md
@@ -1,7 +1,7 @@
 # 063 — Free chat: conversational agent sessions beside tasks
 
 **Issue:** #255
-**Status:** 🔄 in progress (1/2)
+**Status:** ✅ done (3/3)
 
 ## Why
 
@@ -110,8 +110,8 @@ existing first-run acknowledgement already covers it. §6's task FSM,
 | ID | What | Status |
 |---|---|---|
 | 063.1 | The entity end to end: `internal/chatstate`, `internal/chatrun`, migration 0022, store CRUD + claims, `internal/agent` resume capability + claude `--resume`, the `/v1/chats` route family, `internal/apiclient`, `vincent chat`, daemon wiring, `max_parallel_chats`, gc claim sets, owner-named worktree directories, spec and docs | ✅ done |
-| 063.2 | The chats view in the TUI, and `scripts/m13-gate.sh` wired into `ci.yml`'s `gates` job on all three platforms | [ ] |
-| 063.3 | The three gaps the 063.1 documentation audit found, none of which changes a decision above: a chat turn is bounded by **no clock at all** — `internal/chatrun` applies neither `input_timeout` nor `agent_timeout`, so a turn (and the `max_parallel_chats` slot it holds) runs until it is answered or cancelled, and §13.2 carries a dated correction saying so; `vincent chat` has **no `answer` and no `cancel`**, so a chat that enters `awaiting_input` can only be moved on over the API, and `vincent chat send` blocks meanwhile; and the transcript plumbing is task-scoped at both ends — `internal/taskrun`'s pruner walks archived *tasks*, so an **archived chat's transcripts are never reclaimed** by `transcript_retention_days`, and only `internal/taskrun/engine.go` calls `Writer.SetMax`, so a chat turn's transcript is written with **no `transcript_max_bytes` cap**. `vincent chat` also has no `--json`, which is why the blanket claim in the scripting guide was narrowed | [ ] |
+| 063.2 | The chats view in the TUI — a chats board and a chat workspace, two `viewID`s of their own — and an end-to-end chat gate wired into `ci.yml`'s `gates` job on all three platforms. *The gate is `scripts/m14-gate.sh`, not `m13`: task 065 took that name for the workflow editor.* Closed by task 067 | [x] |
+| 063.3 | Closed by task 067. The three gaps the 063.1 documentation audit found, none of which changes a decision above: a chat turn is bounded by **no clock at all** — `internal/chatrun` applies neither `input_timeout` nor `agent_timeout`, so a turn (and the `max_parallel_chats` slot it holds) runs until it is answered or cancelled, and §13.2 carries a dated correction saying so; `vincent chat` has **no `answer` and no `cancel`**, so a chat that enters `awaiting_input` can only be moved on over the API, and `vincent chat send` blocks meanwhile; and the transcript plumbing is task-scoped at both ends — `internal/taskrun`'s pruner walks archived *tasks*, so an **archived chat's transcripts are never reclaimed** by `transcript_retention_days`, and only `internal/taskrun/engine.go` calls `Writer.SetMax`, so a chat turn's transcript is written with **no `transcript_max_bytes` cap**. `vincent chat` also has no `--json`, which is why the blanket claim in the scripting guide was narrowed | [x] |
 
 ### Why 063.2 is separate
 
@@ -124,6 +124,11 @@ written in the sh∩pwsh intersection that has actually been run on all three
 platforms before it is claimed to pass on them. §15 carries a note saying the
 view is not there yet, so the spec does not describe a screen that does not
 exist.
+
+*Closed 2026-08-31 by [task 067](067-chats-in-the-tui.md), issue #269*, which
+landed 063.2 and 063.3 together — the 063.3 gaps are what make a chat drivable
+without curl, and the view is the client that proves it. §15's note is gone
+because the screens it described as absent are there.
 
 ## What the tests prove
 

--- a/docs/tasks/067-chats-in-the-tui.md
+++ b/docs/tasks/067-chats-in-the-tui.md
@@ -1,0 +1,128 @@
+# 067 — A chats view in the TUI: a chats board beside the task board
+
+**Status:** ✅ done (1/1)
+**Issue:** #269
+**Closes:** [063.2](063-free-chat.md) and [063.3](063-free-chat.md)
+
+Task 063 landed the chat entity end to end — the tables, the runner, the route
+family, `vincent chat`, recovery and gc — and deliberately stopped short of two
+things: the TUI view, and three gaps its own documentation audit found. This
+task closes both, in one piece of work, because the 063.3 gaps are what make a
+chat drivable without curl and the view is the client that proves it.
+
+## Decisions
+
+**1. A chat turn gets §7.2/§7.4's clocks verbatim.** `agent_timeout` (60m by
+default) bounds a running turn; `input_timeout` (24h) bounds `awaiting_input`.
+Expiry fails the turn — `ReasonTimeout` and `ReasonInputTimeout`, the existing
+snake_case constants, not new strings — kills the process tree, returns the chat
+to `idle` and releases its `max_parallel_chats` slot.
+
+No new `defaults.*` key. A chat is bounded by the same numbers a step is, and
+inventing `chat_agent_timeout` would make §12.3 carry two vocabularies for one
+clock. There is no per-turn override either, because §8.2's `timeout` and
+`input_timeout` are *workflow step fields* and a chat has no workflow.
+
+This is the option that closes the hole §11 named in its own words —
+live-but-uncounted agent CLIs, here a slot held forever by a chat whose human
+walked away — so it is that amendment extended once more, not excepted.
+
+*Alternative rejected:* a chat-specific pair of keys. It would have documented
+two names for one number and left an operator asking which one applied.
+
+**2. The per-turn transcript is served over the API.** Adding only the SSE route
+would leave a reopened TUI showing finished turns as `ChatTurn.ResultText` and
+nothing else, and would leave §13.3's catch-up seam approximate for chats while
+it is exact for tasks. So `GET /v1/chats/{id}/turns/{seq}/transcript` lands
+beside `GET /v1/chats/{id}/events`, mirroring the step route: same
+`?offset=`/`?tail=` mutual exclusion, same `X-Next-Offset`.
+
+The seam needs no `run_id` analogue — a chat turn *is* its run, and the chunks
+`internal/chatrun` already publishes carry `turn_id` and `offset`, which is the
+pair. Both new routes join the §13.4 exclusion list, as *exclusions* rather than
+under the SSE carve-out: the rule that keeps chats off the tool surface is "a
+human drives a chat", and one rule for the whole family is what stops a later
+chat route being classified by which sentence it happens to match.
+
+**3. One PR.** 063.2 and 063.3 land together, for the reason above.
+
+**4. Attention is the chats board's own.** An `awaiting_input` chat is pinned
+and badged **on the chats board only**. `!` and the home board's
+needs-attention header stay task-only, keeping decision row 29's "never appears
+on the task board" literal in the client as well as in the API. Task 063
+decision 7 is untouched: it governs the daemon's outward `notify:` hook, not a
+client's bell, and nothing here changes `internal/config`'s imports.
+
+**5. The gate is `m14`, not `m13`.** Task 063 planned `scripts/m13-gate.sh`;
+task 065 took that filename for the workflow editor and wired it into
+`ci.yml`. 063.2's row is corrected rather than left naming a file that means
+something else.
+
+**6. The chats board groups by project and by nothing else.**
+`tui.board.group_by`'s workflow scopes are meaningless for a chat, so the `g`
+cycle is not offered. Folds persist in `{data_dir}/tui.json` under their own
+`chat_folds` key rather than sharing `board_folds`: the two boards group by the
+same project names, and one list would make folding a project on one board fold
+it on the other — one fold set pretending to be two.
+
+**7. The §7.4 answer popup is reused, not forked.** `answerForm` grew
+`updateWith`, which takes a submitter; the task path passes a closure that posts
+to the task and the chat path one that posts to the chat. Structured options,
+multi-select and the permission allow/deny distinction come along because the
+request is the same request — `internal/chatrun` stores what the adapter
+emitted, unaltered.
+
+## Sub-tasks
+
+| ID | What | Status |
+|---|---|---|
+| 067.1 | The two API routes, `internal/apiclient`'s `StreamChat` and `ChatTurnTranscript`, the two clocks and the transcript cap in `internal/chatrun`, archived-chat pruning, `vincent chat answer`/`cancel`/`--json`, the chats board and the chat workspace in the TUI, `scripts/m14-gate.sh`, and the spec and docs amendments | ✅ done |
+
+## What the tests prove
+
+- **The stream is a stream** — `internal/apiclient`'s `*live_test.go` against the
+  real handlers: a chat's durable `chat.*` events arrive filtered to that chat,
+  another chat's and a task's do not leak onto it, `Last-Event-ID` resumes the
+  durable events, and live chunks carry `chat_id`/`turn_id`/`offset`.
+- **The seam is exact** — a transcript fetch followed by a resume from its
+  `X-Next-Offset` reproduces the appended records with none duplicated and none
+  dropped; `?offset=` with `?tail=` is a 400 and an unknown turn is a 404.
+- **The clocks bite** — `internal/chatrun`: a turn past `agent_timeout` fails
+  `timeout`, a chat past `input_timeout` in `awaiting_input` fails
+  `input_timeout`, both return the chat to `idle` and free the slot (asserted
+  through `CountChatsHoldingProcess`), and an answer inside the window stops the
+  input clock rather than carrying it into the rest of the turn.
+- **The cap applies** — a turn's transcript stops at `transcript_max_bytes` and
+  the turn fails `transcript_limit`, which only the task engine used to do.
+- **Retention** — `internal/taskrun`: an archived chat's transcript directory is
+  reclaimed on the same pass as an archived task's, and a chat that was never
+  archived keeps its transcripts however old the cutoff.
+- **Refusals render as refusals** — the workspace's `409 chat_cap_reached` path
+  shows a refusal and creates no turn row; the create form renders
+  `400 agent_cannot_resume` as the typed reason.
+- **The answer popup is the same popup** — an `awaiting_input` chat opens
+  `answerForm` from its own pending request, keeps the multi-select shape, and
+  closes when the daemon stops saying `awaiting_input`.
+- **Separation holds both ways** — a `task.*` event does not reload the chats
+  board, and the chats board's attention badge is its own.
+- **MCP** — the tool surface equals `Routes()` minus the five admin routes, the
+  workflow writes and the now nine-route chat family.
+- **`bindings.go`** — every new context has its probe and its palette row; the
+  existing `bindings_test.go` and `palette_test.go` invariants were extended,
+  never exempted.
+
+## Acceptance
+
+`scripts/m14-gate.sh` drives a chat end to end over curl against
+`cmd/fakeagent`: create, send, resume continuity, an `awaiting_input` answer,
+the `max_parallel_chats` `409`, cancel, archive, the per-chat event stream and
+the transcript route's offset seam. It has no workflow `run:` bodies to spell in
+the sh∩pwsh intersection — a chat has no workflow — but its own bash obeys the
+two standing rules: `| tr -d '\r'` on any multi-line `jq` capture, and never
+`| grep -q`.
+
+**Not in this task:** the screenshots. `scripts/screenshots.sh` is the only
+source of `docs/assets/tui-*.png` and it is not run in CI; capturing the two new
+panels is a seeded VHS run on a macOS or Linux workstation, and this task
+deliberately does not ship a drawing in the meantime. `docs/guides/tui.md`
+describes both panels in prose and key tables until that run happens.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -76,10 +76,11 @@ the living engineering specification records implementation contracts.
 | [060](060-daemon-configuration-editing.md) | Edit the daemon configuration from the TUI | ✅ done (8/8) |
 | [061](061-container-step-execution.md) | Run a task's steps inside a container: the exec seam | ✅ done (1/1) |
 | [062](062-agent-steps-in-containers.md) | Agent steps inside the task's container | 📋 planned (0/1) |
-| [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | 🔄 in progress (1/3) |
+| [063](063-free-chat.md) | Free chat: conversational agent sessions beside tasks | ✅ done (3/3) |
 | [064](064-task-from-pull-request.md) | Create a task from a pull request, on the PR's head branch | 🔄 in progress (8/9) |
 | [065](065-workflow-editor-in-the-tui.md) | A workflow editor in the TUI: create, edit and fork through structured forms | ✅ done (13/13) |
 | [066](066-claude-stream-json-surface.md) | Surface more of claude's stream-json in the output view | 🔄 in progress (4/5) |
+| [067](067-chats-in-the-tui.md) | A chats view in the TUI: a chats board beside the task board | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/chatstream.go
+++ b/internal/api/chatstream.go
@@ -1,0 +1,270 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/lezli01/vincent/internal/chatrun"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// handleChatEvents is GET /v1/chats/{id}/events (§13.3): one chat's durable
+// events interleaved with its ephemeral live output, the per-task stream's
+// exact shape for a chat.
+//
+// The filter is the one internal/store's chatEvent already promises. A chat
+// event carries no TaskID — a chat is not a task, and a per-task stream must
+// never deliver one — so this narrows on the payload's `id` instead, which is
+// why matchesChat unmarshals rather than comparing a column. The output
+// subscription rides chatrun.ChatOutputKey, the negative half of the broker's
+// int64 key space, so a task subscriber can never be handed a chat's bytes.
+//
+// Last-Event-ID resumes the durable events only; live-output catch-up is
+// GET /v1/chats/{id}/turns/{seq}/transcript, then follow.
+func (s *Server) handleChatEvents(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Broker == nil {
+		writeError(w, http.StatusInternalServerError, CodeInternal, "event streaming is not available")
+		return
+	}
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	cursor, ok := lastEventID(w, r)
+	if !ok {
+		return
+	}
+
+	sub := s.deps.Broker.SubscribeEvents(eventSubBuffer)
+	defer sub.Close()
+	out := s.deps.Broker.SubscribeOutput(chatrun.ChatOutputKey(chat.ID), outputSubBuffer)
+	defer out.Close()
+
+	// The replay filter is by type, not by id: the events table has no chat
+	// column (the id lives in the payload), so the store narrows to the
+	// chat.* family and matchesChat does the rest. A replay therefore reads
+	// only chat rows, never every task event behind the cursor.
+	rc, lastID, ok := s.startStream(w, r, store.EventFilter{
+		AfterID: cursor, Types: store.ChatEventTypes(),
+	}, cursor)
+	if !ok {
+		return
+	}
+
+	flushTimer := time.NewTicker(outputFlushInterval)
+	defer flushTimer.Stop()
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+	dirty := false
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, chOpen := <-sub.C:
+			if !chOpen {
+				return
+			}
+			if ev.ID <= lastID || !matchesChat(ev, chat.ID) {
+				continue
+			}
+			if !writeSSEEvent(w, ev) || rc.Flush() != nil {
+				return
+			}
+			lastID, dirty = ev.ID, false
+		case chunk, chOpen := <-out.C:
+			if !chOpen {
+				return
+			}
+			if !writeSSEChunk(w, chunk) {
+				return
+			}
+			dirty = true // the flush timer pushes it (§13.3's ~10 Hz)
+		case <-flushTimer.C:
+			if dirty {
+				if rc.Flush() != nil {
+					return
+				}
+				dirty = false
+			}
+		case <-heartbeat.C:
+			if !writeHeartbeat(w, rc) {
+				return
+			}
+		}
+	}
+}
+
+// matchesChat reports whether a durable event belongs to this chat. Only the
+// chat.* family can, and within it the subject is the payload's `id`.
+func matchesChat(ev *store.Event, chatID int64) bool {
+	if !store.IsChatEvent(ev.Type) {
+		return false
+	}
+	var body struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(ev.Payload, &body); err != nil {
+		return false
+	}
+	return body.ID == chatID
+}
+
+// handleChatTurnTranscript is GET /v1/chats/{id}/turns/{seq}/transcript
+// (§13.2): one turn's durable record, with the step transcript's byte range
+// semantics — `offset` and `tail` are mutually exclusive, the body covers
+// whole records, and X-Next-Offset is where the next fetch resumes.
+//
+// There is no run_id analogue because a chat turn *is* its run: the turn's
+// 1-based `seq` names both the row and the `{seq}.jsonl` file beside it, and
+// the chunks on the stream carry `turn_id` + `offset`, which is the pair a
+// client seams against.
+func (s *Server) handleChatTurnTranscript(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	seq, err := strconv.Atoi(r.PathValue("seq"))
+	if err != nil || seq <= 0 {
+		writeError(w, http.StatusNotFound, CodeNotFound, "chat turn sequence numbers are positive integers")
+		return
+	}
+	turns, err := s.deps.Store.ListChatTurns(r.Context(), chat.ID)
+	if err != nil {
+		s.internalError(w, "list chat turns", err)
+		return
+	}
+	var turn *store.ChatTurn
+	for i := range turns {
+		if turns[i].Seq == seq {
+			turn = &turns[i]
+			break
+		}
+	}
+	if turn == nil {
+		writeError(w, http.StatusNotFound, CodeNotFound,
+			fmt.Sprintf("turn %d not found on chat %d", seq, chat.ID))
+		return
+	}
+
+	rng, ok := transcriptRange(w, r)
+	if !ok {
+		return
+	}
+	// The path is derived, not stored: chat turns have no TranscriptPath
+	// column because their name is a pure function of the two ids, exactly
+	// as internal/chatrun computes it when it opens the writer.
+	path := filepath.Join(
+		s.deps.Dirs.Data, "transcripts", worktree.ChatOwner(chat.ID).Dir(),
+		fmt.Sprintf("%d.jsonl", turn.Seq))
+	f, err := os.Open(path) //nolint:gosec // the path is built from two ids
+	if err != nil {
+		writeError(w, http.StatusNotFound, CodeNotFound, "transcript file is gone (pruned or removed)")
+		return
+	}
+	defer func() { _ = f.Close() }()
+	s.serveTranscriptFile(w, f, rng, chat.Agent, turn.ID)
+}
+
+// transcriptRangeSpec is a validated ?offset=/?tail=/?format= triple.
+type transcriptRangeSpec struct {
+	offset     int64
+	tail       int64
+	hasTail    bool
+	normalized bool
+}
+
+// transcriptRange parses the query both transcript routes share. Offset and
+// tail are mutually exclusive: asking for a position and a window at once has
+// no single answer, so it is a client error rather than a precedence rule.
+func transcriptRange(w http.ResponseWriter, r *http.Request) (transcriptRangeSpec, bool) {
+	q := r.URL.Query()
+	rawOffset, rawTail := q.Get("offset"), q.Get("tail")
+	var spec transcriptRangeSpec
+	if rawOffset != "" && rawTail != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"offset and tail are mutually exclusive")
+		return spec, false
+	}
+	var err error
+	if rawOffset != "" {
+		spec.offset, err = strconv.ParseInt(rawOffset, 10, 64)
+		if err != nil || spec.offset < 0 {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, "offset must be a non-negative integer")
+			return spec, false
+		}
+	}
+	if rawTail != "" {
+		spec.tail, err = strconv.ParseInt(rawTail, 10, 64)
+		if err != nil || spec.tail < 0 {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed, "tail must be a non-negative integer")
+			return spec, false
+		}
+		spec.hasTail = true
+	}
+	switch format := q.Get("format"); format {
+	case "", "raw":
+	case "normalized":
+		spec.normalized = true
+	default:
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"format must be raw or normalized")
+		return spec, false
+	}
+	return spec, true
+}
+
+// transcriptFile is what serveTranscriptFile needs of an open transcript:
+// random access plus a size. *os.File satisfies it.
+type transcriptFile interface {
+	io.ReaderAt
+	Stat() (os.FileInfo, error)
+}
+
+// serveTranscriptFile writes the requested byte range of an open transcript,
+// snapped to record boundaries at both ends, with X-Next-Offset naming where
+// the next fetch resumes (§13.2). subject names the run in a log line.
+func (s *Server) serveTranscriptFile(
+	w http.ResponseWriter, f transcriptFile, rng transcriptRangeSpec, agentName string, subject int64,
+) {
+	fi, err := f.Stat()
+	if err != nil {
+		s.internalError(w, "stat transcript", err)
+		return
+	}
+	size := fi.Size()
+
+	end, err := lineBoundary(f, size)
+	if err != nil {
+		s.internalError(w, "scan transcript", err)
+		return
+	}
+	start := min(rng.offset, size)
+	if rng.hasTail {
+		if start, err = lineBoundary(f, size-rng.tail); err != nil {
+			s.internalError(w, "scan transcript", err)
+			return
+		}
+	}
+	start = min(start, end)
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("X-Next-Offset", strconv.FormatInt(end, 10))
+	w.WriteHeader(http.StatusOK)
+	section := io.NewSectionReader(f, start, end-start)
+	if !rng.normalized {
+		_, _ = io.Copy(w, section)
+		return
+	}
+	if err := normalizeTranscript(w, section, s.transcriptParser(agentName)); err != nil {
+		// The status is already on the wire; the client sees a short body and
+		// resumes from the offset it was given, which is still line-aligned.
+		s.deps.Logger.Error("normalize transcript", "run_id", subject, "error", err)
+	}
+}

--- a/internal/api/mcp_parity_test.go
+++ b/internal/api/mcp_parity_test.go
@@ -87,6 +87,13 @@ func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 		{http.MethodPost, "/v1/chats/{id}/answer"},
 		{http.MethodPost, "/v1/chats/{id}/cancel"},
 		{http.MethodPost, "/v1/chats/{id}/archive"},
+		// The two read routes are excluded by the same §13.4 reasoning, not
+		// by the Streaming carve-out: a chat's stream and its per-turn
+		// transcript are the surface a *human* drives a chat through, and an
+		// agent calling either already has a session of its own. Listing them
+		// here rather than in Streaming keeps one rule for the whole family.
+		{http.MethodGet, "/v1/chats/{id}/events"},
+		{http.MethodGet, "/v1/chats/{id}/turns/{seq}/transcript"},
 		// Task 065 decision 5, under the same wording: a workflow file is
 		// what the daemon runs, so an agent editing one is an agent
 		// rewriting the rules it runs under.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -314,8 +314,10 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/chats/{id}/answer", s.handleChatAnswer)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/cancel", s.handleChatCancel)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/archive", s.handleChatArchive)
+	rt.handle(http.MethodGet, "/v1/chats/{id}/turns/{seq}/transcript", s.handleChatTurnTranscript)
 	rt.handle(http.MethodGet, "/v1/events", s.handleEvents)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/events", s.handleTaskEvents)
+	rt.handle(http.MethodGet, "/v1/chats/{id}/events", s.handleChatEvents)
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		writeError(w, http.StatusNotFound, CodeNotFound, "no such endpoint")
 	})

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -1166,39 +1166,10 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 		s.internalError(w, "get step run", err)
 		return
 	}
-	q := r.URL.Query()
-	rawOffset, rawTail := q.Get("offset"), q.Get("tail")
-	if rawOffset != "" && rawTail != "" {
-		writeError(w, http.StatusBadRequest, CodeValidationFailed,
-			"offset and tail are mutually exclusive")
+	rng, ok := transcriptRange(w, r)
+	if !ok {
 		return
 	}
-	var offset, tail int64
-	if rawOffset != "" {
-		offset, err = strconv.ParseInt(rawOffset, 10, 64)
-		if err != nil || offset < 0 {
-			writeError(w, http.StatusBadRequest, CodeValidationFailed, "offset must be a non-negative integer")
-			return
-		}
-	}
-	if rawTail != "" {
-		tail, err = strconv.ParseInt(rawTail, 10, 64)
-		if err != nil || tail < 0 {
-			writeError(w, http.StatusBadRequest, CodeValidationFailed, "tail must be a non-negative integer")
-			return
-		}
-	}
-	normalized := false
-	switch format := q.Get("format"); format {
-	case "", "raw":
-	case "normalized":
-		normalized = true
-	default:
-		writeError(w, http.StatusBadRequest, CodeValidationFailed,
-			"format must be raw or normalized")
-		return
-	}
-
 	if run.TranscriptPath == "" {
 		writeError(w, http.StatusNotFound, CodeNotFound, "step run has no transcript")
 		return
@@ -1209,43 +1180,7 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer func() { _ = f.Close() }()
-	fi, err := f.Stat()
-	if err != nil {
-		s.internalError(w, "stat transcript", err)
-		return
-	}
-	size := fi.Size()
-
-	// The body always covers whole records: it ends at the last newline, and
-	// a tail window starts at the beginning of the record its byte count
-	// lands in (§13.2).
-	end, err := lineBoundary(f, size)
-	if err != nil {
-		s.internalError(w, "scan transcript", err)
-		return
-	}
-	start := min(offset, size)
-	if rawTail != "" {
-		if start, err = lineBoundary(f, size-tail); err != nil {
-			s.internalError(w, "scan transcript", err)
-			return
-		}
-	}
-	start = min(start, end)
-
-	w.Header().Set("Content-Type", "application/x-ndjson")
-	w.Header().Set("X-Next-Offset", strconv.FormatInt(end, 10))
-	w.WriteHeader(http.StatusOK)
-	section := io.NewSectionReader(f, start, end-start)
-	if !normalized {
-		_, _ = io.Copy(w, section)
-		return
-	}
-	if err := normalizeTranscript(w, section, s.transcriptParser(run.Agent)); err != nil {
-		// The status is already on the wire; the client sees a short body and
-		// resumes from the offset it was given, which is still line-aligned.
-		s.deps.Logger.Error("normalize transcript", "run_id", run.ID, "error", err)
-	}
+	s.serveTranscriptFile(w, f, rng, run.Agent, run.ID)
 }
 
 // handleTaskDiff implements GET /v1/tasks/{id}/diff: the worktree against

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -39,6 +39,7 @@ type harness struct {
 	broker    *events.Broker
 	projectID int64
 	taskID    int64
+	dataDir   string
 }
 
 func newHarness(t *testing.T) *harness {
@@ -80,10 +81,14 @@ func newHarness(t *testing.T) *harness {
 		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	s := api.New(api.Deps{
-		Token:       testToken,
-		Config:      config.Default,
-		StartedAt:   time.Now(),
-		ListenAddr:  "127.0.0.1:0",
+		Token:      testToken,
+		Config:     config.Default,
+		StartedAt:  time.Now(),
+		ListenAddr: "127.0.0.1:0",
+		// The chat-turn transcript route derives its path from the data dir
+		// (a chat turn has no stored TranscriptPath), so the harness has to
+		// name the same directory the runner writes into.
+		Dirs:        config.Dirs{Data: dataDir},
 		RequestStop: func() {},
 		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Store:       st,
@@ -97,7 +102,10 @@ func newHarness(t *testing.T) *harness {
 	})
 	ts := httptest.NewServer(s.Handler())
 	t.Cleanup(ts.Close)
-	return &harness{ts: ts, st: st, broker: broker, projectID: p.ID, taskID: task.ID}
+	return &harness{
+		ts: ts, st: st, broker: broker,
+		projectID: p.ID, taskID: task.ID, dataDir: dataDir,
+	}
 }
 
 // append writes one durable event; the store hook publishes it to the broker.
@@ -368,4 +376,21 @@ func TestDiscover(t *testing.T) {
 	if want := "http://127.0.0.1:4242"; c.BaseURL() != want {
 		t.Errorf("BaseURL = %q, want %q", c.BaseURL(), want)
 	}
+}
+
+// getStatus performs an authenticated GET and returns the status code, for
+// the refusals a typed client method cannot express.
+func (h *harness) getStatus(t *testing.T, url string) int {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
 }

--- a/internal/apiclient/chats.go
+++ b/internal/apiclient/chats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -132,4 +133,31 @@ func (c *Client) ArchiveChat(ctx context.Context, id int64, force bool) (*Chat, 
 		return nil, err
 	}
 	return &out, nil
+}
+
+// StreamChat subscribes to GET /v1/chats/{id}/events: that chat's durable
+// events interleaved with its live output (§13.3). It is the per-task stream's
+// twin — Last-Event-ID resumes the durable events, live output is ephemeral
+// and never replayed — so a reconnect catches up by re-fetching the running
+// turn's transcript and discarding chunks at or before its NextOffset.
+func (c *Client) StreamChat(ctx context.Context, chatID int64, opts StreamOptions) <-chan Note {
+	ch := make(chan Note)
+	go c.streamLoop(ctx, "/v1/chats/"+strconv.FormatInt(chatID, 10)+"/events", opts, ch)
+	return ch
+}
+
+// ChatTurnTranscript fetches one turn's transcript in normalized form,
+// returning the records and the offset to resume from. The turn is named by
+// its 1-based seq, not by a run id: a chat turn is its own run.
+func (c *Client) ChatTurnTranscript(
+	ctx context.Context, chatID int64, seq int, opts TranscriptOptions,
+) (records []TranscriptRecord, nextOffset int64, err error) {
+	path := fmt.Sprintf("/v1/chats/%d/turns/%d/transcript%s", chatID, seq, opts.query("normalized"))
+	resp, nextOffset, err := c.transcriptAt(ctx, path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	records, err = decodeTranscript(resp.Body)
+	return records, nextOffset, err
 }

--- a/internal/apiclient/events.go
+++ b/internal/apiclient/events.go
@@ -48,8 +48,15 @@ type EventNote struct{ Event Event }
 // plus the transcript offset just past its line, which is what lets a client
 // join a transcript fetch to the live stream exactly.
 type OutputNote struct {
-	Type    string
+	Type string
+	// RunID names the step_run on a per-task stream; TurnID and ChatID name
+	// the chat turn on a per-chat one. A chunk carries one pair or the other,
+	// never both — a chat turn is its own run, so there is no step_run behind
+	// it — and the pair a client seams a transcript fetch against is
+	// (TurnID, Offset) exactly as it is (RunID, Offset) for a task.
 	RunID   int64
+	TurnID  int64
+	ChatID  int64
 	Offset  int64
 	Payload json.RawMessage
 }
@@ -277,10 +284,13 @@ func outputNote(name, data string) OutputNote {
 	note := OutputNote{Type: name, Payload: json.RawMessage(data)}
 	var ident struct {
 		RunID  int64 `json:"run_id"`
+		TurnID int64 `json:"turn_id"`
+		ChatID int64 `json:"chat_id"`
 		Offset int64 `json:"offset"`
 	}
 	if err := json.Unmarshal([]byte(data), &ident); err == nil {
 		note.RunID, note.Offset = ident.RunID, ident.Offset
+		note.TurnID, note.ChatID = ident.TurnID, ident.ChatID
 	}
 	return note
 }

--- a/internal/apiclient/input.go
+++ b/internal/apiclient/input.go
@@ -50,6 +50,21 @@ func (t TaskDetail) PendingRequest() (req InputRequest, ok bool, err error) {
 	return req, req.Kind != "", nil
 }
 
+// PendingRequest decodes a chat's parked §7.4 request, the same decode a
+// task's takes. It is the same wire shape because it is the same request:
+// internal/chatrun stores what the adapter emitted, unaltered, so the answer
+// popup and `vincent chat answer` need no chat-shaped variant of either
+// (task 063 decision 8).
+func (c Chat) PendingRequest() (req InputRequest, ok bool, err error) {
+	if len(c.PendingInput) == 0 {
+		return InputRequest{}, false, nil
+	}
+	if err := json.Unmarshal(c.PendingInput, &req); err != nil {
+		return InputRequest{}, false, fmt.Errorf("decode pending_input: %w", err)
+	}
+	return req, req.Kind != "", nil
+}
+
 // InputResponse answers an InputRequest. Answers is keyed by question text;
 // Allow decides a permission request.
 type InputResponse struct {

--- a/internal/apiclient/stream_chat_test.go
+++ b/internal/apiclient/stream_chat_test.go
@@ -1,0 +1,228 @@
+package apiclient_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/chatrun"
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// The per-chat stream and the per-turn transcript, against the real handlers
+// (task 067). These are the two routes 063.3 left missing: without them a
+// reopened TUI shows finished turns as ResultText and nothing else, and
+// §13.3's catch-up seam is exact for tasks and approximate for chats.
+
+// chat creates a chat on the harness's project and returns it.
+func (h *harness) chat(t *testing.T, title string) *store.Chat {
+	t.Helper()
+	c := &store.Chat{
+		ProjectID: h.projectID, Title: title, State: chatstate.Idle,
+		Agent: "claude", BaseBranch: "main", Branch: "vincent/1-x",
+	}
+	if err := h.st.CreateChat(t.Context(), c); err != nil {
+		t.Fatalf("CreateChat: %v", err)
+	}
+	return c
+}
+
+// writeChatTranscript lays down one turn's transcript where the route
+// derives its path: {data_dir}/transcripts/chat-{id}/{seq}.jsonl.
+func (h *harness) writeChatTranscript(t *testing.T, chatID int64, seq int, body string) {
+	t.Helper()
+	dir := filepath.Join(h.dataDir, "transcripts", worktree.ChatOwner(chatID).Dir())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir transcripts: %v", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%d.jsonl", seq))
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+}
+
+// TestStreamChatFiltersToOneChat is the filter internal/store's chatEvent
+// promises: a chat event carries no task_id, so the per-chat stream narrows
+// on the payload's id. Another chat's events must not arrive, and a task's
+// must not either.
+func TestStreamChatFiltersToOneChat(t *testing.T) {
+	h := newHarness(t)
+	mine := h.chat(t, "mine")
+	other := h.chat(t, "other")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	notes := h.client().StreamChat(ctx, mine.ID, testStreamOptions())
+	if _, ok := nextNote(t, notes).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note was not ConnectedNote")
+	}
+	waitForChatSubscriber(t, h, mine.ID)
+
+	// Neither of these belongs on this stream.
+	if _, err := h.st.SetChatState(t.Context(), other.ID, chatstate.Running); err != nil {
+		t.Fatalf("SetChatState(other): %v", err)
+	}
+	h.append(t, "task.state_changed")
+	// This one does, and it must be the *next* note — proving the two above
+	// were filtered rather than merely late.
+	if _, err := h.st.SetChatState(t.Context(), mine.ID, chatstate.Running); err != nil {
+		t.Fatalf("SetChatState(mine): %v", err)
+	}
+
+	ev, ok := nextNote(t, notes).(apiclient.EventNote)
+	if !ok {
+		t.Fatalf("expected an EventNote, got %T", ev)
+	}
+	if ev.Event.Type != store.EventChatState {
+		t.Fatalf("first event on the stream was %q, want this chat's state change", ev.Event.Type)
+	}
+}
+
+// TestStreamChatDeliversOutput covers the live half: chunks ride the chat's
+// own broker key, carry (turn_id, offset), and are not durable events.
+func TestStreamChatDeliversOutput(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t, "live")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	notes := h.client().StreamChat(ctx, c.ID, testStreamOptions())
+	if _, ok := nextNote(t, notes).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note was not ConnectedNote")
+	}
+	waitForChatSubscriber(t, h, c.ID)
+
+	h.broker.PublishOutput(chatrun.ChatOutputKey(c.ID), events.Chunk{
+		Type: "output",
+		Payload: map[string]any{
+			"chat_id": c.ID, "turn_id": int64(4), "offset": int64(2048),
+			"raw": `{"type":"agent.output","text":"hi"}`,
+		},
+	})
+	out, ok := nextNote(t, notes).(apiclient.OutputNote)
+	if !ok {
+		t.Fatalf("expected an OutputNote, got %T", out)
+	}
+	if out.TurnID != 4 || out.Offset != 2048 || out.ChatID != c.ID {
+		t.Fatalf("chunk identity = chat %d turn %d offset %d, want %d/4/2048",
+			out.ChatID, out.TurnID, out.Offset, c.ID)
+	}
+}
+
+// TestStreamChatResumesDurableEventsOnly holds §13.3's asymmetry: a
+// Last-Event-ID replay delivers the durable events behind the cursor and
+// never live output, which is ephemeral by construction.
+func TestStreamChatResumesDurableEvents(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t, "resume")
+	// The create event is already behind us; move the chat so there is one
+	// durable event to replay.
+	if _, err := h.st.SetChatState(t.Context(), c.ID, chatstate.Running); err != nil {
+		t.Fatalf("SetChatState: %v", err)
+	}
+	maxID, err := h.st.MaxEventID(t.Context())
+	if err != nil {
+		t.Fatalf("MaxEventID: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notes := h.client().StreamChat(ctx, c.ID, apiclient.StreamOptions{
+		LastEventID:    maxID - 1,
+		InitialBackoff: 20 * time.Millisecond,
+		MaxBackoff:     100 * time.Millisecond,
+	})
+	if _, ok := nextNote(t, notes).(apiclient.ConnectedNote); !ok {
+		t.Fatal("first note was not ConnectedNote")
+	}
+	ev, ok := nextNote(t, notes).(apiclient.EventNote)
+	if !ok || ev.Event.ID != maxID {
+		t.Fatalf("replay note = %+v, want event %d", ev, maxID)
+	}
+}
+
+// TestChatTurnTranscriptSeam is the exactness the TUI's live tail depends on:
+// a fetch reports X-Next-Offset, and resuming from it returns exactly the
+// bytes appended since — no duplicated and no dropped record.
+func TestChatTurnTranscriptSeam(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t, "seam")
+	turn, err := h.st.CreateChatTurn(t.Context(), c.ID, "go")
+	if err != nil {
+		t.Fatalf("CreateChatTurn: %v", err)
+	}
+	// vincent's own annotations pass through normalization under their own
+	// names, so the fixture uses them rather than a dialect line: what this
+	// test is about is the byte range, not the parser.
+	first := `{"type":"vincent.note","kind":"one"}` + "\n"
+	h.writeChatTranscript(t, c.ID, turn.Seq, first)
+
+	records, next, err := h.client().ChatTurnTranscript(
+		t.Context(), c.ID, turn.Seq, apiclient.TranscriptOptions{})
+	if err != nil {
+		t.Fatalf("ChatTurnTranscript: %v", err)
+	}
+	if len(records) != 1 || records[0].Kind != "one" {
+		t.Fatalf("first fetch = %+v, want one record", records)
+	}
+	if next != int64(len(first)) {
+		t.Fatalf("X-Next-Offset = %d, want %d", next, len(first))
+	}
+
+	h.writeChatTranscript(t, c.ID, turn.Seq,
+		first+`{"type":"vincent.note","kind":"two"}`+"\n")
+	records, _, err = h.client().ChatTurnTranscript(
+		t.Context(), c.ID, turn.Seq, apiclient.TranscriptOptions{Offset: next})
+	if err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if len(records) != 1 || records[0].Kind != "two" {
+		t.Fatalf("resume returned %+v, want only the appended record", records)
+	}
+}
+
+// TestChatTurnTranscriptRejectsOffsetAndTail keeps the step route's range
+// contract on the chat route: the two are mutually exclusive.
+func TestChatTurnTranscriptRejectsOffsetAndTail(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t, "range")
+	if _, err := h.st.CreateChatTurn(t.Context(), c.ID, "go"); err != nil {
+		t.Fatalf("CreateChatTurn: %v", err)
+	}
+	url := fmt.Sprintf("%s/v1/chats/%d/turns/1/transcript?offset=1&tail=1", h.ts.URL, c.ID)
+	if code := h.getStatus(t, url); code != 400 {
+		t.Fatalf("offset+tail answered %d, want 400", code)
+	}
+}
+
+// TestChatTurnTranscriptUnknownTurn is a 404 rather than an empty body: a
+// turn that is not on this chat is not a turn with nothing in it.
+func TestChatTurnTranscriptUnknownTurn(t *testing.T) {
+	h := newHarness(t)
+	c := h.chat(t, "missing")
+	url := fmt.Sprintf("%s/v1/chats/%d/turns/9/transcript", h.ts.URL, c.ID)
+	if code := h.getStatus(t, url); code != 404 {
+		t.Fatalf("unknown turn answered %d, want 404", code)
+	}
+}
+
+// waitForChatSubscriber blocks until the server's output subscription for the
+// chat is registered, so a publish cannot race the stream opening.
+func waitForChatSubscriber(t *testing.T, h *harness, chatID int64) {
+	t.Helper()
+	key := chatrun.ChatOutputKey(chatID)
+	deadline := time.Now().Add(noteTimeout)
+	for h.broker.OutputSubscribers(key) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("no output subscriber registered for the chat")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/apiclient/transcript.go
+++ b/internal/apiclient/transcript.go
@@ -184,7 +184,15 @@ func (c *Client) TranscriptRaw(
 func (c *Client) transcript(
 	ctx context.Context, taskID, runID int64, opts TranscriptOptions, format string,
 ) (resp *http.Response, nextOffset int64, err error) {
-	path := fmt.Sprintf("/v1/tasks/%d/steps/%d/transcript%s", taskID, runID, opts.query(format))
+	return c.transcriptAt(ctx, fmt.Sprintf(
+		"/v1/tasks/%d/steps/%d/transcript%s", taskID, runID, opts.query(format)))
+}
+
+// transcriptAt performs one transcript GET and hands back the open body plus
+// the X-Next-Offset resume cursor; the caller closes it. Both the step route
+// and the chat-turn route go through here, so their range semantics cannot
+// drift apart in the client.
+func (c *Client) transcriptAt(ctx context.Context, path string) (resp *http.Response, nextOffset int64, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("build transcript request: %w", err)

--- a/internal/chatrun/runner.go
+++ b/internal/chatrun/runner.go
@@ -41,6 +41,31 @@ const (
 	// written. As on the task path, a run that cannot record what happened
 	// does not get to claim success.
 	ReasonTranscriptIOError = "transcript_io_error"
+	// ReasonTimeout is a turn that ran past `defaults.agent_timeout`
+	// (§7.2, task 067 decision 1). It is the engine's constant spelled the
+	// same, not a chat-shaped variant: a chat turn is bounded by the same
+	// number a step is, and a second vocabulary for one clock would make
+	// §12.3 carry two names for it.
+	ReasonTimeout = "timeout"
+	// ReasonInputTimeout is a chat that sat in `awaiting_input` past
+	// `defaults.input_timeout` (§7.4, task 067 decision 1). This is the hole
+	// §11 named in its own words — a live agent CLI holding a
+	// `max_parallel_chats` slot for a human who walked away.
+	ReasonInputTimeout = "input_timeout"
+	// ReasonTranscriptLimit is a turn that hit `transcript_max_bytes`
+	// (§12.3). It is a failure and not a truncation for the reason the task
+	// engine gives: past the cap the turn stops being recorded, and a run
+	// nobody can read afterwards does not get to claim success.
+	ReasonTranscriptLimit = "transcript_limit"
+)
+
+// The cancel causes the turn's own clocks raise. They are internal: the
+// reason a client sees is the snake_case constant above.
+var (
+	errTurnTimeout     = errors.New("turn timeout")
+	errInputTimeout    = errors.New("input timeout")
+	errTranscriptLimit = errors.New("transcript limit")
+	errCanceled        = errors.New("canceled")
 )
 
 // ErrChatCapReached is a send refused because `max_parallel_chats` chats
@@ -89,6 +114,11 @@ type liveTurn struct {
 	turnID int64
 	handle agent.RunHandle
 	cancel context.CancelFunc
+	// answered wakes the turn's clock loop when a human answers a §7.4
+	// request, so the `input_timeout` stops and the `agent_timeout` resumes.
+	// Buffered so Answer never blocks on a loop that is between selects, and
+	// depth 1 because a coalesced wake is still a wake.
+	answered chan struct{}
 }
 
 // New returns a runner over deps.
@@ -178,6 +208,10 @@ func (r *Runner) Answer(ctx context.Context, chatID int64, resp agent.InputRespo
 	if _, err := r.deps.Store.SetChatState(ctx, chatID, chatstate.Running); err != nil {
 		return err
 	}
+	select {
+	case live.answered <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -204,8 +238,12 @@ func (r *Runner) Running(chatID int64) bool {
 // runTurn is the actor: one goroutine, sole writer of this chat's state and
 // this turn's row, living for exactly one turn.
 func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
-	ctx, cancel := context.WithCancel(r.base)
-	defer cancel()
+	ctx, cancelCause := context.WithCancelCause(r.base)
+	// Cancel is a cause-setting cancel so the ending can tell a human's stop
+	// from a clock's (§7.2, §7.4). The deferred one is last and therefore
+	// never the cause a live path observed.
+	cancel := func() { cancelCause(errCanceled) }
+	defer cancelCause(errCanceled)
 	adapter, ok := r.deps.Agents.Get(chat.Agent)
 	if !ok {
 		r.finish(turn, chatstate.TurnFailed, ReasonAgentUnavailable,
@@ -218,6 +256,11 @@ func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
 		return
 	}
 	defer tr.Close()
+	// The cap is read per turn, not cached: config hot-reloads (§12.3), and
+	// an operator who lowers it after a runaway turn should see the new value
+	// on the next send rather than after a daemon restart. Only the task
+	// engine used to do this, which left chat transcripts unbounded.
+	tr.SetMax(r.cfg().TranscriptMaxBytes.Bytes())
 
 	spec := agent.RunSpec{
 		Prompt:          turn.Prompt,
@@ -237,11 +280,15 @@ func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
 		r.finish(turn, chatstate.TurnFailed, reason, err.Error(), nil)
 		return
 	}
-	r.track(chat.ID, &liveTurn{turnID: turn.ID, handle: handle, cancel: cancel})
+	live := &liveTurn{
+		turnID: turn.ID, handle: handle, cancel: cancel,
+		answered: make(chan struct{}, 1),
+	}
+	r.track(chat.ID, live)
 	defer r.untrack(chat.ID)
 	r.journal(turn, handle)
 
-	r.consume(ctx, chat, turn, handle, tr)
+	r.consume(ctx, cancelCause, live, chat, turn, handle, tr)
 
 	res, waitErr := handle.Wait()
 	turn.ExitCode = &res.ExitCode
@@ -250,11 +297,20 @@ func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
 	if res.SessionID != "" {
 		turn.SessionID = res.SessionID
 	}
-	switch {
+	switch cause := context.Cause(ctx); {
 	case ctx.Err() != nil && r.base.Err() != nil:
 		// The daemon is going away under a live turn. It is interrupted, not
 		// failed, and it is never re-run (decision 5).
 		r.finish(turn, chatstate.TurnInterruptedState, "", "", chat)
+	case errors.Is(cause, errTurnTimeout):
+		r.finish(turn, chatstate.TurnFailed, ReasonTimeout,
+			fmt.Sprintf("turn ran past agent_timeout (%s)", r.agentTimeout()), chat)
+	case errors.Is(cause, errTranscriptLimit):
+		r.finish(turn, chatstate.TurnFailed, ReasonTranscriptLimit,
+			"the turn's transcript reached transcript_max_bytes", chat)
+	case errors.Is(cause, errInputTimeout):
+		r.finish(turn, chatstate.TurnFailed, ReasonInputTimeout,
+			fmt.Sprintf("no answer within input_timeout (%s)", r.inputTimeout()), chat)
 	case ctx.Err() != nil:
 		r.finish(turn, chatstate.TurnFailed, ReasonCanceled, "canceled", chat)
 	case waitErr != nil:
@@ -272,49 +328,186 @@ func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
 }
 
 // consume drains the run's normalized events into the transcript and the live
-// output stream, and applies the §7.4 states as they arrive.
+// output stream, applies the §7.4 states as they arrive, and runs the turn's
+// two clocks (task 067 decision 1).
+//
+// The clocks are a pair, not a sum. `agent_timeout` bounds *work*: it runs
+// while the agent is running and stops while the chat sits in
+// `awaiting_input`, because a human thinking is not the agent burning time.
+// `input_timeout` bounds *that wait*, and is the clock §11 was missing — an
+// unanswered request used to hold a `max_parallel_chats` slot forever. Either
+// expiry cancels the run context with its own cause, which kills the process
+// tree; runTurn maps the cause onto the failure reason and returns the chat
+// to idle, releasing the slot.
+//
+// It is a select loop rather than a `range` over the event channel because a
+// range cannot also watch a timer. The events channel closing is what ends
+// the loop, exactly as before.
 func (r *Runner) consume(
-	ctx context.Context, chat *store.Chat, turn *store.ChatTurn,
-	handle agent.RunHandle, tr *transcript.Writer,
+	ctx context.Context, cancelCause context.CancelCauseFunc, live *liveTurn,
+	chat *store.Chat, turn *store.ChatTurn, handle agent.RunHandle, tr *transcript.Writer,
 ) {
-	for ev := range handle.Events() {
-		if len(ev.Raw) > 0 {
-			at := tr.Raw(ev.Raw)
-			if r.deps.Events != nil {
-				r.deps.Events.PublishOutput(chatOutputKey(chat.ID), events.Chunk{
-					Type: "output",
-					Payload: map[string]any{
-						"chat_id": chat.ID, "turn_id": turn.ID,
-						"raw": string(ev.Raw), "offset": at,
-					},
-				})
+	events := handle.Events()
+	work := time.NewTimer(r.agentTimeout())
+	defer work.Stop()
+	wait := time.NewTimer(r.inputTimeout())
+	// The input clock starts stopped: nothing is pending until the agent
+	// asks. stopTimer drains so a later Reset cannot fire an already-queued
+	// tick.
+	stopTimer(wait)
+	defer wait.Stop()
+	parked := false
+	for {
+		select {
+		case <-ctx.Done():
+			// The daemon is going away, or a human canceled. Either way the
+			// adapter's stream is about to close; runTurn classifies from the
+			// cause.
+			return
+		case <-work.C:
+			tr.Note("timeout", map[string]any{"timeout": r.agentTimeout().String()})
+			r.deps.Logger.Warn("chat turn timed out",
+				"chat", chat.ID, "turn", turn.ID, "timeout", r.agentTimeout())
+			cancelCause(errTurnTimeout)
+			return
+		case <-wait.C:
+			tr.Note("input_timeout", map[string]any{"timeout": r.inputTimeout().String()})
+			r.deps.Logger.Warn("chat input request timed out",
+				"chat", chat.ID, "turn", turn.ID, "timeout", r.inputTimeout())
+			cancelCause(errInputTimeout)
+			return
+		case <-live.answered:
+			// A human answered through Answer, which already CAS'd
+			// awaiting_input → running. The wait clock stops and the work
+			// clock resumes from a full budget: the agent is starting fresh
+			// work on the answer, not resuming a run it was halfway through.
+			if parked {
+				parked = false
+				stopTimer(wait)
+				resetTimer(work, r.agentTimeout())
 			}
-		}
-		switch ev.Type {
-		case agent.EventInputRequest:
-			req, err := json.Marshal(ev.Request)
-			if err != nil {
-				continue
+		case ev, chOpen := <-events:
+			if !chOpen {
+				return
 			}
-			if _, err := r.deps.Store.SetChatPendingInput(ctx, chat.ID, req); err != nil {
-				r.deps.Logger.Warn("store chat pending input", "chat", chat.ID, "error", err)
-				continue
+			r.record(chat, turn, tr, ev)
+			if tr.Exceeded() {
+				r.deps.Logger.Warn("chat transcript hit its cap",
+					"chat", chat.ID, "turn", turn.ID,
+					"limit", r.cfg().TranscriptMaxBytes.Bytes())
+				cancelCause(errTranscriptLimit)
+				return
 			}
-			if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.AwaitingInput); err != nil {
-				r.deps.Logger.Warn("chat awaiting input", "chat", chat.ID, "error", err)
+			switch ev.Type {
+			case agent.EventInputRequest:
+				if !r.park(ctx, chat, ev) {
+					continue
+				}
+				parked = true
+				stopTimer(work)
+				resetTimer(wait, r.inputTimeout())
+			case agent.EventInputCanceled:
+				if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.Running); err != nil {
+					r.deps.Logger.Warn("chat input closed", "chat", chat.ID, "error", err)
+				}
+				if parked {
+					parked = false
+					stopTimer(wait)
+					resetTimer(work, r.agentTimeout())
+				}
+			case agent.EventUsage, agent.EventResult, agent.EventOutput, agent.EventToolUse,
+				agent.EventToolResult, agent.EventThinking, agent.EventRunHeader,
+				agent.EventError, agent.EventUnknown:
+				// Rendering is the client's job: every one of these is already
+				// in the transcript and on the stream, and internal/tui's
+				// outputlines.go decides what a verbosity level shows.
 			}
-		case agent.EventInputCanceled:
-			if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.Running); err != nil {
-				r.deps.Logger.Warn("chat input closed", "chat", chat.ID, "error", err)
-			}
-		case agent.EventUsage, agent.EventResult, agent.EventOutput, agent.EventToolUse,
-			agent.EventToolResult, agent.EventThinking, agent.EventRunHeader,
-			agent.EventError, agent.EventUnknown:
-			// Rendering is the client's job: every one of these is already
-			// in the transcript and on the stream, and internal/tui's
-			// outputlines.go decides what a verbosity level shows.
 		}
 	}
+}
+
+// record writes one event's raw line to the transcript and republishes it on
+// the chat's live-output key. The offset it returns is what a client seams a
+// transcript fetch against (§13.3): chunks at or before the fetch's
+// X-Next-Offset are the ones it already has.
+func (r *Runner) record(chat *store.Chat, turn *store.ChatTurn, tr *transcript.Writer, ev agent.Event) {
+	if len(ev.Raw) == 0 {
+		return
+	}
+	at := tr.Raw(ev.Raw)
+	if r.deps.Events == nil {
+		return
+	}
+	r.deps.Events.PublishOutput(chatOutputKey(chat.ID), events.Chunk{
+		Type: "output",
+		Payload: map[string]any{
+			"chat_id": chat.ID, "turn_id": turn.ID,
+			"raw": string(ev.Raw), "offset": at,
+		},
+	})
+}
+
+// park records a §7.4 request and moves the chat to awaiting_input. It reports
+// whether the chat actually parked: a request that could not be stored is not
+// one a human can answer, so the input clock must not start on it.
+func (r *Runner) park(ctx context.Context, chat *store.Chat, ev agent.Event) bool {
+	req, err := json.Marshal(ev.Request)
+	if err != nil {
+		return false
+	}
+	if _, err := r.deps.Store.SetChatPendingInput(ctx, chat.ID, req); err != nil {
+		r.deps.Logger.Warn("store chat pending input", "chat", chat.ID, "error", err)
+		return false
+	}
+	if _, err := r.deps.Store.SetChatState(ctx, chat.ID, chatstate.AwaitingInput); err != nil {
+		r.deps.Logger.Warn("chat awaiting input", "chat", chat.ID, "error", err)
+		return false
+	}
+	return true
+}
+
+// stopTimer stops a timer and drains a tick that already fired, so a later
+// Reset starts from now rather than firing immediately.
+func stopTimer(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}
+
+// resetTimer restarts a timer at d, draining first for the same reason.
+func resetTimer(t *time.Timer, d time.Duration) {
+	stopTimer(t)
+	t.Reset(d)
+}
+
+// cfg returns the current effective configuration, tolerating a runner built
+// without one (tests) by falling back to the shipped defaults.
+func (r *Runner) cfg() config.Config {
+	if r.deps.Config == nil {
+		return config.Default()
+	}
+	return r.deps.Config()
+}
+
+// agentTimeout is §7.2's clock, applied verbatim to a chat turn. There is no
+// per-turn override: §8.2's `timeout` is a workflow step field, and a chat has
+// no workflow (task 067 decision 1).
+func (r *Runner) agentTimeout() time.Duration {
+	if d := r.cfg().Defaults.AgentTimeout.Std(); d > 0 {
+		return d
+	}
+	return config.Default().Defaults.AgentTimeout.Std()
+}
+
+// inputTimeout is §7.4's clock, likewise verbatim and likewise unoverridable.
+func (r *Runner) inputTimeout() time.Duration {
+	if d := r.cfg().Defaults.InputTimeout.Std(); d > 0 {
+		return d
+	}
+	return config.Default().Defaults.InputTimeout.Std()
 }
 
 // journal records the process identity beside the pid, so §12.4 recovery can

--- a/internal/chatrun/runner_test.go
+++ b/internal/chatrun/runner_test.go
@@ -379,3 +379,132 @@ func waitFor(t *testing.T, cond func() bool) {
 	}
 	t.Fatal("condition never became true")
 }
+
+// The two clocks (task 067 decision 1). A chat turn gets §7.2's and §7.4's
+// numbers verbatim: `agent_timeout` bounds a running turn, `input_timeout`
+// bounds `awaiting_input`. Both expiries kill the process, fail the turn with
+// the shared snake_case reason and return the chat to idle — which is what
+// releases the `max_parallel_chats` slot §11 previously let a walked-away
+// human hold forever.
+
+// TestTurnPastAgentTimeoutFails covers §7.2's clock on a turn that will not
+// stop on its own.
+func TestTurnPastAgentTimeoutFails(t *testing.T) {
+	h := newHarness(t)
+	h.cfg.Defaults.AgentTimeout = config.Duration(150 * time.Millisecond)
+	t.Setenv("FAKEAGENT_SCENARIO", "hang")
+	c := h.chat(t)
+
+	turn := h.sendAndWait(t, c.ID, "run forever")
+	if turn.State != chatstate.TurnFailed || turn.FailReason != ReasonTimeout {
+		t.Fatalf("turn = %s/%s, want failed/%s", turn.State, turn.FailReason, ReasonTimeout)
+	}
+	if got := h.waitIdle(t, c.ID); got.State != chatstate.Idle {
+		t.Fatalf("chat = %s after a timeout, want idle", got.State)
+	}
+	assertSlotFree(t, h)
+}
+
+// TestChatPastInputTimeoutFails is the hole §11 named in its own words: a
+// chat parked on a §7.4 request that nobody answers.
+func TestChatPastInputTimeoutFails(t *testing.T) {
+	h := newHarness(t)
+	// The work clock stays generous: what this test bounds is the *wait*,
+	// and a short agent_timeout would decide the outcome first.
+	h.cfg.Defaults.AgentTimeout = config.Duration(30 * time.Second)
+	h.cfg.Defaults.InputTimeout = config.Duration(150 * time.Millisecond)
+	t.Setenv("FAKEAGENT_SCENARIO", "ask-question")
+	c := h.chat(t)
+
+	turn := h.sendAndWait(t, c.ID, "ask me something")
+	if turn.State != chatstate.TurnFailed || turn.FailReason != ReasonInputTimeout {
+		t.Fatalf("turn = %s/%s, want failed/%s", turn.State, turn.FailReason, ReasonInputTimeout)
+	}
+	if got := h.waitIdle(t, c.ID); got.State != chatstate.Idle {
+		t.Fatalf("chat = %s after an input timeout, want idle", got.State)
+	}
+	assertSlotFree(t, h)
+}
+
+// TestAnsweringStopsTheInputClock proves the pair is a pair and not a sum: a
+// human who answers inside the window resumes the work clock rather than
+// carrying the input clock's remainder into the rest of the turn.
+func TestAnsweringStopsTheInputClock(t *testing.T) {
+	h := newHarness(t)
+	h.cfg.Defaults.AgentTimeout = config.Duration(30 * time.Second)
+	h.cfg.Defaults.InputTimeout = config.Duration(5 * time.Second)
+	t.Setenv("FAKEAGENT_SCENARIO", "ask-question")
+	c := h.chat(t)
+
+	turn, err := h.runner.Send(t.Context(), c.ID, "ask me something")
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	h.waitState(t, c.ID, chatstate.AwaitingInput)
+	if err := h.runner.Answer(t.Context(), c.ID, agent.InputResponse{
+		Answers: map[string][]string{"Which colour?": {"blue"}},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	got := h.waitTurn(t, turn.ID)
+	if got.FailReason == ReasonInputTimeout {
+		t.Fatal("an answered request still expired on the input clock")
+	}
+}
+
+// TestTurnTranscriptStopsAtTheCap covers the other thing only the task engine
+// used to do: `transcript_max_bytes` applies to a chat turn's transcript too.
+func TestTurnTranscriptStopsAtTheCap(t *testing.T) {
+	h := newHarness(t)
+	h.cfg.TranscriptMaxBytes = 256
+	t.Setenv("FAKEAGENT_SCENARIO", "flood")
+	c := h.chat(t)
+
+	turn := h.sendAndWait(t, c.ID, "say a lot")
+	if turn.FailReason != ReasonTranscriptLimit {
+		t.Fatalf("turn = %s/%s, want failed/%s", turn.State, turn.FailReason, ReasonTranscriptLimit)
+	}
+	path := filepath.Join(h.dataDir, "transcripts",
+		worktree.ChatOwner(c.ID).Dir(), fmt.Sprintf("%d.jsonl", turn.Seq))
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat transcript: %v", err)
+	}
+	// The cap bounds what is written, not to the byte: the writer stops at
+	// the first line that would cross it and records that it did.
+	if info.Size() > 64<<10 {
+		t.Fatalf("transcript is %d bytes with a 256-byte cap", info.Size())
+	}
+}
+
+// waitState waits for the chat to reach one state, for the tests that act
+// while a turn is live.
+func (h *harness) waitState(t *testing.T, chatID int64, want chatstate.State) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := h.store.GetChat(t.Context(), chatID)
+		if err != nil {
+			t.Fatalf("GetChat: %v", err)
+		}
+		if got.State == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("chat %d never reached %s", chatID, want)
+}
+
+// assertSlotFree proves the §11 slot came back: the store no longer counts a
+// chat holding a process, which is what a send that was 409 before now
+// depends on.
+func assertSlotFree(t *testing.T, h *harness) {
+	t.Helper()
+	n, err := h.store.CountChatsHoldingProcess(t.Context())
+	if err != nil {
+		t.Fatalf("CountChatsHoldingProcess: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("%d chats still hold a process after the clock fired", n)
+	}
+}

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -15,10 +15,15 @@ import (
 // newChatCmd is `vincent chat` (spec §5.5, §12.1, task 063): the CLI half of
 // free chat, so the feature is not TUI-only.
 //
-// The verbs are the four §5.5 actions plus a read: start, send, list, show,
-// archive. `send` blocks until the turn ends and prints the answer, which is
-// what a conversation in a terminal has to do — a fire-and-forget send would
-// leave the human polling `show`.
+// The verbs are the §5.5 actions plus a read: start, send, answer, cancel,
+// list, show, archive. `send` blocks until the turn ends and prints the
+// answer, which is what a conversation in a terminal has to do — a
+// fire-and-forget send would leave the human polling `show`.
+//
+// `answer` and `cancel` exist because interrupting `send` stops the CLI and
+// not the turn: without them a parked or runaway chat could only be reached
+// from the TUI or with curl, which is exactly the TUI-only feature this
+// command exists to prevent (task 067).
 func newChatCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "chat",
@@ -29,8 +34,8 @@ func newChatCmd() *cobra.Command {
 			"Chats are not tasks: they never appear on the board, they run no workflow, " +
 			"and a chat turn never waits for a scheduler slot.",
 	}
-	cmd.AddCommand(newChatStartCmd(), newChatSendCmd(), newChatListCmd(),
-		newChatShowCmd(), newChatArchiveCmd())
+	cmd.AddCommand(newChatStartCmd(), newChatSendCmd(), newChatAnswerCmd(),
+		newChatCancelCmd(), newChatListCmd(), newChatShowCmd(), newChatArchiveCmd())
 	return cmd
 }
 
@@ -57,10 +62,12 @@ func newChatStartCmd() *cobra.Command {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d  %s  [%s]  %s\n",
-					chat.ID, chat.Title, chat.Agent, chat.Branch)
 				if message == "" {
-					return nil
+					return printChat(cmd, chat)
+				}
+				if !wantJSON(cmd) {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d  %s  [%s]  %s\n",
+						chat.ID, chat.Title, chat.Agent, chat.Branch)
 				}
 				return runChatTurn(ctx, cmd, c, chat.ID, message)
 			})
@@ -73,6 +80,7 @@ func newChatStartCmd() *cobra.Command {
 	cmd.Flags().StringVar(&baseBranch, "base", "", "base branch; default is the project's")
 	cmd.Flags().StringVar(&message, "message", "", "send this first message straight away")
 	_ = cmd.MarkFlagRequired("project")
+	jsonFlag(cmd)
 	return cmd
 }
 
@@ -91,6 +99,7 @@ func newChatSendCmd() *cobra.Command {
 			})
 		},
 	}
+	jsonFlag(cmd)
 	return cmd
 }
 
@@ -123,6 +132,15 @@ func runChatTurn(ctx context.Context, cmd *cobra.Command, c *apiclient.Client, i
 			if t.ID != turn.ID || t.State == "running" {
 				continue
 			}
+			if wantJSON(cmd) {
+				if err := emitJSON(cmd.OutOrStdout(), t); err != nil {
+					return err
+				}
+				if t.State != "done" {
+					return exitError{code: 1}
+				}
+				return nil
+			}
 			if t.State != "done" {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "turn %d %s: %s %s\n",
 					t.Seq, t.State, t.FailReason, t.ErrorMessage)
@@ -147,6 +165,14 @@ func newChatListCmd() *cobra.Command {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}
 				}
+				if wantJSON(cmd) {
+					// An initialized slice, never nil: a script doing
+					// `| jq '.[]'` should see an empty list, not a type error.
+					if chats == nil {
+						chats = []apiclient.Chat{}
+					}
+					return emitJSON(cmd.OutOrStdout(), chats)
+				}
 				if len(chats) == 0 {
 					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No chats.")
 					return nil
@@ -161,6 +187,7 @@ func newChatListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Int64Var(&projectID, "project", 0, "only this project's chats")
+	jsonFlag(cmd)
 	return cmd
 }
 
@@ -181,8 +208,28 @@ func newChatShowCmd() *cobra.Command {
 					return exitError{code: 1}
 				}
 				out := cmd.OutOrStdout()
+				if wantJSON(cmd) {
+					if turns == nil {
+						turns = []apiclient.ChatTurn{}
+					}
+					return emitJSON(out, struct {
+						Chat  *apiclient.Chat      `json:"chat"`
+						Turns []apiclient.ChatTurn `json:"turns"`
+					}{chat, turns})
+				}
 				_, _ = fmt.Fprintf(out, "chat %d  %s\nstate: %s  agent: %s  branch: %s\n",
 					chat.ID, chat.Title, chat.State, chat.Agent, chat.Branch)
+				// The pending request is printed before the turns because it
+				// is the thing that needs doing: `chat answer` numbers its
+				// questions off exactly this list.
+				if req, ok, err := chat.PendingRequest(); err != nil {
+					return err
+				} else if ok {
+					if err := printInputRequest(out, req,
+						fmt.Sprintf("vincent chat answer %d", chat.ID)); err != nil {
+						return err
+					}
+				}
 				for i := range turns {
 					t := &turns[i]
 					_, _ = fmt.Fprintf(out, "\n--- turn %d (%s) ---\n> %s\n", t.Seq, t.State, t.Prompt)
@@ -197,6 +244,7 @@ func newChatShowCmd() *cobra.Command {
 			})
 		},
 	}
+	jsonFlag(cmd)
 	return cmd
 }
 
@@ -217,11 +265,136 @@ func newChatArchiveCmd() *cobra.Command {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}
 				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), chat)
+				}
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d archived\n", chat.ID)
 				return nil
 			})
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "archive even if the worktree has local changes")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// printChat renders one chat, as a line or as JSON.
+func printChat(cmd *cobra.Command, chat *apiclient.Chat) error {
+	if wantJSON(cmd) {
+		return emitJSON(cmd.OutOrStdout(), chat)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "chat %d  %s  [%s]  %s\n",
+		chat.ID, chat.Title, chat.Agent, chat.Branch)
+	return nil
+}
+
+// newChatAnswerCmd is `vincent chat answer`: the §7.4 answer, reached from a
+// terminal.
+//
+// It is `task answer` for a chat, flag for flag, because the request is the
+// same request — internal/chatrun stores what the adapter emitted, unaltered
+// — and a second vocabulary for answering one would be two ways to say the
+// same thing. It is not optional surface: a chat parked on a question is a
+// chat holding a `max_parallel_chats` slot, and until now nothing but the API
+// could release it.
+func newChatAnswerCmd() *cobra.Command {
+	var (
+		answers []string
+		allow   bool
+		deny    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "answer <chat-id>",
+		Short: "Answer the input request a chat is waiting on",
+		Long: "Answers the §7.4 request an awaiting_input chat is parked on; the turn\n" +
+			"resumes in place. Questions are answered by the number 'vincent chat show'\n" +
+			"prints them under — repeat --answer for one index to give a multi-select\n" +
+			"several values — and a permission request takes --allow or --deny.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				// The request has to be read before it can be answered: the
+				// wire format is keyed by question *text* (§13.2), and the
+				// index exists only so nobody retypes quoted prose.
+				chat, _, err := c.GetChat(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				req, ok, err := chat.PendingRequest()
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("chat %d is %s and is not waiting for input", id, chat.State)
+				}
+				resp, err := answerResponse(req, answers, allow, deny)
+				if err != nil {
+					return err
+				}
+				// Local validation is a convenience, never the authority: the
+				// daemon checks the same rules and its answer is the one that
+				// counts.
+				if err := req.Validate(resp); err != nil {
+					return err
+				}
+				if err := c.AnswerChat(ctx, id, resp); err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				updated, _, err := c.GetChat(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				return printChat(cmd, updated)
+			})
+		},
+	}
+	cmd.Flags().StringArrayVar(&answers, "answer", nil,
+		"Answer as <n>=<value>, n being the question number 'vincent chat show' prints; repeat for more")
+	cmd.Flags().BoolVar(&allow, "allow", false, "Allow a permission request")
+	cmd.Flags().BoolVar(&deny, "deny", false, "Deny a permission request")
+	cmd.MarkFlagsMutuallyExclusive("answer", "allow", "deny")
+	cmd.MarkFlagsOneRequired("answer", "allow", "deny")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// newChatCancelCmd is `vincent chat cancel`: stop the live turn and kill its
+// process tree, returning the chat to idle and releasing its slot.
+//
+// Interrupting `vincent chat send` stops the CLI and not the turn — the turn
+// belongs to the daemon, which is the whole point of the daemon — so this is
+// the command that actually stops one.
+func newChatCancelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <chat-id>",
+		Short: "Stop a chat's live turn",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				if err := c.CancelChat(ctx, id); err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				chat, _, err := c.GetChat(ctx, id)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				return printChat(cmd, chat)
+			})
+		},
+	}
+	jsonFlag(cmd)
 	return cmd
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -1051,6 +1051,14 @@ func printPendingRequest(w io.Writer, t apiclient.TaskDetail) error {
 	if !ok {
 		return nil
 	}
+	return printInputRequest(w, req, fmt.Sprintf("vincent task answer %d", t.ID))
+}
+
+// printInputRequest renders a §7.4 request under a numbering both
+// `task answer` and `chat answer` read: question 1 is the first question the
+// daemon sent, in the order it sent them. answerCmd is the invocation the
+// hint names, which is the only thing that differs between the two.
+func printInputRequest(w io.Writer, req apiclient.InputRequest, answerCmd string) error {
 	if _, err := fmt.Fprintf(w, "\nawaiting input: %s\n", req.Kind); err != nil {
 		return err
 	}
@@ -1059,8 +1067,8 @@ func printPendingRequest(w io.Writer, t apiclient.TaskDetail) error {
 			return nil
 		}
 		_, err := fmt.Fprintf(w, "  tool     %s\n  summary  %s\n"+
-			"  answer with `vincent task answer %d --allow` or `--deny`\n",
-			req.Permission.Tool, req.Permission.Summary, t.ID)
+			"  answer with `%s --allow` or `--deny`\n",
+			req.Permission.Tool, req.Permission.Summary, answerCmd)
 		return err
 	}
 	for i, q := range req.Questions {
@@ -1085,6 +1093,6 @@ func printPendingRequest(w io.Writer, t apiclient.TaskDetail) error {
 	if len(req.Questions) == 0 {
 		return nil
 	}
-	_, err = fmt.Fprintf(w, "  answer with `vincent task answer %d --answer 1=<value>`\n", t.ID)
+	_, err := fmt.Fprintf(w, "  answer with `%s --answer 1=<value>`\n", answerCmd)
 	return err
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -72,6 +72,14 @@ var Excluded = []Route{
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/answer"},
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/cancel"},
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/archive"},
+	// The chat read routes are excluded under the same rule, not merely
+	// because they are streams. `GET /v1/chats/{id}/events` follows a live
+	// conversation and the transcript route reads its durable record; both
+	// are the surface a human drives a chat through, and neither is
+	// something an agent needs, since an agent calling one already has a
+	// session of its own (task 063 decision 2, task 067 decision 2).
+	{Method: http.MethodGet, Path: "/v1/chats/{id}/events"},
+	{Method: http.MethodGet, Path: "/v1/chats/{id}/turns/{seq}/transcript"},
 }
 
 // Streaming lists the §13.3 SSE routes. They are not tools because a tool call

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/lezli01/vincent/internal/chatstate"
@@ -20,6 +21,19 @@ const (
 	EventChatTurn     = "chat.turn_changed"
 	EventChatArchived = "chat.archived"
 )
+
+// ChatEventTypes is the chat.* family, in the order it is declared. It exists
+// so a per-chat SSE replay can narrow the events table to chat rows before
+// filtering on the payload's id: a chat event carries no task_id column, so
+// without this a replay would scan every task event behind the cursor.
+func ChatEventTypes() []string {
+	return []string{EventChatCreated, EventChatState, EventChatTurn, EventChatArchived}
+}
+
+// IsChatEvent reports whether an event type belongs to the chat family.
+func IsChatEvent(t string) bool {
+	return slices.Contains(ChatEventTypes(), t)
+}
 
 const chatColumns = `id, project_id, title, state, agent, model, effort, permission_mode,
 	branch, base_branch, base_sha, worktree_path, session_id, pending_input, created_at, updated_at`
@@ -518,4 +532,35 @@ func scanChatTurn(r rowScanner) (*ChatTurn, error) {
 		return nil, err
 	}
 	return &t, nil
+}
+
+// ArchivedChatIDsBefore returns the ids of chats archived before cutoff — the
+// chat half of transcript pruning (§17 retention), the mirror of
+// ArchivedTaskIDsBefore.
+//
+// It measures from `updated_at` rather than from an `archived_at` column
+// because chats have neither: `archived` is a terminal §5.5 state, so the
+// archive transition is the last write a chat row ever takes and its
+// `updated_at` *is* the moment it was archived. Adding a column to restate
+// that would be a migration for a value already on the row.
+func (s *Store) ArchivedChatIDsBefore(ctx context.Context, cutoff time.Time) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM chats WHERE state = ? AND updated_at < ? ORDER BY id`,
+		string(chatstate.Archived), formatTime(cutoff))
+	if err != nil {
+		return nil, fmt.Errorf("list archived chats: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan archived chat id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list archived chats: %w", err)
+	}
+	return ids, nil
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -54,6 +54,16 @@ func (s *Store) SetEventHook(fn func(*Event)) { s.eventHook.Store(&fn) }
 
 // notify runs the event hook, if one is registered.
 func (s *Store) notify(e *Event) {
+	// A nil event is a write that had nothing to announce — updateChat takes
+	// an empty type for the columns no client is told about (session id,
+	// worktree path, pending input) and hands the nil straight here. Publishing
+	// it reached every open SSE stream, each of which dereferences the event it
+	// is handed, so writing a chat's session id panicked
+	// `GET /v1/events` for everyone. Dropped here rather than guarded in three
+	// handlers: "there is no event" is this function's business (task 067).
+	if e == nil {
+		return
+	}
 	if fn := s.eventHook.Load(); fn != nil && *fn != nil {
 		(*fn)(e)
 	}

--- a/internal/taskrun/prune.go
+++ b/internal/taskrun/prune.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // PruneInterval is how often the daemon re-runs retention pruning.
@@ -71,7 +73,7 @@ func (p *TranscriptPruner) once(ctx context.Context) {
 		p.deps.Logger.Error("prune transcripts", "error", err)
 	case removed > 0:
 		p.deps.Logger.Info("pruned transcripts",
-			"tasks", removed, "freed_bytes", freed,
+			"dirs", removed, "freed_bytes", freed,
 			"retention_days", p.deps.Config().TranscriptRetentionDays)
 	default:
 		p.deps.Logger.Debug("prune transcripts: nothing to do")
@@ -98,9 +100,9 @@ func (p *TranscriptPruner) PruneKeys(ctx context.Context, now time.Time) (int64,
 	return p.deps.Store.PruneIdempotencyKeys(ctx, now.Add(-IdempotencyRetention))
 }
 
-// Prune deletes the transcript directory of every task archived before
-// now-retention, returning how many task directories went and how many bytes
-// that freed. A retention of zero or less disables pruning entirely, which is
+// Prune deletes the transcript directory of every task *and every chat*
+// archived before now-retention, returning how many directories went and how
+// many bytes that freed. A retention of zero or less disables pruning entirely, which is
 // how an operator keeps everything.
 //
 // now is a parameter so tests can age data without sleeping.
@@ -114,9 +116,25 @@ func (p *TranscriptPruner) Prune(ctx context.Context, now time.Time) (removed in
 	if err != nil {
 		return 0, 0, err
 	}
+	// Chats keep transcripts under the same root and under the same
+	// retention setting (§17, task 067): a conversation nobody archived is
+	// live, and one archived past the window is as stale as a task's. They
+	// are walked here rather than in a second pruner because the directory,
+	// the config key and the pass are all one.
+	chatIDs, err := p.deps.Store.ArchivedChatIDsBefore(ctx, cutoff)
+	if err != nil {
+		return 0, 0, err
+	}
 	root := filepath.Join(p.deps.DataDir, "transcripts")
+	dirs := make([]string, 0, len(ids)+len(chatIDs))
 	for _, id := range ids {
-		dir := filepath.Join(root, strconv.FormatInt(id, 10))
+		dirs = append(dirs, strconv.FormatInt(id, 10))
+	}
+	for _, id := range chatIDs {
+		dirs = append(dirs, worktree.ChatOwner(id).Dir())
+	}
+	for _, name := range dirs {
+		dir := filepath.Join(root, name)
 		size, err := dirSize(dir)
 		if err != nil {
 			// Already gone is the common case — a task pruned on an earlier
@@ -128,12 +146,12 @@ func (p *TranscriptPruner) Prune(ctx context.Context, now time.Time) (removed in
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
-			p.deps.Logger.Warn("measure transcript dir", "task", id, "error", err)
+			p.deps.Logger.Warn("measure transcript dir", "dir", name, "error", err)
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			// Report the first real failure but keep going: one undeletable
 			// directory must not strand every task behind it.
-			p.deps.Logger.Warn("prune transcript dir", "task", id, "error", err)
+			p.deps.Logger.Warn("prune transcript dir", "dir", name, "error", err)
 			continue
 		}
 		removed++

--- a/internal/taskrun/prune_test.go
+++ b/internal/taskrun/prune_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lezli01/vincent/internal/chatstate"
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // pruneHarness is a store plus a data dir with transcript files on disk —
@@ -218,5 +220,81 @@ func TestPruneKeysDropsExpiredOnly(t *testing.T) {
 	// already-pruned rows must be a no-op rather than an error.
 	if n, err := h.pruner.PruneKeys(t.Context(), time.Now()); err != nil || n != 0 {
 		t.Fatalf("second pass: removed %d, err %v; want 0, nil", n, err)
+	}
+}
+
+// chat creates a chat with a transcript directory, archiving it when asked.
+// It cannot backdate the row — `updated_at` is written by the store — so the
+// tests below age the *cutoff* instead, which is what the now parameter is
+// for.
+func (h *pruneHarness) chat(t *testing.T, title string, archived bool) int64 {
+	t.Helper()
+	c := &store.Chat{
+		ProjectID: h.projectID, Title: title, State: chatstate.Idle,
+		Agent: "claude", BaseBranch: "main", Branch: "vincent/" + title,
+	}
+	if err := h.store.CreateChat(t.Context(), c); err != nil {
+		t.Fatalf("CreateChat: %v", err)
+	}
+	if archived {
+		if _, err := h.store.SetChatState(t.Context(), c.ID, chatstate.Archived); err != nil {
+			t.Fatalf("archive chat: %v", err)
+		}
+	}
+	dir := filepath.Join(h.dataDir, "transcripts", worktree.ChatOwner(c.ID).Dir())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir chat transcripts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "1.jsonl"), []byte("{\"type\":\"x\"}\n"), 0o600); err != nil {
+		t.Fatalf("write chat transcript: %v", err)
+	}
+	return c.ID
+}
+
+func (h *pruneHarness) chatExists(chatID int64) bool {
+	_, err := os.Stat(filepath.Join(h.dataDir, "transcripts", worktree.ChatOwner(chatID).Dir()))
+	return err == nil
+}
+
+// TestPruneReclaimsArchivedChatTranscripts is the chat half of §17 retention
+// (task 067): a chat keeps its transcripts under the same root and the same
+// setting, so an archived one past the window goes the way an archived task's
+// does — and a live conversation's never does, however old.
+func TestPruneReclaimsArchivedChatTranscripts(t *testing.T) {
+	h := newPruneHarness(t, 7)
+	archived := h.chat(t, "done-talking", true)
+	live := h.chat(t, "still-talking", false)
+	task := h.task(t, "old-archived", 30*24*time.Hour)
+
+	// The cutoff is aged rather than the rows: now+30d puts the archived
+	// chat well behind a 7-day window.
+	removed, _, err := h.pruner.Prune(t.Context(), time.Now().Add(30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if removed != 2 {
+		t.Fatalf("Prune removed %d directories, want the archived task and the archived chat", removed)
+	}
+	if h.chatExists(archived) {
+		t.Error("the archived chat's transcript directory survived retention")
+	}
+	if !h.chatExists(live) {
+		t.Error("a chat that was never archived had its transcripts pruned")
+	}
+	if h.exists(task) {
+		t.Error("the archived task's transcript directory survived retention")
+	}
+}
+
+// TestPruneLeavesArchivedChatsInsideTheWindow is the other side: retention is
+// measured from when the chat was archived, so one archived just now stays.
+func TestPruneLeavesArchivedChatsInsideTheWindow(t *testing.T) {
+	h := newPruneHarness(t, 7)
+	id := h.chat(t, "just-archived", true)
+	if _, _, err := h.pruner.Prune(t.Context(), time.Now()); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !h.chatExists(id) {
+		t.Error("a chat archived inside the retention window was pruned")
 	}
 }

--- a/internal/tui/answerform.go
+++ b/internal/tui/answerform.go
@@ -142,6 +142,17 @@ func (f *answerForm) paste(text string) tea.Cmd {
 
 // update handles one key. exit=true asks the caller to leave the form.
 func (f *answerForm) update(msg tea.KeyPressMsg, client *apiclient.Client, taskID int64) (cmd tea.Cmd, exit bool) {
+	return f.updateWith(msg, func(resp apiclient.InputResponse) tea.Cmd {
+		return f.submitTask(resp, client, taskID)
+	})
+}
+
+// updateWith is the form's keyboard over an arbitrary submitter. It exists so
+// a chat's answer popup is *this* popup rather than a fork of it: structured
+// options, multi-select and the permission allow/deny distinction are the same
+// because the request is the same request, and only where the answer is POSTed
+// differs (task 063 decision 8, task 067).
+func (f *answerForm) updateWith(msg tea.KeyPressMsg, submit func(apiclient.InputResponse) tea.Cmd) (cmd tea.Cmd, exit bool) {
 	if f.editing {
 		switch msg.String() {
 		case "enter":
@@ -167,11 +178,26 @@ func (f *answerForm) update(msg tea.KeyPressMsg, client *apiclient.Client, taskI
 	case "e":
 		f.startFreeText()
 	case "enter":
-		return f.submit(client, taskID), false
+		return f.submitTo(submit), false
 	case "esc":
 		return nil, true
 	}
 	return nil, false
+}
+
+// submitTo validates locally, then hands the response to the caller's poster.
+// Local validation is a convenience and never the authority — the daemon
+// checks the same rules — but a form that can say "answer the second
+// question" without a round trip should.
+func (f *answerForm) submitTo(post func(apiclient.InputResponse) tea.Cmd) tea.Cmd {
+	resp := f.response()
+	if err := f.req.Validate(resp); err != nil {
+		f.err = errString(err)
+		return nil
+	}
+	f.err = ""
+	f.submitting = true
+	return post(resp)
 }
 
 // nextSelectable walks past header lines in the given direction, staying put
@@ -286,21 +312,14 @@ func (f *answerForm) response() apiclient.InputResponse {
 	return apiclient.InputResponse{Answers: f.answers, Allow: f.allow}
 }
 
-// submit validates locally first — the daemon validates too and stays the
-// authority, but a form that can say "answer the second question" without a
-// round trip should.
-func (f *answerForm) submit(client *apiclient.Client, taskID int64) tea.Cmd {
-	resp := f.response()
-	if err := f.req.Validate(resp); err != nil {
-		f.err = errString(err)
-		return nil
-	}
+// submitTask posts the answer to a task. It is the submitter the task path
+// hands updateWith.
+func (f *answerForm) submitTask(resp apiclient.InputResponse, client *apiclient.Client, taskID int64) tea.Cmd {
 	if client == nil {
 		f.err = "not connected"
+		f.submitting = false
 		return nil
 	}
-	f.err = ""
-	f.submitting = true
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -57,8 +57,14 @@ const (
 	// owns the keyboard, and a row shared with the graph could only describe
 	// one of the two.
 	ctxWorkflowStep bindingContext = "step detail"
-	ctxDaemon       bindingContext = "daemon"
-	ctxForm         bindingContext = "answer form"
+	// The chat surfaces (task 067). Three contexts for two views: the
+	// new-chat form is a layer over the chats board with its own keyboard,
+	// which is exactly what a bindingContext names.
+	ctxChats   bindingContext = "chats"
+	ctxChat    bindingContext = "chat"
+	ctxNewChat bindingContext = "new chat"
+	ctxDaemon  bindingContext = "daemon"
+	ctxForm    bindingContext = "answer form"
 	// ctxRepairForm is the §6 repair popup (task 025). Its own context
 	// rather than more ctxForm rows: the two popups share a shape and
 	// nothing else — one picks from what an agent asked, the other types a
@@ -143,6 +149,10 @@ var bindings = []binding{
 	{label: "workflows — registry with scopes and validity", scope: scopeGlobal, nav: true, navTarget: viewWorkflows},
 	{label: "daemon — identity, config, adapters, log", scope: scopeGlobal, nav: true, navTarget: viewDaemon},
 	{label: "pull requests — what is open across every GitHub project", scope: scopeGlobal, nav: true, navTarget: viewPullRequests, github: true},
+	// Chats get a palette row and no direct key, the pattern every takeover
+	// but new task follows. `n` is not shared: on the chats board it makes a
+	// chat, everywhere else it still makes a task.
+	{label: "chats — conversations with an agent, each in its own worktree", scope: scopeGlobal, nav: true, navTarget: viewChats},
 
 	// Task actions, gated on available_actions. `p` appears twice because
 	// pause and resume are distinct actions behind one key; the palette
@@ -217,6 +227,26 @@ var bindings = []binding{
 	{key: "+", label: "nudge the priority (+/-; higher runs first)", scope: scopePanel, context: ctxNewTask, hint: "+/- priority", priority: 4},
 	{key: "R", label: "re-probe the adapters (the list is otherwise cache-served)", scope: scopePanel, context: ctxNewTask, hint: "R re-probe", priority: 5},
 	{key: "ctrl+s", label: "create the task", scope: scopePanel, context: ctxNewTask, hint: "ctrl+s create", priority: 1},
+
+	// Chats board.
+	{key: "enter", label: "open the chat's workspace", scope: scopePanel, context: ctxChats, hint: "enter open", priority: 1},
+	{key: "n", label: "start a chat in the project you are looking at", scope: scopePanel, context: ctxChats, hint: "n new", priority: 2},
+	{key: "a", label: "archive the chat (asks first — the worktree is removed)", scope: scopePanel, context: ctxChats, hint: "a archive", priority: 3},
+	{key: "/", label: "filter by title, agent or branch", scope: scopePanel, context: ctxChats, hint: "/ filter", priority: 4},
+	{key: "left", label: "collapse the project group", scope: scopePanel, context: ctxChats, hint: "← fold", priority: 5},
+	{key: "right", label: "expand the project group", scope: scopePanel, context: ctxChats, hint: "→ unfold", priority: 6},
+	{key: "r", label: "reload the board", scope: scopePanel, context: ctxChats, hint: "r reload", priority: 7},
+
+	// Chat workspace.
+	{key: "enter", label: "send the message", scope: scopePanel, context: ctxChat, hint: "enter send", priority: 1},
+	{key: "ctrl+x", label: "stop the running turn (its process tree is killed)", scope: scopePanel, context: ctxChat, hint: "ctrl+x stop", priority: 2},
+	{key: "esc", label: "back to the chats board", scope: scopePanel, context: ctxChat, hint: "esc back", priority: 3},
+
+	// New chat.
+	{key: "ctrl+s", label: "create the chat and open it", scope: scopePanel, context: ctxNewChat, hint: "ctrl+s create", priority: 1},
+	{key: "tab", label: "next field (shift+tab goes back)", scope: scopePanel, context: ctxNewChat, hint: "tab next", priority: 2},
+	{key: "left", label: "previous choice on the project and agent fields", scope: scopePanel, context: ctxNewChat, hint: "← →  choose", priority: 3},
+	{key: "esc", label: "discard the draft", scope: scopePanel, context: ctxNewChat, hint: "esc cancel", priority: 4},
 
 	// Projects.
 	{key: "a", label: "register a repository", scope: scopePanel, context: ctxProjects, hint: "a add", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -52,6 +52,8 @@ func registryKey(t *testing.T, key string) tea.KeyPressMsg {
 		msg = tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
 	case "ctrl+t":
 		msg = tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}
+	case "ctrl+x":
+		msg = tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
 	default:
 		r := []rune(key)
 		if len(r) != 1 {
@@ -369,6 +371,158 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 		},
 	},
 
+	// The chat surfaces (task 067). Every probe drives the real view with
+	// the key the registry publishes and asserts the effect the label
+	// promises.
+	ctxChats: {
+		"enter": func(t *testing.T) {
+			v := chatsFixture()
+			_, cmd := v.updateKey(registryKey(t, "enter"))
+			if cmd == nil {
+				t.Fatal("enter did not open the selected chat's workspace")
+			}
+			if _, ok := drain(cmd).(openChatMsg); !ok {
+				t.Fatalf("enter produced %T, want openChatMsg", drain(cmd))
+			}
+		},
+		"n": func(t *testing.T) {
+			v := chatsFixture()
+			if _, cmd := v.updateKey(registryKey(t, "n")); cmd != nil {
+				drain(cmd)
+			}
+			if v.create == nil {
+				t.Fatal("n did not open the new-chat form")
+			}
+		},
+		"a": func(t *testing.T) {
+			v := chatsFixture()
+			v.updateKey(registryKey(t, "a"))
+			if v.confirm == nil {
+				t.Fatal("a did not ask before archiving")
+			}
+		},
+		"/": func(t *testing.T) {
+			v := chatsFixture()
+			v.updateKey(registryKey(t, "/"))
+			if !v.filtering {
+				t.Fatal("/ did not open the chats filter")
+			}
+		},
+		"left": func(t *testing.T) {
+			v := chatsFixture()
+			v.cursor = 0
+			if _, cmd := v.updateKey(registryKey(t, "left")); cmd != nil {
+				drain(cmd)
+			}
+			if !v.folds.has(foldPath{"repo"}) {
+				t.Fatal("left did not collapse the project group")
+			}
+		},
+		"right": func(t *testing.T) {
+			v := chatsFixture()
+			v.folds = foldSet{foldPath{"repo"}}
+			v.cursor = 0
+			if _, cmd := v.updateKey(registryKey(t, "right")); cmd != nil {
+				drain(cmd)
+			}
+			if v.folds.has(foldPath{"repo"}) {
+				t.Fatal("right did not expand the project group")
+			}
+		},
+		"r": func(t *testing.T) {
+			v := chatsFixture()
+			v.client = nil
+			// With no client the reload is a nil command; what the probe
+			// asserts is that the key reached the reload path rather than
+			// being swallowed by the filter or the confirmation.
+			if _, cmd := v.updateKey(registryKey(t, "r")); cmd != nil {
+				drain(cmd)
+			}
+			if v.filtering || v.confirm != nil {
+				t.Fatal("r was taken by another layer")
+			}
+		},
+	},
+	ctxChat: {
+		"enter": func(t *testing.T) {
+			v := chatViewFixture()
+			v.client = offlineClient()
+			v.composer.SetValue("hello")
+			if _, cmd := v.updateKey(registryKey(t, "enter")); cmd == nil {
+				t.Fatal("enter did not send the message")
+			}
+			if v.composer.Value() != "" {
+				t.Fatalf("the composer still holds %q after a send", v.composer.Value())
+			}
+		},
+		"ctrl+x": func(t *testing.T) {
+			v := chatViewFixture()
+			v.client = offlineClient()
+			v.turns = []apiclient.ChatTurn{{ID: 1, Seq: 1, State: "running"}}
+			if _, cmd := v.updateKey(registryKey(t, "ctrl+x")); cmd == nil {
+				t.Fatal("ctrl+x did not stop the running turn")
+			}
+		},
+		"esc": func(t *testing.T) {
+			v := chatViewFixture()
+			_, cmd := v.updateKey(registryKey(t, "esc"))
+			if cmd == nil {
+				t.Fatal("esc did not leave the chat workspace")
+			}
+			msg, ok := drain(cmd).(selectViewMsg)
+			if !ok || msg.id != viewChats {
+				t.Fatalf("esc went to %v, want the chats board", drain(cmd))
+			}
+		},
+	},
+	ctxNewChat: {
+		"ctrl+s": func(t *testing.T) {
+			v := chatsFixture()
+			v.create = newNewChatForm(nil, 7)
+			v.create.title.SetValue("a chat")
+			if _, cmd := v.updateKey(registryKey(t, "ctrl+s")); cmd != nil {
+				drain(cmd)
+			}
+			if v.create == nil || v.create.err != "not connected" {
+				t.Fatalf("ctrl+s did not attempt to create the chat (err = %q)",
+					func() string {
+						if v.create == nil {
+							return "<form closed>"
+						}
+						return v.create.err
+					}())
+			}
+		},
+		"tab": func(t *testing.T) {
+			v := chatsFixture()
+			v.create = newNewChatForm(nil, 7)
+			before := v.create.focus
+			v.updateKey(registryKey(t, "tab"))
+			if v.create.focus == before {
+				t.Fatalf("tab did not move the focus (still %d)", before)
+			}
+		},
+		"left": func(t *testing.T) {
+			v := chatsFixture()
+			v.create = newNewChatForm(nil, 0)
+			v.create.applyFields(newChatFieldsMsg{projects: []apiclient.Project{
+				{ID: 1, Name: "one"}, {ID: 2, Name: "two"},
+			}})
+			v.create.focus = 0
+			v.updateKey(registryKey(t, "left"))
+			if v.create.projectID != 2 {
+				t.Fatalf("left chose project %d, want the previous one", v.create.projectID)
+			}
+		},
+		"esc": func(t *testing.T) {
+			v := chatsFixture()
+			v.create = newNewChatForm(nil, 7)
+			v.updateKey(registryKey(t, "esc"))
+			if v.create != nil {
+				t.Fatal("esc did not discard the new-chat draft")
+			}
+		},
+	},
 	ctxPullRequests: {
 		"enter": func(t *testing.T) {
 			v := pullRequestsFixture(testPull(11, "claimed", claimedBy(7, "auto")))

--- a/internal/tui/boardfold.go
+++ b/internal/tui/boardfold.go
@@ -428,3 +428,19 @@ func (b *board) foldedHome(rows []boardRow) int {
 		return r.header && r.collapsed && r.path.covers(p)
 	})
 }
+
+// chatFoldsKey is the chats board's field in tui.json, the JSON tag on
+// tuiState.ChatFolds.
+const chatFoldsKey = "chat_folds"
+
+// loadChatFolds and writeChatFolds are loadFolds/writeFolds for the chats
+// board, against its own key. Same file, same fail-open contract, same merge
+// — a different list, because the two boards fold the same project names.
+func loadChatFolds(dataDir string) foldSet { return foldSet(readTUIState(dataDir).ChatFolds) }
+
+func writeChatFolds(dataDir string, f foldSet) error {
+	if f == nil {
+		f = foldSet{}
+	}
+	return mergeTUIState(dataDir, chatFoldsKey, f)
+}

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The chat workspace's rendering: history, live tail, composer.
+
+func (v *chatView) render(width, height int) string {
+	if width < 4 || height < 4 {
+		return ""
+	}
+	head := []string{v.headerLine(width), ""}
+	foot := v.footerLines(width)
+	body := v.bodyLines(width)
+	room := max(height-len(head)-len(foot), 1)
+	// The conversation is anchored at the bottom: the newest turn is the one
+	// being read, and a chat that scrolled to the top on every render would
+	// be unusable while an agent is talking.
+	lines := make([]string, 0, len(head)+room+len(foot))
+	lines = append(lines, head...)
+	lines = append(lines, window(body, max(len(body)-1, 0), room)...)
+	lines = append(lines, foot...)
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, width, "…")
+	}
+	out := strings.Join(lines, "\n")
+	if v.form != nil {
+		return out + "\n" + v.form.render(width, min(v.form.height(width), height/2))
+	}
+	return out
+}
+
+func (v *chatView) headerLine(width int) string {
+	if v.chat == nil {
+		left := " " + styleTitle.Render("chat")
+		if v.loadErr != "" {
+			left += styleDim.Render("  ·  " + v.loadErr)
+		} else {
+			left += styleDim.Render("  ·  loading…")
+		}
+		return padBetween(left, "", width)
+	}
+	left := " " + styleTitle.Render(v.chat.Title) +
+		styleDim.Render("  ·  ") + applyStateStyle(v.chat.State, chatStateLabel(v.chat.State)) +
+		styleDim.Render(fmt.Sprintf("  ·  %s  ·  %s", v.chat.Agent, v.chat.Branch))
+	right := styleDim.Render(fmt.Sprintf("%s ", plural(len(v.turns), "turn", "turns")))
+	return padBetween(left, right, width)
+}
+
+// bodyLines is the whole conversation: every finished turn, then the running
+// turn's live tail.
+func (v *chatView) bodyLines(width int) []string {
+	lines := make([]string, 0, len(v.turns)*4+len(v.scrollback))
+	for i := range v.turns {
+		t := &v.turns[i]
+		lines = append(lines, styleDim.Render(fmt.Sprintf(" ── turn %d ──", t.Seq)))
+		lines = append(lines, wrapCellLines("› "+t.Prompt, width-2, 6)...)
+		switch {
+		case t.State == "running":
+			// The running turn renders from the tail below, not from here:
+			// its ResultText does not exist yet.
+		case t.FailReason != "":
+			lines = append(lines, " "+styleBad.Render(
+				strings.TrimSpace(t.FailReason+" "+t.ErrorMessage)))
+		case t.ResultText != "":
+			lines = append(lines, wrapCellLines(t.ResultText, width-2, 40)...)
+		}
+	}
+	if len(v.scrollback) > 0 {
+		lines = append(lines, styleDim.Render(" ── live ──"))
+		lines = append(lines, v.scrollback...)
+	}
+	if len(lines) == 0 {
+		lines = append(lines, styleDim.Render("  Nothing said yet. Type below and press enter."))
+	}
+	return lines
+}
+
+func (v *chatView) footerLines(width int) []string {
+	out := []string{""}
+	if v.note != "" {
+		style := styleDim
+		if v.noteBad {
+			style = styleBad
+		}
+		out = append(out, " "+style.Render(v.note))
+	}
+	out = append(out, v.composer.View())
+	hint := " enter send · ctrl+x stop the turn · esc back to the chats board"
+	out = append(out, styleDim.Render(ansi.Truncate(hint, width, "…")))
+	return out
+}
+
+// transcriptLines renders fetched transcript records as tail lines. It is
+// deliberately plain: the live tail's job is to show that something is
+// happening and what, and the durable record is one route away.
+func transcriptLines(records []apiclient.TranscriptRecord) []string {
+	out := make([]string, 0, len(records))
+	for _, r := range records {
+		if line := transcriptLine(r); line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func transcriptLine(r apiclient.TranscriptRecord) string {
+	switch r.Type {
+	case "agent.output", "vincent.output", "command.output":
+		return "  " + strings.TrimRight(r.Text, "\n")
+	case "agent.thinking":
+		return "  " + styleDim.Render(strings.TrimRight(r.Text, "\n"))
+	case "agent.tool_use":
+		names := make([]string, 0, len(r.Tools))
+		for _, t := range r.Tools {
+			names = append(names, t.Name)
+		}
+		if len(names) == 0 {
+			return ""
+		}
+		return "  " + styleDim.Render("· "+strings.Join(names, ", "))
+	case "agent.error":
+		return "  " + styleBad.Render(r.Message)
+	default:
+		return ""
+	}
+}
+
+// outputNoteLine renders one live chunk. The chunk carries the agent's own
+// raw line, so it is decoded the same way the transcript route's normalized
+// records are — one shape for scrollback and tail, which is what §13.3's
+// normalization is for.
+func outputNoteLine(note apiclient.OutputNote) string {
+	var body struct {
+		Raw string `json:"raw"`
+	}
+	if err := json.Unmarshal(note.Payload, &body); err != nil || body.Raw == "" {
+		return ""
+	}
+	var rec apiclient.TranscriptRecord
+	if err := json.Unmarshal([]byte(body.Raw), &rec); err == nil && rec.Type != "" {
+		if line := transcriptLine(rec); line != "" {
+			return line
+		}
+	}
+	// A dialect line the client cannot name is still evidence the agent is
+	// working; it is shown dimmed rather than dropped.
+	return "  " + styleDim.Render(ansi.Truncate(strings.TrimSpace(body.Raw), 200, "…"))
+}

--- a/internal/tui/chats.go
+++ b/internal/tui/chats.go
@@ -1,0 +1,501 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The chats board (§15, task 067, closing task 063.2).
+//
+// It is a second board, not a filter on the first. A chat runs no workflow,
+// waits for no scheduler slot and has no §6 action set, so it shares none of
+// the task board's columns and none of its keys beyond the four every table
+// in this TUI has. Decision row 29 says a chat never appears on the task
+// board; this is where it appears instead.
+//
+// Attention is this board's own: an awaiting_input chat is sorted to the top
+// and badged in this header, and nowhere else. `!` and the home board's
+// needs-attention count stay task-only (task 067 decision 4).
+
+// Chats board messages.
+type (
+	chatsRefreshMsg struct{}
+	// chatsLoadedMsg is one whole board: every chat, plus the project names
+	// the headings read from.
+	chatsLoadedMsg struct {
+		chats []apiclient.Chat
+		names map[int64]string
+		err   error
+	}
+	// chatArchivedMsg reports a completed archive, or the refusal that came
+	// back instead — a dirty worktree answers 409 and is offered the force.
+	chatArchivedMsg struct {
+		id  int64
+		err error
+	}
+	// openChatMsg asks the root to open one chat's workspace. It goes through
+	// the root rather than straight to the view because the view is not
+	// active yet, and an inactive view receives nothing.
+	openChatMsg struct{ id int64 }
+)
+
+// archivePrompt is the inline confirmation an archive takes. force is set on
+// the second pass, after the daemon refused a dirty worktree.
+type archivePrompt struct {
+	id    int64
+	title string
+	force bool
+	text  string
+}
+
+// chatsView is the chats board.
+type chatsView struct {
+	client  *apiclient.Client
+	now     func() time.Time
+	dataDir string
+
+	chats []apiclient.Chat
+	names map[int64]string
+
+	loaded   bool
+	loading  bool
+	lastLoad time.Time
+	loadErr  string
+
+	cursor     int
+	selectedID int64
+
+	filter    textinput.Model
+	filtering bool
+
+	folds   foldSet
+	confirm *archivePrompt
+
+	// create is the new-chat form, a layer over this board rather than a
+	// seventh view: it is opened from here, it returns here, and it has no
+	// meaning anywhere else. `n` on the chats board makes a chat; `n`
+	// everywhere else still makes a task.
+	create *newChatForm
+
+	note    string
+	noteBad bool
+
+	width, height int
+}
+
+func newChatsView() *chatsView {
+	fi := textinput.New()
+	fi.Placeholder = "filter by title, agent or branch"
+	fi.Prompt = "/"
+	return &chatsView{now: time.Now, filter: fi, names: map[int64]string{}}
+}
+
+func (v *chatsView) title() string { return "Chats" }
+
+func (v *chatsView) setClient(c *apiclient.Client) tea.Cmd {
+	v.client = c
+	return v.loadCmd()
+}
+
+func (v *chatsView) setDataDir(dir string) {
+	v.dataDir = dir
+	v.folds = loadChatFolds(dir)
+}
+
+func (v *chatsView) capturesInput() bool {
+	if v.create != nil {
+		return v.create.capturesInput()
+	}
+	return v.filtering
+}
+
+func (v *chatsView) paste(text string) tea.Cmd {
+	if v.create != nil {
+		return v.create.paste(text)
+	}
+	if !v.filtering {
+		return nil
+	}
+	var cmd tea.Cmd
+	v.filter, cmd = v.filter.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+// bindingContext names the layer that has the keyboard, so the footer and the
+// ? overlay describe the keys that actually work.
+func (v *chatsView) bindingContext() bindingContext {
+	if v.create != nil {
+		return ctxNewChat
+	}
+	return ctxChats
+}
+
+// hintedProject opens the new-chat form on the project the cursor stands in.
+func (v *chatsView) hintedProject() int64 {
+	if c, ok := v.current(); ok {
+		return c.ProjectID
+	}
+	return 0
+}
+
+func (v *chatsView) update(msg tea.Msg) (panel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width, v.height = msg.Width, msg.Height
+		return v, nil
+	case viewActivatedMsg:
+		if msg.id == viewChats {
+			// A board that was off-screen through a burst of events opens on
+			// what it last fetched; refetching on activation is what keeps
+			// "off-screen" from meaning "stale".
+			return v, v.loadCmd()
+		}
+		return v, nil
+	case chatsRefreshMsg:
+		return v, v.loadCmd()
+	case chatsLoadedMsg:
+		v.applyLoaded(msg)
+		return v, nil
+	case chatArchivedMsg:
+		return v, v.applyArchived(msg)
+	case chatCreatedMsg:
+		return v, v.applyCreated(msg)
+	case noteMsg:
+		// A chat.* event is this board's reconciler tick. Task events are
+		// none of its business and are dropped here, which is the same
+		// separation in the other direction as the task board dropping
+		// chat.* — one entity per board, both ways (decision row 29).
+		return v, v.applyNote(msg)
+	case tea.KeyPressMsg:
+		return v.updateKey(msg)
+	}
+	return v, nil
+}
+
+// applyNote reloads when a chat event says the board changed.
+func (v *chatsView) applyNote(msg noteMsg) tea.Cmd {
+	ev, ok := msg.note.(apiclient.EventNote)
+	if !ok || !strings.HasPrefix(ev.Event.Type, "chat.") {
+		return nil
+	}
+	return v.loadCmd()
+}
+
+// loadCmd fetches every chat and the project names the headings read from.
+func (v *chatsView) loadCmd() tea.Cmd {
+	client := v.client
+	if client == nil {
+		return nil
+	}
+	v.loading = true
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		chats, err := client.ListChats(ctx, 0)
+		if err != nil {
+			return chatsLoadedMsg{err: err}
+		}
+		names := map[int64]string{}
+		// A project listing that fails is not a board that fails: the
+		// headings fall back to the id, which is still a stable grouping.
+		if projects, perr := client.ListProjects(ctx); perr == nil {
+			for _, p := range projects {
+				names[p.ID] = p.Name
+			}
+		}
+		return chatsLoadedMsg{chats: chats, names: names}
+	}
+}
+
+func (v *chatsView) applyLoaded(msg chatsLoadedMsg) {
+	v.loading = false
+	if msg.err != nil {
+		v.loadErr = errString(msg.err)
+		return
+	}
+	v.loadErr = ""
+	v.loaded = true
+	v.lastLoad = v.now()
+	sortChats(msg.chats)
+	v.chats, v.names = msg.chats, msg.names
+	v.folds = pruneChatFolds(v.folds, v.chats, v.names)
+	v.restoreSelection()
+}
+
+func (v *chatsView) applyArchived(msg chatArchivedMsg) tea.Cmd {
+	if msg.err != nil {
+		// A dirty worktree is a refusal to re-offer with the force, not an
+		// error to swallow: the same shape the task board's archive takes.
+		if isChatWorktreeDirty(msg.err) {
+			v.confirm = &archivePrompt{
+				id: msg.id, force: true,
+				text: "worktree has local changes — archive anyway and lose them? (y/n)",
+			}
+			return nil
+		}
+		v.note, v.noteBad = errString(msg.err), true
+		return nil
+	}
+	v.note, v.noteBad = "chat archived", false
+	return v.loadCmd()
+}
+
+func (v *chatsView) applyCreated(msg chatCreatedMsg) tea.Cmd {
+	if msg.err != nil {
+		if v.create != nil {
+			v.create.applyFailure(msg.err)
+		}
+		return nil
+	}
+	v.create = nil
+	v.selectedID = msg.chat.ID
+	// Straight into the workspace: the human asked for a conversation, and
+	// landing them on the board to press enter on the row they just made
+	// would be a step for nothing.
+	id := msg.chat.ID
+	return tea.Batch(v.loadCmd(), func() tea.Msg { return openChatMsg{id: id} })
+}
+
+// rows is the board as it is currently laid out.
+func (v *chatsView) rows() []chatRow {
+	return groupChatRows(filterChats(v.chats, v.filter.Value()), v.names, v.folds)
+}
+
+func (v *chatsView) current() (apiclient.Chat, bool) {
+	rows := v.rows()
+	if v.cursor < 0 || v.cursor >= len(rows) || rows[v.cursor].chat == nil {
+		return apiclient.Chat{}, false
+	}
+	return *rows[v.cursor].chat, true
+}
+
+func (v *chatsView) restoreSelection() {
+	rows := v.rows()
+	if v.selectedID != 0 {
+		for i, r := range rows {
+			if r.chat != nil && r.chat.ID == v.selectedID {
+				v.cursor = i
+				return
+			}
+		}
+	}
+	v.cursor = min(v.cursor, max(len(rows)-1, 0))
+	v.moveCursor(0)
+}
+
+// moveCursor walks by delta, skipping the headings that cannot be selected.
+// delta 0 lands on the nearest selectable row, which is what a re-layout
+// needs after a fold.
+func (v *chatsView) moveCursor(delta int) {
+	rows := v.rows()
+	if len(rows) == 0 {
+		v.cursor = 0
+		return
+	}
+	i := min(max(v.cursor+delta, 0), len(rows)-1)
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	for j := i; j >= 0 && j < len(rows); j += step {
+		if rows[j].selectable() {
+			v.cursor = j
+			v.rememberSelection()
+			return
+		}
+	}
+	// Nothing selectable in that direction: stay where the walk started.
+	for j := i; j >= 0 && j < len(rows); j -= step {
+		if rows[j].selectable() {
+			v.cursor = j
+			v.rememberSelection()
+			return
+		}
+	}
+	v.cursor = i
+}
+
+func (v *chatsView) rememberSelection() {
+	if c, ok := v.current(); ok {
+		v.selectedID = c.ID
+	}
+}
+
+// saveFolds persists the chats board's own fold set. A write failure is a
+// note, never a refusal to fold: the fold already happened on screen.
+func (v *chatsView) saveFolds() tea.Cmd {
+	dir, folds := v.dataDir, v.folds
+	if dir == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		if err := writeChatFolds(dir, folds); err != nil {
+			return noteMsg{}
+		}
+		return nil
+	}
+}
+
+// isChatWorktreeDirty reports the 409 an archive gets when the chat's
+// worktree has local changes (§10). It is the same refusal a task's archive
+// takes, read off the same `reason` detail — the block-reason vocabulary is
+// shared, so the client reads one name here too.
+func isChatWorktreeDirty(err error) bool {
+	var apiErr *apiclient.Error
+	return errors.As(err, &apiErr) && apiErr.Details["reason"] == "worktree_dirty"
+}
+
+// updateKey is the chats board's keyboard. The layers answer in order: the
+// new-chat form, the confirmation, the filter, then the board itself.
+func (v *chatsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if v.create != nil {
+		cmd, done := v.create.update(msg, v.client)
+		if done {
+			v.create = nil
+		}
+		return v, cmd
+	}
+	if v.confirm != nil {
+		return v, v.updateConfirm(msg)
+	}
+	if v.filtering {
+		return v, v.updateFilter(msg)
+	}
+	v.note = ""
+	switch msg.String() {
+	case "esc":
+		if v.filter.Value() != "" {
+			v.filter.SetValue("")
+			v.restoreSelection()
+			return v, nil
+		}
+		return v, func() tea.Msg { return selectViewMsg{id: viewHome} }
+	case "up", "k":
+		v.moveCursor(-1)
+	case "down", "j":
+		v.moveCursor(1)
+	case "/":
+		v.filtering = true
+		v.filter.Focus()
+		return v, nil
+	case "left":
+		return v, v.collapseAtCursor()
+	case "right":
+		return v, v.expandAtCursor()
+	case "enter":
+		if c, ok := v.current(); ok {
+			id := c.ID
+			return v, func() tea.Msg { return openChatMsg{id: id} }
+		}
+	case "n":
+		v.create = newNewChatForm(v.client, v.hintedProject())
+		return v, v.create.init()
+	case "a":
+		if c, ok := v.current(); ok {
+			v.confirm = &archivePrompt{
+				id: c.ID, title: c.Title,
+				text: fmt.Sprintf("archive %q and remove its worktree? (y/n)", c.Title),
+			}
+		}
+	case "r":
+		return v, v.loadCmd()
+	}
+	return v, nil
+}
+
+func (v *chatsView) updateConfirm(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "y", "Y":
+		p := *v.confirm
+		v.confirm = nil
+		return v.archiveCmd(p.id, p.force)
+	default:
+		v.confirm = nil
+		return nil
+	}
+}
+
+func (v *chatsView) updateFilter(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "enter":
+		v.filtering = false
+		v.filter.Blur()
+		v.restoreSelection()
+		return nil
+	case "esc":
+		v.filtering = false
+		v.filter.Blur()
+		v.filter.SetValue("")
+		v.restoreSelection()
+		return nil
+	}
+	var cmd tea.Cmd
+	v.filter, cmd = v.filter.Update(msg)
+	v.restoreSelection()
+	return cmd
+}
+
+func (v *chatsView) archiveCmd(id int64, force bool) tea.Cmd {
+	client := v.client
+	if client == nil {
+		v.note, v.noteBad = "not connected", true
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		_, err := client.ArchiveChat(ctx, id, force)
+		return chatArchivedMsg{id: id, err: err}
+	}
+}
+
+// collapseAtCursor folds the group the cursor is in, naming the row rather
+// than an index: the layout changes under the fold, and reading a cursor
+// index from the old layout against the new one selects a different chat.
+func (v *chatsView) collapseAtCursor() tea.Cmd {
+	rows := v.rows()
+	if v.cursor < 0 || v.cursor >= len(rows) {
+		return nil
+	}
+	path := rows[v.cursor].path
+	if len(path) == 0 || v.folds.has(path) {
+		return nil
+	}
+	v.folds = v.folds.with(path)
+	v.focusHeader(path)
+	return v.saveFolds()
+}
+
+func (v *chatsView) expandAtCursor() tea.Cmd {
+	rows := v.rows()
+	if v.cursor < 0 || v.cursor >= len(rows) {
+		return nil
+	}
+	path := rows[v.cursor].path
+	if len(path) == 0 || !v.folds.has(path) {
+		return nil
+	}
+	v.folds = v.folds.without(path)
+	v.focusHeader(path)
+	return v.saveFolds()
+}
+
+// focusHeader puts the cursor back on the heading it was working on, in the
+// layout the fold produced.
+func (v *chatsView) focusHeader(path foldPath) {
+	for i, r := range v.rows() {
+		if r.header && r.path.equal(path) {
+			v.cursor = i
+			return
+		}
+	}
+	v.restoreSelection()
+}

--- a/internal/tui/chats_test.go
+++ b/internal/tui/chats_test.go
@@ -1,0 +1,115 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// chatsFixture is a chats board with two chats in one project, loaded: one
+// idle, one waiting on a human, which is what every assertion below needs.
+func chatsFixture() *chatsView {
+	v := newChatsView()
+	v.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	v.applyLoaded(chatsLoadedMsg{
+		chats: []apiclient.Chat{
+			testChat(1, "idle", "first"),
+			testChat(2, "awaiting_input", "second"),
+		},
+		names: map[int64]string{7: "repo"},
+	})
+	return v
+}
+
+func testChat(id int64, state, title string) apiclient.Chat {
+	return apiclient.Chat{
+		ID: id, ProjectID: 7, Title: title, State: state, Agent: "claude",
+		Branch: "vincent/1-x", UpdatedAt: time.Date(2026, 8, 31, 11, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestChatsBoardSortsAttentionFirst holds the chats board's own attention
+// rule: a chat waiting on a human is at the top of *this* board (task 067
+// decision 4).
+func TestChatsBoardSortsAttentionFirst(t *testing.T) {
+	v := chatsFixture()
+	c, ok := v.current()
+	if !ok {
+		t.Fatal("the board has no selectable row")
+	}
+	if c.State != "awaiting_input" {
+		t.Fatalf("cursor is on a %s chat, want the one awaiting input", c.State)
+	}
+	if n := countChatsAwaiting(v.chats); n != 1 {
+		t.Fatalf("the header badge counts %d waiting, want 1", n)
+	}
+}
+
+// TestChatsBoardFiltersOnTitleAgentBranch covers the `/` filter's three
+// fields.
+func TestChatsBoardFiltersOnTitleAgentBranch(t *testing.T) {
+	chats := []apiclient.Chat{testChat(1, "idle", "alpha"), testChat(2, "idle", "beta")}
+	for _, q := range []string{"alph", "claude", "vincent/1"} {
+		got := filterChats(chats, q)
+		if q == "alph" && len(got) != 1 {
+			t.Fatalf("filter %q matched %d chats, want 1", q, len(got))
+		}
+		if q != "alph" && len(got) != 2 {
+			t.Fatalf("filter %q matched %d chats, want both", q, len(got))
+		}
+	}
+}
+
+// TestChatsBoardGroupsByProjectOnly holds the grouping decision: a chat has
+// no workflow, so the board offers one level and no cycle.
+func TestChatsBoardGroupsByProjectOnly(t *testing.T) {
+	rows := groupChatRows([]apiclient.Chat{testChat(1, "idle", "a")},
+		map[int64]string{7: "repo"}, nil)
+	if len(rows) != 2 || !rows[0].header || rows[0].label != "repo" {
+		t.Fatalf("rows = %+v, want one project heading and one chat", rows)
+	}
+	if rows[1].chat == nil {
+		t.Fatal("the second row is not a chat")
+	}
+}
+
+// TestChatsBoardFoldSurvivesReload proves the fold set is the chats board's
+// own and that folding hides the group's rows.
+func TestChatsBoardFoldSurvivesReload(t *testing.T) {
+	v := chatsFixture()
+	v.cursor = 0 // the project heading
+	v.collapseAtCursor()
+	rows := v.rows()
+	if len(rows) != 1 || !rows[0].collapsed {
+		t.Fatalf("after folding, rows = %d, want one collapsed heading", len(rows))
+	}
+	v.applyLoaded(chatsLoadedMsg{chats: v.chats, names: v.names})
+	if !v.folds.has(foldPath{"repo"}) {
+		t.Fatal("the fold did not survive a reload")
+	}
+}
+
+// TestChatsBoardDropsTaskEvents is decision row 29 in the other direction: a
+// task event is not this board's news.
+func TestChatsBoardDropsTaskEvents(t *testing.T) {
+	v := chatsFixture()
+	v.client = nil
+	if cmd := v.applyNote(noteMsg{note: apiclient.EventNote{
+		Event: apiclient.Event{Type: "task.state_changed"},
+	}}); cmd != nil {
+		t.Fatal("a task event reloaded the chats board")
+	}
+}
+
+// TestChatsArchiveOffersForceOnDirtyWorktree covers the 409 the archive takes
+// when the worktree has local changes.
+func TestChatsArchiveOffersForceOnDirtyWorktree(t *testing.T) {
+	v := chatsFixture()
+	v.applyArchived(chatArchivedMsg{id: 2, err: &apiclient.Error{
+		Code: "conflict", Details: map[string]string{"reason": "worktree_dirty"},
+	}})
+	if v.confirm == nil || !v.confirm.force {
+		t.Fatalf("a dirty worktree did not re-offer the archive with the force: %+v", v.confirm)
+	}
+}

--- a/internal/tui/chatsrender.go
+++ b/internal/tui/chatsrender.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The chats board's rendering, split from the view for the reason every other
+// screen's is: what a screen *is* and what it *looks like* change for
+// different reasons and at different rates.
+
+func (v *chatsView) render(width, height int) string {
+	if width < 4 || height < 2 {
+		return ""
+	}
+	lines := make([]string, 0, height)
+	lines = append(lines, v.headerLine(width))
+	if v.filtering || v.filter.Value() != "" {
+		lines = append(lines, " "+v.filter.View())
+	}
+	lines = append(lines, "")
+
+	body, cursorRow := v.bodyLines(width)
+	footer := v.footerLines()
+	room := max(height-len(lines)-len(footer), 1)
+	lines = append(lines, window(body, cursorRow, room)...)
+	lines = append(lines, footer...)
+	for i, line := range lines {
+		lines[i] = ansi.Truncate(line, width, "…")
+	}
+	out := strings.Join(lines, "\n")
+	if v.create != nil {
+		return v.create.render(width, height)
+	}
+	return out
+}
+
+// headerLine says what the board is showing and how many chats are waiting on
+// a human. The badge is here and nowhere else: the task board's own
+// needs-attention count is untouched by a chat (task 067 decision 4).
+func (v *chatsView) headerLine(width int) string {
+	left := " " + styleTitle.Render("chats")
+	switch {
+	case v.loadErr != "":
+		left += styleDim.Render("  ·  " + v.loadErr)
+	case !v.loaded && v.loading:
+		left += styleDim.Render("  ·  loading…")
+	default:
+		left += styleDim.Render("  ·  " + plural(len(v.chats), "chat", "chats"))
+		if n := countChatsAwaiting(v.chats); n > 0 {
+			left += styleDim.Render(" · ") +
+				styleWarn.Render(fmt.Sprintf("%d waiting on you", n))
+		}
+	}
+	right := ""
+	if !v.lastLoad.IsZero() {
+		right = styleDim.Render("updated "+v.lastLoad.Format("15:04:05")) + " "
+	}
+	return padBetween(left, right, width)
+}
+
+// bodyLines is the grouped board, and the index of the cursor's line so the
+// window can follow it.
+func (v *chatsView) bodyLines(width int) (lines []string, cursorRow int) {
+	rows := v.rows()
+	if len(rows) == 0 {
+		if v.loaded {
+			return []string{styleDim.Render("  No chats. Press n to start one.")}, 0
+		}
+		return []string{styleDim.Render("  …")}, 0
+	}
+	lines = make([]string, 0, len(rows))
+	for i, r := range rows {
+		if i == v.cursor {
+			cursorRow = len(lines)
+		}
+		lines = append(lines, v.rowLine(r, i == v.cursor, width))
+	}
+	return lines, cursorRow
+}
+
+func (v *chatsView) rowLine(r chatRow, selected bool, width int) string {
+	cursor := "  "
+	if selected {
+		cursor = "▸ "
+	}
+	if r.header {
+		marker := "▾"
+		if r.collapsed {
+			marker = "▸"
+		}
+		return cursor + styleTitle.Render(fmt.Sprintf("%s %s", marker, r.label)) +
+			styleDim.Render(fmt.Sprintf("  (%d)", r.count))
+	}
+	c := r.chat
+	// Columns: id, state, agent, turns, last activity, then the title with
+	// whatever width is left. The title is last because it is the only cell
+	// that can usefully be truncated.
+	fixed := fmt.Sprintf("%-5s %-15s %-8s %5s %8s  ",
+		"#"+strconv.FormatInt(c.ID, 10),
+		applyStateStyle(c.State, chatStateLabel(c.State)),
+		c.Agent,
+		"", // the turn count is not on the list DTO; see chatTurnsCell
+		chatActivity(*c, v.now()))
+	title := c.Title
+	if room := width - len(cursor) - ansi.StringWidth(fixed); room > 0 {
+		title = ansi.Truncate(title, room, "…")
+	}
+	return cursor + fixed + title
+}
+
+// chatStateLabel is §5.5's vocabulary as a human reads it. `awaiting_input`
+// is spelled out because it is the one state that is asking for something.
+func chatStateLabel(state string) string {
+	switch state {
+	case "awaiting_input":
+		return "waiting on you"
+	case "running":
+		return "running"
+	case "idle":
+		return "idle"
+	case "archived":
+		return "archived"
+	default:
+		return state
+	}
+}
+
+func (v *chatsView) footerLines() []string {
+	if v.confirm != nil {
+		return []string{"", " " + styleWarn.Render(v.confirm.text)}
+	}
+	if v.note != "" {
+		style := styleDim
+		if v.noteBad {
+			style = styleWarn
+		}
+		return []string{"", " " + style.Render(v.note)}
+	}
+	return nil
+}

--- a/internal/tui/chatsrows.go
+++ b/internal/tui/chatsrows.go
@@ -1,0 +1,179 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Row shaping for the chats board (§15, task 067). It is boardrows.go's job
+// for a different entity, and it is separate code rather than a generic over
+// both because a chat is not a task: it has no workflow, no step, no cost
+// rollup and no §6 action set, and the four functions that would survive the
+// abstraction are the four trivial ones.
+
+// chatNeedsAttention reports whether a chat is waiting on a human. This is the
+// chats board's own notion and stops here: `!` and the home board's
+// needs-attention header stay task-only, so decision row 29's "a chat never
+// appears on the task board" stays literal (task 067 decision 4).
+func chatNeedsAttention(state string) bool { return state == "awaiting_input" }
+
+// chatBand orders states on the board: what needs a human first, then what is
+// working, then what is idle, then what is done with.
+func chatBand(state string) int {
+	switch state {
+	case "awaiting_input":
+		return 0
+	case "running":
+		return 1
+	case "idle":
+		return 2
+	default: // archived
+		return 3
+	}
+}
+
+// sortChats orders the board: attention, then running, then idle, then
+// archived; within a band the most recently touched first, so the
+// conversation you were just in is at the top. Ties break on id so the order
+// is total and a re-render never reshuffles equal rows.
+func sortChats(chats []apiclient.Chat) {
+	sort.SliceStable(chats, func(i, j int) bool {
+		a, b := chats[i], chats[j]
+		if ba, bb := chatBand(a.State), chatBand(b.State); ba != bb {
+			return ba < bb
+		}
+		if !a.UpdatedAt.Equal(b.UpdatedAt) {
+			return a.UpdatedAt.After(b.UpdatedAt)
+		}
+		return a.ID > b.ID
+	})
+}
+
+// filterChats narrows on a case-insensitive substring of the title, the agent
+// or the branch — the three things a human remembers a conversation by.
+func filterChats(chats []apiclient.Chat, query string) []apiclient.Chat {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return chats
+	}
+	out := make([]apiclient.Chat, 0, len(chats))
+	for _, c := range chats {
+		if strings.Contains(strings.ToLower(c.Title), q) ||
+			strings.Contains(strings.ToLower(c.Agent), q) ||
+			strings.Contains(strings.ToLower(c.Branch), q) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// countChatsAwaiting is the badge on the chats board's header.
+func countChatsAwaiting(chats []apiclient.Chat) int {
+	n := 0
+	for _, c := range chats {
+		if chatNeedsAttention(c.State) {
+			n++
+		}
+	}
+	return n
+}
+
+// chatRow is one line of the chats board: a chat, or a group header.
+type chatRow struct {
+	chat *apiclient.Chat
+	// header names a project heading; collapsed marks it folded.
+	header    bool
+	label     string
+	count     int
+	collapsed bool
+	path      foldPath
+}
+
+func (r chatRow) selectable() bool { return !r.header || r.collapsed }
+
+// groupChatRows lays the board out: one heading per project, in the order the
+// projects were named, with their chats under it.
+//
+// The chats board groups by project and by nothing else: `tui.board.group_by`
+// also offers workflow scopes, and a chat has no workflow, so offering the
+// cycle here would offer a grouping that puts every row under one heading
+// called "—" (task 067).
+func groupChatRows(chats []apiclient.Chat, names map[int64]string, folds foldSet) []chatRow {
+	if len(chats) == 0 {
+		return nil
+	}
+	order := make([]int64, 0, len(chats))
+	byProject := map[int64][]apiclient.Chat{}
+	for _, c := range chats {
+		if _, seen := byProject[c.ProjectID]; !seen {
+			order = append(order, c.ProjectID)
+		}
+		byProject[c.ProjectID] = append(byProject[c.ProjectID], c)
+	}
+	rows := make([]chatRow, 0, len(chats)+len(order))
+	for _, pid := range order {
+		group := byProject[pid]
+		label := names[pid]
+		if label == "" {
+			label = "—"
+		}
+		path := foldPath{label}
+		collapsed := folds.has(path)
+		rows = append(rows, chatRow{
+			header: true, label: label, count: len(group),
+			collapsed: collapsed, path: path,
+		})
+		if collapsed {
+			continue
+		}
+		for i := range group {
+			rows = append(rows, chatRow{chat: &group[i], path: path})
+		}
+	}
+	return rows
+}
+
+// pruneChatFolds drops fold paths that name no project on the board. An empty
+// list prunes nothing, for the reason foldSet.prune gives: a TUI whose daemon
+// went away holds no news about which projects exist.
+func pruneChatFolds(f foldSet, chats []apiclient.Chat, names map[int64]string) foldSet {
+	if len(f) == 0 || len(chats) == 0 {
+		return f
+	}
+	known := map[string]struct{}{}
+	for _, c := range chats {
+		label := names[c.ProjectID]
+		if label == "" {
+			label = "—"
+		}
+		known[label] = struct{}{}
+	}
+	out := make(foldSet, 0, len(f))
+	for _, p := range f {
+		if len(p) == 1 {
+			if _, ok := known[p[0]]; ok {
+				out = append(out, p)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// chatActivity is the "last activity" column: how long ago the chat's row was
+// last written, which for a chat is the last turn boundary or state change.
+func chatActivity(c apiclient.Chat, now time.Time) string {
+	if c.UpdatedAt.IsZero() {
+		return "—"
+	}
+	d := now.Sub(c.UpdatedAt)
+	if d < 0 {
+		d = 0
+	}
+	return formatElapsed(d)
+}

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -1,0 +1,460 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The chat workspace (§15, task 067, closing task 063.2): turn history above,
+// a live tail of the running turn, a composer below.
+//
+// It is taskview.go's structural sibling and none of its code: a task
+// workspace is a timeline of steps with a diff pane and a §6 action bar, and
+// a chat has one turn at a time, no diff to review mid-conversation and three
+// actions. What the two do share is the §7.4 answer popup, which is reused
+// rather than forked — the request is the same request.
+
+// Chat workspace messages.
+type (
+	// chatLoadedMsg is the chat and its whole conversation.
+	chatLoadedMsg struct {
+		id    int64
+		chat  *apiclient.Chat
+		turns []apiclient.ChatTurn
+		err   error
+	}
+	// chatTranscriptMsg is one finished turn's rendered record, or the live
+	// turn's scrollback plus the offset the live tail resumes at.
+	chatTranscriptMsg struct {
+		chatID  int64
+		seq     int
+		records []apiclient.TranscriptRecord
+		// next is the X-Next-Offset the fetch reported. Chunks at or before
+		// it are already in records; that is the whole seam (§13.3).
+		next int64
+		err  error
+	}
+	// chatSentMsg reports POST /v1/chats/{id}/send.
+	chatSentMsg struct {
+		chatID int64
+		turn   *apiclient.ChatTurn
+		err    error
+	}
+	// chatAnsweredMsg reports POST /v1/chats/{id}/answer.
+	chatAnsweredMsg struct {
+		chatID int64
+		err    error
+	}
+	// chatCanceledMsg reports POST /v1/chats/{id}/cancel.
+	chatCanceledMsg struct {
+		chatID int64
+		err    error
+	}
+)
+
+// chatView is the workspace.
+type chatView struct {
+	client *apiclient.Client
+	now    func() time.Time
+
+	chatID int64
+	chat   *apiclient.Chat
+	turns  []apiclient.ChatTurn
+
+	// scrollback is the running turn's transcript as fetched, and liveFrom is
+	// the offset past which the stream's chunks are new. Together they are
+	// the catch-up seam: fetch, then keep every chunk whose offset is past
+	// liveFrom. Without it a reconnect double-prints the tail.
+	scrollback []string
+	liveFrom   int64
+	liveTurn   int64
+
+	composer textarea.Model
+	form     *answerForm
+
+	// stream is the per-chat SSE subscription's cancel, held so opening a
+	// second chat does not leave the first one's stream running.
+	streamStop context.CancelFunc
+
+	note    string
+	noteBad bool
+	loadErr string
+
+	width, height int
+}
+
+func newChatView() *chatView {
+	ta := textarea.New()
+	ta.Placeholder = "message… (enter sends, shift+enter for a newline)"
+	ta.SetHeight(3)
+	return &chatView{now: time.Now, composer: ta}
+}
+
+func (v *chatView) title() string {
+	if v.chat != nil {
+		return "Chat: " + v.chat.Title
+	}
+	return "Chat"
+}
+
+func (v *chatView) setClient(c *apiclient.Client) tea.Cmd {
+	v.client = c
+	if v.chatID == 0 {
+		return nil
+	}
+	return v.open(v.chatID)
+}
+
+// capturesInput is true whenever the composer has the keyboard, which is
+// almost always: this screen is a text field with a conversation above it, so
+// the single-key global bindings must not fire while someone types "q".
+func (v *chatView) capturesInput() bool {
+	if v.form != nil {
+		return v.form.capturing()
+	}
+	return v.composer.Focused()
+}
+
+func (v *chatView) paste(text string) tea.Cmd {
+	if v.form != nil {
+		return v.form.paste(text)
+	}
+	var cmd tea.Cmd
+	v.composer, cmd = v.composer.Update(tea.PasteMsg{Content: text})
+	return cmd
+}
+
+func (v *chatView) bindingContext() bindingContext {
+	if v.form != nil {
+		return ctxForm
+	}
+	return ctxChat
+}
+
+func (v *chatView) hintedProject() int64 {
+	if v.chat != nil {
+		return v.chat.ProjectID
+	}
+	return 0
+}
+
+// open points the workspace at a chat: it loads the conversation and
+// subscribes to that chat's stream, dropping any previous subscription.
+func (v *chatView) open(id int64) tea.Cmd {
+	if v.streamStop != nil {
+		v.streamStop()
+		v.streamStop = nil
+	}
+	v.chatID = id
+	v.chat, v.turns = nil, nil
+	v.scrollback, v.liveFrom, v.liveTurn = nil, 0, 0
+	v.note, v.loadErr = "", ""
+	v.composer.SetValue("")
+	v.composer.Focus()
+	return tea.Batch(v.loadCmd(), v.streamCmd())
+}
+
+func (v *chatView) loadCmd() tea.Cmd {
+	client, id := v.client, v.chatID
+	if client == nil || id == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		chat, turns, err := client.GetChat(ctx, id)
+		return chatLoadedMsg{id: id, chat: chat, turns: turns, err: err}
+	}
+}
+
+// streamCmd subscribes to GET /v1/chats/{id}/events and republishes every
+// note as a tea.Msg. It is the per-task subscription's twin: durable events
+// re-render the header and the turn list, live chunks extend the tail.
+func (v *chatView) streamCmd() tea.Cmd {
+	client, id := v.client, v.chatID
+	if client == nil || id == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	v.streamStop = cancel
+	ch := client.StreamChat(ctx, id, apiclient.StreamOptions{})
+	return func() tea.Msg {
+		note, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return chatNoteMsg{chatID: id, note: note, next: ch}
+	}
+}
+
+// chatNoteMsg is one note off the per-chat stream, carrying the channel so
+// the next read is scheduled without re-subscribing.
+type chatNoteMsg struct {
+	chatID int64
+	note   apiclient.Note
+	next   <-chan apiclient.Note
+}
+
+// readNext schedules the next read off an already-open subscription.
+func readNextChatNote(id int64, ch <-chan apiclient.Note) tea.Cmd {
+	return func() tea.Msg {
+		note, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return chatNoteMsg{chatID: id, note: note, next: ch}
+	}
+}
+
+func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width, v.height = msg.Width, msg.Height
+		v.composer.SetWidth(max(msg.Width-4, 10))
+		return v, nil
+	case openChatMsg:
+		return v, v.open(msg.id)
+	case viewActivatedMsg:
+		if msg.id == viewChat && v.chatID != 0 {
+			return v, v.loadCmd()
+		}
+		return v, nil
+	case chatLoadedMsg:
+		v.applyLoaded(msg)
+		return v, v.fetchLiveTranscript()
+	case chatTranscriptMsg:
+		v.applyTranscript(msg)
+		return v, nil
+	case chatNoteMsg:
+		return v, v.applyChatNote(msg)
+	case chatSentMsg:
+		return v, v.applySent(msg)
+	case chatAnsweredMsg:
+		return v, v.applyAnswered(msg)
+	case chatCanceledMsg:
+		return v, v.applyCanceled(msg)
+	case tea.KeyPressMsg:
+		return v.updateKey(msg)
+	}
+	return v, nil
+}
+
+func (v *chatView) applyLoaded(msg chatLoadedMsg) {
+	if msg.id != v.chatID {
+		return
+	}
+	if msg.err != nil {
+		v.loadErr = errString(msg.err)
+		return
+	}
+	v.loadErr = ""
+	v.chat, v.turns = msg.chat, msg.turns
+	// The popup follows the chat's own state: it opens when the daemon says
+	// awaiting_input and closes when it stops saying so, which is what makes
+	// an answer given elsewhere — the CLI, curl — close it here too.
+	v.syncForm()
+}
+
+// syncForm opens, keeps or closes the §7.4 popup to match the chat's state.
+func (v *chatView) syncForm() {
+	if v.chat == nil || v.chat.State != "awaiting_input" {
+		v.form = nil
+		return
+	}
+	req, ok, err := v.chat.PendingRequest()
+	if err != nil || !ok {
+		v.form = nil
+		return
+	}
+	if v.form != nil && v.form.sameRequest(req) {
+		return
+	}
+	v.form = newAnswerForm(req)
+}
+
+// runningTurn is the turn currently producing output, if any.
+func (v *chatView) runningTurn() *apiclient.ChatTurn {
+	for i := range v.turns {
+		if v.turns[i].State == "running" {
+			return &v.turns[i]
+		}
+	}
+	return nil
+}
+
+// fetchLiveTranscript fetches the running turn's transcript so the tail has
+// scrollback, and records the offset the stream resumes past.
+func (v *chatView) fetchLiveTranscript() tea.Cmd {
+	turn := v.runningTurn()
+	client, id := v.client, v.chatID
+	if turn == nil || client == nil {
+		return nil
+	}
+	if turn.ID == v.liveTurn && v.liveFrom > 0 {
+		return nil // already seamed onto this turn
+	}
+	seq := turn.Seq
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		records, next, err := client.ChatTurnTranscript(ctx, id, seq, apiclient.TranscriptOptions{})
+		return chatTranscriptMsg{chatID: id, seq: seq, records: records, next: next, err: err}
+	}
+}
+
+func (v *chatView) applyTranscript(msg chatTranscriptMsg) {
+	if msg.chatID != v.chatID {
+		return
+	}
+	if msg.err != nil {
+		// A transcript that is gone to retention is not an error worth a
+		// banner: the finished turns still render from ResultText, and a
+		// running turn's tail simply starts empty.
+		return
+	}
+	turn := v.runningTurn()
+	if turn == nil || turn.Seq != msg.seq {
+		return
+	}
+	v.liveTurn, v.liveFrom = turn.ID, msg.next
+	v.scrollback = transcriptLines(msg.records)
+}
+
+// applyChatNote folds one stream note in and schedules the next read.
+func (v *chatView) applyChatNote(msg chatNoteMsg) tea.Cmd {
+	if msg.chatID != v.chatID {
+		return nil // a stale subscription from a chat we left
+	}
+	next := readNextChatNote(msg.chatID, msg.next)
+	switch note := msg.note.(type) {
+	case apiclient.EventNote:
+		if strings.HasPrefix(note.Event.Type, "chat.") {
+			return tea.Batch(next, v.loadCmd())
+		}
+	case apiclient.OutputNote:
+		// The seam: a chunk at or before the offset the transcript fetch
+		// reported is one the fetch already returned. Dropping it here is
+		// what keeps the tail from double-printing a line across a reconnect
+		// or across a turn boundary.
+		if note.TurnID == v.liveTurn && note.Offset <= v.liveFrom {
+			return next
+		}
+		if line := outputNoteLine(note); line != "" {
+			v.scrollback = append(v.scrollback, line)
+		}
+	}
+	return next
+}
+
+func (v *chatView) applySent(msg chatSentMsg) tea.Cmd {
+	if msg.err != nil {
+		// A 409 chat_cap_reached is a refusal, never a queued turn and never
+		// a spinner: the daemon will not run this turn, and a client that
+		// showed one pending would be inventing state (§11, decision 1).
+		var apiErr *apiclient.Error
+		if errors.As(msg.err, &apiErr) && apiErr.Code == "chat_cap_reached" {
+			v.note, v.noteBad = "too many chats are running — "+
+				"finish or cancel one and send again", true
+			return nil
+		}
+		v.note, v.noteBad = errString(msg.err), true
+		return nil
+	}
+	v.note = ""
+	v.scrollback, v.liveFrom, v.liveTurn = nil, 0, 0
+	return v.loadCmd()
+}
+
+func (v *chatView) applyAnswered(msg chatAnsweredMsg) tea.Cmd {
+	if msg.err != nil {
+		if v.form != nil {
+			v.form.err = errString(msg.err)
+			v.form.submitting = false
+		}
+		return nil
+	}
+	v.form = nil
+	return v.loadCmd()
+}
+
+func (v *chatView) applyCanceled(msg chatCanceledMsg) tea.Cmd {
+	if msg.err != nil {
+		v.note, v.noteBad = errString(msg.err), true
+		return nil
+	}
+	v.note, v.noteBad = "turn canceled", false
+	return v.loadCmd()
+}
+
+func (v *chatView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
+	if v.form != nil {
+		cmd, exit := v.form.updateWith(msg, v.answerCmd)
+		if exit {
+			v.form = nil
+		}
+		return v, cmd
+	}
+	switch msg.String() {
+	case "esc":
+		return v, func() tea.Msg { return selectViewMsg{id: viewChats} }
+	case "ctrl+c":
+		return v, nil
+	case "enter":
+		return v, v.sendCmd()
+	case "ctrl+x":
+		return v, v.cancelCmd()
+	}
+	var cmd tea.Cmd
+	v.composer, cmd = v.composer.Update(msg)
+	return v, cmd
+}
+
+func (v *chatView) sendCmd() tea.Cmd {
+	message := strings.TrimSpace(v.composer.Value())
+	if message == "" {
+		return nil
+	}
+	client, id := v.client, v.chatID
+	if client == nil {
+		v.note, v.noteBad = "not connected", true
+		return nil
+	}
+	v.composer.SetValue("")
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		turn, err := client.SendChat(ctx, id, message)
+		return chatSentMsg{chatID: id, turn: turn, err: err}
+	}
+}
+
+func (v *chatView) answerCmd(resp apiclient.InputResponse) tea.Cmd {
+	client, id := v.client, v.chatID
+	if client == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		return chatAnsweredMsg{chatID: id, err: client.AnswerChat(ctx, id, resp)}
+	}
+}
+
+func (v *chatView) cancelCmd() tea.Cmd {
+	client, id := v.client, v.chatID
+	if client == nil || v.runningTurn() == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		return chatCanceledMsg{chatID: id, err: client.CancelChat(ctx, id)}
+	}
+}

--- a/internal/tui/chatview_test.go
+++ b/internal/tui/chatview_test.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// chatViewFixture is a chat workspace pointed at one loaded chat.
+func chatViewFixture() *chatView {
+	v := newChatView()
+	v.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	v.chatID = 1
+	v.chat = &apiclient.Chat{ID: 1, ProjectID: 7, Title: "a chat", State: "idle", Agent: "claude"}
+	v.composer.Focus()
+	return v
+}
+
+// TestChatViewRefusesCapReached holds §11's refusal: a 409 renders as a
+// refusal, never as a queued turn and never as a spinner.
+func TestChatViewRefusesCapReached(t *testing.T) {
+	v := chatViewFixture()
+	v.applySent(chatSentMsg{chatID: 1, err: &apiclient.Error{Code: "chat_cap_reached"}})
+	if !v.noteBad || v.note == "" {
+		t.Fatalf("a cap refusal rendered as %q (bad=%v), want a refusal", v.note, v.noteBad)
+	}
+	if len(v.turns) != 0 {
+		t.Fatalf("a refused send created %d turn rows, want none", len(v.turns))
+	}
+}
+
+// TestChatViewSeamsTranscriptToStream is the catch-up seam: a chunk at or
+// before the fetch's X-Next-Offset is one the fetch already returned, and
+// printing it again would duplicate the line.
+func TestChatViewSeamsTranscriptToStream(t *testing.T) {
+	v := chatViewFixture()
+	v.turns = []apiclient.ChatTurn{{ID: 9, Seq: 1, State: "running"}}
+	v.applyTranscript(chatTranscriptMsg{chatID: 1, seq: 1, next: 120, records: []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "one"},
+	}})
+	if len(v.scrollback) != 1 {
+		t.Fatalf("the fetch produced %d lines, want 1", len(v.scrollback))
+	}
+	// Already covered by the fetch: dropped.
+	v.applyChatNote(chatNoteMsg{chatID: 1, note: apiclient.OutputNote{
+		TurnID: 9, Offset: 120, Payload: []byte(`{"raw":"{\"type\":\"agent.output\",\"text\":\"one\"}"}`),
+	}})
+	if len(v.scrollback) != 1 {
+		t.Fatalf("a chunk at the seam was printed again: %v", v.scrollback)
+	}
+	// Past the seam: new.
+	v.applyChatNote(chatNoteMsg{chatID: 1, note: apiclient.OutputNote{
+		TurnID: 9, Offset: 121, Payload: []byte(`{"raw":"{\"type\":\"agent.output\",\"text\":\"two\"}"}`),
+	}})
+	if len(v.scrollback) != 2 {
+		t.Fatalf("a chunk past the seam was dropped: %v", v.scrollback)
+	}
+}
+
+// TestChatViewOpensTheSameAnswerPopup proves the §7.4 popup is reused rather
+// than forked: the chat's own pending request builds an answerForm, and the
+// answer goes out over AnswerChat.
+func TestChatViewOpensTheSameAnswerPopup(t *testing.T) {
+	v := chatViewFixture()
+	v.applyLoaded(chatLoadedMsg{id: 1, chat: &apiclient.Chat{
+		ID: 1, State: "awaiting_input",
+		PendingInput: []byte(`{"kind":"question","questions":[` +
+			`{"text":"Which files?","options":["a.go","b.go"],"multi_select":true}]}`),
+	}})
+	if v.form == nil {
+		t.Fatal("an awaiting_input chat did not open the answer popup")
+	}
+	if len(v.form.req.Questions) != 1 || !v.form.req.Questions[0].MultiSelect {
+		t.Fatalf("the popup lost the request's shape: %+v", v.form.req)
+	}
+	// Answering elsewhere closes it: the popup follows the daemon's state.
+	v.applyLoaded(chatLoadedMsg{id: 1, chat: &apiclient.Chat{ID: 1, State: "running"}})
+	if v.form != nil {
+		t.Fatal("the popup outlived the awaiting_input state")
+	}
+}
+
+// TestChatViewIgnoresAnotherChatsStream holds the per-chat filter on the
+// client side too: a note from a subscription we left changes nothing.
+func TestChatViewIgnoresAnotherChatsStream(t *testing.T) {
+	v := chatViewFixture()
+	if cmd := v.applyChatNote(chatNoteMsg{chatID: 2, note: apiclient.OutputNote{}}); cmd != nil {
+		t.Fatal("a stale subscription's note was folded in")
+	}
+}

--- a/internal/tui/firstrun.go
+++ b/internal/tui/firstrun.go
@@ -20,6 +20,12 @@ import (
 type tuiState struct {
 	FullAutoNoticeAck bool       `json:"full_auto_notice_ack"`
 	BoardFolds        []foldPath `json:"board_folds,omitempty"`
+	// ChatFolds is the chats board's own set. It is a second field rather
+	// than a second use of BoardFolds because the two boards group by the
+	// same project names: sharing the list would make folding a project on
+	// one board fold it on the other, which is one fold set pretending to be
+	// two (task 067).
+	ChatFolds []foldPath `json:"chat_folds,omitempty"`
 }
 
 func statePath(dataDir string) string { return filepath.Join(dataDir, "tui.json") }

--- a/internal/tui/newchat.go
+++ b/internal/tui/newchat.go
@@ -1,0 +1,318 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The new-chat form (§15, task 067), a layer over the chats board rather than
+// a seventh view: it is opened from there, it returns there, and it means
+// nothing anywhere else.
+//
+// It is deliberately smaller than the new-task form. A chat has no workflow,
+// no fields, no github issue and no scheduling, so the whole form is project,
+// title, agent, model, effort and base branch — and only the first two are
+// required.
+
+// chatCreatedMsg reports the outcome of POST /v1/chats.
+type chatCreatedMsg struct {
+	chat *apiclient.Chat
+	err  error
+}
+
+// newChatFieldsMsg carries what the form needs to offer choices: the
+// registered projects and the adapters that can hold a conversation.
+type newChatFieldsMsg struct {
+	projects []apiclient.Project
+	agents   []apiclient.Agent
+	err      error
+}
+
+// newChatForm is the create form.
+type newChatForm struct {
+	client *apiclient.Client
+
+	projects []apiclient.Project
+	agents   []apiclient.Agent
+
+	projectID int64
+	agentIdx  int
+
+	title  textinput.Model
+	model  textinput.Model
+	effort textinput.Model
+	base   textinput.Model
+
+	// focus indexes the fields in tab order: project, title, agent, model,
+	// effort, base.
+	focus int
+
+	err        string
+	submitting bool
+}
+
+// newChatFields is the number of focusable fields.
+const newChatFields = 6
+
+func newNewChatForm(client *apiclient.Client, hintProject int64) *newChatForm {
+	f := &newChatForm{client: client, projectID: hintProject}
+	f.title = textinput.New()
+	f.title.Placeholder = "what is this conversation about"
+	f.model = textinput.New()
+	f.model.Placeholder = "model override (optional)"
+	f.effort = textinput.New()
+	f.effort.Placeholder = "effort override (optional)"
+	f.base = textinput.New()
+	f.base.Placeholder = "base branch (optional — the project's default)"
+	f.focus = 1
+	f.title.Focus()
+	return f
+}
+
+// init fetches the projects and adapters the pickers offer.
+func (f *newChatForm) init() tea.Cmd {
+	client := f.client
+	if client == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
+		defer cancel()
+		projects, err := client.ListProjects(ctx)
+		if err != nil {
+			return newChatFieldsMsg{err: err}
+		}
+		agents, _ := client.ListAgents(ctx, false)
+		return newChatFieldsMsg{projects: projects, agents: agents}
+	}
+}
+
+func (f *newChatForm) capturesInput() bool {
+	switch f.focus {
+	case 1, 3, 4, 5:
+		return true
+	}
+	return false
+}
+
+func (f *newChatForm) paste(text string) tea.Cmd {
+	var cmd tea.Cmd
+	switch f.focus {
+	case 1:
+		f.title, cmd = f.title.Update(tea.PasteMsg{Content: text})
+	case 3:
+		f.model, cmd = f.model.Update(tea.PasteMsg{Content: text})
+	case 4:
+		f.effort, cmd = f.effort.Update(tea.PasteMsg{Content: text})
+	case 5:
+		f.base, cmd = f.base.Update(tea.PasteMsg{Content: text})
+	}
+	return cmd
+}
+
+// applyFields records the pickers' contents, defaulting the project to the
+// hint and the agent to the first adapter that can resume — which is the
+// daemon's own default, so the form and the API agree before anyone types.
+func (f *newChatForm) applyFields(msg newChatFieldsMsg) {
+	if msg.err != nil {
+		f.err = errString(msg.err)
+		return
+	}
+	f.projects, f.agents = msg.projects, msg.agents
+	if f.projectID == 0 && len(f.projects) > 0 {
+		f.projectID = f.projects[0].ID
+	}
+}
+
+// applyFailure puts the daemon's refusal on the form rather than closing it.
+//
+// `agent_cannot_resume` is rendered as the typed refusal it is: an adapter
+// that cannot resume its own session cannot hold a conversation, and telling
+// the human to pick another adapter is a different sentence from "creation
+// failed" (task 063 decision 3).
+func (f *newChatForm) applyFailure(err error) {
+	f.submitting = false
+	var apiErr *apiclient.Error
+	if errors.As(err, &apiErr) && apiErr.Code == "agent_cannot_resume" {
+		f.err = "that agent cannot resume its own session, so it cannot hold a " +
+			"conversation — pick one that can"
+		return
+	}
+	f.err = errString(err)
+}
+
+// update runs the form's keyboard. done reports that the layer should close.
+func (f *newChatForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd tea.Cmd, done bool) {
+	f.client = client
+	switch msg.String() {
+	case "esc":
+		return nil, true
+	case "tab", "down":
+		f.moveFocus(1)
+		return nil, false
+	case "shift+tab", "up":
+		f.moveFocus(-1)
+		return nil, false
+	case "left":
+		f.cycle(-1)
+		return nil, false
+	case "right":
+		f.cycle(1)
+		return nil, false
+	case "ctrl+s", "enter":
+		if f.focus == 1 || msg.String() == "ctrl+s" {
+			return f.submit(), false
+		}
+		f.moveFocus(1)
+		return nil, false
+	}
+	switch f.focus {
+	case 1:
+		f.title, cmd = f.title.Update(msg)
+	case 3:
+		f.model, cmd = f.model.Update(msg)
+	case 4:
+		f.effort, cmd = f.effort.Update(msg)
+	case 5:
+		f.base, cmd = f.base.Update(msg)
+	}
+	return cmd, false
+}
+
+func (f *newChatForm) moveFocus(delta int) {
+	f.focus = (f.focus + delta + newChatFields) % newChatFields
+	f.title.Blur()
+	f.model.Blur()
+	f.effort.Blur()
+	f.base.Blur()
+	switch f.focus {
+	case 1:
+		f.title.Focus()
+	case 3:
+		f.model.Focus()
+	case 4:
+		f.effort.Focus()
+	case 5:
+		f.base.Focus()
+	}
+}
+
+// cycle steps the two picker fields. The text fields ignore it: left and
+// right are cursor movement there.
+func (f *newChatForm) cycle(delta int) {
+	switch f.focus {
+	case 0:
+		if len(f.projects) == 0 {
+			return
+		}
+		i := 0
+		for j, p := range f.projects {
+			if p.ID == f.projectID {
+				i = j
+				break
+			}
+		}
+		f.projectID = f.projects[(i+delta+len(f.projects))%len(f.projects)].ID
+	case 2:
+		if len(f.agents) == 0 {
+			return
+		}
+		f.agentIdx = (f.agentIdx + delta + len(f.agents)) % len(f.agents)
+	}
+}
+
+func (f *newChatForm) agentName() string {
+	if f.agentIdx < 0 || f.agentIdx >= len(f.agents) {
+		return ""
+	}
+	return f.agents[f.agentIdx].Name
+}
+
+func (f *newChatForm) submit() tea.Cmd {
+	title := strings.TrimSpace(f.title.Value())
+	if title == "" {
+		f.err = "a chat needs a title"
+		return nil
+	}
+	if f.projectID == 0 {
+		f.err = "pick a project"
+		return nil
+	}
+	client := f.client
+	if client == nil {
+		f.err = "not connected"
+		return nil
+	}
+	f.err = ""
+	f.submitting = true
+	req := apiclient.CreateChatRequest{
+		ProjectID: f.projectID, Title: title, Agent: f.agentName(),
+		Model:      strings.TrimSpace(f.model.Value()),
+		Effort:     strings.TrimSpace(f.effort.Value()),
+		BaseBranch: strings.TrimSpace(f.base.Value()),
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+		defer cancel()
+		chat, err := client.CreateChat(ctx, req)
+		return chatCreatedMsg{chat: chat, err: err}
+	}
+}
+
+func (f *newChatForm) projectName() string {
+	for _, p := range f.projects {
+		if p.ID == f.projectID {
+			return p.Name
+		}
+	}
+	if f.projectID == 0 {
+		return "—"
+	}
+	return strconv.FormatInt(f.projectID, 10)
+}
+
+func (f *newChatForm) render(width, height int) string {
+	rows := []struct{ label, value string }{
+		{"project", f.projectName() + styleDim.Render("   ← → to change")},
+		{"title", f.title.View()},
+		{"agent", f.agentLabel()},
+		{"model", f.model.View()},
+		{"effort", f.effort.View()},
+		{"base", f.base.View()},
+	}
+	lines := []string{" " + styleTitle.Render("new chat"), ""}
+	for i, r := range rows {
+		marker := "  "
+		if i == f.focus {
+			marker = "▸ "
+		}
+		lines = append(lines, marker+padRight(r.label, 9)+r.value)
+	}
+	lines = append(lines, "")
+	switch {
+	case f.submitting:
+		lines = append(lines, " "+styleDim.Render("creating…"))
+	case f.err != "":
+		lines = append(lines, " "+styleBad.Render(f.err))
+	default:
+		lines = append(lines, " "+styleDim.Render("ctrl+s create · esc cancel"))
+	}
+	_ = width
+	_ = height
+	return strings.Join(lines, "\n")
+}
+
+func (f *newChatForm) agentLabel() string {
+	name := f.agentName()
+	if name == "" {
+		name = styleDim.Render("the daemon's default")
+	}
+	return name + styleDim.Render("   ← → to change")
+}

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -30,6 +30,7 @@ func TestPaletteReachesEveryRegistryEntry(t *testing.T) {
 		ctxNewTask, ctxProjects, ctxWorkflows, ctxWorkflowGraph, ctxWorkflowEditor,
 		ctxTaskWorkflow,
 		ctxDaemon, ctxPullRequests,
+		ctxChats, ctxChat, ctxNewChat,
 	}
 	for _, b := range bindings {
 		if b.noPalette {
@@ -98,8 +99,11 @@ func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
 	if actions != 0 {
 		t.Errorf("palette offers %d task actions while disconnected, want 0", actions)
 	}
-	if nav != 5 {
-		t.Errorf("palette lists %d navigation entries while disconnected, want all 5", nav)
+	// Six: the five takeovers plus the chats board (task 067). Navigation
+	// survives a disconnect because reaching a screen is not an action on
+	// the daemon.
+	if nav != 6 {
+		t.Errorf("palette lists %d navigation entries while disconnected, want all 6", nav)
 	}
 }
 

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -158,6 +158,15 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 	case selectViewMsg:
 		return m, m.switchTo(msg.id)
+	case openChatMsg:
+		// The chat workspace is not the active view yet, and an inactive
+		// view receives nothing — so the root points it at the chat first
+		// and switches second, the same order every takeover that carries an
+		// argument uses.
+		if v, ok := m.views[viewChat].(*chatView); ok {
+			return m, tea.Batch(v.open(msg.id), m.switchTo(viewChat))
+		}
+		return m, nil
 	case githubProbeMsg:
 		// The listing failing leaves the previous answer standing: a probe
 		// that could not be made is not an integration that stopped working,
@@ -372,6 +381,10 @@ func (m *root) activeContext() bindingContext {
 		return ctxDaemon
 	case viewPullRequests:
 		return ctxPullRequests
+	case viewChats:
+		return m.views[viewChats].(*chatsView).bindingContext()
+	case viewChat:
+		return m.views[viewChat].(*chatView).bindingContext()
 	default:
 		s := m.views[viewHome].(*shell)
 		return s.focusedContext()
@@ -398,6 +411,8 @@ func synthKey(key string) tea.KeyPressMsg {
 		return tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}
 	case "ctrl+c":
 		return tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	case "ctrl+x":
+		return tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
 	default:
 		return tea.KeyPressMsg{Code: rune(key[0]), Text: key}
 	}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -9,7 +9,8 @@ import (
 )
 
 // viewID indexes the root's routed screens: the board-only home screen, the
-// full-screen task workspace, and the five management takeovers (§15).
+// full-screen task workspace, the five management takeovers, and the two chat
+// screens (§15).
 type viewID int
 
 const (
@@ -20,6 +21,11 @@ const (
 	viewWorkflows
 	viewDaemon
 	viewPullRequests
+	// The two chat screens (§15, task 067). They are routed exactly as
+	// viewHome/viewTask are — a board and the workspace one row opens —
+	// because that is the shape of the thing, not because chats are tasks.
+	viewChats
+	viewChat
 	viewCount
 )
 
@@ -117,5 +123,7 @@ func newViews(ctx context.Context) [viewCount]panel {
 		// is the *nav row* that is withheld, not the screen, so nothing here
 		// has to know the answer before the probes land.
 		viewPullRequests: newPullRequestsView(),
+		viewChats:        newChatsView(),
+		viewChat:         newChatView(),
 	}
 }

--- a/scripts/m14-gate.sh
+++ b/scripts/m14-gate.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# M14 phase gate (task 067, closing 063.2; spec §5.5, §11, §13.2, §13.3):
+# drive a chat end to end over the wire, against the committed fakeagent so CI
+# never calls a real agent CLI.
+#
+#   1. POST /v1/chats creates a chat with a worktree and a branch; an adapter
+#      that cannot resume is refused with the typed reason
+#   2. two sends in a row: turn 2 answers with what only turn 1 supplied, so
+#      continuity came from the agent resuming its own session
+#   3. GET /v1/chats/{id}/turns/{seq}/transcript serves the turn, and a
+#      resume from its X-Next-Offset returns only what was appended
+#   4. GET /v1/chats/{id}/events streams this chat's events and nobody else's
+#   5. an awaiting_input chat is answered over /answer and the turn finishes
+#   6. the max_parallel_chats+1-th send is 409 chat_cap_reached — refused,
+#      never queued — and leaves no turn row behind
+#   7. cancel stops a live turn; archive removes the worktree
+#   8. chats never appear in GET /v1/tasks
+#
+# There are no workflow `run:` bodies to spell in the sh∩pwsh intersection —
+# a chat has no workflow — but this script's own bash obeys the two standing
+# rules: `| tr -d '\r'` on any multi-line jq capture, and never `| grep -q`.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+FAKEAGENT="$BIN/fakeagent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+  FAKEAGENT+=".exe"
+fi
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent + fakeagent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent ./cmd/fakeagent)
+
+CONFIG_DIR="$TMP/config"
+DATA_DIR="$TMP/data"
+mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+export VINCENT_CONFIG_DIR
+VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+export VINCENT_DATA_DIR
+VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+
+# The fake CLI's own conversation store, deliberately outside the data dir:
+# continuity has to come from the agent remembering, not from anything vincent
+# kept.
+export FAKEAGENT_SESSION_DIR
+FAKEAGENT_SESSION_DIR="$(hostpath "$TMP/sessions")"
+mkdir -p "$TMP/sessions"
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email gate@example.com
+git -C "$REPO" config user.name "M14 Gate"
+git -C "$REPO" commit -q --allow-empty -m "root"
+
+cat > "$CONFIG_DIR/config.yaml" <<EOF
+max_parallel_chats: 1
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+  codex:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+echo "== start the daemon"
+"$VINCENT" daemon start
+PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+TOKEN="$(cat "$DATA_DIR/token")"
+BASE="http://127.0.0.1:$PORT/v1"
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -X "$method" -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" "$@" "$BASE$path"
+}
+
+# api_status METHOD PATH [curl args...] -> the status code, with the body in
+# $TMP/body.json so a scenario can assert both without a second request.
+api_status() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -o "$TMP/body.json" -w '%{http_code}' -X "$method" \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$@" "$BASE$path"
+}
+
+# wait_chat CHAT_ID STATE — poll until the chat reaches a state.
+wait_chat() {
+  local id="$1" want="$2" i=0 state
+  while (( i < 300 )); do
+    state="$(api GET "/chats/$id" | jq -r .chat.state)"
+    if [[ "$state" == "$want" ]]; then return 0; fi
+    i=$(( i + 1 ))
+    sleep 1
+  done
+  fail "chat $id never reached $want (it is $state)"
+}
+
+# wait_turn CHAT_ID SEQ — poll until that turn is no longer running, echoing
+# its state.
+wait_turn() {
+  local id="$1" seq="$2" i=0 state
+  while (( i < 300 )); do
+    state="$(api GET "/chats/$id" | jq -r --argjson s "$seq" \
+      '.turns[] | select(.seq == $s) | .state')"
+    if [[ -n "$state" && "$state" != "running" ]]; then
+      printf '%s\n' "$state"
+      return 0
+    fi
+    i=$(( i + 1 ))
+    sleep 1
+  done
+  fail "turn $seq of chat $id never finished"
+}
+
+echo "== register the project"
+PROJECT="$(api POST /projects -d "{\"path\": \"$(hostpath "$REPO")\"}")" \
+  || fail "POST /v1/projects failed"
+PROJECT_ID="$(printf '%s' "$PROJECT" | jq -r .id)"
+
+echo "== 1. create a chat; an adapter that cannot resume is refused"
+CODE="$(api_status POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"no memory\", \"agent\": \"codex\"}")"
+[[ "$CODE" == "400" ]] || fail "a codex chat answered $CODE, want 400"
+REASON="$(jq -r .error.code < "$TMP/body.json")"
+[[ "$REASON" == "agent_cannot_resume" ]] \
+  || fail "the refusal is $REASON, want the typed agent_cannot_resume"
+
+CHAT="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"gate talk\", \"agent\": \"claude\"}")" \
+  || fail "POST /v1/chats failed"
+CHAT_ID="$(printf '%s' "$CHAT" | jq -r .id)"
+printf '%s' "$CHAT" | jq -e '.state == "idle" and (.branch | startswith("vincent/"))' >/dev/null \
+  || fail "the created chat is wrong: $CHAT"
+WORKTREE="$(printf '%s' "$CHAT" | jq -r .worktree_path)"
+[[ -d "$WORKTREE" ]] || fail "the chat has no worktree at $WORKTREE"
+
+echo "== 2. two turns, and the second remembers the first"
+api POST "/chats/$CHAT_ID/send" \
+  -d '{"message": "my favourite colour is heliotrope"}' >/dev/null \
+  || fail "the first send failed"
+STATE="$(wait_turn "$CHAT_ID" 1)"
+[[ "$STATE" == "done" ]] || fail "turn 1 is $STATE, want done"
+SESSION="$(api GET "/chats/$CHAT_ID" | jq -r .chat.session_id)"
+[[ -n "$SESSION" && "$SESSION" != "null" ]] \
+  || fail "the chat recorded no session id, so there is nothing to resume"
+
+api POST "/chats/$CHAT_ID/send" -d '{"message": "what is my favourite colour?"}' >/dev/null \
+  || fail "the second send failed"
+STATE="$(wait_turn "$CHAT_ID" 2)"
+[[ "$STATE" == "done" ]] || fail "turn 2 is $STATE, want done"
+# The recall line is in the turn's durable record, which is what the new
+# transcript route serves — so this assertion proves continuity and the route
+# at once.
+RECALL="$(curl -sS -H "Authorization: Bearer $TOKEN" \
+  "$BASE/chats/$CHAT_ID/turns/2/transcript" | tr -d '\r')"
+case "$RECALL" in
+  *heliotrope*) ;;
+  *) fail "turn 2 did not see turn 1; transcript: $RECALL" ;;
+esac
+case "$RECALL" in
+  *recalled:*) ;;
+  *) fail "turn 2 ran a fresh session rather than resuming one" ;;
+esac
+
+echo "== 3. the per-turn transcript, and its offset seam"
+HEADERS="$TMP/transcript.headers"
+BODY1="$TMP/transcript1.ndjson"
+curl -sS -D "$HEADERS" -o "$BODY1" -H "Authorization: Bearer $TOKEN" \
+  "$BASE/chats/$CHAT_ID/turns/1/transcript" || fail "the transcript route failed"
+[[ -s "$BODY1" ]] || fail "the turn 1 transcript is empty"
+NEXT="$(tr -d '\r' < "$HEADERS" | awk 'tolower($1) == "x-next-offset:" { print $2 }')"
+[[ "$NEXT" =~ ^[0-9]+$ ]] || fail "no X-Next-Offset on the transcript response"
+BODY2="$TMP/transcript2.ndjson"
+curl -sS -o "$BODY2" -H "Authorization: Bearer $TOKEN" \
+  "$BASE/chats/$CHAT_ID/turns/1/transcript?offset=$NEXT" \
+  || fail "the transcript resume failed"
+# Nothing was appended after the turn ended, so resuming from the reported
+# offset must return nothing at all. A non-empty body here is a seam that
+# would double-print in a client.
+[[ ! -s "$BODY2" ]] || fail "resuming at X-Next-Offset re-served $(wc -c < "$BODY2") bytes"
+CODE="$(api_status GET "/chats/$CHAT_ID/turns/1/transcript?offset=1&tail=1")"
+[[ "$CODE" == "400" ]] || fail "offset with tail answered $CODE, want 400"
+CODE="$(api_status GET "/chats/$CHAT_ID/turns/99/transcript")"
+[[ "$CODE" == "404" ]] || fail "an unknown turn answered $CODE, want 404"
+
+echo "== 4. the per-chat stream carries this chat and no other"
+OTHER="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"someone else\", \"agent\": \"claude\"}")" \
+  || fail "creating the second chat failed"
+OTHER_ID="$(printf '%s' "$OTHER" | jq -r .id)"
+STREAM="$TMP/stream.sse"
+curl -sN -H "Authorization: Bearer $TOKEN" "$BASE/chats/$CHAT_ID/events" > "$STREAM" &
+STREAM_PID=$!
+sleep 2
+# Both of these happen; only one belongs on the stream above.
+api POST "/chats/$OTHER_ID/archive" >/dev/null || fail "archiving the other chat failed"
+api POST "/chats/$CHAT_ID/send" -d '{"message": "still there?"}' >/dev/null \
+  || fail "the third send failed"
+wait_turn "$CHAT_ID" 3 >/dev/null
+sleep 2
+kill "$STREAM_PID" 2>/dev/null || true
+wait "$STREAM_PID" 2>/dev/null || true
+# A multi-line jq capture, so `tr -d '\r'`: jq writes CRLF on Windows, $( )
+# strips only the trailing one, and the interior CRs would fail the match below.
+IDS="$(sed -n 's/^data: //p' "$STREAM" | jq -r 'select(.payload) | .payload.id' | sort -u | tr -d '\r')"
+case "$IDS" in
+  *"$OTHER_ID"*) fail "another chat's events arrived on chat $CHAT_ID's stream" ;;
+esac
+printf '%s\n' "$IDS" | grep -x "$CHAT_ID" >/dev/null \
+  || fail "this chat's own events never arrived on its stream: $IDS"
+
+echo "== 5. an awaiting_input chat is answered over the API"
+"$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+export FAKEAGENT_SCENARIO=ask-question
+"$VINCENT" daemon start
+PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+TOKEN="$(cat "$DATA_DIR/token")"
+BASE="http://127.0.0.1:$PORT/v1"
+
+ASK="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"a question\", \"agent\": \"claude\"}")" \
+  || fail "creating the question chat failed"
+ASK_ID="$(printf '%s' "$ASK" | jq -r .id)"
+api POST "/chats/$ASK_ID/send" -d '{"message": "ask me something"}' >/dev/null \
+  || fail "the send failed"
+wait_chat "$ASK_ID" awaiting_input
+QUESTION="$(api GET "/chats/$ASK_ID" | jq -r '.chat.pending_input.Questions[0].Text // .chat.pending_input.questions[0].text')"
+[[ -n "$QUESTION" ]] || fail "the parked chat carries no question"
+
+echo "== 6. the cap refuses rather than queues"
+CAP="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"over the cap\", \"agent\": \"claude\"}")" \
+  || fail "creating the cap chat failed"
+CAP_ID="$(printf '%s' "$CAP" | jq -r .id)"
+CODE="$(api_status POST "/chats/$CAP_ID/send" -d '{"message": "me too"}')"
+[[ "$CODE" == "409" ]] || fail "a send over max_parallel_chats answered $CODE, want 409"
+REASON="$(jq -r .error.code < "$TMP/body.json")"
+[[ "$REASON" == "chat_cap_reached" ]] || fail "the refusal is $REASON, want chat_cap_reached"
+TURNS="$(api GET "/chats/$CAP_ID" | jq '.turns | length')"
+[[ "$TURNS" == "0" ]] || fail "a refused send left $TURNS turn rows behind"
+
+api POST "/chats/$ASK_ID/answer" \
+  -d "{\"answers\": {\"$QUESTION\": [\"blue\"]}}" >/dev/null \
+  || fail "POST /v1/chats/{id}/answer failed"
+wait_turn "$ASK_ID" 1 >/dev/null
+wait_chat "$ASK_ID" idle
+
+echo "== 7. cancel stops a live turn; archive removes the worktree"
+unset FAKEAGENT_SCENARIO
+export FAKEAGENT_SCENARIO=hang
+"$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+"$VINCENT" daemon start
+PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+TOKEN="$(cat "$DATA_DIR/token")"
+BASE="http://127.0.0.1:$PORT/v1"
+
+api POST "/chats/$CAP_ID/send" -d '{"message": "run forever"}' >/dev/null \
+  || fail "the hanging send failed"
+wait_chat "$CAP_ID" running
+api POST "/chats/$CAP_ID/cancel" >/dev/null || fail "POST /v1/chats/{id}/cancel failed"
+STATE="$(wait_turn "$CAP_ID" 1)"
+[[ "$STATE" == "failed" ]] || fail "a cancelled turn is $STATE, want failed"
+wait_chat "$CAP_ID" idle
+
+CAP_WORKTREE="$(api GET "/chats/$CAP_ID" | jq -r .chat.worktree_path)"
+api POST "/chats/$CAP_ID/archive" >/dev/null || fail "POST /v1/chats/{id}/archive failed"
+wait_chat "$CAP_ID" archived
+[[ ! -d "$CAP_WORKTREE" ]] || fail "the archived chat's worktree is still at $CAP_WORKTREE"
+
+echo "== 8. chats are not tasks"
+TASKS="$(api GET /tasks | jq 'if type == "array" then length else (.tasks | length) end')"
+[[ "$TASKS" == "0" ]] || fail "GET /v1/tasks lists $TASKS rows on a daemon with only chats"
+
+echo "GATE PASS: m14"


### PR DESCRIPTION
## Summary

Closes 063.2 and 063.3 together, because the 063.3 gaps are what make a chat
drivable without curl and the view is the client that proves it.

**Two views of their own.** A chats board and a chat workspace, reached from the
command palette, routed by `viewID` exactly as the task board and the task
workspace are. A chat is not a task — no workflow, no step `k/n`, no §6 action
set — so it gets a second board rather than rows on the first, which is also
what decision row 29 has always said. The board groups by project and by nothing
else (`tui.board.group_by`'s workflow scopes are meaningless for a chat) and
folds under its own `chat_folds` key in `tui.json`, because both boards group by
the same project names and one list would make folding a project on one board
fold it on the other.

**Attention is the chats board's own.** An `awaiting_input` chat is pinned and
badged there and nowhere else; `!` and the home board's needs-attention count
stay task-only. Task 063 decision 7 is untouched — it governs the daemon's
`notify:` hook, not a client's ordering.

**The answer popup is reused, not forked.** `answerForm` grew `updateWith`,
which takes a submitter; the task path passes a closure that posts to a task and
the chat path one that posts to a chat. Structured options, multi-select and the
permission allow/deny distinction come along because it is the same request.

**A chat turn is now bounded.** `agent_timeout` bounds a running turn and
`input_timeout` bounds `awaiting_input` — §7.2's and §7.4's numbers verbatim,
with no `defaults.chat_*` key and no per-turn override, since §8.2's fields are
workflow step fields and a chat has no workflow. Either expiry kills the process
tree, fails the turn with the existing snake_case reason and returns the chat to
`idle`, **releasing the `max_parallel_chats` slot** a walked-away human used to
hold forever. `transcript_max_bytes` applies to a turn's transcript too, and the
pruner walks archived chats.

**Two read routes.** `GET /v1/chats/{id}/events` filters durable chat events on
the payload's id (a chat event carries no `task_id`, by design) and rides the
chat's own broker key. `GET /v1/chats/{id}/turns/{seq}/transcript` serves a turn
with the step route's range contract — `?offset=`/`?tail=` mutually exclusive,
whole records, `X-Next-Offset` — named by `seq`, because a chat turn is its own
run. Both join §13.4's *exclusion* list rather than the SSE carve-out: the rule
that keeps chats off the tool surface is "a human drives a chat", and one rule
for the family stops a later route being sorted by which sentence it matches.

**CLI.** `vincent chat answer` and `vincent chat cancel`, and `--json` on every
subcommand. `chat show` prints a parked chat's questions numbered, which are the
numbers `chat answer --answer N=VALUE` reads.

**A bug found on the way.** `internal/store`'s `updateChat` published a `nil`
event for the three chat columns no client is told about, and every SSE
subscriber dereferences the event it is handed — so finishing the first turn of
any chat panicked `GET /v1/events` and every per-task stream for everyone
connected. The `nil` is now dropped where it is produced. This is on `master`
today; it is in the Fixed section.

**Acceptance.** `scripts/m14-gate.sh` — `m13` was taken by the workflow editor,
so 063.2's row is corrected — drives a chat end to end over curl against
`cmd/fakeagent`: create, the `agent_cannot_resume` refusal, two turns with
continuity proved from the transcript route, the offset seam, the per-chat
stream carrying this chat and no other, an `awaiting_input` answer, the
`409 chat_cap_reached`, cancel, archive, and `GET /v1/tasks` still empty.
Committed executable and wired into `ci.yml`'s `gates` job on all three
platforms. It has no workflow `run:` bodies to spell in the sh∩pwsh
intersection, and its own bash keeps the two standing rules.

**The documentation audit found six more.** They are fixed in this PR, in a
separate `docs:` commit. `docs/reference/files.md` still said a chat's turn
transcripts are written with no size cap and are never pruned — both halves of
that paragraph became false the moment `internal/chatrun` gained
`Writer.SetMax` and the pruner gained archived chats. `README.md` carried the
two claims the missing chat CLI forced on it ("all but a chat's answer and
cancel have a CLI subcommand", "every subcommand except `vincent chat` takes
`--json`"), and both are now the pre-chat sentences again, verbatim.
`docs/reference/cli.md`'s `vincent chat start` usage block kept its old
continuation line beside the new one and printed `[--base BRANCH]
[--message TEXT]` twice. `docs/reference/api.md`'s Events (SSE) route list, which
is derived from the route table, did not name `GET /v1/chats/{id}/events`.
`docs/guides/tui.md` documented one of the new-chat form's four registry rows,
though §15 lists all four. And `docs/spec.md` §12.3 and §17 still described
`transcript_max_bytes` and `transcript_retention_days` as reaching tasks alone —
§12.3 in particular was named as amended below without having been — so both
now carry a dated note.

**Found and deliberately not fixed here.** `CLAUDE.md`'s gate list stops at
`scripts/m13-gate.sh` and still says "all ten of those run in `ci.yml`'s `gates`
job… `m12` is the eleventh"; `m14` makes that eleven and twelve. It is outside
the paths a documentation step may touch, so it wants a one-line follow-up.
`internal/chatrun` also declares its own `ReasonInputTimeout` and
`ReasonTranscriptLimit` rather than using the ones `internal/taskrun` exports.
The strings are identical, so nothing on the wire or in any table differs, and
`internal/github/reason.go` sets the same precedent — but a reviewer may prefer
one home for them.

**Not in this PR:** the screenshots of the two new panels. `scripts/screenshots.sh`
is the only source of `docs/assets/tui-*.png`, it is macOS/Linux-only and CI does
not run it, so capturing them is a seeded VHS run on a workstation. This PR
deliberately ships no drawing in the meantime — `docs/guides/tui.md` describes
both panels in prose and key tables.

## Related

Closes #269
Closes 063.2 and 063.3 (see `docs/tasks/063-free-chat.md`); the work itself is
`docs/tasks/066-chats-in-the-tui.md`.

This **replaces** a dated correction rather than merely adding to it: §13.2's
2026-08-30 note under `POST /v1/chats/{id}/answer` said a chat turn is bounded
by no clock at all. That was true and is now false, and §5.5, §11 and §12.3 are
amended with it. It is the 2026-08-29 §11 amendment extended once more, not
excepted — that amendment named live-but-uncounted agent CLIs as its cost, and
this is the case where the cost was being paid. 063.2's row also named
`scripts/m13-gate.sh`, a filename task 065 took; the row is corrected.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`docs/` touched: `features.md`, `reference/api.md` (both new routes),
`reference/cli.md` (`answer`, `cancel`, `--json`), `reference/configuration.md`
(both clocks and both transcript keys now naming chats), `guides/tui.md` (the
two panels and their key tables), `guides/scripting.md` (the `--json` claim
un-narrowed), `tasks/README.md` and `tasks/063-free-chat.md`. The audit added
`reference/files.md` (chat transcripts are capped and pruned now),
`README.md` (both narrowed claims restored) and the four corrections above.
No `docs/assets/tui-*.png` went stale: chats never appear on the task board and
every new binding is panel-scoped, so no existing capture shows a screen that
moved. `docs/spec.md` is
amended in §5.5, §11, §13.2, §13.3, §13.4, §15 and decision row 29, each with a
dated note; §15's "chats in the TUI are not in the first cut" note is removed
because the screens it described as absent are there.

Full suite green, and `golangci-lint` clean for `GOOS=darwin`, `linux` and
`windows`. `./scripts/m14-gate.sh` passes locally on macOS; its Linux and
Windows legs are what CI will be the first to walk.
