### PR TITLE
Use the shared picker in the new-chat form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,19 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Changed
 
+- **The new-chat form uses the same list every other create form uses.**
+  Project, agent, model and effort are now `picker` rows: `enter` opens the
+  list, `/` filters it as you type, and the model and effort lists are the
+  selected agent's own catalog — tagged `cli` or `curated`, led by an
+  `(agent default)` row naming what that agent would use, and ending in a row
+  for typing a value the catalog has never heard of. Changing the agent
+  re-scopes both lists and clears anything chosen under the previous one. The
+  base-branch row now names the selected project's actual default branch
+  instead of the words "the project's default", and still submits empty so the
+  daemon resolves it. `←`/`→` still step the project and agent rows in place;
+  `enter` no longer creates from the title row, leaving `ctrl+s` the sole
+  create key, which is what the key table always said. `esc` with a list open
+  closes the list and keeps the draft.
 - **Archiving never deletes a branch vincent did not cut.**
   `delete_empty_branch_on_archive` and `delete_remote_branch_on_archive` both
   skip a task whose branch came from a pull request, and the archive reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -464,12 +464,12 @@ list with the user-facing context a commit subject cannot carry.
   `(agent default)` row naming what that agent would use, and ending in a row
   for typing a value the catalog has never heard of. Changing the agent
   re-scopes both lists and clears anything chosen under the previous one. The
-  base-branch row now names the selected project's actual default branch
-  instead of the words "the project's default", and still submits empty so the
-  daemon resolves it. `←`/`→` still step the project and agent rows in place;
-  `enter` no longer creates from the title row, leaving `ctrl+s` the sole
-  create key, which is what the key table always said. `esc` with a list open
-  closes the list and keeps the draft.
+  base-branch row's placeholder now leads with the selected project's actual
+  default branch — `main (the project's default)` — rather than the phrase
+  alone, and still submits empty so the daemon resolves it. `←`/`→` still step
+  the project and agent rows in place; `enter` no longer creates from the title
+  row, leaving `ctrl+s` the sole create key, which is what the key table always
+  said. `esc` with a list open closes the list and keeps the draft.
 - **Archiving never deletes a branch vincent did not cut.**
   `delete_empty_branch_on_archive` and `delete_remote_branch_on_archive` both
   skip a task whose branch came from a pull request, and the archive reports

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -989,21 +989,41 @@ you straight into the workspace. With no project registered, `n` says so on the
 board instead of opening a form you could not submit — add a repository in the
 Projects view (`4`) first.
 
+Four of the six rows are lists — project, agent, model and effort — and they are
+the same list the new-task and follow-up forms use: `enter` opens one, `/`
+filters it as you type, `↑`/`↓` walk it and `enter` picks. The model and effort
+lists are the selected agent's own catalog, tagged `cli` where the CLI itself
+reported the value and `curated` where it comes from vincent's built-in list and
+may be stale; both lead with an `(agent default)` row naming what that agent
+would use, and both end with a row for typing a value the catalog has never
+heard of — a model shipped this morning is not in it. Changing the agent
+re-scopes both lists and clears anything chosen under the previous one.
+
+`←`/`→` still step the project and agent rows one at a time without opening
+their list, which is quicker when you have two of something. They are not
+offered on the model and effort rows, where stepping through a hundred values
+answers nothing.
+
+Title and base branch are typed. The base row's placeholder names the selected
+project's actual default branch and follows the project row; leave it empty and
+the daemon resolves that default at creation.
+
 Only an agent that can resume its own session can hold a chat, so the agent
-picker offers only those. The daemon refuses the rest at creation with that
+list offers only those. The daemon refuses the rest at creation with that
 reason rather than a generic failure, and the form still renders it — it is the
 backstop, not the thing you are expected to walk into.
 
-The draft owns the keyboard while it is open: every row, including the two
-pickers, so no keystroke leaks out to the global keys. `esc` discards it and
-returns you to the board.
+The draft owns the keyboard while it is open: every row, and every open list, so
+no keystroke leaks out to the global keys. `esc` closes an open list and leaves
+the draft alone; a second press discards the draft and returns you to the board.
 
 | Key | Does, in the create form |
 |---|---|
 | `tab` / `shift+tab` | Next / previous field |
-| `←` / `→` | Choose on the project and agent fields |
+| `enter` | Open the focused field's list, or move on from a text field |
+| `←` / `→` | Step the project and agent fields in place |
 | `ctrl+s` | Create the chat and open it |
-| `esc` | Discard the draft |
+| `esc` | Close an open list, else discard the draft |
 
 ### Chat workspace
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6706,7 +6706,8 @@ board**: `enter` opens the workspace, `n` starts a chat, `a` archives, `/`
 filters, `←`/`→` fold a project group and `r` re-lists. In the **chat
 workspace**: `enter` sends, `ctrl+x` stops the live turn, `esc` returns to the
 board. In the **new-chat form**: `ctrl+s` creates, `tab`/`shift+tab` move
-between fields, `←`/`→` choose on the project and agent fields, `esc` discards.
+between fields, `enter` opens the focused field's list, `←`/`→` step the
+project and agent fields in place, `esc` discards.
 `n` is the one key whose meaning depends on where you are, deliberately: on the
 chats board it makes a chat, and everywhere else it still makes a task. `!` is
 **not** extended to chats — an `awaiting_input` chat is pinned and badged on
@@ -6721,14 +6722,33 @@ registered project does not open the form at all: it says so on the board,
 because a form with no project to create in cannot be submitted and offers no
 field that would accept one.
 
-An **open new-chat draft captures input on every row**, not only on the four
+*Amended 2026-08-31 (issue #281).* Four of the new-chat form's six rows —
+project, agent, model and effort — are the same `picker` the new-task,
+follow-up and repair forms use, so the TUI has one idiom for "choose one of a
+list": incremental filtering, a bounded window, the `cli`/`curated` provenance
+note on the model and effort catalogs, and free text on those two because an
+adapter's catalog is a suggestion (§9.6). Both catalogs scope to the selected
+adapter and are cleared when it changes, and both lead with an "(agent
+default)" row naming that adapter's own default — a chat has no workflow, so
+"(workflow default)" would be the wrong words. Title and base branch stay text
+fields; the base row's placeholder names the selected project's real default
+branch, and submitting it untouched sends no branch at all, so the daemon
+resolves the project's default as before. `enter` opens the focused row's list
+or moves on from a text one, uniformly: `ctrl+s` is the sole create key.
+`←`/`→` survive on the project and agent rows as a fast in-place step — the
+enum-row idiom from the new-task fields editor — and are not offered on the
+two catalog rows, where "next" answers nothing.
+
+An **open new-chat draft captures input on every row**, not only on the two
 text ones. This is a deliberate, scoped exception to the rule above that the
 shell consults the focused panel for capture and leaves the global single-key
-bindings live: four of this form's six rows are text fields and a live draft
-sits behind the two that are not, so a global `q` on the project row quit the
-TUI with the draft. The rule is unchanged for every other form — the new-task
-form still leaves the globals live while navigating — and `esc`, this form's
-layer of the stack below, stays the way out.
+bindings live: only title and base are text fields, a live draft sits behind
+the other four, and a global `q` on the project row quit the TUI with the
+draft. An open list adds a filter row and a free-text row on top of that. The
+rule is unchanged for every other form — the new-task form still leaves the
+globals live while navigating — and `esc`, this form's layer of the stack
+below, stays the way out: with a list open it closes the list only, and the
+draft survives.
 
 **`esc` cancels one layer per press**, by a fixed stack: *(amended 2026-08-30,
 task 063)* a form popup's Task details tab → popup (palette, confirmation,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6713,14 +6713,14 @@ chats board it makes a chat, and everywhere else it still makes a task. `!` is
 **not** extended to chats — an `awaiting_input` chat is pinned and badged on
 its own board and nowhere else.
 
-*Amended 2026-08-31 (issue #279).* The new-chat form's two pickers are fed by
-`GET /v1/projects` and `GET /v1/agents`, and the agent picker offers **only
-adapters that report `supports_resume`** (§9.6, decision row 29) — the
-daemon's `agent_cannot_resume` refusal stays the authority and is still
-rendered, it is simply unreachable from this form. `n` on a chats board with no
-registered project does not open the form at all: it says so on the board,
-because a form with no project to create in cannot be submitted and offers no
-field that would accept one.
+*Amended 2026-08-31 (issue #279).* The new-chat form's project and agent
+pickers are fed by `GET /v1/projects` and `GET /v1/agents`, and the agent
+picker offers **only adapters that report `supports_resume`** (§9.6, decision
+row 29) — the daemon's `agent_cannot_resume` refusal stays the authority and is
+still rendered, it is simply unreachable from this form. `n` on a chats board
+with no registered project does not open the form at all: it says so on the
+board, because a form with no project to create in cannot be submitted and
+offers no field that would accept one.
 
 *Amended 2026-08-31 (issue #281).* Four of the new-chat form's six rows —
 project, agent, model and effort — are the same `picker` the new-task,

--- a/docs/tasks/067-chats-in-the-tui.md
+++ b/docs/tasks/067-chats-in-the-tui.md
@@ -104,6 +104,58 @@ create in: `ctrl+s` could only answer `pick a project`, and no field on the form
 accepts one. Only a positive answer refuses — a board that has not listed the
 projects, or whose listing failed, opens the form as before.
 
+**10. The new-chat form uses the picker every other create form uses.**
+*(Added 2026-08-31, issue #281.)* Project, agent, model and effort became
+`picker` rows; title and base stayed text. The component was already there when
+this form was written, and this was the only create surface in the TUI not
+using it — filtering, the bounded window, the `cli`/`curated` provenance note
+and `allowFree` were all being re-decided by hand here, badly. Four decisions
+qualify the move:
+
+- **`←`/`→` stay, as a fast in-place step.** `enter` opens the list; `←`/`→`
+  continue to step the project and agent rows without opening it. This is the
+  enum-row precedent from the new-task fields editor verbatim
+  (`internal/tui/newtaskpicker.go`): left/right step the members the way a
+  boolean cycles, enter opens the list, which is the only workable control for
+  a long one. The issue proposed retiring the cyclers; the cycler was never the
+  defect — the *absence of a list* was — and two adapters are quicker to step
+  than to open. They are not added to the model and effort rows, which are
+  catalogs of a hundred and more (§9.7) where "next" answers nothing.
+
+- **`base` shows the project's real default branch as a placeholder, and
+  submits empty.** The row reads `main (the project's default)` — the branch
+  name, not the phrase — re-derived whenever the project row changes, while
+  `CreateChatRequest.BaseBranch` stays empty so `handleChatCreate` resolves
+  `base = project.DefaultBranch` as it does today. Seeding the input's *value*
+  was rejected: it pins a branch at draft time and needs a rule for re-seeding
+  after a project change over text the human may have typed. No
+  `GET /v1/projects/{id}/branches`: the new-task form has the same free-text
+  base row, and the two should be decided together rather than one of them
+  smuggled in here.
+
+- **Decision 9 is unchanged.** The agent list keeps hiding adapters that do not
+  publish `supports_resume`; `resumableAgents` is untouched and the daemon's
+  `agent_cannot_resume` refusal stays the authority. A picker *can* now show a
+  row disabled with its reason — the new-task precedent from tasks 010 and 013
+  — and that was considered and declined: an adapter that cannot hold a
+  conversation is out of reach for every chat, not for this one draft, which is
+  the case that precedent covers.
+
+- **TUI only; the daemon is not touched.** The issue's rationale is wrong on
+  one fact and it does not change the outcome. `POST /v1/chats` never validates
+  `model` or `effort` — it stores what it is sent, with no catalog check and no
+  warning, unlike task create, repair and follow-up, which run
+  `checkTaskCatalog`. A typo therefore does not come back as a rejection; it
+  comes back as a failed first turn when the CLI refuses the model, which is a
+  worse failure and a stronger argument for the picker. Giving chat creation
+  §8.2's warnings is a real gap, with its own DTO, apiclient, `docs/reference/api.md`
+  and spec amendments — and is not this issue.
+
+Decision 8 is unchanged in substance and its arithmetic is not: the form now
+has *two* live text rows, not four, and an open list adds a filter row and a
+free-text row on top of them, so `capturesInput` stays unconditionally true for
+a stronger reason than before.
+
 ## Sub-tasks
 
 | ID | What | Status |
@@ -112,6 +164,18 @@ projects, or whose listing failed, opens the form as before.
 
 ## What the tests prove
 
+- **The lists are the daemon's catalogs** *(issue #281)* — `internal/tui`'s
+  `newchat_test.go` at form level and `newchatlive_test.go` against the real
+  handlers: the project list offers every registered project with its path, the
+  agent list only the resumers, the model and effort lists the selected
+  adapter's served catalog with its `cli`/`curated` tags, an `(agent default)`
+  row naming that adapter's default and a free-text row; changing the agent
+  re-scopes both and clears what was chosen under the previous one; `←`/`→`
+  still step the two short rows without opening a list; the base row's
+  placeholder follows the project and an untouched row submits empty, so the
+  daemon resolves the project's default branch; `enter` never creates and
+  `ctrl+s` creates from any row; `esc` with a list open closes the list and
+  leaves the draft.
 - **The stream is a stream** — `internal/apiclient`'s `*live_test.go` against the
   real handlers: a chat's durable `chat.*` events arrive filtered to that chat,
   another chat's and a task's do not leak onto it, `Last-Event-ID` resumes the

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -250,9 +250,10 @@ var bindings = []binding{
 
 	// New chat.
 	{key: "ctrl+s", label: "create the chat and open it", scope: scopePanel, context: ctxNewChat, hint: "ctrl+s create", priority: 1},
-	{key: "tab", label: "next field (shift+tab goes back)", scope: scopePanel, context: ctxNewChat, hint: "tab next", priority: 2},
-	{key: "left", label: "previous choice on the project and agent fields", scope: scopePanel, context: ctxNewChat, hint: "← →  choose", priority: 3},
-	{key: "esc", label: "discard the draft", scope: scopePanel, context: ctxNewChat, hint: "esc cancel", priority: 4},
+	{key: "enter", label: "open the focused field's list, or move on from a text field", scope: scopePanel, context: ctxNewChat, hint: "enter list", priority: 2},
+	{key: "tab", label: "next field (shift+tab goes back)", scope: scopePanel, context: ctxNewChat, hint: "tab next", priority: 3},
+	{key: "left", label: "step the project and agent fields in place (← →); enter opens their list", scope: scopePanel, context: ctxNewChat, hint: "← →  step", priority: 4},
+	{key: "esc", label: "close an open list, else discard the draft", scope: scopePanel, context: ctxNewChat, hint: "esc cancel", priority: 5},
 
 	// Projects.
 	{key: "a", label: "register a repository", scope: scopePanel, context: ctxProjects, hint: "a add", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -495,6 +495,18 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 					}())
 			}
 		},
+		"enter": func(t *testing.T) {
+			v := chatsFixture()
+			v.create = newNewChatForm(nil, 0)
+			v.create.applyFields(newChatFieldsMsg{projects: []apiclient.Project{
+				{ID: 1, Name: "one"}, {ID: 2, Name: "two"},
+			}})
+			v.create.focus = ncProject
+			v.updateKey(registryKey(t, "enter"))
+			if v.create == nil || v.create.pick == nil {
+				t.Fatal("enter on the project row opened no list")
+			}
+		},
 		"tab": func(t *testing.T) {
 			v := chatsFixture()
 			v.create = newNewChatForm(nil, 7)
@@ -510,10 +522,13 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			v.create.applyFields(newChatFieldsMsg{projects: []apiclient.Project{
 				{ID: 1, Name: "one"}, {ID: 2, Name: "two"},
 			}})
-			v.create.focus = 0
+			v.create.focus = ncProject
 			v.updateKey(registryKey(t, "left"))
 			if v.create.projectID != 2 {
 				t.Fatalf("left chose project %d, want the previous one", v.create.projectID)
+			}
+			if v.create.pick != nil {
+				t.Fatal("left opened the project list; it steps in place")
 			}
 		},
 		"esc": func(t *testing.T) {

--- a/internal/tui/newchat.go
+++ b/internal/tui/newchat.go
@@ -20,6 +20,25 @@ import (
 // no fields, no github issue and no scheduling, so the whole form is project,
 // title, agent, model, effort and base branch — and only the first two are
 // required.
+//
+// Four of those six rows are lists, drawn by the same `picker` the new-task,
+// follow-up and repair forms use (issue #281): one component means one set of
+// idioms for "choose one of a list" — incremental filtering, a bounded
+// window, the `cli`/`curated` provenance note, and free text where a catalog
+// is only a suggestion.
+
+// ncRow is one row of the new-chat form, in tab order.
+type ncRow int
+
+const (
+	ncProject ncRow = iota
+	ncTitle
+	ncAgent
+	ncModel
+	ncEffort
+	ncBase
+	ncRowCount
+)
 
 // chatCreatedMsg reports the outcome of POST /v1/chats.
 type chatCreatedMsg struct {
@@ -40,38 +59,34 @@ type newChatForm struct {
 	client *apiclient.Client
 
 	projects []apiclient.Project
-	agents   []apiclient.Agent
+	agents   apiclient.Agents
 
 	projectID int64
 	agentIdx  int
 
-	title  textinput.Model
-	model  textinput.Model
-	effort textinput.Model
-	base   textinput.Model
+	model  string
+	effort string
 
-	// focus indexes the fields in tab order: project, title, agent, model,
-	// effort, base.
-	focus int
+	title textinput.Model
+	base  textinput.Model
+
+	// pick is the list the focused row expands into, nil while navigating.
+	pick *picker
+
+	// focus is the row the cursor is on.
+	focus ncRow
 
 	err        string
 	submitting bool
 }
 
-// newChatFields is the number of focusable fields.
-const newChatFields = 6
-
 func newNewChatForm(client *apiclient.Client, hintProject int64) *newChatForm {
 	f := &newChatForm{client: client, projectID: hintProject}
 	f.title = textinput.New()
 	f.title.Placeholder = "what is this conversation about"
-	f.model = textinput.New()
-	f.model.Placeholder = "model override (optional)"
-	f.effort = textinput.New()
-	f.effort.Placeholder = "effort override (optional)"
 	f.base = textinput.New()
-	f.base.Placeholder = "base branch (optional — the project's default)"
-	f.focus = 1
+	f.base.Placeholder = f.baseHint()
+	f.focus = ncTitle
 	f.title.Focus()
 	return f
 }
@@ -94,30 +109,33 @@ func (f *newChatForm) init() tea.Cmd {
 	}
 }
 
-// capturesInput is true for every row of an open draft, not only the four
-// text ones — a recorded exception to PR L's rule that a form captures input
-// "only while a text row is in edit mode" (task 067 decision 6, §15 amended
+// capturesInput is true for every row of an open draft, not only the two text
+// ones — a recorded exception to PR L's rule that a form captures input "only
+// while a text row is in edit mode" (task 067 decision 8, §15 amended
 // 2026-08-31).
 //
 // The rule is not changed anywhere else: `newTask.capturesInput` still
 // answers false while navigating, and widening it globally would make `?`,
 // `:`, `!` and `M` unreachable from every form in the TUI. The exception is
-// scoped to this form because four of its six rows are text fields and a live
-// draft sits behind the two that are not, so `q` on the project row quit the
-// TUI with the draft (issue #279). `esc` stays the way out.
+// scoped to this form because a live draft sits behind every row: only title
+// and base are text fields, so `q` on the project row quit the TUI with the
+// draft (issue #279). An open picker adds a filter row and a free-text row on
+// top of that. `esc` stays the way out, one layer per press.
 func (f *newChatForm) capturesInput() bool { return true }
 
+// paste types into whichever text entry is open: the picker's free-text row
+// when a list is up, else the focused text field.
 func (f *newChatForm) paste(text string) tea.Cmd {
+	if f.pick != nil {
+		return f.pick.paste(text)
+	}
 	var cmd tea.Cmd
 	switch f.focus {
-	case 1:
+	case ncTitle:
 		f.title, cmd = f.title.Update(tea.PasteMsg{Content: text})
-	case 3:
-		f.model, cmd = f.model.Update(tea.PasteMsg{Content: text})
-	case 4:
-		f.effort, cmd = f.effort.Update(tea.PasteMsg{Content: text})
-	case 5:
+	case ncBase:
 		f.base, cmd = f.base.Update(tea.PasteMsg{Content: text})
+	case ncProject, ncAgent, ncModel, ncEffort, ncRowCount:
 	}
 	return cmd
 }
@@ -134,6 +152,7 @@ func (f *newChatForm) applyFields(msg newChatFieldsMsg) {
 	if f.projectID == 0 && len(f.projects) > 0 {
 		f.projectID = f.projects[0].ID
 	}
+	f.base.Placeholder = f.baseHint()
 }
 
 // resumableAgents is the agent picker's contents: only adapters that can hold
@@ -144,8 +163,13 @@ func (f *newChatForm) applyFields(msg newChatFieldsMsg) {
 // It follows the `input_verdict` precedent: a daemon too old to send
 // `supports_resume` says nothing about any adapter, and nothing is dropped on
 // the strength of a field that was never sent.
-func resumableAgents(agents []apiclient.Agent) []apiclient.Agent {
-	var out []apiclient.Agent
+//
+// A row disabled with its reason — the new-task precedent from tasks 010 and
+// 013 — was considered and declined (task 067 decision 10): an adapter that
+// cannot hold a conversation is out of reach for every chat, not for this one
+// draft, which is the case that precedent covers.
+func resumableAgents(agents []apiclient.Agent) apiclient.Agents {
+	var out apiclient.Agents
 	for _, a := range agents {
 		if !a.CannotResume() {
 			out = append(out, a)
@@ -174,6 +198,19 @@ func (f *newChatForm) applyFailure(err error) {
 // update runs the form's keyboard. done reports that the layer should close.
 func (f *newChatForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd tea.Cmd, done bool) {
 	f.client = client
+	// An open list is a layer above the form in §15's esc stack: every key
+	// goes to it, `ctrl+s` included, so `esc` closes the list and leaves the
+	// draft — one esc, one layer.
+	if f.pick != nil {
+		res := f.pick.update(msg)
+		if res.chosen {
+			f.setRow(ncRow(f.pick.row), res.value)
+		}
+		if res.closed {
+			f.pick = nil
+		}
+		return res.cmd, false
+	}
 	switch msg.String() {
 	case "esc":
 		return nil, true
@@ -189,49 +226,115 @@ func (f *newChatForm) update(msg tea.KeyPressMsg, client *apiclient.Client) (cmd
 	case "right":
 		f.cycle(1)
 		return nil, false
-	case "ctrl+s", "enter":
-		if f.focus == 1 || msg.String() == "ctrl+s" {
-			return f.submit(), false
-		}
-		f.moveFocus(1)
+	case "ctrl+s":
+		return f.submit(), false
+	case "enter":
+		// The same key on every row: open the focused row's list, or move on
+		// from a text one. `ctrl+s` is the sole create key, which is what §15
+		// documents and what the form's own hint line says.
+		f.openRow()
 		return nil, false
 	}
 	switch f.focus {
-	case 1:
+	case ncTitle:
 		f.title, cmd = f.title.Update(msg)
-	case 3:
-		f.model, cmd = f.model.Update(msg)
-	case 4:
-		f.effort, cmd = f.effort.Update(msg)
-	case 5:
+	case ncBase:
 		f.base, cmd = f.base.Update(msg)
+	case ncProject, ncAgent, ncModel, ncEffort, ncRowCount:
 	}
 	return cmd, false
 }
 
-func (f *newChatForm) moveFocus(delta int) {
-	f.focus = (f.focus + delta + newChatFields) % newChatFields
-	f.title.Blur()
-	f.model.Blur()
-	f.effort.Blur()
-	f.base.Blur()
+// openRow expands the focused row into its list. The two text rows have no
+// list, so enter advances from them.
+func (f *newChatForm) openRow() {
+	f.err = ""
 	switch f.focus {
-	case 1:
-		f.title.Focus()
-	case 3:
-		f.model.Focus()
-	case 4:
-		f.effort.Focus()
-	case 5:
-		f.base.Focus()
+	case ncProject:
+		f.pick = newPicker(int(ncProject), "project", f.projectOptions(), false,
+			strconv.FormatInt(f.projectID, 10))
+	case ncAgent:
+		f.pick = newPicker(int(ncAgent), "agent", f.agentOptions(), false, f.agentName())
+	case ncModel:
+		f.pick = newPicker(int(ncModel), "model", f.catalogOptions(f.models(), f.defaultModel()),
+			true, f.model)
+	case ncEffort:
+		f.pick = newPicker(int(ncEffort), "effort", f.catalogOptions(f.efforts(), f.defaultEffort()),
+			true, f.effort)
+	case ncTitle, ncBase, ncRowCount:
+		f.moveFocus(1)
 	}
 }
 
-// cycle steps the two picker fields. The text fields ignore it: left and
-// right are cursor movement there.
+// setRow commits a chosen value.
+func (f *newChatForm) setRow(row ncRow, value string) {
+	switch row {
+	case ncProject:
+		if id, err := strconv.ParseInt(value, 10, 64); err == nil {
+			f.setProject(id)
+		}
+	case ncAgent:
+		f.setAgent(value)
+	case ncModel:
+		f.model = value
+	case ncEffort:
+		f.effort = value
+	case ncTitle, ncBase, ncRowCount:
+	}
+}
+
+// setProject re-derives whatever depends on the project, which is the base
+// row's hint: it names that project's real default branch.
+func (f *newChatForm) setProject(id int64) {
+	f.projectID = id
+	f.base.Placeholder = f.baseHint()
+}
+
+// setAgent selects an adapter by name and drops the model and effort chosen
+// under the previous one. The two catalogs belong to an adapter; keeping
+// values chosen from another one would submit a pair that never existed.
+func (f *newChatForm) setAgent(name string) {
+	for i, a := range f.agents {
+		if a.Name == name {
+			f.setAgentIdx(i)
+			return
+		}
+	}
+}
+
+func (f *newChatForm) setAgentIdx(i int) {
+	if i == f.agentIdx {
+		return
+	}
+	f.agentIdx = i
+	f.model, f.effort = "", ""
+}
+
+func (f *newChatForm) moveFocus(delta int) {
+	f.focus = (f.focus + ncRow(delta) + ncRowCount) % ncRowCount
+	f.title.Blur()
+	f.base.Blur()
+	switch f.focus {
+	case ncTitle:
+		f.title.Focus()
+	case ncBase:
+		f.base.Focus()
+	case ncProject, ncAgent, ncModel, ncEffort, ncRowCount:
+	}
+}
+
+// cycle steps the project and agent rows in place, without opening their
+// list. This is the enum-row idiom from the new-task fields editor verbatim:
+// left/right step through the members the way a boolean cycles, so two
+// adapters stay a single keypress; enter opens the list, which is the only
+// workable control for a long one.
+//
+// The model and effort rows are not stepped: they are catalogs of a hundred
+// and more (§9.7), where "next" is not a cheap answer to anything. The text
+// rows ignore it — left and right are cursor movement there.
 func (f *newChatForm) cycle(delta int) {
 	switch f.focus {
-	case 0:
+	case ncProject:
 		if len(f.projects) == 0 {
 			return
 		}
@@ -242,12 +345,13 @@ func (f *newChatForm) cycle(delta int) {
 				break
 			}
 		}
-		f.projectID = f.projects[(i+delta+len(f.projects))%len(f.projects)].ID
-	case 2:
+		f.setProject(f.projects[(i+delta+len(f.projects))%len(f.projects)].ID)
+	case ncAgent:
 		if len(f.agents) == 0 {
 			return
 		}
-		f.agentIdx = (f.agentIdx + delta + len(f.agents)) % len(f.agents)
+		f.setAgentIdx((f.agentIdx + delta + len(f.agents)) % len(f.agents))
+	case ncTitle, ncModel, ncEffort, ncBase, ncRowCount:
 	}
 }
 
@@ -258,9 +362,125 @@ func (f *newChatForm) agentName() string {
 	return f.agents[f.agentIdx].Name
 }
 
+// projectOptions is one row per registered project, with its path as the
+// note — the same pair the new-task project picker offers.
+func (f *newChatForm) projectOptions() []pickerOption {
+	out := make([]pickerOption, 0, len(f.projects))
+	for _, p := range f.projects {
+		out = append(out, pickerOption{
+			value: strconv.FormatInt(p.ID, 10),
+			label: p.Name,
+			note:  p.Path,
+		})
+	}
+	return out
+}
+
+// agentOptions is the adapter list, already narrowed to those that can hold a
+// conversation, with the availability notes the other pickers carry: an
+// adapter that is installed but not logged in fails every turn, and saying so
+// here saves a chat that was never going to start (§9.5).
+func (f *newChatForm) agentOptions() []pickerOption {
+	out := make([]pickerOption, 0, len(f.agents))
+	for _, a := range f.agents {
+		opt := pickerOption{value: a.Name, label: a.Name}
+		switch {
+		case !a.Available:
+			opt.note = "⚠ unavailable: " + firstNonEmpty(a.Error, "not found")
+		case a.NotAuthenticated():
+			opt.note = "⚠ installed but not logged in"
+		case a.Version != "":
+			opt.note = a.Version
+		}
+		out = append(out, opt)
+	}
+	return out
+}
+
+// catalogOptions renders a catalog with its provenance tags, the way the
+// new-task, follow-up and repair pickers do: "cli" came from the adapter
+// itself and cannot be stale, "curated" is vincent's own list and may be.
+//
+// The leading row is "(agent default)" rather than "(workflow default)": a
+// chat has no workflow, so the only thing behind an unset override is the
+// adapter's own default, which the row names.
+func (f *newChatForm) catalogOptions(opts []apiclient.AgentOption, def string) []pickerOption {
+	out := make([]pickerOption, 0, len(opts)+1)
+	out = append(out, pickerOption{value: "", label: "(agent default)", note: def})
+	for _, o := range opts {
+		out = append(out, pickerOption{value: o.Value, label: o.Value, note: o.Source})
+	}
+	return out
+}
+
+// models, efforts, defaultModel and defaultEffort scope to the selected
+// adapter: its catalog is the only one that means anything for this chat.
+func (f *newChatForm) models() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agentName())
+	if !ok {
+		return nil
+	}
+	return a.Models
+}
+
+func (f *newChatForm) efforts() []apiclient.AgentOption {
+	a, ok := f.agents.Find(f.agentName())
+	if !ok {
+		return nil
+	}
+	return a.Efforts
+}
+
+func (f *newChatForm) defaultModel() string {
+	a, ok := f.agents.Find(f.agentName())
+	if !ok {
+		return ""
+	}
+	return a.DefaultModel
+}
+
+func (f *newChatForm) defaultEffort() string {
+	a, ok := f.agents.Find(f.agentName())
+	if !ok {
+		return ""
+	}
+	return a.DefaultEffort
+}
+
+// baseHint is the base row's placeholder: the selected project's real default
+// branch, re-derived whenever the project row changes.
+//
+// It is a placeholder and not a value on purpose. Seeding the input would pin
+// a branch at draft time and need a rule for re-seeding over text a human may
+// already have typed; leaving the row empty keeps `CreateChatRequest.BaseBranch`
+// empty, so `handleChatCreate` resolves the project's default at creation, as
+// it does today.
+func (f *newChatForm) baseHint() string {
+	for _, p := range f.projects {
+		if p.ID == f.projectID && p.DefaultBranch != "" {
+			return p.DefaultBranch + " (the project's default)"
+		}
+	}
+	return "base branch (optional — the project's default)"
+}
+
+// request is what the form would submit. BaseBranch is whatever the base row
+// holds and nothing else: an untouched row submits empty, and the daemon
+// resolves the project's default branch — the placeholder only says which one
+// that is.
+func (f *newChatForm) request() apiclient.CreateChatRequest {
+	return apiclient.CreateChatRequest{
+		ProjectID:  f.projectID,
+		Title:      strings.TrimSpace(f.title.Value()),
+		Agent:      f.agentName(),
+		Model:      f.model,
+		Effort:     f.effort,
+		BaseBranch: strings.TrimSpace(f.base.Value()),
+	}
+}
+
 func (f *newChatForm) submit() tea.Cmd {
-	title := strings.TrimSpace(f.title.Value())
-	if title == "" {
+	if strings.TrimSpace(f.title.Value()) == "" {
 		f.err = "a chat needs a title"
 		return nil
 	}
@@ -275,12 +495,7 @@ func (f *newChatForm) submit() tea.Cmd {
 	}
 	f.err = ""
 	f.submitting = true
-	req := apiclient.CreateChatRequest{
-		ProjectID: f.projectID, Title: title, Agent: f.agentName(),
-		Model:      strings.TrimSpace(f.model.Value()),
-		Effort:     strings.TrimSpace(f.effort.Value()),
-		BaseBranch: strings.TrimSpace(f.base.Value()),
-	}
+	req := f.request()
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
@@ -302,21 +517,27 @@ func (f *newChatForm) projectName() string {
 }
 
 func (f *newChatForm) render(width, height int) string {
-	rows := []struct{ label, value string }{
-		{"project", f.projectName() + styleDim.Render("   ← → to change")},
-		{"title", f.title.View()},
-		{"agent", f.agentLabel()},
-		{"model", f.model.View()},
-		{"effort", f.effort.View()},
-		{"base", f.base.View()},
+	rows := []struct {
+		row          ncRow
+		label, value string
+	}{
+		{ncProject, "project", f.projectName() + stepHint()},
+		{ncTitle, "title", f.title.View()},
+		{ncAgent, "agent", f.agentLabel()},
+		{ncModel, "model", f.overrideValue(f.model, f.defaultModel())},
+		{ncEffort, "effort", f.overrideValue(f.effort, f.defaultEffort())},
+		{ncBase, "base", f.base.View()},
 	}
 	lines := []string{" " + styleTitle.Render("new chat"), ""}
-	for i, r := range rows {
+	for _, r := range rows {
 		marker := "  "
-		if i == f.focus {
+		if r.row == f.focus && f.pick == nil {
 			marker = "▸ "
 		}
 		lines = append(lines, marker+padRight(r.label, 9)+r.value)
+	}
+	if f.pick != nil {
+		lines = append(lines, f.pick.renderBody()...)
 	}
 	lines = append(lines, "")
 	switch {
@@ -324,12 +545,31 @@ func (f *newChatForm) render(width, height int) string {
 		lines = append(lines, " "+styleDim.Render("creating…"))
 	case f.err != "":
 		lines = append(lines, " "+styleBad.Render(f.err))
+	case f.pick != nil:
+		lines = append(lines, " "+styleDim.Render(
+			"↑/↓ choose · / filter · enter pick · esc close the list"))
 	default:
-		lines = append(lines, " "+styleDim.Render("ctrl+s create · esc cancel"))
+		lines = append(lines, " "+styleDim.Render("enter choose · ctrl+s create · esc cancel"))
 	}
 	_ = width
 	_ = height
 	return strings.Join(lines, "\n")
+}
+
+// stepHint is the dim suffix on the two rows `←`/`→` still step in place.
+func stepHint() string { return styleDim.Render("   ← → step · enter list") }
+
+// overrideValue renders a §8.6-style override row: what was chosen, or what
+// the adapter would use when nothing was.
+func (f *newChatForm) overrideValue(value, def string) string {
+	if value != "" {
+		return value + styleDim.Render("   enter list")
+	}
+	label := "(agent default)"
+	if def != "" {
+		label += " " + def
+	}
+	return styleDim.Render(label + "   enter list")
 }
 
 func (f *newChatForm) agentLabel() string {
@@ -337,5 +577,5 @@ func (f *newChatForm) agentLabel() string {
 	if name == "" {
 		name = styleDim.Render("the daemon's default")
 	}
-	return name + styleDim.Render("   ← → to change")
+	return name + stepHint()
 }

--- a/internal/tui/newchat_test.go
+++ b/internal/tui/newchat_test.go
@@ -7,20 +7,83 @@ import (
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// TestNewChatFormCapturesEveryRow holds task 067 decision 6: an open new-chat
-// draft owns the keyboard on all six rows, not only the four text ones.
+// chatFormWithCatalogs is the form as it stands once `GET /v1/projects` and
+// `GET /v1/agents` have both landed: two projects with different default
+// branches, and two resumable adapters with different catalogs — which is what
+// makes "the catalogs scope to the selected adapter" observable.
+func chatFormWithCatalogs() *newChatForm {
+	f := newNewChatForm(nil, 0)
+	f.applyFields(newChatFieldsMsg{
+		projects: []apiclient.Project{
+			{ID: 1, Name: "alpha", Path: "/repos/alpha", DefaultBranch: "main"},
+			{ID: 2, Name: "beta", Path: "/repos/beta", DefaultBranch: "trunk"},
+		},
+		agents: []apiclient.Agent{
+			{
+				Name: "claude", Available: true, SupportsResume: ptr(true),
+				DefaultModel:  "sonnet",
+				DefaultEffort: "medium",
+				Models: []apiclient.AgentOption{
+					{Value: "sonnet", Source: apiclient.OptionSourceCLI},
+					{Value: "opus", Source: apiclient.OptionSourceCurated},
+				},
+				Efforts: []apiclient.AgentOption{
+					{Value: "medium", Source: apiclient.OptionSourceCurated},
+					{Value: "high", Source: apiclient.OptionSourceCurated},
+				},
+			},
+			{
+				Name: "cursor", Available: true, SupportsResume: ptr(true),
+				DefaultModel: "cursor-fast",
+				Models: []apiclient.AgentOption{
+					{Value: "cursor-fast", Source: apiclient.OptionSourceCLI},
+				},
+			},
+		},
+	})
+	return f
+}
+
+// pickerLabels is what the open list offers, in order.
+func pickerLabels(p *picker) []string {
+	out := make([]string, 0, len(p.options))
+	for _, o := range p.options {
+		out = append(out, o.label)
+	}
+	return out
+}
+
+// openAt focuses a row and presses enter on it, the way a human reaches a
+// list.
+func openAt(t *testing.T, f *newChatForm, row ncRow) {
+	t.Helper()
+	f.focus = row
+	if _, done := f.update(registryKey(t, "enter"), nil); done {
+		t.Fatalf("enter on row %d closed the form", row)
+	}
+}
+
+// TestNewChatFormCapturesEveryRow holds task 067 decision 8: an open new-chat
+// draft owns the keyboard on all six rows, not only the two text ones, and
+// with a list open on top of them.
 //
 // PR L's rule — a form captures input "only while a text row is in edit
 // mode" — is unchanged everywhere else; this is the one recorded exception,
-// because the picker rows sit in the middle of a live draft and `q` on them
+// because the list rows sit in the middle of a live draft and `q` on them
 // quit the TUI with it (issue #279).
 func TestNewChatFormCapturesEveryRow(t *testing.T) {
 	f := newNewChatForm(nil, 7)
-	for i := range newChatFields {
-		f.focus = i
+	for row := ncProject; row < ncRowCount; row++ {
+		f.focus = row
 		if !f.capturesInput() {
-			t.Errorf("focus %d does not capture input; a global `q` would quit the TUI with the draft", i)
+			t.Errorf("row %d does not capture input; a global `q` would quit the TUI with the draft", row)
 		}
+	}
+
+	f = chatFormWithCatalogs()
+	openAt(t, f, ncModel)
+	if !f.capturesInput() {
+		t.Error("an open list does not capture input, so `q` would quit the TUI with the draft under it")
 	}
 }
 
@@ -29,6 +92,9 @@ func TestNewChatFormCapturesEveryRow(t *testing.T) {
 // not offer one the daemon is certain to refuse. An adapter whose daemon sent
 // no `supports_resume` is not judged — nothing is filtered out on the
 // strength of a field that was never sent.
+//
+// The claim is made twice: on what the form holds, and on the list the human
+// actually sees, which is the surface issue #281 moved it to.
 func TestNewChatFormAgentPickerOffersOnlyResumers(t *testing.T) {
 	f := newNewChatForm(nil, 7)
 	f.applyFields(newChatFieldsMsg{agents: []apiclient.Agent{
@@ -46,6 +112,254 @@ func TestNewChatFormAgentPickerOffersOnlyResumers(t *testing.T) {
 	}
 	if name := f.agentName(); name != "claude" {
 		t.Errorf("the form defaults to %q, want the first adapter that can resume", name)
+	}
+
+	openAt(t, f, ncAgent)
+	if f.pick == nil {
+		t.Fatal("enter on the agent row opened no list")
+	}
+	if labels := pickerLabels(f.pick); len(labels) != 2 ||
+		labels[0] != "claude" || labels[1] != "elder" {
+		t.Fatalf("the agent list offers %v, want only the adapters that can resume", labels)
+	}
+	if f.pick.allowFree {
+		t.Error("the agent list allows free text; an adapter vincent does not register cannot hold a chat")
+	}
+}
+
+// TestNewChatFormProjectPickerOffersEveryProject holds the row the issue was
+// filed about: the project row is a list of everything registered, with the
+// path as its note, not a cycler you step through hoping.
+func TestNewChatFormProjectPickerOffersEveryProject(t *testing.T) {
+	f := chatFormWithCatalogs()
+	openAt(t, f, ncProject)
+	if f.pick == nil {
+		t.Fatal("enter on the project row opened no list")
+	}
+	if labels := pickerLabels(f.pick); len(labels) != 2 ||
+		labels[0] != "alpha" || labels[1] != "beta" {
+		t.Fatalf("the project list offers %v, want both registered projects", labels)
+	}
+	if note := f.pick.options[0].note; note != "/repos/alpha" {
+		t.Errorf("the first row's note is %q, want the project's path", note)
+	}
+	if f.pick.allowFree {
+		t.Error("the project list allows free text; a chat needs a registered project")
+	}
+
+	// Choosing the second one commits it and closes the list.
+	f.update(registryKey(t, "down"), nil)
+	f.update(registryKey(t, "enter"), nil)
+	if f.pick != nil {
+		t.Fatal("choosing a project left the list open")
+	}
+	if f.projectID != 2 {
+		t.Fatalf("the form holds project %d, want the one chosen from the list", f.projectID)
+	}
+}
+
+// TestNewChatFormCatalogListsAreTheAdapters holds what the model and effort
+// rows became: the selected adapter's catalog with its `cli`/`curated`
+// provenance, led by an "(agent default)" row naming what the adapter would
+// use, and with the free-text row present because a catalog is a suggestion
+// (§9.6).
+func TestNewChatFormCatalogListsAreTheAdapters(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		row     ncRow
+		labels  []string
+		notes   []string
+		heading string
+	}{
+		{
+			name: "model", row: ncModel, heading: "model",
+			labels: []string{"(agent default)", "sonnet", "opus"},
+			notes:  []string{"sonnet", apiclient.OptionSourceCLI, apiclient.OptionSourceCurated},
+		},
+		{
+			name: "effort", row: ncEffort, heading: "effort",
+			labels: []string{"(agent default)", "medium", "high"},
+			notes:  []string{"medium", apiclient.OptionSourceCurated, apiclient.OptionSourceCurated},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := chatFormWithCatalogs()
+			openAt(t, f, tc.row)
+			if f.pick == nil {
+				t.Fatalf("enter on the %s row opened no list", tc.name)
+			}
+			if f.pick.heading != tc.heading {
+				t.Errorf("the list is headed %q, want %q", f.pick.heading, tc.heading)
+			}
+			if got := pickerLabels(f.pick); !equalStrings(got, tc.labels) {
+				t.Fatalf("the %s list offers %v, want %v", tc.name, got, tc.labels)
+			}
+			for i, want := range tc.notes {
+				if got := f.pick.options[i].note; got != want {
+					t.Errorf("option %d is noted %q, want %q", i, got, want)
+				}
+			}
+			if !f.pick.allowFree {
+				t.Error("the list has no free-text row; a model shipped this morning is not in the catalog")
+			}
+		})
+	}
+}
+
+// TestNewChatFormAgentChangeRescopesTheCatalogs holds the rule followUpForm
+// states: the model and effort catalogs belong to an adapter, so keeping
+// values chosen under another one would submit a pair that never existed.
+func TestNewChatFormAgentChangeRescopesTheCatalogs(t *testing.T) {
+	f := chatFormWithCatalogs()
+	openAt(t, f, ncModel)
+	f.update(registryKey(t, "down"), nil) // (agent default) → sonnet
+	f.update(registryKey(t, "enter"), nil)
+	f.model, f.effort = "sonnet", "high"
+
+	// Stepping the agent row in place re-scopes both.
+	f.focus = ncAgent
+	f.update(registryKey(t, "right"), nil)
+	if f.agentName() != "cursor" {
+		t.Fatalf("→ on the agent row chose %q, want the next adapter", f.agentName())
+	}
+	if f.model != "" || f.effort != "" {
+		t.Fatalf("the form still holds model %q effort %q chosen under the previous adapter", f.model, f.effort)
+	}
+	openAt(t, f, ncModel)
+	if got := pickerLabels(f.pick); !equalStrings(got, []string{"(agent default)", "cursor-fast"}) {
+		t.Fatalf("the model list offers %v, want the newly selected adapter's catalog", got)
+	}
+	if note := f.pick.options[0].note; note != "cursor-fast" {
+		t.Errorf("the default row is noted %q, want the adapter's own default model", note)
+	}
+
+	// So does choosing one from the list.
+	f.pick = nil
+	f.model, f.effort = "cursor-fast", "high"
+	openAt(t, f, ncAgent)
+	// The list opens on the current adapter, so one step up reaches claude.
+	f.update(registryKey(t, "up"), nil)
+	f.update(registryKey(t, "enter"), nil)
+	if f.agentName() != "claude" {
+		t.Fatalf("the list chose %q, want claude", f.agentName())
+	}
+	if f.model != "" || f.effort != "" {
+		t.Fatalf("choosing an adapter kept model %q effort %q from the previous one", f.model, f.effort)
+	}
+}
+
+// TestNewChatFormArrowsStepInPlace holds the decision issue #281 took: `←`/`→`
+// survive as a fast in-place step on the two short rows, the enum-row
+// precedent from the new-task fields editor. They open nothing.
+func TestNewChatFormArrowsStepInPlace(t *testing.T) {
+	f := chatFormWithCatalogs()
+	f.focus = ncProject
+	f.update(registryKey(t, "right"), nil)
+	if f.projectID != 2 || f.pick != nil {
+		t.Fatalf("→ on the project row left project %d, list open = %v; want a step in place",
+			f.projectID, f.pick != nil)
+	}
+	f.focus = ncAgent
+	f.update(registryKey(t, "right"), nil)
+	if f.agentName() != "cursor" || f.pick != nil {
+		t.Fatalf("→ on the agent row left %q, list open = %v; want a step in place",
+			f.agentName(), f.pick != nil)
+	}
+}
+
+// TestNewChatFormBaseRowNamesTheProjectDefault holds the base row's decision:
+// the placeholder names the project's real default branch and follows the
+// project row, while the value stays empty so the daemon resolves it.
+func TestNewChatFormBaseRowNamesTheProjectDefault(t *testing.T) {
+	f := chatFormWithCatalogs()
+	if got := f.base.Placeholder; got != "main (the project's default)" {
+		t.Fatalf("the base row reads %q, want the first project's default branch", got)
+	}
+	f.focus = ncProject
+	f.update(registryKey(t, "right"), nil)
+	if got := f.base.Placeholder; got != "trunk (the project's default)" {
+		t.Fatalf("after changing project the base row reads %q, want the new project's default branch", got)
+	}
+
+	f.title.SetValue("a chat")
+	if req := f.request(); req.BaseBranch != "" {
+		t.Fatalf("an untouched base row submits %q; it must stay empty so the daemon resolves the default",
+			req.BaseBranch)
+	}
+	f.base.SetValue("  release  ")
+	if req := f.request(); req.BaseBranch != "release" {
+		t.Fatalf("a typed base row submits %q, want the branch that was typed", req.BaseBranch)
+	}
+}
+
+// TestNewChatFormSubmitsFreeText holds `allowFree`: a value the adapter's
+// catalog has never heard of is submitted verbatim. `POST /v1/chats` stores
+// model and effort without a catalog check, so the form must not be stricter
+// than the daemon.
+func TestNewChatFormSubmitsFreeText(t *testing.T) {
+	f := chatFormWithCatalogs()
+	f.title.SetValue("a chat")
+	openAt(t, f, ncModel)
+	f.update(registryKey(t, "e"), nil) // the free-text row
+	f.pick.input.SetValue("sonnet-shipped-this-morning")
+	f.update(registryKey(t, "enter"), nil)
+	if f.pick != nil {
+		t.Fatal("committing free text left the list open")
+	}
+	if req := f.request(); req.Model != "sonnet-shipped-this-morning" {
+		t.Fatalf("the form submits model %q, want the value typed into the free-text row", req.Model)
+	}
+}
+
+// TestNewChatFormEscClosesOneLayer holds §15's esc stack: an open list is a
+// layer above the form, so the first press closes the list and leaves the
+// draft, and only the second discards it.
+func TestNewChatFormEscClosesOneLayer(t *testing.T) {
+	f := chatFormWithCatalogs()
+	f.title.SetValue("still being written")
+	openAt(t, f, ncModel)
+
+	if _, done := f.update(registryKey(t, "esc"), nil); done {
+		t.Fatal("esc with a list open closed the whole form, discarding the draft")
+	}
+	if f.pick != nil {
+		t.Fatal("esc left the list open")
+	}
+	if f.title.Value() != "still being written" {
+		t.Fatalf("the draft's title is now %q; closing a list must not touch it", f.title.Value())
+	}
+	if _, done := f.update(registryKey(t, "esc"), nil); !done {
+		t.Fatal("a second esc did not close the form")
+	}
+}
+
+// TestNewChatFormEnterNeverCreates holds the other half of that decision:
+// `enter` opens a list or moves on, uniformly, and `ctrl+s` is the sole create
+// key on every row — which is what §15 documents and what the form's own hint
+// line has always said.
+func TestNewChatFormEnterNeverCreates(t *testing.T) {
+	f := chatFormWithCatalogs()
+	f.title.SetValue("a chat")
+	f.focus = ncTitle
+	if cmd, _ := f.update(registryKey(t, "enter"), nil); cmd != nil {
+		t.Fatal("enter on the title row produced a command; ctrl+s is what creates")
+	}
+	if f.submitting {
+		t.Fatal("enter on the title row started a create")
+	}
+	if f.focus != ncAgent {
+		t.Fatalf("enter on the title row left the cursor on row %d, want the next one", f.focus)
+	}
+
+	// ctrl+s from a row that is not the title still creates; with no client
+	// the attempt stops at "not connected", which is proof it was made.
+	for _, row := range []ncRow{ncProject, ncBase, ncEffort} {
+		f.err = ""
+		f.focus = row
+		f.update(registryKey(t, "ctrl+s"), nil)
+		if f.err != "not connected" {
+			t.Errorf("ctrl+s on row %d did not attempt a create (err = %q)", row, f.err)
+		}
 	}
 }
 

--- a/internal/tui/newchatlive_test.go
+++ b/internal/tui/newchatlive_test.go
@@ -13,12 +13,18 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/agenttest"
+	"github.com/lezli01/vincent/internal/agent/claude"
 	"github.com/lezli01/vincent/internal/api"
 	"github.com/lezli01/vincent/internal/apiclient"
 	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/daemon"
 	"github.com/lezli01/vincent/internal/events"
+	"github.com/lezli01/vincent/internal/gitx"
 	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/testrepo"
+	"github.com/lezli01/vincent/internal/worktree"
 )
 
 // newChatLiveRoot is the shell a human has on screen on a fresh installation
@@ -42,13 +48,32 @@ func newChatLiveRoot(t *testing.T) *root {
 	t.Cleanup(broker.Close)
 	st.SetEventHook(broker.Publish)
 
+	// alpha is a real repository on a non-default branch name, so the base
+	// row's claim — that an empty BaseBranch resolves to *this project's*
+	// default — is falsifiable rather than accidentally right.
 	ctx := context.Background()
+	repos := map[string]string{
+		"alpha": testrepo.Init(t, "trunk"),
+		"beta":  testrepo.Init(t, "main"),
+	}
 	for _, name := range []string{"alpha", "beta"} {
-		p := &store.Project{Name: name, Path: "/nowhere/" + name, DefaultBranch: "main"}
+		p := &store.Project{
+			Name: name, Path: repos[name],
+			DefaultBranch: map[string]string{"alpha": "trunk", "beta": "main"}[name],
+		}
 		if err := st.CreateProject(ctx, p); err != nil {
 			t.Fatalf("CreateProject(%s): %v", name, err)
 		}
 	}
+
+	// The adapter registry is the same one `GET /v1/agents` serves the form
+	// from and the one `POST /v1/chats` gates resume support on: claude
+	// pointed at fakeagent, which is what makes the catalogs in the pickers
+	// the daemon's own rather than a stub's.
+	fake := agenttest.BuildFakeAgent(t)
+	dataDir := t.TempDir()
+	git := gitx.New()
+	agents := agent.NewRegistry(claude.New(func() string { return fake }))
 
 	s := api.New(api.Deps{
 		Token:       token,
@@ -59,6 +84,10 @@ func newChatLiveRoot(t *testing.T) *root {
 		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Store:       st,
 		Broker:      broker,
+		Git:         git,
+		Agents:      agents,
+		Catalog:     agent.NewCatalogCache(agents),
+		Worktrees:   worktree.NewManager(git, dataDir),
 	})
 	ts := httptest.NewServer(s.Handler())
 	t.Cleanup(ts.Close)
@@ -114,8 +143,9 @@ func chatsForm(t *testing.T, m *root) *newChatForm {
 	return v.create
 }
 
-// TestNewChatFormPickersPopulateThroughRoot holds §15's new-chat form: "`←`/`→`
-// choose on the project and agent fields" (amended 2026-08-31, task 067).
+// TestNewChatFormPickersPopulateThroughRoot holds §15's new-chat form: `←`/`→`
+// step the project and agent fields in place (amended 2026-08-31, task 067 and
+// issue #281).
 //
 // It drives the form through the **root** model, which is the layer a real
 // keystroke and a real fetch both take. `newChatForm.init` produces a
@@ -172,5 +202,103 @@ func TestNewChatFormPickersPopulateThroughRoot(t *testing.T) {
 	}
 	if name := f.projectName(); name != "alpha" && name != "beta" {
 		t.Fatalf("the project row renders %q, want one of the registered names", name)
+	}
+}
+
+// TestNewChatFormPickersRenderTheServedCatalogs holds issue #281's seam: the
+// lists the human chooses from are the catalogs `GET /v1/agents` and
+// `GET /v1/projects` actually serve, and a model chosen from one of them
+// travels to `POST /v1/chats` and comes back on the created chat — with the
+// base branch the daemon resolved from the project, because the form sent
+// none.
+//
+// It is wired to the real handlers rather than a stub for the usual reason:
+// the claim is about the seam. A form that built its options from a hand-made
+// `apiclient.Agent` would keep passing the day the wire type changed.
+func TestNewChatFormPickersRenderTheServedCatalogs(t *testing.T) {
+	m := newChatLiveRoot(t)
+
+	_, cmd := m.Update(registryKey(t, "n"))
+	if cmd == nil {
+		t.Fatal("n opened no fetch for the lists' contents")
+	}
+	m.Update(runCmd(t, cmd, 10*time.Second))
+
+	f := chatsForm(t, m)
+	if len(f.agents) == 0 {
+		t.Fatal("the form holds no adapter after GET /v1/agents landed")
+	}
+
+	// What the daemon serves, fetched again through the same client the form
+	// used: the lists must be built from this and nothing else.
+	served, err := m.client.ListAgents(t.Context(), false)
+	if err != nil {
+		t.Fatalf("GET /v1/agents: %v", err)
+	}
+	want, ok := served.Find(f.agentName())
+	if !ok {
+		t.Fatalf("the form selected %q, which GET /v1/agents does not list", f.agentName())
+	}
+	if len(want.Models) == 0 {
+		t.Fatalf("the daemon serves no model catalog for %q, so the list under test would be empty", want.Name)
+	}
+
+	// Walk to the model row the way a human does — the form opens on the
+	// title — and open its list.
+	m.Update(registryKey(t, "tab"))
+	m.Update(registryKey(t, "tab"))
+	f = chatsForm(t, m)
+	if f.focus != ncModel {
+		t.Fatalf("two tabs left the cursor on row %d, want the model row", f.focus)
+	}
+	m.Update(registryKey(t, "enter"))
+	f = chatsForm(t, m)
+	if f.pick == nil {
+		t.Fatal("enter on the model row opened no list")
+	}
+	if got, wantN := len(f.pick.options), len(want.Models)+1; got != wantN {
+		t.Fatalf("the model list has %d rows, want the %d served models plus the (agent default) row",
+			got, len(want.Models))
+	}
+	if f.pick.options[0].note != want.DefaultModel {
+		t.Errorf("the default row is noted %q, want the served default model %q",
+			f.pick.options[0].note, want.DefaultModel)
+	}
+	for i, o := range want.Models {
+		got := f.pick.options[i+1]
+		if got.value != o.Value || got.note != o.Source {
+			t.Errorf("row %d offers %q/%q, want the served %q/%q", i+1, got.value, got.note, o.Value, o.Source)
+		}
+	}
+
+	// Choose the first served model, name the chat, and create.
+	m.Update(registryKey(t, "down"))
+	m.Update(registryKey(t, "enter"))
+	f = chatsForm(t, m)
+	if f.model != want.Models[0].Value {
+		t.Fatalf("the form holds model %q, want the one chosen from the served catalog", f.model)
+	}
+	f.title.SetValue("a live chat")
+
+	_, cmd = m.Update(registryKey(t, "ctrl+s"))
+	if cmd == nil {
+		t.Fatal("ctrl+s posted nothing")
+	}
+	msg, ok := runCmd(t, cmd, 10*time.Second).(chatCreatedMsg)
+	if !ok {
+		t.Fatalf("ctrl+s produced %T, want chatCreatedMsg", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("POST /v1/chats: %v", msg.err)
+	}
+	if msg.chat.Model != want.Models[0].Value {
+		t.Errorf("the created chat runs model %q, want the chosen %q", msg.chat.Model, want.Models[0].Value)
+	}
+	// The base row was never touched, so the request carried no branch and
+	// the daemon resolved the project's own default — which is `trunk` here
+	// and not the `main` a hard-coded fallback would have produced.
+	if msg.chat.BaseBranch != "trunk" {
+		t.Errorf("the created chat is based on %q, want the project's default branch resolved by the daemon",
+			msg.chat.BaseBranch)
 	}
 }


### PR DESCRIPTION
## Summary

The new-chat form was the only create surface in the TUI that did not use the
`picker` component — which was already there when the form was written. Four of
its six rows become picker rows; two stay text.

| row | control | free text |
|---|---|---|
| `project` | list of registered projects, path as the note | no |
| `title` | `textinput`, unchanged | — |
| `agent` | list of `resumableAgents(...)`, filter unchanged | no |
| `model` | the selected adapter's `Models`, `cli`/`curated` noted | yes |
| `effort` | the selected adapter's `Efforts`, same treatment | yes |
| `base` | `textinput`, new placeholder | — |

Nothing new is fetched: `newChatForm.init` already called `ListAgents`, and
`apiclient.Agent` already carried `Models`, `Efforts`, `DefaultModel` and
`DefaultEffort`. The catalog was in the form's memory and simply was not drawn.

Both catalogs scope to the selected adapter and are cleared when the agent row
changes, exactly as `followUpForm.setRow` does — the catalogs belong to an
adapter, and keeping a value chosen from another one would submit a pair that
never existed. Both lead with an `(agent default)` row carrying that adapter's
own default as its note: a chat has no workflow, so "(workflow default)" is the
wrong words here.

Four decisions qualify the move, recorded as decision 10 on
`docs/tasks/067-chats-in-the-tui.md`:

- **`←`/`→` stay, as a fast in-place step.** `enter` opens the focused row's
  list; `←`/`→` continue to step the project and agent rows without opening it.
  This is the enum-row precedent from the new-task fields editor verbatim. The
  issue proposed retiring the cyclers; the cycler was never the defect — the
  *absence of a list* was — and two adapters are quicker to step than to open.
  They are not added to the model and effort rows, catalogs of a hundred and
  more (§9.7) where "next" answers nothing.
- **`base` names the project's real default branch as a placeholder and submits
  empty.** The row reads `main (the project's default)` — the branch name, not
  the phrase — re-derived when the project row changes, while
  `CreateChatRequest.BaseBranch` stays empty so `handleChatCreate` resolves
  `base = project.DefaultBranch` as it does today. Seeding the *value* was
  rejected: it pins a branch at draft time and needs a rule for re-seeding over
  text a human may have typed. No `GET /v1/projects/{id}/branches` here — the
  new-task form has the same free-text base row and the two should be decided
  together.
- **Task 067 decision 9 is unchanged.** The agent list keeps hiding adapters
  that do not publish `supports_resume`; `resumableAgents` is untouched and the
  daemon's `agent_cannot_resume` refusal stays the authority, still rendered by
  `applyFailure`. A picker *can* now show a row disabled with its reason (the
  new-task precedent from tasks 010/013); that was considered and declined —
  an adapter that cannot hold a conversation is out of reach for every chat,
  not for this one draft.
- **TUI only; the daemon is not touched.** The issue's rationale is wrong on one
  fact without changing the outcome: `POST /v1/chats` never validates `model` or
  `effort` — it stores what it is sent, with no catalog check and no warning,
  unlike task create, repair and follow-up, which run `checkTaskCatalog`. A typo
  therefore does not come back as a rejection; it comes back as a failed first
  turn when the CLI refuses the model, which is a worse failure and a stronger
  argument for the picker. Giving chat creation §8.2's warnings is a real gap,
  with its own DTO, apiclient, `docs/reference/api.md` and spec amendments — and
  is not this issue.

`enter` also stops submitting: it opened the create path from the title row and
advanced focus everywhere else, while §15's key table and the form's own hint
line both name `ctrl+s` as the create key. It is now uniform across all six
rows, and `ctrl+s` is the sole create key. With a list open every key goes to
the list, so `esc` closes the list first and the draft survives it — one `esc`,
one layer, per §15's stack.

`capturesInput` stays unconditionally `true` (task 067 decision 8). Its
justification only strengthens — an open list adds a filter row and a free-text
row — but its *arithmetic* changed: the form has two live text rows now, not
four, so the paragraph is rewritten in the code and in §15. While rewriting it,
the comment's citation of "task 067 decision 6" is corrected to 8; decision 9,
which the same file cites, was already right.

Noted, not proposed: `ctxNewChat`'s rows are not marked `noPalette` the way the
other keyboard-owning forms' rows are, even though `capturesInput` means `:` can
never reach the palette from this form.

## Related

Closes #281
Records decision 10 on [067](docs/tasks/067-chats-in-the-tui.md) — the precedent
#279 set on the same document: a done task grows dated decisions rather than
spawning a new document for work whose reasoning belongs beside the decisions it
qualifies. Decisions 8 and 9 are qualified, not revisited: 9's filter is
untouched, and 8's conclusion holds with its arithmetic corrected.

Amends `docs/spec.md` §15 in place with a dated note, as the repository
requires: the new-chat key table gains `enter`, `←`/`→` change meaning, and the
"four of this form's six rows are text fields" sentence in the 2026-08-31/#279
amendment is now false and is fixed.

## Documentation audit

The derivations were walked one at a time against the source. `internal/config`,
the cobra tree, `internal/api/server.go`'s route table, the `Reason*` constants,
`internal/workflow`/`internal/taskrun`'s step types and `internal/agent/*` are
all untouched by this change, so their pages
(`configuration.md`, `cli.md`, `api.md`, the block-reason tables,
`workflow-schema.md`, `task-lifecycle.md`, `agents.md`) were already true — no
adapter gained or lost a capability, and the workflow schema did not move, so
`skills/vincent-workflows/SKILL.md`, `internal/workflow/builtin.go` and this
repository's own `.vincent/workflows/*.yaml` are unaffected. `docs/features.md`
describes chats without describing the form's controls, and no gate walks the
new-chat form. Two claims elsewhere had gone stale and are fixed in this PR:

- **`docs/spec.md` §15** — the 2026-08-31/#279 amendment still opened with "the
  new-chat form's **two** pickers are fed by `GET /v1/projects` and
  `GET /v1/agents`". Four of the six rows are pickers now. It names the project
  and agent pickers instead, which keeps the sentence's real claim — which route
  feeds which — true without asserting a count that will go stale again. The
  section number is untouched.
- **`CHANGELOG.md`** — the entry said the base row now names the project's
  default branch "instead of the words *the project's default*". `baseHint`
  keeps those words: the placeholder reads `main (the project's default)`, the
  branch name leading the phrase rather than replacing it. Reworded to say that.

No screenshot is stale: `scripts/screenshots.sh` has no new-chat tape and there
is no `docs/assets/tui-*chat*.png` to re-capture.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`internal/tui/newchat_test.go` at form level: the model and effort lists are the
selected adapter's catalog with its provenance notes, the `(agent default)` row
and the free-text row; changing the agent re-scopes both and clears what was
chosen under the previous one; the project list offers every project and the
agent list only the resumers (`TestNewChatFormAgentPickerOffersOnlyResumers`
extended to the picker path rather than replaced, so decision 9 stays proven);
`←`/`→` still step in place and open nothing; the base placeholder follows the
project row and an untouched row submits `BaseBranch: ""` while a typed one is
submitted verbatim; free text is submitted verbatim; `esc` closes the list and
leaves the draft, a second `esc` closes the form; `enter` never creates and
`ctrl+s` creates from any row; `capturesInput` stays true on all six rows and
with a list open.

`internal/tui/newchatlive_test.go` against the real handlers over `httptest`,
which is what keeps the wire types from drifting: the model list's rows are the
catalog `GET /v1/agents` actually serves, in order, with its sources and its
default; a model chosen from it travels through `POST /v1/chats` onto the
created chat; and that chat comes back based on the project's own default branch
— `trunk`, not the `main` a hard-coded fallback would produce — because the form
sent none. Its fixture grew a real repository, an adapter registry pointed at
`cmd/fakeagent` and a worktree manager to make that create real.

`docs/guides/tui.md`'s create-form paragraph and key table are rewritten; the
`ctxNewChat` rows in `internal/tui/bindings.go`, which the footer, `?` and the
palette are all derived from, gain an `enter` row and reword the `←`/`→` one,
with a probe for the new row in `panelKeyProbes`. No screenshot re-capture:
`scripts/screenshots.sh` has no new-chat tape.

`go run mage.go test` and `go run mage.go lint` are green, as is
`golangci-lint` cross-built for windows, darwin and linux.
