### PR TITLE
Render assistant markdown in the task and chat output panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Assistant prose renders as Markdown in the task output pane and in chats.**
+  Headings, emphasis, strong text, ordered and unordered lists, nested lists,
+  blockquotes, inline code, fenced code and horizontal rules become terminal
+  structure instead of literal syntax, through the one renderer both workspaces
+  already share. Everything else stays literal — reasoning, tool calls, tool
+  results, command output, errors and unmodeled lines keep their own gutter
+  marks, because Markdown punctuation in a grep hit was never meant as
+  formatting. Structure lives inside the assistant content column, so the
+  two-column activity gutter is unchanged, and every marker is a glyph rather
+  than a colour: a monochrome terminal or an SSH session keeps every
+  distinction. Constructs outside the supported list — tables, links, HTML,
+  footnotes — render as safe literal text, and raw HTML is never parsed,
+  fetched or executed. The transcript on disk and every API payload keep the
+  agent's exact bytes; a resize re-renders from the Markdown. Spec §15.
+
 - **A codex step's output pane now shows what codex actually reported.** The
   adapter read the subset of `codex exec --json` real captures existed for, and
   the upstream schema had grown well past it — so a codex step's pane was
@@ -556,6 +571,23 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **The output pane measures terminal cells rather than runes.** A line
+  containing an emoji, a CJK glyph, a combining mark or a ZWJ sequence was
+  measured by counting runes, so the pane over- or under-filled it and an
+  over-long word was hard-split at a rune index — which could cut a ZWJ emoji
+  into its parts. Every measurement on that path is now `ansi.StringWidth`.
+  This also corrects the answer form, which wraps through the same helper.
+- **Agent-supplied text can no longer drive the terminal.** Escape sequences
+  and C0/C1 control characters in any record — a tool result summary, a
+  command's output body, an error message — reached the pane unfiltered, so an
+  agent that emitted `ESC[2J` or an OSC title sequence could clear the screen
+  or rewrite the window title. They are now stripped before the pane measures
+  or draws anything, and only vincent's own styles are emitted. Spec §16.
+- **A chat turn whose transcript has gone to retention shows its whole
+  answer.** The fallback that renders `result_text` capped it at 40 lines with
+  an ellipsis and narrowed it by two columns; it now goes through the shared
+  renderer at the pane's full width. That answer is all the turn has left, and
+  the cap hid its tail.
 - **A chat's live output was raw agent JSON, and nothing turned it down.** The
   chat workspace rendered every line of a running turn as the agent CLI's own
   dimmed stream-json, clipped at 200 characters — because the daemon published a

--- a/docs/features.md
+++ b/docs/features.md
@@ -203,6 +203,13 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
 - Task detail is a full-screen workspace with Steps & Attempts, Task Details,
   Output, Diff, and Workflow tabs, plus a Pull Request tab on a task that has
   one linked; each tab uses the whole view.
+- The Output tab and the chat workspace share one renderer, and one verbosity
+  level. Assistant prose is rendered as Markdown — headings, lists, blockquotes,
+  inline and fenced code, and rules become terminal structure instead of
+  literal syntax — while reasoning, tool calls, command output and errors stay
+  literal behind their own gutter marks. Every marker is a glyph rather than a
+  colour, so a monochrome terminal keeps every distinction, and the transcript
+  on disk keeps the agent's exact bytes.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -345,6 +345,37 @@ output. It is the sentence that decides whether to open the transcript.
 | `↑`/`↓` | Select an attempt or Task Details section, scroll Output, or move between diff files — according to the active tab |
 | `pgup`/`pgdn` | Scroll the selected Task Details section |
 
+### How the pane reads
+
+Every record is a two-column **gutter** plus its content. What the agent *said*
+is unmarked and sits flush left; what it *did* is glyphed — `·` reasoning, `▸` a
+tool call with its outcome indented under it, `#` the run header, `☰` the plan.
+A monochrome terminal or an SSH session loses nothing to that scheme, which
+colour alone would not survive. There are no timestamps: on an 80-column pane
+they would spend nine columns of every line answering a question the timeline
+already answers per attempt.
+
+**What the agent said is rendered as Markdown.** Headings, emphasis, strong
+text, ordered and unordered lists, nested lists, blockquotes, inline code,
+fenced code and horizontal rules become terminal structure instead of literal
+syntax. That structure lives *inside* the assistant column — the gutter is
+untouched — and every marker is a glyph, not a colour, so a heading's `▌`, a
+quote's `│`, a list's `•`/`◦`/`▪`, a code block's `▏` and an inline span's
+backticks all survive with the styling stripped. A code block keeps its
+indentation and its hard line breaks; a line too long for the pane continues on
+the next one at the block's rail rather than being cut off. Constructs outside
+that list — tables, links, HTML, footnotes — render as the characters the agent
+sent, and raw HTML is never parsed, fetched or executed.
+
+Only the agent's prose is interpreted. Reasoning, tool calls, tool results,
+command output, errors and unmodeled lines stay literal behind their own gutter
+marks: a `#` in a grep hit is a `#`, not a heading. The rendering is derived
+too — the transcript on disk and the API keep the agent's exact bytes, and
+resizing the terminal re-renders from those rather than reflowing what was
+already drawn.
+
+The chat workspace's conversation body is this same pane, at the same level.
+
 ### What `v` adds
 
 `compact` is what the agent **said and did**, and nothing else. Reasoning is

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -14,6 +14,7 @@ vulnerability, use [private security advisories](https://github.com/lezli01/vinc
 - [Full-auto is the headline risk](#full-auto-is-the-headline-risk)
 - [What the worktree does and does not isolate](#what-the-worktree-does-and-does-not-isolate)
 - [Restricted mode](#restricted-mode)
+- [What an agent writes cannot drive your terminal](#what-an-agent-writes-cannot-drive-your-terminal)
 - [The API surface](#the-api-surface)
 - [Credentials](#credentials)
 - [What vincent writes outside its own directories](#what-vincent-writes-outside-its-own-directories)
@@ -188,6 +189,20 @@ step.
 Use `restricted` for steps that have no business running commands: a docs pass, a
 review, a summarization step. See
 [Writing workflows](guides/workflows.md#93-permission-modes).
+
+## What an agent writes cannot drive your terminal
+
+Every record the [output pane](guides/tui.md#how-the-pane-reads) draws — assistant
+prose, a tool result, a command's output, an error — is stripped of ANSI escape
+sequences and of C0/C1 control characters before it is measured or drawn,
+newline and tab excepted. An agent that emits `ESC[2J` or an OSC title sequence,
+or that echoes a file containing one, cannot clear your screen, move the cursor,
+rewrite the window title or overwrite adjacent UI. Only vincent's own styles are
+emitted.
+
+The same holds for the Markdown rendering of assistant prose: it is a fixed
+subset drawn with vincent's own glyphs, and raw HTML is rendered as the
+characters the agent sent — never parsed, fetched or executed.
 
 ## The API surface
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6685,6 +6685,58 @@ Still **no timestamps**, and `parent_call_id` — which every record may now car
 nesting subagent work under its parent is its own design problem with its own
 capture (task 066 decision 2).
 
+*Amended 2026-09-01 (task 073).* Assistant prose is rendered as **Markdown**;
+every other record stays literal.
+
+- **What is interpreted, and only this.** `agent.output` records, in both
+  workspaces — they reach the same renderer — and the chat's §17 retention
+  fallback, which is the same prose arriving by the other door. Reasoning, tool
+  calls, tool results, command output, `agent.raw`, `agent.usage`, every
+  `agent.error` and every `vincent.*` record stay exactly as literal as they
+  were, and so does `agent.result`, including the case where it falls back to
+  its result text: that is a `✓ `/`✗ `-marked line, an event rather than prose,
+  and Markdown must never make prose look like a tool event. Command output and
+  tool summaries contain Markdown punctuation constantly, and none of it was
+  meant as formatting.
+- **The subset is a written-down list**, not CommonMark: headings, paragraphs,
+  emphasis, strong, ordered and unordered lists, nested lists, blockquotes,
+  inline code, fenced code, horizontal rules. Everything else — tables, links,
+  reference links, HTML blocks, footnotes — renders as safe literal text. Raw
+  HTML is never parsed, and nothing is ever fetched or executed. The parser is
+  vincent's own, over that list: the alternatives are a Markdown library plus an
+  AST walker, or glamour, which emits a pre-styled ANSI block with its own
+  wrapping and margins that cannot be folded into the gutter scheme below.
+- **The gutter scheme is unchanged.** Assistant prose still gets the blank
+  gutter and still sits flush left. Markdown structure lives *inside* the
+  content column: a heading's `▌ `, a list's `• `/`◦ `/`▪ ` or its number, a
+  blockquote's `│ ` and a fenced block's `▏ ` are composed after the gutter,
+  the way a tool result composes its `✓ ` into a four-column one. Every one of
+  them is a glyph rather than a colour, so a monochrome terminal keeps every
+  distinction — the same rule the gutters themselves are held to. Inline code
+  keeps its backticks for that reason.
+- **Measurement is terminal cells** (`ansi.StringWidth`), not runes: a CJK
+  glyph and an emoji are two columns, a combining mark is none, and a ZWJ
+  sequence is one grapheme of several runes. **The wrap-plain-then-style
+  invariant above stands** and is not superseded by this — text is still
+  wrapped while plain and each produced line styled afterwards, so no wrapping
+  is ANSI-aware and no escape sequence can be split by a break. What changed is
+  how wide a character is, not when a style is applied.
+- **A blockquote's bar is drawn on every line of the quote.** A wrapped line's
+  hanging indent is otherwise spaces of the gutter's width, which would put the
+  bar on the first line and drop it from the rest — a content gutter that is
+  not a gutter.
+- **Code-block overflow is a hard wrap at the cell boundary**, continued at the
+  block's own rail, with every space kept and every hard break honored. A tab
+  is the four columns lipgloss draws it as, so the measured width and the drawn
+  width agree. Not truncation, which would put the tail of a long line out of
+  reach of the TUI entirely, and not clipping, which is what wrapping replaced.
+- **Rendering is derived and never stored.** The JSONL transcript and every API
+  payload keep the agent's exact bytes (§13.3), no render path mutates a
+  record, and a resize re-renders from the Markdown rather than re-wrapping
+  previously rendered ANSI. A raw/rendered toggle and a copy-raw reader action
+  are follow-ups; the chat composer owns every letter key (task 071 decision
+  4), so a toggle needs its own decision about which key it is.
+
 Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
 serves neither. Takeovers are for surfaces you visit deliberately; popups are
@@ -6992,6 +7044,17 @@ currently true to show (§15 view 6).
 
 - **Trust boundary = the OS user.** API on loopback only + bearer token file (0600)
   so other local users can't drive the daemon. No TLS, no accounts in v1.
+- **Agent text cannot drive the terminal (task 073, added 2026-09-01).** Every
+  record's text is stripped of ANSI escape sequences and of C0/C1 control
+  characters before the output pane measures or draws it — newline and tab
+  excepted, which the pane renders itself. Only vincent's own styles are
+  emitted. Without this an agent, or anything an agent chose to echo, could
+  clear the screen, move the cursor, rewrite the window title or overwrite
+  adjacent UI with a `\x1b[2J` or an OSC sequence in a tool result summary, a
+  command's output body or an error message — none of which are Markdown, which
+  is why the stripping is at the pane's one wrapping chokepoint rather than in
+  the Markdown path. Raw HTML in assistant prose is never parsed, fetched or
+  executed; it renders as the characters the agent sent.
 - **Full-auto agents are the headline risk.** In full-auto, an agent can execute
   arbitrary commands *as the user*, not confined to the worktree. Mitigations:
   per-workflow/step `restricted` mode, everything transcripted, nothing merges or

--- a/docs/tasks/073-assistant-markdown-in-output.md
+++ b/docs/tasks/073-assistant-markdown-in-output.md
@@ -1,0 +1,196 @@
+# 073 — Assistant Markdown in the output pane
+
+**Status:** ✅ done (1/1)
+**Issue:** #289
+**Amends:** §15's "output pane's line model (T4.16)" paragraph and §16
+**Follow-up to:** [071](071-chat-workspace-verbosity.md), which pointed both
+workspaces at one renderer and so gave this defect two surfaces
+
+Assistant prose reached the output pane as literal text: a heading kept its
+`#`, a fenced block kept its backticks, a list lost its indentation. The pane
+also measured width by counting runes, so an emoji, a CJK glyph or a combining
+mark mis-filled every line it appeared on — a defect rich layout would only
+amplify.
+
+The work is entirely client-side and lands in `internal/tui` alone: no daemon
+package, no API route, no store migration. That is not a scoping convenience,
+it is the reason the feature is allowed to exist in this shape. §13.3's chunks
+and the JSONL transcript keep the agent's bytes exactly, and width, theme and
+colour profile are things only the client knows.
+
+## Decisions
+
+### 1. The parser is hand-rolled, over a written-down subset
+
+A line-oriented block scanner plus an inline span splitter, emitting the
+existing `[]segment` / `paneLine` model directly. No new module in `require`.
+
+This follows the posture recorded twice already — [017](017-workflow-visualization.md)
+decision 2 refusing a graph widget ("a large integration surface and
+binary-size cost" for a small amount of drawing code) and
+[055](055-release-check-and-self-update.md) decision 1 refusing `sigstore-go` ("a very
+large dependency tree in a project whose runtime `require` block is fifteen
+lines"). The supported constructs are a fixed list rather than CommonMark:
+headings, paragraphs, emphasis, strong, ordered and unordered lists, nested
+lists, blockquotes, inline code, fenced code, horizontal rules.
+
+*Beat:* `goldmark` plus a custom AST walker — correct parsing for free, but a
+new direct dependency and an AST layer that still has to be written, for a
+subset this size.
+
+*Beat, harder:* `charmbracelet/glamour`. It emits a pre-styled ANSI block with
+its own word wrap and margins. That cannot be folded into the two-column
+activity gutter, it breaks the wrap-plain-then-style invariant below, and it
+drags in chroma, termenv and a probable lipgloss v1/v2 clash against the v2
+this repo is on.
+
+**The subset boundary is documented, not implicit.** Anything outside it —
+tables, links, reference links, HTML blocks, footnotes, setext headings,
+backslash escapes — renders as safe literal text, and
+`TestMarkdownOutsideTheSubsetStaysLiteral` is where that is held. Tables and
+link interaction are the stated follow-ups.
+
+### 2. Cell width, and the wrap-plain-then-style invariant is kept
+
+Read literally, the issue's "replace rune-count width calculations in this path
+with ANSI-aware terminal cell width" would supersede **task 050 decision 8**
+and T4.16's recorded reasoning, which state the opposite: text is wrapped while
+plain and each produced line is styled afterwards, "so no wrapping here has to
+be ANSI-aware". Confirmed with the author: **the invariant stands unamended.**
+
+What was actually wrong is the measurement. `cols()` counted runes, so an
+emoji, a CJK glyph or a combining mark was mis-measured and the pane over- or
+under-filled a line. It is now `ansi.StringWidth` — already a direct dependency,
+already what `wrapCellLines` and twenty other TUI sites use. Nothing in the wrap
+path ever sees an escape sequence, because the styles are still applied to
+already-wrapped plain text.
+
+Two consequences that are easy to miss, and are both in scope:
+
+- `splitWords`' hard split for over-long words sliced `runes[:avail]`. Rune-
+  indexed, so it was wrong for wide runes for the same reason `cols` was, and
+  it cut ZWJ sequences in half. It is now a cell-width walk.
+- `cols` is shared with `answerform.go`. Fixing it fixed the answer form's
+  wrapping too, and that gets its own test rather than being silently
+  inherited.
+
+Because the invariant holds, the segment model already does the work: a
+paragraph with inline `code` and **strong** spans is one `paneLine` with several
+`segment`s, and `wrapLine` measures each token plain and styles runs after. No
+new wrapping machinery for inline Markdown.
+
+### 3. Fenced code hard-wraps at the cell boundary
+
+A code line longer than the pane continues on the next line at the block's own
+rail — no word breaking, no ellipsis, nothing unreachable. This is what the pane
+already does for a long path or a base64 blob, and it is the policy T4.16
+adopted when it replaced clipping.
+
+*Beat:* truncate with `…`, which keeps a code block rectangular but puts the
+tail of a long line out of reach of the TUI entirely.
+
+*Beat:* no wrap, let the viewport clip — precisely the defect T4.16 fixed for
+prose.
+
+Fenced code cannot go through `splitWords`, which collapses runs of whitespace
+via `strings.Fields`. It has a `pre` path that hard-splits at the cell boundary
+and preserves every space. A tab is expanded to the four columns lipgloss draws
+it as: `ansi.StringWidth` calls a tab zero columns wide, so measuring the tab
+and rendering the spaces would disagree by exactly the block's indentation.
+
+### 4. "Keep raw Markdown copyable" means the transcript, and ships nothing new
+
+The criterion had no owner. The TUI has no copy-out action at all —
+`clipboard.go` only reads, for paste — and terminal drag-select copies rendered
+glyphs, so a heading's `#` is gone the moment it renders. There is no way for
+this issue to make the *rendered* pane yield raw Markdown without inventing a
+reader action.
+
+So the criterion is discharged as the property that is already true and now has
+a test: rendering is derived, never stored. The JSONL transcript and every API
+payload keep the agent's exact bytes, and no render path mutates a
+`TranscriptRecord`. A raw/rendered toggle key and a copy-raw action are both
+plausible and both belong in the follow-up issues already scoped — a toggle in
+particular needs its own decision, because the chat composer holds every letter
+key ([071](071-chat-workspace-verbosity.md) decision 4).
+
+### 5. What stays literal, precisely
+
+Markdown interpretation applies to exactly two sites: `agent.output` records,
+in both views since both reach them through `outputLines`, and the chat's
+retained-away answer (§17), which renders `turn.ResultText` when retention has
+taken the transcript away.
+
+Everything else keeps its current literal rendering and its current gutter:
+`agent.thinking`, `agent.tool_use`, `agent.tool_result`, `agent.run_header`,
+`agent.plan`, `agent.command_output`, `agent.usage`, `agent.raw`,
+`command.output`, `vincent.*`, and every `agent.error`.
+
+**`agent.result` stays literal too**, including the case where `renderResult`
+falls back to `ResultText` because the attempt rendered no output. That is a
+`✓ `/`✗ `-marked line — an event, not prose — and the issue's own rule is that
+Markdown must never make prose look like a tool event. The `result_text` the
+issue names is the chat's retention fallback, which is prose with a blank
+gutter.
+
+### 6. Markdown structure lives inside the assistant content column
+
+The two-column activity gutter is untouched: assistant prose still gets
+`gutterNone` and sits flush left. A list marker, a blockquote bar or a code
+block's rail is composed *after* the gutter, exactly as `toolResultLine`
+composes `gutterResult + mark` into a four-column gutter. Nesting depth grows
+that prefix; `wrapLine`'s hanging indent then falls out for free, which is what
+the issue asks for on wrapped list items.
+
+One mechanical extension was needed. `wrapLine` indents continuations with
+*spaces* of the gutter's width, so a blockquote's `│` would appear on the first
+line of a wrapped quote and vanish on the rest — a content gutter that is not a
+gutter. `paneLine` gained an optional `contPrefix`, defaulting to the current
+spaces; blockquotes and code blocks set it to their own rail. Every existing
+caller is unchanged.
+
+Every marker is a glyph rather than a colour, which is the rule §15 already
+holds the activity gutters to: a monochrome terminal or an SSH session that
+lost its profile must keep every distinction. Inline code keeps its backticks
+for the same reason.
+
+### 7. Control sequences are neutralized at one chokepoint
+
+The issue scopes stripping to the Markdown path. It belongs wider, and it is
+cheap there: agent text reached the pane unfiltered, so an agent that emits
+`\x1b[2J` or an OSC title sequence could already clobber the TUI, in records
+that have nothing to do with Markdown — a tool result summary, a command's
+output body, an error message. Sanitizing inside `wrapLine`'s segment emission
+covers every record type at one site and cannot be bypassed by a record type
+added later.
+
+Escape sequences and C0/C1 controls are removed *before* measurement, so they
+can never influence the width arithmetic either. Only vincent-owned styles are
+emitted. Raw HTML is not parsed and never fetched or executed; it renders as
+literal text.
+
+This fixes a pre-existing defect. It is folded in rather than split out because
+adding rich layout on top of unsanitized input is what would turn a cosmetic
+bug into a pane-corrupting one. §16 had no terminal-injection item before this.
+
+## One behaviour change worth calling out
+
+The chat's retention fallback rendered through `wrapCellLines(t.ResultText,
+width-2, 40)` — a **40-line cap** with an ellipsis, and a two-column narrowing
+the `outputLines` path does not apply. Routing it through the shared renderer
+drops both. That is required by the first acceptance criterion (the same
+Markdown must render identically in both views at the same width) and it is a
+strict improvement: the retained-away answer is the only content that turn has
+left, and capping it hid the tail.
+
+## What the tests prove
+
+`internal/tui` is covered by no gate script, so the tests are the whole
+assurance. Construct fidelity per width; the two views agreeing at every level;
+nothing but assistant prose being interpreted, each other record type keeping
+its gutter; every produced line measuring within the pane over ASCII,
+combining marks, emoji, ZWJ sequences and CJK at narrow widths; reflow being
+from the source rather than from rendered ANSI; injection fixtures leaving no
+control character and no widened line; code blocks keeping their whitespace and
+hard-wrapping whole; monochrome keeping every structural distinction; and the
+rendered pane not mutating the records it rendered.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -86,6 +86,7 @@ the living engineering specification records implementation contracts.
 | [070](070-codex-stream-surface.md) | Extend codex output parsing to the full exec event schema, and support thread resume | ✅ done (5/5) |
 | [071](071-chat-workspace-verbosity.md) | The chat workspace renders through the output pane at a shared verbosity level | ✅ done (1/1) |
 | [072](072-codex-and-cursor-in-chat.md) | Chats on codex and cursor | ✅ done (1/1) |
+| [073](073-assistant-markdown-in-output.md) | Assistant Markdown in the output pane | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/answerform_test.go
+++ b/internal/tui/answerform_test.go
@@ -292,3 +292,26 @@ func TestSameRequestSurvivesARefresh(t *testing.T) {
 		t.Error("a different question was treated as the same one")
 	}
 }
+
+// TestAnswerFormWrapsInCells is the answer form's share of task 073
+// decision 2. It wraps through the output pane's splitWords and measures with
+// the same cols, so correcting the measurement corrected this too — and a
+// question in CJK or an option carrying an emoji is exactly the case a rune
+// count got wrong, by up to a factor of two.
+func TestAnswerFormWrapsInCells(t *testing.T) {
+	for _, text := range []string{
+		strings.Repeat("日本語のテキスト ", 10),
+		strings.Repeat("🎉 done ", 20),
+		strings.Repeat("👨‍👩‍👧 family ", 15),
+		strings.Repeat("éẍ ", 40),
+		strings.Repeat("日", 50),
+	} {
+		for _, width := range []int{20, 40, 60} {
+			for i, line := range wrapPlain(text, width) {
+				if w := ansi.StringWidth(line); w > width {
+					t.Errorf("width %d: line %d is %d columns: %q", width, i, w, line)
+				}
+			}
+		}
+	}
+}

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -120,7 +120,16 @@ func (v *chatView) bodyLines(width int) []string {
 			// §17: a transcript that has gone to retention still leaves the
 			// turn's answer, and it is shown with no banner — a reader who
 			// did not ask for the record is not told it is missing.
-			lines = append(lines, wrapCellLines(t.ResultText, width-2, 40)...)
+			//
+			// It goes through the same renderer the records do (task 073
+			// decision 5): the answer is assistant prose whichever door it
+			// came in, and the first acceptance criterion is that the same
+			// Markdown renders identically in both workspaces at the same
+			// width. That drops the 40-line cap and the two-column
+			// narrowing this used to apply — a strict improvement, since a
+			// retained-away answer is all the turn has left and the cap hid
+			// its tail.
+			lines = append(lines, markdownLines(t.ResultText, width)...)
 		}
 		if t.FailReason != "" {
 			lines = append(lines, " "+styleBad.Render(

--- a/internal/tui/chatverbosity_test.go
+++ b/internal/tui/chatverbosity_test.go
@@ -238,3 +238,68 @@ func TestChatLiveAndRefetchedAgree(t *testing.T) {
 		}
 	}
 }
+
+// mdFixture is assistant prose covering the whole supported subset, used to
+// hold the two workspaces to the same rendering.
+const mdFixture = "# Findings\n\nThe **fix** is in `internal/tui`, and it is *small*.\n\n" +
+	"- one, long enough to wrap at eighty columns without any help at all\n" +
+	"  - nested\n1. first\n\n> a quotation\n\n```go\nfunc main() {}\n```\n\n---\n\nDone."
+
+// TestChatAndTaskPaneRenderMarkdownIdentically is the first acceptance
+// criterion of task 073, and it extends the equivalence pattern above: the
+// same assistant Markdown, at the same width and the same level, is the same
+// lines in a task workspace and in a chat. There is one renderer, and this is
+// what says so.
+func TestChatAndTaskPaneRenderMarkdownIdentically(t *testing.T) {
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{{Name: "Edit", CallID: "c1"}}},
+		{Type: "agent.output", Text: mdFixture},
+	}
+	for _, level := range []outputLevel{levelCompact, levelNormal, levelVerbose} {
+		for _, width := range []int{40, 80} {
+			d := newTestDetail(t)
+			d.width = width
+			d.level.set(level)
+			d.records = recs
+			pane := strings.Join(plainLines(d.outputLines()), "\n")
+
+			v := chatViewFixture()
+			v.level.set(level)
+			v.turns = []apiclient.ChatTurn{{ID: 9, Seq: 1, State: "done", Prompt: "ask"}}
+			v.turnRecords[1] = recs
+			body := strings.Join(plainLines(v.bodyLines(width)), "\n")
+
+			if !strings.Contains(body, pane) {
+				t.Errorf("%s at width %d: the chat and the task pane disagree\n"+
+					"pane:\n%s\nchat:\n%s", level, width, pane, body)
+			}
+			if !strings.Contains(pane, "▌ Findings") {
+				t.Errorf("%s at width %d: the fixture did not render as Markdown:\n%s",
+					level, width, pane)
+			}
+		}
+	}
+}
+
+// TestChatRetentionFallbackIsRenderedProse holds decision 5's second site.
+// §17 leaves a turn nothing but its answer, and that answer is assistant
+// prose: it goes through the same renderer the records do, at the pane's full
+// width and with no line cap — the cap this used to apply hid the tail of the
+// only content the turn had left.
+func TestChatRetentionFallbackIsRenderedProse(t *testing.T) {
+	v := finishedChat(t, 1)
+	v.turns[0].ResultText = mdFixture + "\n\n" + strings.Repeat("tail line\n\n", 30)
+	v.applyTranscript(chatTranscriptMsg{chatID: 1, seq: 1, records: nil})
+	body := plainLines(v.bodyLines(80))
+	joined := strings.Join(body, "\n")
+	if !strings.Contains(joined, "▌ Findings") || !strings.Contains(joined, "• one") {
+		t.Errorf("the retained-away answer was not rendered as Markdown:\n%s", joined)
+	}
+	if strings.Count(joined, "tail line") != 30 {
+		t.Errorf("the answer lost its tail to a cap: %d of 30 lines survived:\n%s",
+			strings.Count(joined, "tail line"), joined)
+	}
+	if strings.Contains(joined, "…") {
+		t.Errorf("the fallback still truncates with an ellipsis:\n%s", joined)
+	}
+}

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -1,0 +1,623 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Markdown rendering for assistant prose (task 073, §15).
+//
+// Only assistant prose reaches this file: `agent.output` records in both
+// workspaces, and the chat's §17 retention fallback. Everything else the pane
+// renders — reasoning, tool calls, tool results, command output, errors,
+// vincent's own records — stays literal, because command output and tool
+// summaries routinely contain Markdown punctuation nobody meant as formatting
+// (decision 5).
+//
+// The parser is hand-rolled over a written-down subset rather than delegated
+// to goldmark or glamour (decision 1). glamour in particular emits a
+// pre-styled ANSI block with its own wrapping and margins, which cannot be
+// folded into the two-column activity gutter and would break the
+// wrap-plain-then-style invariant §15 rests on. The subset is exactly:
+//
+//	headings, paragraphs, emphasis, strong, ordered and unordered lists,
+//	nested lists, blockquotes, inline code, fenced code, horizontal rules.
+//
+// Everything outside it — tables, links, reference links, HTML blocks,
+// footnotes, setext headings, backslash escapes — renders as literal text.
+// That is the boundary, and it is a list rather than "whatever CommonMark
+// says", so a construct either appears above or it is safe text.
+//
+// Markdown structure lives *inside* the assistant content column (decision 6).
+// The activity gutter is untouched: prose still gets gutterNone, and a list
+// marker, a blockquote bar or a code block's rail is composed after it, the
+// way toolResultLine composes gutterResult + mark. wrapLine's hanging indent
+// then falls out for free.
+
+var (
+	// styleMDHeading is the section marker and its text. It carries a glyph
+	// as well as a colour because a monochrome terminal must still see the
+	// structure — colour alone would not survive an SSH session, which is
+	// the same reason §15's gutters are glyphs.
+	styleMDHeading = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	// styleMDMarker paints list markers and the code block's rail. Markers
+	// are not prose, so they are dimmer than what they introduce.
+	styleMDMarker = lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+	styleMDQuote  = lipgloss.NewStyle().Faint(true).Italic(true)
+	styleMDRule   = lipgloss.NewStyle().Faint(true)
+	styleMDCode   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+)
+
+// Content-column prefixes. Every one is a single cell wide plus its trailing
+// space, so a nested structure's indent arithmetic is the count of levels.
+const (
+	mdHeadingMark = "▌ "
+	mdQuoteBar    = "│ "
+	mdCodeRail    = "▏ "
+)
+
+// mdBulletsByDepth cycles the unordered marker so a nested list is readable
+// without counting columns. Past the third level the shape repeats; the
+// indent is what carries depth by then.
+var mdBulletsByDepth = []string{"• ", "◦ ", "▪ "}
+
+// mdKind classifies a block, which is all the vertical-spacing rule needs to
+// know: consecutive list items are one list and get no blank between them, a
+// heading is followed straight by what it introduces, and everything else is
+// separated by one line.
+type mdKind int
+
+const (
+	mdParagraph mdKind = iota
+	mdHeading
+	mdItem
+	mdQuote
+	mdCode
+	mdRule
+)
+
+// mdBlock is one parsed block. Its lines are laid out but not yet wrapped,
+// except mdRule, which is drawn to the pane's width at render time and so
+// carries no lines at all.
+type mdBlock struct {
+	kind  mdKind
+	lines []paneLine
+}
+
+// markdownLines renders assistant prose to wrapped pane lines.
+//
+// Reflow is always from this text: nothing here caches a rendered line, so
+// re-rendering at a new width re-parses the Markdown rather than re-wrapping
+// its own escape sequences. The record it was handed is never mutated —
+// rendering is derived, and the transcript on disk stays the agent's bytes
+// (decision 4).
+func markdownLines(text string, width int) []string {
+	blocks := parseMarkdown(sanitizeText(text))
+	out := make([]string, 0, len(blocks)*2)
+	prev := mdParagraph
+	for _, b := range blocks {
+		if len(out) > 0 && mdNeedsBlank(prev, b.kind) {
+			out = append(out, "")
+		}
+		out = append(out, renderMDBlock(b, width)...)
+		prev = b.kind
+	}
+	return out
+}
+
+// mdNeedsBlank is the vertical-spacing rule, which is restrained on purpose:
+// one blank line between blocks, none between the items of a list, and none
+// between a heading and what it introduces — a heading floating a line above
+// its own list reads as a heading about the blank.
+func mdNeedsBlank(prev, next mdKind) bool {
+	if prev == mdHeading {
+		return false
+	}
+	return prev != mdItem || next != mdItem
+}
+
+// renderMDBlock wraps one block to the pane.
+func renderMDBlock(b mdBlock, width int) []string {
+	if b.kind == mdRule {
+		// Width-bounded rather than a fixed run of dashes: a rule is the
+		// separator the pane is wide, and one that stopped short would read
+		// as a line of text.
+		n := max(width-cols(gutterNone), 1)
+		return []string{gutterNone + styleMDRule.Render(strings.Repeat("─", n))}
+	}
+	out := make([]string, 0, len(b.lines))
+	for _, pl := range b.lines {
+		out = append(out, wrapLine(pl, width)...)
+	}
+	return out
+}
+
+// mdPending is the block being accumulated. Paragraphs, list items and
+// blockquotes all span several source lines, and a fenced block spans every
+// line until its closing fence.
+type mdPending struct {
+	kind    mdKind
+	open    bool
+	text    []string
+	marker  string
+	depth   int
+	fence   byte
+	fenceLn int
+}
+
+// parseMarkdown scans the text a line at a time. It is a scanner rather than
+// a grammar because the subset is a list of line shapes: a line either opens
+// a fence, is a fence's content, is a rule, a heading, a quote or a list
+// item, or it is prose that continues whatever came before it.
+func parseMarkdown(text string) []mdBlock {
+	src := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	var (
+		blocks []mdBlock
+		pend   mdPending
+		// stack holds the leading-space column of every open list level, so
+		// nesting depth comes from the source's own indentation rather than
+		// from a fixed step nobody agreed on.
+		stack []int
+	)
+	flush := func() {
+		if b, ok := pend.block(); ok {
+			blocks = append(blocks, b)
+		}
+		pend = mdPending{}
+	}
+	// endList closes any open list: a heading, a rule, a fence, a quote or a
+	// paragraph at the margin all end one.
+	endList := func() { stack = stack[:0] }
+
+	for _, line := range src {
+		if pend.open {
+			if isFenceClose(line, pend.fence, pend.fenceLn) {
+				flush()
+				continue
+			}
+			pend.text = append(pend.text, line)
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			flush()
+			continue
+		}
+		if ch, n, ok := fenceOpen(line); ok {
+			flush()
+			endList()
+			pend = mdPending{kind: mdCode, open: true, fence: ch, fenceLn: n}
+			continue
+		}
+		if isRule(trimmed) {
+			flush()
+			endList()
+			blocks = append(blocks, mdBlock{kind: mdRule})
+			continue
+		}
+		if level, htext, ok := headingOf(line); ok {
+			flush()
+			endList()
+			blocks = append(blocks, mdBlock{
+				kind:  mdHeading,
+				lines: []paneLine{headingPaneLine(level, htext)},
+			})
+			continue
+		}
+		if depth, body, ok := quoteOf(line); ok {
+			if pend.kind == mdQuote && pend.depth == depth && !pend.isEmpty() {
+				pend.text = append(pend.text, body)
+				continue
+			}
+			flush()
+			endList()
+			pend = mdPending{kind: mdQuote, depth: depth, text: []string{body}}
+			continue
+		}
+		if indent, marker, body, ok := listItemOf(line); ok {
+			flush()
+			depth := listDepth(&stack, indent)
+			pend = mdPending{kind: mdItem, depth: depth, marker: marker, text: []string{body}}
+			continue
+		}
+		// Plain prose. It continues a paragraph or an item — a wrapped list
+		// item's second source line belongs to the item, not to a new
+		// paragraph at the margin — and otherwise opens a paragraph.
+		if pend.kind == mdParagraph || pend.kind == mdItem {
+			if !pend.isEmpty() {
+				pend.text = append(pend.text, strings.TrimSpace(line))
+				continue
+			}
+		}
+		flush()
+		endList()
+		pend = mdPending{kind: mdParagraph, text: []string{strings.TrimSpace(line)}}
+	}
+	flush()
+	return blocks
+}
+
+func (p mdPending) isEmpty() bool { return len(p.text) == 0 }
+
+// block turns the accumulated lines into a block. Soft line breaks inside a
+// paragraph, a list item or a quote are joined: they are the author's line
+// length, not the reader's, and rejoining is what lets the pane reflow to its
+// own width. A fenced block is the exception and keeps every line.
+func (p mdPending) block() (mdBlock, bool) {
+	switch p.kind {
+	case mdCode:
+		if !p.open && len(p.text) == 0 {
+			return mdBlock{}, false
+		}
+		lines := make([]paneLine, 0, len(p.text))
+		for _, l := range p.text {
+			lines = append(lines, codePaneLine(l))
+		}
+		if len(lines) == 0 {
+			// An empty fence still says a code block was there.
+			lines = append(lines, codePaneLine(""))
+		}
+		return mdBlock{kind: mdCode, lines: lines}, true
+	case mdItem:
+		if p.isEmpty() {
+			return mdBlock{}, false
+		}
+		return mdBlock{
+			kind:  mdItem,
+			lines: []paneLine{itemPaneLine(p.depth, p.marker, strings.Join(p.text, " "))},
+		}, true
+	case mdQuote:
+		if p.isEmpty() {
+			return mdBlock{}, false
+		}
+		return mdBlock{
+			kind:  mdQuote,
+			lines: []paneLine{quotePaneLine(p.depth, strings.Join(p.text, " "))},
+		}, true
+	default:
+		if p.isEmpty() {
+			return mdBlock{}, false
+		}
+		return mdBlock{
+			kind:  mdParagraph,
+			lines: []paneLine{paragraphPaneLine(strings.Join(p.text, " "))},
+		}, true
+	}
+}
+
+// listDepth resolves an item's indentation against the open list levels. A
+// deeper indent than the innermost open level opens a level; a shallower one
+// closes levels until it fits. The source's own columns decide, so a document
+// indenting by two spaces and one indenting by four both nest once.
+func listDepth(stack *[]int, indent int) int {
+	s := *stack
+	for len(s) > 0 && indent < s[len(s)-1] {
+		s = s[:len(s)-1]
+	}
+	if len(s) == 0 || indent > s[len(s)-1] {
+		s = append(s, indent)
+	}
+	*stack = s
+	return len(s) - 1
+}
+
+// paragraphPaneLine is prose: no marker, flush against the gutter, exactly
+// where an unformatted assistant message already sat.
+func paragraphPaneLine(text string) paneLine {
+	base := lipgloss.NewStyle()
+	return paneLine{
+		gutter:      gutterNone,
+		gutterStyle: base,
+		segs:        inlineSegments(text, base, 0),
+	}
+}
+
+// headingPaneLine marks a section. The glyph is what carries the heading in
+// monochrome; the level is the indent in front of it, so a subsection sits
+// under its section without spending a second glyph on it.
+func headingPaneLine(level int, text string) paneLine {
+	return paneLine{
+		gutter:      gutterNone + strings.Repeat(" ", level-1) + mdHeadingMark,
+		gutterStyle: styleMDHeading,
+		segs:        inlineSegments(text, styleMDHeading, 0),
+	}
+}
+
+// itemPaneLine is one list item. The marker goes in the content column's own
+// gutter, which is what gives a wrapped item its hanging indent for free.
+func itemPaneLine(depth int, marker, text string) paneLine {
+	if marker == "" {
+		marker = mdBulletsByDepth[min(depth, len(mdBulletsByDepth)-1)]
+	}
+	return paneLine{
+		gutter:      gutterNone + strings.Repeat("  ", depth) + marker,
+		gutterStyle: styleMDMarker,
+		segs:        inlineSegments(text, lipgloss.NewStyle(), 0),
+	}
+}
+
+// quotePaneLine draws the bar on every line of the quote, not just the first:
+// wrapLine indents continuations with spaces of the gutter's width by
+// default, which would put the bar on the first line of a wrapped quote and
+// drop it from the rest — a content gutter that is not a gutter (decision 6).
+func quotePaneLine(depth int, text string) paneLine {
+	bar := gutterNone + strings.Repeat(mdQuoteBar, depth)
+	return paneLine{
+		gutter:      bar,
+		gutterStyle: styleMDQuote,
+		contPrefix:  bar,
+		segs:        inlineSegments(text, styleMDQuote, 0),
+	}
+}
+
+// codePaneLine is one line of a fenced block, kept byte for byte. It is
+// preformatted, so it hard-wraps at the cell boundary rather than going
+// through splitWords, which collapses runs of whitespace: a code block that
+// lost its indentation would not be the code the agent wrote (decision 3).
+func codePaneLine(text string) paneLine {
+	rail := gutterNone + mdCodeRail
+	return paneLine{
+		gutter:      rail,
+		gutterStyle: styleMDMarker,
+		contPrefix:  rail,
+		pre:         true,
+		segs:        []segment{{text: text, style: styleMDCode}},
+	}
+}
+
+// fenceOpen reports an opening fence and its run, which the closing fence
+// must match or exceed.
+func fenceOpen(line string) (byte, int, bool) {
+	t := strings.TrimLeft(line, " ")
+	if t == "" {
+		return 0, 0, false
+	}
+	ch := t[0]
+	if ch != '`' && ch != '~' {
+		return 0, 0, false
+	}
+	n := runLen(t, 0, ch)
+	if n < 3 {
+		return 0, 0, false
+	}
+	// An info string may not contain a backtick, which is what keeps
+	// ``a`` in prose from opening a block.
+	if ch == '`' && strings.ContainsRune(t[n:], '`') {
+		return 0, 0, false
+	}
+	return ch, n, true
+}
+
+func isFenceClose(line string, ch byte, n int) bool {
+	t := strings.TrimSpace(line)
+	if t == "" || t[0] != ch {
+		return false
+	}
+	return runLen(t, 0, ch) >= n && strings.Trim(t, string(ch)) == ""
+}
+
+// isRule matches the three spellings of a thematic break. It is checked
+// before list items so `- - -` is a rule rather than an item whose text is a
+// dash.
+func isRule(trimmed string) bool {
+	stripped := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, trimmed)
+	if len(stripped) < 3 {
+		return false
+	}
+	switch stripped[0] {
+	case '-', '*', '_':
+	default:
+		return false
+	}
+	return strings.Trim(stripped, string(stripped[0])) == ""
+}
+
+// headingOf matches an ATX heading. Setext underlines are outside the subset:
+// `---` under a line of prose is a rule here, which is what it looks like.
+func headingOf(line string) (int, string, bool) {
+	t := strings.TrimLeft(line, " ")
+	if len(line)-len(t) > 3 || !strings.HasPrefix(t, "#") {
+		return 0, "", false
+	}
+	level := runLen(t, 0, '#')
+	if level > 6 {
+		return 0, "", false
+	}
+	rest := t[level:]
+	if rest != "" && rest[0] != ' ' {
+		// `#hashtag` is not a heading, which is the whole reason the space
+		// is required.
+		return 0, "", false
+	}
+	// A trailing run of hashes is the closing sequence, not text.
+	return level, strings.TrimSpace(strings.TrimRight(strings.TrimSpace(rest), "#")), true
+}
+
+// quoteOf strips the quote markers and reports how deep they went.
+func quoteOf(line string) (int, string, bool) {
+	t := strings.TrimLeft(line, " ")
+	if !strings.HasPrefix(t, ">") {
+		return 0, "", false
+	}
+	depth := 0
+	for strings.HasPrefix(t, ">") {
+		depth++
+		t = strings.TrimPrefix(t[1:], " ")
+		t = strings.TrimLeft(t, " ")
+	}
+	return depth, t, true
+}
+
+// listItemOf matches a bullet or a number. An empty marker means "use the
+// bullet for this depth"; an ordered item keeps the number the author wrote,
+// because a list that renumbers itself loses the reference the prose made
+// to step 3.
+func listItemOf(line string) (int, string, string, bool) {
+	t := strings.TrimLeft(line, " \t")
+	indent := indentCols(line[:len(line)-len(t)])
+	if t == "" {
+		return 0, "", "", false
+	}
+	switch t[0] {
+	case '-', '*', '+':
+		if len(t) > 1 && t[1] == ' ' {
+			return indent, "", strings.TrimSpace(t[2:]), true
+		}
+		return 0, "", "", false
+	}
+	digits := 0
+	for digits < len(t) && t[digits] >= '0' && t[digits] <= '9' {
+		digits++
+	}
+	if digits == 0 || digits > 9 || digits+1 >= len(t) {
+		return 0, "", "", false
+	}
+	if t[digits] != '.' && t[digits] != ')' {
+		return 0, "", "", false
+	}
+	if t[digits+1] != ' ' {
+		return 0, "", "", false
+	}
+	return indent, t[:digits] + ". ", strings.TrimSpace(t[digits+2:]), true
+}
+
+// indentCols counts a prefix's columns, a tab being the four a terminal's
+// default tab stop is closest to.
+func indentCols(prefix string) int {
+	n := 0
+	for _, r := range prefix {
+		if r == '\t' {
+			n += 4
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// inlineSegments splits one line of prose into styled runs. It emits the
+// existing segment model directly, which is what keeps the wrap-plain-then-
+// style invariant: wrapLine measures every token as plain text and styles the
+// runs afterwards, so no break can land inside an escape sequence
+// (decision 2).
+//
+// depth guards the recursion `**bold with `code`**` needs; nesting past it
+// renders literally rather than growing a stack.
+func inlineSegments(text string, base lipgloss.Style, depth int) []segment {
+	segs := make([]segment, 0, 4)
+	var lit strings.Builder
+	flush := func() {
+		if lit.Len() > 0 {
+			segs = append(segs, segment{text: lit.String(), style: base})
+			lit.Reset()
+		}
+	}
+	for i := 0; i < len(text); {
+		switch text[i] {
+		case '`':
+			// Inline code wins over emphasis, and keeps its delimiters: the
+			// backticks are what a monochrome terminal has left once the
+			// colour is gone.
+			if body, next, ok := codeSpanAt(text, i); ok {
+				flush()
+				segs = append(segs, segment{text: body, style: mdCodeSpanStyle(base)})
+				i = next
+				continue
+			}
+		case '*', '_':
+			if body, marks, next, ok := emphasisAt(text, i); ok && depth < 3 {
+				flush()
+				style := base.Italic(true)
+				if marks >= 2 {
+					style = base.Bold(true)
+				}
+				segs = append(segs, inlineSegments(body, style, depth+1)...)
+				i = next
+				continue
+			}
+		}
+		lit.WriteByte(text[i])
+		i++
+	}
+	flush()
+	if len(segs) == 0 {
+		return []segment{{text: text, style: base}}
+	}
+	return segs
+}
+
+// mdCodeSpanStyle tints an inline code span without losing whatever the
+// surrounding context already set — a code span inside a heading stays bold.
+func mdCodeSpanStyle(base lipgloss.Style) lipgloss.Style {
+	return base.Foreground(lipgloss.Color("3"))
+}
+
+// codeSpanAt matches a backtick run and its partner, returning the span with
+// its delimiters intact.
+func codeSpanAt(text string, i int) (string, int, bool) {
+	n := runLen(text, i, '`')
+	closer := strings.Repeat("`", n)
+	rest := text[i+n:]
+	end := strings.Index(rest, closer)
+	if end < 0 {
+		return "", 0, false
+	}
+	return text[i : i+n+end+n], i + n + end + n, true
+}
+
+// emphasisAt matches `*x*`, `**x**` and their underscore spellings.
+//
+// The underscore spelling is only honored at a word boundary. Agents write
+// file names, identifiers and flags constantly, and `main_test.go` turning
+// half a sentence italic is worse than an underscore that stayed literal.
+func emphasisAt(text string, i int) (string, int, int, bool) {
+	ch := text[i]
+	marks := min(runLen(text, i, ch), 2)
+	delim := strings.Repeat(string(ch), marks)
+	rest := text[i+marks:]
+	if rest == "" || rest[0] == ' ' {
+		return "", 0, 0, false
+	}
+	end := strings.Index(rest, delim)
+	if end <= 0 {
+		return "", 0, 0, false
+	}
+	body := rest[:end]
+	if strings.HasSuffix(body, " ") {
+		return "", 0, 0, false
+	}
+	next := i + marks + end + marks
+	if ch == '_' && (!wordBoundary(text, i-1) || !wordBoundary(text, next)) {
+		return "", 0, 0, false
+	}
+	return body, marks, next, true
+}
+
+// wordBoundary reports whether the byte at i is outside a word, the string's
+// edges counting as outside.
+func wordBoundary(text string, i int) bool {
+	if i < 0 || i >= len(text) {
+		return true
+	}
+	c := text[i]
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return false
+	}
+	return true
+}
+
+// runLen counts how many times the byte at i repeats.
+func runLen(s string, i int, ch byte) int {
+	n := 0
+	for i+n < len(s) && s[i+n] == ch {
+		n++
+	}
+	return n
+}

--- a/internal/tui/markdown_test.go
+++ b/internal/tui/markdown_test.go
@@ -1,0 +1,382 @@
+package tui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// Markdown rendering for assistant prose (task 073).
+//
+// Everything here asserts against ansi.Strip'ped lines rather than against
+// styled ones: what is under test is that structure survives without colour,
+// which is the §15 rule that a monochrome terminal loses nothing.
+
+// stripped renders assistant prose and removes every escape sequence, so a
+// golden line is what a reader on a colour-blind terminal sees.
+func stripped(text string, width int) []string {
+	lines := markdownLines(text, width)
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = ansi.Strip(l)
+	}
+	return out
+}
+
+// TestMarkdownConstructs is the subset, one case per construct, at three
+// widths. The widths matter as much as the constructs: a marker that is
+// composed into the content column has to keep its hanging indent when the
+// pane is 20 columns wide, which is where a renderer that laid its structure
+// out with fixed padding would come apart.
+func TestMarkdownConstructs(t *testing.T) {
+	cases := []struct {
+		name  string
+		src   string
+		width int
+		want  []string
+	}{
+		{
+			name: "heading loses its hashes and keeps a glyph", width: 40,
+			src:  "# Findings",
+			want: []string{"  ▌ Findings"},
+		},
+		{
+			name: "heading level is the indent", width: 40,
+			src:  "### Deeper",
+			want: []string{"    ▌ Deeper"},
+		},
+		{
+			name: "paragraph rejoins its soft breaks", width: 40,
+			src:  "one two\nthree four",
+			want: []string{"  one two three four"},
+		},
+		{
+			name: "emphasis and strong lose their markers", width: 40,
+			src:  "a *soft* and **loud** word",
+			want: []string{"  a soft and loud word"},
+		},
+		{
+			name: "inline code keeps its delimiters", width: 40,
+			src:  "run `go test ./...` first",
+			want: []string{"  run `go test ./...` first"},
+		},
+		{
+			name: "an underscore inside a word stays literal", width: 40,
+			src:  "see main_test.go and _really_ mean it",
+			want: []string{"  see main_test.go and really mean it"},
+		},
+		{
+			name: "unordered list", width: 40,
+			src:  "- one\n- two",
+			want: []string{"  • one", "  • two"},
+		},
+		{
+			name: "ordered list keeps the author's numbers", width: 40,
+			src:  "1. one\n2. two",
+			want: []string{"  1. one", "  2. two"},
+		},
+		{
+			name: "nested lists indent and change marker", width: 40,
+			src:  "- outer\n  - inner\n    - deepest",
+			want: []string{"  • outer", "    ◦ inner", "      ▪ deepest"},
+		},
+		{
+			name: "a wrapped list item hangs under its text", width: 20,
+			src:  "- alpha beta gamma delta",
+			want: []string{"  • alpha beta gamma", "    delta"},
+		},
+		{
+			name: "blockquote keeps its bar on every line", width: 20,
+			src:  "> alpha beta gamma delta",
+			want: []string{"  │ alpha beta gamma", "  │ delta"},
+		},
+		{
+			name: "nested blockquote", width: 40,
+			src:  ">> deep",
+			want: []string{"  │ │ deep"},
+		},
+		{
+			name: "fenced code keeps its indentation", width: 40,
+			src:  "```go\nif x {\n    y()\n}\n```",
+			want: []string{"  ▏ if x {", "  ▏     y()", "  ▏ }"},
+		},
+		{
+			name: "horizontal rule fills the content column", width: 20,
+			src:  "---",
+			want: []string{"  " + strings.Repeat("─", 18)},
+		},
+		{
+			name: "a rule spelled with stars and spaces", width: 20,
+			src:  "* * *",
+			want: []string{"  " + strings.Repeat("─", 18)},
+		},
+		{
+			name: "blocks are separated, list items are not", width: 80,
+			src:  "intro\n\n- one\n- two\n\nouttro",
+			want: []string{"  intro", "", "  • one", "  • two", "", "  outtro"},
+		},
+		{
+			name: "a heading sits straight on what it introduces", width: 80,
+			src:  "## Steps\n\n- one",
+			want: []string{"   ▌ Steps", "  • one"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripped(tc.src, tc.width)
+			if strings.Join(got, "\n") != strings.Join(tc.want, "\n") {
+				t.Errorf("at width %d:\n got %q\nwant %q", tc.width, got, tc.want)
+			}
+			for i, l := range markdownLines(tc.src, tc.width) {
+				if w := ansi.StringWidth(l); w > tc.width {
+					t.Errorf("line %d is %d columns wide, pane is %d: %q", i, w, tc.width, l)
+				}
+			}
+		})
+	}
+}
+
+// TestMarkdownEveryConstructAtEveryWidth is the width sweep the table above
+// only samples: no construct may overflow the pane, at any of the widths §15
+// says the pane must survive.
+func TestMarkdownEveryConstructAtEveryWidth(t *testing.T) {
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"A paragraph with **strong**, *emphasis* and `inline code` in it.",
+		"",
+		"## Section",
+		"",
+		"- an item long enough to wrap at every width under test",
+		"  - a nested item, also long enough to wrap at every width",
+		"1. first",
+		"10. tenth",
+		"",
+		"> a quotation long enough that it has to wrap somewhere",
+		"",
+		"```sh",
+		"echo 'a line of code that is far too long to fit in a narrow pane'",
+		"```",
+		"",
+		"---",
+		"",
+		"The last word.",
+	}, "\n")
+	for _, width := range []int{20, 40, 80} {
+		for i, l := range markdownLines(src, width) {
+			if w := ansi.StringWidth(l); w > width {
+				t.Errorf("width %d: line %d is %d columns: %q", width, i, w, l)
+			}
+		}
+	}
+}
+
+// TestMarkdownOutsideTheSubsetStaysLiteral is the subset boundary, stated as
+// a test rather than left implicit (decision 1). A construct that is not on
+// the list renders as the characters the agent sent — never as something
+// fetched, executed or half-interpreted.
+func TestMarkdownOutsideTheSubsetStaysLiteral(t *testing.T) {
+	cases := map[string]string{
+		"table":           "| a | b |",
+		"table rule":      "|---|---|",
+		"inline link":     "see [the docs](https://example.com/x)",
+		"reference link":  "see [the docs][1]",
+		"html block":      "<script>alert(1)</script>",
+		"inline html":     "a <b>bold</b> word",
+		"footnote":        "a claim[^1]",
+		"image":           "![alt](https://example.com/x.png)",
+		"setext underlin": "Title\n===",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := strings.Join(stripped(src, 80), "\n")
+			for _, line := range strings.Split(src, "\n") {
+				if !strings.Contains(got, line) {
+					t.Errorf("%q was interpreted rather than left literal:\n%s", line, got)
+				}
+			}
+		})
+	}
+}
+
+// TestMarkdownReflowsFromSource is the resize criterion. Rendering at 80 and
+// then at 40 must equal rendering fresh at 40: the pane keeps no rendered
+// line, so a resize re-parses the Markdown rather than re-wrapping its own
+// escape sequences — which is the failure mode ANSI-aware wrapping exists to
+// paper over, and which §15's wrap-plain-then-style invariant avoids instead.
+func TestMarkdownReflowsFromSource(t *testing.T) {
+	src := "# Title\n\nA paragraph long enough to wrap differently at eighty and at forty " +
+		"columns, with **strong** text in it.\n\n- an item that also wraps\n\n> and a quote"
+	wide := markdownLines(src, 80)
+	narrow := markdownLines(src, 40)
+	again := markdownLines(src, 40)
+	if strings.Join(narrow, "\n") != strings.Join(again, "\n") {
+		t.Error("rendering the same source twice at one width disagreed with itself")
+	}
+	if strings.Join(wide, "\n") == strings.Join(narrow, "\n") {
+		t.Fatal("the fixture does not reflow; it proves nothing")
+	}
+	// The wide rendering is not an input to the narrow one anywhere, which is
+	// what the equality above establishes: nothing cached the 80-column pass.
+	if got := markdownLines(src, 40); strings.Join(got, "\n") != strings.Join(narrow, "\n") {
+		t.Error("a render after a wider render differed from a fresh one")
+	}
+}
+
+// TestMarkdownCodeBlockIsWholeAndSafe is decision 3: a code block keeps every
+// space and every hard break, a line longer than the pane continues on the
+// next line at the block's rail rather than being truncated out of reach, and
+// a fence carrying control sequences cannot reach past its own lines.
+func TestMarkdownCodeBlockIsWholeAndSafe(t *testing.T) {
+	src := "```\n    indented\n\ttabbed\n\nblank above\n```"
+	got := stripped(src, 40)
+	// A tab keeps its indentation as the four columns lipgloss renders it
+	// as, so the block's measured width and its drawn width agree.
+	want := []string{"  ▏     indented", "  ▏     tabbed", "  ▏ ", "  ▏ blank above"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("code block whitespace was not preserved:\n got %q\nwant %q", got, want)
+	}
+
+	long := "```\n" + strings.Repeat("x", 100) + "\n```"
+	lines := markdownLines(long, 40)
+	var body strings.Builder
+	for i, l := range lines {
+		if w := ansi.StringWidth(l); w > 40 {
+			t.Errorf("code line %d is %d columns: %q", i, w, l)
+		}
+		body.WriteString(strings.TrimPrefix(ansi.Strip(l), "  ▏ "))
+	}
+	if body.String() != strings.Repeat("x", 100) {
+		t.Errorf("a long code line lost bytes to the wrap: %q", body.String())
+	}
+	if len(lines) < 3 {
+		t.Errorf("a 100-column line in a 40-column pane produced %d lines", len(lines))
+	}
+
+	evil := "```\nclear:\x1b[2J and \x1b]0;pwned\a and \rback\n```"
+	for _, l := range markdownLines(evil, 40) {
+		if strings.ContainsFunc(ansi.Strip(l), isTerminalControl) {
+			t.Errorf("a control sequence survived a code fence: %q", l)
+		}
+	}
+}
+
+// TestMarkdownMonochromeKeepsEveryDistinction is §15's rule applied to the
+// new structure: strip the colour and the document is still a document. A
+// heading, a quote, a list, an inline code span and a rule each have to be
+// visible as characters, because colour alone does not survive a monochrome
+// terminal or an SSH session that lost its profile.
+func TestMarkdownMonochromeKeepsEveryDistinction(t *testing.T) {
+	src := "# Heading\n\n> quoted\n\n- bullet\n\n1. numbered\n\nan `inline` span\n\n---\n\n```\ncode\n```"
+	got := strings.Join(stripped(src, 60), "\n")
+	for _, want := range []string{
+		"▌ Heading", "│ quoted", "• bullet", "1. numbered", "`inline`", "─────", "▏ code",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q is not visible without colour:\n%s", want, got)
+		}
+	}
+}
+
+// TestMarkdownEmitsOnlyVincentStyles is the injection criterion at the
+// renderer's own door. Whatever an agent sends, the escape sequences on a
+// rendered line are the ones vincent asked lipgloss for.
+func TestMarkdownEmitsOnlyVincentStyles(t *testing.T) {
+	src := "before \x1b[2J after\n\n\x1b]0;title\a\n\n- \x1b[31mred\x1b[0m item\n\nbare\rreturn and back\bspace"
+	for _, l := range markdownLines(src, 40) {
+		text := ansi.Strip(l)
+		if strings.ContainsFunc(text, isTerminalControl) {
+			t.Errorf("a control character reached the pane: %q", l)
+		}
+		if strings.Contains(text, "[2J") || strings.Contains(text, "title") {
+			t.Errorf("an escape sequence was rendered as its parameters: %q", l)
+		}
+		if w := ansi.StringWidth(l); w > 40 {
+			t.Errorf("an escape sequence widened a line to %d columns: %q", w, l)
+		}
+	}
+}
+
+// TestMarkdownDoesNotMutateTheRecord discharges "keep raw Markdown copyable"
+// (decision 4). The TUI has no copy-out action, and terminal drag-select
+// copies rendered glyphs — so what this issue can promise is the property
+// that makes the follow-up possible: rendering is derived, and the record the
+// pane rendered is the record the transcript holds.
+func TestMarkdownDoesNotMutateTheRecord(t *testing.T) {
+	const src = "# Title\n\n- **bold** item with `code`\n\n> quote"
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: src},
+		{Type: "agent.result", ResultText: src},
+	}
+	before := append([]apiclient.TranscriptRecord(nil), recs...)
+	for _, width := range []int{20, 40, 80} {
+		outputLines(recs, levelNormal, width, lineOpts{expandKey: "v"})
+	}
+	if !reflect.DeepEqual(recs, before) {
+		t.Errorf("rendering mutated the records:\n got %+v\nwant %+v", recs, before)
+	}
+}
+
+// TestMarkdownWideRunesMeasureInCells is decision 2 at the renderer: a pane
+// full of CJK, emoji or combining marks fills to the same edge an ASCII one
+// does, which a rune count could not do.
+func TestMarkdownWideRunesMeasureInCells(t *testing.T) {
+	cases := map[string]string{
+		"cjk":       strings.Repeat("日本語テキスト ", 8),
+		"emoji":     strings.Repeat("🎉🚀 ", 20),
+		"zwj":       strings.Repeat("👨‍👩‍👧 ", 20),
+		"combining": strings.Repeat("e\u0301x\u0308 ", 20),
+		"mixed":     "**strong** 日本語 `code` 🎉 and plain words to fill the line out",
+	}
+	for name, src := range cases {
+		for _, width := range []int{20, 40, 80} {
+			for i, l := range markdownLines(src, width) {
+				if w := ansi.StringWidth(l); w > width {
+					t.Errorf("%s at width %d: line %d is %d columns: %q",
+						name, width, i, w, l)
+				}
+			}
+		}
+	}
+}
+
+// TestPreformattedContinuationKeepsItsPrefix is the mechanical half of
+// decision 6: wrapLine indents continuations with spaces of the gutter's
+// width unless the caller says otherwise, and a marker that is drawn once and
+// then dropped is not a gutter.
+func TestPreformattedContinuationKeepsItsPrefix(t *testing.T) {
+	pl := paneLine{
+		gutter:      "│ ",
+		gutterStyle: lipgloss.NewStyle(),
+		contPrefix:  "│ ",
+		segs:        []segment{{text: strings.Repeat("word ", 20), style: lipgloss.NewStyle()}},
+	}
+	lines := wrapLine(pl, 30)
+	if len(lines) < 2 {
+		t.Fatalf("fixture did not wrap: %q", lines)
+	}
+	for i, l := range lines {
+		if !strings.HasPrefix(ansi.Strip(l), "│ ") {
+			t.Errorf("line %d lost the bar: %q", i, l)
+		}
+	}
+
+	// The default is unchanged for every caller that predates this.
+	plain := paneLine{
+		gutter:      gutterThinking,
+		gutterStyle: styleThinking,
+		segs:        []segment{{text: strings.Repeat("word ", 20), style: styleThinking}},
+	}
+	got := wrapLine(plain, 30)
+	if len(got) < 2 {
+		t.Fatalf("fixture did not wrap: %q", got)
+	}
+	if !strings.HasPrefix(ansi.Strip(got[1]), "  ") {
+		t.Errorf("continuation = %q, want the hanging indent in spaces", got[1])
+	}
+}

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -4,17 +4,70 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
-// cols is a string's printable width. Every measurement in this file goes
-// through it: the gutters are glyphs, so `·` is one column and three bytes,
-// and byte-wise column math would indent every wrapped reasoning line wrong.
-func cols(s string) int { return utf8.RuneCountInString(s) }
+// cols is a string's printable width in terminal cells. Every measurement in
+// this file goes through it: the gutters are glyphs, so `·` is one column and
+// three bytes, and byte-wise column math would indent every wrapped reasoning
+// line wrong.
+//
+// Cells rather than runes (task 073 decision 2). A rune count is right for
+// ASCII and wrong for everything an agent actually prints: a CJK glyph or an
+// emoji occupies two columns, a combining mark occupies none, and a ZWJ
+// sequence is one grapheme of several runes. ansi.StringWidth is what
+// wrapCellLines and the rest of the TUI already measure with, so there is now
+// one answer to "how wide is this" in the package.
+//
+// This does not make the wrapping ANSI-aware, and it is not meant to: §15's
+// invariant stands — text is wrapped while plain and each produced line is
+// styled afterwards, so no break can land inside an escape sequence.
+func cols(s string) int { return ansi.StringWidth(s) }
+
+// sanitizeText removes everything in agent-supplied text that would drive the
+// terminal rather than fill it (task 073 decision 7).
+//
+// Every record goes through it, not just the Markdown path: agent text
+// reached the pane unfiltered before, so a tool result summary or a command's
+// output body carrying `\x1b[2J` could already clear the screen, and an OSC
+// sequence could already rewrite the window title. Doing it here — at
+// wrapLine's segment emission — covers every record type at one site and
+// cannot be bypassed by a record type added later. It also runs before any
+// measurement, so an escape sequence can never influence the width
+// arithmetic either.
+//
+// Newlines and tabs survive: the first is the pane's own paragraph break and
+// the second is indentation a fenced code block must keep.
+func sanitizeText(s string) string {
+	if strings.IndexFunc(s, isTerminalControl) < 0 {
+		return s
+	}
+	// ansi.Strip removes whole escape sequences, parameters included, which
+	// dropping the ESC alone would not: it would leave `[2J` as text.
+	s = ansi.Strip(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isTerminalControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// isTerminalControl reports the C0 and C1 controls and DEL, minus the two
+// whitespace characters the pane renders itself.
+func isTerminalControl(r rune) bool {
+	if r == '\n' || r == '\t' {
+		return false
+	}
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}
 
 // The output pane's line model (T4.16).
 //
@@ -109,6 +162,17 @@ type paneLine struct {
 	gutter      string
 	gutterStyle lipgloss.Style
 	segs        []segment
+	// contPrefix replaces the spaces a continuation is otherwise indented
+	// with. A blockquote's bar has to appear on every line of the quote: a
+	// marker drawn once and then dropped is a content gutter that is not a
+	// gutter (task 073 decision 6). Empty means the spaces, which is every
+	// caller that predates Markdown.
+	contPrefix string
+	// pre marks preformatted content — a fenced code block's line — which
+	// hard-wraps at the cell boundary and keeps every space and tab instead
+	// of going through splitWords, whose strings.Fields would collapse the
+	// indentation the block exists to show.
+	pre bool
 	// isOutput marks assistant prose, which drives the blank line that
 	// separates one turn from the next.
 	isOutput bool
@@ -143,6 +207,9 @@ const (
 // allowed to overflow — a base64 blob or a path with no spaces would
 // otherwise reintroduce the clipping this replaces.
 func wrapLine(pl paneLine, width int) []string {
+	if pl.pre {
+		return wrapPre(pl, width)
+	}
 	gutterWidth := cols(pl.gutter)
 	avail := width - gutterWidth
 	if avail < 8 {
@@ -150,7 +217,7 @@ func wrapLine(pl paneLine, width int) []string {
 		// width is all that is left.
 		avail = 8
 	}
-	indent := strings.Repeat(" ", gutterWidth)
+	indent := continuationIndent(pl, gutterWidth)
 
 	var out []string
 	var cur strings.Builder
@@ -202,7 +269,7 @@ func wrapLine(pl paneLine, width int) []string {
 	for _, seg := range pl.segs {
 		// Hard breaks in the source are honored: a multi-paragraph assistant
 		// message keeps its paragraphs.
-		for i, para := range strings.Split(seg.text, "\n") {
+		for i, para := range strings.Split(sanitizeText(seg.text), "\n") {
 			if i > 0 {
 				flushLine()
 			}
@@ -253,13 +320,99 @@ func sameStyle(a, b lipgloss.Style) bool {
 	return a.Render(probe) == b.Render(probe)
 }
 
+// continuationIndent is what a wrapped line starts with. It is the gutter's
+// width in spaces unless the caller asked for a prefix, which is padded or
+// cut to exactly that width so the column arithmetic above still holds.
+func continuationIndent(pl paneLine, gutterWidth int) string {
+	if pl.contPrefix == "" {
+		return strings.Repeat(" ", gutterWidth)
+	}
+	return pl.gutterStyle.Render(padCells(pl.contPrefix, gutterWidth))
+}
+
+// padCells makes a string exactly width cells wide.
+func padCells(s string, width int) string {
+	switch n := cols(s); {
+	case n == width:
+		return s
+	case n > width:
+		return ansi.Cut(s, 0, width)
+	default:
+		return s + strings.Repeat(" ", width-n)
+	}
+}
+
+// wrapPre lays a preformatted line out: no word breaking, no collapsing of
+// whitespace, no ellipsis. A code line longer than the pane continues on the
+// next line at the block's own rail (task 073 decision 3), which is what the
+// pane already does for a long path — truncating would put the tail of a
+// long line out of reach of the TUI entirely, and clipping is what T4.16
+// removed.
+func wrapPre(pl paneLine, width int) []string {
+	gutterWidth := cols(pl.gutter)
+	avail := width - gutterWidth
+	if avail < 8 {
+		avail = 8
+	}
+	head := pl.gutterStyle.Render(pl.gutter)
+	cont := head
+	if pl.contPrefix != "" {
+		cont = continuationIndent(pl, gutterWidth)
+	}
+	text, style := "", lipgloss.NewStyle()
+	if len(pl.segs) > 0 {
+		// Tabs are expanded to the four columns lipgloss renders them as.
+		// Measuring the tab and rendering the spaces would disagree —
+		// ansi.StringWidth calls a tab zero columns wide — and a
+		// tab-indented code block would then overflow the pane by exactly
+		// its indentation.
+		text = strings.ReplaceAll(sanitizeText(pl.segs[0].text), "\t", "    ")
+		style = pl.segs[0].style
+	}
+	var out []string
+	for _, src := range strings.Split(text, "\n") {
+		for {
+			chunk := src
+			if cols(src) > avail {
+				chunk = ansi.Cut(src, 0, avail)
+			}
+			if chunk == "" && src != "" {
+				// A single grapheme wider than the pane: emit it whole
+				// rather than spin, since cutting it produces nothing.
+				chunk = src
+			}
+			prefix := cont
+			if len(out) == 0 {
+				prefix = head
+			}
+			line := prefix
+			if chunk != "" {
+				line += style.Render(chunk)
+			}
+			out = append(out, line)
+			rest := ansi.TruncateLeft(src, cols(chunk), "")
+			if rest == "" || rest == src {
+				break
+			}
+			src = rest
+		}
+	}
+	return out
+}
+
 // splitWords breaks a paragraph into words and single-space separators,
 // preserving a leading space so a segment that begins with one — a tool
 // call's " subject" following its name — is not silently joined to the
-// segment before it. Over-long words are hard-split rather than allowed to
-// overflow: a path or a base64 blob with no spaces would otherwise
-// reintroduce the clipping this wrapping replaces. Widths count runes; a
-// byte-wise split would cut a multi-byte rune and emit mojibake.
+// segment before it, and a trailing one so a segment that ends in a space —
+// the prose before an inline `code` span — is not joined to the segment
+// after it. A held separator is dropped at a line break, so preserving it
+// cannot leave trailing whitespace on a rendered line.
+//
+// Over-long words are hard-split rather than allowed to overflow: a path or a
+// base64 blob with no spaces would otherwise reintroduce the clipping this
+// wrapping replaces. The split is by cell, not by rune (task 073 decision 2):
+// slicing a rune index cuts a ZWJ emoji into its parts and mis-measures every
+// wide glyph, for the same reason a rune count did.
 func splitWords(para string, avail int) []string {
 	fields := strings.Fields(para)
 	out := make([]string, 0, len(fields)*2)
@@ -270,12 +423,19 @@ func splitWords(para string, avail int) []string {
 		if i > 0 {
 			out = append(out, " ")
 		}
-		runes := []rune(field)
-		for len(runes) > avail {
-			out = append(out, string(runes[:avail]), " ")
-			runes = runes[avail:]
+		for cols(field) > avail {
+			head := ansi.Cut(field, 0, avail)
+			rest := ansi.TruncateLeft(field, cols(head), "")
+			if head == "" || rest == "" || rest == field {
+				break
+			}
+			out = append(out, head, " ")
+			field = rest
 		}
-		out = append(out, string(runes))
+		out = append(out, field)
+	}
+	if len(fields) > 0 && strings.HasSuffix(para, " ") {
+		out = append(out, " ")
 	}
 	return out
 }
@@ -472,6 +632,23 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 			continue
 		}
 		flushRaw()
+		if rec.Type == "agent.output" {
+			// Assistant prose is the one record type that is Markdown
+			// (task 073 decision 5), and it is handled here rather than in
+			// renderRecord because one record now yields several pane lines
+			// — the same reason agent.thinking is handled above.
+			block := markdownLines(rec.Text, width)
+			if len(block) == 0 {
+				continue
+			}
+			if !lastWasOutput && len(lines) > 0 {
+				lines = append(lines, "")
+			}
+			sawOutput = true
+			lines = append(lines, block...)
+			lastWasOutput = true
+			continue
+		}
 		if rec.Type == "agent.thinking" {
 			if block := thinkingBlock(rec.Text, level, width, opts.expandKey); len(block) > 0 {
 				lines = append(lines, block...)
@@ -503,8 +680,6 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 // that level means "show me the machine".
 func renderRecord(rec apiclient.TranscriptRecord, sawOutput bool, level outputLevel) (paneLine, bool) {
 	switch rec.Type {
-	case "agent.output":
-		return plain(rec.Text, lipgloss.NewStyle(), true), rec.Text != ""
 	case "agent.tool_use":
 		if len(rec.Tools) == 0 {
 			return paneLine{}, false

--- a/internal/tui/outputlines_test.go
+++ b/internal/tui/outputlines_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/lezli01/vincent/internal/apiclient"
 )
@@ -628,5 +629,154 @@ func TestCommandOutputOnlyAtVerbose(t *testing.T) {
 	}
 	if !strings.Contains(got[1], "truncated") {
 		t.Errorf("truncation is silent: %q", got)
+	}
+}
+
+// TestOnlyAssistantProseIsMarkdown is decision 5's boundary, held per record
+// type. Markdown punctuation is ordinary text in a tool result, a command's
+// output, an error or a line vincent's parsers do not model — interpreting it
+// there would make prose out of a grep hit, and would let a tool's output
+// forge something that looks like an agent's own heading.
+func TestOnlyAssistantProseIsMarkdown(t *testing.T) {
+	const src = "# not a heading and *not emphasis*"
+	cases := []struct {
+		name   string
+		rec    apiclient.TranscriptRecord
+		gutter string
+	}{
+		{"thinking", apiclient.TranscriptRecord{Type: "agent.thinking", Text: src}, "· "},
+		{"tool result", apiclient.TranscriptRecord{
+			Type:    "agent.tool_result",
+			Results: []apiclient.TranscriptToolResult{{Summary: src}},
+		}, "    ✓ "},
+		{"command output", apiclient.TranscriptRecord{
+			Type: "agent.command_output", Output: src,
+		}, "  "},
+		{"error", apiclient.TranscriptRecord{Type: "agent.error", Message: src}, "✗ "},
+		{"raw", apiclient.TranscriptRecord{Type: "agent.raw", Line: src}, "  "},
+		{"result text", apiclient.TranscriptRecord{Type: "agent.result", ResultText: src}, "✓ "},
+		{"vincent output", apiclient.TranscriptRecord{Type: "vincent.output", Text: src}, "  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// levelVerbose is where every one of these is visible at once;
+			// each record's own level rule is held elsewhere.
+			got := plainLines(outputLines([]apiclient.TranscriptRecord{tc.rec},
+				levelVerbose, 80, lineOpts{expandKey: "v"}))
+			joined := strings.Join(got, "\n")
+			if !strings.Contains(joined, src) {
+				t.Fatalf("the syntax was interpreted rather than left literal:\n%s", joined)
+			}
+			if !strings.HasPrefix(got[0], tc.gutter) {
+				t.Errorf("gutter = %q, want the %q it had before Markdown", got[0], tc.gutter)
+			}
+			if strings.Contains(joined, mdHeadingMark) {
+				t.Errorf("a non-prose record grew a heading marker:\n%s", joined)
+			}
+		})
+	}
+}
+
+// TestAssistantProseIsMarkdown is the other half: the one record type that
+// does get interpreted, through the same pane every other record uses.
+func TestAssistantProseIsMarkdown(t *testing.T) {
+	d := newTestDetail(t)
+	d.width = 60
+	d.records = []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "# Findings\n\n- one\n- two"},
+	}
+	got := plainLines(d.outputLines())
+	want := []string{"  ▌ Findings", "  • one", "  • two"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("lines = %q, want %q", got, want)
+	}
+}
+
+// TestPaneMeasuresCells generalizes the width assertion this file already
+// made at 80 with a rune count (task 073 decision 2). No produced line may
+// exceed the pane, whatever the text is made of: a CJK glyph and an emoji are
+// two columns, a combining mark is none, and a ZWJ sequence is one grapheme
+// of several runes — a rune count is wrong about all four.
+func TestPaneMeasuresCells(t *testing.T) {
+	fixtures := map[string]string{
+		"ascii":     strings.Repeat("word ", 40),
+		"cjk":       strings.Repeat("日本語テキスト ", 12),
+		"emoji":     strings.Repeat("🎉🚀 ", 30),
+		"zwj":       strings.Repeat("👨‍👩‍👧 ", 30),
+		"combining": strings.Repeat("éẍ ", 30),
+		"unbroken":  strings.Repeat("日", 60),
+		"mixed":     strings.Repeat("ok 日本 🎉 é ", 20),
+	}
+	types := []func(string) apiclient.TranscriptRecord{
+		func(s string) apiclient.TranscriptRecord {
+			return apiclient.TranscriptRecord{Type: "agent.output", Text: s}
+		},
+		func(s string) apiclient.TranscriptRecord {
+			return apiclient.TranscriptRecord{Type: "agent.thinking", Text: s}
+		},
+		func(s string) apiclient.TranscriptRecord {
+			return apiclient.TranscriptRecord{Type: "agent.error", Message: s}
+		},
+		func(s string) apiclient.TranscriptRecord {
+			return apiclient.TranscriptRecord{
+				Type:    "agent.tool_result",
+				Results: []apiclient.TranscriptToolResult{{Summary: s}},
+			}
+		},
+	}
+	for name, text := range fixtures {
+		for _, width := range []int{20, 40, 80} {
+			for i, mk := range types {
+				lines := outputLines([]apiclient.TranscriptRecord{mk(text)},
+					levelVerbose, width, lineOpts{expandKey: "v"})
+				for j, l := range lines {
+					if w := ansi.StringWidth(l); w > width {
+						t.Errorf("%s type %d width %d: line %d is %d columns: %q",
+							name, i, width, j, w, l)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestControlSequencesCannotEscapeThePane is decision 7 at the chokepoint it
+// was put at. Every record type goes through wrapLine, so sanitizing there
+// covers the ones that have nothing to do with Markdown — a tool result
+// summary, a command's output body, an error message — which reached the
+// terminal unfiltered before this.
+func TestControlSequencesCannotEscapeThePane(t *testing.T) {
+	const evil = "clear\x1b[2J title\x1b]0;pwned\a move\x1b[10;10H " +
+		"return\r back\b bell\a <script>alert(1)</script>"
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: evil},
+		{Type: "agent.thinking", Text: evil},
+		{Type: "agent.error", Message: evil},
+		{Type: "agent.raw", Line: evil},
+		{Type: "agent.command_output", Output: evil},
+		{Type: "vincent.output", Text: evil},
+		{Type: "agent.tool_result", Results: []apiclient.TranscriptToolResult{{Summary: evil}}},
+		{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{{Name: evil, CallID: "c"}}},
+	}
+	for _, width := range []int{20, 80} {
+		for i, l := range outputLines(recs, levelVerbose, width, lineOpts{expandKey: "v"}) {
+			text := ansi.Strip(l)
+			if strings.ContainsFunc(text, isTerminalControl) {
+				t.Errorf("width %d line %d carries a control character: %q", width, i, l)
+			}
+			if strings.Contains(text, "[2J") || strings.Contains(text, "10;10H") {
+				t.Errorf("width %d line %d rendered a sequence's parameters: %q", width, i, l)
+			}
+			// Raw HTML is never parsed, so it survives as the characters the
+			// agent sent — visible, inert, and never fetched or executed.
+			if w := ansi.StringWidth(l); w > width {
+				t.Errorf("width %d line %d is %d columns: %q", width, i, w, l)
+			}
+		}
+	}
+	joined := strings.Join(plainLines(outputLines(recs, levelVerbose, 80,
+		lineOpts{expandKey: "v"})), "\n")
+	if !strings.Contains(joined, "<script>alert(1)</script>") {
+		t.Errorf("raw HTML was interpreted rather than shown as text:\n%s", joined)
 	}
 }


### PR DESCRIPTION
## Summary

Assistant prose reached the output pane as literal text — a heading kept its
`#`, a fenced block kept its backticks, a list lost its indentation — and task
071 gave that defect two surfaces by pointing both the task workspace and the
chat workspace at one renderer.

`agent.output` records, in both workspaces, and the chat's §17 retention
fallback now go through a new renderer in `internal/tui/markdown.go`. Nothing
outside `internal/tui` is touched: §13.3's chunks and the JSONL transcript keep
the agent's bytes exactly, and width, theme and colour profile are things only
the client knows.

**The parser is vincent's own**, over a written-down subset: headings,
paragraphs, emphasis, strong, ordered and unordered lists, nested lists,
blockquotes, inline code, fenced code, horizontal rules. Everything outside it —
tables, links, HTML, footnotes — renders as safe literal text. That follows the
posture recorded in task 017 decision 2 and task 055 decision 1; `goldmark` is a
new direct dependency plus an AST walker for a subset this size, and `glamour`
emits a pre-styled ANSI block with its own wrapping and margins that cannot be
folded into the gutter scheme and would break the wrap-plain-then-style
invariant.

**Only assistant prose is interpreted.** Reasoning, tool calls, tool results,
the run header, plans, command output, usage, `agent.raw`, `vincent.*` and every
`agent.error` stay literal with their existing gutters — and so does
`agent.result`, including its result-text fallback, because that is a `✓ `/`✗ `
marked line and Markdown must never make prose look like a tool event.

**Markdown structure lives inside the content column.** The activity gutter is
unchanged; a heading's `▌ `, a list marker, a blockquote's `│ ` and a code
block's `▏ ` are composed after it, the way `toolResultLine` composes
`gutterResult + mark`. `wrapLine`'s hanging indent then falls out for free.
Every marker is a glyph rather than a colour, so a monochrome terminal keeps
every distinction — inline code keeps its backticks for the same reason.

Two defects underneath it are fixed in the same change, because adding rich
layout on top of either is what turns a cosmetic bug into a pane-corrupting one:

- **`cols` counted runes.** An emoji, a CJK glyph or a combining mark was
  mis-measured, and `splitWords` hard-split at a rune index, which cuts a ZWJ
  sequence in half. It is `ansi.StringWidth` now — already a direct dependency
  and already what twenty other TUI sites use. This also corrects
  `answerform.go`, which wraps through the same helper, and that gets its own
  test rather than being silently inherited. §15's **wrap-plain-then-style
  invariant stands unamended**: what changed is how wide a character is, not
  when a style is applied.
- **Agent text reached the pane unfiltered.** `ESC[2J` or an OSC title sequence
  in a tool result summary, a command's output body or an error message could
  already clobber the terminal. Every record is now stripped of escape sequences
  and C0/C1 controls inside `wrapLine`'s segment emission — one chokepoint, so
  no record type can bypass it — and before any measurement, so a sequence
  cannot influence the width arithmetic either.

### One behaviour change worth calling out

The chat's retention fallback rendered through `wrapCellLines(t.ResultText,
width-2, 40)`: a 40-line cap with an ellipsis, and a two-column narrowing the
`outputLines` path does not apply. Routing it through the shared renderer drops
both. That is required by the first acceptance criterion — the same Markdown
must render identically in both views at the same width — and it is a strict
improvement, since a retained-away answer is the only content that turn has left
and the cap hid its tail.

### Not in this PR

`cmd/fakeagent` emits no Markdown in any scenario, so `docs/assets/tui-*.png`
are unaffected and `scripts/screenshots.sh` was not re-run. Adding a
Markdown-emitting scenario, and the capture that has to accompany it, is
deliberately left out of this change. Tables, link interaction, a raw/rendered
toggle key and a copy-raw reader action are the scoped follow-ups; a toggle in
particular needs its own decision, because the chat composer owns every letter
key (task 071 decision 4).

## Related

Closes #289

Closes 073.1. Follow-up to #282 (task 071), which made the defect visible in two
places. It revisits **task 050 decision 8** and T4.16's recorded reasoning:
read literally, the issue's "replace rune-count width calculations in this path
with ANSI-aware terminal cell width" would supersede them, and it does not. The
invariant they record stands; only the measurement was wrong. §15 now says both
things in the same paragraph so a later reader cannot take "cell width" to have
meant "ANSI-aware wrapping".

`docs/spec.md` §15 is amended in place (`*Amended 2026-09-01 (task 073).*`) and
§16 gains its first terminal-injection item. §13.3 and §17 are cited by the
issue and change nothing, on purpose: transcripts and chunk payloads keep the
agent's bytes and the retention fallback keeps its meaning, because rendering is
derived.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`internal/tui` is covered by no gate script, so the tests are the whole
assurance. New and extended: construct fidelity per construct at widths 20/40/80
against `ansi.Strip`ped goldens; the subset boundary held as a test; the two
workspaces agreeing at every level and width on a Markdown fixture; each other
record type keeping its literal text and its gutter; every produced line
measuring within the pane over ASCII, combining marks, emoji, ZWJ sequences and
CJK; reflow being from the source rather than from rendered ANSI; injection
fixtures leaving no control character, no rendered parameters and no widened
line; code blocks keeping whitespace and hard-wrapping whole; monochrome keeping
every structural distinction; and rendering not mutating the records it
rendered.

No key bindings change, so `internal/tui/bindings.go` and §15's key tables are
untouched. `docs/guides/tui.md` gains a "How the pane reads" section,
`docs/features.md` gains a sentence, and `docs/tasks/073` carries the seven
decisions with the alternatives they beat.

The documentation audit found one gap and closed it: `docs/security-model.md`
is the public mirror of §16 — every other bullet there has a section on that
page — and the new terminal-injection item had none. It gains a short "What an
agent writes cannot drive your terminal" section and its table-of-contents
entry. Nothing else was stale: `internal/config`, the cobra tree,
`internal/api`'s route table, `internal/tui/bindings.go`, the `Reason*`
constants, `internal/workflow`/`internal/taskrun`'s step types and
`internal/agent/*` are all untouched by this change, so the configuration, CLI,
API, TUI-key, block-reason, workflow-schema, task-lifecycle and agent pages,
and `skills/vincent-workflows/SKILL.md`, stay true as written.
`docs/gates/m3-gate.md` walks the output pane only as "output is still
arriving" and its `NO_COLOR` leg as "legible as text and glyphs", both of which
this change keeps, so no walkthrough changed.

Green locally: `go run mage.go test`, `go run mage.go lint`, the per-GOOS lint
loop from `CLAUDE.md` for windows/darwin/linux, and `go test -race` on
`internal/tui`, `internal/api` and `internal/apiclient`.
