### PR TITLE
Hand off a chat's worktree and branch to a task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **A chat can now hand its worktree and branch to a task.** An idle chat gains
+  one action — `hand off` — that creates a task adopting the chat's worktree
+  path, branch, base branch and base SHA *exactly as they are*. Nothing is
+  copied, renamed, merged or committed, so committed **and uncommitted** work
+  are both there when the task's first step runs. The chat becomes terminal
+  (`handed_off`) and keeps a permanent link to the task; the task links back
+  with `source_chat_id`. From then on the task is the sole owner of that
+  worktree and branch, which is structural rather than a guard: archiving is
+  not legal on a handed-off chat, so chat cleanup can never remove task-owned
+  state.
+
+  It is one transaction — task row, branch claim, link, transition, claim
+  release and both durable events (`task.created` and the new
+  `chat.handed_off`) — with the scheduler notified only after the commit, so
+  the scheduler cannot admit a task before it owns a complete workspace and
+  `vincent gc` never sees the directory claimed twice or not at all. Everything
+  is validated first, so a refused handoff leaves the chat exactly as it was.
+
+  Reachable everywhere, not just in the TUI: `ctrl+t` in the chat workspace
+  opens the new-task form in handoff mode (the project, base branch and branch
+  shown read-only, because they name a worktree that already exists),
+  `vincent chat handoff CHAT_ID --title ...` carries `vincent task add`'s
+  flags, and `POST /v1/chats/{id}/handoff` takes `POST /v1/tasks`' body and is
+  validated by the same code. Like the rest of the chat family, it is
+  deliberately **not** an MCP tool.
+
+  Two refusals, both `409` and both typed: a chat that is not idle or has no
+  worktree to give, and a worktree partway through a merge, rebase,
+  cherry-pick, revert or bisect — named in `details.operation`, rather than
+  inherited silently and surfacing later as an unexplained `git_error` inside a
+  step. Ordinary uncommitted changes are never refused.
+
 - **Assistant prose renders as Markdown in the task output pane and in chats.**
   Headings, emphasis, strong text, ordered and unordered lists, nested lists,
   blockquotes, inline code, fenced code and horizontal rules become terminal

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,6 +56,15 @@ its own transcript — the accounting a conversation held in a terminal never
 leaves behind. Archiving a chat cleans up its worktree, and an empty branch
 with it, the way archiving a task does.
 
+And when an exploration turns out to be the start of real work, **hand the chat
+off to a task**. The task adopts the chat's worktree, branch, base branch and
+base SHA exactly as they are — no copy, no rename, no hidden commit, so
+committed *and* uncommitted changes are simply already there when the task's
+first step runs. The chat ends, linked to the task; the task owns the worktree
+and branch from then on. `ctrl+t` in the chat workspace,
+[`vincent chat handoff`](reference/cli.md#vincent-chat-handoff), or
+`POST /v1/chats/{id}/handoff`.
+
 Chats never appear on the task board and never enter the scheduler. A turn
 starts the moment you send it, bounded only by its own
 [`max_parallel_chats`](reference/configuration.md#max_parallel_chats) cap — over

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1085,9 +1085,22 @@ them, and a composer at the bottom.
 | `enter` | Send the message |
 | `ctrl+x` | Stop the running turn — its process tree is killed |
 | `ctrl+r` | How much of the conversation to show: compact → normal → verbose |
+| `ctrl+t` | Hand the worktree and branch to a new task — the chat ends |
 | `pgup` / `pgdown` | Scroll the conversation |
 | `ctrl+g` | Jump to the live end and follow it again |
 | `esc` | Back to the chats board |
+
+`ctrl+t` opens the new-task form in **handoff mode**: the project, the base
+branch and the branch are the chat's, shown but marked `(from the chat)` and
+not editable, because they name a worktree that already exists. Fill in the
+title, the workflow and whatever else the task needs — the description is where
+the conversation's context goes, since nothing about the chat reaches the
+workflow's prompts by itself — and the form lands you on the created task. The
+task adopts the worktree exactly as it stands, uncommitted changes included.
+The chat is then terminal: its header carries a permanent link to the task, it
+sorts into the board's done band, and it cannot be sent to, archived or handed
+off again. Only an idle chat can be handed off, and a worktree in the middle of
+a merge or rebase is refused with the operation named.
 
 The body is the task workspace's [output pane](#task-detail), same records
 and same marks: `▸` a tool call, the outcome indented under it, `·` reasoning,

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1383,13 +1383,33 @@ POST   /v1/chats/{id}/send            start a turn
 POST   /v1/chats/{id}/answer          answer a mid-run request
 POST   /v1/chats/{id}/cancel          stop the live turn
 POST   /v1/chats/{id}/archive         remove the worktree; terminal
+POST   /v1/chats/{id}/handoff         give the worktree and branch to a new task; terminal
 GET    /v1/chats/{id}/events          SSE: this chat's events plus its live output
 GET    /v1/chats/{id}/turns/{seq}/transcript
                                       one turn's transcript, with ?offset= / ?tail=
 ```
 
 None of these is an [MCP tool](#the-mcp-endpoint) — the whole family is
-excluded, the stream and the transcript included.
+excluded, the stream and the transcript included. `handoff` is on that list for
+a reason worth stating: it creates a task, and `task_create`'s bounds
+(`mcp.max_depth`, `mcp.max_tasks`) are walked over `created_by_task_id`, which
+a chat is not in.
+
+`POST /v1/chats/{id}/handoff` takes `POST /v1/tasks`' body and is validated by
+the same code, so it accepts exactly the task the create route accepts.
+`project_id`, `base_branch` and `branch_name` are the chat's and are ignored.
+It answers `201 { "task": {...}, "chat": {...} }`: the task carries
+`source_chat_id`, and the chat comes back `handed_off` with `handoff_task_id`
+set and its `worktree_path` cleared — the claim moved, in one transaction with
+the task row, the link, both durable events (`task.created` and
+`chat.handed_off`) and the transition.
+
+Everything is validated before anything is written, so a refusal leaves the
+chat exactly as it was: `400` when the task does not validate, `409` when the
+chat is not idle, has no worktree to give, or its worktree is partway through a
+git operation (code `repo_operation_in_progress`, with `details.operation`
+naming it). Ordinary uncommitted work is preserved, never refused and never
+committed.
 
 ### Creating one
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1435,9 +1435,11 @@ list.
 ### States
 
 `idle` → `running` → `idle`, with `awaiting_input` in the middle when the agent
-asks something, and `archived` as the only terminal state. Anything outside that
-table is a `409` — sending to an archived chat, answering one that asked
-nothing. There is no pause: a paused chat is an idle one nobody has sent to.
+asks something, and two terminal states: `archived`, and `handed_off` for a chat
+whose worktree and branch now belong to a task. Anything outside that table is a
+`409` — sending to an archived chat, answering one that asked nothing, handing
+off one that has already been handed off. There is no pause: a paused chat is an
+idle one nobody has sent to.
 
 ### Sending a turn
 
@@ -1643,7 +1645,7 @@ task.created            task.state_changed      task.priority_changed
 task.step_advanced      task.status_changed     task.children_changed
 task.github_pull_changed
 chat.created            chat.state_changed      chat.turn_changed
-chat.archived
+chat.archived           chat.handed_off
 project.*               workflow.registry_changed
 agent.quota_changed     daemon.shutting_down
 ```
@@ -1680,7 +1682,9 @@ they need.
 - The `chat.*` events belong to the [chat](#chats) family and carry the chat's
   `project_id`, so `?project_id=` filters them the way it filters a task's.
   Each payload is `{ id, title, state }`; `chat.turn_changed` adds `turn_id`,
-  `turn_seq`, `turn_state` and — when the turn failed — `fail_reason`.
+  `turn_seq`, `turn_state` and — when the turn failed — `fail_reason`, and
+  `chat.handed_off` adds `handoff_task_id`, so a follower can link the chat to
+  its task without a fetch.
   Re-fetch `GET /v1/chats/{id}` when you see one. There is **no per-chat event
   stream and no live-output route**: a chat's normalized output is written to
   the turn's transcript file, and over HTTP a finished turn's `result_text` is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1122,6 +1122,33 @@ Removes the chat's worktree and, under `delete_empty_branch_on_archive`, an
 empty branch with it — the same archive a task gets. A worktree with local
 changes is refused; `--force` is the way past it.
 
+### `vincent chat handoff`
+
+```sh
+vincent chat handoff CHAT_ID --title TITLE [--workflow NAME] [--description TEXT]
+                     [--field name=value ...] [--fields-file FILE] [--priority N]
+                     [--agent NAME] [--model NAME] [--effort LEVEL] [--json]
+```
+
+Creates a task that adopts the chat's worktree, branch, base branch and base
+SHA exactly as they are, and leaves the chat terminal (`handed_off`) and linked
+to the task. Nothing is copied, renamed or committed: committed *and*
+uncommitted work are both there when the task's first step runs, because the
+directory is simply not touched.
+
+The flags are `vincent task add`'s, minus the three a handoff has no say in —
+the project, the base branch and the branch name all come from the chat.
+`--description` is where the conversation's context goes: nothing about the
+chat reaches the workflow's prompts automatically.
+
+Only an idle chat can be handed off. A live turn must be finished or cancelled
+first (409), a worktree in the middle of a merge, rebase, cherry-pick, revert
+or bisect is refused by name (409, code `repo_operation_in_progress`), and a
+chat that has already been handed off or archived is refused for the same
+reason (409). Ordinary uncommitted changes are **not** a refusal. From then on
+the task owns the worktree and the branch: `vincent chat archive` is not legal
+on a handed-off chat, so chat cleanup can never remove task-owned state.
+
 ## `vincent workflow`
 
 Aliased as `vincent wf`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1132,12 +1132,15 @@ vincent chat handoff CHAT_ID --title TITLE [--workflow NAME] [--description TEXT
 
 Creates a task that adopts the chat's worktree, branch, base branch and base
 SHA exactly as they are, and leaves the chat terminal (`handed_off`) and linked
-to the task. Nothing is copied, renamed or committed: committed *and*
-uncommitted work are both there when the task's first step runs, because the
-directory is simply not touched.
+to the task. It prints the task and the workspace it inherited; `--json` emits
+`{"task": …, "chat": …}`, the created task and the chat as it now stands.
+Nothing is copied, renamed or committed: committed *and* uncommitted work are
+both there when the task's first step runs, because the directory is simply not
+touched.
 
-The flags are `vincent task add`'s, minus the three a handoff has no say in —
-the project, the base branch and the branch name all come from the chat.
+The flags are `vincent task add`'s, minus the ones a handoff has no say in: the
+project, the base branch and the branch name all come from the chat, and the two
+GitHub prefills (`--github-issue`, `--github-pull`) are not offered.
 `--description` is where the conversation's context goes: nothing about the
 chat reaches the workflow's prompts automatically.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -559,11 +559,14 @@ reboots rather than only on the restarts it no longer has.
 
 Task and step rows are **never** deleted — only the transcript files.
 
-This covers [chats](cli.md#vincent-chat) too: an archived chat's turn
+This covers [chats](cli.md#vincent-chat) too: an **ended** chat's turn
 transcripts under `{data_dir}/transcripts/chat-{chat_id}/` are pruned on the
-same pass, under the same setting, measured from when the chat was archived. A
-chat that was never archived keeps its transcripts however old it is, exactly as
-a task does. Chat and turn rows are never deleted either.
+same pass, under the same setting, measured from when the chat ended. Both
+endings count — `archived` and [`handed_off`](cli.md#vincent-chat-handoff) — and
+a handed-off chat's transcripts are its own rather than the worktree's, so
+pruning them never reaches the task that inherited it. A chat that has not ended
+keeps its transcripts however old it is, exactly as a task does. Chat and turn
+rows are never deleted either.
 
 That same pass also drops
 [idempotency keys](api.md#transport-and-auth) older than a fixed 24 hours. This

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -121,6 +121,12 @@ The name is informational: `vincent gc` decides what is a stray from the
 database claims, which cover both tables, so a chat's worktree is never
 mistaken for an orphan.
 
+That is also why a task [handed a chat's worktree](cli.md#vincent-chat-handoff)
+keeps living in `worktrees/chat-{chat_id}/` for the rest of its life. The
+handoff transfers the claim, not the name, and nothing derives a task's
+directory from its id — so the one directory it is safe to be surprised by is
+this one.
+
 Two rules worth internalizing:
 
 - **The worktree is disposable.** Archiving a task removes it. If it has
@@ -171,10 +177,12 @@ Transcripts are bounded by `transcript_max_bytes` per attempt and pruned for
 [Configuration](configuration.md).
 
 Both of those cover a [chat](cli.md#vincent-chat) too: a turn's transcript is
-capped by `transcript_max_bytes`, and an **archived** chat's directory under
+capped by `transcript_max_bytes`, and an **ended** chat's directory under
 `transcripts/chat-{chat_id}/` is reclaimed by the same retention pass, measured
-from when the chat was archived. A chat nobody archived keeps its transcripts
-however old they are, exactly as a task does.
+from when it ended — archived or [handed off](cli.md#vincent-chat-handoff), both
+count, and a handed-off chat's transcripts stay under `chat-{chat_id}/`, which
+the task that took its worktree never claims. A chat that has not ended keeps its transcripts however old they
+are, exactly as a task does.
 
 **What reclaims a transcript.** Retention, for as long as the task row exists.
 Deleting a project deletes its task rows, and retention walks rows — so those

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -7,9 +7,9 @@ and every task representation carries `available_actions`, so no client ever
 restates it.
 
 This page is about **tasks**. A [chat](cli.md#vincent-chat) has its own, much
-smaller vocabulary — `idle`, `running`, `awaiting_input`, `archived` — kept
-deliberately separate so no task query or board legend has to decide whether it
-means chats too. It is documented with the [chat routes](api.md#chats).
+smaller vocabulary — `idle`, `running`, `awaiting_input`, `archived`,
+`handed_off` — kept deliberately separate so no task query or board legend has
+to decide whether it means chats too. It is documented with the [chat routes](api.md#chats).
 
 - [The diagram](#the-diagram)
 - [States](#states)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3912,7 +3912,10 @@ tui:                           # view preference; the daemon validates and relay
 `max_parallel_chats` slot (§11, §13.2); `transcript_max_bytes` caps a turn's
 transcript and fails it `transcript_limit`; and `transcript_retention_days`
 reclaims an **archived** chat's transcripts on the same pass as an archived
-task's (§17). `notify:` stays the one exception, silent on chats for the reason
+task's (§17) — *amended 2026-09-01 (task 074, issue #288): an **ended** chat's,
+either terminal state, measured from the same `updated_at`; a handed-off chat's
+transcripts stay under `chat-{id}`, which the task that inherited its worktree
+never claims*. `notify:` stays the one exception, silent on chats for the reason
 its own comment gives.
 
 **`container:` (task 061, added 2026-08-30).** `image` is the whole switch and
@@ -7460,6 +7463,7 @@ else.
 | Agent process dies while `awaiting_input` | Attempt fails with its exit code (retry policy applies); `pending_input` cleared |
 | `input_timeout` expires | Process killed; attempt fails with reason `input_timeout`; normal retry/blocked policy (§7.2) |
 | Unparseable/unknown control request from an agent | Transcripted verbatim; attempt fails with `input_protocol_error` (retry policy applies) — vincent never waits on a request it can't render |
+| A chat's worktree is mid-merge or mid-rebase when it is handed off | *Added 2026-09-01 (task 074, issue #288).* `409 repo_operation_in_progress`, with `details.operation` naming which of merge, rebase (either backend), cherry-pick, revert or bisect — probed from the repository's own state files through the linked worktree's real git dir. Nothing is written: the chat stays `idle` and keeps its §10 claim. Ordinary dirty state is **not** refused — preserving it is the point of a handoff — and a chat with no `worktree_path` is a *different* `409`: it has nothing to hand over, and a task created with an empty path would have admission quietly cut a new worktree instead (§5.5) |
 | Clock skew / DST | All timestamps stored UTC RFC3339 |
 
 ## 19. Milestones

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -132,7 +132,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 26 | GitHub issue linking | **Read-only, daemon-side.** A task may be created *from* a GitHub issue when the project's `origin` parses as a github.com repository and `github.enabled` is on. The daemon prefers the `gh` CLI and falls back to `GITHUB_TOKEN`/`GH_TOKEN` from its inherited environment; **vincent stores no credential**, keeping §2's secret-management non-goal intact. The issue is fetched **once at creation**, snapshotted onto the task and never re-fetched, so `.Issue` (§8.4) renders offline and a run stays reproducible. The daemon makes every call — at pick time and create time only, never in the step path — and nothing here writes to GitHub, so row 11 is untouched (§5.3, §8.4, §12.3, §13.2, §14, §15; task 035, added 2026-08-26). *Narrowed 2026-08-29 (task 052):* this row is about **issues**; pull requests are row 27, which stores a pointer rather than a snapshot and reverses nothing here |
 | 27 | GitHub pull requests | **Daemon-side, and read-only until task 069**, like row 26 and through the same gate and credential. *Amended 2026-08-31 (task 068): the read side grows a live **check rollup** for a linked pull request's head commit — `GET /v1/tasks/{id}/github/pull/checks`, one normalized row per check run and per legacy commit status from either leg, never stored — and unlink gains a second home on the task workspace's Pull Request tab (§15 view 2). Task 068 decision 1 settled that merge, close, re-run and comment are written from the TUI only, human-triggered, and 068.4 is the sub-task that lands them and rewrites row 11.* A project's **open** pull requests are listed on demand, and a task is linked to the pull request whose head branch equals its own `branch_name` — by a daemon-side reconciler on a `github.poll_interval` tick, never as a side effect of a GET. Only the *link* is stored (`github_pull_json`: repo, number, source, suppressed) and it is a **pointer, not a snapshot** — the deliberate opposite of row 26, because draft, state and merged status are live by nature and a stored copy of them would read exactly like a current one while being wrong. A human may link or unlink; a human unlink is *sticky* and the reconciler never re-applies it, never overwrites a human link and never un-suppresses one. **Row 11 stands unamended**: vincent pushes nothing, opens nothing and merges nothing, and the “create a PR” affordance is a *constructed* compare URL — no request is made to GitHub when it is built — that a human clicks. `internal/github` gains no write method, no `POST` and no mutating `gh` subcommand. Task 035 decision 5's “repo identity is not stored” was revisited exactly as it predicted: the identity landed on the **task**, beside the number, and no `github_repo` column was added to projects (§5.3, §12.3, §13.2, §13.3, §14, §20; task 052, added 2026-08-29). *Narrowed 2026-08-30 (task 064):* the read-only posture holds in full — no write method, no `POST`, no mutating `gh` subcommand — and a task may now be created **from** a pull request and run on its head branch. That adds a flag to the same envelope (`branch`, `fork`) rather than a snapshot: nothing renderable is stored, so "a pointer, never a snapshot" is unchanged, and there is still no `.Pull` template variable. The consequences live in §10 (a second worktree creation mode, and archive never touching a branch vincent did not cut) and in §5.3's branch-name chain, which gains `pull` above the per-task literal. The listing above is narrowed the same way: it still **defaults** to open, but `?state=` (§13.2) makes a closed or merged pull request reachable, because acting on a merged one and redoing a reverted one are exactly what creating a task from one is for *Amended 2026-08-31 (task 069, issue #273):* the read-only posture gains **exactly one write path** — pull-request creation, from a human. `internal/github.CreatePull` is the only method here that writes, on both legs (`gh pr create`, `POST /repos/{owner}/{name}/pulls`); nothing updates, comments on, closes or merges anything, and `github.enabled` is the only gate on it (§12.3, decision 2: the consent is the keypress and the editable popup in front of it, not a second config key nobody would turn on). Every *other* half of this row is unchanged and load-bearing: the link is still a pointer and never a snapshot, the listing is still pure, the reconciler still never overwrites a human link, and the compare URL is still built by string construction with no request made — it is now the **fallback**, opened when there is no write credential or the create call fails, and the branch behind it has been pushed, so it is no longer a dead page. A create writes the link immediately as `source: human`, which is why the reconciler's poll interval does not make a just-created pull request read as unlinked |
 | 28 | MCP from the daemon | **A second protocol on the existing listener, not a second server.** `/mcp` is registered in §13.2's route table inside the same `recover → log → auth` chain, so row 4 is *added to*, not reversed: same loopback listener, same `Authorization: Bearer {token}` from `{data_dir}/token`, same `daemon.json` discovery. The tool surface **is** the route table — a call replays its arguments as an in-process request against the same handler, so the §13.1 bounds, the validation, the `409` + `details.state` envelopes and `Idempotency-Key` hold by construction — **minus five destructive-admin routes** (`daemon/stop`, `daemon/backup`, `DELETE projects/{id}`, `maintenance/gc`, `doctor/fix`), which is a design line: an agent must not be able to stop, garbage-collect or reconfigure the daemon supervising it. §13.3's SSE routes are replaced by a bounded blocking `task_wait` with a hard ceiling, whose result is complete for a client that drops every progress notification. A step parked in that wait **keeps its §11 slot** and a self-blocking wait is *refused*, not released — releasing it would create a §6 state owning a live agent process and holding no slot, which no state does today. The daemon wires its own agent steps to a **per-step endpoint** (`/mcp/step/{run_id}`, per-run secret), which is identity for the refusal and the provenance column and is explicitly **not** a security boundary (§16). Recursion is bounded by `created_by_task_id` + `mcp.max_depth`/`mcp.max_tasks`, deliberately **not** by `parent_task_id`, which the `awaiting_children` join counts (§9.1, §9.2, §9.3, §9.4, §9.7, §11, §12.3, §12.4, §13.4, §14, §16, §20; task 057, issue #243, added 2026-08-29) |
-| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). *Amended 2026-08-31 (issue #279):* `GET /v1/agents` publishes that answer as `supports_resume` (§9.6) so a client's picker offers only adapters that can hold a chat; the creation-time refusal is unchanged and stays the authority, and an absent field — an older daemon — filters nothing. A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15). *Amended 2026-08-31 (task 070, issue #268):* **codex resumes now**, so "codex and cursor are refused at creation with a typed reason" reads **cursor alone** — codex met the precondition task 063 decision 3 attached to it, a capture against a named build (codex-cli 0.150.1) pinning `codex exec --json resume <thread_id>`, and its `thread.started` id is read into `RunResult.SessionID` (§9.3). Nothing else in this row moves: continuity still comes from the CLI resuming its own session, vincent still replays no log as prompt context, and the refusal is still the authority for the adapters that cannot (§9.7). *Amended 2026-08-31 (task 071, issue #282):* a chat's live output is **normalized in the daemon exactly as a task's is** — §13.3's typed chunks, with the verbatim line kept as `raw` — and the chat workspace renders it with the output pane's own renderer at the session's shared verbosity level. The chat is still its own entity; what it is not is its own rendering vocabulary *Amended 2026-08-31 (task 072, issue #283):* **cursor resumes too**, pinned to a capture against cursor-agent 2026.08.11-e8db854, so "codex and cursor are refused at creation" is retired entirely and **no shipped adapter is refused**. The refusal path is unchanged and unretired — it is the contract for the next adapter — and is now proven against a stub adapter rather than a shipped one, which is what stops it asserting the opposite of the truth the day a capability lands. Two consequences are stated positively rather than worked around: a resumed codex run is always full-auto, because `codex exec resume` has no `--sandbox`, guarded structurally by chats having no requestable permission mode; and cursor cannot report a lost session at all, because it adopts an unknown `--resume` id and answers rather than refusing (§9.3, §9.7) |
+| 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). *Amended 2026-08-31 (issue #279):* `GET /v1/agents` publishes that answer as `supports_resume` (§9.6) so a client's picker offers only adapters that can hold a chat; the creation-time refusal is unchanged and stays the authority, and an absent field — an older daemon — filters nothing. A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15). *Amended 2026-08-31 (task 070, issue #268):* **codex resumes now**, so "codex and cursor are refused at creation with a typed reason" reads **cursor alone** — codex met the precondition task 063 decision 3 attached to it, a capture against a named build (codex-cli 0.150.1) pinning `codex exec --json resume <thread_id>`, and its `thread.started` id is read into `RunResult.SessionID` (§9.3). Nothing else in this row moves: continuity still comes from the CLI resuming its own session, vincent still replays no log as prompt context, and the refusal is still the authority for the adapters that cannot (§9.7). *Amended 2026-08-31 (task 071, issue #282):* a chat's live output is **normalized in the daemon exactly as a task's is** — §13.3's typed chunks, with the verbatim line kept as `raw` — and the chat workspace renders it with the output pane's own renderer at the session's shared verbosity level. The chat is still its own entity; what it is not is its own rendering vocabulary *Amended 2026-08-31 (task 072, issue #283):* **cursor resumes too**, pinned to a capture against cursor-agent 2026.08.11-e8db854, so "codex and cursor are refused at creation" is retired entirely and **no shipped adapter is refused**. The refusal path is unchanged and unretired — it is the contract for the next adapter — and is now proven against a stub adapter rather than a shipped one, which is what stops it asserting the opposite of the truth the day a capability lands. Two consequences are stated positively rather than worked around: a resumed codex run is always full-auto, because `codex exec resume` has no `--sandbox`, guarded structurally by chats having no requestable permission mode; and cursor cannot report a lost session at all, because it adopts an unknown `--resume` id and answers rather than refusing (§9.3, §9.7). *Amended 2026-09-01 (task 074, issue #288):* a chat has **two** terminal states, not one — an idle chat may `hand_off` its worktree and branch to a task that adopts them verbatim, and `handed_off` is terminal because reusing `archived` would run the archive path, which removes the worktree this transfers. The chat remains a separate entity and this row's "never a task with a `kind` column" is untouched: what is added is a lifecycle transition *between* the two entities, with one authoritative foreign key (`chats.handoff_task_id`) and the reverse direction served by a lookup. It is one transaction — task row, branch claim, link, transition, claim release, both events — with the scheduler notified after the commit, so the scheduler cannot admit a task before it owns a complete workspace and gc never sees the directory claimed twice or not at all. The task becomes the sole owner of that worktree and branch (§10). The new route joins this row's own MCP exclusion list rather than excepting it, which is why it is a chats-family route and not a field on `POST /v1/tasks` (§13.4). §7.3 is untouched: the chat's session is not transferred, and workflow steps still start fresh (§5.5, §10, §12.3, §13.2, §13.3, §13.4, §14, §15) |
 
 ## 4. Architecture
 
@@ -483,12 +483,13 @@ talking to can edit files and make commits without colliding with any task.
 | Field | Notes |
 |---|---|
 | `id`, `project_id`, `title` | as a task's |
-| `state` | `idle` \| `running` \| `awaiting_input` \| `archived` (below) |
+| `state` | `idle` \| `running` \| `awaiting_input` \| `archived` \| `handed_off` (below) |
 | `agent` | fixed at creation, and must be an adapter that can resume (§9.1) |
 | `model`, `effort`, `permission_mode` | resolved once at creation, not per turn |
 | `branch`, `base_branch`, `base_sha`, `worktree_path` | §10, exactly a task's |
 | `session_id` | **the agent CLI's own conversation id** — the whole of §7.3's chat-only amendment. Empty before the first turn finishes |
 | `pending_input` | the §7.4 request being awaited; non-null exactly in `awaiting_input` |
+| `handoff_task_id` | *Added 2026-09-01 (task 074, issue #288):* the task this chat's worktree and branch were handed to. The **one authoritative foreign key** between the two records; a task's `source_chat_id` (§13.2) is this column read backwards, one indexed query per list, never a second stored copy. Non-null exactly in `handed_off` |
 
 A **ChatTurn** is one exchange: the human's message and the agent run it
 produced. Its accounting columns are `step_runs`' — tokens, cost, duration,
@@ -517,14 +518,52 @@ chats too — the same objection that kept a `kind` column off `tasks`.
 | `idle` | no live turn; the state a chat is created in and the one every finished turn returns it to |
 | `running` | a live turn: an agent process is up, owned by the chat's runner goroutine |
 | `awaiting_input` | a turn holding its process while the agent waits on a §7.4 request. It **holds** its cap slot, for §6's reason: the process is alive on its stdin. *Amended 2026-08-31 (task 067, issue #269): that hold is now **bounded** by `defaults.input_timeout` — the wait expires, the turn fails `input_timeout`, the process tree is killed and the chat returns to `idle`, releasing the slot* |
-| `archived` | the only terminal state. The worktree is gone; nothing further can run in it |
+| `archived` | terminal. The worktree is gone; nothing further can run in it. *Amended 2026-09-01 (task 074, issue #288): this was "the only terminal state"; there are now two* |
+| `handed_off` | *Added 2026-09-01 (task 074, issue #288):* terminal. The worktree and branch belong to the task named by `handoff_task_id`, which is the **sole owner** of their cleanup and lifecycle from then on (§10). `worktree_path` is cleared in the handoff transaction — that is what transferring the §10 claim means concretely — while `branch`, `base_branch` and `base_sha` stay on the row as history. Reusing `archived` was rejected on mechanism, not taste: archiving *removes* the worktree and may delete the branch, which is exactly the state a handoff transfers, so "archiving a handed-off chat must never remove task-owned workspace state" is true by construction — `archive` is simply not legal from here |
 
 Human actions: `send` (idle → running), `answer` (awaiting_input → running),
-`cancel` (running/awaiting_input → idle), `archive` (idle → archived). There is
+`cancel` (running/awaiting_input → idle), `archive` (idle → archived) and
+*(added 2026-09-01, task 074)* `hand_off` (idle → handed_off). There is
 no pause: a chat is a foreground conversation, and a paused one is just an idle
 one nobody has sent to. Anything outside this table is a `409`, decided by
 `internal/chatstate` — the pure FSM both the API and `internal/chatrun` consult,
 the arrangement `internal/taskstate` has for §6.
+
+#### Handoff (added 2026-09-01, task 074, issue #288)
+
+`hand_off` creates a task in the chat's project that **adopts** the chat's
+`worktree_path`, `branch`, `base_branch` and `base_sha` verbatim. Nothing is
+copied, renamed, merged or committed: committed *and* uncommitted work are both
+present when the task's first step runs, because the directory is not touched.
+No third worktree-creation mode exists behind this — the engine's
+`ensureWorktree` already returns early for a task that arrives with a path, so
+admission runs no git at all. The worktree keeps the name the chat gave it,
+which is informational: the claim decides, not the name (§10).
+
+Everything is validated before anything is written, and everything written
+commits together: the task row and its branch claim, the link, the transition,
+the release of the chat's §10 claim and both durable events (`task.created` and
+`chat.handed_off`, §13.3) are one transaction, and the scheduler is notified
+only after it commits. So the scheduler cannot admit a task before it owns a
+complete workspace, and gc never observes the directory claimed twice or not at
+all. The chat's state is re-read and required to be `idle` **inside** that
+transaction: a `send` racing a handoff loses one of the two, never both.
+
+Two refusals, both `409`. A worktree partway through a git operation — merge,
+rebase, cherry-pick, revert or bisect — is refused with the operation named
+(`repo_operation_in_progress`, §18); gating on merge alone would let a
+half-finished rebase be inherited silently and surface later as an unexplained
+`git_error` inside a step. A chat with no `worktree_path` has nothing to hand
+over, and is refused rather than producing a task whose empty path admission
+would quietly fill in by cutting a new worktree. **Ordinary dirty state is not a
+refusal**: preserving it is the feature.
+
+Conversational context reaches the workflow through the task's `description`
+and nothing else. There is no `handoff_note` column and no new §8.4 template
+key: the handoff form asks the human for the objective the way the new-task
+form does, so "the transcript is not injected wholesale into workflow prompts"
+holds by there being nothing to inject. §7.3 is untouched and the chat's
+`session_id` is not transferred — workflow steps still start fresh sessions.
 
 `send` over `max_parallel_chats` is **refused, not queued** (§11). That refusal
 is not in the FSM: the cap is about how many chats are running, not about what
@@ -3168,6 +3207,18 @@ Two consequences are handled rather than assumed away:
 
   Keeping chat directories in a root the reclaimer does not scan was considered
   and rejected: it trades a false positive for no gc coverage at all.
+
+  *Amended 2026-09-01 (task 074, issue #288): ownership transfers.* A chat may
+  hand its worktree and branch to a task (§5.5). The transfer is one write —
+  the task row names the directory in the same transaction the chat's
+  `worktree_path` is cleared in — so the claim set never holds two owners for
+  one path and never holds none. The claim is **by path**, so the reclaimer
+  needs no change at all: the task's claim covers the inherited directory,
+  whose name still says `chat-{id}` and is still informational. Only the
+  transcript half stays keyed to the chat, under `chat-{id}`, which the task
+  never claims. After the handoff the **task is the sole owner** of that
+  worktree's cleanup and that branch's lifecycle; `archive` is not legal from
+  `handed_off`, so no chat-side path can reach them.
 - **Isolation caveat (documented, not solved):** git worktrees isolate the working
   tree and index, but share the object store and refs — and **do not** isolate
   process-level resources (global caches, package stores, ports, docker). True
@@ -4801,6 +4852,19 @@ POST   /v1/chats/{id}/cancel            stops the live turn and kills its proces
 POST   /v1/chats/{id}/archive           removes the worktree and deletes the branch when it
                                         received nothing (§10, task 008 semantics), `?force=`
                                         for the dirty-worktree refusal. Terminal
+POST   /v1/chats/{id}/handoff           *Added 2026-09-01 (task 074, issue #288).* Takes
+                                        `POST /v1/tasks`' body, **validated by the same code** so
+                                        the two routes accept exactly the same task; `project_id`,
+                                        `base_branch` and `branch_name` are the chat's and are
+                                        ignored. `201 { task, chat }`: the task carries
+                                        `source_chat_id` and the chat comes back `handed_off` with
+                                        `handoff_task_id` set and `worktree_path` cleared. One
+                                        transaction, scheduler notified after the commit (§5.5).
+                                        `400` when the task does not validate; `409` outside
+                                        `idle`, with no worktree to give, or with a git operation
+                                        in progress (`repo_operation_in_progress`, the operation
+                                        in `details.operation`). Every refusal leaves the chat
+                                        exactly as it was. It is **not** an MCP tool (§13.4)
 GET    /v1/chats/{id}/events            *Added 2026-08-31 (task 067).* SSE: this chat's durable
                                         `chat.*` events interleaved with its live output, the
                                         per-task stream's shape for a chat. The filter is the
@@ -5312,7 +5376,10 @@ Two kinds of streams:
 
 **Chat events (added 2026-08-30, task 063).** Chats ride the one durable event
 table and the one broker; there is no second stream. The durable kinds are
-`chat.created`, `chat.state_changed`, `chat.turn_changed` and `chat.archived`,
+`chat.created`, `chat.state_changed`, `chat.turn_changed`, `chat.archived` and
+— *added 2026-09-01 (task 074)* — `chat.handed_off`, which carries
+`handoff_task_id` beside the chat's id, title and state so a follower can link
+the two without a fetch,
 carrying the chat id and — for turn changes — the turn id, seq and state. A
 turn's live output is published exactly as a step's is, with the same ~10 Hz
 coalescing and the same drop-the-slow-subscriber rule, because the turn's
@@ -5422,6 +5489,9 @@ is excluded too, on the same kind of line:
     POST   /v1/chats/{id}/answer
     POST   /v1/chats/{id}/cancel
     POST   /v1/chats/{id}/archive
+    POST   /v1/chats/{id}/handoff
+
+*(The last line added 2026-09-01, task 074, issue #288.)*
 
 Two reasons, either sufficient. A chat turn starts an agent CLI **without going
 through admission** (§11), so a tool that could send one would let an agent
@@ -5431,6 +5501,16 @@ chain, so making chats reachable would mean inventing depth semantics for a
 non-task rather than reusing the ones that exist. An agent that needs a
 conversation already has its own session; it does not need vincent to hold one
 for it.
+
+*Amended 2026-09-01 (task 074, issue #288).* `POST /v1/chats/{id}/handoff`
+joins that list under the same rule rather than as an exception to it, and this
+is **why the route is in the chats family at all**. A `source_chat_id` field on
+`POST /v1/tasks` — the shape task 064 used for `github_pull` — was rejected
+because `POST /v1/tasks` *is* the `task_create` tool: a field on it would need a
+field-level MCP guard, a shape this list does not have. Handoff creates a task,
+which is exactly what makes it dangerous here — the bounds walk
+`created_by_task_id`, and a chat is not in that chain — so an agent that could
+hand a chat off would be creating tasks outside the bound.
 
 *Amended 2026-08-30 (task 065, issue #261).* **Fifteen**, with `POST` and
 `PATCH /v1/workflows`, under the same wording task 057 decision 4 gave the
@@ -5705,7 +5785,8 @@ CREATE TABLE chats (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     project_id      INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     title           TEXT    NOT NULL,
-    state           TEXT    NOT NULL, -- §5.5: idle | running | awaiting_input | archived
+    state           TEXT    NOT NULL, -- §5.5: idle | running | awaiting_input | archived | handed_off
+    handoff_task_id INTEGER REFERENCES tasks(id) ON DELETE SET NULL, -- task 074; the one authoritative edge
     agent           TEXT    NOT NULL, -- must be an adapter that can resume (§9.1)
     model           TEXT,
     effort          TEXT,
@@ -6941,14 +7022,26 @@ their own rows in the registry (`internal/tui/bindings.go`), which is what the
 `?` overlay, the footer and the palette are derived from. On the **chats
 board**: `enter` opens the workspace, `n` starts a chat, `a` archives, `/`
 filters, `←`/`→` fold a project group and `r` re-lists. In the **chat
-workspace**: `enter` sends, `ctrl+x` stops the live turn, `esc` returns to the
-board. In the **new-chat form**: `ctrl+s` creates, `tab`/`shift+tab` move
+workspace**: `enter` sends, `ctrl+x` stops the live turn, `ctrl+t` hands the
+worktree and branch to a task *(added 2026-09-01, task 074)*, `esc` returns to
+the board. In the **new-chat form**: `ctrl+s` creates, `tab`/`shift+tab` move
 between fields, `enter` opens the focused field's list, `←`/`→` step the
 project and agent fields in place, `esc` discards.
 `n` is the one key whose meaning depends on where you are, deliberately: on the
 chats board it makes a chat, and everywhere else it still makes a task. `!` is
 **not** extended to chats — an `awaiting_input` chat is pinned and badged on
 its own board and nowhere else.
+
+*Amended 2026-09-01 (task 074, issue #288).* `ctrl+t` on the chat workspace
+opens the **new-task form in handoff mode**, seeded with the chat: the project,
+the base branch and the branch are the chat's and are shown read-only, marked
+"(from the chat)", because they name a worktree that already exists and there is
+nothing here to decide. The issue row is hidden — the chat is the source
+already. Submitting posts to the chat's own route, not to `POST /v1/tasks`
+(§13.4), and lands on the created task. A handed-off chat's header carries a
+**permanent** link to that task; the state renders as "handed off" and the chat
+sorts into the board's terminal band beside archived ones. It is a ctrl
+combination for the reason `ctrl+r` is: the composer owns every printable key.
 
 *Amended 2026-08-31 (issue #279).* The new-chat form's project and agent
 pickers are fed by `GET /v1/projects` and `GET /v1/agents`, and the agent
@@ -7221,7 +7314,11 @@ global cursor config is untouched.
   operator reason to keep one. The table is counted in
   `GET /v1/doctor`'s `database.table_rows` like every other, by enumeration
   rather than by name. *Amended 2026-08-31 (task 067, issue #269):* an
-  **archived chat**'s turn transcripts (§5.5) are pruned by the same pass under
+  **ended chat**'s turn transcripts (§5.5) — *amended 2026-09-01 (task 074): both
+  terminal states, `archived` and `handed_off`, measured from the same
+  `updated_at`; a handed-off chat's transcripts live under `chat-{id}`, which the
+  task that inherited its worktree never claims, so pruning them cannot reach
+  task-owned state* — are pruned by the same pass under
   the same key, measured from when the chat was archived. The pruner walked
   archived tasks alone until then, so a chat's transcripts outlived every
   retention window.

--- a/docs/tasks/074-chat-handoff.md
+++ b/docs/tasks/074-chat-handoff.md
@@ -93,9 +93,10 @@ them:
 8. **§7.3's fresh-session rule is untouched** and the chat's `session_id` is
    not transferred. §5.5's chat-only amendment stays chat-only.
 
-**§17 needed no amendment**: its aggregates are over `step_runs`, whose
+**§17's aggregates needed no amendment**: they are over `step_runs`, whose
 `task_id` stays `NOT NULL`, and a handed-off task's step runs are ordinary
-ones. **§11 needed none either**: `handed_off` holds no process, so the
+ones. Its retention bullet did — both terminal chat states are pruned, and
+§12.3 says so beside it. **§11 needed none either**: `handed_off` holds no process, so the
 `max_parallel_chats` tally is unchanged.
 
 ## Risks named before the pull request

--- a/docs/tasks/074-chat-handoff.md
+++ b/docs/tasks/074-chat-handoff.md
@@ -1,0 +1,116 @@
+# 074 — Hand off a chat's worktree and branch to a task
+
+**Status:** ✅ done (1/1)
+**Issue:** #288
+**Follows:** [063](063-free-chat.md) (free chat), and is a sibling of
+[064](064-task-from-pull-request.md) — the existing precedent for "a task whose
+workspace was not cut the ordinary way"
+
+Chats ended only by being archived. A chat could explore a change for as long
+as it took, in its own worktree and on its own branch, and there was no
+supported way to turn that exploration into a structured task without
+abandoning the workspace or coordinating the branch by hand.
+
+An idle chat now has one more human action, `hand_off`. It creates a task in
+the chat's project that adopts the chat's worktree path, branch, base branch
+and base SHA verbatim, links the two records, and moves the chat to a second
+terminal state, `handed_off`.
+
+## Why it needed no new machinery
+
+Three facts made this cheap rather than invasive, and the design is built on
+them:
+
+- `internal/taskrun/engine.go:ensureWorktree` opens with
+  `if task.WorktreePath != "" { return nil }`. A task created with its worktree
+  already set adopts it and runs no git at admission, so there is **no third
+  worktree-creation mode** — unlike 064, which had to add `CreatePullAndClaim`.
+- `worktree.Manager.Path` has no non-test callers, so nothing derives a task's
+  directory from its id. The task can live in `{root}/chat-7` forever, which is
+  what makes "no worktree rename" free rather than a fight with
+  `worktree.Owner` (063 decision 9), whose directory name that decision already
+  calls informational — the claim decides, not the name.
+- `internal/taskrun/reclaim.go:claimSets` claims worktrees **by path**, so the
+  task's claim covers the inherited directory with no change to gc at all. Only
+  the transcript half is name-keyed, and it stays keyed to the chat.
+
+## Decisions
+
+1. **Handoff is a chats-family route: `POST /v1/chats/{id}/handoff`**, taking
+   `POST /v1/tasks`' body. A `source_chat_id` field on `POST /v1/tasks` — 064's
+   shape for `github_pull` — was rejected: that route **is** the `task_create`
+   MCP tool, and 063 decision 2 excluded the whole chat family from MCP
+   precisely so an agent cannot start agent processes outside the
+   `created_by_task_id` chain `mcp.max_depth`/`mcp.max_tasks` walk. A field
+   would need a field-level MCP guard, a shape the exclusion list does not
+   have. 063 decision 2 is therefore **extended, not excepted**: the route
+   joins the literal list in `internal/mcp/tools.go`. The cost is that
+   task-create validation is shared rather than duplicated — see Risks.
+2. **The authoritative foreign key is `chats.handoff_task_id`**; a task's
+   `source_chat_id` is the reverse lookup. A stored `tasks.source_chat_id` was
+   rejected: 063's posture is that no existing task query changes meaning when
+   chats exist, and the chat is the entity whose lifecycle this changes. The
+   reverse direction is one indexed query per list call, built into a map,
+   never one per rendered task.
+3. **Conversational context reaches the workflow through `tasks.description`.**
+   No `handoff_note` column and no new §8.4 template key. The handoff form asks
+   the human for the objective the way the new-task form does, so the issue's
+   "not injected wholesale into workflow prompts" holds by there being nothing
+   to inject.
+4. **Handoff refuses a worktree with a git operation in progress**, with a
+   typed 409 naming which. `worktree.InMerge` generalised to
+   `worktree.InProgressOp`, covering `MERGE_HEAD`, `rebase-merge/`,
+   `rebase-apply/`, `CHERRY_PICK_HEAD`, `REVERT_HEAD` and `BISECT_LOG`, reusing
+   `merge.go`'s resolution of a linked worktree's real git dir. New reason
+   `ReasonRepoOperationInProgress`. Gating on merge alone was rejected: a
+   half-finished rebase would be inherited silently and surface later as an
+   unexplained `git_error` inside a step. **Ordinary dirty state is not a
+   refusal** — the acceptance criterion is met by the worktree not being
+   touched.
+5. **`handed_off` is a second terminal chat state**, and §5.5's "archived is
+   the only terminal state" is amended. Reusing `archived` was rejected on
+   mechanism: `handleChatArchive` removes the worktree and may delete the
+   branch, exactly the state transfer moves. The chat's `worktree_path` is
+   cleared in the handoff transaction — that is what transferring the claim
+   means — while `branch`, `base_branch` and `base_sha` stay as history.
+   `archive` is not legal from `handed_off`, so "archiving a handed-off chat
+   must never remove task-owned workspace state" is satisfied structurally
+   rather than by a guard.
+6. **Transcript retention treats `handed_off` as terminal.**
+   `ArchivedChatIDsBefore` widened to both states and renamed
+   `TerminalChatIDsBefore`. It already measures from `updated_at`, and the
+   handoff transition is the last write the chat row takes, so its existing
+   justification transfers verbatim and no `archived_at` column is needed. The
+   chat's transcripts live under `{transcripts}/chat-{id}`, which the task
+   never claims, so pruning cannot reach task-owned state.
+7. **The branch-name chain is not touched.** 064 grew it with a `pull` level
+   because a PR task is created through `POST /v1/tasks`, whose form previews
+   the branch through `/v1/resolve`. A handoff has its own route and its own
+   read-only field, so the branch is passed verbatim and `ResolveBranchName`
+   gains nothing. `claimBranchTx` still runs on the inherited name inside the
+   transaction, so a live task already holding that branch collides here
+   exactly as any other create does.
+8. **§7.3's fresh-session rule is untouched** and the chat's `session_id` is
+   not transferred. §5.5's chat-only amendment stays chat-only.
+
+**§17 needed no amendment**: its aggregates are over `step_runs`, whose
+`task_id` stays `NOT NULL`, and a handed-off task's step runs are ordinary
+ones. **§11 needed none either**: `handed_off` holds no process, so the
+`max_parallel_chats` tally is unchanged.
+
+## Risks named before the pull request
+
+The one real cost of decision 1 is that `handleTaskCreate`'s validation —
+workflow resolution and snapshot, include expansion, fan-out resolution, the
+GitHub prefills, declared fields, the base branch, the agent/model/effort
+override, MCP provenance and the four capability gates — had to be **factored
+out and shared**, not copied. A second copy would drift, and the drift would
+show up as a task the handoff route accepts and the create route rejects. That
+extraction (`prepareTaskCreate`) is the largest part of the diff and landed as
+its own commit ahead of the feature, so a regression in it is bisectable
+separately.
+
+`chatstate`'s `TestArchivedIsTheOnlyTerminal` was not patched quietly — it was
+063's lifecycle shape written down. It was rewritten as
+`TestTheTwoTerminalStates`, with the amendment cited, in the same commit as the
+spec edit.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -87,6 +87,7 @@ the living engineering specification records implementation contracts.
 | [071](071-chat-workspace-verbosity.md) | The chat workspace renders through the output pane at a shared verbosity level | ✅ done (1/1) |
 | [072](072-codex-and-cursor-in-chat.md) | Chats on codex and cursor | ✅ done (1/1) |
 | [073](073-assistant-markdown-in-output.md) | Assistant Markdown in the output pane | ✅ done (1/1) |
+| [074](074-chat-handoff.md) | Hand off a chat's worktree and branch to a task | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/chathandoff.go
+++ b/internal/api/chathandoff.go
@@ -1,0 +1,135 @@
+package api
+
+// POST /v1/chats/{id}/handoff — handing a chat's worktree and branch to a new
+// task (task 074, spec §5.5, §10, §13.2).
+//
+// The route lives in the chats family rather than as a `source_chat_id` field
+// on POST /v1/tasks, which is the shape task 064 used for `github_pull`
+// (decision 1). `POST /v1/tasks` *is* the `task_create` MCP tool, and task 063
+// decision 2 excluded the whole chat family from MCP precisely so an agent
+// cannot start agent processes outside the `created_by_task_id` chain that
+// `mcp.max_depth` and `mcp.max_tasks` walk. A chat is not in that chain, so a
+// field on the task-create route would need a field-level MCP guard — a shape
+// the exclusion list does not have. The exclusion is therefore extended rather
+// than excepted: this route joins the literal list in internal/mcp.
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// handleChatHandoff creates a task that adopts the chat's worktree, branch,
+// base branch and base SHA verbatim, and leaves the chat terminal.
+//
+// The body is `POST /v1/tasks`' body, validated by the same code (§13.2): the
+// two routes must accept the same task or the difference becomes a task one
+// takes and the other refuses. `project_id`, `base_branch` and `branch_name`
+// are the chat's and are ignored — a handoff has nothing to name, because the
+// branch already exists and is what is being transferred.
+//
+// Everything is validated before anything is written, and everything that is
+// written commits together. The order matters: the workflow, the fields and
+// the git state are checked first, so a refusal leaves the chat exactly as it
+// was; only then does one transaction create the task, link it, transition the
+// chat and release its §10 claim; and only after that commit is the scheduler
+// woken, so it cannot admit a task whose workspace it does not yet own.
+func (s *Server) handleChatHandoff(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	var req taskCreateRequest
+	// The large bound, for the reason POST /v1/tasks takes it: the
+	// description is what the workflow templates into an agent's prompt, and
+	// on this route it is the *only* thing carrying the conversation's
+	// context — nothing about the chat is injected automatically (decision 3).
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
+		return
+	}
+	if b := boundTaskCreate(&req); b != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
+		return
+	}
+	if !chatstate.Allowed(chat.State, chatstate.HandOff) {
+		writeConflict(w, "only an idle chat can be handed off to a task",
+			map[string]string{"state": string(chat.State), "action": string(chatstate.HandOff)})
+		return
+	}
+	// A chat with no claim has nothing to hand over: creation failed partway,
+	// or the row was archived. Refusing here is what stops the alternative —
+	// a task with an empty worktree_path, which admission would quietly
+	// resolve by cutting a *new* worktree, silently defeating the whole
+	// feature.
+	if chat.WorktreePath == "" {
+		writeConflict(w, "this chat has no worktree to hand over",
+			map[string]string{"state": string(chat.State), "action": string(chatstate.HandOff)})
+		return
+	}
+	ctx := r.Context()
+	// Git state before the database, because it is the check most likely to
+	// fail and the one whose failure must leave the chat untouched. Ordinary
+	// dirty state is not a refusal: uncommitted work is what a handoff
+	// preserves (decision 4).
+	op, err := s.deps.Worktrees.InProgressOp(ctx, chat.WorktreePath)
+	if err != nil {
+		s.internalError(w, "probe worktree state", err)
+		return
+	}
+	if op != "" {
+		writeJSON(w, http.StatusConflict, errorBody{Error: errorDetail{
+			Code: CodeRepoOperationInProgress,
+			Message: "this chat's worktree is in the middle of a " + op +
+				"; finish or abort it before handing off",
+			Details: map[string]string{
+				"state": string(chat.State), "action": string(chatstate.HandOff), "operation": op,
+			},
+		}})
+		return
+	}
+	req.ProjectID = chat.ProjectID
+	prep, ok := s.prepareTaskCreate(ctx, w, &req, chat.BaseBranch)
+	if !ok {
+		return
+	}
+	t := prep.task
+	// The inheritance, character for character. There is no third worktree
+	// creation mode behind this: taskrun's ensureWorktree returns early for a
+	// task that already has a path, so admission runs no git at all and the
+	// directory keeps the name the chat gave it — informational, since the
+	// claim decides (063 decision 9).
+	t.BranchName = chat.Branch
+	t.BaseBranch = chat.BaseBranch
+	t.BaseSHA = chat.BaseSHA
+	t.WorktreePath = chat.WorktreePath
+	updated, err := s.deps.Store.HandoffChat(ctx, chat.ID, &t)
+	var claimed *store.BranchClaimedError
+	switch {
+	case errors.As(err, &claimed):
+		// A live task already on this branch. The transaction rolled back, so
+		// the chat is still idle and still owns its worktree.
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"branch "+claimed.Branch+" is already claimed by another task")
+		return
+	case errors.Is(err, store.ErrInvalidChatAction):
+		// The compare-and-set lost: a `send` landed between the read above
+		// and the write. Exactly one of the two happened, and it was not this.
+		writeConflict(w, "this chat changed state while the handoff was being prepared",
+			map[string]string{"state": string(chat.State), "action": string(chatstate.HandOff)})
+		return
+	case err != nil:
+		s.internalError(w, "hand off chat", err)
+		return
+	}
+	if s.deps.WakeRunner != nil {
+		s.deps.WakeRunner()
+	}
+	resp := toTaskResponse(&t, s.snaps.get(t.ID, t.WorkflowSnapshot))
+	resp.Warnings = prep.warnings
+	resp.SourceChatID = &chat.ID
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"task": resp, "chat": renderChat(updated),
+	})
+}

--- a/internal/api/chathandoff_test.go
+++ b/internal/api/chathandoff_test.go
@@ -1,0 +1,302 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// handoffFixture creates one chat and returns its id and the chat body.
+func handoffFixture(t *testing.T, h *chatHarness) (int64, map[string]any) {
+	t.Helper()
+	code, body := h.create(t, "claude")
+	if code != http.StatusCreated {
+		t.Fatalf("create chat = %d (%v)", code, body)
+	}
+	id, ok := body["id"].(float64)
+	if !ok {
+		t.Fatalf("chat body has no id: %v", body)
+	}
+	return int64(id), body
+}
+
+func (h *chatHarness) handoff(t *testing.T, id int64, req map[string]any) (int, map[string]any) {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/chats/"+strconv.FormatInt(id, 10)+"/handoff", req)
+	var out map[string]any
+	_ = json.Unmarshal(body, &out)
+	return resp.StatusCode, out
+}
+
+// TestHandoffInheritsTheWorkspaceExactly is the acceptance criterion, asserted
+// character for character: the task's workspace is the chat's, not a copy of
+// it and not a replacement for it.
+func TestHandoffInheritsTheWorkspaceExactly(t *testing.T) {
+	h := newChatHarness(t)
+	id, chat := handoffFixture(t, h)
+	code, body := h.handoff(t, id, map[string]any{"title": "finish the exploration"})
+	if code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+	task, _ := body["task"].(map[string]any)
+	for _, f := range []struct{ task, chat string }{
+		{"branch_name", "branch"},
+		{"base_branch", "base_branch"},
+		{"worktree_path", "worktree_path"},
+		{"base_sha", "base_sha"},
+	} {
+		if got, want := task[f.task], chat[f.chat]; got != want {
+			t.Errorf("task %s = %v, want the chat's %s %v", f.task, got, f.chat, want)
+		}
+	}
+	if task["project_id"] != chat["project_id"] {
+		t.Errorf("task project_id = %v, want %v", task["project_id"], chat["project_id"])
+	}
+	// And the link, in both directions.
+	after, _ := body["chat"].(map[string]any)
+	if after["state"] != string(chatstate.HandedOff) {
+		t.Errorf("chat state = %v, want handed_off", after["state"])
+	}
+	if after["handoff_task_id"] != task["id"] {
+		t.Errorf("chat handoff_task_id = %v, want %v", after["handoff_task_id"], task["id"])
+	}
+	if task["source_chat_id"] != chat["id"] {
+		t.Errorf("task source_chat_id = %v, want %v", task["source_chat_id"], chat["id"])
+	}
+	// The claim moved rather than being shared: two rows naming one directory
+	// is the ambiguity gc must never see (§10).
+	if after["worktree_path"] != nil && after["worktree_path"] != "" {
+		t.Errorf("chat still claims %v after the handoff", after["worktree_path"])
+	}
+	// The reverse lookup is a real query, not a rendering of the response.
+	got, err := h.store.SourceChatID(t.Context(), int64(task["id"].(float64)))
+	if err != nil {
+		t.Fatalf("source chat: %v", err)
+	}
+	if got != id {
+		t.Errorf("SourceChatID = %d, want %d", got, id)
+	}
+}
+
+// TestHandoffPreservesDirtyAndCommittedWork is the "no implicit commit, copy,
+// merge or rename" criterion: the directory is simply not touched.
+func TestHandoffPreservesDirtyAndCommittedWork(t *testing.T) {
+	h := newChatHarness(t)
+	id, chat := handoffFixture(t, h)
+	dir, _ := chat["worktree_path"].(string)
+	if dir == "" {
+		t.Fatal("the chat has no worktree")
+	}
+	committed := filepath.Join(dir, "committed.txt")
+	if err := os.WriteFile(committed, []byte("kept\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "committed.txt"},
+		{"-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "chat work"},
+	} {
+		cmd := exec.CommandContext(t.Context(), "git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	dirty := filepath.Join(dir, "dirty.txt")
+	if err := os.WriteFile(dirty, []byte("uncommitted\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	head := gitOut(t, dir, "rev-parse", "HEAD")
+
+	code, body := h.handoff(t, id, map[string]any{"title": "carry on"})
+	if code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+	task, _ := body["task"].(map[string]any)
+	if task["worktree_path"] != dir {
+		t.Fatalf("task worktree = %v, want %s", task["worktree_path"], dir)
+	}
+	for _, f := range []string{committed, dirty} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("%s did not survive the handoff: %v", f, err)
+		}
+	}
+	// No hidden commit: HEAD is exactly where the conversation left it, and
+	// the uncommitted file is still uncommitted.
+	if got := gitOut(t, dir, "rev-parse", "HEAD"); got != head {
+		t.Errorf("HEAD moved from %s to %s", head, got)
+	}
+	if out := gitOut(t, dir, "status", "--porcelain"); out == "" {
+		t.Error("the uncommitted file was committed or removed by the handoff")
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestHandoffIsTerminal covers the whole of "the chat cannot be resumed or
+// handed off twice", through the routes a client would actually try.
+func TestHandoffIsTerminal(t *testing.T) {
+	h := newChatHarness(t)
+	id, _ := handoffFixture(t, h)
+	if code, body := h.handoff(t, id, map[string]any{"title": "first"}); code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+	for _, tc := range []struct {
+		route string
+		body  map[string]any
+	}{
+		{"handoff", map[string]any{"title": "second"}},
+		{"send", map[string]any{"message": "hello?"}},
+		{"cancel", nil},
+		{"archive", nil},
+	} {
+		resp, body := h.doJSON(t, http.MethodPost, "/v1/chats/"+strconv.FormatInt(id, 10)+"/"+tc.route, tc.body)
+		if resp.StatusCode != http.StatusConflict {
+			t.Errorf("%s on a handed-off chat = %d, want 409 (%s)", tc.route, resp.StatusCode, body)
+		}
+	}
+	// answer takes an InputResponse, and is refused for the same reason.
+	resp, body := h.doJSON(t, http.MethodPost, "/v1/chats/"+strconv.FormatInt(id, 10)+"/answer",
+		map[string]any{"text": "no"})
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("answer on a handed-off chat = %d, want 409 (%s)", resp.StatusCode, body)
+	}
+}
+
+// TestHandoffLeavesTheChatAloneWhenTheTaskDoesNotValidate is the atomicity
+// half a client can see: validation happens before anything is written, so a
+// refused handoff is indistinguishable from one that never happened.
+func TestHandoffLeavesTheChatAloneWhenTheTaskDoesNotValidate(t *testing.T) {
+	h := newChatHarness(t)
+	id, chat := handoffFixture(t, h)
+	for _, tc := range []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"unknown workflow", map[string]any{"title": "x", "workflow": "nope"}, http.StatusBadRequest},
+		{"no title", map[string]any{}, http.StatusBadRequest},
+		{"unknown agent", map[string]any{"title": "x", "agent": "nope"}, http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if code, body := h.handoff(t, id, tc.body); code != tc.want {
+				t.Fatalf("handoff = %d, want %d (%v)", code, tc.want, body)
+			}
+			c, err := h.store.GetChat(t.Context(), id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.State != chatstate.Idle {
+				t.Errorf("chat state = %s, want idle", c.State)
+			}
+			if c.WorktreePath != chat["worktree_path"] {
+				t.Errorf("chat worktree = %q, want %v", c.WorktreePath, chat["worktree_path"])
+			}
+			if c.HandoffTaskID != nil {
+				t.Errorf("chat links task %d after a refused handoff", *c.HandoffTaskID)
+			}
+			tasks, err := h.store.ListTasks(t.Context(), store.TaskFilter{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tasks) != 0 {
+				t.Errorf("a refused handoff left %d task(s) behind", len(tasks))
+			}
+		})
+	}
+}
+
+// TestHandoffRefusesAnOperationInProgress is decision 4: a half-finished
+// rebase is named rather than inherited silently.
+func TestHandoffRefusesAnOperationInProgress(t *testing.T) {
+	h := newChatHarness(t)
+	id, chat := handoffFixture(t, h)
+	dir, _ := chat["worktree_path"].(string)
+	gitDir := gitOut(t, dir, "rev-parse", "--absolute-git-dir")
+	if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	code, body := h.handoff(t, id, map[string]any{"title": "carry on"})
+	if code != http.StatusConflict {
+		t.Fatalf("handoff over a rebase = %d, want 409 (%v)", code, body)
+	}
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["code"] != worktree.ReasonRepoOperationInProgress {
+		t.Errorf("error code = %v, want %q", errObj["code"], worktree.ReasonRepoOperationInProgress)
+	}
+	details, _ := errObj["details"].(map[string]any)
+	if details["operation"] != "rebase" {
+		t.Errorf("details.operation = %v, want rebase", details["operation"])
+	}
+	// Ordinary dirty state, by contrast, is not a refusal: it is the feature.
+	if err := os.RemoveAll(filepath.Join(gitDir, "rebase-merge")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code, body := h.handoff(t, id, map[string]any{"title": "carry on"}); code != http.StatusCreated {
+		t.Fatalf("handoff over a dirty worktree = %d, want 201 (%v)", code, body)
+	}
+}
+
+// TestHandoffRefusesAChatWithNoWorktree is the edge case the brief names: a
+// chat whose claim is gone produces a typed refusal, never a task with no
+// workspace that admission would quietly fill in by cutting a new one.
+func TestHandoffRefusesAChatWithNoWorktree(t *testing.T) {
+	h := newChatHarness(t)
+	id, _ := handoffFixture(t, h)
+	if _, err := h.store.SetChatWorktree(t.Context(), id, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	code, body := h.handoff(t, id, map[string]any{"title": "x"})
+	if code != http.StatusConflict {
+		t.Fatalf("handoff of a claimless chat = %d, want 409 (%v)", code, body)
+	}
+}
+
+// TestHandoffDoesNotChangeTheOrphanCount is the ownership criterion: gc sees
+// exactly one claim on the directory across the transfer, so a handed-off
+// worktree is never reported as an orphan.
+func TestHandoffDoesNotChangeTheOrphanCount(t *testing.T) {
+	h := newChatHarness(t)
+	id, _ := handoffFixture(t, h)
+	before := h.orphans(t)
+	if code, body := h.handoff(t, id, map[string]any{"title": "own it"}); code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+	if after := h.orphans(t); after != before {
+		t.Fatalf("orphan count went from %v to %v across the handoff", before, after)
+	}
+}
+
+func (h *chatHarness) orphans(t *testing.T) float64 {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/info", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/info = %d (%s)", resp.StatusCode, body)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatal(err)
+	}
+	n, _ := out["orphans"].(float64)
+	return n
+}

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -26,6 +26,15 @@ const CodeAgentCannotResume = "agent_cannot_resume"
 // already running (§11, decision 1). It is a 409 and never a queue.
 const CodeChatCapReached = "chat_cap_reached"
 
+// CodeRepoOperationInProgress is a handoff refused because the chat's worktree
+// is partway through a git operation — a conflicted merge, a stopped rebase, a
+// cherry-pick awaiting a commit (task 074 decision 4). It is its own code
+// because the remedy is specific and the details name the operation: finish or
+// abort it, then hand off.
+//
+// Ordinary uncommitted work is *not* refused. Preserving it is the feature.
+const CodeRepoOperationInProgress = worktree.ReasonRepoOperationInProgress
+
 // chatBody is a chat as the API renders it (§5.5, §13.2).
 type chatBody struct {
 	ID           int64           `json:"id"`
@@ -41,8 +50,12 @@ type chatBody struct {
 	WorktreePath string          `json:"worktree_path,omitempty"`
 	SessionID    string          `json:"session_id,omitempty"`
 	PendingInput json.RawMessage `json:"pending_input,omitempty"`
-	CreatedAt    time.Time       `json:"created_at"`
-	UpdatedAt    time.Time       `json:"updated_at"`
+	// HandoffTaskID is the task this chat's worktree and branch were handed
+	// to (§5.5, task 074). It is the one authoritative edge; a task's
+	// `source_chat_id` is this read backwards.
+	HandoffTaskID *int64    `json:"handoff_task_id,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 // chatTurnBody is one turn as the API renders it.
@@ -70,7 +83,7 @@ func renderChat(c *store.Chat) chatBody {
 		ID: c.ID, ProjectID: c.ProjectID, Title: c.Title, State: string(c.State),
 		Agent: c.Agent, Model: c.Model, Effort: c.Effort, Branch: c.Branch,
 		BaseBranch: c.BaseBranch, BaseSHA: c.BaseSHA, WorktreePath: c.WorktreePath,
-		SessionID: c.SessionID, PendingInput: c.PendingInput,
+		SessionID: c.SessionID, PendingInput: c.PendingInput, HandoffTaskID: c.HandoffTaskID,
 		CreatedAt: c.CreatedAt, UpdatedAt: c.UpdatedAt,
 	}
 }

--- a/internal/api/mcp_parity_test.go
+++ b/internal/api/mcp_parity_test.go
@@ -106,6 +106,12 @@ func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 		// human is the one pressing it. An agent's path to the same outcome —
 		// `git push` and `gh pr create` in its own worktree — is untouched.
 		{http.MethodPost, "/v1/tasks/{id}/github/pull/create"},
+		// Task 074 decision 1: handoff creates a task, and that is exactly
+		// why it belongs here. `task_create` is bounded by mcp.max_depth and
+		// mcp.max_tasks walking `created_by_task_id`; a chat is not in that
+		// chain, so an agent that could hand one off would be creating tasks
+		// outside the bound. 063 decision 2 is extended, not excepted.
+		{http.MethodPost, "/v1/chats/{id}/handoff"},
 	}
 	if len(mcp.Excluded) != len(want) {
 		t.Fatalf("mcp.Excluded has %d entries, want %d", len(mcp.Excluded), len(want))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -316,6 +316,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/chats/{id}/answer", s.handleChatAnswer)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/cancel", s.handleChatCancel)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/archive", s.handleChatArchive)
+	rt.handle(http.MethodPost, "/v1/chats/{id}/handoff", s.handleChatHandoff)
 	rt.handle(http.MethodGet, "/v1/chats/{id}/turns/{seq}/transcript", s.handleChatTurnTranscript)
 	rt.handle(http.MethodGet, "/v1/events", s.handleEvents)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}/events", s.handleTaskEvents)

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -140,6 +140,10 @@ type taskResponse struct {
 	// It reflects earlier edit+retry rewrites, because the snapshot is this
 	// task's execution truth (§5.3).
 	WorkflowSteps []snapshotStepResponse `json:"workflow_steps,omitempty"`
+	// SourceChatID names the chat this task was handed off from (§5.5, task
+	// 074). It is the reverse of the one stored edge, `chats.handoff_task_id`,
+	// read as a single indexed query per list rather than per rendered task.
+	SourceChatID *int64 `json:"source_chat_id,omitempty"`
 }
 
 // snapshotStepResponse is one step of the task's snapshot (spec §13.2).
@@ -393,8 +397,9 @@ type taskCreateRequest struct {
 }
 
 // boundTaskCreate applies §13.1's size bounds to a task-create body. It is
-// factored out for the reason prepareTaskCreate is: two copies would drift
-// into a body one create path accepts and another rejects.
+// shared with the handoff route (task 074) for the reason prepareTaskCreate
+// is: two copies would drift into a body one route accepts and the other
+// rejects.
 func boundTaskCreate(req *taskCreateRequest) string {
 	for _, b := range []string{
 		boundTaskFields(req.Title, ptrValue(req.Description), req.Fields),
@@ -412,9 +417,9 @@ func boundTaskCreate(req *taskCreateRequest) string {
 // applies before a branch name is decided: the project, the resolved and
 // expanded workflow, and the task row built from both.
 //
-// It stops short of the branch because that is where a second create path
-// differs: POST /v1/tasks resolves a name through §5.3's chain, while a path
-// that inherits an existing worktree has no chain to walk.
+// It stops short of the branch because that is exactly where the two callers
+// differ. POST /v1/tasks resolves a name through §5.3's chain; a handoff
+// (task 074) inherits the chat's verbatim and has no chain to walk.
 type preparedTask struct {
 	project  *store.Project
 	task     store.Task
@@ -429,16 +434,15 @@ type preparedTask struct {
 // the agent/model/effort override, MCP provenance and the four capability
 // gates.
 //
-// It is factored out rather than copied because a second route that creates a
-// task must accept exactly the task this one accepts: a second copy would
-// drift, and the drift would surface as a body one route takes and the other
-// refuses. It writes its own 400s, the way applyIssuePrefill beside it does,
-// and reports false once it has.
+// It is factored out rather than copied because `POST /v1/chats/{id}/handoff`
+// must accept exactly the task POST /v1/tasks accepts (task 074 decision 1):
+// a second copy would drift, and the drift would surface as a task the handoff
+// route takes and the create route refuses. It writes its own 400s, the way
+// applyIssuePrefill beside it does, and reports false once it has.
 //
 // inheritedBase, when non-empty, replaces the request's `base_branch` and is
-// taken verbatim: a base branch inherited from an existing worktree is a fact
-// about that worktree, not a name to validate against the repository as it is
-// now.
+// taken verbatim: a handoff's base branch is a fact about a worktree that
+// already exists, not a name to validate against the repository as it is now.
 func (s *Server) prepareTaskCreate(
 	ctx context.Context, w http.ResponseWriter, req *taskCreateRequest, inheritedBase string,
 ) (*preparedTask, bool) {
@@ -519,8 +523,8 @@ func (s *Server) prepareTaskCreate(
 	// An inherited base branch skips the repository check on purpose: it
 	// names the commit an existing worktree was cut from, and a task that
 	// adopts that worktree is not about to cut another. Refusing it because
-	// the branch has since been deleted locally would reject the create for a
-	// fact that no longer has any bearing on it.
+	// the branch has since been deleted locally would reject a handoff for a
+	// fact that no longer has any bearing on it (task 074).
 	baseBranch := inheritedBase
 	if baseBranch == "" {
 		baseBranch = project.DefaultBranch
@@ -1124,6 +1128,12 @@ func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]list
 	for i := range projects {
 		names[projects[i].ID] = projects[i].Name
 	}
+	// One indexed query over the handed-off chats, turned into a map, rather
+	// than a `source_chat_id` column on every task row (task 074 decision 2).
+	sources, err := s.deps.Store.SourceChatIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	out := make([]listTaskResponse, 0, len(tasks))
 	for i := range tasks {
@@ -1138,6 +1148,9 @@ func (s *Server) toListResponse(ctx context.Context, tasks []store.Task) ([]list
 		row.Loop = s.loopRollup(ctx, t, summary)
 		row.ProjectName = names[t.ProjectID]
 		row.StatusMessage = nilIfEmpty(statuses[t.ID])
+		if chatID, ok := sources[t.ID]; ok {
+			row.SourceChatID = &chatID
+		}
 		if ru := rollups[t.ID]; ru.HasCost {
 			cost := ru.CostUSD
 			row.CostUSD = &cost
@@ -1167,6 +1180,12 @@ func (s *Server) handleTaskGet(w http.ResponseWriter, r *http.Request) {
 	// than making each client join it back (T4.4 walkthrough finding).
 	if p, err := s.deps.Store.GetProject(r.Context(), t.ProjectID); err == nil {
 		resp.ProjectName = p.Name
+	}
+	// The reverse of `chats.handoff_task_id` (task 074 decision 2): one
+	// indexed lookup, so the detail view can link back to the conversation
+	// this task's workspace came out of.
+	if chatID, err := s.deps.Store.SourceChatID(r.Context(), t.ID); err == nil && chatID != 0 {
+		resp.SourceChatID = &chatID
 	}
 	// The children rollup (§13.2, task 014 decisions 13, 27). Present
 	// whenever the task has lanes, in any state — a parent mid-join, or one

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -392,58 +392,65 @@ type taskCreateRequest struct {
 	GitHubPull *int `json:"github_pull"`
 }
 
-// handleTaskCreate implements POST /v1/tasks (spec §13.2). The workflow is
-// resolved through the registry and snapshotted onto the task (§5.3). The
-// optional agent/model/effort override is validated per §8.2 with the
-// override applied to every agent step's resolved triple: the agent must
-// name a registered adapter, a known-invalid model/effort is a 400, and a
-// catalog-unknown value passes with a warning on the 201 body (T2.11).
-func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
-	var req taskCreateRequest
-	// The large bound: a task's description and fields are what the workflow
-	// templates into an agent's prompt, so this body legitimately carries prose
-	// (§13.1, amended 2026-08-25).
-	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
-		return
-	}
+// boundTaskCreate applies §13.1's size bounds to a task-create body. It is
+// factored out for the reason prepareTaskCreate is: two copies would drift
+// into a body one create path accepts and another rejects.
+func boundTaskCreate(req *taskCreateRequest) string {
 	for _, b := range []string{
 		boundTaskFields(req.Title, ptrValue(req.Description), req.Fields),
 		boundString("base_branch", ptrValue(req.BaseBranch), maxNameBytes),
 		boundString("branch_name", ptrValue(req.BranchName), maxNameBytes),
 	} {
 		if b != "" {
-			writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
-			return
+			return b
 		}
 	}
-	// Replay protection (§13.1, task 040). The digest is taken here, over the
-	// request as it arrived and before applyIssuePrefill mutates it below, so
-	// an issue edited between two identical sends cannot manufacture a 409.
-	idemKey, ok := readIdempotencyKey(w, r)
-	if !ok {
-		return
-	}
-	var idemSHA string
-	if idemKey != "" {
-		var derr error
-		if idemSHA, derr = idempotencyDigest(&req); derr != nil {
-			s.internalError(w, "digest task create request", derr)
-			return
-		}
-		if s.replayTaskCreate(w, r, idemKey, idemSHA) {
-			return
-		}
-	}
-	ctx := r.Context()
+	return ""
+}
+
+// preparedTask is a task-create body that has passed every validation §13.2
+// applies before a branch name is decided: the project, the resolved and
+// expanded workflow, and the task row built from both.
+//
+// It stops short of the branch because that is where a second create path
+// differs: POST /v1/tasks resolves a name through §5.3's chain, while a path
+// that inherits an existing worktree has no chain to walk.
+type preparedTask struct {
+	project  *store.Project
+	task     store.Task
+	workflow *workflow.Workflow
+	pull     *github.PullRequest
+	warnings []string
+}
+
+// prepareTaskCreate is the whole of POST /v1/tasks' validation up to the
+// branch: project, workflow resolution and snapshot, include expansion,
+// fan-out resolution, the GitHub prefills, declared fields, the base branch,
+// the agent/model/effort override, MCP provenance and the four capability
+// gates.
+//
+// It is factored out rather than copied because a second route that creates a
+// task must accept exactly the task this one accepts: a second copy would
+// drift, and the drift would surface as a body one route takes and the other
+// refuses. It writes its own 400s, the way applyIssuePrefill beside it does,
+// and reports false once it has.
+//
+// inheritedBase, when non-empty, replaces the request's `base_branch` and is
+// taken verbatim: a base branch inherited from an existing worktree is a fact
+// about that worktree, not a name to validate against the repository as it is
+// now.
+func (s *Server) prepareTaskCreate(
+	ctx context.Context, w http.ResponseWriter, req *taskCreateRequest, inheritedBase string,
+) (*preparedTask, bool) {
 	project, err := s.deps.Store.GetProject(ctx, req.ProjectID)
 	if errors.Is(err, store.ErrNotFound) {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			fmt.Sprintf("project %d not found", req.ProjectID))
-		return
+		return nil, false
 	}
 	if err != nil {
 		s.internalError(w, "get project", err)
-		return
+		return nil, false
 	}
 	// Workflow resolution (§5.3): the named workflow, else the project's
 	// default, else the built-in adhoc. The entry's source becomes the
@@ -453,12 +460,12 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			fmt.Sprintf("workflow %q not found for project %d", workflowName, project.ID))
-		return
+		return nil, false
 	}
 	if !entry.Valid() {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			fmt.Sprintf("workflow %q is invalid: %s", workflowName, entry.Errors.Error()))
-		return
+		return nil, false
 	}
 	// Platform restriction (§8.1.1, task 010). Rejected at creation rather than
 	// at admission: a task that can never run should not reach the board, and
@@ -466,7 +473,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	if mismatch := entry.Workflow.PlatformMismatch(workflow.HostPlatform()); mismatch != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			fmt.Sprintf("workflow %q cannot run here: %s", workflowName, mismatch))
-		return
+		return nil, false
 	}
 	// The GitHub issue prefill (task 035), before field validation because it
 	// is one of the things being validated, and before the title check
@@ -474,24 +481,24 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	if req.GitHubIssue != nil && req.GitHubPull != nil {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed,
 			"github_issue and github_pull cannot both be given: they would prefill the same fields from different sources")
-		return
+		return nil, false
 	}
-	issue, ok := s.applyIssuePrefill(r.Context(), w, project, entry.Workflow, &req)
+	issue, ok := s.applyIssuePrefill(ctx, w, project, entry.Workflow, req)
 	if !ok {
-		return
+		return nil, false
 	}
 	// The pull-request prefill (task 064), in the same place and for the same
 	// reasons: before field validation because it is one of the things being
 	// validated, and before the title check because filling the title in is
 	// half of what it is for.
-	pull, pullRepo, ok := s.applyPullPrefill(r.Context(), w, project, entry.Workflow, &req)
+	pull, pullRepo, ok := s.applyPullPrefill(ctx, w, project, entry.Workflow, req)
 	if !ok {
-		return
+		return nil, false
 	}
 	title := strings.TrimSpace(req.Title)
 	if title == "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, "title is required")
-		return
+		return nil, false
 	}
 	// Workflow-declared fields (§8.1.2, task 022) are a contract on the
 	// selected root workflow. The map remains open: ValidateTaskFields checks
@@ -507,20 +514,24 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	req.Fields = entry.Workflow.PrepareTaskFields(req.Fields)
 	if fieldErrs := entry.Workflow.ValidateTaskFields(req.Fields); len(fieldErrs) > 0 {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, fieldErrs.Error())
-		return
+		return nil, false
 	}
-	baseBranch := project.DefaultBranch
-	if req.BaseBranch != nil && strings.TrimSpace(*req.BaseBranch) != "" {
-		baseBranch = strings.TrimSpace(*req.BaseBranch)
-	}
-	if !s.localBranchExists(ctx, project.Path, baseBranch) {
-		writeError(w, http.StatusBadRequest, CodeValidationFailed,
-			fmt.Sprintf("base_branch %q does not resolve to a local branch in %s", baseBranch, project.Path))
-		return
-	}
-	var branchName string
-	if req.BranchName != nil {
-		branchName = strings.TrimSpace(*req.BranchName)
+	// An inherited base branch skips the repository check on purpose: it
+	// names the commit an existing worktree was cut from, and a task that
+	// adopts that worktree is not about to cut another. Refusing it because
+	// the branch has since been deleted locally would reject the create for a
+	// fact that no longer has any bearing on it.
+	baseBranch := inheritedBase
+	if baseBranch == "" {
+		baseBranch = project.DefaultBranch
+		if req.BaseBranch != nil && strings.TrimSpace(*req.BaseBranch) != "" {
+			baseBranch = strings.TrimSpace(*req.BaseBranch)
+		}
+		if !s.localBranchExists(ctx, project.Path, baseBranch) {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("base_branch %q does not resolve to a local branch in %s", baseBranch, project.Path))
+			return nil, false
+		}
 	}
 	var agentOverride string
 	if req.Agent != nil && strings.TrimSpace(*req.Agent) != "" {
@@ -530,7 +541,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusBadRequest, CodeValidationFailed,
 					fmt.Sprintf("unknown agent %q (available: %s)", agentOverride,
 						strings.Join(s.deps.Agents.Names(), ", ")))
-				return
+				return nil, false
 			}
 		}
 	}
@@ -560,7 +571,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		})
 		if xerr != nil {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed, xerr.Error())
-			return
+			return nil, false
 		}
 		// Re-validate the expansion, not just its shape. The nesting rules an
 		// include can break — no `loop` inside a `loop`, no `fan_out` inside a
@@ -570,14 +581,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 		out, merr := workflow.Marshal(expanded)
 		if merr != nil {
 			s.internalError(w, "re-encode expanded snapshot", merr)
-			return
+			return nil, false
 		}
 		revalidated, _, verr := workflow.Parse(out, s.deps.Workflows.Options())
 		if verr != nil {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed,
 				fmt.Sprintf("workflow %q does not validate once its includes are expanded: %s",
 					workflowName, verr.Error()))
-			return
+			return nil, false
 		}
 		wf, snapshot = revalidated, string(out)
 	}
@@ -594,12 +605,12 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 			workflow.Limits{MaxDepth: cfg.FanOut.MaxDepth, MaxTasks: cfg.FanOut.MaxTasks})
 		if terr != nil {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed, terr.Error())
-			return
+			return nil, false
 		}
 		out, merr := workflow.Marshal(resolved)
 		if merr != nil {
 			s.internalError(w, "re-encode resolved fan-out snapshot", merr)
-			return
+			return nil, false
 		}
 		wf, snapshot = resolved, string(out)
 	}
@@ -638,7 +649,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	if creator, viaMCP := mcp.CreatorTaskID(ctx); viaMCP {
 		if msg := s.checkMCPBounds(ctx, creator); msg != "" {
 			writeError(w, http.StatusBadRequest, CodeValidationFailed, msg)
-			return
+			return nil, false
 		}
 		t.CreatedByTaskID = &creator
 	}
@@ -657,14 +668,14 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	warnings, cerr := s.checkTaskCatalog(wf, &t)
 	if cerr != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, cerr)
-		return
+		return nil, false
 	}
 	// The `on_input: require` gate (§7.4, task 013), after the catalog check
 	// so a task with two problems reports the model one first — that is the
 	// field the human just typed.
 	if mismatch := s.inputMismatch(ctx, wf, &t); mismatch != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
-		return
+		return nil, false
 	}
 	// The `permission_mode: restricted` gate (§9.4, task 041), last of the
 	// three capability checks for the same reason the input one is second:
@@ -672,7 +683,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	// platform fact is the least surprising thing to be told about.
 	if mismatch := s.restrictedMismatch(wf, &t); mismatch != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
-		return
+		return nil, false
 	}
 	// The container gate (§16, task 061 decision 3), after the three
 	// capability checks: it is a fact about the host and the daemon's config,
@@ -680,8 +691,58 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
 	// thing to be told about last.
 	if mismatch := s.containerMismatch(ctx, wf); mismatch != "" {
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, mismatch)
+		return nil, false
+	}
+	return &preparedTask{project: project, task: t, workflow: wf, pull: pull, warnings: warnings}, true
+}
+
+// handleTaskCreate implements POST /v1/tasks (spec §13.2). The workflow is
+// resolved through the registry and snapshotted onto the task (§5.3). The
+// optional agent/model/effort override is validated per §8.2 with the
+// override applied to every agent step's resolved triple: the agent must
+// name a registered adapter, a known-invalid model/effort is a 400, and a
+// catalog-unknown value passes with a warning on the 201 body (T2.11).
+func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request) {
+	var req taskCreateRequest
+	// The large bound: a task's description and fields are what the workflow
+	// templates into an agent's prompt, so this body legitimately carries prose
+	// (§13.1, amended 2026-08-25).
+	if !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
 		return
 	}
+	if b := boundTaskCreate(&req); b != "" {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, b)
+		return
+	}
+	// Replay protection (§13.1, task 040). The digest is taken here, over the
+	// request as it arrived and before applyIssuePrefill mutates it below, so
+	// an issue edited between two identical sends cannot manufacture a 409.
+	idemKey, ok := readIdempotencyKey(w, r)
+	if !ok {
+		return
+	}
+	var idemSHA string
+	if idemKey != "" {
+		var derr error
+		if idemSHA, derr = idempotencyDigest(&req); derr != nil {
+			s.internalError(w, "digest task create request", derr)
+			return
+		}
+		if s.replayTaskCreate(w, r, idemKey, idemSHA) {
+			return
+		}
+	}
+	ctx := r.Context()
+	prep, ok := s.prepareTaskCreate(ctx, w, &req, "")
+	if !ok {
+		return
+	}
+	project, t, pull, warnings := prep.project, prep.task, prep.pull, prep.warnings
+	var branchName string
+	if req.BranchName != nil {
+		branchName = strings.TrimSpace(*req.BranchName)
+	}
+
 	// Branch naming (§5.3, task 001): `default < config.yaml < project < literal`.
 	// Resolve before the insert so a bad name is a 400 rather than a task that
 	// blocks later, and so the git-side checks run with no transaction open.

--- a/internal/apiclient/chats.go
+++ b/internal/apiclient/chats.go
@@ -25,8 +25,11 @@ type Chat struct {
 	WorktreePath string          `json:"worktree_path,omitempty"`
 	SessionID    string          `json:"session_id,omitempty"`
 	PendingInput json.RawMessage `json:"pending_input,omitempty"`
-	CreatedAt    time.Time       `json:"created_at"`
-	UpdatedAt    time.Time       `json:"updated_at"`
+	// HandoffTaskID is the task this chat's worktree and branch were handed
+	// to (task 074). Set exactly in `handed_off`.
+	HandoffTaskID *int64    `json:"handoff_task_id,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 // ChatTurn is one exchange in a chat.
@@ -133,6 +136,25 @@ func (c *Client) ArchiveChat(ctx context.Context, id int64, force bool) (*Chat, 
 		return nil, err
 	}
 	return &out, nil
+}
+
+// HandoffChat hands the chat's worktree and branch to a new task (task 074).
+// The request is a task-create body: `project_id`, `base_branch` and
+// `branch_name` are the chat's and are ignored.
+//
+// It returns the created task and the chat as it now stands — terminal, and
+// naming the task. A 409 means the chat was not idle, had nothing to hand
+// over, or its worktree is mid-merge or mid-rebase; a 400 means the task
+// itself did not validate, and in every case the chat is untouched.
+func (c *Client) HandoffChat(ctx context.Context, id int64, req CreateTaskRequest) (TaskDetail, Chat, error) {
+	var out struct {
+		Task TaskDetail `json:"task"`
+		Chat Chat       `json:"chat"`
+	}
+	if err := c.post(ctx, "/v1/chats/"+strconv.FormatInt(id, 10)+"/handoff", req, &out); err != nil {
+		return TaskDetail{}, Chat{}, err
+	}
+	return out.Task, out.Chat, nil
 }
 
 // StreamChat subscribes to GET /v1/chats/{id}/events: that chat's durable

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -348,6 +348,9 @@ type TaskDetail struct {
 	// WorkflowSteps is the task's snapshot: the text edit+retry opens in an
 	// editor, and a gate's instructions.
 	WorkflowSteps []WorkflowStep `json:"workflow_steps,omitempty"`
+	// SourceChatID is the chat this task was handed off from (task 074), or
+	// nil when it was created any other way.
+	SourceChatID *int64 `json:"source_chat_id,omitempty"`
 }
 
 // WorkflowOrigin is a task's recorded workflow provenance (§5.3, task 043):

--- a/internal/chatstate/chatstate.go
+++ b/internal/chatstate/chatstate.go
@@ -31,13 +31,24 @@ const (
 	// a §7.4 mid-run request. As in §6 it holds its slot, because the
 	// process is alive and idle on its stdin (task 063 decision 8).
 	AwaitingInput State = "awaiting_input"
-	// Archived is the only terminal state. Its worktree is gone and its
-	// branch may have been deleted, so nothing further can run in it.
+	// Archived is a terminal state. Its worktree is gone and its branch may
+	// have been deleted, so nothing further can run in it.
 	Archived State = "archived"
+	// HandedOff is the other terminal state (task 074, §5.5 amended
+	// 2026-09-01): the chat's worktree and branch now belong to the task it
+	// created, and the chat is kept only as the linked history of how that
+	// task's workspace came to exist.
+	//
+	// It is not `archived` because archiving *removes* the worktree and may
+	// delete the branch, which is exactly the state a handoff transfers. A
+	// second terminal state makes "archiving a handed-off chat must never
+	// remove task-owned workspace state" true by construction rather than by
+	// a guard: `archive` is simply not legal from here.
+	HandedOff State = "handed_off"
 )
 
 // All lists every state, in the order §5.5 documents them.
-var All = []State{Idle, Running, AwaitingInput, Archived}
+var All = []State{Idle, Running, AwaitingInput, Archived, HandedOff}
 
 // Valid reports whether s is a known state.
 func Valid(s State) bool {
@@ -57,8 +68,10 @@ func Valid(s State) bool {
 // stdin, and a cap that did not count it would be a cap on nothing.
 func HoldsProcess(s State) bool { return s == Running || s == AwaitingInput }
 
-// Terminal reports whether no further transition is possible.
-func Terminal(s State) bool { return s == Archived }
+// Terminal reports whether no further transition is possible. There are two
+// such states, not one: a chat ends either by being archived or by being
+// handed off to a task (task 074).
+func Terminal(s State) bool { return s == Archived || s == HandedOff }
 
 // Action is something that moves a chat between states: a human action or a
 // runner event.
@@ -82,6 +95,11 @@ const (
 	// Archive removes the worktree and may delete the empty branch, the way
 	// task 008 archives a task (§10).
 	Archive Action = "archive"
+	// HandOff creates a task that adopts this chat's worktree, branch, base
+	// branch and base SHA verbatim, and leaves the chat terminal (task 074).
+	// Nothing is copied, renamed or committed: the transfer *is* the task row
+	// naming the same directory the chat named.
+	HandOff Action = "hand_off"
 )
 
 // Runner events. They are transitions the daemon performs while running a
@@ -109,6 +127,7 @@ var transitions = map[State]map[Action]State{
 	Idle: {
 		Send:    Running,
 		Archive: Archived,
+		HandOff: HandedOff,
 	},
 	Running: {
 		InputRequested:  AwaitingInput,
@@ -124,7 +143,8 @@ var transitions = map[State]map[Action]State{
 		TurnInterrupted: Idle,
 		Cancel:          Idle,
 	},
-	Archived: {},
+	Archived:  {},
+	HandedOff: {},
 }
 
 // Next returns the state a reaches from s, and whether the pair is legal.

--- a/internal/chatstate/chatstate_test.go
+++ b/internal/chatstate/chatstate_test.go
@@ -11,7 +11,7 @@ import (
 // that quietly does something §5.5 does not describe.
 func TestTransitionTable(t *testing.T) {
 	allActions := []Action{
-		Send, Answer, Cancel, Archive,
+		Send, Answer, Cancel, Archive, HandOff,
 		TurnStarted, InputRequested, InputClosed, TurnFinished, TurnInterrupted,
 	}
 	// want[state][action] is the state the pair reaches; a missing entry
@@ -20,6 +20,7 @@ func TestTransitionTable(t *testing.T) {
 		Idle: {
 			Send:    Running,
 			Archive: Archived,
+			HandOff: HandedOff,
 		},
 		Running: {
 			TurnStarted:     Running,
@@ -35,7 +36,8 @@ func TestTransitionTable(t *testing.T) {
 			TurnInterrupted: Idle,
 			Cancel:          Idle,
 		},
-		Archived: {},
+		Archived:  {},
+		HandedOff: {},
 	}
 	for _, s := range All {
 		for _, a := range allActions {
@@ -55,16 +57,30 @@ func TestTransitionTable(t *testing.T) {
 	}
 }
 
-// TestArchivedIsTheOnlyTerminal pins the shape of the lifecycle: a chat is
-// never parked. A failed turn leaves the chat idle and usable, which is the
-// difference from §6 that made a separate FSM worth having.
-func TestArchivedIsTheOnlyTerminal(t *testing.T) {
+// TestTheTwoTerminalStates pins the shape of the lifecycle: a chat is never
+// parked — a failed turn leaves it idle and usable, which is the difference
+// from §6 that made a separate FSM worth having — and it ends in exactly one
+// of two ways.
+//
+// This replaces TestArchivedIsTheOnlyTerminal, which was 063's lifecycle shape
+// written down and is amended rather than patched: §5.5's "archived is the
+// only terminal state" was amended 2026-09-01 by task 074, because handing a
+// chat off transfers the worktree that archiving would remove.
+func TestTheTwoTerminalStates(t *testing.T) {
+	terminal := map[State]bool{Archived: true, HandedOff: true}
 	for _, s := range All {
-		if got, want := Terminal(s), s == Archived; got != want {
+		if got, want := Terminal(s), terminal[s]; got != want {
 			t.Errorf("Terminal(%s) = %v, want %v", s, got, want)
 		}
-		if len(Actions(s)) == 0 && s != Archived {
-			t.Errorf("state %s is a dead end but is not archived", s)
+		if len(Actions(s)) == 0 && !terminal[s] {
+			t.Errorf("state %s is a dead end but is not terminal", s)
+		}
+	}
+	// A handed-off chat accepts nothing at all: not another message, not an
+	// answer, not a cancel, not an archive, and not a second handoff.
+	for _, a := range []Action{Send, Answer, Cancel, Archive, HandOff} {
+		if Allowed(HandedOff, a) {
+			t.Errorf("Allowed(handed_off, %s) = true", a)
 		}
 	}
 }
@@ -81,6 +97,7 @@ func TestHoldsProcess(t *testing.T) {
 		{Running, true},
 		{AwaitingInput, true},
 		{Archived, false},
+		{HandedOff, false},
 	} {
 		if got := HoldsProcess(tc.state); got != tc.want {
 			t.Errorf("HoldsProcess(%s) = %v, want %v", tc.state, got, tc.want)
@@ -104,11 +121,14 @@ func TestValid(t *testing.T) {
 // TestActionsSorted keeps the affordance list stable, since a client renders
 // it directly.
 func TestActionsSorted(t *testing.T) {
-	if got, want := Actions(Idle), []Action{Archive, Send}; !reflect.DeepEqual(got, want) {
+	if got, want := Actions(Idle), []Action{Archive, HandOff, Send}; !reflect.DeepEqual(got, want) {
 		t.Errorf("Actions(idle) = %v, want %v", got, want)
 	}
 	if got := Actions(Archived); len(got) != 0 {
 		t.Errorf("Actions(archived) = %v, want none", got)
+	}
+	if got := Actions(HandedOff); len(got) != 0 {
+		t.Errorf("Actions(handed_off) = %v, want none", got)
 	}
 }
 

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -35,7 +35,8 @@ func newChatCmd() *cobra.Command {
 			"and a chat turn never waits for a scheduler slot.",
 	}
 	cmd.AddCommand(newChatStartCmd(), newChatSendCmd(), newChatAnswerCmd(),
-		newChatCancelCmd(), newChatListCmd(), newChatShowCmd(), newChatArchiveCmd())
+		newChatCancelCmd(), newChatListCmd(), newChatShowCmd(), newChatArchiveCmd(),
+		newChatHandoffCmd())
 	return cmd
 }
 

--- a/internal/cli/chathandoff.go
+++ b/internal/cli/chathandoff.go
@@ -1,0 +1,137 @@
+package cli
+
+// `vincent chat handoff` — the CLI half of task 074, so handing a chat's
+// worktree to a task is not a TUI-only feature.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// newChatHandoffCmd carries `vincent task add`'s flags, minus the three a
+// handoff has no say in: the project, the base branch and the branch name all
+// come from the chat, verbatim. Everything else — the workflow, the title, the
+// description, the fields, the priority and the §8.6 overrides — is the
+// ordinary task-create body, validated daemon-side by the same code
+// `POST /v1/tasks` uses.
+//
+// The description is where conversational context goes (task 074 decision 3).
+// Nothing about the chat is injected into the workflow's prompts
+// automatically: the objective is asked for here the way `task add` asks for
+// it, which is the issue's "not injected wholesale" honoured by having nothing
+// to inject.
+func newChatHandoffCmd() *cobra.Command {
+	var (
+		workflow    string
+		title       string
+		description string
+		priority    int
+		agent       string
+		model       string
+		effort      string
+		fields      []string
+		fieldsFile  string
+	)
+	cmd := &cobra.Command{
+		Use:   "handoff <chat-id>",
+		Short: "Hand a chat's worktree and branch to a new task",
+		Long: "Creates a task that adopts the chat's worktree, branch, base branch and base " +
+			"SHA exactly as they are — no copy, no rename, no implicit commit, so committed " +
+			"and uncommitted work are both there when the task's first step runs.\n\n" +
+			"The chat becomes terminal (`handed_off`) and links to the task; the task owns " +
+			"the worktree and the branch from then on. Only an idle chat can be handed off, " +
+			"and a worktree in the middle of a merge or rebase is refused by name.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("chat id: %w", err)
+			}
+			flagFields, err := parseFieldFlags(fields)
+			if err != nil {
+				return err
+			}
+			var fileFields map[string]string
+			if cmd.Flags().Changed("fields-file") {
+				if fileFields, err = readFieldsFile(fieldsFile, cmd.InOrStdin()); err != nil {
+					return err
+				}
+			}
+			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+				req := apiclient.CreateTaskRequest{
+					Title: title, Fields: mergeTaskFields(fileFields, flagFields),
+				}
+				for _, f := range []struct {
+					name string
+					dst  **string
+					src  *string
+				}{
+					{"workflow", &req.Workflow, &workflow},
+					{"description", &req.Description, &description},
+					{"agent", &req.Agent, &agent},
+					{"model", &req.Model, &model},
+					{"effort", &req.Effort, &effort},
+				} {
+					if cmd.Flags().Changed(f.name) {
+						v := *f.src
+						*f.dst = &v
+					}
+				}
+				if cmd.Flags().Changed("priority") {
+					p := priority
+					req.Priority = &p
+				}
+				task, chat, err := c.HandoffChat(ctx, id, req)
+				if err != nil {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+					return exitError{code: 1}
+				}
+				if wantJSON(cmd) {
+					return emitJSON(cmd.OutOrStdout(), map[string]any{"task": task, "chat": chat})
+				}
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "chat %d handed off to task %d: %s (%s)\n",
+					chat.ID, task.ID, task.Title, task.Workflow); err != nil {
+					return err
+				}
+				// The workspace, said out loud: this is the whole claim the
+				// command makes, and it is the one thing a reader wants
+				// confirmed rather than assumed.
+				worktreePath := ""
+				if task.WorktreePath != nil {
+					worktreePath = *task.WorktreePath
+				}
+				if _, err := fmt.Fprintf(out, "  branch %s in %s\n",
+					task.BranchName, worktreePath); err != nil {
+					return err
+				}
+				for _, w := range task.Warnings {
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning:", w)
+				}
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&workflow, "workflow", "", "Workflow name (default: the project's)")
+	cmd.Flags().StringVar(&title, "title", "", "Task title (required)")
+	cmd.Flags().StringVar(&description, "description", "",
+		"Task description; this is where the conversation's context goes, since nothing "+
+			"about the chat reaches the workflow automatically")
+	cmd.Flags().IntVar(&priority, "priority", 0, "Scheduling priority; higher runs first")
+	cmd.Flags().StringVar(&agent, "agent", "", "Agent override (§8.6 level 2)")
+	cmd.Flags().StringVar(&model, "model", "", "Model override (§8.6 level 2)")
+	cmd.Flags().StringVar(&effort, "effort", "", "Effort override (§8.6 level 2)")
+	cmd.Flags().StringArrayVar(&fields, "field", nil,
+		"Task field as name=value; repeat for additional fields")
+	cmd.Flags().StringVar(&fieldsFile, "fields-file", "",
+		"Read task fields from a JSON object of strings in this file, or `-` for stdin; "+
+			"a --field of the same name wins")
+	_ = cmd.MarkFlagRequired("title")
+	jsonFlag(cmd)
+	return cmd
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -83,6 +83,13 @@ var Excluded = []Route{
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/answer"},
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/cancel"},
 	{Method: http.MethodPost, Path: "/v1/chats/{id}/archive"},
+	// Handoff joins the list under the same rule rather than as an exception
+	// to it (task 074 decision 1). It creates a task, which is exactly what
+	// makes it dangerous here: `task_create` is bounded by mcp.max_depth and
+	// mcp.max_tasks walking `created_by_task_id`, and a chat is not in that
+	// chain — so an agent that could hand a chat off would be creating tasks
+	// outside the bound.
+	{Method: http.MethodPost, Path: "/v1/chats/{id}/handoff"},
 	// The chat read routes are excluded under the same rule, not merely
 	// because they are streams. `GET /v1/chats/{id}/events` follows a live
 	// conversation and the transcript route reads its durable record; both

--- a/internal/store/chathandoff.go
+++ b/internal/store/chathandoff.go
@@ -1,0 +1,153 @@
+package store
+
+// Handing a chat's worktree and branch to a task (task 074, spec §5.5, §10).
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+// HandoffChat creates t as the task that adopts chat chatID's workspace, in
+// **one** transaction: the task row and its branch claim, the link, the chat's
+// transition to `handed_off`, the release of the chat's §10 claim, and both
+// durable events.
+//
+// One transaction is the whole point of the feature, not an implementation
+// detail. Split in two it becomes reachable to have a task owning a worktree
+// no chat released, or a terminal chat that never produced a task; the
+// scheduler could admit the task before it owned a complete workspace, and gc
+// could observe the directory claimed twice or not at all.
+//
+// The chat's state is re-read and required to be `idle` *inside* the
+// transaction rather than checked by the caller: the API's read and this write
+// are separate statements, and a `send` that lands between them must lose one
+// of the two. It loses this one, with ErrInvalidChatAction — the same error,
+// and so the same 409, an illegal action anywhere else produces.
+//
+// `worktree_path` is cleared because that is what transferring the claim means
+// concretely: the reclaimer's rule is that the claim decides, and two rows
+// naming one directory is exactly the ambiguity it must never see. `branch`,
+// `base_branch` and `base_sha` stay on the chat row as history — nothing reads
+// them for ownership once the chat is terminal.
+//
+// t is filled in as insertTaskTx fills it: id, timestamps and, when it needs
+// one, its branch name. Its workspace fields are the caller's to have set from
+// the chat; the store does not invent them.
+func (s *Store) HandoffChat(ctx context.Context, chatID int64, t *Task) (*Chat, error) {
+	now := time.Now()
+	var chat *Chat
+	var taskEv, chatEv *Event
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `SELECT `+chatColumns+` FROM chats WHERE id = ?`, chatID)
+		c, err := scanChat(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("chat %d: %w", chatID, ErrNotFound)
+		}
+		if err != nil {
+			return fmt.Errorf("get chat %d: %w", chatID, err)
+		}
+		next, ok := chatstate.Next(c.State, chatstate.HandOff)
+		if !ok {
+			return fmt.Errorf("chat %d: %w", chatID, ErrInvalidChatAction)
+		}
+		// No resolveBranch: a handed-off task's branch is the chat's,
+		// verbatim, so there is no name that needs the id. claimBranchTx
+		// still runs inside insertTaskTx, so a live task already holding
+		// this branch collides here exactly as any other create does.
+		if taskEv, err = insertTaskTx(ctx, tx, t, now, nil); err != nil {
+			return err
+		}
+		c.State = next
+		c.HandoffTaskID = &t.ID
+		c.WorktreePath = ""
+		c.PendingInput = nil
+		c.UpdatedAt = now
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE chats SET state = ?, handoff_task_id = ?, worktree_path = NULL,
+				pending_input = NULL, updated_at = ?
+			WHERE id = ? AND state = ?`,
+			string(c.State), t.ID, formatTime(c.UpdatedAt), chatID, string(chatstate.Idle)); err != nil {
+			return fmt.Errorf("hand off chat %d: %w", chatID, err)
+		}
+		if chatEv, err = chatHandoffEvent(c, t.ID); err != nil {
+			return err
+		}
+		chat = c
+		return appendEventTx(ctx, tx, chatEv)
+	})
+	if err != nil {
+		return nil, err
+	}
+	// After the commit, task first: a subscriber that reacts to
+	// chat.handed_off by fetching the task must find it.
+	s.notify(taskEv)
+	s.notify(chatEv)
+	return chat, nil
+}
+
+// chatHandoffEvent is chatEvent plus the task id — the whole of what a client
+// needs to follow the link without a fetch (§13.3).
+func chatHandoffEvent(c *Chat, taskID int64) (*Event, error) {
+	ev, err := chatEvent(EventChatHandedOff, c, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body map[string]any
+	if err := json.Unmarshal(ev.Payload, &body); err != nil {
+		return nil, fmt.Errorf("marshal %s event: %w", EventChatHandedOff, err)
+	}
+	body["handoff_task_id"] = taskID
+	if ev.Payload, err = json.Marshal(body); err != nil {
+		return nil, fmt.Errorf("marshal %s event: %w", EventChatHandedOff, err)
+	}
+	return ev, nil
+}
+
+// SourceChatIDs returns task id → chat id for every handed-off chat: the
+// reverse of the one authoritative foreign key (task 074 decision 2).
+//
+// It is one indexed query, read once per list and turned into a map, rather
+// than a column on `tasks`: a second stored copy is a second thing that can
+// disagree, and 063's posture is that no existing task query changes meaning
+// when chats exist.
+func (s *Store) SourceChatIDs(ctx context.Context) (map[int64]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT handoff_task_id, id FROM chats WHERE handoff_task_id IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("list chat handoffs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[int64]int64)
+	for rows.Next() {
+		var taskID, chatID int64
+		if err := rows.Scan(&taskID, &chatID); err != nil {
+			return nil, fmt.Errorf("scan chat handoff: %w", err)
+		}
+		out[taskID] = chatID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate chat handoffs: %w", err)
+	}
+	return out, nil
+}
+
+// SourceChatID returns the id of the chat task taskID was handed off from, or
+// 0 when it was created any other way.
+func (s *Store) SourceChatID(ctx context.Context, taskID int64) (int64, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id FROM chats WHERE handoff_task_id = ?`, taskID).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("source chat of task %d: %w", taskID, err)
+	}
+	return id, nil
+}

--- a/internal/store/chathandoff_test.go
+++ b/internal/store/chathandoff_test.go
@@ -1,0 +1,182 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+func testChat(t *testing.T, s *Store, projectID int64) *Chat {
+	t.Helper()
+	c := &Chat{
+		ProjectID: projectID, Title: "a talk", Agent: "claude",
+		Branch: "vincent/1-a-talk", BaseBranch: "main", BaseSHA: "abc123",
+		WorktreePath: "/wt/chat-1", PermissionMode: "full_auto",
+	}
+	if err := s.CreateChat(t.Context(), c); err != nil {
+		t.Fatalf("CreateChat: %v", err)
+	}
+	return c
+}
+
+// TestHandoffChatIsOneTransaction is the atomicity the whole feature rests on:
+// either the task, the link, the transition and both events all happened, or
+// none of them did.
+func TestHandoffChatIsOneTransaction(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+
+	task := newTask(p.ID, "carry on", TaskQueued)
+	task.BranchName, task.BaseBranch, task.BaseSHA = c.Branch, c.BaseBranch, c.BaseSHA
+	task.WorktreePath = c.WorktreePath
+	after, err := s.HandoffChat(ctx, c.ID, task)
+	if err != nil {
+		t.Fatalf("HandoffChat: %v", err)
+	}
+	if after.State != chatstate.HandedOff {
+		t.Errorf("state = %s, want handed_off", after.State)
+	}
+	if after.HandoffTaskID == nil || *after.HandoffTaskID != task.ID {
+		t.Errorf("handoff_task_id = %v, want %d", after.HandoffTaskID, task.ID)
+	}
+	// The claim moved: the chat stops naming the directory in the same write
+	// that gives it to the task.
+	if after.WorktreePath != "" {
+		t.Errorf("chat still claims %q", after.WorktreePath)
+	}
+	// The branch is kept as history — it is not a claim, and reading it back
+	// is how a terminal chat still says what it worked on.
+	if after.Branch != c.Branch || after.BaseBranch != c.BaseBranch || after.BaseSHA != c.BaseSHA {
+		t.Errorf("the chat lost its history: %+v", after)
+	}
+	stored, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.WorktreePath != c.WorktreePath || stored.BranchName != c.Branch {
+		t.Errorf("task workspace = %q/%q, want %q/%q",
+			stored.WorktreePath, stored.BranchName, c.WorktreePath, c.Branch)
+	}
+	// Both events, durable, behind one commit.
+	events, err := s.ListEvents(ctx, EventFilter{Types: []string{EventTaskCreated, EventChatHandedOff}})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want task.created and chat.handed_off", len(events))
+	}
+	// And the reverse lookup, which is the only direction that is not stored.
+	sources, err := s.SourceChatIDs(ctx)
+	if err != nil {
+		t.Fatalf("SourceChatIDs: %v", err)
+	}
+	if sources[task.ID] != c.ID {
+		t.Errorf("SourceChatIDs[%d] = %d, want %d", task.ID, sources[task.ID], c.ID)
+	}
+}
+
+// TestHandoffChatRollsBackOnABranchClash: the insert fails inside the
+// transaction, so the chat is untouched and no task row survives.
+func TestHandoffChatRollsBackOnABranchClash(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+
+	holder := newTask(p.ID, "holder", TaskQueued)
+	holder.BranchName = c.Branch
+	if err := s.CreateTask(ctx, holder, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	task := newTask(p.ID, "carry on", TaskQueued)
+	task.BranchName, task.WorktreePath = c.Branch, c.WorktreePath
+	var claimed *BranchClaimedError
+	if _, err := s.HandoffChat(ctx, c.ID, task); !errors.As(err, &claimed) {
+		t.Fatalf("HandoffChat over a claimed branch = %v, want BranchClaimedError", err)
+	}
+	got, err := s.GetChat(ctx, c.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != chatstate.Idle || got.WorktreePath != c.WorktreePath || got.HandoffTaskID != nil {
+		t.Fatalf("a rolled-back handoff changed the chat: %+v", got)
+	}
+	tasks, err := s.ListTasks(ctx, TaskFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("tasks = %d, want only the holder", len(tasks))
+	}
+}
+
+// TestHandoffChatLosesToAConcurrentSend is the compare-and-set. The store has
+// one writer, so the two transactions serialize; whichever runs second must
+// see the first and refuse, and the refusal is the same ErrInvalidChatAction
+// any illegal §5.5 action produces.
+func TestHandoffChatLosesToAConcurrentSend(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+
+	if _, err := s.CreateChatTurn(ctx, c.ID, "hello"); err != nil {
+		t.Fatalf("CreateChatTurn: %v", err)
+	}
+	task := newTask(p.ID, "carry on", TaskQueued)
+	task.BranchName, task.WorktreePath = c.Branch, c.WorktreePath
+	if _, err := s.HandoffChat(ctx, c.ID, task); !errors.Is(err, ErrInvalidChatAction) {
+		t.Fatalf("HandoffChat on a running chat = %v, want ErrInvalidChatAction", err)
+	}
+	// And the other order: a send after a handoff is refused just as flatly.
+	if _, err := s.SetChatState(ctx, c.ID, chatstate.Idle); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.HandoffChat(ctx, c.ID, task); err != nil {
+		t.Fatalf("HandoffChat: %v", err)
+	}
+	if _, err := s.CreateChatTurn(ctx, c.ID, "still there?"); !errors.Is(err, ErrInvalidChatAction) {
+		t.Fatalf("send after a handoff = %v, want ErrInvalidChatAction", err)
+	}
+}
+
+// TestTerminalChatIDsBeforeCountsBothEndings is decision 6: retention treats
+// handed_off exactly as it treats archived, measured from the same column.
+func TestTerminalChatIDsBeforeCountsBothEndings(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+
+	idle := testChat(t, s, p.ID)
+	archived := testChat(t, s, p.ID)
+	handed := testChat(t, s, p.ID)
+	if _, err := s.SetChatState(ctx, archived.ID, chatstate.Archived); err != nil {
+		t.Fatal(err)
+	}
+	task := newTask(p.ID, "carry on", TaskQueued)
+	task.BranchName = "vincent/9-carry-on"
+	task.WorktreePath = handed.WorktreePath
+	if _, err := s.HandoffChat(ctx, handed.ID, task); err != nil {
+		t.Fatalf("HandoffChat: %v", err)
+	}
+	ids, err := s.TerminalChatIDsBefore(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("TerminalChatIDsBefore: %v", err)
+	}
+	want := map[int64]bool{archived.ID: true, handed.ID: true}
+	if len(ids) != len(want) {
+		t.Fatalf("terminal chats = %v, want %v", ids, want)
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Errorf("chat %d is not terminal but was listed for pruning", id)
+		}
+		if id == idle.ID {
+			t.Error("an idle chat was listed for pruning")
+		}
+	}
+}

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -20,6 +20,10 @@ const (
 	EventChatState    = "chat.state_changed"
 	EventChatTurn     = "chat.turn_changed"
 	EventChatArchived = "chat.archived"
+	// EventChatHandedOff is a chat whose worktree and branch now belong to a
+	// task (task 074). It carries the task's id, so a client that follows the
+	// stream can link the two without a fetch.
+	EventChatHandedOff = "chat.handed_off"
 )
 
 // ChatEventTypes is the chat.* family, in the order it is declared. It exists
@@ -27,7 +31,7 @@ const (
 // filtering on the payload's id: a chat event carries no task_id column, so
 // without this a replay would scan every task event behind the cursor.
 func ChatEventTypes() []string {
-	return []string{EventChatCreated, EventChatState, EventChatTurn, EventChatArchived}
+	return []string{EventChatCreated, EventChatState, EventChatTurn, EventChatArchived, EventChatHandedOff}
 }
 
 // IsChatEvent reports whether an event type belongs to the chat family.
@@ -36,7 +40,8 @@ func IsChatEvent(t string) bool {
 }
 
 const chatColumns = `id, project_id, title, state, agent, model, effort, permission_mode,
-	branch, base_branch, base_sha, worktree_path, session_id, pending_input, created_at, updated_at`
+	branch, base_branch, base_sha, worktree_path, session_id, pending_input, handoff_task_id,
+	created_at, updated_at`
 
 const chatTurnColumns = `id, chat_id, seq, prompt, state, fail_reason, error_message, result_text,
 	session_id, input_tokens, output_tokens, cost_usd, exit_code, pid, proc_identity,
@@ -487,11 +492,16 @@ func (s *Store) ListChatIDs(ctx context.Context) ([]int64, error) {
 func scanChat(r rowScanner) (*Chat, error) {
 	var c Chat
 	var model, effort, baseSHA, worktreePath, sessionID, pending sql.NullString
+	var handoffTaskID sql.NullInt64
 	var createdAt, updatedAt string
 	if err := r.Scan(&c.ID, &c.ProjectID, &c.Title, (*string)(&c.State), &c.Agent, &model, &effort,
 		&c.PermissionMode, &c.Branch, &c.BaseBranch, &baseSHA, &worktreePath, &sessionID, &pending,
-		&createdAt, &updatedAt); err != nil {
+		&handoffTaskID, &createdAt, &updatedAt); err != nil {
 		return nil, err
+	}
+	if handoffTaskID.Valid {
+		id := handoffTaskID.Int64
+		c.HandoffTaskID = &id
 	}
 	c.Model, c.Effort = model.String, effort.String
 	c.BaseSHA, c.WorktreePath, c.SessionID = baseSHA.String, worktreePath.String, sessionID.String
@@ -534,33 +544,39 @@ func scanChatTurn(r rowScanner) (*ChatTurn, error) {
 	return &t, nil
 }
 
-// ArchivedChatIDsBefore returns the ids of chats archived before cutoff — the
-// chat half of transcript pruning (§17 retention), the mirror of
+// TerminalChatIDsBefore returns the ids of chats that ended before cutoff —
+// the chat half of transcript pruning (§12.3 retention), the mirror of
 // ArchivedTaskIDsBefore.
 //
+// Both terminal states count (task 074). A handed-off chat's transcripts age
+// out on the same clock an archived one's do, and they can: they live under
+// `{transcripts}/chat-{id}`, which the task that took the worktree never
+// claims, so pruning them cannot reach task-owned state. The turn rows and the
+// link survive — that is what "immutable linked history" means here.
+//
 // It measures from `updated_at` rather than from an `archived_at` column
-// because chats have neither: `archived` is a terminal §5.5 state, so the
-// archive transition is the last write a chat row ever takes and its
-// `updated_at` *is* the moment it was archived. Adding a column to restate
-// that would be a migration for a value already on the row.
-func (s *Store) ArchivedChatIDsBefore(ctx context.Context, cutoff time.Time) ([]int64, error) {
+// because chats have neither: both endings are terminal §5.5 states, so the
+// transition into one is the last write a chat row ever takes and its
+// `updated_at` *is* the moment it ended. Adding a column to restate that would
+// be a migration for a value already on the row.
+func (s *Store) TerminalChatIDsBefore(ctx context.Context, cutoff time.Time) ([]int64, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id FROM chats WHERE state = ? AND updated_at < ? ORDER BY id`,
-		string(chatstate.Archived), formatTime(cutoff))
+		`SELECT id FROM chats WHERE state IN (?, ?) AND updated_at < ? ORDER BY id`,
+		string(chatstate.Archived), string(chatstate.HandedOff), formatTime(cutoff))
 	if err != nil {
-		return nil, fmt.Errorf("list archived chats: %w", err)
+		return nil, fmt.Errorf("list terminal chats: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var ids []int64
 	for rows.Next() {
 		var id int64
 		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan archived chat id: %w", err)
+			return nil, fmt.Errorf("scan terminal chat id: %w", err)
 		}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("list archived chats: %w", err)
+		return nil, fmt.Errorf("list terminal chats: %w", err)
 	}
 	return ids, nil
 }

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 22
+const latestSchemaVersion = 23
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0023_chat_handoff.sql
+++ b/internal/store/migrations/0023_chat_handoff.sql
@@ -1,0 +1,22 @@
+-- 0023_chat_handoff: a chat handed off to a task (task 074, spec §5.5, §14).
+--
+-- One nullable foreign key, on `chats`, and no column on `tasks`. The reverse
+-- direction — a task's `source_chat_id` — is a lookup over this index, not a
+-- second stored copy, so there is exactly one authoritative edge and no way
+-- for the two ends to disagree.
+--
+-- The column is on `chats` rather than on `tasks` because task 063's posture
+-- is that no existing task query changes meaning when chats exist, and the
+-- chat is the entity whose lifecycle a handoff changes: a handed-off chat is
+-- terminal, and this is the fact that makes it so.
+--
+-- ON DELETE SET NULL rather than CASCADE: deleting the task must not delete
+-- the conversation that produced it. The chat stays `handed_off` — the state
+-- is a lifecycle fact, not a rendering of this column — and simply stops
+-- naming a task that no longer exists.
+ALTER TABLE chats ADD COLUMN handoff_task_id INTEGER REFERENCES tasks(id) ON DELETE SET NULL;
+
+-- Partial, because the only query over it asks for the rows that have one:
+-- `WHERE handoff_task_id IS NOT NULL`, read once per task list and turned into
+-- a map, never once per rendered task.
+CREATE INDEX chats_handoff_task_idx ON chats (handoff_task_id) WHERE handoff_task_id IS NOT NULL;

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -504,8 +504,13 @@ type Chat struct {
 	// PendingInput is the §7.4 request this chat is waiting on, verbatim as
 	// the API renders it. Non-nil exactly in `awaiting_input`.
 	PendingInput json.RawMessage
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	// HandoffTaskID names the task this chat was handed off to (task 074).
+	// It is the one authoritative edge between the two records; a task's
+	// `source_chat_id` is this column read backwards. Non-nil exactly in
+	// `handed_off`, unless that task has since been deleted.
+	HandoffTaskID *int64
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
 }
 
 // ChatTurn is one exchange: a human message and the agent run it produced

--- a/internal/taskrun/prune.go
+++ b/internal/taskrun/prune.go
@@ -117,11 +117,15 @@ func (p *TranscriptPruner) Prune(ctx context.Context, now time.Time) (removed in
 		return 0, 0, err
 	}
 	// Chats keep transcripts under the same root and under the same
-	// retention setting (§17, task 067): a conversation nobody archived is
-	// live, and one archived past the window is as stale as a task's. They
+	// retention setting (§12.3, task 067): a conversation nobody ended is
+	// live, and one that ended past the window is as stale as a task's. They
 	// are walked here rather than in a second pruner because the directory,
 	// the config key and the pass are all one.
-	chatIDs, err := p.deps.Store.ArchivedChatIDsBefore(ctx, cutoff)
+	//
+	// Both endings count (task 074). A handed-off chat's transcripts live
+	// under `chat-{id}`, which the task that inherited its worktree never
+	// claims, so pruning them cannot touch task-owned state.
+	chatIDs, err := p.deps.Store.TerminalChatIDsBefore(ctx, cutoff)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -251,7 +251,10 @@ var bindings = []binding{
 	{key: "ctrl+r", label: "how much of the conversation to show (compact → normal → verbose)", scope: scopePanel, context: ctxChat, hint: "ctrl+r detail", priority: 3},
 	{key: "pgup", label: "scroll the conversation back (pgdown goes forward)", scope: scopePanel, context: ctxChat, hint: "pgup/pgdown scroll", priority: 4},
 	{key: "ctrl+g", label: "jump to the live end and follow it again", scope: scopePanel, context: ctxChat, hint: "ctrl+g live", priority: 5},
-	{key: "esc", label: "back to the chats board", scope: scopePanel, context: ctxChat, hint: "esc back", priority: 6},
+	// ctrl+t rather than `h`, for the reason ctrl+r is a combination: the
+	// composer owns every printable key (task 074).
+	{key: "ctrl+t", label: "hand the worktree and branch to a new task (the chat ends)", scope: scopePanel, context: ctxChat, hint: "ctrl+t hand off", priority: 6},
+	{key: "esc", label: "back to the chats board", scope: scopePanel, context: ctxChat, hint: "esc back", priority: 7},
 
 	// New chat.
 	{key: "ctrl+s", label: "create the chat and open it", scope: scopePanel, context: ctxNewChat, hint: "ctrl+s create", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -474,6 +474,24 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("ctrl+x did not stop the running turn")
 			}
 		},
+		"ctrl+t": func(t *testing.T) {
+			v := chatViewFixture()
+			v.client = offlineClient()
+			_, cmd := v.updateKey(registryKey(t, "ctrl+t"))
+			if cmd == nil {
+				t.Fatal("ctrl+t did not open the handoff form")
+			}
+			msg, ok := cmd().(newTaskFromChatMsg)
+			if !ok {
+				t.Fatalf("ctrl+t produced %T, want newTaskFromChatMsg", cmd())
+			}
+			if msg.chat.ID != v.chat.ID {
+				t.Fatalf("handoff seeded chat %d, want %d", msg.chat.ID, v.chat.ID)
+			}
+			if v.composer.Value() != "" {
+				t.Fatalf("ctrl+t reached the composer: %q", v.composer.Value())
+			}
+		},
 		"ctrl+r": func(t *testing.T) {
 			v := chatViewFixture()
 			before := v.level.get()

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -78,6 +78,12 @@ func (v *chatView) headerLine(width int) string {
 	left := " " + styleTitle.Render(v.chat.Title) +
 		styleDim.Render("  ·  ") + applyStateStyle(v.chat.State, chatStateLabel(v.chat.State)) +
 		styleDim.Render(fmt.Sprintf("  ·  %s  ·  %s", v.chat.Agent, v.chat.Branch))
+	// The link is permanent and lives in the header rather than in the note
+	// line, which is transient: a handed-off chat is history, and the one
+	// thing a reader of it wants is where the work went (task 074).
+	if v.chat.HandoffTaskID != nil {
+		left += styleDim.Render(fmt.Sprintf("  ·  handed off to task %d", *v.chat.HandoffTaskID))
+	}
 	right := plural(len(v.turns), "turn", "turns")
 	// The level rides in the header for the reason the output pane's title
 	// carries it: ctrl+r on a conversation with no reasoning and no

--- a/internal/tui/chatsrender.go
+++ b/internal/tui/chatsrender.go
@@ -124,6 +124,8 @@ func chatStateLabel(state string) string {
 		return "idle"
 	case "archived":
 		return "archived"
+	case "handed_off":
+		return "handed off"
 	default:
 		return state
 	}

--- a/internal/tui/chatsrows.go
+++ b/internal/tui/chatsrows.go
@@ -30,7 +30,7 @@ func chatBand(state string) int {
 		return 1
 	case "idle":
 		return 2
-	default: // archived
+	default: // archived, handed_off — both terminal (task 074)
 		return 3
 	}
 }

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -596,6 +596,8 @@ func (v *chatView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return v, v.sendCmd()
 	case "ctrl+x":
 		return v, v.cancelCmd()
+	case chatHandoffKey:
+		return v, v.handoffCmd()
 	case chatExpandKey:
 		// The level, not the composer: ctrl+r is the one key here that can
 		// raise or lower how much of the conversation is drawn (decision 4).
@@ -617,6 +619,27 @@ func (v *chatView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	var cmd tea.Cmd
 	v.composer, cmd = v.composer.Update(msg)
 	return v, cmd
+}
+
+// chatHandoffKey opens the handoff form (task 074). It is a ctrl combination
+// for the reason ctrl+r is: the composer owns every printable key, so a plain
+// letter would be typed into the message.
+const chatHandoffKey = "ctrl+t"
+
+// handoffCmd opens the new-task form as this chat's handoff form. Nothing is
+// written here: the form collects the task and the daemon does the whole
+// transfer in one transaction.
+func (v *chatView) handoffCmd() tea.Cmd {
+	chat := v.chat
+	if chat == nil {
+		return nil
+	}
+	if chat.State != "idle" {
+		v.note, v.noteBad = "only an idle chat can be handed off to a task", true
+		return nil
+	}
+	seed := *chat
+	return func() tea.Msg { return newTaskFromChatMsg{chat: seed} }
 }
 
 func (v *chatView) sendCmd() tea.Cmd {

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -65,6 +65,10 @@ type (
 	// newTaskMsg opens the form, seeded with the project the caller was
 	// looking at.
 	newTaskMsg struct{ projectID int64 }
+	// newTaskFromChatMsg opens the form as the handoff form for a chat
+	// (task 074): the project is fixed, and the branch and base branch are
+	// the chat's, shown but not editable.
+	newTaskFromChatMsg struct{ chat apiclient.Chat }
 
 	// newTaskFromPullMsg opens the form seeded with a pull request (task
 	// 064). It carries the row the takeover was looking at, not a prefill:
@@ -213,6 +217,13 @@ type newTask struct {
 	// pullPrefilled records that the daemon's prefill for pull has landed, so
 	// a second listing reply cannot overwrite rows the human has since edited.
 	pullPrefilled bool
+	// handoff is the chat this draft hands off (task 074), nil for every
+	// other draft. It turns the form into the handoff form: the project is
+	// the chat's, and the base branch and the branch are the chat's and are
+	// shown read-only — they name a worktree that already exists, so there is
+	// nothing here to decide. Submitting posts to the chat's handoff route
+	// rather than to POST /v1/tasks.
+	handoff *apiclient.Chat
 
 	cursor   ntRow
 	mode     ntMode
@@ -257,7 +268,22 @@ func newNewTask() *newTask {
 	}
 }
 
-func (n *newTask) title() string { return "New task" }
+func (n *newTask) title() string {
+	if n.handoff != nil {
+		return "Hand off to task"
+	}
+	return "New task"
+}
+
+// inherited reports whether row names something the chat decided and this
+// form may only display (task 074). The project, the base branch and the
+// branch all belong to a worktree that already exists.
+func (n *newTask) inherited(row ntRow) bool {
+	if n.handoff == nil {
+		return false
+	}
+	return row == ntProject || row == ntBranch || row == ntBranchName
+}
 
 // titleText is the trimmed title as it would be sent.
 func (n *newTask) titleText() string { return strings.TrimSpace(n.titleIn.Value()) }
@@ -491,6 +517,19 @@ func (n *newTask) update(msg tea.Msg) (panel, tea.Cmd) {
 		cmd := n.open(msg.projectID)
 		n.pull = msg.pull
 		return n, cmd
+	case newTaskFromChatMsg:
+		// open() resets first, so the inherited values are written after it,
+		// exactly as the pull-request seed is.
+		cmd := n.open(msg.chat.ProjectID)
+		chat := msg.chat
+		n.handoff = &chat
+		n.titleIn.SetValue(chat.Title)
+		n.branch.SetValue(chat.BaseBranch)
+		n.branchName.SetValue(chat.Branch)
+		// The title is the one seeded row worth landing on: it is the task's
+		// objective, and the chat's title was written for a conversation.
+		n.cursor = ntTitle
+		return n, cmd
 	case ntLoadedMsg:
 		return n, n.applyLoaded(msg)
 	case ntWorkflowsMsg:
@@ -550,6 +589,7 @@ func (n *newTask) reset() {
 	n.loaded, n.loadErr = false, nil
 	n.github, n.githubProject = apiclient.GitHubStatus{}, 0
 	n.issues, n.issuesFor, n.issuesErr, n.issue = nil, issuesKey{}, "", nil
+	n.handoff, n.pull, n.pullPrefilled = nil, nil, false
 }
 
 func (n *newTask) applyLoaded(msg ntLoadedMsg) tea.Cmd {
@@ -775,6 +815,11 @@ func abs(v int) int {
 // cannot be reached. In all three the row is simply absent — the form does not
 // offer a control that would fail (task 035).
 func (n *newTask) rowVisible(row ntRow) bool {
+	// A handoff has a source already — the chat — so the issue row would be a
+	// second one competing to prefill the same title and description.
+	if n.handoff != nil && row == ntIssue {
+		return false
+	}
 	if row != ntIssue {
 		return true
 	}
@@ -800,6 +845,9 @@ func (n *newTask) visibleRows() []ntRow {
 
 // activate opens whatever the focused row edits.
 func (n *newTask) activate() tea.Cmd {
+	if n.inherited(n.cursor) {
+		return nil
+	}
 	switch n.cursor {
 	case ntProject, ntWorkflow, ntIssue, ntAgent, ntModel, ntEffort:
 		n.openPicker(n.cursor)
@@ -940,7 +988,7 @@ func (n *newTask) applyDescription(msg ntDescriptionMsg) {
 func (n *newTask) submit() tea.Cmd {
 	n.rowErr = map[ntRow]string{}
 	n.err = ""
-	if n.projectID == 0 {
+	if n.projectID == 0 && n.handoff == nil {
 		n.rowErr[ntProject] = "pick a project"
 	}
 	if n.titleText() == "" {
@@ -985,6 +1033,21 @@ func (n *newTask) submit() tea.Cmd {
 	req := n.request()
 	client := n.client
 	n.submitting = true
+	if n.handoff != nil {
+		// The chat's route, not POST /v1/tasks (task 074 decision 1). The
+		// body is the same one; the daemon supplies the project, the base
+		// branch and the branch from the chat and ignores whatever is here.
+		chatID := n.handoff.ID
+		return func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+			defer cancel()
+			task, _, err := client.HandoffChat(ctx, chatID, req)
+			if err != nil {
+				return ntFailedMsg{err: err}
+			}
+			return taskCreatedMsg{task: task}
+		}
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -266,6 +266,9 @@ func (n *newTask) renderRow(row ntRow) string {
 	}
 	if row == ntCreate {
 		label := "create task"
+		if n.handoff != nil {
+			label = "hand off to task"
+		}
 		if n.submitting {
 			label = "creating…"
 		}
@@ -273,6 +276,12 @@ func (n *newTask) renderRow(row ntRow) string {
 			styleDim.Render("enter · ctrl+s from anywhere")
 	}
 	line := fmt.Sprintf("%s%-12s %s", cursor, ntLabels[row], n.rowValue(row))
+	// An inherited row is drawn like any other and marked as what it is: the
+	// worktree it names exists, so this is a fact being confirmed rather than
+	// a choice being offered (task 074).
+	if n.inherited(row) {
+		line += "  " + styleDim.Render("(from the chat)")
+	}
 	if msg, bad := n.rowErr[row]; bad {
 		line += "  " + styleBad.Render("⚠ "+msg)
 	}

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -178,6 +178,8 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.broadcast(msg)
 	case newTaskFromPullMsg:
 		return m.updateNewTaskFromPull(msg)
+	case newTaskFromChatMsg:
+		return m.updateNewTaskFromChat(msg)
 	case taskCreatedMsg:
 		return m.updateTaskCreated(msg)
 	case connectedMsg:
@@ -475,6 +477,15 @@ func (m *root) openNewTask() tea.Cmd {
 // form has to be told to open before it is shown, because opening is what
 // resets the draft and fetches the catalogs.
 func (m *root) updateNewTaskFromPull(msg newTaskFromPullMsg) (tea.Model, tea.Cmd) {
+	cmd := m.deliver(viewNewTask, msg)
+	return m, tea.Batch(cmd, m.switchTo(viewNewTask))
+}
+
+// updateNewTaskFromChat opens the form as a chat's handoff form (task 074),
+// through the root for the reason the two above go through it: the form must
+// be told to open before it is shown, because opening is what resets the draft
+// and fetches the catalogs.
+func (m *root) updateNewTaskFromChat(msg newTaskFromChatMsg) (tea.Model, tea.Cmd) {
 	cmd := m.deliver(viewNewTask, msg)
 	return m, tea.Batch(cmd, m.switchTo(viewNewTask))
 }

--- a/internal/worktree/inprogress.go
+++ b/internal/worktree/inprogress.go
@@ -1,0 +1,71 @@
+package worktree
+
+// Detecting a repository operation a human left half-finished (task 074,
+// spec §10 amended 2026-09-01).
+//
+// This lives beside InMerge, which is its one-operation ancestor: handing a
+// chat's worktree to a task inherits whatever the directory is in the middle
+// of, and gating on a merge alone would let a half-finished rebase through to
+// surface later as an unexplained git_error inside a step.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// ReasonRepoOperationInProgress is a worktree whose repository is partway
+// through an operation — a conflicted merge, a stopped rebase, a cherry-pick
+// or revert awaiting a commit, a running bisect. It belongs to the shared
+// snake_case vocabulary internal/taskrun draws block reasons from, so the same
+// string means the same thing wherever it originated.
+//
+// Ordinary dirty state is deliberately not one of these: uncommitted work is
+// what a handoff preserves, not what it refuses.
+const ReasonRepoOperationInProgress = "repo_operation_in_progress"
+
+// inProgressMarkers maps the name a human would recognise the operation by to
+// the path, relative to the worktree's own git dir, git records it at. Order
+// is the order they are probed in, so a worktree in two of them reports the
+// one a reader is most likely to be looking for.
+var inProgressMarkers = []struct {
+	op   string
+	path string
+}{
+	{"merge", "MERGE_HEAD"},
+	// `rebase-merge` covers interactive and merge-backend rebases;
+	// `rebase-apply` is the am/patch backend and also `git am`. Both are
+	// directories rather than files, which os.Stat reports just the same.
+	{"rebase", "rebase-merge"},
+	{"rebase", "rebase-apply"},
+	{"cherry-pick", "CHERRY_PICK_HEAD"},
+	{"revert", "REVERT_HEAD"},
+	{"bisect", "BISECT_LOG"},
+}
+
+// InProgressOp names the repository operation the worktree is partway
+// through, or "" when it is not in one.
+//
+// It reads git's own markers rather than a persisted cursor, for the reason
+// InMerge does: git holds the fact authoritatively, and a stored copy
+// disagrees the moment a human runs `git rebase --abort` themselves. The
+// markers live in the worktree's *own* git dir — `.git/worktrees/{name}` for a
+// linked worktree, which is every worktree vincent makes — so the resolution
+// gitDir already does is reused rather than restated.
+func (m *Manager) InProgressOp(ctx context.Context, worktreePath string) (string, error) {
+	dir, err := m.gitDir(ctx, worktreePath)
+	if err != nil {
+		return "", err
+	}
+	for _, marker := range inProgressMarkers {
+		switch _, statErr := os.Stat(filepath.Join(dir, marker.path)); {
+		case statErr == nil:
+			return marker.op, nil
+		case os.IsNotExist(statErr):
+			continue
+		default:
+			return "", &Error{Reason: ReasonGitError, Err: statErr}
+		}
+	}
+	return "", nil
+}

--- a/internal/worktree/inprogress_test.go
+++ b/internal/worktree/inprogress_test.go
@@ -1,0 +1,82 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// TestInProgressOp is the table decision 4 rests on, exercised **inside a
+// linked worktree** rather than in the repository itself: that is where every
+// vincent worktree lives, and the markers are in `.git/worktrees/{name}`, not
+// in the repository's `.git`. A test that probed the repository would pass
+// while the real path read the wrong directory.
+//
+// The markers are created rather than provoked with real conflicts on purpose:
+// what is under test is the reading, and hand-built markers are the one form
+// that behaves identically on all three platforms.
+func TestInProgressOp(t *testing.T) {
+	repo := testrepo.Init(t, "main")
+	m := newManager(t)
+	ctx := context.Background()
+	path, err := m.Create(ctx, repo, TaskOwner(3), "vincent/3-probe", "main", false)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	gitDir, err := m.gitDir(ctx, path)
+	if err != nil {
+		t.Fatalf("gitDir: %v", err)
+	}
+	// The whole point of the fixture: a linked worktree's git dir is not the
+	// repository's, so an implementation that read `{repo}/.git` would find
+	// nothing here and report every worktree clean.
+	if gitDir == filepath.Join(repo, ".git") {
+		t.Fatalf("git dir resolved to the repository's own %s", gitDir)
+	}
+
+	if op, err := m.InProgressOp(ctx, path); err != nil || op != "" {
+		t.Fatalf("a fresh worktree reports %q (%v), want none", op, err)
+	}
+	// Ordinary dirty state is not an operation: it is what a handoff keeps.
+	if err := os.WriteFile(filepath.Join(path, "dirty.txt"), []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if op, err := m.InProgressOp(ctx, path); err != nil || op != "" {
+		t.Fatalf("a dirty worktree reports %q (%v), want none", op, err)
+	}
+
+	for _, tc := range []struct {
+		marker string
+		dir    bool
+		want   string
+	}{
+		{"MERGE_HEAD", false, "merge"},
+		{"rebase-merge", true, "rebase"},
+		{"rebase-apply", true, "rebase"},
+		{"CHERRY_PICK_HEAD", false, "cherry-pick"},
+		{"REVERT_HEAD", false, "revert"},
+		{"BISECT_LOG", false, "bisect"},
+	} {
+		t.Run(tc.marker, func(t *testing.T) {
+			p := filepath.Join(gitDir, tc.marker)
+			if tc.dir {
+				if err := os.MkdirAll(p, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(p, []byte("marker\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(p) })
+			op, err := m.InProgressOp(ctx, path)
+			if err != nil {
+				t.Fatalf("InProgressOp: %v", err)
+			}
+			if op != tc.want {
+				t.Fatalf("InProgressOp with %s = %q, want %q", tc.marker, op, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/m14-gate.sh
+++ b/scripts/m14-gate.sh
@@ -351,4 +351,72 @@ echo "== 8. chats are not tasks"
 TASKS="$(api GET /tasks | jq 'if type == "array" then length else (.tasks | length) end')"
 [[ "$TASKS" == "0" ]] || fail "GET /v1/tasks lists $TASKS rows on a daemon with only chats"
 
+echo "== 9. handoff: a task adopts the chat's worktree and branch (task 074)"
+unset FAKEAGENT_SCENARIO
+HAND="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"an exploration\", \"agent\": \"claude\"}")" \
+  || fail "creating the handoff chat failed"
+HAND_ID="$(printf '%s' "$HAND" | jq -r .id)"
+HAND_WORKTREE="$(printf '%s' "$HAND" | jq -r .worktree_path)"
+HAND_BRANCH="$(printf '%s' "$HAND" | jq -r .branch)"
+HAND_BASE="$(printf '%s' "$HAND" | jq -r .base_branch)"
+[[ -d "$HAND_WORKTREE" ]] || fail "the handoff chat has no worktree at $HAND_WORKTREE"
+
+# Uncommitted work, written the way every gate writes a file: `git config -f`
+# is in the sh∩pwsh intersection, and this is the change the handoff must
+# preserve without committing it.
+git -C "$HAND_WORKTREE" config -f explored.ini gate.explored yes \
+  || fail "seeding the dirty file failed"
+git -C "$HAND_WORKTREE" commit --allow-empty -m "chat work" >/dev/null 2>&1 \
+  || fail "committing on the chat branch failed"
+HAND_HEAD="$(git -C "$HAND_WORKTREE" rev-parse HEAD)"
+
+HANDOFF="$(api POST "/chats/$HAND_ID/handoff" \
+  -d '{"title": "finish the exploration"}')" || fail "POST /v1/chats/{id}/handoff failed"
+TASK_ID="$(printf '%s' "$HANDOFF" | jq -r .task.id)"
+[[ "$TASK_ID" != "null" && -n "$TASK_ID" ]] || fail "the handoff returned no task: $HANDOFF"
+
+# The inheritance, field by field, off the task the daemon actually stored.
+TASK="$(api GET "/tasks/$TASK_ID")"
+for pair in "worktree_path:$HAND_WORKTREE" "branch_name:$HAND_BRANCH" "base_branch:$HAND_BASE"; do
+  FIELD="${pair%%:*}"
+  WANT="${pair#*:}"
+  GOT="$(printf '%s' "$TASK" | jq -r ".$FIELD")"
+  [[ "$GOT" == "$WANT" ]] || fail "the task's $FIELD is $GOT, want the chat's $WANT"
+done
+[[ "$(printf '%s' "$TASK" | jq -r .source_chat_id)" == "$HAND_ID" ]] \
+  || fail "the task does not link back to chat $HAND_ID"
+
+# The workspace is untouched: no new commit, and the uncommitted file is still
+# uncommitted and still there.
+[[ "$(git -C "$HAND_WORKTREE" rev-parse HEAD)" == "$HAND_HEAD" ]] \
+  || fail "the handoff moved HEAD in $HAND_WORKTREE"
+[[ "$(git -C "$HAND_WORKTREE" config -f explored.ini --get gate.explored)" == "yes" ]] \
+  || fail "the uncommitted file did not survive the handoff"
+STATUS="$(git -C "$HAND_WORKTREE" status --porcelain)"
+[[ -n "$STATUS" ]] || fail "the handoff committed the dirty worktree"
+
+# The chat is terminal, links the task, and has released its claim.
+wait_chat "$HAND_ID" handed_off
+HAND_AFTER="$(api GET "/chats/$HAND_ID" | jq .chat)"
+[[ "$(printf '%s' "$HAND_AFTER" | jq -r .handoff_task_id)" == "$TASK_ID" ]] \
+  || fail "the chat does not link task $TASK_ID"
+[[ "$(printf '%s' "$HAND_AFTER" | jq -r '.worktree_path // ""')" == "" ]] \
+  || fail "the handed-off chat still claims a worktree"
+
+# Terminal means terminal: every chat action is a 409, archive included, so
+# chat cleanup can never reach the task's worktree.
+for ROUTE in handoff send cancel archive; do
+  BODY='{}'
+  if [[ "$ROUTE" == "send" ]]; then BODY='{"message": "still there?"}'; fi
+  if [[ "$ROUTE" == "handoff" ]]; then BODY='{"title": "again"}'; fi
+  CODE="$(api_status POST "/chats/$HAND_ID/$ROUTE" -d "$BODY")"
+  [[ "$CODE" == "409" ]] || fail "$ROUTE on a handed-off chat is $CODE, want 409"
+done
+[[ -d "$HAND_WORKTREE" ]] || fail "a refused archive removed the task's worktree"
+
+# And the ownership claim gc sees: the inherited directory is not an orphan.
+ORPHANS="$(api GET /info | jq -r '.orphans // 0')"
+[[ "$ORPHANS" == "0" ]] || fail "the handoff left $ORPHANS orphan(s) behind"
+
 echo "GATE PASS: m14"


### PR DESCRIPTION
## Summary

An idle chat gains one human action, **hand off**. It creates a task in the
chat's project that adopts the chat's `worktree_path`, `branch`, `base_branch`
and `base_sha` **verbatim**, links the two records, and moves the chat to a
second terminal state, `handed_off`. Nothing is copied, renamed, merged or
committed, so committed *and* uncommitted work are both there when the task's
first step runs — the acceptance criterion is met by the directory simply not
being touched.

It needed no new worktree machinery. `ensureWorktree` already returns early for
a task that arrives with a path, so admission runs no git; `reclaim.claimSets`
claims **by path**, so the task's claim covers the inherited directory with no
change to gc; and `worktree.Manager.Path` has no non-test callers, so the task
can live in `{root}/chat-7` forever — the claim decides, not the name.

Everything is validated before anything is written. The task row and its branch
claim, the link, the chat transition, the release of the chat's §10 claim and
both durable events (`task.created`, the new `chat.handed_off`) commit in **one
transaction**, with a compare-and-set on `state='idle'` inside it so a `send`
racing a handoff loses exactly one of the two. The scheduler is woken only
after that commit, so it cannot admit a task before it owns a complete
workspace, and gc never sees the directory claimed twice or not at all.

Two typed `409`s: a chat that is not idle or has no worktree to give, and a
worktree partway through a git operation — `worktree.InMerge` generalised to
`InProgressOp`, covering merge, rebase (both backends), cherry-pick, revert and
bisect, with the operation named in `details.operation`. Gating on merge alone
would let a half-finished rebase be inherited silently and surface later as an
unexplained `git_error` inside a step. **Ordinary dirty state is never
refused.**

The route is `POST /v1/chats/{id}/handoff`, taking `POST /v1/tasks`' body and
validated by the same code. It **joins** task 063's MCP exclusion list rather
than excepting it, and that is why it is a chats-family route rather than a
`source_chat_id` field on `POST /v1/tasks`: that route *is* the `task_create`
tool, `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking
`created_by_task_id`, and a chat is not in that chain — so a field there would
need a field-level MCP guard, a shape the exclusion list does not have.

`chats.handoff_task_id` (migration `0023`) is the one authoritative edge; a
task's `source_chat_id` is that column read backwards, one indexed query per
list built into a map, never one per rendered task. Retention treats both
terminal states alike (`ArchivedChatIDsBefore` widened and renamed
`TerminalChatIDsBefore`, still measured from `updated_at`); a handed-off chat's
transcripts live under `chat-{id}`, which the task never claims, so pruning
cannot reach task-owned state.

Surfaces, so it is not TUI-only: `ctrl+t` in the chat workspace opens the
new-task form in handoff mode (project, base branch and branch shown read-only
and marked `(from the chat)`), `vincent chat handoff CHAT_ID --title …` carries
`vincent task add`'s flags with `--json`, and the chat header keeps a permanent
link to the task.

**The one cost worth reviewing carefully** is that `handleTaskCreate`'s
validation had to be factored out and shared rather than copied — a second copy
would drift into a task one route accepts and the other rejects. That
extraction is `prepareTaskCreate`, and it lands as its **own commit ahead of
the feature** so a regression in it is bisectable separately. It is
behaviour-preserving for `POST /v1/tasks`: same checks, same order, same
messages.

## Related

Closes #288. Closes 073.1 (`docs/tasks/073-chat-handoff.md`).

This **amends** two recorded decisions, deliberately and in the same branch as
the code:

- §5.5's "archived is the only terminal state" (task 063). Reusing `archived`
  was rejected on mechanism, not taste: `handleChatArchive` removes the
  worktree and may delete the branch, which is exactly the state a handoff
  transfers. With two terminal states, "archiving a handed-off chat must never
  remove task-owned workspace state" is true by construction — `archive` is not
  legal from `handed_off` — rather than by a guard.
- Task 063 decision 2's MCP exclusion list is **extended, not excepted**; task
  057's assertion that the tool surface equals `Routes()` minus the exclusions
  holds unchanged.

`chatstate`'s `TestArchivedIsTheOnlyTerminal` was 063's lifecycle shape written
down, so it was not patched quietly: it is rewritten as
`TestTheTwoTerminalStates`, citing the amendment, in the same commit as the
spec edit.

§17 and §11 are cited by the issue and neither moves: §17's aggregates are over
`step_runs`, whose `task_id` stays `NOT NULL`, and `handed_off` holds no
process, so the `max_parallel_chats` tally is unchanged. §7.3 is untouched — the
chat's `session_id` is not transferred, and workflow steps still start fresh.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Tests: the `chatstate` transition table over the whole (state × action)
product; store-level atomicity (one transaction, rollback on a branch clash
leaving the chat idle with no task row, the compare-and-set against a
concurrent send, both terminal states counted for retention); API-level
inheritance asserted field by field against the chat's own body, dirty **and**
committed work surviving with `HEAD` unmoved and the file still uncommitted,
every chat action 409 afterwards, the `repo_operation_in_progress` refusal with
`details.operation`, the claimless-chat edge case, and `GET /v1/info`'s orphan
count unchanged across the transfer; `InProgressOp` as a table over a real repo
**inside a linked worktree**, so the git-dir resolution is covered on all three
platforms; the MCP surface test proving the route is not a tool; and a ninth
leg on `scripts/m14-gate.sh` proving the same end to end over curl.

Docs: `docs/spec.md` amended in place and dated (§5.5, §10, §12.3, §13.2,
§13.3, §13.4, §14, §15, §17's retention bullet, §18, decision row 29), plus
`docs/features.md`, `docs/reference/api.md`, `docs/reference/cli.md`,
`docs/reference/configuration.md`, `docs/reference/files.md`,
`docs/reference/task-lifecycle.md`, the TUI guide's chat key table, and
`docs/tasks/073-chat-handoff.md` with its index row. A documentation audit
followed the feature commit and closed six derived-page claims that still
described a chat which could only be archived — the chat's terminal states in
`api.md` and `task-lifecycle.md`, the `chat.handed_off` durable event and its
payload, retention in `configuration.md` and `files.md`, the task worktree path
in `files.md` (a handed-off task keeps `worktrees/chat-{chat_id}/` for life),
and `vincent chat handoff`'s flag set, which is `vincent task add`'s minus five
flags rather than three.

### Found in the audit and deliberately not fixed here

- **`internal/chatstate`'s package doc is now out of date.** It still says a
  chat has "its own four-state lifecycle" and that "the only end is
  `archived`". The states, the `Terminal` helper and §5.5 all say two endings;
  only the package comment lags. Left to a code commit — the documentation step
  commits documentation.
- **The handoff route accepts `github_pull`, and probably should not.**
  Validation is shared with `POST /v1/tasks`, so a handoff body naming a pull
  request gets `github_pull.branch = true` written on the task — the flag that
  records "this task's branch came from the pull request", which admission,
  archive and the retry guard read — while the branch and worktree are then
  overwritten with the chat's and the head branch is never checked out. Not
  reachable from the CLI (`vincent chat handoff` offers no `--github-issue` or
  `--github-pull`) or the TUI (the handoff form hides the issue row); an API
  caller can reach it. Worth a follow-up: either refuse the two fields on this
  route or write the link without `branch`.
- **Two sentences in `docs/reference/api.md` predate this branch and are
  wrong.** Under the chat sections it still says "A chat has no live-output
  stream over HTTP" and "There is **no per-chat event stream and no
  live-output route**", while the same page's route table and spec §13.3 both
  carry `GET /v1/chats/{id}/events` — added by task 067. Untouched here because
  it is task 067's staleness, not this change's.

Not done, and why: no screenshot re-run. `scripts/screenshots.sh` photographs
the board, the task workspace and the new-task form as they are captured today;
the handoff form is the same form with three rows annotated and no layout
change, and no existing `docs/assets/tui-*.png` shows the chat workspace's key
footer.
