### PR TITLE
Let the chats board's n start a chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,19 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **`n` on the chats board opened the new-task form.** The chats board's own
+  `n` — "start a chat in the project you are looking at", the one key whose
+  meaning depends on where you are — never reached the board: the root's global
+  `n` consumed it first and swapped the screen for the new-task form. The
+  palette row went the same way, since a keyed palette entry replays its
+  keypress through that same handler, which left the new-chat form with no
+  route into it from the TUI at all (chats were still creatable with `vincent
+  chat start` and over the API). A global single-key binding now stands down
+  when the surface underneath it declares the same key in the binding registry,
+  so the collision is answered by the registry rather than by a list of views;
+  the palette's "new task" row still opens the new-task form from the chats
+  board, by navigating instead of replaying the key.
+
 - **Writing a chat's session id crashed every open event stream.** The store
   publishes an event after each write, and the three chat columns no client is
   told about — session id, worktree path, pending input — handed it a `nil`

--- a/internal/tui/chatsroot_test.go
+++ b/internal/tui/chatsroot_test.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// connectedChatsRoot is the shell a human has on screen when they press a key
+// on the chats board: connected, sized, chats active and holding rows.
+func connectedChatsRoot(t *testing.T) *root {
+	t.Helper()
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	m.views[viewChats] = chatsFixture()
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.switchTo(viewChats)
+	if m.active != viewChats {
+		t.Fatalf("fixture is on %v, want the chats board", m.active)
+	}
+	return m
+}
+
+// assertStartedAChat holds the acceptance of §15's one context-dependent key:
+// the chats board stays on screen and its new-chat form is up.
+func assertStartedAChat(t *testing.T, m *root) {
+	t.Helper()
+	if m.active == viewNewTask {
+		t.Fatal("n on the chats board opened the new-task form; §15: on the chats board it makes a chat")
+	}
+	if m.active != viewChats {
+		t.Fatalf("n left the chats board for %v", m.active)
+	}
+	if v, ok := m.views[viewChats].(*chatsView); !ok {
+		t.Fatalf("the chats slot holds %T", m.views[viewChats])
+	} else if v.create == nil {
+		t.Fatal("n did not open the new-chat form")
+	}
+}
+
+// TestChatsBoardNStartsAChatThroughRoot drives the key through the layer a
+// real keystroke takes — the root model — rather than calling
+// chatsView.updateKey directly the way the registry probes in
+// bindings_test.go do. §15 (amended 2026-08-31, task 067) makes `n` the one
+// key whose meaning depends on where you are: "on the chats board it makes a
+// chat, and everywhere else it still makes a task". A resting chats board
+// captures no input, so root.updateKey's global `n` runs first and never
+// delegates. The palette subtest is the same defect by the other route: a
+// keyed entry replays its keypress through root.updateKey.
+func TestChatsBoardNStartsAChatThroughRoot(t *testing.T) {
+	t.Run("direct key", func(t *testing.T) {
+		m := connectedChatsRoot(t)
+		m.Update(key("n"))
+		assertStartedAChat(t, m)
+	})
+
+	t.Run("palette", func(t *testing.T) {
+		m := connectedChatsRoot(t)
+		m.Update(key(":"))
+		if m.palette == nil {
+			t.Fatal(": did not open the palette")
+		}
+		const label = "start a chat in the project you are looking at"
+		found := false
+		for i, e := range m.palette.matches() {
+			if e.label == label {
+				m.palette.cursor, found = i, true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("the palette on the chats board offers no %q row", label)
+		}
+		m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+		if m.palette != nil {
+			t.Fatal("running the entry did not close the palette")
+		}
+		assertStartedAChat(t, m)
+	})
+}
+
+// TestChatsBoardPaletteStillReachesNewTask guards the other half of the same
+// collision. The chats board owns `n`, but the palette's "new task" row names
+// its destination in its label, so it must still land there rather than
+// replaying a keypress the board now answers with a chat.
+func TestChatsBoardPaletteStillReachesNewTask(t *testing.T) {
+	m := connectedChatsRoot(t)
+	m.Update(key(":"))
+	if m.palette == nil {
+		t.Fatal(": did not open the palette")
+	}
+	const label = "new task — for the project you are looking at"
+	found := false
+	for i, e := range m.palette.matches() {
+		if e.label == label {
+			m.palette.cursor, found = i, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("the palette on the chats board offers no %q row", label)
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.active != viewNewTask {
+		t.Fatalf("the palette's new-task row left the root on %v", m.active)
+	}
+	if v, ok := m.views[viewChats].(*chatsView); ok && v.create != nil {
+		t.Fatal("the palette's new-task row opened the new-chat form instead")
+	}
+}

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -317,8 +317,15 @@ func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "n":
 		// Not while the form is already up: there, n is "no" to the discard
 		// prompt, and re-opening would throw away the draft it is asking
-		// about.
-		if m.phase == phaseConnected && m.active != viewNewTask {
+		// about. And not when the active surface declares n as a row of its
+		// own — §15 makes n the one key whose meaning depends on where you
+		// are, so on the chats board it falls through to delegate and makes a
+		// chat. The yield is scoped to this arm rather than sitting ahead of
+		// the switch because n is the only global key that both collides with
+		// a panel row and consumes the key unconditionally: esc is declared by
+		// ctxChat and ctxNewChat too, and must still close the help overlay
+		// first.
+		if m.phase == phaseConnected && m.active != viewNewTask && !m.panelOwnsKey(key) {
 			return m, m.openNewTask()
 		}
 	case "r":
@@ -341,7 +348,11 @@ func (m *root) updatePaletteKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if run == nil {
 		return m, cmd
 	}
-	if run.nav && run.key == "" {
+	// A keyed nav entry replays its key — except where the active surface owns
+	// that key as a row of its own, since the replay would then run the
+	// panel's command instead of the navigation the entry names. On the chats
+	// board that is "new task", whose key n now makes a chat.
+	if run.nav && (run.key == "" || m.panelOwnsKey(run.key)) {
 		return m, m.switchTo(run.navTarget)
 	}
 	return m.updateKey(synthKey(run.key))
@@ -361,6 +372,19 @@ func (m *root) openPalette() {
 	}
 	m.palette = newPalette(paletteEntries(
 		ctx, target, editable, m.phase == phaseConnected, m.githubAvailable()))
+}
+
+// panelOwnsKey reports whether the active surface declares key as one of its
+// own panel rows. It is what a global single-key binding consults before
+// consuming a key the view underneath it also claims, so the registry answers
+// the collision rather than a list of view special cases in updateKey.
+func (m *root) panelOwnsKey(key string) bool {
+	for _, b := range bindingsFor(m.activeContext()) {
+		if b.key == key {
+			return true
+		}
+	}
+	return false
 }
 
 // activeContext names the active surface for the binding registry.


### PR DESCRIPTION
## Summary

With the chats board active, `n` opened the **new-task** form instead of
starting a chat — on a screen whose footer said `n new` and whose `?` overlay
said "start a chat in the project you are looking at".

**Root cause.** The `case "n":` arm of `root.updateKey` (`internal/tui/root.go`)
consumed the key and returned without ever reaching `m.delegate(msg)` at the
bottom of the function. Its only exception was `m.active != viewNewTask` — there
so that `n` can mean "no" to the form's own discard prompt — and the only
escape hatch ahead of the switch is `m.activeCapturesInput()`, which a resting
chats board fails (`chatsView.capturesInput` is true only while the filter is
focused or the create form is already up). So `chatsView.updateKey`'s
`case "n"` was dead code, and `newNewChatForm` had **no reachable caller**: the
new-chat form could not be opened from the TUI by any route. The palette row was
the same defect by the other path, because a keyed palette entry replays its
keypress through that very handler (`root.updatePaletteKey` →
`m.updateKey(synthKey(run.key))`). Chats were still creatable with
`vincent chat start` and over the API, so this was TUI-only reachability.

**The fix.** A global single-key binding now stands down when the active
surface declares the same key as a panel row of its own — a lookup through
`bindingsFor(m.activeContext())` (new `root.panelOwnsKey`), so the registry
answers the collision rather than a growing list of `&& m.active != viewX`.
The palette is repaired for free, since it replays through the same handler.

Two things the shape of the fix is deliberate about:

- **The yield is scoped to the `n` arm, not placed ahead of the switch.** `n`
  is the only global key that both collides with a panel row *and* consumes
  unconditionally. `esc` is declared under `ctxChat` and `ctxNewChat` too, and
  a blanket rule would hand it to those views before the help overlay could
  close — `?` would become uncloseable on a chat screen.
- **The palette's "new task" row navigates instead of replaying.** Without
  this, the fix would have regressed it: on the chats board that row would have
  replayed `n`, which now makes a chat. A keyed nav entry replays its key so
  the palette cannot diverge from the shortcut it teaches; where the surface
  owns that key, there is no shortcut to agree with, and the row's label names
  its destination outright. `TestChatsBoardPaletteStillReachesNewTask` fails if
  that clause is removed (verified by reverting it).

This restores what `docs/spec.md` §15 (amended 2026-08-31 for task 067) and
`internal/tui/bindings.go` already specify — "`n` is the one key whose meaning
depends on where you are, deliberately: on the chats board it makes a chat, and
everywhere else it still makes a task". The code was the wrong side, so **no
spec amendment is needed** and the registry is unchanged.

**How the regression test catches it coming back.**
`internal/tui/chatsroot_test.go` drives the key through the **root** model —
the layer a real keystroke takes — rather than calling `chatsView.updateKey`
directly the way `bindings_test.go:390` does. That existing registry probe is
exactly why this shipped green: it bypasses the layer that ate the key. The two
subtests assert the active view stays `viewChats` and the chats view's `create`
form is non-nil, by the direct key and by the palette route. Both were run
against the unfixed code and observed to fail with "n on the chats board opened
the new-task form".

No behaviour was asserted away and no assertion was relaxed; the only test edit
was the addition of the third test above, which guards a behaviour this PR
introduces.

**No replacement route for "new task" from the chats board** was added, per the
diagnosis: `esc` back to the task board and press `n` there — and the palette's
"new task" row works from the chats board as it always did.

## Related

Closes #277

Restores the behaviour decided in `docs/tasks/067-chats-in-the-tui.md` and
recorded in spec §15; it relitigates nothing.

## Found during the documentation audit, not fixed here

- **The palette still prints `n` beside "new task" on the chats board.** The
  behaviour is now right — that row navigates instead of replaying — but its
  key column is built unconditionally from the registry
  (`internal/tui/palette.go:73`, rendered at `:186`), so on the chats board the
  overlay lists `new task … n` above `start a chat … n` while `n` there only
  does the second. Spec §15's *Discovery* paragraph is what this rubs against:
  each palette row carries "its direct key beside it, so the palette teaches
  shortcuts rather than replacing them". Keyless nav rows already render `—`, so
  suppressing the key when `panelOwnsKey(b.key)` would close it. Left alone
  because `internal/tui/palette.go` is outside a documentation step's scope, and
  no page under `docs/` states the palette's per-row key column — nothing
  documented is false today. **No spec amendment was made**, for the same reason
  this PR did not need one for the original bug: the intended design is already
  written down and the code is the side that diverges.

- **`?` on the chats board lists `n` twice** — once under CHATS and once under
  NAV (`internal/tui/help.go:52-68`) — of which only the first is true there.
  Pre-existing at HEAD rather than introduced here: `bindings.go` is unchanged
  and both rows were already listed; this PR only changes which of the two the
  key actually performs.

- **No screenshot is stale.** There is no chats-board capture in
  `docs/assets/`, and nothing about panel rendering changed — the footer hint
  `n new` comes from the unchanged registry — so `scripts/screenshots.sh` does
  not need re-running for this change.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected pages under `docs/` audited (config, CLI, API, TUI keys, block reasons, workflow schema, adapters, spec, tasks, gates) — **none needed changing.** The TUI key tables track `internal/tui/bindings.go`, which is unchanged: `docs/guides/tui.md:979` already documents "`n` — Start a chat in the project you are looking at", `tui.md:985` already carries the exception in prose, and spec §15 already states the intended routing in both its 2026-08-31 amendments (`docs/spec.md:6184`, `:6694`). The docs described the behaviour correctly; the code did not. Full audit in `.vincent-issue/docs.md`.

## Verification

- `go test ./...` — green (33 packages).
- `go tool golangci-lint run ./...` with `GOOS=windows`, `GOOS=darwin` and
  `GOOS=linux` — 0 issues on each. The change is in `internal/tui` key
  routing, which is platform-independent and carries no build tags.
