### PR TITLE
Make chats work on codex and cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,19 @@ list with the user-facing context a commit subject cannot carry.
   one, so a second adapter that reports a plan fills the same record. Because
   transcripts are re-normalized on every read, this improves codex transcripts
   **already on disk**. Full detail in spec §9.3, §13.2, §13.3 and §15.
-- **Chats work on codex.** `codex exec resume <thread_id>` is wired and
-  `thread.started`'s id is read, so a chat on codex holds context across turns
-  instead of being refused at creation with `agent_cannot_resume`. The argv is
-  pinned by a capture against codex-cli 0.150.1, in which the resumed turn
-  reports the same thread id and answers a question about the previous one —
-  the fixture requirement task 063 attached to this. cursor still cannot resume
-  and is still refused, which is stated rather than emulated (spec §9.7).
+- **Chats work on codex and cursor.** Both adapters now resume their own
+  session, so a chat can be created on either and turn 2 sees turn 1 — codex
+  through `codex exec --json resume <thread_id>`, cursor through
+  `--resume <session_id>`. Each half is pinned to a fixture captured from a
+  named CLI build (codex-cli 0.150.1, cursor-agent 2026.08.11-e8db854), which
+  was the condition task 063 attached to this. Nothing replays a log as prompt
+  context; the `agent_cannot_resume` refusal is kept as the contract for the
+  next adapter, and now has no shipped adapter to refuse. Two limitations are
+  stated rather than worked around: a resumed codex run is always full-auto
+  (`codex exec resume` has no `--sandbox`, and a chat has no permission mode to
+  ask for), and cursor never reports `session_lost` — handed an id it does not
+  know it starts a fresh chat under that id and answers, so a cursor chat whose
+  session has aged out replies without remembering (spec §9.3, §9.7).
 - **`agent.result` reports codex's cache and reasoning token spend.** All five
   of `turn.completed.usage`'s counters are read now, not two:
   `cached_input_tokens` and `cache_write_input_tokens` land in the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,17 @@ list with the user-facing context a commit subject cannot carry.
   whose transcript has aged out still shows its answer.
   See [Using the TUI](docs/guides/tui.md#chat-workspace) (#282).
 
+- **A chat turn that hit its transcript cap, either clock or a cancel could
+  hang forever.** When a turn ended early the runner stopped reading the
+  adapter's event stream and waited for the run to finish — but an adapter's
+  reader goroutine blocks handing an event over, and its wait does not return
+  until that reader is done. With a talkative agent the two waited on each
+  other: the turn never reached a terminal state, the chat never came back to
+  idle, its `max_parallel_chats` slot was never released, and stopping the
+  daemon blocked with it. The runner now drains the stream it abandons, the
+  way the task engine already did. Only chats were affected; a workflow step
+  hitting the same cap always drained.
+
 - **The new-chat form's pickers never filled, and its picker rows leaked
   keys.** The form fetched the projects and the adapters and then dropped the
   answer on the floor: the message it comes back in had no case in the chats

--- a/cmd/fakeagent/codex.go
+++ b/cmd/fakeagent/codex.go
@@ -35,25 +35,28 @@ func codexLoginStatus() {
 }
 
 // codexMain is the codex dialect (T2.9): argv shaped like
-// `codex exec --json …`, prompt from stdin, `codex exec --json` JSONL on
+// `codex exec --json …` or `codex exec resume --json … <id> -`, prompt from
+// stdin, `codex exec --json` JSONL on
 // stdout. The emitted shapes mirror the fixtures captured from a real
 // codex-cli 0.142.5 (internal/agent/codex/testdata).
 func codexMain(scenario string) {
 	prompt, _ := io.ReadAll(os.Stdin)
 
-	// The conversation is resolved before a line is emitted, as in the
-	// claude dialect: `codex exec --json resume <id>` of an id the store
-	// does not hold ends here (task 070). codex reports the thread id on
+	// The conversation is resolved before a single stream line is emitted,
+	// as in the claude dialect: `codex exec --json resume <id>` of an id the
+	// store does not hold ends here (task 070), with the refusal on stderr
+	// and no stream at all, which is the shape internal/agent/codex
+	// classifies as `session_lost`. codex reports the thread id on
 	// `thread.started`, and a resumed run reports the *same* id — which is
 	// what the real 0.150.1 capture shows (testdata/resume_0.150.1.jsonl).
-	prior := openSession()
+	prior := openSession(dialectCodex)
 	rememberPrompt(prompt)
 
 	emit(map[string]any{"type": "thread.started", "thread_id": codexThreadID()})
 	emit(map[string]any{"type": "turn.started"})
 	if line := recallLine(prior); line != "" {
 		// What a resumed thread remembers. A fresh one says nothing here, so
-		// a vincent that dropped the resume argv fails by omission.
+		// a vincent that dropped the resume id fails by omission.
 		emitCodexMessage(line)
 	}
 	switch scenario {

--- a/cmd/fakeagent/cursor.go
+++ b/cmd/fakeagent/cursor.go
@@ -23,21 +23,34 @@ Tip: use --model <id> (or /model <id> in interactive mode) to switch.
 `
 
 // cursorMain is the cursor dialect (T5.2): argv shaped like
-// `cursor-agent -p --output-format stream-json --trust …`, prompt from stdin,
+// `cursor-agent -p --output-format stream-json --trust [--resume <id>] …`,
+// prompt from stdin,
 // cursor stream-json on stdout. The emitted shapes mirror the fixtures
 // captured from a real cursor-agent 2026.08.04-aaa8809
 // (internal/agent/cursor/testdata).
 func cursorMain(scenario string) {
 	prompt, _ := io.ReadAll(os.Stdin)
 
+	// The conversation is resolved before a single stream line is emitted
+	// (task 072). Unlike the other two dialects there is no refusal leg:
+	// cursor adopts an id it does not know and starts a fresh chat under it.
+	// The session id then rides on every line, which emit fills in.
+	prior := openSession(dialectCursor)
+	rememberPrompt(prompt)
+
 	emit(map[string]any{
 		"type": "system", "subtype": "init", "apiKeySource": "login",
-		"session_id": "fake-session-1", "model": "Fake", "permissionMode": "default",
+		"model": "Fake", "permissionMode": "default",
 	})
 	emit(map[string]any{"type": "user", "message": map[string]any{
 		"role":    "user",
 		"content": []any{map[string]any{"type": "text", "text": string(prompt)}},
-	}, "session_id": "fake-session-1"})
+	}})
+	if line := recallLine(prior); line != "" {
+		// What a resumed chat remembers. A fresh one says nothing here, so a
+		// vincent that dropped --resume fails by omission.
+		emitCursorText(line)
+	}
 
 	switch scenario {
 	case "error-event":

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -78,13 +78,16 @@
 //	                      to this worktree-relative tracked file, so gate
 //	                      runs produce a non-empty diff
 //	FAKEAGENT_SPAWN_CHILD hang: spawn a sleeping child first and emit its pid
-//	FAKEAGENT_SESSION_DIR gives the claude dialect a memory (task 063): a
+//	FAKEAGENT_SESSION_DIR gives every dialect a memory (task 063, 070): a
 //	                      directory of conversations keyed by the session id
-//	                      it mints and stamps on every line. `--resume <id>`
-//	                      reloads one and the run says what it recalls; an id
-//	                      the directory does not hold is refused on stderr
-//	                      with a nonzero exit and no stream, which is the
-//	                      `session_lost` leg. Unset, the run mints an id,
+//	                      it mints. Resume is spelled per dialect — `--resume
+//	                      <id>` for claude and cursor, `exec resume … <id> -`
+//	                      for codex — and the run then says what it recalls.
+//	                      An id the directory does not hold is refused on
+//	                      stderr with a nonzero exit and no stream by claude
+//	                      and codex (the `session_lost` leg); cursor adopts
+//	                      it and starts a fresh chat, because that is what the
+//	                      real one does. Unset, the run mints an id,
 //	                      remembers nothing, and behaves exactly as before
 //	                      as {"type":"fakeagent.child","pid":N} — lets tests
 //	                      verify tree-kill reaps grandchildren
@@ -240,7 +243,7 @@ func main() {
 	// (task 063): a `--resume` of an id the store does not hold ends here,
 	// with the refusal on stderr and no stream at all, which is the shape
 	// internal/agent/claude classifies as `session_lost`.
-	prior := openSession()
+	prior := openSession(dialectClaude)
 	rememberPrompt(prompt)
 
 	emit(map[string]any{"type": "system", "subtype": "init", "model": "fake-1"})
@@ -596,11 +599,11 @@ func askPermission(prompt []byte, rd *bufio.Reader) {
 }
 
 func emit(v map[string]any) {
-	// Every claude stream line carries the session id (task 063), which is
-	// how internal/agent/claude learns the id to resume next turn. The
-	// global is only ever set by the claude dialect, so the codex and cursor
-	// emissions below are untouched.
-	if sessionID != "" {
+	// Every claude and cursor stream line carries the session id (task 063,
+	// 070), which is how those adapters learn the id to resume next turn. The
+	// codex dialect sets its own `thread_id` on `thread.started` and carries
+	// no session_id at all, which is what stampSessionID switches off.
+	if stampSessionID && sessionID != "" {
 		if _, ok := v["session_id"]; !ok {
 			v["session_id"] = sessionID
 		}

--- a/cmd/fakeagent/session.go
+++ b/cmd/fakeagent/session.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// A fake CLI with a memory (task 063).
+// A fake CLI with a memory (task 063, extended to every dialect by task 072).
 //
 // Chat continuity is the one feature whose acceptance cannot be staged: the
 // question is whether turn 2 sees turn 1, and only a CLI that actually keeps
@@ -22,10 +22,28 @@ import (
 // it on every line as claude does, and remembers nothing — which is every
 // existing test, unchanged.
 
-// sessionID is the conversation this run belongs to. Empty until the claude
-// dialect resolves one; emit stamps it on every line while it is set, because
-// that is what claude does and what internal/agent/claude reads back.
+// sessionID is the conversation this run belongs to. Empty until the dialect
+// resolves one; emit stamps it on every line while it is set, because that is
+// what claude and cursor do and what their adapters read back. The codex
+// dialect emits it once, on `thread.started`, because that is the only line
+// real codex puts a thread id on.
 var sessionID string
+
+// dialect names which CLI this run is imitating. It decides how resume is
+// spelled on argv and what an unknown id does — nothing else in the store.
+type dialect int
+
+const (
+	dialectClaude dialect = iota
+	dialectCodex
+	dialectCursor
+)
+
+// stampSessionID is whether emit should add `session_id` to every line. True
+// for the dialects whose real CLI does that (claude, cursor); false for
+// codex, which reports its thread id once, on `thread.started`, and would be
+// misrepresented by a field the real one never writes.
+var stampSessionID bool
 
 // session is one conversation as the fake CLI stores it: the prompts it has
 // been given, oldest first. It is deliberately the whole context — a resumed
@@ -46,16 +64,19 @@ func sessionPath(id string) string {
 	return filepath.Join(sessionDir(), filepath.Base(id)+".json")
 }
 
-// resumeArg returns the value of `--resume` on argv, and whether it was
-// present. Matching the flag by hand rather than with the flag package keeps
+// resumeArg returns the resume id on argv, and whether this run is a resume
+// at all. Matching by hand rather than with the flag package keeps
 // fakeagent's argv handling uniform: every other flag here is read the same
 // way, because the point is to be faithful to argv, not to parse it well.
+//
+// The dialect is not consulted, because the two spellings differ only in the
+// word: claude and cursor say `--resume <id>`, codex says it with a
+// subcommand — `codex exec --json resume <id>` (task 070) — and in both the
+// id is the argument straight after the word. One walk covers all three
+// rather than each getting its own. Nothing else can be mistaken for it: the
+// prompt is on stdin in every dialect, so no free text reaches argv.
 func resumeArg() (string, bool) {
 	for i, a := range os.Args[1:] {
-		// codex says it with a subcommand rather than a flag: `codex exec
-		// --json resume <id>` (task 070). The id is the argument after the
-		// word, exactly as it is after `--resume`, so both spellings share
-		// this walk rather than each getting their own.
 		if a != "--resume" && a != "resume" {
 			continue
 		}
@@ -73,6 +94,13 @@ func resumeArg() (string, bool) {
 // caveat, argued in the same place.
 const sessionLostMessage = "No conversation found with session ID: "
 
+// codexSessionLostMessage is codex's, and this one *is* fixture-verified:
+// codex-cli 0.150.1 refusing an id it never minted
+// (internal/agent/codex/testdata/resume_lost_0.150.1.txt). Reproduced
+// verbatim so internal/agent/codex/failure.go is matched against the wording
+// it was written for.
+const codexSessionLostMessage = "Error: thread/resume: thread/resume failed: no rollout found for thread id "
+
 // openSession resolves this run's conversation before any output is emitted.
 //
 // It returns the prior prompts a resumed session carries. A resume of an id
@@ -81,7 +109,8 @@ const sessionLostMessage = "No conversation found with session ID: "
 // `session_lost` leg (decision 4), and it is reached by asking for a session
 // that was never written rather than by a scenario flag, so the test exercises
 // the same code path a genuinely expired id would.
-func openSession() []string {
+func openSession(d dialect) []string {
+	stampSessionID = d != dialectCodex
 	id, resuming := resumeArg()
 	dir := sessionDir()
 	if resuming && id == "" {
@@ -89,8 +118,9 @@ func openSession() []string {
 		os.Exit(1)
 	}
 	if dir == "" {
-		// No memory. Still mint an id: every claude line carries one, and a
-		// run that emitted none would hide a parse regression.
+		// No memory. Still mint an id: every claude and cursor line carries
+		// one and codex opens with one, and a run that emitted none would
+		// hide a parse regression.
 		sessionID = id
 		if sessionID == "" {
 			sessionID = "fake-session-1"
@@ -104,8 +134,21 @@ func openSession() []string {
 	var s session
 	b, err := os.ReadFile(sessionPath(id))
 	if err != nil || json.Unmarshal(b, &s) != nil {
-		fmt.Fprintln(os.Stderr, sessionLostMessage+id)
-		os.Exit(1)
+		// An id nobody wrote. What happens next is the dialect's, not this
+		// file's opinion — see the note at the top.
+		switch d {
+		case dialectCodex:
+			fmt.Fprintln(os.Stderr, codexSessionLostMessage+id+" (code -32600)")
+			os.Exit(1)
+		case dialectCursor:
+			// No refusal exists to imitate: cursor adopts the id and starts
+			// a fresh chat under it, which is a run with no prior prompts.
+			sessionID = id
+			return nil
+		default:
+			fmt.Fprintln(os.Stderr, sessionLostMessage+id)
+			os.Exit(1)
+		}
 	}
 	sessionID = id
 	return s.Prompts

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,7 +46,8 @@ ask the next question with the first still in context.
 
 Continuity is the agent CLI resuming **its own** session, not vincent replaying
 the conversation into the next prompt. That means only an adapter that can
-resume may hold a chat: today that is `claude` and `codex`, and `cursor` is
+resume may hold a chat — all three of `claude`, `codex` and `cursor` can, each
+pinned to a captured fixture from a named CLI build. One that could not would be
 refused at creation rather than having continuity faked for it.
 
 A chat is real work, not a scratchpad. The agent may commit to the chat's

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -34,7 +34,7 @@ silently drops.
 | `effort:` | ✅ | ✅ | **—** (it lives in the model id) |
 | `restricted` mode | ✅ | ✅ | ✅ on macOS/Linux, **refused on Windows** |
 | Carries [vincent's MCP server](mcp.md) for one run | ✅ `--mcp-config` | ✅ `-c mcp_servers.…` | ✅ `.cursor/mcp.json` **in the worktree** |
-| Tested-build list | `2.1.224`, `2.1.226` | `0.142.5`, `0.147.0` | `2026.08.04-aaa8809`, `2026.08.11-e8db854` |
+| Tested-build list | `2.1.224`, `2.1.226` | `0.142.5`, `0.147.0`, `0.150.1` | `2026.08.04-aaa8809`, `2026.08.11-e8db854` |
 | Reports whether you are logged in | — | — | ✅ |
 | Recognizes a usage limit / auth failure in a run | ✅ | — | — |
 | Reports **remaining** quota without running | — | — | — |

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -27,7 +27,8 @@ silently drops.
 | Binary | `claude` | `codex` | **`cursor-agent`** |
 | `agent:` value | `claude` | `codex` | `cursor` |
 | Mid-run questions (`awaiting_input`) | ✅ | — | — |
-| Resumes its own session ([chats](../reference/cli.md#vincent-chat)) | ✅ `--resume` | ✅ `exec resume <thread_id>` | — |
+| Resumes its own session ([chats](../reference/cli.md#vincent-chat)) | ✅ `--resume` | ✅ `exec resume` | ✅ `--resume` |
+| Reports a session it can no longer resume | ✅ `session_lost` | ✅ `session_lost` | **—** (it adopts the id and answers) |
 | Reports cost | ✅ | — | — |
 | `model:` | ✅ | ✅ (free text) | ✅ (~180 enumerated) |
 | `effort:` | ✅ | ✅ | **—** (it lives in the model id) |
@@ -138,11 +139,23 @@ a step that reaches the engine anyway fails with `input_unsupported`.
   `awaiting_input`, and `on_input: wait|deny` has no effect on it. `on_input:
   require` is the one that does: a step declaring it cannot use codex at all,
   and a workflow pinning `agent: codex` on such a step fails validation.
-- **Resumes its own thread**, so codex holds a chat like Claude Code does.
-  vincent reads the `thread_id` the stream reports and hands it back as
-  `codex exec --json resume <thread_id>` on the next turn. The argv is pinned
-  by a capture against codex-cli 0.150.1; nothing is emulated, and vincent
-  never replays a conversation into the prompt.
+- **Resumes its own session**, so codex holds a
+  [chat](../reference/cli.md#vincent-chat) like Claude Code does. Resume is a
+  subcommand rather than a flag — `codex exec --json resume <thread_id>` —
+  and the prompt stays on stdin, because `exec resume` reads stdin when it is
+  given no prompt argument. vincent stores the `thread_id` the stream reports
+  on `thread.started` and hands it back on the next turn. The argv is pinned by
+  a capture against codex-cli 0.150.1; nothing is emulated, and vincent never
+  replays a conversation into the prompt. Workflow steps never set it: every
+  step still gets a fresh session. Two consequences, both stated rather than
+  worked around:
+  - A **resumed run is always full-auto.** `codex exec resume` has no
+    `--sandbox`, so `restricted` has no spelling on it. Only a chat turn ever
+    resumes, and a chat is always full-auto — there is no permission mode to
+    ask for on one — so this is a combination you cannot reach rather than a
+    restriction that gets dropped.
+  - A thread codex no longer knows fails that turn with `session_lost` rather
+    than quietly starting a new one.
 - **The plan and command output are surfaced.** Codex reports a running to-do
   list, which the pane shows with a `☰` gutter at the `normal` and `verbose`
   output levels, ticking over as the agent works. What a command printed shows
@@ -182,9 +195,12 @@ and would open a GUI. **Workflow value:** `agent: cursor`.
 - Reports token usage but **no cost**, and `supports_input: false` — so, like
   codex, cursor cannot back a step declaring `on_input: require`, and pinning it
   on one is a validation error.
-- **Cannot resume a session** either, and is refused for chats the same way.
-  `cursor-agent` has a `--resume` and emits a `session_id`; as with codex,
-  neither is wired here and no fixture pins the flag against a named build.
+- **Resumes its own session** too, with `--resume <session_id>` — the same
+  `session_id` its stream stamps on every line — so cursor can hold a chat.
+  Unlike claude and codex it has **no way to tell you a session is gone**:
+  handed a `--resume` id it has never seen it starts a fresh chat under that
+  id and answers normally, so a cursor chat whose session has aged out replies
+  without remembering the conversation instead of failing `session_lost`.
 - Errors do not arrive in the stream — an invalid model id exits 1 with a message
   on stderr and no result line — so the adapter reports "stream ended without a
   result event" plus the stderr tail, which is what makes an everyday typo
@@ -420,7 +436,8 @@ authority there, and you find out at run time.
 ## Choosing between them
 
 - **Anything where you may want to answer a question mid-run** — claude. It is
-  the only adapter that can be asked and resumed.
+  the only adapter that can be asked something mid-run; all three can be
+  resumed, so all three can hold a chat.
 - **Cost tracking matters** — claude. The other two report none, so the board's
   cost column stays empty for them and a configured per-task spend cap never
   fires. Vincent will not estimate money from token counts.

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1027,9 +1027,10 @@ project's actual default branch and follows the project row; leave it empty and
 the daemon resolves that default at creation.
 
 Only an agent that can resume its own session can hold a chat, so the agent
-list offers only those. The daemon refuses the rest at creation with that
-reason rather than a generic failure, and the form still renders it — it is the
-backstop, not the thing you are expected to walk into.
+picker offers only those — which today is all three of them. The daemon refuses
+anything else at creation with that reason rather than a generic failure, and
+the form still renders it — it is the backstop for the next adapter, not
+something you are expected to walk into.
 
 The draft owns the keyboard while it is open: every row, and every open list, so
 no keystroke leaks out to the global keys. `esc` closes an open list and leaves

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -337,7 +337,7 @@ daemon running.
   "agents":   [ { "name": "codex", "available": true, "path": "…",
                   "version": "0.147.0", "logged_in": true,
                   "supports_input": false, "version_verdict": "tested",
-                  "tested_versions": "0.142.5, 0.147.0",
+                  "tested_versions": "0.142.5, 0.147.0, 0.150.1",
                   "restricted_verdict": "supported" } ],
   "storage":  { "worktrees_dir": "…", "disk_free_bytes": 127310651392,
                 "disk_total_bytes": 494384795648,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -190,8 +190,8 @@ answered even for a CLI that is missing.
 `GET /v1/info`'s and `GET /v1/doctor`'s `agents[]`, beside `supports_input`.
 
 `supports_resume` is whether the adapter can resume its own session, and so
-whether it may hold a [chat](cli.md#vincent-chat): `true` for claude and codex,
-`false` for cursor. It is the same answer `POST /v1/chats` gates on, so a
+whether it may hold a [chat](cli.md#vincent-chat): `true` for all three shipped
+adapters. It is the same answer `POST /v1/chats` gates on, so a
 picker built on it and the `agent_cannot_resume` refusal cannot disagree, and
 like `restricted_verdict` it is answered for a CLI that is missing. It is
 `null` — never `false` — when the daemon has no adapter registry to ask, and a
@@ -1403,14 +1403,14 @@ continuity. An adapter that cannot resume is refused:
 
 ```json
 {"error": {"code": "agent_cannot_resume",
-           "message": "agent \"cursor\" cannot resume its own session, so it cannot hold a conversation; vincent refuses this rather than replaying the log as prompt context"}}
+           "message": "agent \"someagent\" cannot resume its own session, so it cannot hold a conversation; vincent refuses this rather than replaying the log as prompt context"}}
 ```
 
-Today that is cursor alone. codex joined claude when its `exec resume
-<thread_id>` was pinned by a capture against a named build; cursor-agent has a
-`--resume` of some shape and vincent does not read it yet, and faking continuity
-by replaying the log into the prompt is exactly what this refusal exists to
-prevent.
+All three shipped adapters can resume, so today nothing hits this. It is kept
+because it is the contract for the next adapter: faking continuity by replaying
+the log into the prompt is exactly what the refusal exists to prevent. Ask
+[`GET /v1/agents`](#get-v1agents) for `supports_resume` rather than assuming a
+list.
 
 ### States
 
@@ -1485,7 +1485,10 @@ Two failure reasons are worth knowing:
   fails, the chat stays usable and keeps its id, and nothing starts a fresh
   session behind your back: an agent answering with none of the conversation in
   context reads exactly like one that has it, so starting over is a decision you
-  make explicitly.
+  make explicitly. claude and codex both report this; **cursor cannot** — it
+  adopts an unknown session id and answers — so a cursor chat is the one place
+  that reading is unavoidable, and it is a property of the CLI rather than a
+  choice vincent makes.
 - **`interrupted`** — the daemon restarted under a live turn. It is **not**
   re-run, unlike a task's step: re-running would re-send your message into a
   session that died with the process. The chat returns to `idle`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1022,8 +1022,9 @@ Chats are not tasks. They never appear on the board, they run no workflow, and
 a chat turn never waits for a scheduler slot: it starts when you send it, or it
 is refused because `max_parallel_chats` chats are already running.
 
-Only an agent CLI that can resume its own session can hold a chat. Today that
-is `claude` and `codex`; `cursor` is refused at creation with
+Only an agent CLI that can resume its own session can hold a chat. All three
+shipped adapters can — `claude` with `--resume`, `codex` with `exec --json resume <id>`,
+`cursor` with `--resume`. An adapter that cannot is refused at creation with
 `agent_cannot_resume` rather than having the conversation faked by replaying
 the log as prompt context.
 
@@ -1048,7 +1049,10 @@ Sends a message and blocks until the turn ends, then prints the agent's answer
 on stdout. A failed turn prints its reason on stderr and exits 1 — including
 `session_lost`, which means the agent CLI no longer knows the session this chat
 was resuming. The chat stays usable; starting a fresh conversation is a
-decision you make, not one vincent makes silently.
+decision you make, not one vincent makes silently. `cursor` is the exception,
+and not one vincent can fix: it never refuses an unknown session id — it
+starts a fresh chat under it and answers — so a cursor chat whose session has
+aged out replies without remembering rather than failing.
 
 If the agent asks a question mid-turn the chat enters `awaiting_input` and the
 send keeps waiting, because the turn has not ended. Answer it from another

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,7 +132,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 26 | GitHub issue linking | **Read-only, daemon-side.** A task may be created *from* a GitHub issue when the project's `origin` parses as a github.com repository and `github.enabled` is on. The daemon prefers the `gh` CLI and falls back to `GITHUB_TOKEN`/`GH_TOKEN` from its inherited environment; **vincent stores no credential**, keeping §2's secret-management non-goal intact. The issue is fetched **once at creation**, snapshotted onto the task and never re-fetched, so `.Issue` (§8.4) renders offline and a run stays reproducible. The daemon makes every call — at pick time and create time only, never in the step path — and nothing here writes to GitHub, so row 11 is untouched (§5.3, §8.4, §12.3, §13.2, §14, §15; task 035, added 2026-08-26). *Narrowed 2026-08-29 (task 052):* this row is about **issues**; pull requests are row 27, which stores a pointer rather than a snapshot and reverses nothing here |
 | 27 | GitHub pull requests | **Daemon-side, and read-only until task 069**, like row 26 and through the same gate and credential. *Amended 2026-08-31 (task 068): the read side grows a live **check rollup** for a linked pull request's head commit — `GET /v1/tasks/{id}/github/pull/checks`, one normalized row per check run and per legacy commit status from either leg, never stored — and unlink gains a second home on the task workspace's Pull Request tab (§15 view 2). Task 068 decision 1 settled that merge, close, re-run and comment are written from the TUI only, human-triggered, and 068.4 is the sub-task that lands them and rewrites row 11.* A project's **open** pull requests are listed on demand, and a task is linked to the pull request whose head branch equals its own `branch_name` — by a daemon-side reconciler on a `github.poll_interval` tick, never as a side effect of a GET. Only the *link* is stored (`github_pull_json`: repo, number, source, suppressed) and it is a **pointer, not a snapshot** — the deliberate opposite of row 26, because draft, state and merged status are live by nature and a stored copy of them would read exactly like a current one while being wrong. A human may link or unlink; a human unlink is *sticky* and the reconciler never re-applies it, never overwrites a human link and never un-suppresses one. **Row 11 stands unamended**: vincent pushes nothing, opens nothing and merges nothing, and the “create a PR” affordance is a *constructed* compare URL — no request is made to GitHub when it is built — that a human clicks. `internal/github` gains no write method, no `POST` and no mutating `gh` subcommand. Task 035 decision 5's “repo identity is not stored” was revisited exactly as it predicted: the identity landed on the **task**, beside the number, and no `github_repo` column was added to projects (§5.3, §12.3, §13.2, §13.3, §14, §20; task 052, added 2026-08-29). *Narrowed 2026-08-30 (task 064):* the read-only posture holds in full — no write method, no `POST`, no mutating `gh` subcommand — and a task may now be created **from** a pull request and run on its head branch. That adds a flag to the same envelope (`branch`, `fork`) rather than a snapshot: nothing renderable is stored, so "a pointer, never a snapshot" is unchanged, and there is still no `.Pull` template variable. The consequences live in §10 (a second worktree creation mode, and archive never touching a branch vincent did not cut) and in §5.3's branch-name chain, which gains `pull` above the per-task literal. The listing above is narrowed the same way: it still **defaults** to open, but `?state=` (§13.2) makes a closed or merged pull request reachable, because acting on a merged one and redoing a reverted one are exactly what creating a task from one is for *Amended 2026-08-31 (task 069, issue #273):* the read-only posture gains **exactly one write path** — pull-request creation, from a human. `internal/github.CreatePull` is the only method here that writes, on both legs (`gh pr create`, `POST /repos/{owner}/{name}/pulls`); nothing updates, comments on, closes or merges anything, and `github.enabled` is the only gate on it (§12.3, decision 2: the consent is the keypress and the editable popup in front of it, not a second config key nobody would turn on). Every *other* half of this row is unchanged and load-bearing: the link is still a pointer and never a snapshot, the listing is still pure, the reconciler still never overwrites a human link, and the compare URL is still built by string construction with no request made — it is now the **fallback**, opened when there is no write credential or the create call fails, and the branch behind it has been pushed, so it is no longer a dead page. A create writes the link immediately as `source: human`, which is why the reconciler's poll interval does not make a just-created pull request read as unlinked |
 | 28 | MCP from the daemon | **A second protocol on the existing listener, not a second server.** `/mcp` is registered in §13.2's route table inside the same `recover → log → auth` chain, so row 4 is *added to*, not reversed: same loopback listener, same `Authorization: Bearer {token}` from `{data_dir}/token`, same `daemon.json` discovery. The tool surface **is** the route table — a call replays its arguments as an in-process request against the same handler, so the §13.1 bounds, the validation, the `409` + `details.state` envelopes and `Idempotency-Key` hold by construction — **minus five destructive-admin routes** (`daemon/stop`, `daemon/backup`, `DELETE projects/{id}`, `maintenance/gc`, `doctor/fix`), which is a design line: an agent must not be able to stop, garbage-collect or reconfigure the daemon supervising it. §13.3's SSE routes are replaced by a bounded blocking `task_wait` with a hard ceiling, whose result is complete for a client that drops every progress notification. A step parked in that wait **keeps its §11 slot** and a self-blocking wait is *refused*, not released — releasing it would create a §6 state owning a live agent process and holding no slot, which no state does today. The daemon wires its own agent steps to a **per-step endpoint** (`/mcp/step/{run_id}`, per-run secret), which is identity for the refusal and the provenance column and is explicitly **not** a security boundary (§16). Recursion is bounded by `created_by_task_id` + `mcp.max_depth`/`mcp.max_tasks`, deliberately **not** by `parent_task_id`, which the `awaiting_children` join counts (§9.1, §9.2, §9.3, §9.4, §9.7, §11, §12.3, §12.4, §13.4, §14, §16, §20; task 057, issue #243, added 2026-08-29) |
-| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). *Amended 2026-08-31 (issue #279):* `GET /v1/agents` publishes that answer as `supports_resume` (§9.6) so a client's picker offers only adapters that can hold a chat; the creation-time refusal is unchanged and stays the authority, and an absent field — an older daemon — filters nothing. A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15). *Amended 2026-08-31 (task 070, issue #268):* **codex resumes now**, so "codex and cursor are refused at creation with a typed reason" reads **cursor alone** — codex met the precondition task 063 decision 3 attached to it, a capture against a named build (codex-cli 0.150.1) pinning `codex exec --json resume <thread_id>`, and its `thread.started` id is read into `RunResult.SessionID` (§9.3). Nothing else in this row moves: continuity still comes from the CLI resuming its own session, vincent still replays no log as prompt context, and the refusal is still the authority for the adapters that cannot (§9.7). *Amended 2026-08-31 (task 071, issue #282):* a chat's live output is **normalized in the daemon exactly as a task's is** — §13.3's typed chunks, with the verbatim line kept as `raw` — and the chat workspace renders it with the output pane's own renderer at the session's shared verbosity level. The chat is still its own entity; what it is not is its own rendering vocabulary |
+| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). *Amended 2026-08-31 (issue #279):* `GET /v1/agents` publishes that answer as `supports_resume` (§9.6) so a client's picker offers only adapters that can hold a chat; the creation-time refusal is unchanged and stays the authority, and an absent field — an older daemon — filters nothing. A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15). *Amended 2026-08-31 (task 070, issue #268):* **codex resumes now**, so "codex and cursor are refused at creation with a typed reason" reads **cursor alone** — codex met the precondition task 063 decision 3 attached to it, a capture against a named build (codex-cli 0.150.1) pinning `codex exec --json resume <thread_id>`, and its `thread.started` id is read into `RunResult.SessionID` (§9.3). Nothing else in this row moves: continuity still comes from the CLI resuming its own session, vincent still replays no log as prompt context, and the refusal is still the authority for the adapters that cannot (§9.7). *Amended 2026-08-31 (task 071, issue #282):* a chat's live output is **normalized in the daemon exactly as a task's is** — §13.3's typed chunks, with the verbatim line kept as `raw` — and the chat workspace renders it with the output pane's own renderer at the session's shared verbosity level. The chat is still its own entity; what it is not is its own rendering vocabulary *Amended 2026-08-31 (task 072, issue #283):* **cursor resumes too**, pinned to a capture against cursor-agent 2026.08.11-e8db854, so "codex and cursor are refused at creation" is retired entirely and **no shipped adapter is refused**. The refusal path is unchanged and unretired — it is the contract for the next adapter — and is now proven against a stub adapter rather than a shipped one, which is what stops it asserting the opposite of the truth the day a capability lands. Two consequences are stated positively rather than worked around: a resumed codex run is always full-auto, because `codex exec resume` has no `--sandbox`, guarded structurally by chats having no requestable permission mode; and cursor cannot report a lost session at all, because it adopts an unknown `--resume` id and answers rather than refusing (§9.3, §9.7) |
 
 ## 4. Architecture
 
@@ -2021,8 +2021,10 @@ type RunSpec struct {
 // resume its own session (task 063). Optional rather than a method on
 // AgentAdapter so "a new adapter is one implementation with zero core changes"
 // stays true — an adapter that says nothing cannot resume. All three shipped
-// adapters implement it anyway, because §9.x states a missing capability
-// positively: codex and cursor return false with the reason written down.
+// adapters implement it anyway. Since task 070 (2026-08-31) all three return
+// true, each pinned to a named build; the false leg is exercised against a
+// stub adapter in internal/agent/agenttest, which is what keeps the refusal
+// proven now that nothing shipped answers no.
 type Resumer interface {
     SupportsResume() bool
 }
@@ -2408,8 +2410,31 @@ transcript is something people paste into issues.
   but a run with no `PROMPT` argument reads stdin anyway, which is what
   `RunSpec.Prompt`'s stdin-only contract (the Windows argv limit) requires.
   Nothing is emulated — codex resumes its own session, and vincent never
-  replays a conversation as prompt context. cursor still cannot (§9.7), and is
-  the adapter `m14`'s refusal leg now states this over.
+  replays a conversation as prompt context. *Amended 2026-08-31 (task 072,
+  issue #283):* the sentence that said "cursor still cannot" is retired —
+  cursor resumes too (§9.7), so `m14` has no shipped adapter left to state a
+  refusal over and that leg moved to a stub in Go.
+- **A resumed codex run is always full-auto (2026-08-31, task 072 decision
+  1).** `codex exec resume` carries no `-s/--sandbox` at all, so `restricted`
+  has no argv spelling on it and the adapter does not invent one — it always
+  passes `--dangerously-bypass-approvals-and-sandbox`. That is safe only
+  because the combination is unreachable rather than merely unreached:
+  `POST /v1/chats` hardcodes `full_auto` and exposes no request field to
+  override it, and nothing else in vincent sets `RunSpec.ResumeSessionID`. The
+  guard is structural — an `internal/api` test asserts chat creation cannot
+  produce a chat in any other mode — so the day chats gain a permission mode
+  this decision is reopened deliberately instead of being discovered as a
+  silent escalation in the field. Dropping a restriction quietly is the one
+  outcome worth spending a test on.
+- **`session_lost` is the only failure codex classifies (2026-08-31, task 072
+  decision 2).** A thread id codex no longer knows is refused on stderr with a
+  nonzero exit and no JSONL at all — `no rollout found for thread id <id>
+  (code -32600)`, captured from 0.150.1 — and that wording is matched **only**
+  for a run that actually passed a resume id, so no workflow step can be
+  misdiagnosed (§9.2's rule, verbatim). The usage-limit and unauthenticated
+  wordings stay unclassified, and task 003's decision still holds for them: an
+  account cannot be made to hit its quota on demand, so those have no
+  capturable fixture, while a bad thread id costs nothing to reproduce.
 - Normalizes Codex's JSONL events (`thread.started`, `item.started`,
   `item.updated`, `item.completed`, `turn.completed`, `turn.failed`, `error`);
   token usage comes from `turn.completed` (`input_tokens` taken verbatim, as
@@ -2812,15 +2837,28 @@ would invalidate every one of them.
   fixtures — and the shared vocabulary was designed so cursor can fill these
   later without another wire change. Until it does, all of them stay zero and
   none of them is emulated, asserted over every cursor fixture.
-- **Cannot resume (stated positively, 2026-08-30, task 063).**
-  `agent.CanResume` is false and a chat on cursor is refused at creation.
-  cursor-agent has a `--resume`, and its stream carries `session_id`, but the
-  adapter reads neither and no captured fixture pins the behaviour. Same rule,
-  same reason, same deferral (§20). *Amended 2026-08-31 (task 070):* this used
-  to open "As with codex" — it no longer holds. codex met exactly this bullet's
-  precondition and resumes now (§9.3), which leaves cursor the only adapter a
-  chat is refused on, and the one `m14`'s refusal leg is written against.
-- Invocation (pinned against cursor-agent 2026.08.04-aaa8809):
+- **Resume (pinned against cursor-agent 2026.08.11-e8db854, 2026-08-31, task
+  072).** `agent.CanResume` is true for cursor, so a chat may run on it (§5.5,
+  §13.2), replacing task 063's "cannot resume" on that decision's own deferral
+  terms. The flag is `--resume <chatId>`, and the id it accepts **is** the
+  `session_id` the stream stamps on every line — the single open question this
+  work carried, settled by capture, and the reason no `SessionCreator` seam
+  was built. `--resume` takes an *optional* value, which would be a hazard for
+  a CLI that also took a positional prompt; it is safe here only because this
+  adapter passes none (the prompt is piped on stdin), so the id is the last
+  thing on argv with nothing after it to swallow.
+- **cursor cannot report a lost session (stated positively, 2026-08-31, task
+  072 decision 2).** Handed a `--resume` id it has never seen, cursor-agent
+  does not refuse: it starts a fresh chat *under that id*, stamps it on every
+  line and exits 0 (captured against 2026.08.11-e8db854). So this adapter
+  ships no `session_lost` classifier — there is no refusal to recognize, and
+  inventing a match for a CLI that answered would be exactly the emulation
+  §9.x forbids. A cursor chat whose id has aged out gets an answer with no
+  memory of the conversation rather than a `session_lost` failure. The
+  usage-limit and unauthenticated wordings stay unclassified for task 003's
+  original reason, unchanged.
+- Invocation (pinned against cursor-agent 2026.08.04-aaa8809, and
+  2026.08.11-e8db854 for `--resume`):
   `cursor-agent -p --output-format stream-json --trust`, cwd = worktree,
   prompt via **stdin** (piped, no prompt argument — verified: the echoed
   `user` line carries the piped text). Full-auto adds `--force`; restricted
@@ -7475,13 +7513,16 @@ the † descoping at roughly its gap to Linux. Details in tasks.md T4.6.
   future work on landing, 2026-08-30** (§5.5, task 063, issue #255). Like the
   MCP entry above it was never listed here, so it is recorded as promoted rather
   than struck through. Named here so the next person does not rediscover them,
-  the pieces deliberately left out of the first cut: ~~**codex `exec resume
-  <thread_id>`**~~ — **landed 2026-08-31 (task 070, issue #268)**, with the
-  fixture that entry required, captured against codex-cli 0.150.1 (§9.3) — and
-  **cursor `--resume`**, which still lands with a fixture captured against a
-  named CLI version the way every other adapter capability has; until then
-  cursor is *refused* at chat creation, never emulated by replaying a log as
-  prompt context; a **`notify.chat_on` key**, if
+  the pieces deliberately left out of the first cut. Two are now done:
+  ~~**codex `exec resume <thread_id>`**~~ — **landed 2026-08-31 (task 070,
+  issue #268)** — and ~~**cursor `--resume`**~~ — **landed 2026-08-31 (task
+  072, issue #283)** — each pinned to a captured fixture from a named build,
+  codex-cli 0.150.1 and cursor-agent 2026.08.11-e8db854, which is the
+  condition this entry and task 063 decision 3 both attached (§9.3, §9.7). No
+  shipped adapter is refused at chat creation any more; the
+  `agent_cannot_resume` path itself is kept, is still the contract for the
+  next adapter, and is proven against a stub. Still open: a
+  **`notify.chat_on` key**, if
   `awaiting_input` on a long-open chat proves to need an outward signal (§12.3);
   and **chat routes as MCP tools**, which stays refused on the design line in
   §13.4 rather than merely deferred.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2501,6 +2501,10 @@ transcript is something people paste into issues.
 *Amended 2026-08-28 (task 041).* Verified builds: `0.142.5` (the invocation
 pinned above) and `0.147.0` (the reasoning capture, T4.17). `Detect` reports
 `version_verdict` against that list, advisory in exactly the way §9.2 records.
+*Amended 2026-08-31 (task 070):* `0.150.1` joins them — the `exec resume`
+capture above, which pins the resumed argv, `thread.started` and the refusal of
+an unknown thread id. Three entries, one per capture, because the list is what
+`tested_versions` publishes and a build vincent has fixtures for belongs in it.
 
 *Added 2026-08-29 (task 057).* codex has no `--mcp-config`, but `codex exec`
 takes `-c key=value` dotted TOML overrides and (verified against 0.150.1)

--- a/docs/tasks/072-codex-and-cursor-in-chat.md
+++ b/docs/tasks/072-codex-and-cursor-in-chat.md
@@ -1,0 +1,133 @@
+# 072 — Chats on codex and cursor
+
+**Status:** ✅ done (1/1)
+**Issue:** #283
+**Closes:** [063](063-free-chat.md) decision 3's deferral, and §20's chat entry
+for codex and cursor
+
+Task 063 shipped chats on claude only and refused codex and cursor at creation
+with `agent_cannot_resume`. That refusal was never a judgement that those CLIs
+cannot resume — it was that the capability had not been *proved*. Every record
+that touched it deferred rather than closed the question, and each named the
+same unblocking condition: a fixture captured against a named CLI build.
+
+- **063 decision 3** — "codex `exec resume <thread_id>` and cursor `--resume`
+  are follow-up work, each landing with a fixture captured against a named CLI
+  version."
+- **§20's chat entry** — names both, "until then those adapters are *refused*".
+- **§9.3 / §9.7 "Cannot resume"** — "no fixture captured against a named codex
+  build proves the argv", "Deferred to §20 with the fixture requirement
+  attached."
+
+The condition is met: `codex-cli 0.150.1` and `cursor-agent
+2026.08.11-e8db854`, both captured for this work. What is **not** reopened:
+replaying the conversation as prompt context stays rejected, `agent.Resumer`
+stays an optional interface rather than an `Adapter` method (§9.1), and the
+`agent_cannot_resume` path is kept rather than deleted.
+
+## Decisions
+
+**1. A resumed codex run is full-auto, and that is made unreachable rather than
+merely unreached.** `codex exec resume` carries `--json`, `-m`, `-c` and
+`--dangerously-bypass-approvals-and-sandbox`, but no `-s/--sandbox` at all, so
+`restricted` has no argv spelling on it. The adapter does not invent one: a
+resumed run always passes the bypass flag, and §9.3 states that positively the
+way every other codex limitation is stated.
+
+Silently dropping a restriction is the one outcome worth guarding, so the guard
+is structural rather than a run-time check. `POST /v1/chats` hardcodes
+`PermissionMode: full_auto` and has no request field to override it — the
+decoder rejects unknown fields, so there is nothing to ask with — and nothing
+else in the codebase sets `RunSpec.ResumeSessionID`. `TestChatsAreAlwaysFullAuto`
+in `internal/api` asserts both halves. The day chats gain a permission mode, it
+fails, and this is reopened deliberately instead of being discovered as an
+escalation in the field. `-c sandbox_mode="workspace-write"` was considered and
+rejected: more capture work than an unreachable branch is worth.
+
+**2. The classifier is `session_lost`, on codex only, and nothing else.** codex
+gains a `failure.go` recognizing exactly one condition, matched **only** when
+the run actually passed a resume id, so no workflow step can be misdiagnosed
+(§9.2's rule, verbatim). `usage_limit` and `unauthenticated` stay unclassified
+on both adapters: an account cannot be made to hit its quota on demand, so
+those wordings still have no capturable fixture and task 003's decision still
+holds for them. `TestQuotaAndAuthStopsStayUnclassified` passes untouched on
+both — its scenarios pass no resume id — and its doc comment's "this adapter
+recognizes nothing" was amended rather than left to become false.
+
+cursor gets **no** `failure.go`, and for a stronger reason than a missing
+fixture. The capture (`resume_unknown_2026.08.11.jsonl`) shows cursor-agent
+does not refuse an unknown `--resume` id at all: it starts a fresh chat under
+that id, stamps it on every line and exits 0. There is no refusal to
+recognize, so matching one would be a guess about a CLI that answered. The
+brief anticipated a `failure.go` here; the capture said otherwise and the
+capture wins, which is exactly the "provisional until pinned by fixtures" rule
+this work was run under.
+
+**3. cursor's stream id *is* the id `--resume` accepts, so no `SessionCreator`
+was built.** This was the single largest risk in the issue and the one thing
+that made cursor contingent: every line of the existing cursor fixture carries
+`session_id`, but the capture scrubbed it, so nothing on disk showed the
+stream's id was the resume key. A two-turn capture settled it — turn 2 resumed
+turn 1's `session_id` and answered from it. The contingent optional
+`agent.SessionCreator` interface, and `create-chat`, are therefore not built:
+no core change at all, which is the evidence the optional-interface choice in
+§9.1 was right.
+
+**4. The prompt on a resumed codex run is the literal `-`.** `codex exec
+[PROMPT]` reads stdin when the prompt argument is absent, which is why a fresh
+run passes none. `codex exec resume [SESSION_ID] [PROMPT]` does **not**: its
+help says stdin is read only "if `-` is used". So the resumed argv is `exec
+resume --json <flags> <id> -`, and `buildArgs` grows positionals it has never
+had. Getting this wrong hangs the child on a stdin nobody reads until the step
+timeout, which is why it is a decision and not an implementation detail.
+
+**5. The refusal is proven against a stub, and the gate loses its refusal
+leg.** `internal/api/chats_test.go` and `internal/chatrun/runner_test.go` used
+codex and cursor as their non-resuming examples, and would now assert the
+opposite of the truth. Both re-point at `agenttest.StubNonResuming` — placed in
+`internal/agent/agenttest` because both packages need it. That is not just a
+fix: a refusal pinned to whichever CLI happens to lack a capability today will
+keep inverting itself, and a stub cannot.
+
+`scripts/m14-gate.sh`'s refusal leg goes, because after this no shipped adapter
+is refused and a real daemon has no subject that can reach it. Registering a
+test-only non-resuming adapter in the daemon was rejected — shipping a fake
+adapter in the production registry cuts against the same §9.1 property this
+exists to protect — and re-pointing the leg at an unknown agent name was
+rejected because that asserts `validation_failed`, a different code and a
+different contract. The gate instead walks the two-turn continuity check on all
+three adapters.
+
+## What shipped
+
+- `internal/agent/codex` — `buildArgs` changes shape for a resumed run;
+  `stream.go` gains `threadIDOf` and an explicit `thread.started` case;
+  `failure.go` is new; `SupportsResume()` is true; `testedVersions` gains
+  `0.150.1`. Fixtures: `resume_0.150.1.jsonl`, `resume_lost_0.150.1.txt`.
+- `internal/agent/cursor` — `buildArgs` appends `--resume <id>` last (an
+  optional-value flag must have nothing after it to swallow, which is safe only
+  because the prompt is piped); `stream.go` gains `sessionIDOf`;
+  `SupportsResume()` is true. Fixtures: `resume_2026.08.11.jsonl`,
+  `resume_unknown_2026.08.11.jsonl`.
+- **No core change.** `internal/api/chats.go`, `GET /v1/agents`'
+  `supports_resume` and the TUI's `resumableAgents` all read `agent.CanResume`
+  and were not touched.
+- `cmd/fakeagent` — the session store is dialect-aware: codex's `exec resume
+  <id> -`, cursor's `--resume <id>`, each with the lost-session behaviour its
+  real CLI has (codex refuses in codex's captured wording; cursor adopts the
+  id). `codexMain` and `cursorMain` gained the `openSession`/`rememberPrompt`/
+  `recallLine` calls only `claudeMain` made, and codex's hardcoded
+  `"thread_id": "fake-thread-1"` is now the minted id.
+- `scripts/m14-gate.sh` — refusal leg out, two-turn walk on all three adapters.
+- Spec §9.1, §9.3, §9.7, §20 and decision row 29 amended in place, dated;
+  `docs/features.md`, `docs/guides/agents.md`, `docs/guides/tui.md`,
+  `docs/reference/api.md` and `docs/reference/cli.md` updated.
+
+## Out of scope, stated
+
+Neither `codex exec` nor `cursor-agent -p` has a mid-run input channel
+(`InputSupport: InputNever`, §9.3/§9.7), so a chat on either never enters
+`awaiting_input`: no mid-run questions, no permission prompts, and the chat
+answer route does nothing for it. Documented positively like every other
+missing capability; explicitly not worked around, and not a blocker on the chat
+being useful.

--- a/docs/tasks/072-codex-and-cursor-in-chat.md
+++ b/docs/tasks/072-codex-and-cursor-in-chat.md
@@ -131,3 +131,25 @@ Neither `codex exec` nor `cursor-agent -p` has a mid-run input channel
 answer route does nothing for it. Documented positively like every other
 missing capability; explicitly not worked around, and not a blocker on the chat
 being useful.
+
+## One thing found on the way (2026-08-31)
+
+Running three adapters through `internal/chatrun`'s tests instead of one made
+the package slow enough to lose a race that had been latent since task 063, and
+`TestTurnTranscriptStopsAtTheCap` hung the package at its 10-minute deadline.
+
+`chatrun.consume` returned on every early exit — cancel, `agent_timeout`,
+`input_timeout`, the transcript cap — leaving the adapter's stream unread. An
+adapter's reader goroutine blocks on the handover (claude's `readLoop` → `mux`
+→ `events`) and its `Wait` blocks until the reader is done, so nothing ever
+finished: the turn stayed non-terminal, the chat never returned to idle, its
+§11 slot was never released and `Runner.Stop` blocked with it. The 64+64-event
+buffers are what hid it — the deadlock lands only when the agent got that far
+ahead before the kill.
+
+`internal/taskrun` never had the bug and says why in `steps.go` ("the stream is
+left to drain so Wait still reports an exit"). `consume` now does the same
+through `Runner.drain`, and `TestTurnDrainsTheStreamItAbandons` holds it there
+against a stub adapter with no buffers at all, so the assertion does not depend
+on winning a race. Fixed here rather than deferred: it is the check for this
+task that went red, and it is a hang a user reaches with any talkative agent.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -85,6 +85,7 @@ the living engineering specification records implementation contracts.
 | [069](069-open-a-pull-request-from-vincent.md) | Open a pull request from vincent itself | 🔄 in progress (7/8) |
 | [070](070-codex-stream-surface.md) | Extend codex output parsing to the full exec event schema, and support thread resume | ✅ done (5/5) |
 | [071](071-chat-workspace-verbosity.md) | The chat workspace renders through the output pane at a shared verbosity level | ✅ done (1/1) |
+| [072](072-codex-and-cursor-in-chat.md) | Chats on codex and cursor | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -96,9 +96,11 @@ var ErrResumeUnsupported = errors.New("this agent CLI cannot resume a previous s
 // It is an optional interface rather than an Adapter method so that "adding an
 // agent CLI is one new implementation with zero core changes" stays true: an
 // adapter that says nothing cannot resume. All three shipped adapters
-// implement it anyway, because §9.x states a missing capability positively —
-// codex and cursor return false with the reason in their doc comment rather
-// than leaving a reader to infer it from an absence.
+// implement it, and since task 070 all three return true, each pinned to a
+// fixture from a named CLI build. The false leg is exercised against
+// agenttest.StubNonResuming — a refusal proven only against whichever CLI
+// happens to lack the capability today inverts itself the day that CLI gains
+// it, which is exactly what happened here.
 type Resumer interface {
 	// SupportsResume reports whether Start honors RunSpec.ResumeSessionID.
 	SupportsResume() bool
@@ -597,6 +599,12 @@ const (
 	// FailureSessionLost is a resume the CLI refused because the session id
 	// it was given is gone or expired (task 063 decision 4). Only a chat
 	// turn can produce it — nothing else sets RunSpec.ResumeSessionID.
+	//
+	// claude and codex report it; cursor cannot, and that is the CLI's doing
+	// rather than a gap in its adapter — handed an id it has never seen,
+	// cursor-agent starts a fresh chat under that id and answers (§9.7, task
+	// 070 decision 2). So a cursor chat is the one place the reading below
+	// actually happens, and it is stated rather than emulated.
 	//
 	// The engine fails the turn with `session_lost` rather than falling back
 	// to a fresh session: the human asked to continue a conversation, and an

--- a/internal/agent/agenttest/stub.go
+++ b/internal/agent/agenttest/stub.go
@@ -1,0 +1,70 @@
+package agenttest
+
+import (
+	"context"
+	"errors"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// NonResumingName is the adapter name StubNonResuming registers under. It is
+// deliberately not the name of any shipped CLI: the point of the stub is that
+// the refusal outlives the three adapters that happen to exist today.
+const NonResumingName = "stubnoresume"
+
+// StubNonResuming is an adapter that cannot resume a prior session, and does
+// nothing else at all.
+//
+// It exists because the `agent_cannot_resume` refusal (§5.5, task 063
+// decision 3) has to keep being proven after task 070 taught codex and cursor
+// to resume, and nothing shipped answers false any more. Pointing those tests
+// at a shipped adapter is what made them assert the opposite of the truth the
+// day the capability landed; pointing them here is what stops that recurring
+// for the next adapter.
+//
+// It is a stub rather than a fakeagent dialect on purpose: `SupportsResume()
+// == false` is the entire behaviour under test, and no subprocess can make
+// that statement any truer. Nothing registers it in the daemon's real
+// registry — shipping a fake adapter in production would cut against the same
+// §9.1 property this test is defending.
+type StubNonResuming struct{}
+
+var errStub = errors.New("stub adapter: never started")
+
+// Name implements agent.Adapter.
+func (StubNonResuming) Name() string { return NonResumingName }
+
+// Detect implements agent.Adapter: present enough to be listed, so a test can
+// reach the refusal rather than an "agent not found".
+func (StubNonResuming) Detect(context.Context) (agent.Availability, error) {
+	return agent.Availability{Found: true, Path: NonResumingName, Version: "0"}, nil
+}
+
+// Options implements agent.Adapter: nothing to select.
+func (StubNonResuming) Options(context.Context) (agent.Options, error) {
+	return agent.Options{}, nil
+}
+
+// Path implements agent.Adapter.
+func (StubNonResuming) Path() (string, error) { return NonResumingName, nil }
+
+// Curated implements agent.Adapter.
+func (StubNonResuming) Curated() agent.Options { return agent.Options{} }
+
+// NewLineParser implements agent.Adapter: every line is unknown, since this
+// adapter never writes one.
+func (StubNonResuming) NewLineParser() agent.LineParser {
+	return func(raw []byte) agent.Event {
+		return agent.Event{Type: agent.EventUnknown, Raw: raw}
+	}
+}
+
+// Start implements agent.Adapter, in the negative: a chat on this adapter is
+// refused before anything is started, so reaching here is the bug.
+func (StubNonResuming) Start(context.Context, agent.RunSpec) (agent.RunHandle, error) {
+	return nil, errStub
+}
+
+// SupportsResume implements agent.Resumer, in the negative — the one thing
+// this type is for.
+func (StubNonResuming) SupportsResume() bool { return false }

--- a/internal/agent/codex/codex.go
+++ b/internal/agent/codex/codex.go
@@ -1,7 +1,8 @@
 // Package codex implements the agent adapter for the Codex CLI: headless
 // `codex exec --json` runs with JSONL event parsing, model/effort
 // passthrough, and tree-kill support (spec §9.3; T2.9). Invocation and
-// stream shapes are pinned against codex-cli 0.142.5.
+// stream shapes are pinned against codex-cli 0.142.5, and the resumed
+// invocation (`exec resume`, §5.5) against 0.150.1.
 package codex
 
 import (
@@ -144,15 +145,31 @@ func (a *Adapter) loggedIn(ctx context.Context, path string) *bool {
 }
 
 // buildArgs assembles the pinned CLI invocation (spec §9.3, verified against
-// codex-cli 0.142.5). Full-auto is the documented automation switch;
-// restricted confines writes to the worktree — note that a `git commit` from
-// a restricted step may be denied in a linked worktree, whose real git dir
-// lives under the main repo (vincent itself never needs commits). The prompt
-// is never an argv element: with stdin piped and no prompt argument, codex
-// reads the instructions from stdin.
+// codex-cli 0.142.5 for a fresh run and 0.150.1 for a resumed one). Full-auto
+// is the documented automation switch; restricted confines writes to the
+// worktree — note that a `git commit` from a restricted step may be denied in
+// a linked worktree, whose real git dir lives under the main repo (vincent
+// itself never needs commits).
+//
+// A resumed run is a different subcommand, not a flag: `codex exec resume
+// [SESSION_ID] [PROMPT]`. Two consequences the fresh shape does not have:
+//
+//   - The prompt must be the literal `-`. `codex exec` with no prompt
+//     argument reads stdin, which is why a fresh run passes none; `exec
+//     resume` reads stdin only "if `-` is used" (0.150.1 --help). Omitting it
+//     leaves the child waiting on a stdin nobody reads until the step
+//     timeout.
+//   - `exec resume` has no `-s/--sandbox`, so restricted has no argv spelling
+//     here at all and a resumed run is always full-auto (task 072 decision 1).
+//     Nothing in vincent can reach that combination: only a chat turn sets
+//     ResumeSessionID, and POST /v1/chats hardcodes full_auto with no request
+//     field to override it. The day that stops being true, this needs an
+//     answer rather than a silently dropped restriction, which is what
+//     TestChatsAreAlwaysFullAuto in internal/api exists to force.
 func buildArgs(spec agent.RunSpec) []string {
+	resuming := spec.ResumeSessionID != ""
 	args := []string{"exec", "--json"}
-	if spec.ResumeSessionID != "" {
+	if resuming {
 		// `codex exec resume [SESSION_ID] [PROMPT]`, verified against
 		// codex-cli 0.150.1 (task 070). The prompt is left off argv on
 		// purpose: `resume`'s help documents `-` for stdin, but a run with
@@ -160,13 +177,25 @@ func buildArgs(spec agent.RunSpec) []string {
 		// "Reading prompt from stdin…" — which is what `exec` does and what
 		// RunSpec.Prompt's stdin-only contract needs (Windows argv limit).
 		//
-		// `resume` takes the same options as `exec`, so everything below
-		// still applies; only the subcommand and the id are inserted here.
+		// `resume` takes the same options as `exec` bar one, so everything
+		// below still applies; only the subcommand and the id are inserted
+		// here.
 		args = append(args, "resume", spec.ResumeSessionID)
 	}
-	if spec.PermissionMode == agent.Restricted {
+	switch {
+	case resuming:
+		// The one option `exec resume` does not take is `-s/--sandbox`; it
+		// carries only --dangerously-bypass-approvals-and-sandbox. So
+		// Restricted has no argv spelling on a resumed run, and such a run is
+		// always full-auto (§9.3, task 072 decision 1). That is guarded
+		// structurally rather than by a run-time check: POST /v1/chats
+		// hardcodes full_auto with no request field to override it, nothing
+		// else in the codebase sets RunSpec.ResumeSessionID, and
+		// TestChatsAreAlwaysFullAuto fails the day either changes.
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+	case spec.PermissionMode == agent.Restricted:
 		args = append(args, "--sandbox", "workspace-write")
-	} else {
+	default:
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 	if spec.Model != "" {
@@ -236,6 +265,7 @@ func (a *Adapter) Start(ctx context.Context, spec agent.RunSpec) (agent.RunHandl
 	}
 	r := &run{
 		cmd:        cmd,
+		resuming:   spec.ResumeSessionID != "",
 		proc:       proc,
 		stderr:     stderr,
 		events:     make(chan agent.Event, 64),
@@ -263,8 +293,20 @@ type run struct {
 	readerDone chan struct{}
 	procDone   chan struct{}
 
+	// resuming records that this run was started with a thread id, so Wait
+	// can tell a thread codex refused to load from any other failure
+	// (task 072 decision 2).
+	resuming bool
+
 	mu       sync.Mutex
 	terminal *agent.RunResult // assembled from turn.completed / turn.failed
+	// sessionID is the last `thread_id` codex reported. Only `thread.started`
+	// carries one — unlike claude, codex does not stamp it on every line — and
+	// a resumed run repeats the id it was given (verified against 0.150.1,
+	// testdata/resume_0.150.1.jsonl). Last-wins anyway, matching claude (§9.2):
+	// what a future build does with a forked thread is its business, and the
+	// id the run actually finished in is the one a chat must store.
+	sessionID string
 	// streamErr is readLoop's own reader failing, latched for Wait. It is
 	// vincent losing the stream, not the CLI failing, and Wait says so with
 	// agent.FailureStreamError rather than letting the exit code speak for a
@@ -291,6 +333,11 @@ func (r *run) readLoop(rd io.Reader) {
 		copy(line, sc.Bytes())
 		if len(strings.TrimSpace(string(line))) == 0 {
 			continue
+		}
+		if tid := threadIDOf(line); tid != "" {
+			r.mu.Lock()
+			r.sessionID = tid
+			r.mu.Unlock()
 		}
 		ev := st.parse(line)
 		if ev.Type == agent.EventResult && ev.Result != nil {
@@ -336,13 +383,12 @@ func (r *run) PID() int { return r.cmd.Process.Pid }
 // consumed and the process has exited, then assembles the RunResult per
 // §7.1: the terminal turn event plus the exit code.
 //
-// RunResult.Failure is deliberately left nil (task 003): codex's usage-limit
-// and unauthenticated wordings are not fixture-verified, and this adapter
-// ships no guess in their place. A quota stop here therefore reads exactly as
-// it did before task 003 — nonzero_exit or agent_error — rather than as an
-// invented match. Adding it later is a `classify` beside this call and a
-// `usage-limit` case in cmd/fakeagent's codex dialect, which is already there
-// and already asserted to produce today's behaviour.
+// A usage-limit or unauthenticated stop is still deliberately left
+// unclassified (task 003): those wordings are not fixture-verified, and this
+// adapter ships no guess in their place. A quota stop here therefore reads
+// exactly as it did before task 003 — nonzero_exit or agent_error. The one
+// condition it does name is a thread codex refused to resume, which is
+// fixture-verified (task 070; testdata/resume_lost_0.150.1.txt).
 func (r *run) Wait() (agent.RunResult, error) {
 	r.waitOnce.Do(func() {
 		<-r.readerDone
@@ -356,8 +402,9 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal, streamErr := r.terminal, r.streamErr
+		terminal, streamErr, sessionID := r.terminal, r.streamErr, r.sessionID
 		r.mu.Unlock()
+		res.SessionID = sessionID
 		if terminal != nil {
 			res.IsError = terminal.IsError
 			res.ErrorMessage = terminal.ErrorMessage
@@ -378,6 +425,12 @@ func (r *run) Wait() (agent.RunResult, error) {
 				res.ErrorMessage += ": " + tail
 			}
 		}
+		// The adapter's verdict on *why* the run stopped (§9.1). It happens
+		// here because this is the one place that holds both the terminal
+		// result and the stderr tail; the engine sees neither. A refused
+		// resume is the only thing codex classifies, and only for a run that
+		// actually passed a thread id (task 072 decision 2).
+		res.Failure = classifyResume(res, r.stderr.String(), r.resuming)
 		// A stream vincent could not read to the end outranks whatever the
 		// exit code says: the run may well have finished cleanly, but the
 		// record of it is missing lines, and §7.1 success is a claim about
@@ -427,4 +480,8 @@ func (r *run) Argv() []string { return r.cmd.Args }
 // thread_id and answers a question about the previous turn). Nothing is
 // emulated: codex resumes its own session, and vincent never replays a
 // conversation as prompt context.
+//
+// Resuming is what lets a chat (§5.5) run on this adapter. Each of its three
+// halves has a captured fixture under testdata/: the argv in buildArgs, the
+// `thread_id` in stream.go, and the refusal of a dead id in failure.go.
 func (a *Adapter) SupportsResume() bool { return true }

--- a/internal/agent/codex/failure.go
+++ b/internal/agent/codex/failure.go
@@ -1,0 +1,47 @@
+package codex
+
+import (
+	"strings"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// threadLostMarkers are the phrasings that mean "the thread id you asked me
+// to resume is not one I know". Captured from codex-cli 0.150.1 refusing an
+// id it had never minted (testdata/resume_lost_0.150.1.txt):
+//
+//	Error: thread/resume: thread/resume failed: no rollout found for thread id
+//	00000000-0000-4000-8000-000000000000 (code -32600)
+//
+// The refusal arrives on stderr and stdout carries no JSONL at all, so Wait's
+// no-result branch is what folds it into the error message; classifyResume
+// reads the stderr tail directly as well, for the same reason claude's does.
+//
+// Unlike claude's usage-limit and unauthenticated markers, these *are*
+// fixture-verified — a bad id costs nothing to reproduce, which is precisely
+// why this is the one condition codex classifies and the quota wordings still
+// are not (task 072 decision 2).
+var threadLostMarkers = []string{
+	"no rollout found for thread id",
+	"thread/resume failed",
+}
+
+// classifyResume names a resume codex refused (task 072 decision 2). It
+// returns nil for a run that did not resume at all, and for a resumed run
+// that succeeded — a chat turn's ordinary case.
+//
+// The `resuming` guard is not defensive: it is §9.2's rule verbatim. A
+// workflow step never passes a thread id, so no step can be misdiagnosed as a
+// lost session however its output is worded.
+func classifyResume(res agent.RunResult, stderr string, resuming bool) *agent.Failure {
+	if !resuming || !res.IsError {
+		return nil
+	}
+	text := strings.ToLower(strings.Join([]string{res.ErrorMessage, res.ResultText, stderr}, "\n"))
+	for _, m := range threadLostMarkers {
+		if strings.Contains(text, m) {
+			return &agent.Failure{Kind: agent.FailureSessionLost}
+		}
+	}
+	return nil
+}

--- a/internal/agent/codex/failure_test.go
+++ b/internal/agent/codex/failure_test.go
@@ -3,9 +3,16 @@ package codex
 import "testing"
 
 // TestQuotaAndAuthStopsStayUnclassified pins the codex half of task 003's
-// decision: this adapter recognizes nothing, because its usage-limit and
-// unauthenticated wordings are not fixture-verified, so a run stopped by
-// either reads exactly as it did before — an ordinary failure under §7.2.
+// decision: this adapter recognizes neither of these two, because its
+// usage-limit and unauthenticated wordings are not fixture-verified, so a run
+// stopped by either reads exactly as it did before — an ordinary failure under
+// §7.2.
+//
+// "Neither of these two", not "nothing at all", since task 070: a thread codex
+// refused to resume *is* classified, because a bad id costs nothing to
+// reproduce and its wording has a fixture. These scenarios pass no resume id,
+// so they never reach that classifier — which is the same guard stated from
+// the other side in TestClassifyResumeIsNarrow.
 //
 // The test exists rather than the classification because the risk here is the
 // opposite of a missing feature: an adapter that starts guessing would send a

--- a/internal/agent/codex/resume_test.go
+++ b/internal/agent/codex/resume_test.go
@@ -1,0 +1,187 @@
+package codex
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// resumedThreadID is the id testdata/resume_0.150.1.jsonl was scrubbed to. The
+// capture's own UUID is replaced, but with one value on every line, because
+// the fact being pinned is that a resumed run reports the id it was given.
+const resumedThreadID = "01a0586e-5a43-7001-9628-cde66a53e993"
+
+// TestBuildArgsResume pins the resumed invocation against codex-cli 0.150.1
+// (§9.3, task 070). Two things are load-bearing and neither is inferable from
+// the fresh shape:
+//
+//   - `resume` is a subcommand taking the id as a positional, so the argv
+//     changes shape rather than gaining a flag.
+//   - `exec resume` has no `-s/--sandbox` — it carries only
+//     --dangerously-bypass-approvals-and-sandbox — so Restricted has no
+//     spelling here and a resumed run is always full-auto (decision 1,
+//     guarded in internal/api by TestChatsAreAlwaysFullAuto).
+//
+// The prompt stays off argv: `resume`'s help documents `-` for stdin, but a
+// run with no PROMPT argument reads stdin anyway ("Reading prompt from
+// stdin…" on the capture's stderr), which is what RunSpec.Prompt's
+// stdin-only contract needs under the Windows argv limit.
+func TestBuildArgsResume(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec agent.RunSpec
+		want []string
+	}{
+		{
+			name: "resume is a subcommand with the prompt on stdin",
+			spec: agent.RunSpec{PermissionMode: agent.FullAuto, ResumeSessionID: "t-1"},
+			want: []string{
+				"exec", "--json", "resume", "t-1",
+				"--dangerously-bypass-approvals-and-sandbox",
+			},
+		},
+		{
+			name: "restricted has no spelling on resume, so the run is full-auto",
+			spec: agent.RunSpec{PermissionMode: agent.Restricted, ResumeSessionID: "t-1"},
+			want: []string{
+				"exec", "--json", "resume", "t-1",
+				"--dangerously-bypass-approvals-and-sandbox",
+			},
+		},
+		{
+			name: "model and effort still ride behind the positional",
+			spec: agent.RunSpec{
+				Model: "gpt-5.6-sol", Effort: "xhigh", ResumeSessionID: "t-1",
+			},
+			want: []string{
+				"exec", "--json", "resume", "t-1",
+				"--dangerously-bypass-approvals-and-sandbox",
+				"-m", "gpt-5.6-sol", "-c", "model_reasoning_effort=xhigh",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildArgs(tt.spec)
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Errorf("buildArgs = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResumeFixtureReportsItsThreadID pins the stream half: a resumed run
+// opens with `thread.started` carrying the id it was handed, which is what
+// RunResult.SessionID must end up holding.
+func TestResumeFixtureReportsItsThreadID(t *testing.T) {
+	var last string
+	for _, line := range fixtureLines(t, "resume_0.150.1.jsonl") {
+		if id := threadIDOf(line); id != "" {
+			last = id
+		}
+	}
+	if last != resumedThreadID {
+		t.Fatalf("thread id = %q, want %q", last, resumedThreadID)
+	}
+	// And the turn itself parsed, so the id did not come from a stream the
+	// normalizer choked on.
+	res := terminal(t, parseFixture(t, "resume_0.150.1.jsonl"))
+	if res.IsError || res.ResultText == "" {
+		t.Fatalf("resumed turn = %+v, want a completed turn with text", res)
+	}
+}
+
+// TestThreadStartedIsNotAnEvent states what `thread.started` is for: it
+// carries the run's identity, not something a transcript reader needs
+// normalized. It still arrives verbatim, which is what Raw is for.
+func TestThreadStartedIsNotAnEvent(t *testing.T) {
+	ev := (&stream{}).parse([]byte(`{"type":"thread.started","thread_id":"t-1"}`))
+	if ev.Type != agent.EventUnknown {
+		t.Errorf("thread.started = %q, want %q", ev.Type, agent.EventUnknown)
+	}
+	if len(ev.Raw) == 0 {
+		t.Error("thread.started lost its raw line")
+	}
+	if got := threadIDOf(ev.Raw); got != "t-1" {
+		t.Errorf("threadIDOf = %q, want t-1", got)
+	}
+	if got := threadIDOf([]byte("not json")); got != "" {
+		t.Errorf("threadIDOf(garbage) = %q, want empty", got)
+	}
+}
+
+// TestClassifyResumeMatchesTheCapturedRefusal is decision 2's narrow
+// classifier, against the wording codex-cli 0.150.1 actually printed
+// (testdata/resume_lost_0.150.1.txt). The refusal arrives on stderr with no
+// JSONL at all, which is why Wait's no-result branch is the shape under test.
+func TestClassifyResumeMatchesTheCapturedRefusal(t *testing.T) {
+	stderr := readFixtureText(t, "resume_lost_0.150.1.txt")
+	res := agent.RunResult{
+		ExitCode: 1, IsError: true,
+		ErrorMessage: "stream ended without a result event: " + stderr,
+	}
+	f := classifyResume(res, stderr, true)
+	if f == nil || f.Kind != agent.FailureSessionLost {
+		t.Fatalf("classifyResume = %+v, want %s", f, agent.FailureSessionLost)
+	}
+}
+
+// TestClassifyResumeIsNarrow is §9.2's rule verbatim, and the reason a
+// workflow step can never be misdiagnosed: a run that passed no thread id is
+// never a lost session, whatever it says.
+func TestClassifyResumeIsNarrow(t *testing.T) {
+	stderr := readFixtureText(t, "resume_lost_0.150.1.txt")
+	failed := agent.RunResult{ExitCode: 1, IsError: true, ErrorMessage: stderr}
+	if f := classifyResume(failed, stderr, false); f != nil {
+		t.Errorf("a step that never resumed was classified %+v", f)
+	}
+	// A resumed run that failed for some other reason is not one either.
+	other := agent.RunResult{ExitCode: 3, IsError: true, ErrorMessage: "the model refused"}
+	if f := classifyResume(other, "", true); f != nil {
+		t.Errorf("an unrelated failure was classified %+v", f)
+	}
+	// Nor is a resumed run that succeeded.
+	ok := agent.RunResult{ResultText: "no rollout found for thread id, said the agent"}
+	if f := classifyResume(ok, "", true); f != nil {
+		t.Errorf("a successful resume was classified %+v", f)
+	}
+}
+
+// TestSupportsResume is the capability statement §5.5 reads.
+func TestSupportsResume(t *testing.T) {
+	if !agent.CanResume(New(nil)) {
+		t.Error("codex reports it cannot resume; it can, since 0.150.1 was pinned")
+	}
+}
+
+// fixtureLines returns a fixture's non-empty lines, for the assertions that
+// are about a raw line rather than a normalized event.
+func fixtureLines(t *testing.T, name string) [][]byte {
+	t.Helper()
+	f, err := os.Open(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	var out [][]byte
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			out = append(out, []byte(line))
+		}
+	}
+	return out
+}
+
+func readFixtureText(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/agent/codex/stream.go
+++ b/internal/agent/codex/stream.go
@@ -238,6 +238,21 @@ func commandOutput(it *execItem) *agent.CommandOutput {
 	}
 }
 
+// threadIDOf reads codex's `thread_id` off one verbatim JSONL line, or ""
+// when the line has none or does not parse. Only `thread.started` carries
+// one, and both a fresh and a resumed run open with it (verified against
+// 0.150.1). It is deliberately separate from parse: a thread id is not an
+// event — it is a property of the run, and the run records it (§9.1, §9.3).
+func threadIDOf(raw []byte) string {
+	var line struct {
+		ThreadID string `json:"thread_id"`
+	}
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return ""
+	}
+	return line.ThreadID
+}
+
 // stream normalizes codex JSONL lines into agent.Events. Unlike claude,
 // codex has no single result event: the result text is the last
 // agent_message and usage arrives with turn.completed, so normalization
@@ -270,6 +285,10 @@ func (s *stream) parse(raw []byte) agent.Event {
 		// Not an event in its own right: nothing renders a thread id, and
 		// the run it identifies has not produced anything yet. It is held
 		// for the terminal result, which is what a chat reads (task 070).
+		// It falls through to EventUnknown, which still transcripts the line
+		// verbatim. threadIDOf reads the same field off the raw line for the
+		// run itself, which is what carries the id when a run produces no
+		// terminal result at all — a refused resume (failure.go).
 		s.threadID = line.ThreadID
 	case "item.started":
 		if line.Item == nil {

--- a/internal/agent/codex/testdata/resume_lost_0.150.1.txt
+++ b/internal/agent/codex/testdata/resume_lost_0.150.1.txt
@@ -1,0 +1,1 @@
+Error: thread/resume: thread/resume failed: no rollout found for thread id 00000000-0000-4000-8000-000000000000 (code -32600)

--- a/internal/agent/codex/versions.go
+++ b/internal/agent/codex/versions.go
@@ -5,11 +5,12 @@ import "github.com/lezli01/vincent/internal/agent"
 // Version compatibility for the codex CLI (spec §9.3, task 041).
 
 // testedVersions are the builds vincent's parsers were captured against:
-// 0.142.5 is the invocation pinned in §9.3, and reasoning_0.147.0.jsonl pins
-// the reasoning dialect. A build outside this list is `untested`, which is
+// 0.142.5 is the fresh invocation pinned in §9.3, reasoning_0.147.0.jsonl
+// pins the reasoning dialect, and 0.150.1 pins `exec resume` — its argv, its
+// `thread.started`, and its refusal of an unknown id (task 070). A build outside this list is `untested`, which is
 // the normal state for a user on a current CLI and changes nothing about how
 // a step runs.
-var testedVersions = []string{"0.142.5", "0.147.0"}
+var testedVersions = []string{"0.142.5", "0.147.0", "0.150.1"}
 
 // incompatibleVersions are builds vincent knows break. It ships empty: no
 // codex release has been observed to break these parsers. Tests inject one

--- a/internal/agent/cursor/cursor.go
+++ b/internal/agent/cursor/cursor.go
@@ -184,7 +184,7 @@ var errRestricted = fmt.Errorf(
 	agent.ErrRestrictedUnsupported)
 
 // buildArgs assembles the pinned CLI invocation (spec §9.7, verified against
-// cursor-agent 2026.08.04-aaa8809).
+// cursor-agent 2026.08.04-aaa8809, and 2026.08.11-e8db854 for --resume).
 //
 // --trust rides in both permission modes: every task runs in a git worktree
 // the CLI has never seen, and a workspace-trust prompt in a headless run is a
@@ -220,6 +220,14 @@ func buildArgs(spec agent.RunSpec) ([]string, error) {
 		// run stops on a trust prompt for the server vincent just configured,
 		// which is a hang rather than a question (§9.7).
 		args = append(args, "--approve-mcps")
+	}
+	if spec.ResumeSessionID != "" {
+		// `--resume [chatId]` takes an *optional* value, which would be a
+		// hazard for a CLI that also takes a positional prompt — the prompt
+		// would be swallowed as the flag's value. It is safe here because
+		// this adapter never passes one: the prompt goes on stdin (above),
+		// so the id is the only thing that can follow the flag (§9.7).
+		args = append(args, "--resume", spec.ResumeSessionID)
 	}
 	// spec.Effort is deliberately dropped: cursor has no effort flag, and
 	// reasoning depth is selected through the model id (spec §9.7).
@@ -297,6 +305,13 @@ type run struct {
 
 	mu       sync.Mutex
 	terminal *agent.RunResult // assembled from the result event
+	// sessionID is the last `session_id` cursor stamped on a stream line.
+	// Every line carries it, claude's shape rather than codex's, so the last
+	// one seen is the session the run actually ran in — and a resumed run
+	// repeats the id it was given (verified against 2026.08.11-e8db854,
+	// testdata/resume_2026.08.11.jsonl). Last-wins regardless, matching
+	// claude (§9.2).
+	sessionID string
 	// streamErr is readLoop's own reader failing, latched for Wait. It is
 	// vincent losing the stream, not the CLI failing, and Wait says so with
 	// agent.FailureStreamError rather than letting the exit code speak for a
@@ -329,6 +344,11 @@ func (r *run) readLoop(rd io.Reader) {
 		copy(line, sc.Bytes())
 		if len(strings.TrimSpace(string(line))) == 0 {
 			continue
+		}
+		if sid := sessionIDOf(line); sid != "" {
+			r.mu.Lock()
+			r.sessionID = sid
+			r.mu.Unlock()
 		}
 		ev := parse(line)
 		if ev.Type == agent.EventResult && ev.Result != nil {
@@ -385,6 +405,13 @@ func (r *run) PID() int { return r.cmd.Process.Pid }
 // reads exactly as it did before task 003. Note that the §9.5 `logged_in`
 // probe is unaffected and still flags an unauthenticated CLI *before* a task
 // is created — this is only about classifying a run that already failed.
+//
+// FailureSessionLost is absent for a different and stronger reason: cursor
+// never produces it. Asked to `--resume` an id it has never seen, 2026.08.11
+// does not refuse — it starts a fresh chat under that id, exits 0 and answers
+// normally (testdata/resume_unknown_2026.08.11.jsonl). There is no wording to
+// match because there is no refusal, so this adapter states the gap rather
+// than inventing a match for it (§9.7, task 072 decision 2).
 func (r *run) Wait() (agent.RunResult, error) {
 	r.waitOnce.Do(func() {
 		<-r.readerDone
@@ -404,8 +431,9 @@ func (r *run) Wait() (agent.RunResult, error) {
 		}
 		res := agent.RunResult{ExitCode: r.cmd.ProcessState.ExitCode()}
 		r.mu.Lock()
-		terminal, streamErr := r.terminal, r.streamErr
+		terminal, streamErr, sessionID := r.terminal, r.streamErr, r.sessionID
 		r.mu.Unlock()
+		res.SessionID = sessionID
 		if terminal != nil {
 			res.IsError = terminal.IsError
 			res.ErrorMessage = terminal.ErrorMessage
@@ -461,9 +489,10 @@ func (w *tailWriter) String() string {
 // Argv implements agent.RunHandle: the command line actually spawned.
 func (r *run) Argv() []string { return r.cmd.Args }
 
-// SupportsResume implements agent.Resumer, in the negative (§9.7, task 063
-// decision 3). cursor-agent has a `--resume` of its own and emits a
-// `session_id`, but as with codex neither is wired here and no captured
-// fixture pins the flag against a named cursor-agent build. Chat creation
-// refuses cursor rather than replaying the log as prompt context.
-func (a *Adapter) SupportsResume() bool { return false }
+// SupportsResume implements agent.Resumer: cursor-agent reloads one of its
+// own chats with `--resume <session_id>` (§9.7), which is what lets a chat
+// (§5.5) run on this adapter. Pinned against cursor-agent 2026.08.11-e8db854:
+// the `session_id` the stream stamps on every line is the id `--resume`
+// accepts, and a resumed run answers from the earlier turn
+// (testdata/resume_2026.08.11.jsonl).
+func (a *Adapter) SupportsResume() bool { return true }

--- a/internal/agent/cursor/failure_test.go
+++ b/internal/agent/cursor/failure_test.go
@@ -10,6 +10,12 @@ import "testing"
 //
 // The §9.5 `logged_in` probe is unaffected: an unauthenticated cursor is still
 // flagged before a task is created. This is only about a run that has failed.
+//
+// Task 070 left this whole-hearted "nothing" intact, unlike codex's, and for a
+// stronger reason than a missing fixture: cursor has no session-lost refusal
+// either. Handed a `--resume` id it has never seen it starts a fresh chat and
+// exits 0 (testdata/resume_unknown_2026.08.11.jsonl), so there is no wording
+// to match, and TestUnknownSessionIsAdoptedNotRefused says so directly.
 func TestQuotaAndAuthStopsStayUnclassified(t *testing.T) {
 	for _, scenario := range []string{"usage-limit", "unauthenticated"} {
 		t.Run(scenario, func(t *testing.T) {

--- a/internal/agent/cursor/resume_test.go
+++ b/internal/agent/cursor/resume_test.go
@@ -1,0 +1,135 @@
+package cursor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/agent"
+)
+
+// resumedSessionID is the id testdata/resume_2026.08.11.jsonl was scrubbed to.
+// The capture's own UUID is replaced, but with one value on every line,
+// because the fact being pinned is that a resumed run reports the id it was
+// given — the id vincent then hands back on the turn after.
+const resumedSessionID = "4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14"
+
+// TestBuildArgsResume pins the resumed invocation against cursor-agent
+// 2026.08.11-e8db854 (§9.7, task 072).
+//
+// `--resume [chatId]` takes an *optional* value, which would be a hazard for a
+// CLI that also took a positional prompt — the prompt would be eaten as the
+// flag's value. It is safe here only because this adapter puts the prompt on
+// stdin and passes no positional at all, so the assertion that matters is that
+// the id is the last thing on argv and nothing follows it.
+func TestBuildArgsResume(t *testing.T) {
+	restore := SetSandboxAvailable(true)
+	defer restore()
+	for _, tt := range []struct {
+		name string
+		spec agent.RunSpec
+		want []string
+	}{
+		{
+			name: "full auto",
+			spec: agent.RunSpec{PermissionMode: agent.FullAuto, ResumeSessionID: "s-1"},
+			want: []string{
+				"-p", "--output-format", "stream-json", "--trust", "--force",
+				"--model", "auto", "--resume", "s-1",
+			},
+		},
+		{
+			name: "restricted keeps its sandbox; resume is orthogonal here",
+			spec: agent.RunSpec{PermissionMode: agent.Restricted, ResumeSessionID: "s-1"},
+			want: []string{
+				"-p", "--output-format", "stream-json", "--trust", "--sandbox", "enabled",
+				"--model", "auto", "--resume", "s-1",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildArgs(tt.spec)
+			if err != nil {
+				t.Fatalf("buildArgs: %v", err)
+			}
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Fatalf("buildArgs = %q, want %q", got, tt.want)
+			}
+			if got[len(got)-1] != "s-1" {
+				t.Errorf("the resume id is not last on argv (%q); an optional-value "+
+					"flag must have nothing after it to swallow", got)
+			}
+		})
+	}
+}
+
+// TestResumeFixtureReportsItsSessionID pins the stream half: a resumed run
+// stamps the id it was handed on every line, which is what RunResult.SessionID
+// must end up holding.
+func TestResumeFixtureReportsItsSessionID(t *testing.T) {
+	var last string
+	for _, line := range strings.Split(readFixture(t, "resume_2026.08.11.jsonl"), "\n") {
+		if line = strings.TrimSpace(line); line == "" {
+			continue
+		}
+		if id := sessionIDOf([]byte(line)); id != "" {
+			last = id
+		}
+	}
+	if last != resumedSessionID {
+		t.Fatalf("session id = %q, want %q", last, resumedSessionID)
+	}
+	if got := sessionIDOf([]byte("not json")); got != "" {
+		t.Errorf("sessionIDOf(garbage) = %q, want empty", got)
+	}
+}
+
+// TestUnknownSessionIsAdoptedNotRefused states the gap positively (§9.7, task
+// 070 decision 2), because a capability an adapter lacks is stated and never
+// emulated.
+//
+// cursor-agent 2026.08.11 does not refuse `--resume` of an id it has never
+// seen. It starts a fresh chat *under that id*, stamps it on every line and
+// exits 0 — captured in testdata/resume_unknown_2026.08.11.jsonl by resuming
+// an all-zero UUID. So this adapter ships no FailureSessionLost: there is no
+// refusal to recognize, and inventing one would be a guess about a CLI that
+// answered.
+func TestUnknownSessionIsAdoptedNotRefused(t *testing.T) {
+	const unknown = "00000000-0000-4000-8000-000000000000"
+	var res *agent.RunResult
+	for _, ev := range parseFixture(t, "resume_unknown_2026.08.11.jsonl") {
+		if ev.Type == agent.EventResult {
+			res = ev.Result
+		}
+	}
+	if res == nil {
+		t.Fatal("no result event: the capture would have to be of a refusal")
+	}
+	if res.IsError {
+		t.Fatalf("the capture is of a refused resume after all: %+v", res)
+	}
+	for _, line := range strings.Split(readFixture(t, "resume_unknown_2026.08.11.jsonl"), "\n") {
+		if line = strings.TrimSpace(line); line == "" {
+			continue
+		}
+		if id := sessionIDOf([]byte(line)); id != "" && id != unknown {
+			t.Fatalf("session id = %q, want the unknown id %q it was handed", id, unknown)
+		}
+	}
+}
+
+// TestSupportsResume is the capability statement §5.5 reads.
+func TestSupportsResume(t *testing.T) {
+	if !agent.CanResume(New(nil)) {
+		t.Error("cursor reports it cannot resume; it can, since 2026.08.11 was pinned")
+	}
+}
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return string(b)
+}

--- a/internal/agent/cursor/stream.go
+++ b/internal/agent/cursor/stream.go
@@ -47,6 +47,21 @@ type streamLine struct {
 	} `json:"usage"`
 }
 
+// sessionIDOf reads cursor's `session_id` off one verbatim stream line, or ""
+// when the line has none or does not parse. Every line carries it, including
+// the opening `system`/`init`. It is deliberately separate from parse: a
+// session id is not an event — it is a property of the run, and the run
+// records it (§9.1, §9.7).
+func sessionIDOf(raw []byte) string {
+	var line struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return ""
+	}
+	return line.SessionID
+}
+
 // stream normalizes cursor stream-json lines. The result text needs no state
 // — cursor's terminal `result` carries it whole, unlike codex — but thinking
 // does: reasoning arrives as token-level `delta` lines and is accumulated

--- a/internal/agent/cursor/testdata/resume_2026.08.11.jsonl
+++ b/internal/agent/cursor/testdata/resume_2026.08.11.jsonl
@@ -1,0 +1,14 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/tmp/worktree","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"What word did I ask you to remember? Reply with just that word."}]},"session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14"}
+{"type":"thinking","subtype":"delta","text":"The user wants me to","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192676229}
+{"type":"thinking","subtype":"delta","text":" recall a word from ","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192676231}
+{"type":"thinking","subtype":"delta","text":"a previous message.","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192676231}
+{"type":"thinking","subtype":"delta","text":"\n\nThe word is \"pomegranate\".","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192676231}
+{"type":"thinking","subtype":"completed","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192676231}
+{"type":"thinking","subtype":"delta","text":"The user wants me to","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678135}
+{"type":"thinking","subtype":"delta","text":" recall a word they ","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678187}
+{"type":"thinking","subtype":"delta","text":"previously asked me ","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678188}
+{"type":"thinking","subtype":"delta","text":"to remember.","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678188}
+{"type":"thinking","subtype":"delta","text":"\n\nThe word is \"pomegranate\".","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678188}
+{"type":"thinking","subtype":"completed","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","timestamp_ms":1788192678188}
+{"type":"result","subtype":"success","duration_ms":4741,"duration_api_ms":4741,"is_error":false,"result":"","session_id":"4b7d1e28-3a90-4f6c-8b21-5d0c7e93af14","request_id":"REQUEST","usage":{"inputTokens":92,"outputTokens":93,"cacheReadTokens":35318,"cacheWriteTokens":0}}

--- a/internal/agent/cursor/testdata/resume_unknown_2026.08.11.jsonl
+++ b/internal/agent/cursor/testdata/resume_unknown_2026.08.11.jsonl
@@ -1,0 +1,9 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/tmp/worktree","session_id":"00000000-0000-4000-8000-000000000000","model":"Auto","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]},"session_id":"00000000-0000-4000-8000-000000000000"}
+{"type":"thinking","subtype":"delta","text":"The user sent a greeting.","session_id":"00000000-0000-4000-8000-000000000000","timestamp_ms":1788192685934}
+{"type":"thinking","subtype":"delta","text":"\n\nPreparing a friendly","session_id":"00000000-0000-4000-8000-000000000000","timestamp_ms":1788192685937}
+{"type":"thinking","subtype":"delta","text":" response and offering","session_id":"00000000-0000-4000-8000-000000000000","timestamp_ms":1788192685937}
+{"type":"thinking","subtype":"delta","text":" assistance.","session_id":"00000000-0000-4000-8000-000000000000","timestamp_ms":1788192685937}
+{"type":"thinking","subtype":"completed","session_id":"00000000-0000-4000-8000-000000000000","timestamp_ms":1788192685938}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello! How can I help you today? I can assist with code, debugging, exploring this repo, or anything else you're working on."}]},"session_id":"00000000-0000-4000-8000-000000000000"}
+{"type":"result","subtype":"success","duration_ms":2667,"duration_api_ms":2667,"is_error":false,"result":"Hello! How can I help you today? I can assist with code, debugging, exploring this repo, or anything else you're working on.","session_id":"00000000-0000-4000-8000-000000000000","request_id":"REQUEST","usage":{"inputTokens":10946,"outputTokens":64,"cacheReadTokens":5746,"cacheWriteTokens":0}}

--- a/internal/api/agents_test.go
+++ b/internal/api/agents_test.go
@@ -262,8 +262,9 @@ func TestAgentsWithoutCatalog(t *testing.T) {
 // 2026-08-31, issue #279): the field the TUI's chat picker filters on. It
 // comes from the same `agent.CanResume` the creation gate in
 // POST /v1/chats consults, so the picker and the `agent_cannot_resume`
-// refusal cannot disagree (decision row 29) — claude yes, codex and cursor
-// no, whether or not a binary is installed.
+// refusal cannot disagree (decision row 29). All three shipped adapters
+// answer yes since task 070, and agenttest.StubNonResuming carries the no —
+// the answer comes from the adapter, whether or not a binary is installed.
 //
 // Null is a fourth answer rather than a false: a daemon with no registry to
 // ask says nothing, and no client may filter an adapter out on that.
@@ -274,6 +275,7 @@ func TestAgentsReportSupportsResume(t *testing.T) {
 			claude.New(func() string { return fake }),
 			codex.New(func() string { return "/nonexistent/codex-not-here" }),
 			cursor.New(func() string { return "/nonexistent/cursor-agent-not-here" }),
+			agenttest.StubNonResuming{},
 		)
 	}
 	probe := func(t *testing.T, withRegistry bool) map[string]*bool {
@@ -311,9 +313,13 @@ func TestAgentsReportSupportsResume(t *testing.T) {
 	}
 
 	got := probe(t, true)
-	// codex joined claude with task 070: `exec resume <thread_id>`, pinned by
-	// a capture. cursor is the one that still cannot (§9.7).
-	for name, want := range map[string]bool{"claude": true, "codex": true, "cursor": false} {
+	// Every shipped adapter resumes since task 070: claude and codex reload a
+	// session, cursor a chat, each pinned by a capture against a named build.
+	// The stub is what states the false case now that no shipped adapter does.
+	for name, want := range map[string]bool{
+		"claude": true, "codex": true, "cursor": true,
+		agenttest.NonResumingName: false,
+	} {
 		switch v := got[name]; {
 		case v == nil:
 			t.Errorf("%s supports_resume = null, want %v — the registry was asked", name, want)

--- a/internal/api/chats_test.go
+++ b/internal/api/chats_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 // chatHarness is the chat spine over the *real* handlers: server + store +
-// worktrees + a chat runner, with all three adapters pointed at fakeagent so
-// the refusal of codex and cursor is decided by the adapters themselves rather
-// than by a test double.
+// worktrees + a chat runner, with all three shipped adapters pointed at
+// fakeagent so what a chat may be created on is decided by the adapters
+// themselves rather than by a test double. agenttest.StubNonResuming rides
+// alongside them for the one thing none of the three says any more: no.
 type chatHarness struct {
 	*projectHarness
 	runner    *chatrun.Runner
@@ -49,7 +50,10 @@ func newChatHarness(t *testing.T) *chatHarness {
 	git := gitx.New()
 	wt := worktree.NewManager(git, dataDir)
 	bin := func() string { return fake }
-	reg := agent.NewRegistry(claude.New(bin), codex.New(bin), cursor.New(bin))
+	reg := agent.NewRegistry(
+		claude.New(bin), codex.New(bin), cursor.New(bin),
+		agenttest.StubNonResuming{},
+	)
 	h := &chatHarness{cfg: config.Default()}
 	cfg := func() config.Config { return h.cfg }
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -109,28 +113,82 @@ func (h *chatHarness) create(t *testing.T, agentName string) (int, map[string]an
 	return resp.StatusCode, out
 }
 
-// TestChatCreateRefusesAdaptersThatCannotResume is decision 3: the capability
-// is stated, never emulated. The refusal happens at creation, so a human never
-// gets a chat that cannot hold a conversation.
+// TestChatCreateRefusesAdaptersThatCannotResume is task 063 decision 3: the
+// capability is stated, never emulated. The refusal happens at creation, so a
+// human never gets a chat that cannot hold a conversation.
+//
+// The subject is the stub, not a shipped adapter. Task 070 taught codex and
+// cursor to resume and the two names this used to iterate then asserted the
+// opposite of the truth — which is exactly the failure mode a refusal pinned
+// to whichever CLI happens to lack the capability today will keep having.
 func TestChatCreateRefusesAdaptersThatCannotResume(t *testing.T) {
 	h := newChatHarness(t)
-	// cursor alone, since task 070. codex was refused here for want of a
-	// captured `exec resume` argv; that capture exists now, so a codex chat
-	// is created like a claude one and the refusal has one adapter left to
-	// state it over (§9.7).
-	for _, name := range []string{"cursor"} {
-		code, body := h.create(t, name)
-		if code != http.StatusBadRequest {
-			t.Fatalf("create on %s = %d, want 400 (%v)", name, code, body)
-		}
-		errObj, _ := body["error"].(map[string]any)
-		if got := errObj["code"]; got != CodeAgentCannotResume {
-			t.Fatalf("create on %s error code = %v, want %q", name, got, CodeAgentCannotResume)
-		}
+	code, body := h.create(t, agenttest.NonResumingName)
+	if code != http.StatusBadRequest {
+		t.Fatalf("create on %s = %d, want 400 (%v)", agenttest.NonResumingName, code, body)
 	}
-	for _, name := range []string{"claude", "codex"} {
+	errObj, _ := body["error"].(map[string]any)
+	if got := errObj["code"]; got != CodeAgentCannotResume {
+		t.Fatalf("error code = %v, want %q", got, CodeAgentCannotResume)
+	}
+	// And every shipped adapter is now on the other side of it (task 070).
+	for _, name := range []string{"claude", "codex", "cursor"} {
 		if code, body := h.create(t, name); code != http.StatusCreated {
 			t.Fatalf("create on %s = %d, want 201 (%v)", name, code, body)
+		}
+	}
+}
+
+// TestChatsAreAlwaysFullAuto is task 072 decision 1's structural guard, and it
+// is a guard rather than a happy-path assertion.
+//
+// A resumed codex run has no argv spelling for `restricted`: `codex exec
+// resume` carries no --sandbox at all, so the adapter always passes
+// --dangerously-bypass-approvals-and-sandbox (§9.3). That is only safe while
+// nothing can ask a chat for a restricted turn — POST /v1/chats hardcodes
+// full_auto and exposes no request field to override it, and no other caller
+// sets RunSpec.ResumeSessionID.
+//
+// So this asserts the absence: a request that tries to pick a mode does not
+// get one. The day chats gain a permission mode, this fails, and the decision
+// is reopened deliberately rather than discovered as a silent escalation on a
+// user's machine.
+func TestChatsAreAlwaysFullAuto(t *testing.T) {
+	h := newChatHarness(t)
+	// There is no field to ask with. The decoder rejects unknown ones, which
+	// is the guard: adding `permission_mode` to the request type turns this
+	// 400 into a 201 and fails here.
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/chats", map[string]any{
+		"project_id": h.projectID, "title": "a talk",
+		"agent": "codex", "permission_mode": string(agent.Restricted),
+	})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("create with permission_mode = %d, want 400; a chat's mode is not "+
+			"requestable (task 072 decision 1) (%s)", resp.StatusCode, body)
+	}
+	// And what creation does produce is full_auto, on every adapter.
+	for _, name := range []string{"claude", "codex", "cursor"} {
+		resp, body := h.doJSON(t, http.MethodPost, "/v1/chats", map[string]any{
+			"project_id": h.projectID, "title": "a talk", "agent": name,
+		})
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create on %s = %d (%s)", name, resp.StatusCode, body)
+		}
+		var out struct {
+			ID int64 `json:"id"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			t.Fatalf("chat body: %v", err)
+		}
+		// Read the row rather than the DTO: the wire shape does not carry a
+		// permission mode either, which is half of why this is safe.
+		c, err := h.store.GetChat(t.Context(), out.ID)
+		if err != nil {
+			t.Fatalf("GetChat: %v", err)
+		}
+		if c.PermissionMode != string(agent.FullAuto) {
+			t.Fatalf("chat on %s = %q, want %q: a resumed codex run has no argv "+
+				"spelling for restricted (§9.3)", name, c.PermissionMode, agent.FullAuto)
 		}
 	}
 }

--- a/internal/chatrun/drain_test.go
+++ b/internal/chatrun/drain_test.go
@@ -1,0 +1,186 @@
+package chatrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+// floodAgentName is the adapter newHarness registers alongside the three real
+// ones for this test. It is a stub rather than a fakeagent dialect because
+// what is under test is a handover between goroutines, not an argv: no
+// subprocess can make a blocked channel send any more blocked than this one.
+const floodAgentName = "floodstub"
+
+// floodEvents is more events than the runner can want. The cap is reached on
+// the first, so every one after it is a send nobody has asked for — which is
+// the only condition under which the deadlock this file guards can happen.
+const floodEvents = 8
+
+// floodSendTimeout bounds an abandoned handover. Without it a regression is a
+// hung package (`panic: test timed out after 10m0s`, and a goroutine dump to
+// read); with it the run gives up, the turn finishes, and the assertion below
+// says in one line what went wrong.
+const floodSendTimeout = 10 * time.Second
+
+// floodAdapter is an agent whose stream outlives the consumer's interest in
+// it: it hands events over on an *unbuffered* channel and its Wait does not
+// return until the goroutine doing the handing over is finished.
+//
+// That is the shape of every shipped adapter — internal/agent/claude's
+// readLoop feeds a mux which feeds the events channel, and Wait blocks on
+// readerDone — with the buffers removed. The buffers are the only reason the
+// real adapters hid this: 128 events fit between the CLI and the loop, so a
+// consumer that stopped reading deadlocked only when the agent had got that
+// far ahead before the kill landed.
+type floodAdapter struct {
+	mu  sync.Mutex
+	run *floodRun
+}
+
+// Name implements agent.Adapter.
+func (a *floodAdapter) Name() string { return floodAgentName }
+
+// Detect implements agent.Adapter.
+func (a *floodAdapter) Detect(context.Context) (agent.Availability, error) {
+	return agent.Availability{Found: true, Path: floodAgentName, Version: "0"}, nil
+}
+
+// Options implements agent.Adapter.
+func (a *floodAdapter) Options(context.Context) (agent.Options, error) {
+	return agent.Options{}, nil
+}
+
+// Path implements agent.Adapter.
+func (a *floodAdapter) Path() (string, error) { return floodAgentName, nil }
+
+// Curated implements agent.Adapter.
+func (a *floodAdapter) Curated() agent.Options { return agent.Options{} }
+
+// NewLineParser implements agent.Adapter.
+func (a *floodAdapter) NewLineParser() agent.LineParser {
+	return func(raw []byte) agent.Event { return agent.Event{Type: agent.EventOutput, Raw: raw} }
+}
+
+// SupportsResume implements agent.Resumer, so a chat on this adapter is not
+// refused at creation before it can reach the loop.
+func (a *floodAdapter) SupportsResume() bool { return true }
+
+// Start implements agent.Adapter.
+func (a *floodAdapter) Start(context.Context, agent.RunSpec) (agent.RunHandle, error) {
+	r := &floodRun{events: make(chan agent.Event), done: make(chan struct{})}
+	a.mu.Lock()
+	a.run = r
+	a.mu.Unlock()
+	go r.emit()
+	return r, nil
+}
+
+// started reports the run Start handed out, or nil if nothing ran.
+func (a *floodAdapter) started() *floodRun {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.run
+}
+
+// floodRun is one run of floodAdapter.
+type floodRun struct {
+	events  chan agent.Event
+	done    chan struct{}
+	mu      sync.Mutex
+	drained bool
+}
+
+func (r *floodRun) emit() {
+	defer close(r.done)
+	defer close(r.events)
+	// Each line is over the 256-byte cap on its own, so the runner reaches
+	// the cap on the first event and stops wanting the rest.
+	line := fmt.Sprintf(`{"type":"assistant","text":%q}`, strings.Repeat("flooding ", 40))
+	for range floodEvents {
+		select {
+		case r.events <- agent.Event{Type: agent.EventOutput, Text: line, Raw: []byte(line)}:
+		case <-time.After(floodSendTimeout):
+			// Nobody is reading. The real adapters have no such escape and
+			// would sit here for as long as the daemon lives.
+			return
+		}
+	}
+	r.mu.Lock()
+	r.drained = true
+	r.mu.Unlock()
+}
+
+// wasDrained reports whether every event was taken before the stream closed.
+func (r *floodRun) wasDrained() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.drained
+}
+
+// Events implements agent.RunHandle.
+func (r *floodRun) Events() <-chan agent.Event { return r.events }
+
+// Wait implements agent.RunHandle: it blocks until the goroutine that owns
+// the stream is finished, which is what makes an undrained stream a hang
+// rather than a lost line.
+func (r *floodRun) Wait() (agent.RunResult, error) {
+	<-r.done
+	return agent.RunResult{ExitCode: 0, SessionID: "flood-1"}, nil
+}
+
+// Respond implements agent.RunHandle.
+func (r *floodRun) Respond(agent.InputResponse) error {
+	return errors.New("the flood stub is non-interactive")
+}
+
+// Terminate implements agent.RunHandle.
+func (r *floodRun) Terminate() error { return nil }
+
+// Kill implements agent.RunHandle.
+func (r *floodRun) Kill() error { return nil }
+
+// PID implements agent.RunHandle.
+func (r *floodRun) PID() int { return 0 }
+
+// Argv implements agent.RunHandle.
+func (r *floodRun) Argv() []string { return []string{floodAgentName} }
+
+// TestTurnDrainsTheStreamItAbandons is the regression test for a hang, not a
+// wrong answer. Every early exit from consume — cancel, either clock, the
+// transcript cap — leaves an agent that is still talking, and the adapter's
+// Wait does not return until that agent's reader goroutine is finished. A
+// consumer that simply returned parked the reader on a channel nobody empties
+// and runTurn on a Wait that never returns: the turn stayed non-terminal, the
+// chat never came back to idle, and its §11 slot was held until the daemon
+// restarted. Runner.Stop then blocked too, so a shutdown hung with it.
+//
+// It is asserted through the transcript cap because that is the exit reached
+// soonest and most deterministically; all four share drain.
+func TestTurnDrainsTheStreamItAbandons(t *testing.T) {
+	h := newHarness(t)
+	h.cfg.TranscriptMaxBytes = 256
+	c := h.chatOn(t, floodAgentName)
+
+	turn := h.sendAndWait(t, c.ID, "say a lot")
+	if turn.State != chatstate.TurnFailed || turn.FailReason != ReasonTranscriptLimit {
+		t.Fatalf("turn = %s/%s, want failed/%s", turn.State, turn.FailReason, ReasonTranscriptLimit)
+	}
+	run := h.flood.started()
+	if run == nil {
+		t.Fatal("the flood adapter was never started")
+	}
+	if !run.wasDrained() {
+		t.Fatal("the abandoned stream was never drained: a real adapter's reader would still be " +
+			"blocked handing over an event, and its Wait with it")
+	}
+	// And the chat is usable again, which is the half a human notices.
+	h.waitIdle(t, c.ID)
+}

--- a/internal/chatrun/runner.go
+++ b/internal/chatrun/runner.go
@@ -26,9 +26,15 @@ import (
 // produce.
 const (
 	// ReasonSessionLost is a turn whose stored session id the CLI no longer
-	// knows (decision 4). The chat stays usable; whether to start a fresh
-	// conversation is a human decision, because an agent answering with none
-	// of the thread in context reads exactly like one that has it.
+	// knows (task 063 decision 4). The chat stays usable; whether to start a
+	// fresh conversation is a human decision, because an agent answering with
+	// none of the thread in context reads exactly like one that has it.
+	//
+	// Only an adapter that recognizes its CLI's refusal can reach this:
+	// claude and codex do, cursor cannot, because cursor-agent adopts an
+	// unknown resume id and answers rather than refusing (§9.7, task 070
+	// decision 2). Nothing here compensates for that — the runner acts on the
+	// adapter's verdict and never guesses at one.
 	ReasonSessionLost = "session_lost"
 	// ReasonAgentError is the generic "the run failed" reason, spelled the
 	// same as the engine's.

--- a/internal/chatrun/runner.go
+++ b/internal/chatrun/runner.go
@@ -349,6 +349,9 @@ func (r *Runner) runTurn(chat *store.Chat, turn *store.ChatTurn) {
 // It is a select loop rather than a `range` over the event channel because a
 // range cannot also watch a timer. The events channel closing is what ends
 // the loop, exactly as before.
+//
+// Every *other* way out goes through drain first, and none of them may
+// simply return — see drain.
 func (r *Runner) consume(
 	ctx context.Context, cancelCause context.CancelCauseFunc, live *liveTurn,
 	chat *store.Chat, turn *store.ChatTurn, handle agent.RunHandle, tr *transcript.Writer,
@@ -369,18 +372,21 @@ func (r *Runner) consume(
 			// The daemon is going away, or a human canceled. Either way the
 			// adapter's stream is about to close; runTurn classifies from the
 			// cause.
+			r.drain(events, chat, turn, tr)
 			return
 		case <-work.C:
 			tr.Note("timeout", map[string]any{"timeout": r.agentTimeout().String()})
 			r.deps.Logger.Warn("chat turn timed out",
 				"chat", chat.ID, "turn", turn.ID, "timeout", r.agentTimeout())
 			cancelCause(errTurnTimeout)
+			r.drain(events, chat, turn, tr)
 			return
 		case <-wait.C:
 			tr.Note("input_timeout", map[string]any{"timeout": r.inputTimeout().String()})
 			r.deps.Logger.Warn("chat input request timed out",
 				"chat", chat.ID, "turn", turn.ID, "timeout", r.inputTimeout())
 			cancelCause(errInputTimeout)
+			r.drain(events, chat, turn, tr)
 			return
 		case <-live.answered:
 			// A human answered through Answer, which already CAS'd
@@ -402,6 +408,7 @@ func (r *Runner) consume(
 					"chat", chat.ID, "turn", turn.ID,
 					"limit", r.cfg().TranscriptMaxBytes.Bytes())
 				cancelCause(errTranscriptLimit)
+				r.drain(events, chat, turn, tr)
 				return
 			}
 			switch ev.Type {
@@ -430,6 +437,33 @@ func (r *Runner) consume(
 				// outputlines.go decides what a verbosity level shows.
 			}
 		}
+	}
+}
+
+// drain empties the adapter's event channel until the stream closes, and is
+// what every early exit from consume owes the run it is abandoning.
+//
+// An adapter hands its events over on a channel written by goroutines that
+// block on the send — internal/agent/claude's readLoop feeds a mux which
+// feeds the events channel — and its Wait blocks until those goroutines are
+// finished. Cancelling the context kills the process tree, but it does not
+// unblock a goroutine already parked mid-handover: a consumer that stopped
+// reading leaves the reader waiting on a channel nobody empties and Wait
+// waiting on the reader, so runTurn never returns, the turn never reaches a
+// terminal state and its §11 slot is held until the daemon restarts. The
+// buffers are what hid it — 128 events fit between the CLI and the loop, so
+// the deadlock only lands when the agent got that far ahead before the kill,
+// which is why it showed up as a rare hang under load rather than as a red
+// test. internal/taskrun keeps its loop running for the same reason ("the
+// stream is left to drain so Wait still reports an exit", steps.go).
+//
+// Draining records rather than discards, exactly as the task engine does: the
+// lines were written, the cap suppresses them once it is reached, and a
+// transcript that stops mid-sentence for a reason nobody can see is the thing
+// §12.3 exists to avoid.
+func (r *Runner) drain(events <-chan agent.Event, chat *store.Chat, turn *store.ChatTurn, tr *transcript.Writer) {
+	for ev := range events {
+		r.record(chat, turn, tr, ev)
 	}
 }
 

--- a/internal/chatrun/runner_test.go
+++ b/internal/chatrun/runner_test.go
@@ -74,15 +74,17 @@ func newHarness(t *testing.T) *harness {
 	return h
 }
 
-// chat creates a chat with a real worktree, the way the API does. It is always
-// on claude: the other two adapters cannot resume, so a chat on one never gets
-// past creation — which is asserted at the adapter level in
-// TestAdaptersThatCannotResume and over the wire in internal/api.
-func (h *harness) chat(t *testing.T) *store.Chat {
+// chat creates a chat with a real worktree, the way the API does, on claude —
+// the adapter whose dialect every scenario in this file was written against.
+func (h *harness) chat(t *testing.T) *store.Chat { return h.chatOn(t, "claude") }
+
+// chatOn is chat, on a named adapter. All three shipped adapters can resume
+// since task 070, so the tests that are *about* resuming run on each of them.
+func (h *harness) chatOn(t *testing.T, agentName string) *store.Chat {
 	t.Helper()
 	c := &store.Chat{
 		ProjectID: h.project.ID, Title: "a talk", State: chatstate.Idle,
-		Agent: "claude", PermissionMode: string(agent.FullAuto), BaseBranch: "main",
+		Agent: agentName, PermissionMode: string(agent.FullAuto), BaseBranch: "main",
 	}
 	if err := h.store.CreateChat(t.Context(), c); err != nil {
 		t.Fatalf("CreateChat: %v", err)
@@ -156,38 +158,50 @@ func (h *harness) waitTurn(t *testing.T, turnID int64) *store.ChatTurn {
 // reason the feature exists: the second turn answers with something only the
 // first supplies. Nothing here replays a log — the fake CLI is asked to resume
 // its own session, and it says what it remembers.
+//
+// It runs on all three adapters since task 070. Each subtest exercises a
+// different argv and a different stream: claude's `--resume <id>` with the id
+// on every line, codex's `exec resume <id> -` with a `thread_id` on one, and
+// cursor's `--resume <id>` with a `session_id` on every line. A vincent that
+// dropped the id for any one of them fails by omission — a fresh session emits
+// no recall line at all — rather than by a difference a reader has to squint
+// at.
 func TestTurnTwoSeesTurnOne(t *testing.T) {
-	h := newHarness(t)
-	c := h.chat(t)
+	for _, agentName := range []string{"claude", "codex", "cursor"} {
+		t.Run(agentName, func(t *testing.T) {
+			h := newHarness(t)
+			c := h.chatOn(t, agentName)
 
-	first := h.sendAndWait(t, c.ID, "my favourite colour is heliotrope")
-	if first.State != chatstate.TurnDone {
-		t.Fatalf("turn 1 = %s (%s: %s)", first.State, first.FailReason, first.ErrorMessage)
-	}
-	if first.SessionID == "" {
-		t.Fatal("turn 1 recorded no session id, so there is nothing to resume")
-	}
-	// The chat, not the turn, is what the next turn resumes.
-	after := h.waitIdle(t, c.ID)
-	if after.SessionID != first.SessionID {
-		t.Fatalf("chat session id = %q, want the turn's %q", after.SessionID, first.SessionID)
-	}
+			first := h.sendAndWait(t, c.ID, "my favourite colour is heliotrope")
+			if first.State != chatstate.TurnDone {
+				t.Fatalf("turn 1 = %s (%s: %s)", first.State, first.FailReason, first.ErrorMessage)
+			}
+			if first.SessionID == "" {
+				t.Fatal("turn 1 recorded no session id, so there is nothing to resume")
+			}
+			// The chat, not the turn, is what the next turn resumes.
+			after := h.waitIdle(t, c.ID)
+			if after.SessionID != first.SessionID {
+				t.Fatalf("chat session id = %q, want the turn's %q", after.SessionID, first.SessionID)
+			}
 
-	second := h.sendAndWait(t, c.ID, "what is it again?")
-	if second.State != chatstate.TurnDone {
-		t.Fatalf("turn 2 = %s (%s: %s)", second.State, second.FailReason, second.ErrorMessage)
-	}
-	// The recall line is only ever emitted by a run that was handed a
-	// session the store already held, so its presence is the proof.
-	body := h.transcript(t, c.ID, second.Seq)
-	if !strings.Contains(body, "heliotrope") {
-		t.Fatalf("turn 2 does not recall turn 1; transcript:\n%s", body)
-	}
-	if !strings.Contains(body, "recalled:") {
-		t.Fatalf("turn 2 ran a fresh session, not a resume; transcript:\n%s", body)
-	}
-	if second.Seq != 2 {
-		t.Fatalf("turn 2 seq = %d, want 2", second.Seq)
+			second := h.sendAndWait(t, c.ID, "what is it again?")
+			if second.State != chatstate.TurnDone {
+				t.Fatalf("turn 2 = %s (%s: %s)", second.State, second.FailReason, second.ErrorMessage)
+			}
+			// The recall line is only ever emitted by a run that was handed a
+			// session the store already held, so its presence is the proof.
+			body := h.transcript(t, c.ID, second.Seq)
+			if !strings.Contains(body, "heliotrope") {
+				t.Fatalf("turn 2 does not recall turn 1; transcript:\n%s", body)
+			}
+			if !strings.Contains(body, "recalled:") {
+				t.Fatalf("turn 2 ran a fresh session, not a resume; transcript:\n%s", body)
+			}
+			if second.Seq != 2 {
+				t.Fatalf("turn 2 seq = %d, want 2", second.Seq)
+			}
+		})
 	}
 }
 
@@ -203,34 +217,73 @@ func (h *harness) transcript(t *testing.T, chatID int64, seq int) string {
 	return string(b)
 }
 
-// TestSessionLostFailsTheTurnAndLeavesTheChatUsable is decision 4. A silently
-// fresh session would answer as if it had context it does not have, and a
-// reader could not tell that apart from a working conversation.
+// TestSessionLostFailsTheTurnAndLeavesTheChatUsable is task 063 decision 4. A
+// silently fresh session would answer as if it had context it does not have,
+// and a reader could not tell that apart from a working conversation.
+//
+// claude and codex both refuse an id they never minted, in their own wordings,
+// and both fixtures back their adapter's markers. cursor is absent on purpose
+// and TestCursorAdoptsAnUnknownSession is why.
 func TestSessionLostFailsTheTurnAndLeavesTheChatUsable(t *testing.T) {
+	for _, agentName := range []string{"claude", "codex"} {
+		t.Run(agentName, func(t *testing.T) {
+			h := newHarness(t)
+			c := h.chatOn(t, agentName)
+			if _, err := h.store.SetChatSession(t.Context(), c.ID, "fake-session-gone"); err != nil {
+				t.Fatalf("SetChatSession: %v", err)
+			}
+
+			turn := h.sendAndWait(t, c.ID, "still there?")
+			if turn.State != chatstate.TurnFailed {
+				t.Fatalf("turn state = %s, want failed", turn.State)
+			}
+			if turn.FailReason != ReasonSessionLost {
+				t.Fatalf("fail reason = %q, want %q", turn.FailReason, ReasonSessionLost)
+			}
+			after := h.waitIdle(t, c.ID)
+			if after.SessionID != "fake-session-gone" {
+				t.Fatalf("session id = %q; a lost session is not silently cleared", after.SessionID)
+			}
+			// And nothing was fabricated: no fresh conversation was written.
+			entries, err := os.ReadDir(h.sessionDir)
+			if err != nil {
+				t.Fatalf("read session dir: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("a fresh session was started behind the human's back: %v", entries)
+			}
+		})
+	}
+}
+
+// TestCursorAdoptsAnUnknownSession states cursor's gap positively, which is
+// the project's rule for a capability an adapter lacks (§9.7, task 070
+// decision 2).
+//
+// cursor-agent 2026.08.11 does not refuse `--resume` of an id it has never
+// seen: it starts a fresh chat *under that id*, exits 0 and answers normally
+// (internal/agent/cursor/testdata/resume_unknown_2026.08.11.jsonl). There is
+// no wording to classify because there is no refusal, so a cursor chat whose
+// id has aged out gets an answer with no memory rather than `session_lost`.
+// The turn succeeds, and the test says so rather than pretending otherwise.
+func TestCursorAdoptsAnUnknownSession(t *testing.T) {
 	h := newHarness(t)
-	c := h.chat(t)
+	c := h.chatOn(t, "cursor")
 	if _, err := h.store.SetChatSession(t.Context(), c.ID, "fake-session-gone"); err != nil {
 		t.Fatalf("SetChatSession: %v", err)
 	}
 
 	turn := h.sendAndWait(t, c.ID, "still there?")
-	if turn.State != chatstate.TurnFailed {
-		t.Fatalf("turn state = %s, want failed", turn.State)
+	if turn.State != chatstate.TurnDone {
+		t.Fatalf("turn = %s (%s: %s), want done: cursor has no session-lost refusal to classify",
+			turn.State, turn.FailReason, turn.ErrorMessage)
 	}
-	if turn.FailReason != ReasonSessionLost {
-		t.Fatalf("fail reason = %q, want %q", turn.FailReason, ReasonSessionLost)
+	if body := h.transcript(t, c.ID, turn.Seq); strings.Contains(body, "recalled:") {
+		t.Fatalf("a chat with no prior turns recalled something; transcript:\n%s", body)
 	}
 	after := h.waitIdle(t, c.ID)
 	if after.SessionID != "fake-session-gone" {
-		t.Fatalf("session id = %q; a lost session is not silently cleared", after.SessionID)
-	}
-	// And nothing was fabricated: no fresh conversation was written.
-	entries, err := os.ReadDir(h.sessionDir)
-	if err != nil {
-		t.Fatalf("read session dir: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("a fresh session was started behind the human's back: %v", entries)
+		t.Fatalf("session id = %q; cursor keeps the id it was handed", after.SessionID)
 	}
 }
 
@@ -348,9 +401,15 @@ func TestRecoverFinalizesInterruptedAndDoesNotResend(t *testing.T) {
 	}
 }
 
-// TestAdaptersThatCannotResume states the capability positively, in both
-// directions (decision 3). No adapter ever replays a log as prompt context.
-func TestAdaptersThatCannotResume(t *testing.T) {
+// TestAdaptersThatCanResume states the capability positively, in both
+// directions (task 063 decision 3, task 070). No adapter ever replays a log as
+// prompt context; the ones that cannot resume are refused instead.
+//
+// The false leg is agenttest.StubNonResuming rather than a shipped adapter.
+// Until task 070 it was codex and cursor, and the day they learned to resume
+// this test asserted the opposite of the truth — which is what any refusal
+// pinned to whichever CLI happens to lack a capability today will keep doing.
+func TestAdaptersThatCanResume(t *testing.T) {
 	fake := agenttest.BuildFakeAgent(t)
 	bin := func() string { return fake }
 	for _, tc := range []struct {
@@ -360,7 +419,8 @@ func TestAdaptersThatCannotResume(t *testing.T) {
 	}{
 		{"claude", claude.New(bin), true},
 		{"codex", codex.New(bin), true},
-		{"cursor", cursor.New(bin), false},
+		{"cursor", cursor.New(bin), true},
+		{agenttest.NonResumingName, agenttest.StubNonResuming{}, false},
 	} {
 		if got := agent.CanResume(tc.a); got != tc.want {
 			t.Errorf("CanResume(%s) = %v, want %v", tc.name, got, tc.want)

--- a/internal/chatrun/runner_test.go
+++ b/internal/chatrun/runner_test.go
@@ -36,6 +36,10 @@ type harness struct {
 	// agent remembering, not from anything vincent kept.
 	sessionDir string
 	cfg        config.Config
+	// flood is the stub adapter drain_test.go drives. It is registered here
+	// rather than there because the registry is built once, and an adapter
+	// nothing selects costs the other tests nothing.
+	flood *floodAdapter
 }
 
 func newHarness(t *testing.T) *harness {
@@ -54,7 +58,7 @@ func newHarness(t *testing.T) *harness {
 	}
 	h := &harness{
 		store: st, repo: repo, project: project, dataDir: dataDir,
-		sessionDir: t.TempDir(), cfg: config.Default(),
+		sessionDir: t.TempDir(), cfg: config.Default(), flood: &floodAdapter{},
 	}
 	t.Setenv("FAKEAGENT_SESSION_DIR", h.sessionDir)
 	h.runner = New(Deps{
@@ -65,6 +69,7 @@ func newHarness(t *testing.T) *harness {
 			claude.New(func() string { return fake }),
 			codex.New(func() string { return fake }),
 			cursor.New(func() string { return fake }),
+			h.flood,
 		),
 		DataDir: dataDir,
 		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/scripts/m14-gate.sh
+++ b/scripts/m14-gate.sh
@@ -3,10 +3,10 @@
 # drive a chat end to end over the wire, against the committed fakeagent so CI
 # never calls a real agent CLI.
 #
-#   1. POST /v1/chats creates a chat with a worktree and a branch; an adapter
-#      that cannot resume is refused with the typed reason
+#   1. POST /v1/chats creates a chat with a worktree and a branch
 #   2. two sends in a row: turn 2 answers with what only turn 1 supplied, so
-#      continuity came from the agent resuming its own session
+#      continuity came from the agent resuming its own session — walked on
+#      every shipped adapter, since each spells resume differently (task 070)
 #   3. GET /v1/chats/{id}/turns/{seq}/transcript serves the turn, and a
 #      resume from its X-Next-Offset returns only what was appended
 #   4. GET /v1/chats/{id}/events streams this chat's events and nobody else's
@@ -15,6 +15,13 @@
 #      never queued — and leaves no turn row behind
 #   7. cancel stops a live turn; archive removes the worktree
 #   8. chats never appear in GET /v1/tasks
+#
+# The `agent_cannot_resume` refusal is deliberately *not* here. Since task 070
+# no shipped adapter is refused, so a real daemon has no subject to reach it
+# with; it stays proven in Go against agenttest.StubNonResuming, in
+# internal/api and internal/chatrun. Registering a fake adapter in the
+# daemon's own registry to keep the leg would put a test double in the
+# production registry, which is the §9.1 property the refusal exists to guard.
 #
 # There are no workflow `run:` bodies to spell in the sh∩pwsh intersection —
 # a chat has no workflow — but this script's own bash obeys the two standing
@@ -78,6 +85,8 @@ agents:
     path: "$(hostpath "$FAKEAGENT")"
   codex:
     path: "$(hostpath "$FAKEAGENT")"
+  cursor:
+    path: "$(hostpath "$FAKEAGENT")"
 EOF
 
 echo "== start the daemon"
@@ -137,17 +146,7 @@ PROJECT="$(api POST /projects -d "{\"path\": \"$(hostpath "$REPO")\"}")" \
   || fail "POST /v1/projects failed"
 PROJECT_ID="$(printf '%s' "$PROJECT" | jq -r .id)"
 
-echo "== 1. create a chat; an adapter that cannot resume is refused"
-# cursor, since task 070: codex gained `exec resume <thread_id>` and is
-# created like claude now, so cursor is the adapter left to state the refusal
-# over. An adapter that cannot resume is refused at creation, never emulated.
-CODE="$(api_status POST /chats \
-  -d "{\"project_id\": $PROJECT_ID, \"title\": \"no memory\", \"agent\": \"cursor\"}")"
-[[ "$CODE" == "400" ]] || fail "a cursor chat answered $CODE, want 400"
-REASON="$(jq -r .error.code < "$TMP/body.json")"
-[[ "$REASON" == "agent_cannot_resume" ]] \
-  || fail "the refusal is $REASON, want the typed agent_cannot_resume"
-
+echo "== 1. create a chat"
 CHAT="$(api POST /chats \
   -d "{\"project_id\": $PROJECT_ID, \"title\": \"gate talk\", \"agent\": \"claude\"}")" \
   || fail "POST /v1/chats failed"
@@ -185,32 +184,41 @@ case "$RECALL" in
   *) fail "turn 2 ran a fresh session rather than resuming one" ;;
 esac
 
-echo "== 2b. a codex chat resumes its own thread"
-CODEX_CHAT="$(api POST /chats \
-  -d "{\"project_id\": $PROJECT_ID, \"title\": \"codex talk\", \"agent\": \"codex\"}")" \
-  || fail "a codex chat was refused; task 070 made codex resumable"
-CODEX_ID="$(printf '%s' "$CODEX_CHAT" | jq -r .id)"
-api POST "/chats/$CODEX_ID/send" -d '{"message": "my favourite colour is heliotrope"}' >/dev/null \
-  || fail "the first codex send failed"
-STATE="$(wait_turn "$CODEX_ID" 1)"
-[[ "$STATE" == "done" ]] || fail "codex turn 1 is $STATE, want done"
-CODEX_SESSION="$(api GET "/chats/$CODEX_ID" | jq -r .chat.session_id)"
-[[ -n "$CODEX_SESSION" && "$CODEX_SESSION" != "null" ]] \
-  || fail "the codex chat recorded no thread id, so there is nothing to resume"
-api POST "/chats/$CODEX_ID/send" -d '{"message": "what is my favourite colour?"}' >/dev/null \
-  || fail "the second codex send failed"
-STATE="$(wait_turn "$CODEX_ID" 2)"
-[[ "$STATE" == "done" ]] || fail "codex turn 2 is $STATE, want done"
-# The stand-in has no model, so this proves the plumbing and not the memory:
-# vincent handed the thread id back on argv, and the child recognized it.
-# That context genuinely survives is the owner walkthrough's job — the same
-# division m5 draws, and the reason m3 seeds rather than asserts.
-CODEX_RECALL="$(curl -sS -H "Authorization: Bearer $TOKEN" \
-  "$BASE/chats/$CODEX_ID/turns/2/transcript" | tr -d '\r')"
-case "$CODEX_RECALL" in
-  *heliotrope*) ;;
-  *) fail "codex turn 2 did not see turn 1; transcript: $CODEX_RECALL" ;;
-esac
+echo "== 2b. the same two turns on codex and cursor"
+# Each adapter spells resume differently — claude and cursor take
+# `--resume <id>`, codex an `exec --json resume <id>` subcommand — and each
+# reports its id off a different stream shape. A daemon that dropped the id for
+# one of them fails here by omission: a fresh session emits no recall line.
+for AGENT in codex cursor; do
+  OTHER="$(api POST /chats \
+    -d "{\"project_id\": $PROJECT_ID, \"title\": \"$AGENT talk\", \"agent\": \"$AGENT\"}")" \
+    || fail "POST /v1/chats on $AGENT failed"
+  OTHER_ID="$(printf '%s' "$OTHER" | jq -r .id)"
+  api POST "/chats/$OTHER_ID/send" \
+    -d '{"message": "my favourite colour is heliotrope"}' >/dev/null \
+    || fail "the first send on $AGENT failed"
+  STATE="$(wait_turn "$OTHER_ID" 1)"
+  [[ "$STATE" == "done" ]] || fail "$AGENT turn 1 is $STATE, want done"
+  SESSION="$(api GET "/chats/$OTHER_ID" | jq -r .chat.session_id)"
+  [[ -n "$SESSION" && "$SESSION" != "null" ]] \
+    || fail "the $AGENT chat recorded no session id, so there is nothing to resume"
+
+  api POST "/chats/$OTHER_ID/send" -d '{"message": "what is my favourite colour?"}' >/dev/null \
+    || fail "the second send on $AGENT failed"
+  STATE="$(wait_turn "$OTHER_ID" 2)"
+  [[ "$STATE" == "done" ]] || fail "$AGENT turn 2 is $STATE, want done"
+  RECALL="$(curl -sS -H "Authorization: Bearer $TOKEN" \
+    "$BASE/chats/$OTHER_ID/turns/2/transcript" | tr -d '\r')"
+  case "$RECALL" in
+    *heliotrope*) ;;
+    *) fail "$AGENT turn 2 did not see turn 1; transcript: $RECALL" ;;
+  esac
+  case "$RECALL" in
+    *recalled:*) ;;
+    *) fail "$AGENT turn 2 ran a fresh session rather than resuming one" ;;
+  esac
+  api POST "/chats/$OTHER_ID/archive" >/dev/null || fail "archiving the $AGENT chat failed"
+done
 
 echo "== 3. the per-turn transcript, and its offset seam"
 HEADERS="$TMP/transcript.headers"


### PR DESCRIPTION
## Summary

Chats only worked on claude. codex and cursor were refused at creation with
`400 agent_cannot_resume` — not because those CLIs cannot resume, but because
nobody had *proved* they could. Every record that touched it deferred rather
than closed the question, and each named the same unblocking condition: a
fixture captured against a named CLI build. Both CLIs were on hand, so this
captures them and lands the capability.

**codex** resumes with a subcommand, not a flag: `codex exec resume --json
<flags> <thread_id> -`. The trailing `-` is load-bearing and is the one place
the resumed argv is not the fresh argv plus an id — `codex exec` reads the
prompt from stdin when no prompt argument is given, but `exec resume` reads it
from stdin only "if `-` is used", so omitting it hangs the child on a stdin
nobody reads. The thread id arrives on `thread.started`, which the parser had
no case for at all.

**cursor** resumes with `--resume <session_id>`, and the id it accepts is the
`session_id` its stream stamps on every line. That was the single largest risk
in the issue — the existing fixture scrubs the id, so nothing on disk showed
the stream's id was the resume key — and a two-turn capture settled it. So the
contingent `agent.SessionCreator` seam was **not** built, and there is no core
change here at all: `internal/api/chats.go`, `GET /v1/agents`'
`supports_resume` and the TUI's `resumableAgents` all read `agent.CanResume`
and were untouched. That is the evidence §9.1's optional-interface choice was
right.

Two limitations are stated positively rather than worked around:

- **A resumed codex run is always full-auto.** `codex exec resume` has no
  `-s/--sandbox` at all, so `restricted` has no argv spelling on it and the
  adapter does not invent one. That is safe only because the combination is
  unreachable rather than merely unreached: `POST /v1/chats` hardcodes
  `full_auto`, its decoder rejects unknown fields so there is nothing to ask
  with, and nothing else sets `RunSpec.ResumeSessionID`.
  `TestChatsAreAlwaysFullAuto` asserts both halves, so the day chats gain a
  permission mode this is reopened deliberately instead of being discovered as
  a silent escalation on someone's machine.
- **cursor cannot report a lost session.** Handed a `--resume` id it has never
  seen it does not refuse — it starts a fresh chat *under that id*, stamps it
  on every line and exits 0. So cursor ships no `session_lost` classifier:
  there is no refusal to recognize, and matching one would be a guess about a
  CLI that answered. The brief expected a `failure.go` here; the capture said
  otherwise and the capture wins. codex does classify it, against its captured
  wording, and only for a run that actually passed a resume id — §9.2's rule
  verbatim, so no workflow step can be misdiagnosed.

`usage_limit` and `unauthenticated` stay unclassified on both adapters: task
003's reasoning is untouched, because an account cannot be made to hit its
quota on demand and those wordings still have no capturable fixture. A bad
session id costs nothing to reproduce, which is exactly why one is classified
and the others are not.

The `agent_cannot_resume` refusal is **kept, not deleted** — it is the contract
for the next adapter — and is now proven against `agenttest.StubNonResuming`
rather than a shipped adapter. That is not just a fix for two inverted tests: a
refusal pinned to whichever CLI happens to lack a capability today will keep
asserting the opposite of the truth every time one learns it. For the same
reason `scripts/m14-gate.sh` loses its refusal leg — no shipped adapter is
refused, so a real daemon has no subject that can reach it — and gains the
two-turn continuity walk on all three adapters instead.

Fixtures are captured from `codex-cli 0.150.1` and `cursor-agent
2026.08.11-e8db854`, named for their build under `testdata/`, with session ids
scrubbed to fixed placeholders (consistently, so "the same id on every line" is
still what they pin).

## One fix that was not in the plan

Putting three adapters through `internal/chatrun`'s tests instead of one made
the package slow enough to lose a race that had been latent since task 063:
`TestTurnTranscriptStopsAtTheCap` hung the whole package at its 10-minute
deadline. It is a real hang, not a test artefact, so it is fixed here.

`chatrun.consume` returned on every early exit — a cancel, `agent_timeout`,
`input_timeout`, the transcript cap — and stopped reading the adapter's event
stream. But an adapter's reader goroutine blocks *handing an event over*
(claude's `readLoop` → `mux` → `events`), and its `Wait` does not return until
that reader is finished. With a talkative agent the two waited on each other
forever: the turn never reached a terminal state, the chat never came back to
idle, its `max_parallel_chats` slot was never released, and `Runner.Stop` — so
a daemon shutdown — blocked with it. Killing the process tree does not help;
it does not unblock a goroutine already parked mid-handover. The 64+64-event
buffers are what hid it, which is why it surfaced as a rare hang under load
rather than a red test.

`internal/taskrun` never had the bug and says why in `steps.go` ("the stream
is left to drain so Wait still reports an exit"). `consume` now does the same
through `Runner.drain`. `TestTurnDrainsTheStreamItAbandons` pins it against a
stub adapter with no buffers at all, so the assertion does not depend on
winning the race; with `drain` removed it fails in ten seconds with a sentence
rather than hanging the package.

## Related

Closes #283.

Supersedes [063](docs/tasks/063-free-chat.md) decision 3 on that decision's own
stated terms — it deferred rather than closed the question and named the
fixture as the unblocking condition. Closes §20's chat entry for codex and
cursor, and reverses the §9.3/§9.7 "Cannot resume" bullets and decision row
29's "codex and cursor are refused at creation". Task 003's decision about
`usage_limit`/`unauthenticated` is **not** reopened. New record:
[docs/tasks/070-codex-and-cursor-in-chat.md](docs/tasks/070-codex-and-cursor-in-chat.md).

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Docs touched: `docs/spec.md` (§9.1, §9.3, §9.7, §20, decision row 29 — dated
in-place amendments), `docs/features.md`, `docs/guides/agents.md` (capability
table and both adapter sections), `docs/guides/tui.md`,
`docs/reference/api.md` (`supports_resume`, the refusal example — it named
codex, now generic — and the `session_lost` note), `docs/reference/cli.md`.
No config key, route, TUI binding or `Reason*` constant changed, so those pages
needed nothing. The chat-hang fix restores documented behaviour rather than
changing it, so it needed no page of its own beyond `CHANGELOG.md` and the
task record.

A documentation audit over the same diff caught one derivation the first pass
missed and fixed it in `docs: add codex 0.150.1 to the tested-build list
everywhere it is published`. `testedVersions` gained `0.150.1` with the `exec
resume` capture, but the three places that publish that list by hand had not
followed: the capability table in the agents guide, the `tested_versions` value
in the doctor example response, and §9.3's task 041 amendment naming the
verified builds — so a user on 0.150.1 would read `version_verdict: tested`
from the daemon and a list excluding their build from the docs. §9.3 is amended
in place with a dated note, per the spec's own rule.

Found and deliberately not fixed here, since both are outside a documentation
commit's scope and neither is this change's doing: `CLAUDE.md`'s gate list stops
at `m13` and has never named `m14-gate.sh` (it arrived with task 067), and
there is no `docs/assets/tui-*.png` of the chats board or the new-chat form at
all — so no screenshot went stale, but the chats views remain the only TUI
surface with no capture.

Verified: `go test ./...`, `golangci-lint` for `GOOS=darwin/linux/windows`, and
`./scripts/m14-gate.sh` all green locally on macOS. The gate's Windows and
Linux legs run in CI.
