### PR TITLE
Add a raw view and copy actions for assistant Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,14 +80,6 @@ list with the user-facing context a commit subject cannot carry.
   palette had been unreachable from the chat workspace since it landed. `ctrl+p`
   is hoisted above the input-capture gate the way `ctrl+v` already is, and works
   everywhere `:` does.
-
-### Fixed
-
-- **Palette entries for `ctrl+`-modified keys did nothing.** Running one
-  replays its direct key, and the replay had a hand-written case per ctrl key
-  that had fallen a registry behind — the chat's `ctrl+r` (detail level) and
-  `ctrl+g` (follow the live end) both replayed as a bare `c`. Any
-  `ctrl+<letter>` is now synthesized by rule.
 - **Assistant prose renders as Markdown in the task output pane and in chats.**
   Headings, emphasis, strong text, ordered and unordered lists, nested lists,
   blockquotes, inline code, fenced code and horizontal rules become terminal
@@ -647,6 +639,11 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **Palette entries for `ctrl+`-modified keys did nothing.** Running one
+  replays its direct key, and the replay had a hand-written case per ctrl key
+  that had fallen a registry behind — the chat's `ctrl+r` (detail level) and
+  `ctrl+g` (follow the live end) both replayed as a bare `c`. Any
+  `ctrl+<letter>` is now synthesized by rule.
 - **The output pane measures terminal cells rather than runes.** A line
   containing an emoji, a CJK glyph, a combining mark or a ZWJ sequence was
   measured by counting runes, so the pane over- or under-filled it and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,25 @@ list with the user-facing context a commit subject cannot carry.
   with a plain fallback for the rest; the tint is styling only, so stripping it
   gives back the agent's bytes exactly. Reference links, autolinks, bare URLs
   and titled links stay literal. Spec §15, §16.
+- **Rendered/raw toggle and copy actions for assistant Markdown.** `ctrl+o`
+  swaps the rendered view for the stored Markdown in both the task output pane
+  and the chat workspace — one session-wide choice, shared by the two, nothing
+  persisted — and `ctrl+y` opens a copy picker offering each assistant message
+  as its Markdown, as plain text with the punctuation gone, and each fenced code
+  block on its own without its fence or language label. Payloads are built from
+  the source rather than from what is drawn, so the pane's width is never baked
+  into what you paste, and they are stripped of escape sequences and control
+  characters on the way out. The system clipboard is tried first and the
+  terminal's own OSC 52 second, which is the one that works over SSH; the notice
+  says which ran and never claims an unverified copy. A plain-text copy keeps
+  each link's `[1]` marker and the `[1] https://…` block that resolves it, so a
+  destination survives the punctuation being stripped; copying one on its own is
+  still a follow-up.
+- **`ctrl+p` opens the command palette from a text field.** `:` is a printable
+  key, so in a chat it typed a colon into the draft and opened nothing — the
+  palette had been unreachable from the chat workspace since it landed. `ctrl+p`
+  is hoisted above the input-capture gate the way `ctrl+v` already is, and works
+  everywhere `:` does.
 - **Assistant prose renders as Markdown in the task output pane and in chats.**
   Headings, emphasis, strong text, ordered and unordered lists, nested lists,
   blockquotes, inline code, fenced code and horizontal rules become terminal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ list with the user-facing context a commit subject cannot carry.
   palette had been unreachable from the chat workspace since it landed. `ctrl+p`
   is hoisted above the input-capture gate the way `ctrl+v` already is, and works
   everywhere `:` does.
+
+### Fixed
+
+- **Palette entries for `ctrl+`-modified keys did nothing.** Running one
+  replays its direct key, and the replay had a hand-written case per ctrl key
+  that had fallen a registry behind — the chat's `ctrl+r` (detail level) and
+  `ctrl+g` (follow the live end) both replayed as a bare `c`. Any
+  `ctrl+<letter>` is now synthesized by rule.
 - **Assistant prose renders as Markdown in the task output pane and in chats.**
   Headings, emphasis, strong text, ordered and unordered lists, nested lists,
   blockquotes, inline code, fenced code and horizontal rules become terminal

--- a/docs/features.md
+++ b/docs/features.md
@@ -222,7 +222,11 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   never opened or turned into a terminal hyperlink; a fenced block shows its
   language and is tinted with styling only. Every marker is a glyph rather than
   a colour, so a monochrome terminal keeps every distinction, and the
-  transcript on disk keeps the agent's exact bytes.
+  transcript on disk keeps the agent's exact bytes. One key swaps the rendered
+  view for the stored Markdown when a render surprises you, and another opens a
+  picker that puts a message, its plain text, or a single fenced code block on
+  the clipboard — built from the source, so the pane's width is never baked
+  into what you paste.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -341,6 +341,8 @@ output. It is the sentence that decides whether to open the transcript.
 | `←`/`→` or `h`/`l` | On Output, select which attempt's output to show |
 | `f` or `G` | Follow the live output again |
 | `v` | More or less detail: compact → normal → verbose (reasoning, the run's own metadata, then unrecognized lines) |
+| `ctrl+o` | Show the assistant's original Markdown instead of the rendered view |
+| `ctrl+y` | Copy an assistant message, its plain text, or one of its code blocks |
 | `e` | Open this attempt's **whole** transcript in `$EDITOR` |
 | `↑`/`↓` | Select an attempt or Task Details section, scroll Output, or move between diff files — according to the active tab |
 | `pgup`/`pgdn` | Scroll the selected Task Details section |
@@ -392,6 +394,38 @@ resizing the terminal re-renders from those rather than reflowing what was
 already drawn.
 
 The chat workspace's conversation body is this same pane, at the same level.
+
+### Seeing the source, and taking it away
+
+`ctrl+o` swaps the rendered view for the **stored Markdown**, exactly as the
+agent wrote it — `#` back on the headings, backticks back on the fences. It is
+the escape hatch for a render that surprised you, and it is a display state and
+nothing more: the records, the live tail, the level and the transcript on disk
+are untouched. Like `v`'s level, it is one choice for the whole session and
+shared with the chat workspace — set it in either place and both follow — and it
+is gone when you quit. The pane's title says `raw` while it is on.
+
+`ctrl+y` opens a **copy picker**: a searchable list of what can be taken out of
+the assistant prose on screen, newest message first.
+
+| Row | Puts on the clipboard |
+|---|---|
+| `markdown` | The message as the agent wrote it |
+| `plain text` | The same structure with the punctuation gone — headings as their own line, `•` list markers, quotes prefixed, fences dropped |
+| `code block` | One fenced block's contents, with no fence and no language label, whitespace and tabs kept |
+
+Payloads come from the source, not from what is drawn, so the pane's width never
+ends up baked into what you paste, and nothing that arrives after you open the
+picker moves the row you are pointing at. Escape sequences and control
+characters are stripped on the way out for the same reason they are stripped on
+the way in: a clipboard gets pasted into a terminal.
+
+vincent tries your system clipboard first and, if that refuses, hands the text
+to your terminal over OSC 52 — which is the one that works over SSH. The notice
+says which happened, and never claims a copy it could not verify.
+
+Copying a link's destination is not here yet: links still render as the
+characters the agent sent, so there is no destination for the picker to offer.
 
 ### What `v` adds
 
@@ -1103,6 +1137,8 @@ them, and a composer at the bottom.
 | `ctrl+x` | Stop the running turn — its process tree is killed |
 | `ctrl+r` | How much of the conversation to show: compact → normal → verbose |
 | `ctrl+t` | Hand the worktree and branch to a new task — the chat ends |
+| `ctrl+o` | Show the assistant's original Markdown instead of the rendered view |
+| `ctrl+y` | Copy an assistant message, its plain text, or one of its code blocks |
 | `pgup` / `pgdown` | Scroll the conversation |
 | `ctrl+g` | Jump to the live end and follow it again |
 | `esc` | Back to the chats board |
@@ -1244,9 +1280,13 @@ reading.
 
 ## The command palette
 
-`:` opens it. Everything reachable in the TUI is in there by name — navigation
-to every screen, and every task action the daemon currently offers. Type to
-filter, `enter` to run, `esc` to close.
+`:` opens it — or `ctrl+p`, which works everywhere `:` does *and* while a text
+field has the keyboard. In a chat the composer takes every printable key, so
+there `:` types a colon into your draft and `ctrl+p` is the way in.
+
+Everything reachable in the TUI is in there by name — navigation to every
+screen, and every task action the daemon currently offers. Type to filter,
+`enter` to run, `esc` to close.
 
 The palette exists so the takeover screens do not need memorized number keys. If you cannot remember a binding, `:` and `?` are the two keys worth
 knowing.
@@ -1262,6 +1302,7 @@ Global bindings — active whenever the focused surface is not capturing text:
 | Key | Does |
 |---|---|
 | `:` | Command palette |
+| `ctrl+p` | Command palette, also while a text field has the keyboard |
 | `?` | Toggle help |
 | `tab` / `shift+tab` | Move between task tabs; on the board filter, commit it |
 | `!` | Jump to the next task needing a human |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -202,7 +202,16 @@ emitted.
 
 The same holds for the Markdown rendering of assistant prose: it is a fixed
 subset drawn with vincent's own glyphs, and raw HTML is rendered as the
-characters the agent sent — never parsed, fetched or executed.
+characters the agent sent — never parsed, fetched or executed. The
+[rendered/raw toggle](guides/tui.md#seeing-the-source-and-taking-it-away) is
+bound by it too: raw mode shows the agent's bytes as Markdown *source*, not as
+terminal input.
+
+It holds on the way out as well. What the copy actions put on the clipboard is
+stripped on the same terms as what is drawn, so "copy the original Markdown"
+means the stored Markdown minus escape sequences and C0/C1 controls. A
+clipboard is pasted into a terminal, which is precisely the boundary this rule
+exists to hold.
 
 Links and images in that prose are text and nothing more. A link's label is
 prose and its destination is printed literally, whatever its scheme, in a

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6868,16 +6868,60 @@ every other record stays literal.
 - **Rendering is derived and never stored.** The JSONL transcript and every API
   payload keep the agent's exact bytes (§13.3), no render path mutates a
   record, and a resize re-renders from the Markdown rather than re-wrapping
-  previously rendered ANSI. A raw/rendered toggle and a copy-raw reader action
-  are follow-ups, and so is a link picker, which the reference numbering is
-  what a later action would address; the chat composer owns every letter key
-  (task 071 decision 4), so a toggle needs its own decision about which key it
-  is.
+  previously rendered ANSI. A link picker is still a follow-up: the reference
+  numbering is what a later action would name.
+
+*Amended 2026-09-01 (task 076).* The reader can see the source and take it
+away. Both actions are client-side and session-scoped; nothing about them is
+persisted, sent to the daemon or written to a transcript.
+
+- **`ctrl+o` toggles rendered/raw** for assistant prose, in the task
+  workspace's output pane and the chat workspace alike. Raw shows the stored
+  Markdown as source — one pane line per source line, preformatted, hard-wrapped
+  at the pane's edge, no parse — and it is what the §17 retention fallback shows
+  too. The choice is **one session value shared by both workspaces**, held the
+  way the verbosity level beside it is and persisted no more than that: moving
+  between the two panes, or between tasks, never resets it. Raw is presentation
+  only — it does not touch the records, the streaming offset, the level, the
+  transcript, follow mode, or any task or chat state — and it still goes through
+  §16's stripping (below).
+- **`ctrl+y` opens the copy picker**, a popup listing what can be copied out of
+  the assistant prose currently loaded, newest first: per document its
+  **Markdown** (the stored text) and its **plain text** (the pane's structure
+  with the punctuation gone — headings as their own line, the pane's own list
+  markers, blockquotes prefixed, fences dropped), plus one row per **fenced code
+  block** (its interior, no fence and no info string, whitespace kept). Every
+  payload is built from the source, never from rendered lines, so a copy made at
+  width 40 and one made at width 200 are byte-identical. Each row captures its
+  text **when the popup is built**, which is what keeps a target stable across a
+  resize, a transcript reload and incremental rendering: there is no index left
+  to drift.
+- **The clipboard has two transports, and the notice says which ran.** The
+  system clipboard is tried first because its answer can be trusted; when it
+  refuses, the text is handed to the terminal over OSC 52, which is the correct
+  destination over SSH but reports nothing back. So a copy reads "copied" only
+  when it was verified, and otherwise says it was sent to the terminal and names
+  the system clipboard's error. A payload that sanitizes away to nothing is an
+  error, not a silent no-op.
+- **Link actions are still not here.** The renderer grew links while this was
+  in flight (task 075), so what is missing is no longer the construct but a way
+  to say *which* reference a reader means — the same targeting problem the
+  picker answers for documents and fences, and the one the numbering above was
+  written to leave open. Copying a destination, inspecting one and opening one
+  are that follow-up's. What the payloads do owe the numbering is to carry it:
+  a plain-text copy keeps each `[n]` and ends with the same `[n] dest` block
+  the pane draws, because a destination stripped of both its punctuation and
+  its reference would be a destination deleted.
+- **Both keys are ctrl-modified in both contexts**, unlike the `v`/`ctrl+r`
+  split task 071 chose: one action should have one name in the help overlay and
+  the palette. A bare letter cannot work in a chat, where the composer owns
+  every printable key.
 
 Views 3–7 stay full-screen because they are forms and lists, not observations: the
 new-task flow is eight fields with pickers, and squeezing it beside a live tail
 serves neither. Takeovers are for surfaces you visit deliberately; popups are
-for what interrupts you — the palette, confirmations, and the three form popups.
+for what interrupts you — the palette, confirmations, the three form popups and
+the copy picker.
 *(Amended 2026-08-30, task 063: the dividing line is the interruption, not the
 size. A form popup with a tab strip takes the whole height budget and carries
 the task inspector inside it, and is no longer a small thing.)*
@@ -7017,6 +7061,13 @@ holding the same invariant the action bar always had: an action that cannot happ
 is not on screen. Navigation living here is what lets view-switching keys be
 retired without substituting a different set to memorise.
 
+*Amended 2026-09-01 (task 076).* **`ctrl+p` opens the same palette**, and it is
+hoisted above the input-capture gate the way `ctrl+v` is. `:` is a printable
+key, so on a surface that owns the keyboard — the chat composer, a filter — it
+types a colon into the draft and opens nothing; the palette is this section's
+"what can be done right now" surface, and it must be reachable from everywhere,
+not only from a resting list.
+
 **The footer is one line and never wraps.** Left to right: the focused panel's
 keys (at most five, in registry priority order), then the task's
 `available_actions`, then — pinned right and never truncated — `: commands`,
@@ -7028,7 +7079,7 @@ narrow terminal dropping it would fail exactly when the human is most lost.
 
 ### Keys
 
-Global: `:` palette · `?` help · `n` new task · `q` quit (the daemon keeps running;
+Global: `:` palette (`ctrl+p` where a text field has the keyboard) · `?` help · `n` new task · `q` quit (the daemon keeps running;
 a status line reminds of the running task count on exit) · `tab`/`shift+tab` move
 focus between panels · `M` toggle mouse.
 
@@ -7193,10 +7244,17 @@ currently true to show (§15 view 6).
 
 - **Trust boundary = the OS user.** API on loopback only + bearer token file (0600)
   so other local users can't drive the daemon. No TLS, no accounts in v1.
-- **Agent text cannot drive the terminal (task 073, added 2026-09-01).** Every
-  record's text is stripped of ANSI escape sequences and of C0/C1 control
-  characters before the output pane measures or draws it — newline and tab
-  excepted, which the pane renders itself. Only vincent's own styles are
+- **Agent text cannot drive the terminal (task 073, added 2026-09-01;
+  extended 2026-09-01 by task 076).** Every record's text is stripped of ANSI
+  escape sequences and of C0/C1 control characters before the output pane
+  measures or draws it — newline and tab excepted, which the pane renders
+  itself. **What is put on the clipboard is stripped on the same terms**: a
+  clipboard is pasted into a terminal, which is precisely the boundary this
+  rule exists to hold, so "copy the original Markdown" means the stored
+  Markdown minus escape sequences and C0/C1 controls. The rendered/raw toggle
+  is bound by it too — raw mode shows the agent's bytes as Markdown *source*,
+  not as terminal input, and is an escape hatch for a surprising render rather
+  than a hole in the one chokepoint. Only vincent's own styles are
   emitted. Without this an agent, or anything an agent chose to echo, could
   clear the screen, move the cursor, rewrite the window title or overwrite
   adjacent UI with a `\x1b[2J` or an OSC sequence in a tool result summary, a

--- a/docs/tasks/076-reader-actions-on-assistant-markdown.md
+++ b/docs/tasks/076-reader-actions-on-assistant-markdown.md
@@ -241,6 +241,10 @@ holds them, plus four registry probes in `bindings_test.go`:
   and it survives opening a fresh view.
 - Injection fixtures produce no ESC and no C0/C1 in raw mode, and no line wider
   than the pane.
+- Task 075's blocks reach the clipboard as the pane's structure: a table as the
+  stacked `column: value` records, a link as its label plus the `[n]` the pane
+  gave it, with the reference block closing the payload and one number for one
+  destination.
 - Markdown copy is the record's stored text; plain-text copy carries no `#`, `*`
   or backtick and no ANSI; code-block copy has neither fence nor info string and
   keeps interior whitespace and tabs; every payload is sanitized.

--- a/docs/tasks/076-reader-actions-on-assistant-markdown.md
+++ b/docs/tasks/076-reader-actions-on-assistant-markdown.md
@@ -260,7 +260,13 @@ holds them, plus four registry probes in `bindings_test.go`:
   chat's hand-written footer line.
 
 The existing `TestPaletteReachesEveryRegistryEntry` covers the new rows'
-palette reachability in both contexts without a new test.
+palette reachability in both contexts without a new test — but only that they
+are *listed*. Running one exposed a standing defect: `synthKey`, which replays a
+palette entry's direct key, had a hand-written case per ctrl key and was already
+a registry behind, so `ctrl+r` and `ctrl+g` — both `ctxChat` rows the palette
+lists — replayed as a bare `c`. It is now a rule over any `ctrl+<letter>` rather
+than a list, and `TestPaletteRunsTheReaderActions` holds both the synthesis and
+the whole palette → replay → effect path.
 
 ## Left open
 

--- a/docs/tasks/076-reader-actions-on-assistant-markdown.md
+++ b/docs/tasks/076-reader-actions-on-assistant-markdown.md
@@ -1,0 +1,277 @@
+# 076 — Reader actions on assistant Markdown
+
+**Status:** ✅ done (1/1)
+**Issue:** #292
+**Amends:** §15's task 073 amendment, §15's command-palette and popup
+paragraphs, and §16's terminal-injection item
+**Follow-up to:** [073](073-assistant-markdown-in-output.md), whose decision 4
+parked this work by name
+
+Rendered Markdown improves readability, but a terminal conversation also needs
+a way to inspect and act on the original: an ANSI-styled pane is a poor
+clipboard format, and a surprising render needs an immediate source escape
+hatch. Task 073's §15 amendment said as much — "a raw/rendered toggle key and a
+copy-raw action are both plausible and both belong in the follow-up issues
+already scoped — a toggle in particular needs its own decision, because the
+chat composer holds every letter key". This is that follow-up, and this is its
+decision.
+
+The work is entirely client-side and lands in `internal/tui` alone: no daemon
+package, no API route, no store migration — the same shape task 073 argued for
+and for the same reason. §13.3's chunks and the JSONL transcript already keep
+the agent's exact bytes, and width, theme and clipboard are things only the
+client knows.
+
+## Decisions
+
+### 1. Link actions are not in this task
+
+Copy-link-destination, inspect-destination and open-link move to a follow-up.
+
+The reason changed while this was in flight and the decision did not. It was
+written against a renderer with no link construct at all, whose parsing
+**#290** owned; #290 has since landed as [075](075-rich-markdown-blocks.md),
+so a link *is* an entity now — a label carrying a dim `[n]`, resolved by a
+reference block at the end of the message. What is still missing is the half
+this task would have had to build either way: a way to say *which* `[n]` a
+reader means. That is the same targeting problem decision 6 answers for
+documents and fenced blocks with a captured-at-pick-time popup, and task 075
+named it in §15 in those words — "the numbering is what a later reader action
+would name". Adding a third row type to the picker for it is a small change on
+top of what lands here, and it is a change with its own decisions: whether a
+destination is offered per message or per link, and what an action does with a
+scheme `openURL` refuses.
+
+The infrastructure that follow-up needs already exists and is untouched:
+`openurl.go` + `openurl_{darwin,unix,windows}.go` validate the scheme
+(`http`/`https` only), pass the URL as a separate argv element and never
+through a shell, bound the helper at 10 s, and fail visibly. That is already
+the issue's "open allowed HTTP(S) links with a platform-native launcher" and
+"unsupported URI schemes remain visible but cannot be launched", written for
+task 052.6.
+
+**Consequence for the issue's acceptance criteria:** criteria 4 and 5 (link
+inspection and opening; unsupported schemes) and the link half of criteria 3
+and 8 are not discharged here. They move to the follow-up.
+
+What this task does owe #290 is that the payloads carry what the pane shows:
+the plain-text payload keeps a link's `[n]` and ends with the same `[n] dest`
+reference block, because a destination stripped of its punctuation and of its
+reference would be a destination deleted (decision 5).
+
+### 2. Raw is a session-level value, held the way the verbosity level is
+
+A `rawHolder` created in `newViews` beside the existing `levelHolder`, pointed
+at by both `newDetail` and `newChatView` — [071](071-chat-workspace-verbosity.md)
+decision 3's shape exactly. Nothing is persisted: no `tui.json` entry, no
+`tui:` config key, matching what §15 already reasons for the level. Toggling in
+one workspace is visible in the other.
+
+The flag rides into the renderer on `lineOpts`, which already exists as
+`outputLines`' carrier for pane-specific display choices (071 decision 2). Two
+call sites branch on it, through one `assistantLines` helper: the `agent.output`
+record in `outputlines.go`, and §17's retention fallback in `chatrender.go`.
+Nothing else changes, because nothing else was ever interpreted (073
+decision 5).
+
+Raw mode is presentation only. It does not touch `records`, `nextOffset`, the
+verbosity level, the transcript, follow mode, or any task or chat state.
+
+*Beat:* a per-document override. §15's reason for the level being session state
+— moving around should not reset what a reader chose to see — applies unchanged,
+and per-document state needs the identity model #291 owns.
+
+### 3. Raw still goes through the pane's sanitizer
+
+Raw renders the stored Markdown through the existing literal path —
+`wrapLine`/`wrapPre`'s segment emission, where §16's ANSI/C0/C1 stripping
+lives — one pane line per source line, preformatted so leading whitespace
+survives.
+
+"Exact stored Markdown" means the agent's bytes as Markdown *source*, not the
+agent's bytes as terminal input. Raw mode is the escape hatch for a surprising
+*render*; it is not a hole in the one chokepoint §16 was added to guarantee.
+
+### 4. Clipboard payloads are sanitized too, and carry no pane wrapping
+
+The issue asks for both "copy an assistant document as its original Markdown"
+and "never place terminal ANSI sequences on the clipboard". Those conflict for
+an agent that emitted `\x1b[2J` inside its prose, and §16 settles it: every
+clipboard payload goes through the same `sanitizeText` chokepoint, in
+`writeClipboardCmd` rather than at each call site. A clipboard is pasted into a
+terminal, which is precisely the boundary §16 exists to hold. "Original
+Markdown" therefore means the stored Markdown minus escape sequences and C0/C1
+controls — a definition the whole feature is already committed to.
+
+Payloads are also built from the **source**, never from rendered lines, so a
+copy made at width 40 and one made at width 200 are byte-identical. The pane's
+hard wraps are a property of the pane.
+
+### 5. Three copy payloads, and one parse feeds three emitters
+
+- **Markdown** — the record's stored text, sanitized.
+- **Plain text** — the parsed block tree emitted unstyled and unwrapped:
+  headings as their own text, list items with the pane's own `• `/`◦ `/`▪ `
+  markers and their nesting indent, blockquotes prefixed, fenced code as its
+  interior lines. This is "rendered structure without Markdown punctuation"
+  read as *the structure the pane draws*, minus lipgloss and minus width.
+  Task 075's two new blocks follow that reading rather than getting a rule of
+  their own: a **table** emits as the stacked `column: value` records
+  `renderMDTableStacked` draws, because that is the form that does not depend
+  on a width, and a **link** keeps the `[n]` the pane gave it with the same
+  `[n] dest` block closing the payload.
+- **Fenced code block** — the block's interior lines verbatim, with no fence
+  and no info string, whitespace and tabs preserved.
+
+`mdBlock` was extended to carry its **source** (depth, marker, text) beside the
+laid-out `paneLine`s, so that all three emitters and the picker's fenced-block
+scan read one parse. A block that had *only* become styled segments could serve
+the pane alone: recovering "the text without its punctuation" from a rendered
+line means unpicking lipgloss, which is the wrong direction. Layout stays at
+parse time rather than moving into the emitters because parse order is where
+task 075 numbers a link's destination, and a message's numbering has to follow
+document order — a table, whose cells are resolved to segments at parse time,
+would otherwise be numbered before prose that precedes it. Inline spans are the
+same one scanner — `inlineSegments` already emits emphasis with its marks gone
+and a link as its label plus `[n]`, so the only thing left to undo is the code
+span's backticks, which a new `segment.code` flag marks.
+
+*Beat:* a second inline parser for the plain payload. Two answers to "is this
+emphasis" is exactly the drift the single registry and the single renderer exist
+to prevent.
+
+### 6. Targets are picked from a popup, and captured at pick time
+
+The output pane is a `viewport.Model` over rendered `[]string`. It has no
+cursor, no selection and no block identity — `markdownLines` returns strings and
+`apiclient.TranscriptRecord` carries no id.
+
+So `ctrl+y` opens a popup listing what can be copied from the records currently
+loaded, newest first: two rows per assistant document and one per fenced block,
+with a search input over them. It follows `palette.go` and its `m.palette != nil`
+handling in `root.go` — a short-lived popup that owns the keyboard, top of the
+§15 esc stack — and is dormant until asked for.
+
+Each row **captures its source text when the popup is built**, rather than
+holding an index into `records`. That answers the issue's "targets remain stable
+across resize, transcript reload and incremental rendering" outright, with no
+identity model: there is no index left to drift when a chunk arrives, a resize
+re-renders, or the chat's `maxRecords` cap prunes the front of the slice.
+
+*Beat:* a semantic `(turn, document, block)` identity — which is what **#291**
+is for. When #291 lands its document model the picker's rows become references
+to it; nothing in the copy payloads changes.
+
+*Beat:* a block cursor with `tab`/`shift+tab` in the pane — rejected by the
+issue's own alternatives ("make every code block permanently focused … adds
+heavy navigation state to ordinary reading").
+
+### 7. The palette gets `ctrl+p`, because it does not exist in a chat today
+
+The issue says to prefer the command palette in chat. There was no palette in
+chat: `chatView.capturesInput()` is true whenever the composer is focused, and
+`root.updateKey` hands a capturing view every key but `ctrl+c`, so `:` types a
+colon into the draft and opens nothing (071 decision 4).
+
+`ctrl+p` is therefore hoisted above the input-capture gate in `root.updateKey`,
+alongside the `ctrl+v` paste that is already hoisted for the same reason, and
+opens the palette in both workspaces. This is a real fix beyond this issue — the
+palette is §15's "what can be done right now" surface, and the chat workspace
+has been unable to reach it since task 067 — and it is what discharges the
+issue's "every action is reachable through keyboard help/palette in both
+contexts".
+
+Two direct keys sit on top, registered in `ctxOutput` and `ctxChat`:
+**`ctrl+o`** toggles rendered/raw and **`ctrl+y`** opens the copy picker. Both
+are ctrl-modified in both contexts rather than a letter in `ctxOutput` and a
+ctrl twin in `ctxChat` (the `v`/`ctrl+r` split task 071 chose) — one action
+should have one name in the help overlay and the palette, and the existing split
+is a cost, not a model. `ctrl+o` and `ctrl+y` were free in both contexts;
+`ctrl+o` is bound only in the create-PR form, which is a popup neither key can
+be pressed under.
+
+### 8. Two clipboard transports, and only one of them can be believed
+
+`github.com/atotto/clipboard` is already a direct dependency (`clipboard.go`
+reads with it) and returns a real error, which is what the "visible
+success/failure notice" criterion needs. It is also wrong over SSH — with
+`xclip` installed on the remote box it succeeds against the *remote* display.
+`tea.SetClipboard` is OSC 52: terminal-native, correct destination over SSH, no
+helper binary, and fire-and-forget with no failure signal.
+
+So: `WriteAll` first, OSC 52 on its error, and a notice that says which
+happened — "copied" for the verified path, "sent to the terminal" for the
+unverified one.
+
+**Amendment to the brief.** The brief asked for a third notice, "failure of both
+naming the error". OSC 52 cannot report failure — the brief says so itself — so
+that state is not representable, and a notice claiming it would be a guess. The
+fallback's notice **names the system clipboard's error inline** instead
+("… sent to the terminal — the system clipboard refused (exec: "xclip": not
+found)"), which carries the same information at the moment it is known. The
+third outcome that *is* real — a payload that sanitizes away to nothing — is an
+error notice rather than a silent no-op, following `openurl.go`'s posture that a
+key press a human made must never fail silently.
+
+The write is indirected through a package variable the way `openURL` is, so the
+seam is asserted without a system clipboard.
+
+## Tasks
+
+- [x] **076.1** Rendered/raw toggle, copy picker, `ctrl+p` palette hoist ✓ 2026-09-01
+
+**Done when:** `ctrl+o` toggles raw in both workspaces off one shared session
+value; `ctrl+y` picks and copies Markdown, plain text and fenced blocks with a
+visible notice; `ctrl+p` opens the palette while the chat composer holds focus
+and the composer still receives every printable key; §15, §16 and
+`docs/guides/tui.md` say so.
+
+## What the tests prove
+
+`internal/tui` is covered by no gate script, so the hermetic tests are the whole
+assurance — task 073's position, unchanged. `internal/tui/readerpicker_test.go`
+holds them, plus four registry probes in `bindings_test.go`:
+
+- The same assistant document renders identically raw in the task pane and the
+  chat at several widths, keeps its punctuation, and wraps within the pane at
+  narrow widths.
+- Toggling raw mutates no `apiclient.TranscriptRecord`, does not move
+  `nextOffset`, does not disturb the verbosity level and does not drop follow.
+- Raw is one shared session value: toggling in one view is visible in the other,
+  and it survives opening a fresh view.
+- Injection fixtures produce no ESC and no C0/C1 in raw mode, and no line wider
+  than the pane.
+- Markdown copy is the record's stored text; plain-text copy carries no `#`, `*`
+  or backtick and no ANSI; code-block copy has neither fence nor info string and
+  keeps interior whitespace and tabs; every payload is sanitized.
+- Every payload is identical at width 40 and width 200.
+- The clipboard seam: the verified notice, `WriteAll` failing over to OSC 52
+  with a notice naming its error, and an empty payload reported rather than
+  dropped. Both workspaces turn a result into their own notice.
+- The picker lists every assistant document and fenced block newest first; two
+  documents with identical opening text stay distinguishable by ordinal; a
+  document with no fence contributes no code row; a reasoning record contributes
+  nothing; and a pick copies what was on screen when the popup opened even after
+  further records arrive and the pane is resized.
+- `ctrl+p` opens the palette while the chat composer holds focus, and the
+  composer still receives every letter, both arrows and a `:` typed into a
+  draft; the whole `ctrl+y` → popup → pick → clipboard → notice path runs
+  through the root model; the footer hints name the ctrl keys, including the
+  chat's hand-written footer line.
+
+The existing `TestPaletteReachesEveryRegistryEntry` covers the new rows'
+palette reachability in both contexts without a new test.
+
+## Left open
+
+- **All link actions**, to the follow-up. #290 landed as task 075 while this
+  was in flight, so the blocker is no longer the renderer: it is naming a
+  reference, which decision 1 leaves to that task. Issue criteria 4 and 5, and
+  the link parts of 3 and 8, are theirs.
+- **Semantic identities.** Captured text is the stability mechanism until #291
+  has a document model to reference.
+- **`?` in a chat.** Still swallowed by the composer. The palette answers the
+  issue's reachability criterion; moving help is a separate call.
+- **No new screenshot.** Raw is a display state of an existing panel and the
+  picker is a panel no capture shows; the chat views have never been captured at
+  all (task 071, "Not done here").

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -89,6 +89,7 @@ the living engineering specification records implementation contracts.
 | [073](073-assistant-markdown-in-output.md) | Assistant Markdown in the output pane | ✅ done (1/1) |
 | [074](074-chat-handoff.md) | Hand off a chat's worktree and branch to a task | ✅ done (1/1) |
 | [075](075-rich-markdown-blocks.md) | Tables, links and code blocks in the output pane | ✅ done (1/1) |
+| [076](076-reader-actions-on-assistant-markdown.md) | Rendered/raw toggle and copy actions for assistant Markdown | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -132,6 +132,11 @@ type binding struct {
 var bindings = []binding{
 	// Global chrome.
 	{key: ":", label: "open the command palette", scope: scopeGlobal, noPalette: true},
+	// The same palette, reachable where `:` is not: a chat's composer owns
+	// every printable key, so the palette had been unreachable there since
+	// task 067 (task 076 decision 7). noPalette for the reason `:` is —
+	// a row teaching the way to open the thing you already opened.
+	{key: paletteAltKey, label: "open the command palette (works while a text field has the keyboard)", scope: scopeGlobal, noPalette: true},
 	{key: "?", label: "toggle this help", scope: scopeGlobal},
 	{key: "tab", label: "move to the next task tab (shift+tab goes back)", scope: scopeGlobal},
 	{key: "!", label: "jump to the next task needing a human", scope: scopeGlobal},
@@ -212,6 +217,8 @@ var bindings = []binding{
 	{key: "]", label: "move to the next task view ([ goes back)", scope: scopePanel, context: ctxOutput, hint: "[/] views", priority: 2},
 	{key: "f", label: "follow the live output again (f/G)", scope: scopePanel, context: ctxOutput, hint: "f follow", priority: 2},
 	{key: "v", label: "show more or less: compact → normal → verbose (reasoning, then unrecognized lines)", scope: scopePanel, context: ctxOutput, hint: "v detail", priority: 3},
+	{key: rawToggleKey, label: "show the assistant's original Markdown instead of the rendered view", scope: scopePanel, context: ctxOutput, hint: "ctrl+o raw", priority: 6},
+	{key: copyPickKey, label: "copy an assistant message, its plain text, or one of its code blocks", scope: scopePanel, context: ctxOutput, hint: "ctrl+y copy", priority: 7},
 	{key: "e", label: "open this attempt's whole transcript in $EDITOR (the pane holds only the end of it)", scope: scopePanel, context: ctxOutput, hint: "e transcript", priority: 5},
 	{key: "down", label: "scroll (↑/↓; scrolling up pauses follow)", scope: scopePanel, context: ctxOutput, hint: "↑/↓ scroll", priority: 4},
 	{key: "right", label: "select which attempt's output to show (←/→ or h/l)", scope: scopePanel, context: ctxOutput},
@@ -255,6 +262,8 @@ var bindings = []binding{
 	// composer owns every printable key (task 074).
 	{key: "ctrl+t", label: "hand the worktree and branch to a new task (the chat ends)", scope: scopePanel, context: ctxChat, hint: "ctrl+t hand off", priority: 6},
 	{key: "esc", label: "back to the chats board", scope: scopePanel, context: ctxChat, hint: "esc back", priority: 7},
+	{key: rawToggleKey, label: "show the assistant's original Markdown instead of the rendered view", scope: scopePanel, context: ctxChat, hint: "ctrl+o raw", priority: 8},
+	{key: copyPickKey, label: "copy an assistant message, its plain text, or one of its code blocks", scope: scopePanel, context: ctxChat, hint: "ctrl+y copy", priority: 9},
 
 	// New chat.
 	{key: "ctrl+s", label: "create the chat and open it", scope: scopePanel, context: ctxNewChat, hint: "ctrl+s create", priority: 1},
@@ -445,3 +454,18 @@ func withoutGitHub(rows []binding, available bool) []binding {
 	}
 	return out
 }
+
+// The reader-action keys (task 076 decision 7). Both are ctrl-modified in
+// both contexts rather than a letter in the output pane and a ctrl twin in
+// the chat — the `v`/`ctrl+r` split task 071 chose is a cost, not a model,
+// and one action should have one name in the help overlay and the palette.
+// A bare letter cannot work in a chat at all: the composer owns every
+// printable key.
+const (
+	rawToggleKey = "ctrl+o"
+	copyPickKey  = "ctrl+y"
+	// paletteAltKey reaches the palette from a surface that is capturing
+	// text, where `:` types a colon into the draft. The root hoists it above
+	// the input-capture gate the way it already hoists ctrl+v.
+	paletteAltKey = "ctrl+p"
+)

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -57,6 +57,8 @@ func registryKey(t *testing.T, key string) tea.KeyPressMsg {
 		msg = tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}
 	case "ctrl+x":
 		msg = tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
+	case "ctrl+y":
+		msg = tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl}
 	case "ctrl+r":
 		msg = tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}
 	case "ctrl+g":
@@ -517,6 +519,35 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("pgup left the body following the live end")
 			}
 		},
+		"ctrl+o": func(t *testing.T) {
+			v := chatViewFixture()
+			before := v.raw.get()
+			v.updateKey(registryKey(t, "ctrl+o"))
+			if v.raw.get() == before {
+				t.Fatal("ctrl+o did not toggle raw mode")
+			}
+			if v.composer.Value() != "" {
+				t.Fatalf("ctrl+o reached the composer: %q", v.composer.Value())
+			}
+		},
+		"ctrl+y": func(t *testing.T) {
+			v := chatViewFixture()
+			v.turns = []apiclient.ChatTurn{{ID: 1, Seq: 1, State: "done", Prompt: "hi"}}
+			v.turnRecords[1] = []apiclient.TranscriptRecord{
+				{Type: "agent.output", Text: "# Findings\n\nall good"},
+			}
+			_, cmd := v.updateKey(registryKey(t, "ctrl+y"))
+			if cmd == nil {
+				t.Fatal("ctrl+y did not open the copy picker")
+			}
+			msg, ok := drain(cmd).(openCopyPickerMsg)
+			if !ok || len(msg.items) == 0 {
+				t.Fatalf("ctrl+y produced %#v, want a copy picker with rows", drain(cmd))
+			}
+			if v.composer.Value() != "" {
+				t.Fatalf("ctrl+y reached the composer: %q", v.composer.Value())
+			}
+		},
 		"ctrl+g": func(t *testing.T) {
 			v := chatViewFixture()
 			v.following = false
@@ -739,6 +770,37 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			d.updateKey(registryKey(t, "down"))
 			if !d.following {
 				t.Fatal("down did not reach the output pane's scroll path (follow was never re-synced)")
+			}
+		},
+		"ctrl+o": func(t *testing.T) {
+			d := newTestDetail(t)
+			d.taskID = 4
+			loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+			d.focus = focusOutput
+			before := d.raw.get()
+			d.updateKey(registryKey(t, "ctrl+o"))
+			if d.raw.get() == before {
+				t.Fatal("ctrl+o did not toggle raw mode")
+			}
+			if !d.outputDirty {
+				t.Fatal("ctrl+o left the pane's rendered content standing")
+			}
+		},
+		"ctrl+y": func(t *testing.T) {
+			d := newTestDetail(t)
+			d.taskID = 4
+			loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+			d.focus = focusOutput
+			d.records = []apiclient.TranscriptRecord{
+				{Type: "agent.output", Text: "# Findings\n\nall good"},
+			}
+			cmd := d.updateKey(registryKey(t, "ctrl+y"))
+			if cmd == nil {
+				t.Fatal("ctrl+y did not open the copy picker")
+			}
+			msg, ok := drain(cmd).(openCopyPickerMsg)
+			if !ok || len(msg.items) == 0 {
+				t.Fatalf("ctrl+y produced %#v, want a copy picker with rows", drain(cmd))
 			}
 		},
 		"e": func(t *testing.T) {

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -22,6 +22,28 @@ import (
 // (decision 4).
 const chatExpandKey = "ctrl+r"
 
+// copyDocs is the chat's source for the copy picker: every assistant
+// document in the loaded conversation, newest first — the newest turn's
+// newest record is "message 1".
+//
+// A turn whose transcript has gone to retention contributes its ResultText
+// instead (§17), which is what the pane is drawing for it: the picker offers
+// what is on screen, not what is on disk.
+func (v *chatView) copyDocs() []string {
+	docs := make([]string, 0, len(v.turns))
+	for i := len(v.turns) - 1; i >= 0; i-- {
+		t := &v.turns[i]
+		if recs := v.turnRecords[t.Seq]; len(recs) > 0 {
+			docs = append(docs, copyDocsFromRecords(recs)...)
+			continue
+		}
+		if t.ResultText != "" {
+			docs = append(docs, t.ResultText)
+		}
+	}
+	return docs
+}
+
 func (v *chatView) render(width, height int) string {
 	if width < 4 || height < 4 {
 		return ""
@@ -92,6 +114,9 @@ func (v *chatView) headerLine(width int) string {
 	if l := v.level.get(); l != levelNormal {
 		right = l.String() + "  ·  " + right
 	}
+	if v.raw.get() {
+		right = "raw  ·  " + right
+	}
 	if !v.following {
 		right = "⏸ " + right
 	}
@@ -111,6 +136,7 @@ func (v *chatView) bodyLines(width int) []string {
 			"… earlier output truncated — the transcripts on disk are whole"))
 	}
 	level := v.level.get()
+	raw := v.raw.get()
 	for i := range v.turns {
 		t := &v.turns[i]
 		v.turnAt[t.Seq] = len(lines)
@@ -119,7 +145,7 @@ func (v *chatView) bodyLines(width int) []string {
 		switch recs := v.turnRecords[t.Seq]; {
 		case len(recs) > 0:
 			lines = append(lines, outputLines(recs, level, width,
-				lineOpts{expandKey: chatExpandKey})...)
+				lineOpts{expandKey: chatExpandKey, raw: raw})...)
 		case t.State == "running":
 			// Nothing has arrived yet; the tail fills in as it does.
 		case t.ResultText != "":
@@ -135,7 +161,10 @@ func (v *chatView) bodyLines(width int) []string {
 			// narrowing this used to apply — a strict improvement, since a
 			// retained-away answer is all the turn has left and the cap hid
 			// its tail.
-			lines = append(lines, markdownLines(t.ResultText, width)...)
+			// It follows the rendered/raw toggle too (task 076 decision 2):
+			// a retained-away answer is still assistant prose, and the
+			// mode is the session's, not the record's.
+			lines = append(lines, assistantLines(t.ResultText, width, raw)...)
 		}
 		if t.FailReason != "" {
 			lines = append(lines, " "+styleBad.Render(
@@ -159,6 +188,7 @@ func (v *chatView) footerLines(width int) []string {
 	}
 	out = append(out, v.composer.View())
 	hint := " enter send · ctrl+x stop the turn · ctrl+r detail · " +
+		rawToggleKey + " raw · " + copyPickKey + " copy · " +
 		"pgup/pgdown scroll · ctrl+g live · esc back to the chats board"
 	out = append(out, styleDim.Render(ansi.Truncate(hint, width, "…")))
 	return out

--- a/internal/tui/chatverbosity_test.go
+++ b/internal/tui/chatverbosity_test.go
@@ -98,8 +98,9 @@ func TestChatLevelsMeanWhatTheSpecSays(t *testing.T) {
 // round, and leaving a chat and returning changes nothing.
 func TestChatLevelIsTheOutputPanesLevel(t *testing.T) {
 	level := newLevelHolder()
-	d := newDetail(testCtx(t), level)
-	v := newChatView(level)
+	raw := newRawHolder()
+	d := newDetail(testCtx(t), level, raw)
+	v := newChatView(level, raw)
 	v.chatID = 1
 
 	if _, cmd := v.updateKey(registryKey(t, "ctrl+r")); cmd != nil {

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -92,6 +92,9 @@ type chatView struct {
 	// level is the session's one verbosity level, shared with the task
 	// workspace's output pane (decision 3).
 	level *levelHolder
+	// raw is the session's rendered/raw choice, shared with the task
+	// workspace's output pane (task 076 decision 2).
+	raw *rawHolder
 
 	// vp scrolls the conversation; following means it is showing the end,
 	// which a manual scroll drops and ctrl+g re-arms (decision 5).
@@ -118,7 +121,7 @@ type chatView struct {
 	width, height int
 }
 
-func newChatView(level *levelHolder) *chatView {
+func newChatView(level *levelHolder, raw *rawHolder) *chatView {
 	ta := textarea.New()
 	ta.Placeholder = "message… (enter sends, shift+enter for a newline)"
 	ta.SetHeight(3)
@@ -126,6 +129,7 @@ func newChatView(level *levelHolder) *chatView {
 		now:         time.Now,
 		composer:    ta,
 		level:       level,
+		raw:         raw,
 		vp:          viewport.New(),
 		following:   true,
 		turnRecords: map[int][]apiclient.TranscriptRecord{},
@@ -265,6 +269,9 @@ func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
 	case chatLoadedMsg:
 		v.applyLoaded(msg)
 		return v, v.fetchTranscripts()
+	case clipboardResultMsg:
+		v.note, v.noteBad = msg.notice()
+		return v, nil
 	case chatTranscriptMsg:
 		v.applyTranscript(msg)
 		return v, nil
@@ -604,6 +611,15 @@ func (v *chatView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		v.level.cycle()
 		v.bodyDirty = true
 		return v, nil
+	case rawToggleKey:
+		// Ctrl-modified for the same reason ctrl+r is: the composer owns
+		// every letter, so a bare key would land in the draft (task 076
+		// decision 7).
+		v.raw.toggle()
+		v.bodyDirty = true
+		return v, nil
+	case copyPickKey:
+		return v, openCopyPicker(v.copyDocs())
 	case "pgup":
 		v.vp.PageUp()
 		v.syncFollowToViewport()

--- a/internal/tui/chatview_test.go
+++ b/internal/tui/chatview_test.go
@@ -9,7 +9,7 @@ import (
 
 // chatViewFixture is a chat workspace pointed at one loaded chat.
 func chatViewFixture() *chatView {
-	v := newChatView(newLevelHolder())
+	v := newChatView(newLevelHolder(), newRawHolder())
 	v.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
 	v.chatID = 1
 	v.chat = &apiclient.Chat{ID: 1, ProjectID: 7, Title: "a chat", State: "idle", Agent: "claude"}

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"errors"
+	"fmt"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
 )
@@ -31,5 +34,79 @@ func readClipboardCmd() tea.Cmd {
 			return nil
 		}
 		return tea.PasteMsg{Content: text}
+	}
+}
+
+// Writing is the other direction, and it has two transports (task 076).
+//
+// github.com/atotto/clipboard shells out to the platform's helper — pbcopy,
+// clip.exe, xclip/xsel/wl-copy — and returns a real error, which is what a
+// visible success/failure notice needs. It is also wrong over SSH: with
+// xclip installed on the remote box it succeeds against the *remote* display,
+// and the text never reaches the human's machine.
+//
+// tea.SetClipboard is OSC 52 — the terminal itself is asked to take the
+// text, so it lands on the machine the human is sitting at, no helper binary
+// is needed, and it works over SSH. It is fire-and-forget: the terminal may
+// refuse (many do by default) and says nothing either way.
+//
+// So: the helper first, because its answer can be trusted, and OSC 52 when it
+// refuses, because an unverified copy beats none. The notice says which
+// happened rather than claiming success for both — and the fallback's notice
+// names the helper's error, following openurl.go's posture that a key press a
+// human made must never fail silently.
+
+// clipboardWrite is the system-clipboard write, indirected so tests assert
+// the seam without a display, a helper binary or a real clipboard — the way
+// openURL is.
+var clipboardWrite = clipboard.WriteAll
+
+// clipboardResultMsg reports what became of a copy. label names what was
+// copied ("markdown", "code block") so the notice can say it.
+type clipboardResultMsg struct {
+	label string
+	// osc is the payload the terminal must still be asked to take, set only
+	// when the system clipboard refused. err then carries its refusal, which
+	// the notice names.
+	osc string
+	err error
+}
+
+// notice renders the result as the line a human reads, and whether it is bad.
+func (msg clipboardResultMsg) notice() (string, bool) {
+	label := msg.label
+	if label == "" {
+		label = "copy"
+	}
+	switch {
+	case msg.osc != "":
+		// Not an error: the text was handed to the terminal, which usually
+		// takes it. Unverified, so it does not claim "copied".
+		return fmt.Sprintf("%s sent to the terminal — the system clipboard refused (%s)",
+			label, errString(msg.err)), false
+	case msg.err != nil:
+		return fmt.Sprintf("%s: %s", label, errString(msg.err)), true
+	default:
+		return label + " copied", false
+	}
+}
+
+// writeClipboardCmd puts text on the clipboard.
+//
+// The payload is sanitized here rather than at the call sites: a clipboard is
+// pasted into a terminal, which is precisely the boundary §16 exists to hold,
+// so every payload goes through the same chokepoint the pane's own text does
+// (task 076 decision 4). "Original Markdown" therefore means the stored
+// Markdown minus escape sequences and C0/C1 controls.
+func writeClipboardCmd(label, text string) tea.Cmd {
+	return func() tea.Msg {
+		clean := sanitizeText(text)
+		if clean == "" {
+			return clipboardResultMsg{label: label, err: errors.New("nothing to copy")}
+		}
+		if err := clipboardWrite(clean); err != nil {
+			return clipboardResultMsg{label: label, osc: clean, err: err}
+		}
+		return clipboardResultMsg{label: label}
 	}
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -142,6 +142,9 @@ type detail struct {
 	// chose to look at, and neither must walking into the chat workspace and
 	// back (task 071 decision 3).
 	level *levelHolder
+	// raw is the session's rendered/raw choice, shared with the chat
+	// workspace the same way the level is (task 076 decision 2).
+	raw *rawHolder
 
 	following bool
 	newLines  int
@@ -171,12 +174,13 @@ type detail struct {
 	width, height int
 }
 
-func newDetail(ctx context.Context, level *levelHolder) *detail {
+func newDetail(ctx context.Context, level *levelHolder, raw *rawHolder) *detail {
 	return &detail{
 		ctx:       ctx,
 		now:       time.Now,
 		vp:        viewport.New(),
 		level:     level,
+		raw:       raw,
 		following: true,
 		actions:   &actionBar{},
 		diff:      newDiffPane(),
@@ -208,6 +212,12 @@ func (d *detail) update(msg tea.Msg) tea.Cmd {
 		if len(msg.task.Warnings) > 0 {
 			d.actions.setStatus("created with warnings: "+strings.Join(msg.task.Warnings, "; "), false)
 		}
+		return nil
+	case clipboardResultMsg:
+		// The copy's outcome, said where every other action's is said: a
+		// key press a human made never fails silently (task 076).
+		text, bad := msg.notice()
+		d.actions.setStatus(text, bad)
 		return nil
 	case detailTranscriptMsg:
 		d.applyTranscript(msg)
@@ -695,6 +705,10 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 		// having to focus the pane first to change what it shows is a step
 		// nobody would guess at.
 		return d.cycleLevel()
+	case rawToggleKey:
+		return d.toggleRaw()
+	case copyPickKey:
+		return openCopyPicker(copyDocsFromRecords(d.records))
 	}
 
 	// Action keys work from any focus: they act on the task, not on a pane.
@@ -733,6 +747,16 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 		return cmd
 	}
 	d.syncFollowToViewport()
+	return nil
+}
+
+// toggleRaw flips the pane between the rendered Markdown and the stored
+// source, and rebuilds. Nothing else moves: the records, the offset, the
+// level and follow mode are untouched — raw is a way of drawing what is
+// already there (task 076 decision 2).
+func (d *detail) toggleRaw() tea.Cmd {
+	d.raw.toggle()
+	d.outputDirty = true
 	return nil
 }
 

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -17,7 +17,7 @@ var fixedNow = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
 
 func newTestDetail(t *testing.T) *detail {
 	t.Helper()
-	d := newDetail(testCtx(t), newLevelHolder())
+	d := newDetail(testCtx(t), newLevelHolder(), newRawHolder())
 	d.now = func() time.Time { return fixedNow }
 	d.width, d.height = 120, 30
 	return d

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -176,6 +176,12 @@ func (d *detail) outputTitle() string {
 	if l := d.level.get(); l != levelNormal {
 		level = styleDim.Render(" · " + l.String())
 	}
+	// Raw rides there too, and for a stronger version of the same reason: a
+	// conversation with no Markdown in it looks identical either way, so the
+	// title is the only thing that says which mode the pane is in.
+	if d.raw.get() {
+		level += styleDim.Render(" · raw")
+	}
 	return strip + level + d.followIndicator()
 }
 
@@ -984,7 +990,7 @@ func (d *detail) outputLines() []string {
 		note = "… earlier output truncated — press e for the whole transcript"
 	}
 	return outputLines(d.records, d.level.get(), max(d.width, 1),
-		lineOpts{expandKey: "v", truncatedNote: note})
+		lineOpts{expandKey: "v", truncatedNote: note, raw: d.raw.get()})
 }
 
 // plain is a record with the blank gutter: assistant prose and command

--- a/internal/tui/editor_test.go
+++ b/internal/tui/editor_test.go
@@ -44,7 +44,7 @@ func (r *retryRecorder) client(t *testing.T) *apiclient.Client {
 // editor replaced by a function that writes what the "human" typed.
 func editorDetail(t *testing.T, client *apiclient.Client, typed string, runErr error) *detail {
 	t.Helper()
-	d := newDetail(testCtx(t), newLevelHolder())
+	d := newDetail(testCtx(t), newLevelHolder(), newRawHolder())
 	d.client = client
 	d.taskID = 1
 	d.loaded = true

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -91,15 +92,37 @@ const (
 // except mdRule, which is drawn to the pane's width at render time and so
 // carries no lines at all, and mdTable, whose layout is two-dimensional and
 // so cannot be a list of paneLines either.
+//
+// It also keeps its *source* — the nesting depth, the marker an ordered item
+// wrote for itself, and the text — because three emitters read these blocks
+// now (task 076 decision 5): the pane's own rendering, the plain-text
+// clipboard payload, and the copy picker's fenced-block scan. Only the first
+// can read laid-out lines; recovering "the text without its Markdown
+// punctuation" from a rendered line means unpicking lipgloss, which is the
+// wrong direction. Layout stays at parse time rather than moving to the
+// emitters because that is where a link's destination is numbered (task 075
+// decision 2), and numbering has to follow document order.
 type mdBlock struct {
-	kind  mdKind
-	lines []paneLine
+	kind   mdKind
+	lines  []paneLine
+	depth  int
+	marker string
+	// text is the block's source lines. Everything but mdCode joins them
+	// with a space when emitted: a soft line break inside a paragraph, a
+	// list item or a quote is the author's line length, not the reader's,
+	// and rejoining is what lets a surface reflow to its own width. A fenced
+	// block keeps every line, byte for byte. An mdTable carries none — its
+	// cells are parsed, not source, for the numbering reason above.
+	text []string
 	// info is a fenced block's info string, first word only. Empty for
 	// every other kind and for a fence that declared no language.
 	info string
 	// table is set on mdTable and nil everywhere else.
 	table *mdTableBlock
 }
+
+// joined is the block's prose as one line, ready to be wrapped or emitted.
+func (b mdBlock) joined() string { return strings.Join(b.text, " ") }
 
 // markdownLines renders assistant prose to wrapped pane lines.
 //
@@ -291,6 +314,8 @@ func parseMarkdown(text string, refs *mdRefs) []mdBlock {
 			blocks = append(blocks, mdBlock{
 				kind:  mdHeading,
 				lines: []paneLine{headingPaneLine(level, htext, refs)},
+				depth: level,
+				text:  []string{htext},
 			})
 			continue
 		}
@@ -342,29 +367,34 @@ func (p mdPending) isEmpty() bool { return len(p.text) == 0 }
 // block turns the accumulated lines into a block. Soft line breaks inside a
 // paragraph, a list item or a quote are joined: they are the author's line
 // length, not the reader's, and rejoining is what lets the pane reflow to its
-// own width. A fenced block is the exception and keeps every line.
+// own width. A fenced block is the exception and keeps every line. The source
+// rides along beside the laid-out lines for the other two emitters.
 func (p mdPending) block() (mdBlock, bool) {
 	switch p.kind {
 	case mdCode:
 		if !p.open && len(p.text) == 0 {
 			return mdBlock{}, false
 		}
-		lines := make([]paneLine, 0, len(p.text))
-		for _, l := range p.text {
+		text := p.text
+		if len(text) == 0 {
+			// An empty fence still says a code block was there.
+			text = []string{""}
+		}
+		lines := make([]paneLine, 0, len(text))
+		for _, l := range text {
 			lines = append(lines, codePaneLine(l, p.info))
 		}
-		if len(lines) == 0 {
-			// An empty fence still says a code block was there.
-			lines = append(lines, codePaneLine("", p.info))
-		}
-		return mdBlock{kind: mdCode, lines: lines, info: p.info}, true
+		return mdBlock{kind: mdCode, lines: lines, text: text, info: p.info}, true
 	case mdItem:
 		if p.isEmpty() {
 			return mdBlock{}, false
 		}
 		return mdBlock{
-			kind:  mdItem,
-			lines: []paneLine{itemPaneLine(p.depth, p.marker, strings.Join(p.text, " "), p.refs)},
+			kind:   mdItem,
+			lines:  []paneLine{itemPaneLine(p.depth, p.marker, strings.Join(p.text, " "), p.refs)},
+			depth:  p.depth,
+			marker: p.marker,
+			text:   p.text,
 		}, true
 	case mdQuote:
 		if p.isEmpty() {
@@ -373,6 +403,8 @@ func (p mdPending) block() (mdBlock, bool) {
 		return mdBlock{
 			kind:  mdQuote,
 			lines: []paneLine{quotePaneLine(p.depth, strings.Join(p.text, " "), p.refs)},
+			depth: p.depth,
+			text:  p.text,
 		}, true
 	default:
 		if p.isEmpty() {
@@ -381,6 +413,7 @@ func (p mdPending) block() (mdBlock, bool) {
 		return mdBlock{
 			kind:  mdParagraph,
 			lines: []paneLine{paragraphPaneLine(strings.Join(p.text, " "), p.refs)},
+			text:  p.text,
 		}, true
 	}
 }
@@ -660,7 +693,7 @@ func inlineSegments(text string, base lipgloss.Style, depth int, refs *mdRefs) [
 			// colour is gone.
 			if body, next, ok := codeSpanAt(text, i); ok {
 				flush()
-				segs = append(segs, segment{text: body, style: mdCodeSpanStyle(base)})
+				segs = append(segs, segment{text: body, style: mdCodeSpanStyle(base), code: true})
 				i = next
 				continue
 			}
@@ -804,4 +837,193 @@ func runLen(s string, i int, ch byte) int {
 		n++
 	}
 	return n
+}
+
+// The other two emitters over the same blocks (task 076).
+//
+// markdownLines above draws the pane. rawLines shows the source instead of
+// the render, and markdownPlainText is the clipboard's "structure without
+// punctuation" payload. All three read one parse, so a construct the pane
+// understands is a construct the clipboard understands.
+
+// rawLines shows the stored Markdown as source: one pane line per source
+// line, preformatted, no parse at all.
+//
+// Preformatted rather than reflowed (decision 3): raw mode exists to answer
+// "what did the agent actually write", and a source line whose leading spaces
+// were collapsed is not that line. Long lines hard-wrap at the pane's edge,
+// which wrapPre already does for fenced code.
+//
+// It still goes through wrapLine's segment emission, which is where §16's
+// ANSI/C0/C1 stripping lives. "Exact stored Markdown" means the agent's bytes
+// as Markdown *source*, not the agent's bytes as terminal input: raw mode is
+// the escape hatch for a surprising render, not a hole in the one chokepoint
+// §16 was added to guarantee.
+func rawLines(text string, width int) []string {
+	src := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(src))
+	for _, line := range src {
+		out = append(out, wrapLine(paneLine{
+			gutter:      gutterNone,
+			gutterStyle: styleDim,
+			pre:         true,
+			segs:        []segment{{text: line, style: styleRaw}},
+		}, width)...)
+	}
+	return out
+}
+
+// styleRaw draws raw source. It is dimmer than prose on purpose: raw mode is
+// a mode, and the pane has to say so on every line rather than only in the
+// header, since a reader who scrolled away from the header is the one most
+// likely to wonder why the headings stopped rendering.
+var styleRaw = lipgloss.NewStyle().Faint(true)
+
+// markdownPlainText renders assistant prose as unstyled, unwrapped plain
+// text: the structure the pane draws, minus lipgloss and minus width
+// (decision 5).
+//
+// Unwrapped because the payload is built from the source and never from
+// rendered lines — a copy made at width 40 and one made at width 200 are
+// byte-identical, since the pane's hard wraps are a property of the pane
+// (decision 4). The markers are the pane's own, so what lands on the
+// clipboard is recognisably what was on screen — including a link's `[n]`
+// and the reference block that resolves it (task 075 decision 2), which is
+// the only place the destination survives once the punctuation is gone.
+func markdownPlainText(text string) string {
+	refs := &mdRefs{}
+	blocks := parseMarkdown(sanitizeText(text), refs)
+	out := make([]string, 0, len(blocks)*2)
+	prev := mdParagraph
+	for i, b := range blocks {
+		if i > 0 && mdNeedsBlank(prev, b.kind) {
+			out = append(out, "")
+		}
+		out = append(out, b.plainLines(refs)...)
+		prev = b.kind
+	}
+	if len(refs.order) > 0 {
+		if len(out) > 0 {
+			out = append(out, "")
+		}
+		for i, dest := range refs.order {
+			out = append(out, "["+strconv.Itoa(i+1)+"] "+dest)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// mdPlainRule is a thematic break with no pane to be as wide as. Three cells,
+// not a run sized to some assumed terminal: the clipboard has no width.
+const mdPlainRule = "───"
+
+// plainLines emits one block as plain text.
+//
+// refs is the message's registry, already filled by the parse: an inline link
+// re-resolves to the number the pane gave it, because mdRefs.add is a lookup
+// on second sight.
+func (b mdBlock) plainLines(refs *mdRefs) []string {
+	switch b.kind {
+	case mdRule:
+		return []string{mdPlainRule}
+	case mdCode:
+		// Interior lines verbatim, fence and info string dropped: the fence
+		// is Markdown punctuation, and this payload carries none.
+		return slices.Clone(b.text)
+	case mdTable:
+		return tablePlainLines(b.table)
+	case mdItem:
+		marker := b.marker
+		if marker == "" {
+			marker = mdBulletsByDepth[min(b.depth, len(mdBulletsByDepth)-1)]
+		}
+		return []string{strings.Repeat("  ", b.depth) + marker + inlinePlain(b.joined(), refs)}
+	case mdQuote:
+		return []string{strings.Repeat(mdQuoteBar, b.depth) + inlinePlain(b.joined(), refs)}
+	default:
+		// Headings and paragraphs alike: a heading's text is its own line,
+		// with no `#` in front of it and no glyph standing in for one.
+		return []string{inlinePlain(b.joined(), refs)}
+	}
+}
+
+// tablePlainLines emits a table as the stacked records renderMDTableStacked
+// draws (task 075), because that is the form that does not depend on a width:
+// an aligned table is arithmetic over the pane's columns, and the clipboard
+// has none. The cells are already segments, so the punctuation is gone by
+// construction and a link in a cell keeps the number it was given.
+func tablePlainLines(t *mdTableBlock) []string {
+	if t == nil {
+		return nil
+	}
+	keys := make([]string, len(t.header))
+	for i, h := range t.header {
+		keys[i] = h.plain
+	}
+	out := make([]string, 0, len(t.rows)*len(keys))
+	for r, row := range t.rows {
+		if r > 0 {
+			out = append(out, "")
+		}
+		for c, cell := range row {
+			prefix := "  "
+			if c == 0 {
+				prefix = mdBulletsByDepth[len(mdBulletsByDepth)-1]
+			}
+			key := ""
+			if c < len(keys) {
+				key = keys[c]
+			}
+			out = append(out, prefix+key+": "+segsPlain(cell.segs))
+		}
+	}
+	if len(out) == 0 {
+		// A table with a header and no body rows still says what its columns
+		// were.
+		out = append(out, strings.Join(keys, ", "))
+	}
+	return out
+}
+
+// codeBlocks returns every fenced block's interior, in document order, for
+// the copy picker to offer. Whitespace and tabs are kept: a code block that
+// lost its indentation would not be the code the agent wrote.
+func codeBlocks(text string) []string {
+	var out []string
+	for _, b := range parseMarkdown(sanitizeText(text), &mdRefs{}) {
+		if b.kind == mdCode {
+			out = append(out, strings.Join(b.text, "\n"))
+		}
+	}
+	return out
+}
+
+// inlinePlain strips inline Markdown from one line of prose.
+//
+// It runs the *same* scanner the pane does and reads its output: emphasis
+// already arrives with its marks gone, because inlineSegments emits the body
+// rather than the delimiters, and a link arrives as its label plus the ` [n]`
+// the pane shows. So the only thing left to undo is the code span's
+// backticks — which is exactly what segment.code marks.
+func inlinePlain(text string, refs *mdRefs) string {
+	var b strings.Builder
+	for _, seg := range inlineSegments(text, lipgloss.NewStyle(), 0, refs) {
+		if seg.code {
+			b.WriteString(codeSpanBody(seg.text))
+			continue
+		}
+		b.WriteString(seg.text)
+	}
+	return b.String()
+}
+
+// codeSpanBody drops a code span's matching backtick runs. The run length is
+// whatever opened the span, so a double-backtick span keeps any single
+// backtick inside it.
+func codeSpanBody(span string) string {
+	n := runLen(span, 0, '`')
+	if n == 0 || len(span) < 2*n {
+		return span
+	}
+	return span[n : len(span)-n]
 }

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -137,6 +137,26 @@ func (h *levelHolder) set(l outputLevel) { h.level = l }
 // cycle advances the level.
 func (h *levelHolder) cycle() { h.level = h.level.next() }
 
+// rawHolder is the one rendered/raw choice the whole session is on, held the
+// way the verbosity level beside it is (task 076 decision 2): both panes that
+// render assistant prose point at one holder, so toggling in the chat is
+// visible in the task workspace and walking between them resets nothing.
+//
+// Nothing persists it — no tui.json entry, no `tui:` config key — for the
+// reason §15 already gives for the level: it dies with the process.
+//
+// Raw is presentation only. It does not touch the records, the streaming
+// offset, the verbosity level, the transcript, follow mode, or any task or
+// chat state.
+type rawHolder struct{ raw bool }
+
+func newRawHolder() *rawHolder { return &rawHolder{} }
+
+func (h *rawHolder) get() bool { return h.raw }
+
+// toggle flips between the rendered view and the stored Markdown.
+func (h *rawHolder) toggle() { h.raw = !h.raw }
+
 // thinkingLines is how many wrapped lines of a reasoning block levelNormal
 // shows before collapsing the rest behind a count. It is counted in *display*
 // lines rather than source lines because the two dialects disagree about
@@ -150,6 +170,13 @@ const thinkingLines = 3
 type segment struct {
 	text  string
 	style lipgloss.Style
+	// code marks an inline code span, whose text still carries its backticks
+	// — they are what a monochrome terminal has left once the colour is
+	// gone. The pane ignores this; the plain-text clipboard payload is what
+	// reads it, because that is the one consumer that must strip the
+	// delimiters (task 076 decision 5). Marking the span here rather than
+	// re-scanning the line keeps one inline scanner.
+	code bool
 }
 
 // paneLine is one record laid out but not yet wrapped.
@@ -612,6 +639,11 @@ func formatAgentDuration(ms int64) string {
 type lineOpts struct {
 	expandKey     string
 	truncatedNote string
+	// raw shows assistant prose as its stored Markdown source instead of
+	// the rendered view (task 076). It reaches the renderer on the opts
+	// rather than as a fourth argument because it is a pane-specific
+	// display choice, which is exactly what this struct carries.
+	raw bool
 }
 
 // outputLines renders the normalized records into wrapped pane lines.
@@ -662,7 +694,7 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 			// (task 073 decision 5), and it is handled here rather than in
 			// renderRecord because one record now yields several pane lines
 			// — the same reason agent.thinking is handled above.
-			block := markdownLines(rec.Text, width)
+			block := assistantLines(rec.Text, width, opts.raw)
 			if len(block) == 0 {
 				continue
 			}
@@ -696,6 +728,18 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 	}
 	flushRaw()
 	return lines
+}
+
+// assistantLines renders one assistant document, rendered or raw. It is the
+// single branch task 076 adds to the pane: the two call sites that draw
+// assistant prose — this one and the chat's §17 retention fallback — go
+// through it, and nothing else changes, because nothing else was ever
+// interpreted as Markdown (task 073 decision 5).
+func assistantLines(text string, width int, raw bool) []string {
+	if raw {
+		return rawLines(text, width)
+	}
+	return markdownLines(text, width)
 }
 
 // renderRecord maps one normalized record to a pane line. A record with

--- a/internal/tui/readerpicker.go
+++ b/internal/tui/readerpicker.go
@@ -1,0 +1,259 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The copy picker (task 076 decision 6): one key lists what can be copied
+// out of the assistant prose currently on screen, and a pick puts it on the
+// clipboard.
+//
+// It is a popup rather than a cursor in the pane. The output pane is a
+// viewport over rendered []string — it has no cursor, no selection and no
+// block identity, and apiclient.TranscriptRecord carries no id — so a "copy
+// the focused block" key would first have to invent a navigation model. The
+// issue's own alternatives reject that ("make every code block permanently
+// focused … adds heavy navigation state to ordinary reading"), so the picker
+// stays dormant until asked for, follows palette.go's shape, and owns the
+// keyboard while it is up, at the top of the §15 esc stack.
+//
+// Each row **captures its payload when the popup is built** rather than
+// holding an index into the records. That is what makes a target stable
+// across resize, transcript reload and incremental rendering: there is no
+// index left to drift when a chunk arrives, a re-render happens, or the
+// chat's maxRecords cap prunes the front of the slice. When #291 lands a
+// semantic document model the rows become references to it, and none of the
+// payloads below change.
+
+// copyItem is one offer: what it is called, and the exact text a pick puts on
+// the clipboard.
+type copyItem struct {
+	// group is the document the row belongs to — "message 1" is the newest.
+	// Ordinals rather than the opening words alone, because two documents
+	// that start the same way have to stay distinguishable.
+	group string
+	label string
+	// snippet is a one-line preview, which is what makes the right document
+	// findable when a conversation has twenty of them.
+	snippet string
+	text    string
+}
+
+// copyItemLabels are the three payloads (decision 5).
+const (
+	copyLabelMarkdown = "markdown"
+	copyLabelPlain    = "plain text"
+	copyLabelCode     = "code block"
+)
+
+// copyItemsFrom lists what can be copied out of one assistant document, in
+// the order a reader would look for them: the whole thing as its source, the
+// whole thing without the punctuation, then each fenced block.
+func copyItemsFrom(group, text string) []copyItem {
+	clean := sanitizeText(text)
+	if strings.TrimSpace(clean) == "" {
+		return nil
+	}
+	snippet := copySnippet(clean)
+	out := []copyItem{
+		{group: group, label: copyLabelMarkdown, snippet: snippet, text: clean},
+		{group: group, label: copyLabelPlain, snippet: snippet, text: markdownPlainText(clean)},
+	}
+	blocks := codeBlocks(clean)
+	for i, code := range blocks {
+		label := copyLabelCode
+		if len(blocks) > 1 {
+			// Numbered only when there is a choice to make: "code block 1"
+			// on a document with one of them is noise.
+			label = fmt.Sprintf("%s %d", copyLabelCode, i+1)
+		}
+		out = append(out, copyItem{
+			group: group, label: label, snippet: copySnippet(code), text: code,
+		})
+	}
+	return out
+}
+
+// copyDocs collects the picker's rows from assistant documents already
+// handed to it newest-first. It is the one place the "message N" ordinals are
+// assigned, so the task pane's records and the chat's turns number the same
+// way.
+func copyDocs(docs []string) []copyItem {
+	out := make([]copyItem, 0, len(docs)*2)
+	n := 0
+	for _, text := range docs {
+		group := fmt.Sprintf("message %d", n+1)
+		items := copyItemsFrom(group, text)
+		if len(items) == 0 {
+			continue
+		}
+		n++
+		out = append(out, items...)
+	}
+	return out
+}
+
+// copyDocsFromRecords is the task workspace's source: the assistant prose in
+// the loaded records, newest first. Only agent.output is offered, because it
+// is the only record type that was ever read as Markdown (task 073
+// decision 5).
+func copyDocsFromRecords(records []apiclient.TranscriptRecord) []string {
+	docs := make([]string, 0, len(records))
+	for i := len(records) - 1; i >= 0; i-- {
+		if records[i].Type == "agent.output" {
+			docs = append(docs, records[i].Text)
+		}
+	}
+	return docs
+}
+
+// copySnippet is a row's preview: the first line with anything on it,
+// whitespace collapsed, so a preview never spans two rows.
+func copySnippet(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return strings.Join(strings.Fields(t), " ")
+		}
+	}
+	return ""
+}
+
+// openCopyPickerMsg asks the root to raise the picker. A view sends it rather
+// than owning a popup of its own: the picker overlays the whole screen and
+// takes the keyboard, which is the root's job for the palette already — and
+// building the items in the view is what captures them at pick time.
+type openCopyPickerMsg struct{ items []copyItem }
+
+// openCopyPicker turns a view's collected documents into that message.
+func openCopyPicker(docs []string) tea.Cmd {
+	items := copyDocs(docs)
+	return func() tea.Msg { return openCopyPickerMsg{items: items} }
+}
+
+// readerPicker is the popup itself: a search line over the captured rows.
+type readerPicker struct {
+	input  textinput.Model
+	items  []copyItem
+	cursor int
+}
+
+func newReaderPicker(items []copyItem) *readerPicker {
+	in := textinput.New()
+	in.Placeholder = "type to search what can be copied"
+	in.Prompt = ": "
+	in.Focus()
+	return &readerPicker{input: in, items: items}
+}
+
+// matches filters rows against the typed query, over label, group and
+// preview — the same three fields the row shows.
+func (p *readerPicker) matches() []copyItem {
+	q := strings.ToLower(strings.TrimSpace(p.input.Value()))
+	if q == "" {
+		return p.items
+	}
+	out := make([]copyItem, 0, len(p.items))
+	for _, e := range p.items {
+		hay := strings.ToLower(e.label + " " + e.group + " " + e.snippet)
+		if strings.Contains(hay, q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// update handles one key. done reports the popup should close; run is the row
+// that was chosen.
+func (p *readerPicker) update(msg tea.KeyPressMsg) (run *copyItem, done bool, cmd tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return nil, true, nil
+	case "up":
+		p.cursor = max(p.cursor-1, 0)
+		return nil, false, nil
+	case "down":
+		p.cursor = min(p.cursor+1, max(len(p.matches())-1, 0))
+		return nil, false, nil
+	case "enter":
+		m := p.matches()
+		if len(m) == 0 {
+			return nil, true, nil
+		}
+		e := m[min(p.cursor, len(m)-1)]
+		return &e, true, nil
+	}
+	var c tea.Cmd
+	p.input, c = p.input.Update(msg)
+	if n := len(p.matches()); p.cursor >= n {
+		p.cursor = max(n-1, 0)
+	}
+	return nil, false, c
+}
+
+// paste types into the search line — the picker is a text field like the
+// palette, and the root routes paste to whichever popup has the keyboard.
+func (p *readerPicker) paste(text string) tea.Cmd {
+	var cmd tea.Cmd
+	p.input, cmd = p.input.Update(tea.PasteMsg{Content: text})
+	if n := len(p.matches()); p.cursor >= n {
+		p.cursor = max(n-1, 0)
+	}
+	return cmd
+}
+
+// render draws the popup for overlaying: the search line, then the rows
+// windowed around the cursor and grouped by document.
+func (p *readerPicker) render(w, h int) string {
+	inner := max(w-2, 10)
+	lines := make([]string, 0, h)
+	lines = append(lines, " "+p.input.View())
+
+	m := p.matches()
+	if len(m) == 0 {
+		body := "  nothing to copy — esc closes"
+		if len(p.items) > 0 {
+			body = "  nothing matches — esc closes"
+		}
+		lines = append(lines, styleDim.Render(body))
+		return frame("copy", strings.Join(lines, "\n"), w, h, true)
+	}
+	cursor := min(p.cursor, len(m)-1)
+
+	rows := make([]string, 0, len(m)*2)
+	cursorRow := 0
+	group := ""
+	for i, e := range m {
+		if e.group != group {
+			group = e.group
+			if len(rows) > 0 {
+				rows = append(rows, "")
+			}
+			label := " " + strings.ToUpper(group) + " "
+			fill := max(inner-ansi.StringWidth(label)-1, 0)
+			rows = append(rows, styleTitle.Render(label)+
+				styleDim.Render(strings.Repeat("─", fill)))
+		}
+		mark, style := "  ", styleDim
+		if i == cursor {
+			mark, style = styleFocus.Render("› "), styleTitle
+			cursorRow = len(rows)
+		}
+		// The preview is dim and to the right of the payload's name: what a
+		// row *is* is what a reader picks by, and the words are how they
+		// tell two of them apart.
+		label := e.label
+		pad := max(inner-2-ansi.StringWidth(label)-1, 1)
+		snippet := ansi.Truncate(e.snippet, max(pad-1, 1), "…")
+		rows = append(rows, mark+style.Render(label)+
+			strings.Repeat(" ", max(pad-ansi.StringWidth(snippet), 1))+styleDim.Render(snippet))
+	}
+	lines = append(lines, window(rows, cursorRow, h-3)...)
+	return frame("copy", strings.Join(lines, "\n"), w, h, true)
+}

--- a/internal/tui/readerpicker_test.go
+++ b/internal/tui/readerpicker_test.go
@@ -1,0 +1,520 @@
+package tui
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The reader actions (task 076). internal/tui is covered by no gate script,
+// so these hermetic tests are the whole assurance — task 073's position,
+// unchanged.
+
+const readerDoc = "# Findings\n\n" +
+	"The `parse` step is **wrong**.\n\n" +
+	"- first\n" +
+	"- second\n\n" +
+	"```go\nfunc main() {\n\tprintln(\"hi\")\n}\n```\n\n" +
+	"> and a quote\n"
+
+// stubClipboard points the write seam at a recorder for one test.
+func stubClipboard(t *testing.T, err error) *[]string {
+	t.Helper()
+	var wrote []string
+	prev := clipboardWrite
+	clipboardWrite = func(text string) error {
+		wrote = append(wrote, text)
+		return err
+	}
+	t.Cleanup(func() { clipboardWrite = prev })
+	return &wrote
+}
+
+// copyOne runs the payload named by label out of the picker rows.
+func copyOne(t *testing.T, items []copyItem, group, label string) string {
+	t.Helper()
+	for _, it := range items {
+		if it.group == group && it.label == label {
+			return it.text
+		}
+	}
+	t.Fatalf("no %q row under %q in %d rows", label, group, len(items))
+	return ""
+}
+
+// TestRawIsTheSameSourceInBothWorkspaces is the first acceptance criterion in
+// its raw form: one document, one rendering, whichever pane draws it.
+func TestRawIsTheSameSourceInBothWorkspaces(t *testing.T) {
+	for _, width := range []int{40, 80, 200} {
+		recs := []apiclient.TranscriptRecord{{Type: "agent.output", Text: readerDoc}}
+		task := outputLines(recs, levelNormal, width, lineOpts{expandKey: "v", raw: true})
+		chat := outputLines(recs, levelNormal, width, lineOpts{expandKey: chatExpandKey, raw: true})
+		if strings.Join(task, "\n") != strings.Join(chat, "\n") {
+			t.Fatalf("width %d: the two panes drew the same raw document differently", width)
+		}
+		// The source is what is on screen, punctuation and all.
+		body := ansi.Strip(strings.Join(task, "\n"))
+		for _, want := range []string{"# Findings", "**wrong**", "```go", "- first"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("width %d: raw mode dropped %q:\n%s", width, want, body)
+			}
+		}
+	}
+}
+
+// TestRawWrapsAtNarrowWidths: raw is still the pane's, not a dump.
+func TestRawWrapsAtNarrowWidths(t *testing.T) {
+	long := "a line of source that is far longer than the pane it has to fit inside of, several times over"
+	recs := []apiclient.TranscriptRecord{{Type: "agent.output", Text: long}}
+	for _, width := range []int{20, 40, 80} {
+		for i, l := range outputLines(recs, levelNormal, width, lineOpts{expandKey: "v", raw: true}) {
+			if got := ansi.StringWidth(l); got > width {
+				t.Fatalf("width %d: raw line %d is %d cells wide: %q", width, i, got, ansi.Strip(l))
+			}
+		}
+	}
+}
+
+// TestRawStripsTerminalControls: raw mode is an escape hatch for a surprising
+// render, not a hole in §16's one chokepoint (decision 3).
+func TestRawStripsTerminalControls(t *testing.T) {
+	evil := "before\x1b[2Jafter\x1b]0;title\x07\x07\n\x9bmore\x00end"
+	recs := []apiclient.TranscriptRecord{{Type: "agent.output", Text: evil}}
+	for _, width := range []int{20, 80} {
+		out := strings.Join(outputLines(recs, levelNormal, width, lineOpts{expandKey: "v", raw: true}), "\n")
+		for _, r := range ansi.Strip(out) {
+			if isTerminalControl(r) {
+				t.Fatalf("width %d: raw output kept control %#U", width, r)
+			}
+		}
+		if strings.Contains(out, "\x1b[2J") || strings.Contains(out, "\x1b]0;") {
+			t.Fatalf("width %d: raw output kept an escape sequence: %q", width, out)
+		}
+	}
+}
+
+// TestRawTouchesNothingDurable: presentation only (decision 2).
+func TestRawTouchesNothingDurable(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 4
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: readerDoc}}
+	d.nextOffset = 17
+	before := d.records[0]
+	level := d.level.get()
+
+	d.toggleRaw()
+
+	if !reflect.DeepEqual(d.records[0], before) {
+		t.Fatal("toggling raw mutated the record")
+	}
+	if d.nextOffset != 17 {
+		t.Fatalf("toggling raw moved nextOffset to %d", d.nextOffset)
+	}
+	if d.level.get() != level {
+		t.Fatalf("toggling raw changed the level to %v", d.level.get())
+	}
+	if !d.following {
+		t.Fatal("toggling raw dropped follow")
+	}
+}
+
+// TestRawIsOneSessionValue mirrors task 071's level test: one holder, both
+// workspaces, and it survives leaving and reopening a view.
+func TestRawIsOneSessionValue(t *testing.T) {
+	level, raw := newLevelHolder(), newRawHolder()
+	d := newDetail(testCtx(t), level, raw)
+	v := newChatView(level, raw)
+
+	d.toggleRaw()
+	if !v.raw.get() {
+		t.Fatal("raw toggled in the task workspace is not visible in the chat")
+	}
+	v.updateKey(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	if d.raw.get() {
+		t.Fatal("raw toggled back in the chat is not visible in the task workspace")
+	}
+
+	raw.toggle()
+	if !newChatView(level, raw).raw.get() {
+		t.Fatal("a freshly opened chat view lost the session's raw choice")
+	}
+}
+
+// TestChatRetentionFallbackFollowsRaw: §17's answer is assistant prose too.
+func TestChatRetentionFallbackFollowsRaw(t *testing.T) {
+	v := chatViewFixture()
+	v.turns = []apiclient.ChatTurn{{ID: 1, Seq: 1, State: "done", Prompt: "hi", ResultText: readerDoc}}
+
+	rendered := ansi.Strip(strings.Join(v.bodyLines(80), "\n"))
+	if strings.Contains(rendered, "# Findings") {
+		t.Fatalf("the rendered fallback kept its Markdown punctuation:\n%s", rendered)
+	}
+	v.raw.toggle()
+	if raw := ansi.Strip(strings.Join(v.bodyLines(80), "\n")); !strings.Contains(raw, "# Findings") {
+		t.Fatalf("the retention fallback ignored raw mode:\n%s", raw)
+	}
+	// And it is offered to the picker.
+	if len(copyDocs(v.copyDocs())) == 0 {
+		t.Fatal("the retention fallback contributed no copy targets")
+	}
+}
+
+// TestCopyPayloads pins what each of the three payloads is (decision 5).
+func TestCopyPayloads(t *testing.T) {
+	items := copyDocs([]string{readerDoc})
+
+	md := copyOne(t, items, "message 1", copyLabelMarkdown)
+	if md != readerDoc {
+		t.Fatalf("the markdown payload is not the stored text:\n%q", md)
+	}
+
+	plain := copyOne(t, items, "message 1", copyLabelPlain)
+	for _, punct := range []string{"#", "*", "`"} {
+		if strings.Contains(plain, punct) {
+			t.Fatalf("the plain-text payload kept %q:\n%s", punct, plain)
+		}
+	}
+	if strings.Contains(plain, "\x1b") {
+		t.Fatalf("the plain-text payload carries ANSI:\n%q", plain)
+	}
+	for _, want := range []string{"Findings", "The parse step is wrong.", "• first", "func main() {"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("the plain-text payload dropped %q:\n%s", want, plain)
+		}
+	}
+
+	code := copyOne(t, items, "message 1", copyLabelCode)
+	if want := "func main() {\n\tprintln(\"hi\")\n}"; code != want {
+		t.Fatalf("the code payload is %q, want %q", code, want)
+	}
+}
+
+// TestCopyPayloadsAreWidthIndependent: no pane wrapping on the clipboard
+// (decision 4).
+func TestCopyPayloadsAreWidthIndependent(t *testing.T) {
+	// The picker is built from the source, so width cannot reach it — this
+	// asserts the property by rendering the pane at both widths first, which
+	// is what a real session does before pressing the key.
+	recs := []apiclient.TranscriptRecord{{Type: "agent.output", Text: readerDoc}}
+	var payloads [2]string
+	for i, width := range []int{40, 200} {
+		outputLines(recs, levelNormal, width, lineOpts{expandKey: "v"})
+		var b strings.Builder
+		for _, it := range copyDocs(copyDocsFromRecords(recs)) {
+			b.WriteString(it.label + "\x00" + it.text + "\x00")
+		}
+		payloads[i] = b.String()
+	}
+	if payloads[0] != payloads[1] {
+		t.Fatal("the clipboard payloads differ between width 40 and width 200")
+	}
+}
+
+// TestCopyPayloadsAreSanitized: §16 holds at the clipboard boundary too
+// (decision 4).
+func TestCopyPayloadsAreSanitized(t *testing.T) {
+	wrote := stubClipboard(t, nil)
+	evil := "# Title\x1b[2J\n\nbody\x07 and \x9bmore\n"
+	items := copyDocs([]string{evil})
+	if len(items) == 0 {
+		t.Fatal("no copy rows for a document that has text")
+	}
+	for _, it := range items {
+		msg := drain(writeClipboardCmd(it.label, it.text))
+		if res, ok := msg.(clipboardResultMsg); !ok || res.err != nil {
+			t.Fatalf("%s: %#v", it.label, msg)
+		}
+	}
+	for _, got := range *wrote {
+		for _, r := range got {
+			if isTerminalControl(r) {
+				t.Fatalf("a clipboard payload kept control %#U: %q", r, got)
+			}
+		}
+	}
+}
+
+// TestCopyPickerLists covers what the popup offers and in what order.
+func TestCopyPickerLists(t *testing.T) {
+	twin := "Here is the answer.\n\nno fence in this one\n"
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: twin},
+		{Type: "agent.thinking", Text: "not prose"},
+		{Type: "agent.output", Text: readerDoc},
+		{Type: "agent.output", Text: twin},
+	}
+	items := copyDocs(copyDocsFromRecords(recs))
+
+	// Newest first, and two documents with identical opening text stay
+	// distinguishable by their ordinal.
+	if items[0].group != "message 1" || items[0].text != twin {
+		t.Fatalf("the newest document is not message 1: %#v", items[0])
+	}
+	groups := map[string]bool{}
+	for _, it := range items {
+		groups[it.group] = true
+	}
+	if len(groups) != 3 {
+		t.Fatalf("got %d documents, want 3: %v", len(groups), groups)
+	}
+	// A document with no fence contributes no code row; the reasoning record
+	// contributes nothing at all.
+	for _, it := range items {
+		if it.group != "message 2" && strings.HasPrefix(it.label, copyLabelCode) {
+			t.Fatalf("%s has a code row it should not: %#v", it.group, it)
+		}
+		if strings.Contains(it.text, "not prose") {
+			t.Fatalf("a reasoning record reached the picker: %#v", it)
+		}
+	}
+}
+
+// TestCopyPickerCapturesAtPickTime is the "targets remain stable" criterion:
+// the rows hold text, not indices, so nothing that happens afterwards moves
+// the target (decision 6).
+func TestCopyPickerCapturesAtPickTime(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 4
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: readerDoc}}
+	d.width = 200
+
+	msg, ok := drain(d.updateKey(tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl})).(openCopyPickerMsg)
+	if !ok {
+		t.Fatal("ctrl+y did not open the picker")
+	}
+	p := newReaderPicker(msg.items)
+
+	// The world moves on: more output arrives, the front of the slice is
+	// pruned, and the pane is resized.
+	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: "something else entirely"}}
+	d.width = 40
+	d.outputLines()
+
+	run, done, _ := p.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done || run == nil {
+		t.Fatal("enter did not pick a row")
+	}
+	if run.text != readerDoc {
+		t.Fatalf("the pick copied %q, want the document that was on screen", run.text)
+	}
+}
+
+// TestCopyPickerFilters: the search line narrows the rows, as the palette's
+// does.
+func TestCopyPickerFilters(t *testing.T) {
+	p := newReaderPicker(copyDocs([]string{readerDoc}))
+	for _, r := range "code" {
+		p.update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	m := p.matches()
+	if len(m) == 0 {
+		t.Fatal("searching for \"code\" matched nothing")
+	}
+	for _, it := range m {
+		if !strings.Contains(it.label, "code") {
+			t.Fatalf("%q matched the query \"code\"", it.label)
+		}
+	}
+	if _, done, _ := p.update(tea.KeyPressMsg{Code: tea.KeyEscape}); !done {
+		t.Fatal("esc did not close the picker")
+	}
+}
+
+// TestClipboardSeam covers the three outcomes a copy can have.
+func TestClipboardSeam(t *testing.T) {
+	t.Run("system clipboard takes it", func(t *testing.T) {
+		wrote := stubClipboard(t, nil)
+		msg, ok := drain(writeClipboardCmd("markdown", "hello")).(clipboardResultMsg)
+		if !ok || msg.err != nil || msg.osc != "" {
+			t.Fatalf("got %#v, want a plain success", msg)
+		}
+		if len(*wrote) != 1 || (*wrote)[0] != "hello" {
+			t.Fatalf("wrote %v", *wrote)
+		}
+		if text, bad := msg.notice(); bad || text != "markdown copied" {
+			t.Fatalf("notice %q bad=%v", text, bad)
+		}
+	})
+
+	t.Run("falls over to OSC 52", func(t *testing.T) {
+		stubClipboard(t, errors.New("exec: \"xclip\": not found"))
+		msg, ok := drain(writeClipboardCmd("code block", "hello")).(clipboardResultMsg)
+		if !ok || msg.osc != "hello" {
+			t.Fatalf("got %#v, want the payload handed to the terminal", msg)
+		}
+		text, bad := msg.notice()
+		if bad {
+			t.Fatal("the fallback reads as a failure")
+		}
+		if !strings.Contains(text, "sent to the terminal") || !strings.Contains(text, "xclip") {
+			t.Fatalf("the fallback notice %q names neither the transport nor the error", text)
+		}
+	})
+
+	t.Run("nothing to copy", func(t *testing.T) {
+		stubClipboard(t, nil)
+		msg := drain(writeClipboardCmd("markdown", "\x1b[2J")).(clipboardResultMsg)
+		text, bad := msg.notice()
+		if !bad || !strings.Contains(text, "nothing to copy") {
+			t.Fatalf("notice %q bad=%v", text, bad)
+		}
+	})
+}
+
+// TestCopyResultBecomesANotice: a key press a human made never fails
+// silently, in either workspace.
+func TestCopyResultBecomesANotice(t *testing.T) {
+	d := newTestDetail(t)
+	d.update(clipboardResultMsg{label: "markdown"})
+	if d.actions.status != "markdown copied" || d.actions.statusBad {
+		t.Fatalf("the task workspace said %q (bad=%v)", d.actions.status, d.actions.statusBad)
+	}
+
+	v := chatViewFixture()
+	v.update(clipboardResultMsg{label: "markdown", err: errors.New("boom")})
+	if !v.noteBad || !strings.Contains(v.note, "boom") {
+		t.Fatalf("the chat said %q (bad=%v)", v.note, v.noteBad)
+	}
+}
+
+// connectedChatRoot is a chat workspace on screen with its composer focused,
+// which is where every one of these keys is hardest.
+func connectedChatRoot(t *testing.T) *root {
+	t.Helper()
+	m := newRoot(testCtx(t), fakeConnector(), ackedDir(t))
+	m.phase = phaseConnected
+	v := chatViewFixture()
+	v.turns = []apiclient.ChatTurn{{ID: 1, Seq: 1, State: "done", Prompt: "hi"}}
+	v.turnRecords[1] = []apiclient.TranscriptRecord{{Type: "agent.output", Text: readerDoc}}
+	m.views[viewChat] = v
+	m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m.switchTo(viewChat)
+	if m.active != viewChat {
+		t.Fatalf("fixture is on %v, want the chat workspace", m.active)
+	}
+	if !m.activeCapturesInput() {
+		t.Fatal("fixture's composer does not hold the keyboard")
+	}
+	return m
+}
+
+// TestPaletteReachableFromAChat is decision 7: the palette is §15's "what can
+// be done right now" surface and the chat workspace had been unable to reach
+// it since task 067, because `:` types a colon into the draft.
+func TestPaletteReachableFromAChat(t *testing.T) {
+	m := connectedChatRoot(t)
+	v := m.views[viewChat].(*chatView)
+
+	m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
+	if m.palette == nil {
+		t.Fatal("ctrl+p did not open the palette from a chat")
+	}
+	if v.composer.Value() != "" {
+		t.Fatalf("ctrl+p reached the composer: %q", v.composer.Value())
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.palette != nil {
+		t.Fatal("esc did not close the palette")
+	}
+
+	// And the composer still owns everything it owned before: every letter,
+	// both arrows, and the colon that is the palette's other key.
+	for _, k := range []string{"q", "n", "v", ":"} {
+		m.Update(key(k))
+	}
+	if m.palette != nil {
+		t.Fatal("a printable key opened the palette from inside the composer")
+	}
+	if got := v.composer.Value(); got != "qnv:" {
+		t.Fatalf("the composer holds %q, want every key typed into it", got)
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if got := v.composer.Value(); got != "qnv:" {
+		t.Fatalf("the arrows changed the draft to %q", got)
+	}
+}
+
+// TestCopyPickerThroughTheRoot drives the whole path a human takes: the key
+// in the workspace, the popup owning the keyboard, the pick, the clipboard,
+// and the notice.
+func TestCopyPickerThroughTheRoot(t *testing.T) {
+	wrote := stubClipboard(t, nil)
+	m := connectedChatRoot(t)
+	v := m.views[viewChat].(*chatView)
+
+	// The key asks for the popup with a command; the runtime delivers its
+	// message, which is what a test has to do by hand.
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl})
+	m.Update(drain(cmd))
+	if m.reader == nil {
+		t.Fatal("ctrl+y did not open the copy picker")
+	}
+	if v.composer.Value() != "" {
+		t.Fatalf("ctrl+y reached the composer: %q", v.composer.Value())
+	}
+	// The popup owns the keyboard: a letter searches, it does not quit.
+	m.Update(key("q"))
+	if m.reader == nil {
+		t.Fatal("q closed the picker instead of typing into its search line")
+	}
+	if v.composer.Value() != "" {
+		t.Fatalf("a key reached the composer under the popup: %q", v.composer.Value())
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.reader != nil {
+		t.Fatal("esc did not close the picker")
+	}
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl})
+	m.Update(drain(cmd))
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.reader != nil {
+		t.Fatal("enter left the picker open")
+	}
+	m.Update(drain(cmd))
+	if len(*wrote) != 1 || (*wrote)[0] != readerDoc {
+		t.Fatalf("the clipboard got %v, want the assistant's stored Markdown", *wrote)
+	}
+	if v.note != "markdown copied" || v.noteBad {
+		t.Fatalf("the chat said %q (bad=%v)", v.note, v.noteBad)
+	}
+}
+
+// TestReaderHintsNameTheCtrlKeys: the footer is derived from the registry, so
+// what it prints is what the keys are.
+func TestReaderHintsNameTheCtrlKeys(t *testing.T) {
+	for _, ctx := range []bindingContext{ctxOutput, ctxChat} {
+		var hints []string
+		for _, b := range bindingsFor(ctx) {
+			if b.key == rawToggleKey || b.key == copyPickKey {
+				hints = append(hints, b.hint)
+			}
+		}
+		if len(hints) != 2 {
+			t.Fatalf("%s: the registry hints the reader actions %v", ctx, hints)
+		}
+		for _, h := range hints {
+			if !strings.HasPrefix(h, "ctrl+") {
+				t.Fatalf("%s: hint %q does not name a ctrl key", ctx, h)
+			}
+		}
+	}
+	// The chat's own footer line is hand-written rather than derived, so it
+	// has to be checked against the registry by hand.
+	v := chatViewFixture()
+	foot := ansi.Strip(strings.Join(v.footerLines(200), "\n"))
+	for _, k := range []string{rawToggleKey, copyPickKey} {
+		if !strings.Contains(foot, k) {
+			t.Fatalf("the chat footer does not name %s:\n%s", k, foot)
+		}
+	}
+}

--- a/internal/tui/readerpicker_test.go
+++ b/internal/tui/readerpicker_test.go
@@ -518,3 +518,34 @@ func TestReaderHintsNameTheCtrlKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestPaletteRunsTheReaderActions closes the loop the palette promises: a
+// listed entry replays its direct key, so an entry whose key the replay could
+// not synthesize would be a row that does nothing.
+func TestPaletteRunsTheReaderActions(t *testing.T) {
+	for _, key := range []string{rawToggleKey, copyPickKey, chatExpandKey, "ctrl+g"} {
+		if got := synthKey(key); got.String() != key {
+			t.Fatalf("synthKey(%q) produces %q", key, got.String())
+		}
+	}
+
+	m := connectedChatRoot(t)
+	v := m.views[viewChat].(*chatView)
+	m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl})
+	if m.palette == nil {
+		t.Fatal("ctrl+p did not open the palette")
+	}
+	for _, r := range "original Markdown" {
+		m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+	}
+	if got := len(m.palette.matches()); got != 1 {
+		t.Fatalf("the query matched %d entries, want the raw toggle alone", got)
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !v.raw.get() {
+		t.Fatal("running the palette entry did not toggle raw mode")
+	}
+	if v.composer.Value() != "" {
+		t.Fatalf("the palette's replay typed into the composer: %q", v.composer.Value())
+	}
+}

--- a/internal/tui/readerpicker_test.go
+++ b/internal/tui/readerpicker_test.go
@@ -36,9 +36,12 @@ func stubClipboard(t *testing.T, err error) *[]string {
 	return &wrote
 }
 
-// copyOne runs the payload named by label out of the picker rows.
-func copyOne(t *testing.T, items []copyItem, group, label string) string {
+// copyOne runs the payload named by label out of the first message's picker
+// rows. Every caller builds its own one-document picker, so the group is the
+// first one rather than a parameter.
+func copyOne(t *testing.T, items []copyItem, label string) string {
 	t.Helper()
+	const group = "message 1"
 	for _, it := range items {
 		if it.group == group && it.label == label {
 			return it.text
@@ -170,12 +173,12 @@ func TestChatRetentionFallbackFollowsRaw(t *testing.T) {
 func TestCopyPayloads(t *testing.T) {
 	items := copyDocs([]string{readerDoc})
 
-	md := copyOne(t, items, "message 1", copyLabelMarkdown)
+	md := copyOne(t, items, copyLabelMarkdown)
 	if md != readerDoc {
 		t.Fatalf("the markdown payload is not the stored text:\n%q", md)
 	}
 
-	plain := copyOne(t, items, "message 1", copyLabelPlain)
+	plain := copyOne(t, items, copyLabelPlain)
 	for _, punct := range []string{"#", "*", "`"} {
 		if strings.Contains(plain, punct) {
 			t.Fatalf("the plain-text payload kept %q:\n%s", punct, plain)
@@ -190,7 +193,7 @@ func TestCopyPayloads(t *testing.T) {
 		}
 	}
 
-	code := copyOne(t, items, "message 1", copyLabelCode)
+	code := copyOne(t, items, copyLabelCode)
 	if want := "func main() {\n\tprintln(\"hi\")\n}"; code != want {
 		t.Fatalf("the code payload is %q, want %q", code, want)
 	}
@@ -547,5 +550,48 @@ func TestPaletteRunsTheReaderActions(t *testing.T) {
 	}
 	if v.composer.Value() != "" {
 		t.Fatalf("the palette's replay typed into the composer: %q", v.composer.Value())
+	}
+}
+
+// TestCopyPayloadsCarryTask075Blocks: the two blocks task 075 added reach the
+// clipboard as the structure the pane draws (decision 5). A table becomes the
+// stacked `column: value` records — the pane's own width-free form — and a
+// link keeps the number the pane gave it, with the reference block that
+// resolves it closing the payload, because a destination stripped of both its
+// punctuation and its reference would be a destination deleted.
+func TestCopyPayloadsCarryTask075Blocks(t *testing.T) {
+	doc := "See [the spec](https://example.test/spec) and [it again](https://example.test/spec).\n" +
+		"\n" +
+		"| Step | State |\n" +
+		"|---|---|\n" +
+		"| build | ok |\n"
+	items := copyDocs([]string{doc})
+
+	plain := copyOne(t, items, copyLabelPlain)
+	for _, punct := range []string{"](", "|", "---"} {
+		if strings.Contains(plain, punct) {
+			t.Fatalf("the plain-text payload kept %q:\n%s", punct, plain)
+		}
+	}
+	for _, want := range []string{
+		"See the spec [1] and it again [1].", // one number for one destination
+		"▪ Step: build",
+		"  State: ok",
+		"[1] https://example.test/spec",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("the plain-text payload dropped %q:\n%s", want, plain)
+		}
+	}
+
+	// The Markdown payload is still the stored text, table pipes and all.
+	if md := copyOne(t, items, copyLabelMarkdown); md != doc {
+		t.Fatalf("the markdown payload is not the stored text:\n%q", md)
+	}
+	// A document with no fence contributes no code row.
+	for _, it := range items {
+		if it.label == copyLabelCode {
+			t.Fatalf("a document with no fenced block offered %q", it.label)
+		}
 	}
 }

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -474,15 +474,16 @@ func synthKey(key string) tea.KeyPressMsg {
 		return tea.KeyPressMsg{Code: tea.KeyDown}
 	case "space":
 		return tea.KeyPressMsg{Code: ' ', Text: " "}
-	case "ctrl+s":
-		return tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}
-	case "ctrl+c":
-		return tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
-	case "ctrl+x":
-		return tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}
-	default:
-		return tea.KeyPressMsg{Code: rune(key[0]), Text: key}
 	}
+	// Any ctrl+<letter>, rather than a case per key. The named list above had
+	// grown three of them and was already one behind the registry: ctrl+r and
+	// ctrl+g are ctxChat rows the palette lists, and replaying either through
+	// the default arm below synthesized `c` with the whole label as its text
+	// (task 074). A rule the registry cannot outrun is the fix.
+	if mod, ok := strings.CutPrefix(key, "ctrl+"); ok && len([]rune(mod)) == 1 {
+		return tea.KeyPressMsg{Code: []rune(mod)[0], Mod: tea.ModCtrl}
+	}
+	return tea.KeyPressMsg{Code: rune(key[0]), Text: key}
 }
 
 // updateNoticeKey is the §16 overlay's key handling: it swallows everything

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -70,6 +70,11 @@ type root struct {
 	// the root because it must overlay every screen, takeovers included —
 	// while disconnected it is how the daemon view stays reachable.
 	palette *palette
+	// reader is the task 076 copy picker, open when non-nil. It lives beside
+	// the palette and is routed exactly like it: a short-lived popup that
+	// owns the keyboard while it is up. The two are never open together —
+	// each closes on the key that would open the other.
+	reader *readerPicker
 	// mouseOn drives tea.View's mouse mode: on by default, M toggles (§15
 	// Mouse). Off restores native click-drag text selection.
 	mouseOn bool
@@ -199,11 +204,16 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		return m.updateMouseClick(msg)
 	case tea.MouseWheelMsg:
-		if m.notice.active || m.palette != nil || m.help {
+		if m.notice.active || m.palette != nil || m.reader != nil || m.help {
 			return m, nil
 		}
 		msg.Y-- // the body starts under the header line
 		return m, m.deliver(m.active, msg)
+	case openCopyPickerMsg:
+		m.reader = newReaderPicker(msg.items)
+		return m, nil
+	case clipboardResultMsg:
+		return m, m.updateClipboardResult(msg)
 	case noteMsg:
 		return m.updateNote(msg.note)
 	case streamDoneMsg:
@@ -232,6 +242,9 @@ func (m *root) updatePaste(text string) tea.Cmd {
 	if text == "" || m.notice.active || m.help {
 		return nil
 	}
+	if m.reader != nil {
+		return m.reader.paste(text)
+	}
 	if m.palette != nil {
 		return m.palette.paste(text)
 	}
@@ -249,7 +262,7 @@ func (m *root) updatePaste(text string) tea.Cmd {
 // everything else lands in the active screen's body. Popups stay keyboard;
 // right-clicks and the rest are out of scope.
 func (m *root) updateMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
-	if msg.Button != tea.MouseLeft || m.notice.active || m.palette != nil || m.help {
+	if msg.Button != tea.MouseLeft || m.notice.active || m.palette != nil || m.reader != nil || m.help {
 		return m, nil
 	}
 	if m.height > 0 && msg.Y == m.height-1 {
@@ -274,13 +287,26 @@ func (m *root) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// tea.PasteMsg and takes the same route bracketed paste does. Nothing
 	// capturing text means nothing to paste into — don't shell out to read a
 	// clipboard whose contents would be dropped.
-	if msg.String() == "ctrl+v" && (m.palette != nil || m.activeCapturesInput()) {
+	if msg.String() == "ctrl+v" && (m.palette != nil || m.reader != nil || m.activeCapturesInput()) {
 		return m, readClipboardCmd()
 	}
-	// An open palette owns every key but ctrl+c — it is a popup, the top of
-	// the §15 esc stack.
+	// An open popup owns every key but ctrl+c — it is the top of the §15 esc
+	// stack.
+	if m.reader != nil && msg.String() != "ctrl+c" {
+		return m.updateReaderKey(msg)
+	}
 	if m.palette != nil && msg.String() != "ctrl+c" {
 		return m.updatePaletteKey(msg)
+	}
+	// ctrl+p is `:` for a surface that is capturing text. It is hoisted above
+	// the input-capture gate the way ctrl+v is, and for the same reason: a
+	// chat's composer takes every printable key, so `:` there types a colon
+	// into the draft and opens nothing (task 076 decision 7). The palette is
+	// §15's "what can be done right now" surface, and it had been unreachable
+	// from a chat since the workspace landed.
+	if msg.String() == paletteAltKey {
+		m.openPalette()
+		return m, nil
 	}
 	// A view that is capturing text (the board's filter) owns every key but
 	// ctrl+c: typing "q" into a filter must not quit the TUI.
@@ -358,6 +384,21 @@ func (m *root) updatePaletteKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, m.switchTo(run.navTarget)
 	}
 	return m.updateKey(synthKey(run.key))
+}
+
+// updateReaderKey routes keys into the open copy picker and puts whatever it
+// picks on the clipboard. The payload was captured when the popup was built,
+// so what is copied is what was on screen then — records that arrived since,
+// and a resize, change nothing.
+func (m *root) updateReaderKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	run, done, cmd := m.reader.update(msg)
+	if done {
+		m.reader = nil
+	}
+	if run == nil {
+		return m, cmd
+	}
+	return m, writeClipboardCmd(run.label, run.text)
 }
 
 // openPalette builds the palette for the active surface.
@@ -656,13 +697,13 @@ func (m *root) View() tea.View {
 	b.WriteString("\n")
 	b.WriteString(m.footerLine())
 	frame := b.String()
-	if m.palette != nil {
+	if popup, ok := m.popupRender(); ok {
 		pw := min(m.width-8, 64)
 		if pw < 24 {
 			pw = max(m.width-2, 10)
 		}
 		ph := min(18, max(m.height-4, 6))
-		frame = overlay(frame, m.palette.render(pw, ph), max((m.width-pw)/2, 0), 2)
+		frame = overlay(frame, popup(pw, ph), max((m.width-pw)/2, 0), 2)
 	}
 	v := tea.NewView(frame)
 	if m.mouseOn && !m.notice.active {
@@ -872,4 +913,30 @@ func errString(err error) string {
 		return "unknown error"
 	}
 	return err.Error()
+}
+
+// popupRender names the popup the root itself owns and is drawing, if any.
+// They are mutually exclusive and share one box, so the geometry is decided
+// once rather than copied per popup.
+func (m *root) popupRender() (func(w, h int) string, bool) {
+	switch {
+	case m.reader != nil:
+		return m.reader.render, true
+	case m.palette != nil:
+		return m.palette.render, true
+	default:
+		return nil, false
+	}
+}
+
+// updateClipboardResult turns a copy's outcome into the active surface's own
+// notice (§15). It goes to the active view rather than being broadcast: the
+// human pressed the key on one screen and is looking at it.
+func (m *root) updateClipboardResult(msg clipboardResultMsg) tea.Cmd {
+	cmds := []tea.Cmd{m.deliver(m.active, msg)}
+	if msg.osc != "" {
+		// The system clipboard refused; ask the terminal itself (OSC 52).
+		cmds = append(cmds, tea.SetClipboard(msg.osc))
+	}
+	return tea.Batch(cmds...)
 }

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -74,10 +74,10 @@ type shell struct {
 	bannerLines int
 }
 
-func newShell(ctx context.Context, level *levelHolder) *shell {
+func newShell(ctx context.Context, level *levelHolder, raw *rawHolder) *shell {
 	s := &shell{
 		board:     newBoard(),
-		detail:    newDetail(ctx, level),
+		detail:    newDetail(ctx, level, raw),
 		bar:       &actionBar{},
 		connected: true,
 	}

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -20,7 +20,7 @@ import (
 // exactly the openStream calls syncStream made.
 func newShellFixture(t *testing.T, tasks ...apiclient.Task) (*shell, *int) {
 	t.Helper()
-	s := newShell(testCtx(t), newLevelHolder())
+	s := newShell(testCtx(t), newLevelHolder(), newRawHolder())
 	s.board.now = func() time.Time { return testNow }
 	s.board.bell = func() {}
 	// Flat, for the same reason testBoard is: these tests count rendered rows

--- a/internal/tui/taskview_test.go
+++ b/internal/tui/taskview_test.go
@@ -226,7 +226,7 @@ func TestTaskDetailsSidebarSupportsMouseSelection(t *testing.T) {
 func taskDetailFixture(t *testing.T) *detail {
 	t.Helper()
 	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
-	d := newDetail(context.Background(), newLevelHolder())
+	d := newDetail(context.Background(), newLevelHolder(), newRawHolder())
 	d.taskID = 7
 	d.loaded = true
 	d.task = apiclient.TaskDetail{

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -109,7 +109,11 @@ func newViews(ctx context.Context) [viewCount]panel {
 	// transcript records (task 071 decision 3). Built here because this is
 	// the one place that constructs both of them.
 	level := newLevelHolder()
-	home := newShell(ctx, level)
+	// And one rendered/raw choice, held the same way and for the same reason
+	// (task 076 decision 2): toggling raw in a chat is visible in the task
+	// workspace, and neither one resets it.
+	raw := newRawHolder()
+	home := newShell(ctx, level, raw)
 	// Keep the board and detail sub-models independently testable while routing
 	// them as separate screens. The task view owns detail updates; the home shell
 	// retains the pointer only so both screens share the established action state.
@@ -128,6 +132,6 @@ func newViews(ctx context.Context) [viewCount]panel {
 		// has to know the answer before the probes land.
 		viewPullRequests: newPullRequestsView(),
 		viewChats:        newChatsView(),
-		viewChat:         newChatView(level),
+		viewChat:         newChatView(level, raw),
 	}
 }


### PR DESCRIPTION
## Summary

Assistant prose renders as Markdown since #289, but there was no way to see
what the agent actually wrote or to get any of it onto the clipboard. This adds
both, shared by the task workspace's output pane and the chat workspace.

**`ctrl+o` toggles rendered/raw.** Raw shows the stored Markdown as source —
one pane line per source line, preformatted, hard-wrapped at the pane's edge,
no parse — and the §17 retention fallback follows it too. The choice is one
session value shared by both workspaces, held the way the verbosity level
beside it is and persisted no more than that. It is presentation only: it does
not touch the records, `nextOffset`, the level, the transcript or follow mode.
It still goes through `wrapLine`'s segment emission, so §16's stripping is not
bypassed — raw is the agent's bytes as Markdown *source*, not as terminal
input.

**`ctrl+y` opens a copy picker** listing what can be taken out of the assistant
prose currently loaded, newest first: per document its Markdown and its plain
text (the pane's structure with the punctuation gone), plus one row per fenced
code block (interior only, no fence, no info string, whitespace kept). Payloads
are built from the source rather than from rendered lines, so a copy at width 40
and one at width 200 are byte-identical, and each row captures its text when the
popup is built — which is what makes a target stable across a resize, a
transcript reload and incremental rendering, with no identity model needed.
Everything on the clipboard goes through the same `sanitizeText` chokepoint the
pane does; a clipboard is pasted into a terminal.

`mdBlock` now carries its **source** (kind, depth, marker, text) rather than
laid-out `paneLine`s, so the pane's renderer, the plain-text emitter and the
picker's fenced-block scan all read one parse. A new `segment.code` flag lets
the plain payload strip a code span's backticks off the *existing* inline
scanner rather than growing a second one.

**`ctrl+p` opens the command palette from a text field.** `:` is a printable
key, so in a chat it typed a colon into the draft and opened nothing — the
palette has been unreachable from the chat workspace since task 067. `ctrl+p` is
hoisted above the input-capture gate the way `ctrl+v` already is. That is what
discharges the issue's "every action is reachable through keyboard help/palette
in both contexts", and it is a fix beyond this issue's scope.

Both new keys are ctrl-modified in **both** contexts rather than a letter in
`ctxOutput` and a ctrl twin in `ctxChat` (the `v`/`ctrl+r` split task 071 chose):
one action should have one name in the help overlay and the palette.

Two clipboard transports, and only one can be believed: `atotto/clipboard`
first, because it returns a real error, and OSC 52 (`tea.SetClipboard`) on its
refusal, because that is the one that reaches the right machine over SSH. The
notice says which ran and never claims a copy it could not verify. The write is
indirected through a package variable the way `openURL` is, so tests assert the
seam without a system clipboard.

**Link actions are not here** (decision 1). The renderer has no link construct
and no destination to copy — #290 owns that parsing, and building a second
answer here would fork it. Issue criteria 4 and 5, and the link half of 3 and 8,
move to a follow-up gated on #290. `openurl.go` and its three platform files,
which already do scheme validation and shell-free argv, are untouched and
waiting.

Entirely client-side: `internal/tui` alone, no daemon package, no API route, no
store migration.

**A standing defect fell out of the last test.** A palette entry runs by
replaying its direct key, and `synthKey` had a hand-written case per ctrl key
that was already a registry behind: the chat's `ctrl+r` (detail level) and
`ctrl+g` (follow the live end) are rows the palette lists, and both replayed as
a bare `c`. The new rows would have been the third and fourth. It is now a rule
over any `ctrl+<letter>`, in its own `fix:` commit.

One documented amendment to the agreed brief: it asked for a third notice for
"both transports failed". OSC 52 reports nothing back — the brief says so
itself — so that state is not representable, and the fallback notice names the
system clipboard's error inline instead. The third outcome that *is* real, a
payload that sanitizes away to nothing, is an error notice rather than a silent
no-op. Recorded as decision 8 in the task document.

## Related

Closes #292 — closes 074.1.

Follows [073](docs/tasks/073-assistant-markdown-in-output.md), whose decision 4
and §15 amendment parked this work by name ("a raw/rendered toggle key and a
copy-raw action are both plausible and both belong in the follow-up issues
already scoped"). This is that follow-up. It does not revisit any recorded
decision: 073 decision 5 (only `agent.output` is Markdown), 073 decision 7 /
§16 (one stripping chokepoint) and 071 decision 3 (session-level display state
shared by pointer) are all applied as they stand.

New task document:
[074](docs/tasks/074-reader-actions-on-assistant-markdown.md), with its index
row.

Two commits: the feature, and the `synthKey` fix above.

## Documentation audit

The docs pass found one defect in this branch's own `CHANGELOG.md` edit and
fixed it: a second `### Fixed` heading had been inserted in the middle of
`[Unreleased]`'s `### Added` list, which refiled every Added entry below it —
the codex output pane, chats on codex and cursor, the Pull Request tab and the
rest — as a fix. `[Unreleased]` already had a `### Fixed` section further down;
the palette-replay entry now lives there and the stray heading is gone.

Two derived pages were behind and are updated in the same `docs:` commit:
`docs/security-model.md`, whose terminal-injection section is the public form
of §16 and did not carry §16's new clipboard clause, and `docs/features.md`,
whose output-pane bullet already described the Markdown rendering.

Nothing else was stale. The config, CLI, API, block-reason, workflow-schema,
task-lifecycle and adapter derivations are all untouched by this change — it
is `internal/tui` only. No `docs/assets/tui-*.png` goes stale: raw mode is a
display state of a panel already captured and the copy picker is a popup no
capture shows. No gate walkthrough changed: `docs/gates/m3-gate.md`'s output-pane
leg walks `f`/`G`, `d`, `enter` and `C`, none of which moved.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — `internal/tui/readerpicker_test.go` (raw at three widths in both panes, narrow-width wrapping, injection fixtures, nothing durable touched, one shared session value, the three payloads, width-independence, the clipboard seam's three outcomes, the picker's rows and their capture-at-pick-time stability, `ctrl+p` from a focused composer, the whole key → popup → clipboard → notice path through the root, and the palette → replay → effect path that caught the `synthKey` bug) plus four `panelKeyProbes` rows in `bindings_test.go`
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — the raw toggle, the copy picker and `ctrl+p` under `### Added`, the palette-replay fix under the existing `### Fixed`
- [x] Affected page under `docs/` updated — `docs/guides/tui.md` (both key tables, a new "Seeing the source, and taking it away" section, the palette section's `:`-only claim, the global key table), `docs/spec.md` §15 and §16 amended in place with dated notes, `docs/security-model.md` (the clipboard and the raw toggle are inside the same stripping rule §16 states) and `docs/features.md` (the output-pane bullet that already carried the Markdown rendering)
