### PR TITLE
Render Markdown tables, links and code blocks responsively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,9 @@ list with the user-facing context a commit subject cannot carry.
   than a colour: a monochrome terminal or an SSH session keeps every
   distinction. Constructs outside the supported list — reference links,
   autolinks, bare URLs, titled links, HTML, footnotes — render as safe literal
-  text, and raw HTML is never parsed, fetched or executed. The transcript on disk and every API payload keep the
-  agent's exact bytes; a resize re-renders from the Markdown. Spec §15.
+  text, and raw HTML is never parsed, fetched or executed. The transcript on
+  disk and every API payload keep the agent's exact bytes; a resize re-renders
+  from the Markdown. Spec §15.
 
 - **A codex step's output pane now shows what codex actually reported.** The
   adapter read the subset of `codex exec --json` real captures existed for, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ list with the user-facing context a commit subject cannot carry.
   inherited silently and surfacing later as an unexplained `git_error` inside a
   step. Ordinary uncommitted changes are never refused.
 
+- **Tables, links and highlighted code blocks in assistant prose.** A Markdown
+  table is laid out to the pane rather than left as pipes: aligned with a rule
+  under its header when it fits, and — when the pane is narrower than its
+  columns' widest unbreakable words — stacked as one `column: value` record per
+  row, never clipped and never behind a sideways scroll. Surplus width is
+  shared between columns in proportion to what each still wants, so the same
+  source at the same width always draws the same table. A link renders its
+  label as prose with a dim `[1]`, and the message ends with the `[1] https://…`
+  lines that resolve them, one per distinct destination; an image is its alt
+  text plus its source. Nothing is fetched, nothing is opened, and vincent
+  emits no OSC 8 hyperlink, so a destination — whatever its scheme — is text
+  you can read and copy. A fenced block now shows the language it declared and
+  tints its body from vincent's own palette over a written-down language list,
+  with a plain fallback for the rest; the tint is styling only, so stripping it
+  gives back the agent's bytes exactly. Reference links, autolinks, bare URLs
+  and titled links stay literal. Spec §15, §16.
 - **Assistant prose renders as Markdown in the task output pane and in chats.**
   Headings, emphasis, strong text, ordered and unordered lists, nested lists,
   blockquotes, inline code, fenced code and horizontal rules become terminal
@@ -55,9 +71,9 @@ list with the user-facing context a commit subject cannot carry.
   formatting. Structure lives inside the assistant content column, so the
   two-column activity gutter is unchanged, and every marker is a glyph rather
   than a colour: a monochrome terminal or an SSH session keeps every
-  distinction. Constructs outside the supported list — tables, links, HTML,
-  footnotes — render as safe literal text, and raw HTML is never parsed,
-  fetched or executed. The transcript on disk and every API payload keep the
+  distinction. Constructs outside the supported list — reference links,
+  autolinks, bare URLs, titled links, HTML, footnotes — render as safe literal
+  text, and raw HTML is never parsed, fetched or executed. The transcript on disk and every API payload keep the
   agent's exact bytes; a resize re-renders from the Markdown. Spec §15.
 
 - **A codex step's output pane now shows what codex actually reported.** The

--- a/docs/features.md
+++ b/docs/features.md
@@ -214,11 +214,15 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   one linked; each tab uses the whole view.
 - The Output tab and the chat workspace share one renderer, and one verbosity
   level. Assistant prose is rendered as Markdown — headings, lists, blockquotes,
-  inline and fenced code, and rules become terminal structure instead of
-  literal syntax — while reasoning, tool calls, command output and errors stay
-  literal behind their own gutter marks. Every marker is a glyph rather than a
-  colour, so a monochrome terminal keeps every distinction, and the transcript
-  on disk keeps the agent's exact bytes.
+  inline and fenced code, rules, tables, links and images become terminal
+  structure instead of literal syntax — while reasoning, tool calls, command
+  output and errors stay literal behind their own gutter marks. A table is laid
+  out to the pane and degrades to stacked `column: value` records rather than
+  being clipped; a link's destination is printed in a numbered reference list,
+  never opened or turned into a terminal hyperlink; a fenced block shows its
+  language and is tinted with styling only. Every marker is a glyph rather than
+  a colour, so a monochrome terminal keeps every distinction, and the
+  transcript on disk keeps the agent's exact bytes.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -363,9 +363,26 @@ untouched — and every marker is a glyph, not a colour, so a heading's `▌`, a
 quote's `│`, a list's `•`/`◦`/`▪`, a code block's `▏` and an inline span's
 backticks all survive with the styling stripped. A code block keeps its
 indentation and its hard line breaks; a line too long for the pane continues on
-the next one at the block's rail rather than being cut off. Constructs outside
-that list — tables, links, HTML, footnotes — render as the characters the agent
-sent, and raw HTML is never parsed, fetched or executed.
+the next one at the block's rail rather than being cut off. It also shows the
+language the fence declared, as a dim word at the rail, and tints its body — the
+tint is styling and nothing else, so stripping the escape sequences gives back
+exactly the code the agent wrote, and a language vincent does not know renders
+plain.
+
+**Tables and links, too.** A table needs its delimiter row to be a table, so
+prose containing a `|` stays prose. When it fits, it is drawn aligned with a
+rule under the header and no borders; when the pane is too narrow for its
+columns' widest unbreakable words, each row becomes a stacked
+`column: value` record opened by `▪` — never a clipped grid, and never a
+sideways scroll. A link renders its label as ordinary text with a dim `[1]`,
+and the message ends with the `[1] https://…` lines that resolve them, one per
+distinct destination. An image is its alt text plus its source in that same
+list. Nothing here is fetched, opened, or turned into a terminal hyperlink:
+vincent emits no OSC 8, so a destination is text you can read and copy.
+
+Constructs outside that list — reference links, autolinks, bare URLs, titled
+links, HTML, footnotes — render as the characters the agent sent, and raw HTML
+is never parsed, fetched or executed.
 
 Only the agent's prose is interpreted. Reasoning, tool calls, tool results,
 command output, errors and unmodeled lines stay literal behind their own gutter

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -204,6 +204,16 @@ The same holds for the Markdown rendering of assistant prose: it is a fixed
 subset drawn with vincent's own glyphs, and raw HTML is rendered as the
 characters the agent sent — never parsed, fetched or executed.
 
+Links and images in that prose are text and nothing more. A link's label is
+prose and its destination is printed literally, whatever its scheme, in a
+numbered reference list at the end of the message; an image is its alt text
+plus its printed source. **vincent emits no OSC 8 hyperlink and the pane opens
+nothing**, so a `javascript:` or `file:` destination an agent wrote is
+something you can read and copy but not something the terminal can be made to
+act on. No remote image is ever fetched — there is no fetch in that path to
+disable. Syntax highlighting in fenced code adds colour and never characters:
+strip the styling and the block is byte-for-byte what the agent sent.
+
 ## The API surface
 
 - **Loopback only.** `listen:` is validated to a loopback host; anything else is

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6784,12 +6784,17 @@ every other record stays literal.
   meant as formatting.
 - **The subset is a written-down list**, not CommonMark: headings, paragraphs,
   emphasis, strong, ordered and unordered lists, nested lists, blockquotes,
-  inline code, fenced code, horizontal rules. Everything else — tables, links,
-  reference links, HTML blocks, footnotes — renders as safe literal text. Raw
-  HTML is never parsed, and nothing is ever fetched or executed. The parser is
-  vincent's own, over that list: the alternatives are a Markdown library plus an
-  AST walker, or glamour, which emits a pre-styled ANSI block with its own
-  wrapping and margins that cannot be folded into the gutter scheme below.
+  inline code, fenced code, horizontal rules, and — *amended 2026-09-01 (task
+  075, issue #290)* — tables, inline links and inline images. Everything else
+  renders as safe literal text: reference links (`[label][ref]`), autolinks
+  (`<https://…>`), bare URLs, titled links (`[label](url "title")`), HTML
+  blocks, footnotes and setext headings. Raw HTML is never parsed, and nothing
+  is ever fetched or executed. The parser is vincent's own, over that list: the
+  alternatives are a Markdown library plus an AST walker, or glamour, which
+  emits a pre-styled ANSI block with its own wrapping and margins that cannot
+  be folded into the gutter scheme below. A bare URL displays as exactly
+  itself, which is the strongest reading of "without silently changing it"; it
+  gains no reference number and no styling.
 - **The gutter scheme is unchanged.** Assistant prose still gets the blank
   gutter and still sits flush left. Markdown structure lives *inside* the
   content column: a heading's `▌ `, a list's `• `/`◦ `/`▪ ` or its number, a
@@ -6814,12 +6819,60 @@ every other record stays literal.
   is the four columns lipgloss draws it as, so the measured width and the drawn
   width agree. Not truncation, which would put the tail of a long line out of
   reach of the TUI entirely, and not clipping, which is what wrapping replaced.
+- **A table is laid out by arithmetic, and degrades to records** *(added
+  2026-09-01, task 075)*. It is recognized only with its delimiter row, so
+  prose containing a `|` stays a paragraph. Each column has a **natural** width
+  (its widest cell) and a **minimum** width (its widest unbreakable token; a
+  cell that is a single inline-code span is unbreakable whole). Against the
+  content column, with two spaces between columns and no borders: Σ natural ≤
+  available draws natural widths; Σ minimum ≤ available < Σ natural gives every
+  column its minimum and shares the surplus **in proportion to each column's
+  remaining demand** (natural − minimum); Σ minimum > available switches to a
+  **stacked record** per row — `column: value` pairs, one per line, opened by
+  the `▪ ` already in the bullet vocabulary and separated by a blank line, so
+  the row boundary is a glyph and survives monochrome and an empty cell. A
+  wrapped cell's continuation stays inside its own column, and the header is
+  separated by a per-column run of `─` — a rule, not a grid. The two rejected
+  alternatives are named because the rule exists to avoid them: a **clipped
+  pipe table**, which loses the cells the reader came for, and a **second
+  scrolling axis** inside the viewport, which makes keyboard and mouse
+  behaviour ambiguous in a pane that has only ever scrolled one way.
+- **A link's destination is a numbered reference, never a hyperlink escape**
+  *(added 2026-09-01, task 075)*. An inline link's label renders as ordinary
+  prose carrying a dim `[n]`, and the message ends with a block of `[n] dest`
+  lines — one per distinct destination, numbered per rendered message,
+  identical destinations sharing a number. Those lines are preformatted, so a
+  destination is never word-collapsed and a long one hard-wraps at the cell
+  boundary. An image renders its **alt text** as the link-shaped item and its
+  source as the reference; nothing is fetched, and there is no fetch in this
+  path to disable. Destinations are shown literally whatever their scheme.
+  **vincent emits no OSC 8 hyperlink**, here or by default: there is no
+  reliable capability probe, the payload would carry an agent-supplied URL
+  inside an escape sequence, and a link spanning a wrap boundary would have to
+  be closed and reopened per line under an invariant that keeps escape
+  sequences out of wrapping entirely. The numbering is what a later reader
+  action would name.
+- **A fenced block shows its language and is highlighted with styles only**
+  *(added 2026-09-01, task 075)*. The info string's first word is drawn as a
+  dim header at the block's rail when present. Body lines are tinted by a
+  vincent-owned coarse token scanner (comment, string, number, keyword,
+  punctuation, plain) over a written-down language list, with a plain fallback
+  for everything not on it, from a vincent-owned palette a monochrome or ASCII
+  profile flattens to nothing. The scanner is not a parser, and a pathological
+  string or a nested-comment dialect will be mis-tinted; nothing depends on it
+  being right. **Highlighting emits styles and never characters**: with the
+  escapes stripped a rendered block is byte-for-byte the fence's content — tab
+  expansion and the hard wrap above aside — which is what makes "highlighting
+  cannot change what is copied or transcripted" checkable rather than
+  asserted.
 - **Rendering is derived and never stored.** The JSONL transcript and every API
   payload keep the agent's exact bytes (§13.3), no render path mutates a
   record, and a resize re-renders from the Markdown rather than re-wrapping
   previously rendered ANSI. A raw/rendered toggle and a copy-raw reader action
-  are follow-ups; the chat composer owns every letter key (task 071 decision
-  4), so a toggle needs its own decision about which key it is.
+  are follow-ups, and so is a link picker, which the reference numbering is
+  what a later action would address; the chat composer owns every letter key
+  (task 071 decision 4), so a toggle needs its own decision about which key it
+  is.
 
 Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
@@ -7150,7 +7203,13 @@ currently true to show (§15 view 6).
   command's output body or an error message — none of which are Markdown, which
   is why the stripping is at the pane's one wrapping chokepoint rather than in
   the Markdown path. Raw HTML in assistant prose is never parsed, fetched or
-  executed; it renders as the characters the agent sent.
+  executed; it renders as the characters the agent sent. *Added 2026-09-01
+  (task 075):* vincent emits **no OSC 8 hyperlink** and the pane opens nothing,
+  so a link in agent prose is text a human may read and copy, never a thing the
+  terminal can be made to act on — and an image is its alt text plus a printed
+  source, never a fetch. The one opener in the TUI (`openURLCmd`, reached from
+  the pull-request surfaces) still refuses every scheme but http and https, and
+  the renderer never reaches it.
 - **Full-auto agents are the headline risk.** In full-auto, an agent can execute
   arbitrary commands *as the user*, not confined to the worktree. Mitigations:
   per-workflow/step `restricted` mode, everything transcripted, nothing merges or

--- a/docs/tasks/075-rich-markdown-blocks.md
+++ b/docs/tasks/075-rich-markdown-blocks.md
@@ -1,0 +1,167 @@
+# 075 — Tables, links and code blocks in the output pane
+
+**Status:** ✅ done (1/1)
+**Issue:** #290
+**Amends:** §15's task-073 Markdown amendment, and §16
+**Follow-up to:** [073](073-assistant-markdown-in-output.md), which shipped the
+Markdown renderer over a written-down subset and named tables and link
+interaction as its stated follow-ups
+
+Task 073 left tables, links and images outside the subset, held there as safe
+literal text by `TestMarkdownOutsideTheSubsetStaysLiteral`, and captured a
+fence's content while discarding its info string. This is that follow-up: three
+constructs join the subset and fenced blocks gain a language header and a tint.
+
+It contradicts no recorded decision. 073 decision 2's wrap-plain-then-style
+invariant, decision 5's "only assistant prose is interpreted" and decision 7's
+one-chokepoint sanitizing all survive it unamended, and the two parts of the
+issue that would have strained them — chroma-grade highlighting and OSC 8 —
+were resolved with the author before the work started and are recorded below.
+
+The work is entirely client-side and lands in `internal/tui` alone: no daemon
+package, no API route, no store migration. §13.3's chunks and the JSONL
+transcript keep the agent's bytes exactly, and width, theme and colour profile
+are things only the client knows. `agent.output` in both workspaces and the
+chat's §17 retention fallback remain the only two doors, unchanged from 073
+decision 5.
+
+## Decisions
+
+### 1. The highlighter is vincent's own, not chroma
+
+A coarse token scanner — comment, string, number, keyword, punctuation, plain —
+over a written-down language list, with a plain fallback for everything not on
+it, in `internal/tui/markdownhighlight.go`.
+
+This is the same posture as 073 decision 1's hand-rolled parser,
+[017](017-workflow-visualization.md) decision 2's refused graph widget and
+[055](055-release-check-and-self-update.md) decision 1's refused `sigstore-go`. The runtime
+`require` block stays seventeen lines; chroma is present today only as a
+linter's indirect dependency and stays there.
+
+The cost is accepted and stated rather than hidden: this is not real parsing.
+Scanning is per line and carries no state between lines, so a string or a block
+comment spanning two lines is tinted as two independent lines, and a
+nested-comment dialect will be mis-tinted. Nothing depends on the tint being
+right, which is what makes that acceptable — see decision 3's property.
+
+**Beat:** `alecthomas/chroma/v2` as a direct runtime dependency. Correct lexing
+for ~250 languages, at a large dependency and several MB of binary in a project
+that has twice recorded a refusal of exactly that trade.
+
+### 2. A destination is discoverable through per-message numbered references
+
+An inline link renders its label as prose carrying a dim `[n]`, and the message
+ends with a block of `[n] dest` lines — one per distinct destination, numbered
+per rendered message, identical destinations sharing a number. The exact
+destination is therefore always on screen without OSC 8 and without a
+keybinding, and the numbering is what a later picker action would name.
+
+**Beat:** an inline host suffix — `label (example.com)` — which is compact but
+is not the exact destination: two paths on one host render identically.
+**Beat:** storing the URL as segment metadata and shipping nothing visible,
+which fails the issue's own criterion the moment OSC 8 is absent.
+**Beat:** a reader action shipped alongside. It needs its own key decision,
+because the chat composer owns every letter key ([071](071-chat-workspace-verbosity.md)
+decision 4, which is why verbosity is `ctrl+r` there), and the pane has no
+per-record cursor to hang a picker on.
+
+### 3. No OSC 8 hyperlink is emitted, in this task or by default
+
+There is no reliable capability probe. The payload would carry an
+agent-supplied URL inside an escape sequence, which is the one thing §16 as
+amended by 073 decision 7 says the pane does not do. And a link spanning a wrap
+boundary would have to be closed and reopened per line, under an invariant that
+deliberately keeps escape sequences out of wrapping.
+
+The reference block satisfies every acceptance criterion without it. OSC 8
+becomes its own issue if it is wanted, with the escaping rules and the gating as
+its subject.
+
+The same reasoning gives the highlighter its safety property, asserted by
+`TestHighlightingEmitsStylesNeverCharacters`: highlighting emits **styles only,
+never characters**, so stripping the escapes from a rendered block reproduces
+the fence's content byte for byte — tab expansion and the existing hard wrap
+aside. "Highlighting must not change copying or transcript contents" is
+therefore checkable rather than asserted.
+
+### 4. Only inline links and inline images join the subset
+
+Reference links (`[label][ref]`), autolinks (`<https://…>`), bare URLs and
+titled links (`[label](url "title")`) stay literal, and §15's boundary list is
+amended to say so rather than shrinking silently. A link whose destination
+contains whitespace does not match, which is what makes the titled form fall out
+without a rule of its own.
+
+The consequence is stated rather than papered over: the issue's "give bare URLs
+a compact presentation" is discharged as **literal rendering**. A bare URL
+displays as exactly itself — the strongest reading of "without silently
+changing them" — but gains no reference number and no styling.
+
+### 5. The wrap-plain-then-style invariant is not touched by any of this
+
+Table cells, highlight runs and link labels are all measured as plain text and
+styled after layout. The issue's "measure columns using ANSI-aware terminal cell
+width" is read as 073 decision 2 already settled it: `ansi.StringWidth` is the
+measurement, and nothing in the wrap path ever sees an escape sequence.
+
+The one mechanical consequence is that `wrapPre` became multi-segment. It
+rendered `pl.segs[0]` alone, which a highlighted code line and a reference line
+both outgrow; it now lays every segment out as one continuous stream of cells,
+still measuring plain and re-opening a style run on each produced line.
+
+### 6. A table's layout is arithmetic, and its degradation is a stated width
+
+Two widths per column — *natural* (the widest cell) and *minimum* (the widest
+unbreakable token; a cell that is a single inline-code span is unbreakable
+whole, which is the issue's "preserving literal/code cells"). Then, against the
+content column with two spaces between columns and no borders:
+
+| available | outcome |
+|---|---|
+| Σ natural ≤ available | natural widths, drawn aligned |
+| Σ minimum ≤ available < Σ natural | minimum widths, surplus shared in proportion to each column's remaining demand (natural − minimum) |
+| Σ minimum > available | the stacked form |
+
+Stating the middle case as arithmetic is what makes "allocate surplus width by
+content rather than giving it all to one column" reproducible at every width,
+and it is what `TestTableSurplusGoesWhereTheDemandIs` asserts directly. The
+switch to the stacked form is likewise a computed threshold in
+`TestTableDegradesToStackedAtItsStatedWidth`, not an observed one.
+
+**Beat:** a clipped pipe table, which loses the cells the reader came for.
+**Beat:** a horizontal scroll inside the pane, which is a second scrolling axis
+and a keyboard/mouse ambiguity this pane has never had. The issue rejects both,
+and the arithmetic exists so neither is ever needed.
+
+A table cannot go through `wrapLine`, which is a one-dimensional layout of one
+`paneLine`, so it has its own `mdTable` block kind and its own renderer emitting
+composed lines directly, the way `mdRule` already renders without lines.
+
+## What shipped
+
+- `internal/tui/markdown.go` — info-string capture, table block scanning, link
+  and image inline handling, the per-message reference registry, block dispatch.
+- `internal/tui/markdowntable.go` — column measurement, surplus allocation,
+  aligned rendering, the stacked fallback.
+- `internal/tui/markdownhighlight.go` — the token scanner, its language table
+  and the vincent-owned palette.
+- `internal/tui/outputlines.go` — `wrapPre` is multi-segment.
+- Tests: `markdowntable_test.go` and `markdownhighlight_test.go` are new, and
+  `TestMarkdownOutsideTheSubsetStaysLiteral` lost its `table`, `table rule`,
+  `inline link` and `image` cases and gained `autolink`, `bare url` and
+  `titled link` in their place. `internal/tui` is covered by no gate script, so
+  the tests are the whole assurance, as they were for 073.
+
+## Not done here
+
+A raw/rendered toggle, a copy-raw action and a link picker remain the follow-ups
+073 decision 4 scoped; the reference numbering is what a picker would address.
+OSC 8 is its own issue per decision 3. Reference links, autolinks and bare-URL
+styling are out per decision 4, and are the obvious content of a later
+subset-widening issue if agent output makes the case for them.
+
+`scripts/screenshots.sh` was **not** re-run: the seeded assistant text contains
+no table, link or fenced block, so the panel the existing shots photograph is
+unchanged. Extending the seed to show the feature would mean regenerating the
+shots with the script, never drawing them.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -88,6 +88,7 @@ the living engineering specification records implementation contracts.
 | [072](072-codex-and-cursor-in-chat.md) | Chats on codex and cursor | ✅ done (1/1) |
 | [073](073-assistant-markdown-in-output.md) | Assistant Markdown in the output pane | ✅ done (1/1) |
 | [074](074-chat-handoff.md) | Hand off a chat's worktree and branch to a task | ✅ done (1/1) |
+| [075](075-rich-markdown-blocks.md) | Tables, links and code blocks in the output pane | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -22,12 +23,14 @@ import (
 // wrap-plain-then-style invariant §15 rests on. The subset is exactly:
 //
 //	headings, paragraphs, emphasis, strong, ordered and unordered lists,
-//	nested lists, blockquotes, inline code, fenced code, horizontal rules.
+//	nested lists, blockquotes, inline code, fenced code, horizontal rules,
+//	tables, inline links, inline images (task 075).
 //
-// Everything outside it — tables, links, reference links, HTML blocks,
-// footnotes, setext headings, backslash escapes — renders as literal text.
-// That is the boundary, and it is a list rather than "whatever CommonMark
-// says", so a construct either appears above or it is safe text.
+// Everything outside it — reference links, autolinks, bare URLs, titled
+// links, HTML blocks, footnotes, setext headings, backslash escapes —
+// renders as literal text. That is the boundary, and it is a list rather than
+// "whatever CommonMark says", so a construct either appears above or it is
+// safe text.
 //
 // Markdown structure lives *inside* the assistant content column (decision 6).
 // The activity gutter is untouched: prose still gets gutterNone, and a list
@@ -47,6 +50,12 @@ var (
 	styleMDQuote  = lipgloss.NewStyle().Faint(true).Italic(true)
 	styleMDRule   = lipgloss.NewStyle().Faint(true)
 	styleMDCode   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	// styleMDRef paints a link's `[n]` marker and the reference block that
+	// resolves it (task 075 decision 2). Both are dim: the destination is
+	// what a reader goes looking for, not what they read past.
+	styleMDRef = lipgloss.NewStyle().Faint(true)
+	// styleMDLang is the fenced block's info string, drawn at the rail.
+	styleMDLang = lipgloss.NewStyle().Faint(true).Italic(true)
 )
 
 // Content-column prefixes. Every one is a single cell wide plus its trailing
@@ -75,14 +84,21 @@ const (
 	mdQuote
 	mdCode
 	mdRule
+	mdTable
 )
 
 // mdBlock is one parsed block. Its lines are laid out but not yet wrapped,
 // except mdRule, which is drawn to the pane's width at render time and so
-// carries no lines at all.
+// carries no lines at all, and mdTable, whose layout is two-dimensional and
+// so cannot be a list of paneLines either.
 type mdBlock struct {
 	kind  mdKind
 	lines []paneLine
+	// info is a fenced block's info string, first word only. Empty for
+	// every other kind and for a fence that declared no language.
+	info string
+	// table is set on mdTable and nil everywhere else.
+	table *mdTableBlock
 }
 
 // markdownLines renders assistant prose to wrapped pane lines.
@@ -93,7 +109,8 @@ type mdBlock struct {
 // rendering is derived, and the transcript on disk stays the agent's bytes
 // (decision 4).
 func markdownLines(text string, width int) []string {
-	blocks := parseMarkdown(sanitizeText(text))
+	refs := &mdRefs{}
+	blocks := parseMarkdown(sanitizeText(text), refs)
 	out := make([]string, 0, len(blocks)*2)
 	prev := mdParagraph
 	for _, b := range blocks {
@@ -102,6 +119,60 @@ func markdownLines(text string, width int) []string {
 		}
 		out = append(out, renderMDBlock(b, width)...)
 		prev = b.kind
+	}
+	if lines := renderMDRefs(refs, width); len(lines) > 0 {
+		if len(out) > 0 {
+			out = append(out, "")
+		}
+		out = append(out, lines...)
+	}
+	return out
+}
+
+// mdRefs numbers the destinations one rendered message links to (task 075
+// decision 2). Numbering is per message and by first appearance, and two
+// identical destinations share a number: what the reference block is for is
+// putting the exact destination on screen without an OSC 8 hyperlink and
+// without a keybinding, and repeating a URL under two numbers would only make
+// that list longer.
+type mdRefs struct {
+	order []string
+	index map[string]int
+}
+
+// add returns the 1-based number for a destination, assigning one on first
+// sight.
+func (r *mdRefs) add(dest string) int {
+	if n, ok := r.index[dest]; ok {
+		return n
+	}
+	if r.index == nil {
+		r.index = make(map[string]int, 4)
+	}
+	r.order = append(r.order, dest)
+	r.index[dest] = len(r.order)
+	return len(r.order)
+}
+
+// renderMDRefs draws the reference block. Its lines are preformatted, so a
+// destination is never folded at a space it happens to contain and a long one
+// hard-wraps at the cell boundary exactly as a long code line does.
+func renderMDRefs(r *mdRefs, width int) []string {
+	if r == nil || len(r.order) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(r.order))
+	for i, dest := range r.order {
+		pl := paneLine{
+			gutter:      gutterNone,
+			gutterStyle: styleMDRef,
+			pre:         true,
+			segs: []segment{
+				{text: "[" + strconv.Itoa(i+1) + "] ", style: styleMDRef},
+				{text: dest, style: styleMDRef},
+			},
+		}
+		out = append(out, wrapLine(pl, width)...)
 	}
 	return out
 }
@@ -119,14 +190,29 @@ func mdNeedsBlank(prev, next mdKind) bool {
 
 // renderMDBlock wraps one block to the pane.
 func renderMDBlock(b mdBlock, width int) []string {
-	if b.kind == mdRule {
+	switch b.kind {
+	case mdRule:
 		// Width-bounded rather than a fixed run of dashes: a rule is the
 		// separator the pane is wide, and one that stopped short would read
 		// as a line of text.
 		n := max(width-cols(gutterNone), 1)
 		return []string{gutterNone + styleMDRule.Render(strings.Repeat("─", n))}
+	case mdTable:
+		return renderMDTable(b.table, width)
 	}
-	out := make([]string, 0, len(b.lines))
+	out := make([]string, 0, len(b.lines)+1)
+	if b.kind == mdCode && b.info != "" {
+		// The declared language, at the block's own rail. Dim and one word,
+		// because it labels the block rather than being part of it — and it
+		// is text, so a monochrome terminal reads it too.
+		out = append(out, wrapLine(paneLine{
+			gutter:      gutterNone + mdCodeRail,
+			gutterStyle: styleMDMarker,
+			contPrefix:  gutterNone + mdCodeRail,
+			pre:         true,
+			segs:        []segment{{text: b.info, style: styleMDLang}},
+		}, width)...)
+	}
 	for _, pl := range b.lines {
 		out = append(out, wrapLine(pl, width)...)
 	}
@@ -144,13 +230,15 @@ type mdPending struct {
 	depth   int
 	fence   byte
 	fenceLn int
+	info    string
+	refs    *mdRefs
 }
 
 // parseMarkdown scans the text a line at a time. It is a scanner rather than
 // a grammar because the subset is a list of line shapes: a line either opens
 // a fence, is a fence's content, is a rule, a heading, a quote or a list
 // item, or it is prose that continues whatever came before it.
-func parseMarkdown(text string) []mdBlock {
+func parseMarkdown(text string, refs *mdRefs) []mdBlock {
 	src := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
 	var (
 		blocks []mdBlock
@@ -170,7 +258,8 @@ func parseMarkdown(text string) []mdBlock {
 	// paragraph at the margin all end one.
 	endList := func() { stack = stack[:0] }
 
-	for _, line := range src {
+	for i := 0; i < len(src); i++ {
+		line := src[i]
 		if pend.open {
 			if isFenceClose(line, pend.fence, pend.fenceLn) {
 				flush()
@@ -184,10 +273,10 @@ func parseMarkdown(text string) []mdBlock {
 			flush()
 			continue
 		}
-		if ch, n, ok := fenceOpen(line); ok {
+		if ch, n, info, ok := fenceOpen(line); ok {
 			flush()
 			endList()
-			pend = mdPending{kind: mdCode, open: true, fence: ch, fenceLn: n}
+			pend = mdPending{kind: mdCode, open: true, fence: ch, fenceLn: n, info: info}
 			continue
 		}
 		if isRule(trimmed) {
@@ -201,8 +290,18 @@ func parseMarkdown(text string) []mdBlock {
 			endList()
 			blocks = append(blocks, mdBlock{
 				kind:  mdHeading,
-				lines: []paneLine{headingPaneLine(level, htext)},
+				lines: []paneLine{headingPaneLine(level, htext, refs)},
 			})
+			continue
+		}
+		// A table is recognized only with its delimiter row. Without it the
+		// pipes stay a paragraph, which is what keeps prose containing `|`
+		// from becoming a grid (task 075).
+		if tbl, next, ok := tableAt(src, i, refs); ok {
+			flush()
+			endList()
+			blocks = append(blocks, mdBlock{kind: mdTable, table: tbl})
+			i = next - 1
 			continue
 		}
 		if depth, body, ok := quoteOf(line); ok {
@@ -212,13 +311,13 @@ func parseMarkdown(text string) []mdBlock {
 			}
 			flush()
 			endList()
-			pend = mdPending{kind: mdQuote, depth: depth, text: []string{body}}
+			pend = mdPending{kind: mdQuote, depth: depth, text: []string{body}, refs: refs}
 			continue
 		}
 		if indent, marker, body, ok := listItemOf(line); ok {
 			flush()
 			depth := listDepth(&stack, indent)
-			pend = mdPending{kind: mdItem, depth: depth, marker: marker, text: []string{body}}
+			pend = mdPending{kind: mdItem, depth: depth, marker: marker, text: []string{body}, refs: refs}
 			continue
 		}
 		// Plain prose. It continues a paragraph or an item — a wrapped list
@@ -232,7 +331,7 @@ func parseMarkdown(text string) []mdBlock {
 		}
 		flush()
 		endList()
-		pend = mdPending{kind: mdParagraph, text: []string{strings.TrimSpace(line)}}
+		pend = mdPending{kind: mdParagraph, text: []string{strings.TrimSpace(line)}, refs: refs}
 	}
 	flush()
 	return blocks
@@ -252,20 +351,20 @@ func (p mdPending) block() (mdBlock, bool) {
 		}
 		lines := make([]paneLine, 0, len(p.text))
 		for _, l := range p.text {
-			lines = append(lines, codePaneLine(l))
+			lines = append(lines, codePaneLine(l, p.info))
 		}
 		if len(lines) == 0 {
 			// An empty fence still says a code block was there.
-			lines = append(lines, codePaneLine(""))
+			lines = append(lines, codePaneLine("", p.info))
 		}
-		return mdBlock{kind: mdCode, lines: lines}, true
+		return mdBlock{kind: mdCode, lines: lines, info: p.info}, true
 	case mdItem:
 		if p.isEmpty() {
 			return mdBlock{}, false
 		}
 		return mdBlock{
 			kind:  mdItem,
-			lines: []paneLine{itemPaneLine(p.depth, p.marker, strings.Join(p.text, " "))},
+			lines: []paneLine{itemPaneLine(p.depth, p.marker, strings.Join(p.text, " "), p.refs)},
 		}, true
 	case mdQuote:
 		if p.isEmpty() {
@@ -273,7 +372,7 @@ func (p mdPending) block() (mdBlock, bool) {
 		}
 		return mdBlock{
 			kind:  mdQuote,
-			lines: []paneLine{quotePaneLine(p.depth, strings.Join(p.text, " "))},
+			lines: []paneLine{quotePaneLine(p.depth, strings.Join(p.text, " "), p.refs)},
 		}, true
 	default:
 		if p.isEmpty() {
@@ -281,7 +380,7 @@ func (p mdPending) block() (mdBlock, bool) {
 		}
 		return mdBlock{
 			kind:  mdParagraph,
-			lines: []paneLine{paragraphPaneLine(strings.Join(p.text, " "))},
+			lines: []paneLine{paragraphPaneLine(strings.Join(p.text, " "), p.refs)},
 		}, true
 	}
 }
@@ -304,36 +403,36 @@ func listDepth(stack *[]int, indent int) int {
 
 // paragraphPaneLine is prose: no marker, flush against the gutter, exactly
 // where an unformatted assistant message already sat.
-func paragraphPaneLine(text string) paneLine {
+func paragraphPaneLine(text string, refs *mdRefs) paneLine {
 	base := lipgloss.NewStyle()
 	return paneLine{
 		gutter:      gutterNone,
 		gutterStyle: base,
-		segs:        inlineSegments(text, base, 0),
+		segs:        inlineSegments(text, base, 0, refs),
 	}
 }
 
 // headingPaneLine marks a section. The glyph is what carries the heading in
 // monochrome; the level is the indent in front of it, so a subsection sits
 // under its section without spending a second glyph on it.
-func headingPaneLine(level int, text string) paneLine {
+func headingPaneLine(level int, text string, refs *mdRefs) paneLine {
 	return paneLine{
 		gutter:      gutterNone + strings.Repeat(" ", level-1) + mdHeadingMark,
 		gutterStyle: styleMDHeading,
-		segs:        inlineSegments(text, styleMDHeading, 0),
+		segs:        inlineSegments(text, styleMDHeading, 0, refs),
 	}
 }
 
 // itemPaneLine is one list item. The marker goes in the content column's own
 // gutter, which is what gives a wrapped item its hanging indent for free.
-func itemPaneLine(depth int, marker, text string) paneLine {
+func itemPaneLine(depth int, marker, text string, refs *mdRefs) paneLine {
 	if marker == "" {
 		marker = mdBulletsByDepth[min(depth, len(mdBulletsByDepth)-1)]
 	}
 	return paneLine{
 		gutter:      gutterNone + strings.Repeat("  ", depth) + marker,
 		gutterStyle: styleMDMarker,
-		segs:        inlineSegments(text, lipgloss.NewStyle(), 0),
+		segs:        inlineSegments(text, lipgloss.NewStyle(), 0, refs),
 	}
 }
 
@@ -341,13 +440,13 @@ func itemPaneLine(depth int, marker, text string) paneLine {
 // wrapLine indents continuations with spaces of the gutter's width by
 // default, which would put the bar on the first line of a wrapped quote and
 // drop it from the rest — a content gutter that is not a gutter (decision 6).
-func quotePaneLine(depth int, text string) paneLine {
+func quotePaneLine(depth int, text string, refs *mdRefs) paneLine {
 	bar := gutterNone + strings.Repeat(mdQuoteBar, depth)
 	return paneLine{
 		gutter:      bar,
 		gutterStyle: styleMDQuote,
 		contPrefix:  bar,
-		segs:        inlineSegments(text, styleMDQuote, 0),
+		segs:        inlineSegments(text, styleMDQuote, 0, refs),
 	}
 }
 
@@ -355,38 +454,49 @@ func quotePaneLine(depth int, text string) paneLine {
 // preformatted, so it hard-wraps at the cell boundary rather than going
 // through splitWords, which collapses runs of whitespace: a code block that
 // lost its indentation would not be the code the agent wrote (decision 3).
-func codePaneLine(text string) paneLine {
+//
+// The line is split into highlight runs (task 075), which is a styling of the
+// same bytes and never a rewriting of them: concatenating the segments
+// reproduces the argument exactly, so stripping the escape sequences from a
+// rendered block gives back the fence's content.
+func codePaneLine(text, lang string) paneLine {
 	rail := gutterNone + mdCodeRail
 	return paneLine{
 		gutter:      rail,
 		gutterStyle: styleMDMarker,
 		contPrefix:  rail,
 		pre:         true,
-		segs:        []segment{{text: text, style: styleMDCode}},
+		segs:        highlightSegments(lang, text),
 	}
 }
 
-// fenceOpen reports an opening fence and its run, which the closing fence
-// must match or exceed.
-func fenceOpen(line string) (byte, int, bool) {
+// fenceOpen reports an opening fence, its run — which the closing fence must
+// match or exceed — and the first word of its info string, which is the
+// declared language (task 075). The rest of the info string is dropped: it is
+// attribute syntax nobody agreed on, and what the header names is a language.
+func fenceOpen(line string) (byte, int, string, bool) {
 	t := strings.TrimLeft(line, " ")
 	if t == "" {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
 	ch := t[0]
 	if ch != '`' && ch != '~' {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
 	n := runLen(t, 0, ch)
 	if n < 3 {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
 	// An info string may not contain a backtick, which is what keeps
 	// ``a`` in prose from opening a block.
 	if ch == '`' && strings.ContainsRune(t[n:], '`') {
-		return 0, 0, false
+		return 0, 0, "", false
 	}
-	return ch, n, true
+	info := ""
+	if fields := strings.Fields(t[n:]); len(fields) > 0 {
+		info = fields[0]
+	}
+	return ch, n, info, true
 }
 
 func isFenceClose(line string, ch byte, n int) bool {
@@ -509,7 +619,12 @@ func indentCols(prefix string) int {
 //
 // depth guards the recursion `**bold with `code`**` needs; nesting past it
 // renders literally rather than growing a stack.
-func inlineSegments(text string, base lipgloss.Style, depth int) []segment {
+//
+// refs collects link and image destinations for the message's reference block
+// (task 075 decision 2). It is never nil on the paths that reach here from
+// markdownLines; a nil registry renders a link as its literal source, which is
+// what a caller that cannot show a reference block should get.
+func inlineSegments(text string, base lipgloss.Style, depth int, refs *mdRefs) []segment {
 	segs := make([]segment, 0, 4)
 	var lit strings.Builder
 	flush := func() {
@@ -520,6 +635,25 @@ func inlineSegments(text string, base lipgloss.Style, depth int) []segment {
 	}
 	for i := 0; i < len(text); {
 		switch text[i] {
+		case '[', '!':
+			// An inline link or image. The label is prose and the
+			// destination becomes a numbered reference; nothing here opens,
+			// fetches or hyperlinks anything (decisions 2 and 3).
+			if label, dest, next, ok := linkAt(text, i); ok && depth < 3 && refs != nil {
+				flush()
+				if label == "" {
+					// An image with no alt text, or `[](x)`: the marker is
+					// all that is left to hang the reference on.
+					label = dest
+				}
+				segs = append(segs, inlineSegments(label, base, depth+1, refs)...)
+				segs = append(segs, segment{
+					text:  " [" + strconv.Itoa(refs.add(dest)) + "]",
+					style: base.Faint(true),
+				})
+				i = next
+				continue
+			}
 		case '`':
 			// Inline code wins over emphasis, and keeps its delimiters: the
 			// backticks are what a monochrome terminal has left once the
@@ -537,7 +671,7 @@ func inlineSegments(text string, base lipgloss.Style, depth int) []segment {
 				if marks >= 2 {
 					style = base.Bold(true)
 				}
-				segs = append(segs, inlineSegments(body, style, depth+1)...)
+				segs = append(segs, inlineSegments(body, style, depth+1, refs)...)
 				i = next
 				continue
 			}
@@ -569,6 +703,56 @@ func codeSpanAt(text string, i int) (string, int, bool) {
 		return "", 0, false
 	}
 	return text[i : i+n+end+n], i + n + end + n, true
+}
+
+// linkAt matches an inline link `[label](dest)` and an inline image
+// `![alt](src)`, and nothing else (task 075 decision 4).
+//
+// The destination may not contain whitespace, which is what makes the titled
+// form `[label](url "title")` fall out of the subset without a rule of its
+// own, and reference links, autolinks and bare URLs never reach here at all.
+// A construct that does not match is left to the caller as literal text.
+func linkAt(text string, i int) (string, string, int, bool) {
+	open := i
+	if text[open] == '!' {
+		open++
+	}
+	if open >= len(text) || text[open] != '[' {
+		return "", "", 0, false
+	}
+	label := strings.IndexByte(text[open+1:], ']')
+	if label < 0 {
+		return "", "", 0, false
+	}
+	rest := text[open+1+label+1:]
+	if !strings.HasPrefix(rest, "(") {
+		return "", "", 0, false
+	}
+	// The closing paren is the balanced one, so a destination that contains
+	// a pair of its own — `javascript:alert(1)` as much as a wikipedia URL —
+	// is captured whole rather than cut at the first `)`.
+	paren, depth := 0, 0
+	for j := range len(rest) {
+		switch rest[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+		if depth == 0 {
+			paren = j
+			break
+		}
+	}
+	// paren < 2 is either no balanced closing paren or an empty destination.
+	if paren < 2 {
+		return "", "", 0, false
+	}
+	dest := rest[1:paren]
+	if strings.ContainsAny(dest, " \t[]") {
+		return "", "", 0, false
+	}
+	return text[open+1 : open+1+label], dest, open + label + paren + 3, true
 }
 
 // emphasisAt matches `*x*`, `**x**` and their underscore spellings.

--- a/internal/tui/markdown_test.go
+++ b/internal/tui/markdown_test.go
@@ -103,7 +103,7 @@ func TestMarkdownConstructs(t *testing.T) {
 		{
 			name: "fenced code keeps its indentation", width: 40,
 			src:  "```go\nif x {\n    y()\n}\n```",
-			want: []string{"  ▏ if x {", "  ▏     y()", "  ▏ }"},
+			want: []string{"  ▏ go", "  ▏ if x {", "  ▏     y()", "  ▏ }"},
 		},
 		{
 			name: "horizontal rule fills the content column", width: 20,
@@ -182,14 +182,13 @@ func TestMarkdownEveryConstructAtEveryWidth(t *testing.T) {
 // fetched, executed or half-interpreted.
 func TestMarkdownOutsideTheSubsetStaysLiteral(t *testing.T) {
 	cases := map[string]string{
-		"table":           "| a | b |",
-		"table rule":      "|---|---|",
-		"inline link":     "see [the docs](https://example.com/x)",
 		"reference link":  "see [the docs][1]",
+		"autolink":        "see <https://example.com/x>",
+		"bare url":        "see https://example.com/x for more",
+		"titled link":     `see [the docs](https://example.com/x "Docs")`,
 		"html block":      "<script>alert(1)</script>",
 		"inline html":     "a <b>bold</b> word",
 		"footnote":        "a claim[^1]",
-		"image":           "![alt](https://example.com/x.png)",
 		"setext underlin": "Title\n===",
 	}
 	for name, src := range cases {
@@ -378,5 +377,82 @@ func TestPreformattedContinuationKeepsItsPrefix(t *testing.T) {
 	}
 	if !strings.HasPrefix(ansi.Strip(got[1]), "  ") {
 		t.Errorf("continuation = %q, want the hanging indent in spaces", got[1])
+	}
+}
+
+// TestMarkdownLinksNumberTheirDestinations is task 075 decision 2: the label
+// is prose, the destination is on screen as a numbered reference, and nothing
+// depends on OSC 8 or on a keybinding that does not exist yet.
+func TestMarkdownLinksNumberTheirDestinations(t *testing.T) {
+	got := stripped("see [the docs](https://example.com/x) now", 80)
+	want := []string{"  see the docs [1] now", "", "  [1] https://example.com/x"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+// TestMarkdownRepeatedDestinationSharesANumber keeps the reference block as
+// short as the set of destinations, not as long as the count of links.
+func TestMarkdownRepeatedDestinationSharesANumber(t *testing.T) {
+	got := strings.Join(stripped(
+		"[a](https://example.com/x) and [b](https://example.com/x) and [c](https://example.com/y)", 80), "\n")
+	for _, want := range []string{"a [1]", "b [1]", "c [2]", "[1] https://example.com/x", "[2] https://example.com/y"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing from:\n%s", want, got)
+		}
+	}
+	if n := strings.Count(got, "https://example.com/x"); n != 1 {
+		t.Errorf("a repeated destination was listed %d times, want 1:\n%s", n, got)
+	}
+}
+
+// TestMarkdownImageRendersAltTextAndItsSource is the image half: alt text is
+// the link-shaped item, the source is a reference, and nothing is fetched —
+// there is no I/O in this path to disable.
+func TestMarkdownImageRendersAltTextAndItsSource(t *testing.T) {
+	got := stripped("![a diagram](https://example.com/x.png)", 80)
+	want := []string{"  a diagram [1]", "", "  [1] https://example.com/x.png"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+// TestMarkdownUnsafeSchemesAreTextAndNothingElse is the security criterion.
+// Destinations are shown literally whatever their scheme, and the pane ships
+// no action that could open one — openURLCmd, which is the only opener in the
+// package, is not reachable from the renderer and still refuses everything but
+// http and https.
+func TestMarkdownUnsafeSchemesAreTextAndNothingElse(t *testing.T) {
+	for _, dest := range []string{"javascript:alert(1)", "file:///etc/passwd", "data:text/html,x"} {
+		got := strings.Join(stripped("[click]("+dest+")", 80), "\n")
+		if !strings.Contains(got, "[1] "+dest) {
+			t.Errorf("%q was not shown literally:\n%s", dest, got)
+		}
+		if strings.Contains(got, "\x1b]8;") {
+			t.Errorf("an OSC 8 hyperlink was emitted for %q", dest)
+		}
+	}
+	// The one opener in the package still refuses a non-http scheme, which is
+	// the guard for the day a reader action arrives (decision 3).
+	if msg, ok := drain(openURLCmd("javascript:alert(1)")).(openedURLMsg); !ok || msg.err == nil {
+		t.Errorf("openURLCmd accepted a javascript: URL: %+v", msg)
+	}
+}
+
+// TestMarkdownLinksInBothWorkspacesAgree is the two-door criterion extended to
+// the new constructs: `agent.output` in the task workspace and the chat's §17
+// retention fallback reach the same renderer, so the same source at the same
+// width renders identically.
+func TestMarkdownRichBlocksRenderTheSameThroughBothDoors(t *testing.T) {
+	const src = "| a | b |\n|---|---|\n| 1 | 2 |\n\nsee [docs](https://example.com/x)\n\n```go\nvar x = 1\n```"
+	for _, width := range []int{40, 80} {
+		direct := strings.Join(markdownLines(src, width), "\n")
+		pane := strings.Join(outputLines(
+			[]apiclient.TranscriptRecord{{Type: "agent.output", Text: src}},
+			levelNormal, width, lineOpts{expandKey: "v"}), "\n")
+		if !strings.Contains(pane, direct) {
+			t.Errorf("width %d: the output pane did not render the shared renderer's lines:\n%s\n---\n%s",
+				width, pane, direct)
+		}
 	}
 }

--- a/internal/tui/markdownhighlight.go
+++ b/internal/tui/markdownhighlight.go
@@ -1,0 +1,277 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Syntax highlighting for fenced code blocks (task 075, §15).
+//
+// The highlighter is vincent's own, over a written-down language list, and not
+// chroma (decision 1). That follows the posture recorded twice already —
+// task 017 decision 2 refusing a graph widget and task 055 decision 1 refusing
+// sigstore-go — and the runtime `require` block stays where it is. The cost is
+// stated rather than hidden: this is a coarse token scanner, not a parser, and
+// a pathological string or a dialect with nested block comments will be
+// mis-tinted. Nothing depends on it being right; it is a tint over text that
+// is already correct.
+//
+// Two properties make that trade safe, and both are asserted by tests:
+//
+//   - **Styles only, never characters.** Concatenating the returned segments
+//     reproduces the argument byte for byte. A highlighted block therefore has
+//     exactly the fence's content once the escape sequences are stripped, so
+//     highlighting cannot change what a reader copies out of the pane, and the
+//     transcript on disk was never in this path at all.
+//   - **Colour is the only thing added.** Every structural distinction the
+//     block already had — the rail, the language header, the indentation, the
+//     hard wrap — is a character, so a monochrome or ASCII profile loses the
+//     tint and nothing else.
+//
+// Scanning is per line and carries no state between lines: a block comment or
+// a string spanning two lines is tinted as two independent lines. That is the
+// coarseness above, made explicit rather than half-fixed.
+
+var (
+	styleHLComment = lipgloss.NewStyle().Faint(true)
+	styleHLString  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	styleHLNumber  = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	styleHLKeyword = lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Bold(true)
+	styleHLPunct   = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+)
+
+// mdLang is one language's coarse model: how a comment starts, what quotes a
+// string, and which identifiers are keywords. A language absent from the table
+// renders plain, which is the fallback and not a failure.
+type mdLang struct {
+	lineComment []string
+	quotes      string
+	keywords    map[string]bool
+}
+
+// mdKeywords builds a keyword set from a space-separated list, which is how
+// the table below stays readable.
+func mdKeywords(list string) map[string]bool {
+	out := make(map[string]bool)
+	for _, w := range strings.Fields(list) {
+		out[w] = true
+	}
+	return out
+}
+
+// mdLangs is the written-down list. Aliases are separate entries rather than a
+// normalization table, so what an agent may write is visible here.
+var mdLangs = func() map[string]*mdLang {
+	cLike := []string{"//", "/*"}
+	goLang := &mdLang{
+		lineComment: cLike,
+		quotes:      "\"'`",
+		keywords: mdKeywords(`break case chan const continue default defer else fallthrough for func go goto
+			if import interface map package range return select struct switch type var
+			nil true false iota make new len cap append copy delete panic recover
+			string int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 byte rune
+			float32 float64 bool error any`),
+	}
+	python := &mdLang{
+		lineComment: []string{"#"},
+		quotes:      "\"'",
+		keywords: mdKeywords(`and as assert async await break class continue def del elif else except
+			finally for from global if import in is lambda none nonlocal not or pass raise
+			return try while with yield True False None self print len range`),
+	}
+	js := &mdLang{
+		lineComment: cLike,
+		quotes:      "\"'`",
+		keywords: mdKeywords(`async await break case catch class const continue debugger default delete do
+			else export extends finally for function if import in instanceof let new of return
+			static super switch this throw try typeof var void while with yield
+			true false null undefined interface type enum implements readonly namespace declare`),
+	}
+	rust := &mdLang{
+		lineComment: cLike,
+		quotes:      "\"'",
+		keywords: mdKeywords(`as async await break const continue crate dyn else enum extern fn for if impl
+			in let loop match mod move mut pub ref return self Self static struct super trait
+			type unsafe use where while true false Some None Ok Err String Vec Option Result`),
+	}
+	cLang := &mdLang{
+		lineComment: cLike,
+		quotes:      "\"'",
+		keywords: mdKeywords(`auto break case char class const constexpr continue default delete do double
+			else enum extern float for friend goto if inline int long namespace new nullptr
+			operator private protected public register return short signed sizeof static
+			struct switch template this throw try typedef typename union unsigned using
+			virtual void volatile while true false NULL include define ifdef ifndef endif`),
+	}
+	java := &mdLang{
+		lineComment: cLike,
+		quotes:      "\"'",
+		keywords: mdKeywords(`abstract assert boolean break byte case catch char class const continue
+			default do double else enum extends final finally float for goto if implements
+			import instanceof int interface long native new package private protected public
+			return short static strictfp super switch synchronized this throw throws
+			transient try void volatile while true false null var record sealed`),
+	}
+	shell := &mdLang{
+		lineComment: []string{"#"},
+		quotes:      "\"'",
+		keywords: mdKeywords(`if then else elif fi for while until do done case esac function return
+			in select time coproc local export readonly declare unset shift eval exec exit
+			set trap source echo cd test`),
+	}
+	ruby := &mdLang{
+		lineComment: []string{"#"},
+		quotes:      "\"'",
+		keywords: mdKeywords(`alias and begin break case class def defined do else elsif end ensure false
+			for if in module next nil not or redo rescue retry return self super then true
+			undef unless until when while yield require attr_accessor puts`),
+	}
+	sql := &mdLang{
+		lineComment: []string{"--"},
+		quotes:      "\"'",
+		keywords: mdKeywords(`select from where insert into values update set delete create table drop
+			alter add column primary key foreign references index unique not null default
+			join left right inner outer on group by order having limit offset union all
+			distinct as and or in exists between like case when then else end begin commit
+			rollback transaction with returning`),
+	}
+	json := &mdLang{quotes: "\"", keywords: mdKeywords(`true false null`)}
+	yaml := &mdLang{
+		lineComment: []string{"#"},
+		quotes:      "\"'",
+		keywords:    mdKeywords(`true false null yes no on off`),
+	}
+	return map[string]*mdLang{
+		"go": goLang, "golang": goLang,
+		"python": python, "py": python,
+		"javascript": js, "js": js, "typescript": js, "ts": js, "tsx": js, "jsx": js,
+		"rust": rust, "rs": rust,
+		"c": cLang, "cpp": cLang, "c++": cLang, "h": cLang, "hpp": cLang,
+		"java": java,
+		"sh":   shell, "bash": shell, "zsh": shell, "shell": shell, "console": shell,
+		"ruby": ruby, "rb": ruby,
+		"sql":  sql,
+		"json": json,
+		"yaml": yaml, "yml": yaml,
+	}
+}()
+
+// highlightSegments splits one line of a fenced block into styled runs.
+//
+// The returned segments concatenate to the argument exactly — the property the
+// whole scheme rests on. A language that is not on the list, or a fence with no
+// info string, gets one plain segment, which is what every fenced block looked
+// like before this.
+func highlightSegments(lang, line string) []segment {
+	l := mdLangs[strings.ToLower(lang)]
+	if l == nil || line == "" {
+		return []segment{{text: line, style: styleMDCode}}
+	}
+	var out []segment
+	emit := func(text string, style lipgloss.Style) {
+		if text == "" {
+			return
+		}
+		if n := len(out); n > 0 && sameStyle(out[n-1].style, style) {
+			out[n-1].text += text
+			return
+		}
+		out = append(out, segment{text: text, style: style})
+	}
+	for i := 0; i < len(line); {
+		if l.commentAt(line, i) > 0 {
+			// A comment runs to the end of the line. A `/*` that closes on a
+			// later line is the stateless coarseness above.
+			emit(line[i:], styleHLComment)
+			break
+		}
+		if strings.IndexByte(l.quotes, line[i]) >= 0 {
+			end := stringEnd(line, i)
+			emit(line[i:end], styleHLString)
+			i = end
+			continue
+		}
+		if isDigitByte(line[i]) {
+			end := i
+			for end < len(line) && (isWordByte(line[end]) || line[end] == '.') {
+				end++
+			}
+			emit(line[i:end], styleHLNumber)
+			i = end
+			continue
+		}
+		if isWordByte(line[i]) {
+			end := i
+			for end < len(line) && isWordByte(line[end]) {
+				end++
+			}
+			word := line[i:end]
+			style := styleMDCode
+			if l.keywords[word] {
+				style = styleHLKeyword
+			}
+			emit(word, style)
+			i = end
+			continue
+		}
+		if isPunctByte(line[i]) {
+			emit(line[i:i+1], styleHLPunct)
+			i++
+			continue
+		}
+		// Whitespace and everything multi-byte: plain, one byte at a time, so
+		// a UTF-8 sequence is never split between two segments of different
+		// styles — emit coalesces the runs back together anyway.
+		end := i + 1
+		for end < len(line) && !isWordByte(line[end]) && !isPunctByte(line[end]) &&
+			strings.IndexByte(l.quotes, line[end]) < 0 && l.commentAt(line, end) == 0 {
+			end++
+		}
+		emit(line[i:end], styleMDCode)
+		i = end
+	}
+	if len(out) == 0 {
+		return []segment{{text: line, style: styleMDCode}}
+	}
+	return out
+}
+
+// commentAt reports the length of the comment opener at i, or 0.
+func (l *mdLang) commentAt(line string, i int) int {
+	for _, c := range l.lineComment {
+		if strings.HasPrefix(line[i:], c) {
+			return len(c)
+		}
+	}
+	return 0
+}
+
+// stringEnd finds the byte after a quoted run, honoring backslash escapes and
+// stopping at the end of the line for a string that does not close on it.
+func stringEnd(line string, i int) int {
+	q := line[i]
+	for j := i + 1; j < len(line); j++ {
+		switch line[j] {
+		case '\\':
+			j++
+		case q:
+			return j + 1
+		}
+	}
+	return len(line)
+}
+
+func isDigitByte(c byte) bool { return c >= '0' && c <= '9' }
+
+func isWordByte(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', isDigitByte(c), c == '_':
+		return true
+	}
+	return false
+}
+
+func isPunctByte(c byte) bool {
+	return strings.IndexByte("{}()[]<>,;:.!?=+-*/%&|^~@#$", c) >= 0
+}

--- a/internal/tui/markdownhighlight_test.go
+++ b/internal/tui/markdownhighlight_test.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Fenced code blocks: the language header and the highlighting (task 075).
+
+// TestCodeFenceDrawsItsLanguage is the header: present when the fence declared
+// a language, absent when it did not, and text rather than colour, so a
+// monochrome terminal reads it too.
+func TestCodeFenceDrawsItsLanguage(t *testing.T) {
+	got := stripped("```go\nvar x = 1\n```", 40)
+	want := []string{"  ▏ go", "  ▏ var x = 1"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+	if got := stripped("```\nvar x = 1\n```", 40); len(got) != 1 {
+		t.Errorf("a fence with no info string drew a header: %q", got)
+	}
+	// Only the first word: the rest of an info string is attribute syntax
+	// nobody agreed on, and what the header names is a language.
+	if got := stripped("```go title=\"x\"\nvar x = 1\n```", 40); got[0] != "  ▏ go" {
+		t.Errorf("the header rendered the whole info string: %q", got[0])
+	}
+}
+
+// TestHighlightingEmitsStylesNeverCharacters is the property the whole scheme
+// rests on: strip the escape sequences from a highlighted block and what is
+// left is the fence's own content. Anything else would change what a reader
+// copies out of the pane.
+func TestHighlightingEmitsStylesNeverCharacters(t *testing.T) {
+	body := []string{
+		`package main`,
+		``,
+		`// a comment with "quotes" and 42`,
+		`func main() {`,
+		"\tconst greeting = \"hello, world\" // trailing",
+		`	n := 0x1f + 3.5`,
+		`	fmt.Println(greeting, n)`,
+		`}`,
+	}
+	src := "```go\n" + strings.Join(body, "\n") + "\n```"
+	var got []string
+	for i, l := range markdownLines(src, 200) {
+		if i == 0 {
+			continue // the language header, which is vincent's, not the fence's
+		}
+		got = append(got, strings.TrimPrefix(ansi.Strip(l), "  ▏ "))
+	}
+	// Tabs are the four columns the pane draws them as, which predates this.
+	want := make([]string, len(body))
+	for i, l := range body {
+		want[i] = strings.ReplaceAll(l, "\t", "    ")
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("highlighting changed the block's bytes:\n got %q\nwant %q", got, want)
+	}
+}
+
+// TestHighlightSegmentsConcatenateToTheirSource is the same property at the
+// scanner's own door, across every language on the list and a few it has
+// never heard of.
+func TestHighlightSegmentsConcatenateToTheirSource(t *testing.T) {
+	lines := []string{
+		`x := "a string with a # and a // in it"`,
+		`# a comment`,
+		`-- another one`,
+		`SELECT * FROM t WHERE a = 'b' -- note`,
+		`{"key": [1, 2.5, true, null]}`,
+		`日本語 := "🎉 emoji" // 👨‍👩‍👧`,
+		`if (a && b) { return c ?? d; }`,
+		`unterminated "string`,
+		``,
+		`    `,
+	}
+	langs := []string{"go", "python", "js", "ts", "rust", "c", "java", "sh", "sql", "json", "yaml", "ruby", "brainfuck", ""}
+	for _, lang := range langs {
+		for _, line := range lines {
+			segs := highlightSegments(lang, line)
+			if got := segsPlain(segs); got != line {
+				t.Errorf("%s: %q became %q", lang, line, got)
+			}
+		}
+	}
+}
+
+// TestHighlightingFallsBackToPlain is the written-down list's other side: a
+// language that is not on it renders exactly as an undeclared fence does,
+// which is one plain run.
+func TestHighlightingFallsBackToPlain(t *testing.T) {
+	const line = `func main() { return "x" }`
+	if segs := highlightSegments("brainfuck", line); len(segs) != 1 {
+		t.Errorf("an unknown language produced %d runs, want one plain run", len(segs))
+	}
+	if segs := highlightSegments("go", line); len(segs) < 2 {
+		t.Errorf("go produced %d runs; the fixture should tint something", len(segs))
+	}
+}
+
+// TestHighlightedBlockKeepsItsStructureWithoutColour is §15's monochrome rule
+// applied to the new tint: the rail, the header, the indentation and the hard
+// wrap are all characters, so stripping the styling loses the colour and
+// nothing else.
+func TestHighlightedBlockKeepsItsStructureWithoutColour(t *testing.T) {
+	src := "```python\ndef f():\n    return 1  # done\n```"
+	got := stripped(src, 40)
+	want := []string{"  ▏ python", "  ▏ def f():", "  ▏     return 1  # done"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+// TestHighlightedLongLineStillWrapsAtTheRail is task 073 decision 3 under the
+// new multi-segment lines: a line too long for the pane continues at the rail
+// with every byte intact, whether or not it is highlighted.
+func TestHighlightedLongLineStillWrapsAtTheRail(t *testing.T) {
+	const line = `const message = "` + `abcdefghij abcdefghij abcdefghij abcdefghij abcdefghij` + `"`
+	src := "```go\n" + line + "\n```"
+	lines := markdownLines(src, 30)
+	var body strings.Builder
+	for i, l := range lines {
+		if w := ansi.StringWidth(l); w > 30 {
+			t.Errorf("line %d is %d columns: %q", i, w, l)
+		}
+		if !strings.HasPrefix(ansi.Strip(l), "  ▏ ") {
+			t.Errorf("line %d lost the rail: %q", i, l)
+		}
+		if i == 0 {
+			continue
+		}
+		body.WriteString(strings.TrimPrefix(ansi.Strip(l), "  ▏ "))
+	}
+	if body.String() != line {
+		t.Errorf("a wrapped highlighted line lost bytes:\n got %q\nwant %q", body.String(), line)
+	}
+}
+
+// TestHighlightingCannotSmuggleAnEscapeSequence keeps decision 7's chokepoint
+// honest now that a code line arrives as several segments: whatever the fence
+// contains, what reaches the pane is text plus vincent's own styles.
+func TestHighlightingCannotSmuggleAnEscapeSequence(t *testing.T) {
+	src := "```go\nx := \"\x1b[2J\" // \x1b]0;pwned\a\n```"
+	for _, l := range markdownLines(src, 40) {
+		text := ansi.Strip(l)
+		if strings.ContainsFunc(text, isTerminalControl) {
+			t.Errorf("a control character survived highlighting: %q", l)
+		}
+		if strings.Contains(text, "[2J") || strings.Contains(text, "pwned") {
+			t.Errorf("an escape sequence was rendered as its parameters: %q", l)
+		}
+	}
+}

--- a/internal/tui/markdowntable.go
+++ b/internal/tui/markdowntable.go
@@ -1,0 +1,489 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Markdown tables in the output pane (task 075, §15).
+//
+// A table cannot go through wrapLine, which is a one-dimensional layout of one
+// paneLine. It gets its own block kind and its own renderer, emitting composed
+// lines directly the way mdRule already does.
+//
+// The layout rule is arithmetic rather than a heuristic, so the same source at
+// the same width always draws the same table and the width at which it
+// degrades is a stated number rather than an observed one:
+//
+//	Σ natural ≤ available            → natural widths, drawn aligned
+//	Σ minimum ≤ available < Σ natural → minimum widths plus the surplus,
+//	                                    shared in proportion to each column's
+//	                                    remaining demand (natural − minimum)
+//	Σ minimum > available            → the stacked form
+//
+// Neither fallback is a clipped table and neither is a second scrolling axis:
+// the first loses cells the reader came for, and the second makes keyboard and
+// mouse behaviour ambiguous inside a pane that has only ever scrolled one way.
+//
+// The wrap-plain-then-style invariant (task 073 decision 2) is untouched here.
+// A cell's segments are measured by the summed cols() of their *plain* text,
+// wrapped plain, padded plain, and each run is styled only once the line is
+// laid out.
+
+// mdTableGap is the space between two columns. Two cells rather than a border:
+// a drawn grid is visually expensive in a narrow terminal and spends width
+// that belongs to the content.
+const mdTableGap = 2
+
+// mdAlign is a column's alignment, taken from the delimiter row's colons.
+type mdAlign int
+
+const (
+	mdAlignLeft mdAlign = iota
+	mdAlignCenter
+	mdAlignRight
+)
+
+// mdCell is one table cell: its inline segments, the plain text they measure
+// as, and whether it may be broken across lines at all.
+type mdCell struct {
+	segs  []segment
+	plain string
+	// unbreakable marks a cell that is a single inline-code span. A code
+	// cell wrapped mid-token is no longer the literal the author wrote, so
+	// its whole width is the column's minimum.
+	unbreakable bool
+}
+
+// mdTableBlock is a parsed table. Header and body cells are already inline
+// segments: everything a cell may hold — emphasis, strong text, an inline code
+// span, a link — is resolved at parse time, so the reference numbering a link
+// in a cell produces follows document order like any other.
+type mdTableBlock struct {
+	header []mdCell
+	rows   [][]mdCell
+	align  []mdAlign
+}
+
+// tableAt recognizes a table starting at src[i]: a header row of pipe cells,
+// then a delimiter row of the same width, then body rows until a blank line or
+// a line that is not a row. It returns the block and the index of the first
+// line after it.
+//
+// The delimiter row is required, which is the whole point: prose containing a
+// pipe stays a paragraph, and a lone `| a | b |` is a line of text.
+func tableAt(src []string, i int, refs *mdRefs) (*mdTableBlock, int, bool) {
+	if i+1 >= len(src) || !isTableRow(src[i]) {
+		return nil, 0, false
+	}
+	align, ok := delimiterRow(src[i+1])
+	if !ok {
+		return nil, 0, false
+	}
+	// The header must have exactly the delimiter's columns. A row of a
+	// different width is not a table's header — it is a line of prose above
+	// something that looks like a rule.
+	if len(splitTableCells(strings.TrimSpace(src[i]))) != len(align) {
+		return nil, 0, false
+	}
+	header := tableCells(src[i], len(align), refs)
+	tbl := &mdTableBlock{header: header, align: align}
+	n := i + 2
+	for ; n < len(src) && isTableRow(src[n]); n++ {
+		tbl.rows = append(tbl.rows, tableCells(src[n], len(align), refs))
+	}
+	return tbl, n, true
+}
+
+// isTableRow reports a line that could be a row: non-blank and containing a
+// pipe that is not inside an inline code span.
+func isTableRow(line string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	return len(splitTableCells(t)) > 0 && strings.Count(t, "|") > 0
+}
+
+// delimiterRow parses `|---|:--:|---:|` into per-column alignments.
+func delimiterRow(line string) ([]mdAlign, bool) {
+	cells := splitTableCells(strings.TrimSpace(line))
+	if len(cells) == 0 || !strings.Contains(line, "|") {
+		return nil, false
+	}
+	out := make([]mdAlign, 0, len(cells))
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		left := strings.HasPrefix(c, ":")
+		right := strings.HasSuffix(c, ":")
+		body := strings.Trim(c, ":")
+		if body == "" || strings.Trim(body, "-") != "" {
+			return nil, false
+		}
+		switch {
+		case left && right:
+			out = append(out, mdAlignCenter)
+		case right:
+			out = append(out, mdAlignRight)
+		default:
+			out = append(out, mdAlignLeft)
+		}
+	}
+	return out, true
+}
+
+// tableCells splits a row and resolves each cell's inline Markdown. A short
+// row is padded with empty cells and a long one is cut, so the grid stays
+// rectangular whatever the author wrote.
+func tableCells(line string, want int, refs *mdRefs) []mdCell {
+	raw := splitTableCells(strings.TrimSpace(line))
+	out := make([]mdCell, want)
+	base := lipgloss.NewStyle()
+	for i := range out {
+		src := ""
+		if i < len(raw) {
+			src = strings.TrimSpace(raw[i])
+		}
+		src = strings.ReplaceAll(src, "\\|", "|")
+		segs := inlineSegments(src, base, 0, refs)
+		out[i] = mdCell{
+			segs:        segs,
+			plain:       segsPlain(segs),
+			unbreakable: isCodeSpanCell(src),
+		}
+	}
+	return out
+}
+
+// splitTableCells splits on the pipes that separate cells: not an escaped
+// `\|`, and not one inside an inline code span, so a cell may hold `a|b`. A
+// leading and a trailing pipe are the row's own frame and produce no cell.
+func splitTableCells(line string) []string {
+	var (
+		cells []string
+		cur   strings.Builder
+	)
+	for i := 0; i < len(line); {
+		switch line[i] {
+		case '\\':
+			if i+1 < len(line) && line[i+1] == '|' {
+				cur.WriteString("\\|")
+				i += 2
+				continue
+			}
+		case '`':
+			if span, next, ok := codeSpanAt(line, i); ok {
+				cur.WriteString(span)
+				i = next
+				continue
+			}
+		case '|':
+			cells = append(cells, cur.String())
+			cur.Reset()
+			i++
+			continue
+		}
+		cur.WriteByte(line[i])
+		i++
+	}
+	cells = append(cells, cur.String())
+	// Drop the frame: an empty first cell when the row opened with a pipe,
+	// an empty last one when it closed with one.
+	if len(cells) > 0 && strings.TrimSpace(cells[0]) == "" && strings.HasPrefix(line, "|") {
+		cells = cells[1:]
+	}
+	if len(cells) > 0 && strings.TrimSpace(cells[len(cells)-1]) == "" && strings.HasSuffix(line, "|") {
+		cells = cells[:len(cells)-1]
+	}
+	return cells
+}
+
+// isCodeSpanCell reports a cell that is one inline code span and nothing else.
+func isCodeSpanCell(src string) bool {
+	if !strings.HasPrefix(src, "`") {
+		return false
+	}
+	_, next, ok := codeSpanAt(src, 0)
+	return ok && next == len(src)
+}
+
+// segsPlain is the text a run of segments measures as — the wrap-plain-then-
+// style invariant's "plain".
+func segsPlain(segs []segment) string {
+	var b strings.Builder
+	for _, s := range segs {
+		b.WriteString(s.text)
+	}
+	return b.String()
+}
+
+// mdTableWidths computes the per-column widths for a table in avail cells, and
+// reports whether an aligned table fits at all. A false means the stacked form.
+func mdTableWidths(t *mdTableBlock, avail int) ([]int, bool) {
+	n := len(t.align)
+	if n == 0 {
+		return nil, false
+	}
+	natural := make([]int, n)
+	minimum := make([]int, n)
+	rows := make([][]mdCell, 0, len(t.rows)+1)
+	rows = append(rows, t.header)
+	rows = append(rows, t.rows...)
+	for _, row := range rows {
+		for c, cell := range row {
+			natural[c] = max(natural[c], cols(cell.plain))
+			minimum[c] = max(minimum[c], cellMinWidth(cell))
+		}
+	}
+	gaps := mdTableGap * (n - 1)
+	sumNat, sumMin := gaps, gaps
+	for c := range n {
+		natural[c] = max(natural[c], 1)
+		minimum[c] = max(min(minimum[c], natural[c]), 1)
+		sumNat += natural[c]
+		sumMin += minimum[c]
+	}
+	if sumNat <= avail {
+		return natural, true
+	}
+	if sumMin > avail {
+		return nil, false
+	}
+	// The surplus goes where the demand is, in proportion to it, rather than
+	// to whichever column happens to come first.
+	widths := append([]int(nil), minimum...)
+	demand := make([]int, n)
+	total := 0
+	for c := range n {
+		demand[c] = natural[c] - minimum[c]
+		total += demand[c]
+	}
+	surplus := avail - sumMin
+	if total == 0 {
+		return widths, true
+	}
+	given := 0
+	for c := range n {
+		share := surplus * demand[c] / total
+		widths[c] += share
+		given += share
+	}
+	// The division's remainder, handed out one cell at a time to the columns
+	// still short of their natural width. Left to right, so the outcome is
+	// reproducible rather than dependent on a map's iteration order.
+	for rest := surplus - given; rest > 0; {
+		moved := false
+		for c := range n {
+			if rest == 0 {
+				break
+			}
+			if widths[c] < natural[c] {
+				widths[c]++
+				rest--
+				moved = true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+	return widths, true
+}
+
+// cellMinWidth is the narrowest column a cell can live in: its longest
+// unbreakable token, or the whole cell when it is a code span.
+func cellMinWidth(c mdCell) int {
+	if c.unbreakable {
+		return cols(c.plain)
+	}
+	n := 1
+	for _, w := range strings.Fields(c.plain) {
+		n = max(n, cols(w))
+	}
+	return n
+}
+
+// renderMDTable draws a table, aligned when it fits and stacked when it does
+// not.
+func renderMDTable(t *mdTableBlock, width int) []string {
+	if t == nil || len(t.align) == 0 {
+		return nil
+	}
+	avail := max(width-cols(gutterNone), 1)
+	widths, ok := mdTableWidths(t, avail)
+	if !ok {
+		return renderMDTableStacked(t, width)
+	}
+	out := make([]string, 0, len(t.rows)+2)
+	out = append(out, mdTableRow(t.header, widths, t.align)...)
+	// A per-column rule rather than a grid: the header stays legible with the
+	// styling stripped, and no width is spent on vertical borders.
+	rule := make([]string, len(widths))
+	for c, w := range widths {
+		rule[c] = strings.Repeat("─", w)
+	}
+	out = append(out, gutterNone+styleMDRule.Render(strings.Join(rule, strings.Repeat(" ", mdTableGap))))
+	for _, row := range t.rows {
+		out = append(out, mdTableRow(row, widths, t.align)...)
+	}
+	return out
+}
+
+// mdTableRow lays one row out. A row is as tall as its tallest cell and a
+// wrapped cell's continuation stays inside its own column, which is the
+// hanging alignment a wrapped table needs to stay readable.
+func mdTableRow(row []mdCell, widths []int, align []mdAlign) []string {
+	wrapped := make([][][]segment, len(widths))
+	height := 1
+	for c := range widths {
+		var segs []segment
+		if c < len(row) {
+			segs = row[c].segs
+		}
+		wrapped[c] = wrapSegments(segs, widths[c])
+		height = max(height, len(wrapped[c]))
+	}
+	out := make([]string, 0, height)
+	for ln := range height {
+		var b strings.Builder
+		b.WriteString(gutterNone)
+		for c, w := range widths {
+			if c > 0 {
+				b.WriteString(strings.Repeat(" ", mdTableGap))
+			}
+			var line []segment
+			if ln < len(wrapped[c]) {
+				line = wrapped[c][ln]
+			}
+			b.WriteString(padSegments(line, w, align[c]))
+		}
+		// Padding is plain, so trimming it cannot cut an escape sequence —
+		// and a line that ended in spaces would hand them to the terminal's
+		// own text selection.
+		out = append(out, strings.TrimRight(b.String(), " "))
+	}
+	return out
+}
+
+// padSegments renders one wrapped cell line into exactly width cells,
+// positioned by the column's alignment. The padding is plain text and the runs
+// are styled individually, which is the invariant restated at the one place a
+// table could have broken it.
+func padSegments(line []segment, width int, align mdAlign) string {
+	var b strings.Builder
+	n := 0
+	for _, s := range line {
+		n += cols(s.text)
+	}
+	pad := max(width-n, 0)
+	left, right := 0, pad
+	switch align {
+	case mdAlignRight:
+		left, right = pad, 0
+	case mdAlignCenter:
+		left, right = pad/2, pad-pad/2
+	}
+	b.WriteString(strings.Repeat(" ", left))
+	for _, s := range line {
+		b.WriteString(s.style.Render(s.text))
+	}
+	b.WriteString(strings.Repeat(" ", right))
+	return b.String()
+}
+
+// wrapSegments word-wraps a run of segments to width cells, returning one
+// list of styled runs per produced line. It is wrapLine's word loop without a
+// gutter: measured on plain text, styled afterwards.
+func wrapSegments(segs []segment, width int) [][]segment {
+	width = max(width, 1)
+	var (
+		lines [][]segment
+		cur   []segment
+	)
+	col := 0
+	pendingSpace := false
+	push := func(text string, st lipgloss.Style) {
+		if n := len(cur); n > 0 && sameStyle(cur[n-1].style, st) {
+			cur[n-1].text += text
+			return
+		}
+		cur = append(cur, segment{text: text, style: st})
+	}
+	flush := func() {
+		lines = append(lines, cur)
+		cur = nil
+		col = 0
+		pendingSpace = false
+	}
+	for _, seg := range segs {
+		for _, tok := range splitWords(sanitizeText(seg.text), width) {
+			if tok == " " {
+				pendingSpace = col > 0
+				continue
+			}
+			need := cols(tok)
+			if pendingSpace {
+				need++
+			}
+			if col+need > width && col > 0 {
+				flush()
+				need = cols(tok)
+			}
+			if pendingSpace {
+				push(" ", seg.style)
+				pendingSpace = false
+			}
+			push(tok, seg.style)
+			col += need
+		}
+	}
+	if col > 0 || len(lines) == 0 {
+		flush()
+	}
+	return lines
+}
+
+// renderMDTableStacked is the fallback: one record per row, `column: value`
+// one pair per line.
+//
+// It is a record rather than a narrower table because below the minimum widths
+// there is no table left — every column would be wrapping mid-token. The row
+// boundary is a glyph and a blank line rather than a colour, so it survives a
+// monochrome terminal and an empty cell, and the key is dim because it is the
+// header repeating rather than the value the reader is after.
+func renderMDTableStacked(t *mdTableBlock, width int) []string {
+	keys := make([]string, len(t.header))
+	for i, h := range t.header {
+		keys[i] = h.plain
+	}
+	out := make([]string, 0, len(t.rows)*len(keys))
+	for r, row := range t.rows {
+		if r > 0 {
+			out = append(out, "")
+		}
+		for c, cell := range row {
+			marker := "  "
+			if c == 0 {
+				marker = mdBulletsByDepth[len(mdBulletsByDepth)-1]
+			}
+			key := ""
+			if c < len(keys) {
+				key = keys[c]
+			}
+			segs := []segment{{text: key + ": ", style: styleMDRef}}
+			segs = append(segs, cell.segs...)
+			out = append(out, wrapLine(paneLine{
+				gutter:      gutterNone + marker,
+				gutterStyle: styleMDMarker,
+				segs:        segs,
+			}, width)...)
+		}
+	}
+	if len(out) == 0 {
+		// A table with a header and no body rows still says what its columns
+		// were.
+		out = append(out, gutterNone+styleMDRef.Render(strings.Join(keys, ", ")))
+	}
+	return out
+}

--- a/internal/tui/markdowntable_test.go
+++ b/internal/tui/markdowntable_test.go
@@ -1,0 +1,249 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Markdown tables in the output pane (task 075).
+//
+// Everything here asserts against ansi.Strip'ped lines, for the same reason
+// the rest of the Markdown tests do: what is under test is that the structure
+// survives without colour.
+
+const tableSrc = "| Name | Count |\n|------|------:|\n| alpha | 1 |\n| beta | 22 |"
+
+// wideTableSrc has a column whose longest token is wide enough that the table
+// runs out of room at a width the pane actually reaches, which is what makes
+// the degradation and the reflow observable at all.
+const wideTableSrc = "| Name | Description |\n|------|-------------|\n" +
+	"| alpha | supercalifragilistic expialidocious |\n" +
+	"| beta | short |"
+
+// TestTableRendersAlignedWhenItFits is the aligned form: a rule under the
+// header, two spaces between columns, no borders, and the right-aligned column
+// flush to its own edge.
+func TestTableRendersAlignedWhenItFits(t *testing.T) {
+	got := stripped(tableSrc, 40)
+	want := []string{
+		"  Name   Count",
+		"  ─────  ─────",
+		"  alpha      1",
+		"  beta      22",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+// TestTableKeepsEveryCellAtEveryWidth is the acceptance criterion stated as a
+// sweep: no width loses a cell, and no produced line overflows the pane.
+func TestTableKeepsEveryCellAtEveryWidth(t *testing.T) {
+	for _, width := range []int{20, 30, 40, 60, 80} {
+		lines := markdownLines(tableSrc, width)
+		joined := strings.Join(stripped(tableSrc, width), "\n")
+		for _, cell := range []string{"Name", "Count", "alpha", "beta", "22"} {
+			if !strings.Contains(joined, cell) {
+				t.Errorf("width %d lost %q:\n%s", width, cell, joined)
+			}
+		}
+		for i, l := range lines {
+			if w := ansi.StringWidth(l); w > width {
+				t.Errorf("width %d: line %d is %d columns: %q", width, i, w, l)
+			}
+		}
+	}
+}
+
+// TestTableDegradesToStackedAtItsStatedWidth is the deterministic switch. The
+// threshold is computed from the same rule the renderer uses rather than read
+// off an observed rendering, so the test says *why* the form changed.
+func TestTableDegradesToStackedAtItsStatedWidth(t *testing.T) {
+	refs := &mdRefs{}
+	blocks := parseMarkdown(wideTableSrc, refs)
+	if len(blocks) != 1 || blocks[0].kind != mdTable {
+		t.Fatalf("fixture did not parse as one table: %+v", blocks)
+	}
+	tbl := blocks[0].table
+
+	// The narrowest available width that still lays out as a table.
+	narrowest := 0
+	for avail := 1; avail <= 80; avail++ {
+		if _, ok := mdTableWidths(tbl, avail); ok {
+			narrowest = avail
+			break
+		}
+	}
+	if narrowest == 0 {
+		t.Fatal("the fixture never fits, at any width")
+	}
+	fits := stripped(wideTableSrc, narrowest+cols(gutterNone))
+	if !strings.Contains(strings.Join(fits, "\n"), "─") {
+		t.Errorf("at the stated minimum the table did not draw its rule:\n%s", strings.Join(fits, "\n"))
+	}
+	stacked := stripped(wideTableSrc, narrowest-1+cols(gutterNone))
+	joined := strings.Join(stacked, "\n")
+	if strings.Contains(joined, "─") {
+		t.Errorf("one column below the minimum the table still drew a rule:\n%s", joined)
+	}
+	for _, want := range []string{
+		"▪ Name: alpha", "Description:", "supercalifragilistic",
+		"▪ Name: beta", "Description: short",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("the stacked form lost %q:\n%s", want, joined)
+		}
+	}
+	// Records are separated by a blank line, so the row boundary is not a
+	// colour and holds when a cell is empty.
+	if !strings.Contains(joined, "\n\n") {
+		t.Errorf("the stacked form did not separate its records:\n%s", joined)
+	}
+	// Neither fallback is a clipped pipe table.
+	if strings.Contains(joined, "|") {
+		t.Errorf("the stacked form fell back to pipe syntax:\n%s", joined)
+	}
+}
+
+// TestTableSurplusGoesWhereTheDemandIs asserts the allocation directly: at a
+// width between the minimum and the natural sum, both columns grow and neither
+// absorbs the whole surplus.
+func TestTableSurplusGoesWhereTheDemandIs(t *testing.T) {
+	src := "| a | b |\n|---|---|\n| " +
+		strings.Repeat("xx ", 6) + "| " + strings.Repeat("yyyy ", 3) + "|"
+	blocks := parseMarkdown(src, &mdRefs{})
+	tbl := blocks[0].table
+
+	full, ok := mdTableWidths(tbl, 200)
+	if !ok {
+		t.Fatal("the fixture does not fit even at 200 columns")
+	}
+	sum := full[0] + full[1] + mdTableGap
+	avail := sum - 10
+	got, ok := mdTableWidths(tbl, avail)
+	if !ok {
+		t.Fatalf("the fixture stacked at %d columns; it should still lay out", avail)
+	}
+	if got[0]+got[1]+mdTableGap != avail {
+		t.Errorf("widths %v do not spend the %d columns available", got, avail)
+	}
+	minWidths := []int{cellMinWidth(tbl.rows[0][0]), cellMinWidth(tbl.rows[0][1])}
+	for c := range got {
+		if got[c] <= minWidths[c] {
+			t.Errorf("column %d got %d, its minimum is %d: the surplus skipped it",
+				c, got[c], minWidths[c])
+		}
+		if got[c] >= full[c] {
+			t.Errorf("column %d got %d of a %d natural width: it absorbed the whole surplus",
+				c, got[c], full[c])
+		}
+	}
+}
+
+// TestTableCellsSurviveInlineMarkdownAndWideRunes is the corruption criterion:
+// the same fixtures task 073 used for prose, now inside cells. Every produced
+// line has to measure within the pane and every column has to stay aligned.
+func TestTableCellsSurviveInlineMarkdownAndWideRunes(t *testing.T) {
+	src := strings.Join([]string{
+		"| Item | Note |",
+		"|------|------|",
+		"| `go test ./...` | **strong** and *soft* text that is long enough to wrap |",
+		"| 日本語テキスト | 🎉🚀 emoji and 👨‍👩‍👧 a ZWJ sequence |",
+		"| e\u0301x\u0308 | a combining mark |",
+	}, "\n")
+	for _, width := range []int{30, 40, 60, 80} {
+		lines := markdownLines(src, width)
+		for i, l := range lines {
+			if w := ansi.StringWidth(l); w > width {
+				t.Errorf("width %d: line %d is %d columns: %q", width, i, w, l)
+			}
+		}
+		plain := stripped(src, width)
+		if !strings.Contains(strings.Join(plain, "\n"), "`go test ./...`") {
+			t.Errorf("width %d broke the code cell, which is unbreakable:\n%s",
+				width, strings.Join(plain, "\n"))
+		}
+		// Every body line of an aligned table starts its second column at the
+		// same cell, which is the hanging alignment a wrapped cell needs.
+		if !strings.Contains(strings.Join(plain, "\n"), "─") {
+			continue // stacked at this width; alignment is not what it promises
+		}
+		want := -1
+		for _, l := range plain {
+			if !strings.Contains(l, "─") {
+				continue
+			}
+			if want = strings.Index(l, "  ─"); want >= 0 {
+				break
+			}
+		}
+		if want < 0 {
+			t.Errorf("width %d drew a rule with only one column: %q", width, plain)
+		}
+	}
+}
+
+// TestTableNeedsItsDelimiterRow is what keeps prose containing a pipe from
+// becoming a grid.
+func TestTableNeedsItsDelimiterRow(t *testing.T) {
+	for name, src := range map[string]string{
+		"a lone row":        "| a | b |",
+		"a lone rule":       "|---|---|",
+		"prose with pipes":  "run a | b | c to see it",
+		"a mismatched rule": "| a | b |\n|---|",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := strings.Join(stripped(src, 80), "\n")
+			for _, line := range strings.Split(src, "\n") {
+				if !strings.Contains(got, line) {
+					t.Errorf("%q became a table rather than staying a paragraph:\n%s", line, got)
+				}
+			}
+		})
+	}
+}
+
+// TestTableCellsMayLinkAndTheReferenceIsNumberedInOrder proves the two
+// features compose: a link inside a cell is resolved at parse time, so its
+// number follows document order like any other.
+func TestTableCellsMayLinkAndTheReferenceIsNumberedInOrder(t *testing.T) {
+	src := "see [first](https://example.com/a)\n\n| Doc | Where |\n|-----|-------|\n" +
+		"| api | [second](https://example.com/b) |"
+	got := strings.Join(stripped(src, 80), "\n")
+	for _, want := range []string{
+		"first [1]", "second [2]",
+		"[1] https://example.com/a", "[2] https://example.com/b",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing from:\n%s", want, got)
+		}
+	}
+}
+
+// TestTableReflowsFromSource is the resize criterion for the new block kind:
+// a table re-lays out from its Markdown rather than from a drawn grid.
+func TestTableReflowsFromSource(t *testing.T) {
+	wide := strings.Join(markdownLines(wideTableSrc, 80), "\n")
+	narrow := strings.Join(markdownLines(wideTableSrc, 40), "\n")
+	if wide == narrow {
+		t.Fatal("the fixture does not reflow; it proves nothing")
+	}
+	if again := strings.Join(markdownLines(wideTableSrc, 40), "\n"); again != narrow {
+		t.Error("a render after a wider render differed from a fresh one")
+	}
+}
+
+// TestTableMonochromeKeepsHeaderAndRowBoundaries is §15's rule applied to the
+// grid: strip the colour and the header, the rule and every row boundary are
+// still characters.
+func TestTableMonochromeKeepsHeaderAndRowBoundaries(t *testing.T) {
+	got := strings.Join(stripped(tableSrc, 40), "\n")
+	if !strings.Contains(got, "Name") || !strings.Contains(got, "─") {
+		t.Errorf("the header lost its meaning without colour:\n%s", got)
+	}
+	if lines := stripped(tableSrc, 40); len(lines) != 4 {
+		t.Errorf("a two-row table drew %d lines, want a header, a rule and two rows", len(lines))
+	}
+}

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -348,6 +348,11 @@ func padCells(s string, width int) string {
 // pane already does for a long path — truncating would put the tail of a
 // long line out of reach of the TUI entirely, and clipping is what T4.16
 // removed.
+// A preformatted line may carry several segments (task 075): a highlighted
+// code line is one run per token and a reference line is its number plus its
+// destination. They are laid out as one continuous stream of cells — the run
+// boundaries are styling, not layout — so a wrap lands wherever the cell
+// boundary falls, exactly as it did when the line was a single run.
 func wrapPre(pl paneLine, width int) []string {
 	gutterWidth := cols(pl.gutter)
 	avail := width - gutterWidth
@@ -359,44 +364,64 @@ func wrapPre(pl paneLine, width int) []string {
 	if pl.contPrefix != "" {
 		cont = continuationIndent(pl, gutterWidth)
 	}
-	text, style := "", lipgloss.NewStyle()
-	if len(pl.segs) > 0 {
+
+	var (
+		out []string
+		cur strings.Builder
+	)
+	col := 0
+	flush := func() {
+		prefix := cont
+		if len(out) == 0 {
+			prefix = head
+		}
+		out = append(out, prefix+cur.String())
+		cur.Reset()
+		col = 0
+	}
+	for _, seg := range pl.segs {
 		// Tabs are expanded to the four columns lipgloss renders them as.
 		// Measuring the tab and rendering the spaces would disagree —
 		// ansi.StringWidth calls a tab zero columns wide — and a
 		// tab-indented code block would then overflow the pane by exactly
 		// its indentation.
-		text = strings.ReplaceAll(sanitizeText(pl.segs[0].text), "\t", "    ")
-		style = pl.segs[0].style
-	}
-	var out []string
-	for _, src := range strings.Split(text, "\n") {
-		for {
-			chunk := src
-			if cols(src) > avail {
-				chunk = ansi.Cut(src, 0, avail)
+		text := strings.ReplaceAll(sanitizeText(seg.text), "\t", "    ")
+		for i, src := range strings.Split(text, "\n") {
+			if i > 0 {
+				flush()
 			}
-			if chunk == "" && src != "" {
-				// A single grapheme wider than the pane: emit it whole
-				// rather than spin, since cutting it produces nothing.
-				chunk = src
+			for src != "" {
+				room := avail - col
+				if room <= 0 {
+					flush()
+					room = avail
+				}
+				chunk := src
+				if cols(src) > room {
+					chunk = ansi.Cut(src, 0, room)
+				}
+				if chunk == "" {
+					// A single grapheme wider than the room left. Take the
+					// next line if there is one to take, and otherwise emit
+					// it whole rather than spin, since cutting it produces
+					// nothing.
+					if col > 0 {
+						flush()
+						continue
+					}
+					chunk = src
+				}
+				cur.WriteString(seg.style.Render(chunk))
+				col += cols(chunk)
+				rest := ansi.TruncateLeft(src, cols(chunk), "")
+				if rest == src {
+					break
+				}
+				src = rest
 			}
-			prefix := cont
-			if len(out) == 0 {
-				prefix = head
-			}
-			line := prefix
-			if chunk != "" {
-				line += style.Render(chunk)
-			}
-			out = append(out, line)
-			rest := ansi.TruncateLeft(src, cols(chunk), "")
-			if rest == "" || rest == src {
-				break
-			}
-			src = rest
 		}
 	}
+	flush()
 	return out
 }
 


### PR DESCRIPTION
## Summary

Tables, inline links and inline images join the assistant-prose Markdown subset
task 073 wrote down, and a fenced code block gains its declared language and a
tint. Everything is client-side in `internal/tui`: no daemon package, no API
route, no store migration. §13.3's chunks and the JSONL transcript keep the
agent's bytes exactly, and `agent.output` in both workspaces plus the chat's
§17 retention fallback remain the only two doors.

**Tables.** Recognized only with the delimiter row, so prose containing a `|`
stays a paragraph. Layout is arithmetic rather than a heuristic, which is what
makes the outcome reproducible at every width: each column has a *natural*
width (its widest cell) and a *minimum* width (its widest unbreakable token — a
cell that is a single inline-code span is unbreakable whole). Σ natural ≤
available draws natural widths; Σ minimum ≤ available < Σ natural gives every
column its minimum and shares the surplus **in proportion to each column's
remaining demand**; below that, each row becomes a stacked `column: value`
record opened by `▪` and separated by a blank line. Neither fallback is a
clipped pipe table and neither is a second scrolling axis — the issue rejects
both, and the arithmetic exists so neither is needed. A table cannot go through
`wrapLine`, which lays out one `paneLine` in one dimension, so it has its own
block kind and its own renderer.

**Links and images.** A link's label renders as ordinary prose carrying a dim
`[n]`, and the message ends with a preformatted block of `[n] dest` lines — one
per distinct destination, numbered per message, identical destinations sharing a
number. An image renders its alt text as the link-shaped item and its source as
the reference. Destinations are printed literally whatever their scheme.
**No OSC 8 is emitted, nothing is fetched and nothing is opened**, so "unsafe
schemes are never executed" holds structurally rather than by a filter;
`openURLCmd`'s existing http/https-only refusal is untouched and is not reached
from this path.

**Code blocks.** The info string's first word is drawn as a dim header at the
block's rail. Body lines are tinted by a vincent-owned coarse token scanner over
a written-down language list, with a plain fallback for everything else. It
emits **styles and never characters**: strip the escapes from a rendered block
and you have the fence's content byte for byte, which is what makes
"highlighting must not change copying or transcript contents" checkable rather
than asserted. `wrapPre` became multi-segment to carry the runs, still measuring
plain and re-opening a style run per produced line — task 073 decision 2's
wrap-plain-then-style invariant is untouched by all three features.

Reference links, autolinks, bare URLs and titled links stay literal per decision
4, and `TestMarkdownOutsideTheSubsetStaysLiteral` now names them instead of the
constructs that moved in. The issue's "give bare URLs a compact presentation" is
therefore discharged as literal rendering — a bare URL displays as exactly
itself — which is stated in the spec rather than left implicit.

`docs/spec.md` §15's task-073 amendment is amended in place with a dated note
(the subset list, three new bullets for the table rule, the reference block and
styles-only highlighting), and §16 gains the OSC 8 consequence.

## Related

Closes #290
Closes 074

Follows [073](../docs/tasks/073-assistant-markdown-in-output.md), which named
tables and link interaction as its stated follow-ups. It relitigates nothing:
073's decisions 2, 5 and 7 survive unamended, and the two parts of the issue
that would have strained them — chroma-grade highlighting and OSC 8 — are
recorded as decisions 1 and 3 in `docs/tasks/074-rich-markdown-blocks.md` with
the alternatives they beat.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — `markdowntable_test.go` and
      `markdownhighlight_test.go` are new; `markdown_test.go` gained the link,
      image, unsafe-scheme and both-doors cases and had its boundary test
      amended. `internal/tui` is covered by no gate script, so the tests are the
      whole assurance, as they were for 073.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
      and 073's own unreleased entry was corrected, since it listed tables and
      links as literal in the same release.
- [x] Affected page under `docs/` updated — `guides/tui.md` (the pane's Markdown
      paragraph), `security-model.md` (the link/image posture), `features.md`,
      `spec.md` §15 and §16, and `tasks/074-rich-markdown-blocks.md` with its
      index row.

`scripts/screenshots.sh` was deliberately **not** re-run, and the reason was
checked rather than assumed: `cmd/fakeagent` emits no fence, no `[label](dest)`
and no delimiter row, and the script seeds nothing else into an assistant
message, so no `docs/assets/tui-*.png` photographs a panel this change alters.
Extending the seed to show the feature would mean regenerating the shots with
the script, never drawing them.

## Documentation audit

The documentation was audited separately after the implementation landed. Every
derivation `CLAUDE.md` names was checked one at a time and one defect was found
and fixed:

- `CHANGELOG.md` — the edit that restated task 073's literal list left the
  sentence after it unwrapped at 112 columns. Rewrapped; no claim changed.

Nothing else was stale. `internal/config`, the cobra tree, `internal/api`'s
route table, `internal/tui/bindings.go`, the `Reason*` constants, the
`internal/workflow`/`internal/taskrun` step types and `internal/agent/*` are all
untouched by this change, so `reference/configuration.md`, `reference/cli.md`,
`reference/api.md`, the tui key tables, the block-reason tables,
`reference/workflow-schema.md`, `reference/task-lifecycle.md` and
`guides/agents.md` were already true. No gate walks the output pane's Markdown,
and `skills/vincent-workflows/SKILL.md` is untouched because the workflow schema
did not move — `vincent workflow validate` and `vincent workflow render` are
green over all three of this repository's `.vincent/workflows/*.yaml`. The
prose claims in `guides/tui.md`, `features.md`, `security-model.md` and
spec §15/§16 were each read back against the source that makes them true
(`mdTableGap = 2`, the `▪` stacked marker, the faint `[n]` reference registry,
`fenceOpen`'s first-word info string, the plain-language fallback, and the
single `sanitizeText` chokepoint in `renderMarkdown`). No bug in the change
itself was found.
