### PR TITLE
Read consecutive assistant records as one Markdown document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **An assistant message split across records renders as one message.** When an
+  agent delivers one answer as several output records, consecutive records are
+  now read as a single Markdown document rather than one document each. A
+  table, a list or a fenced code block spread across two of them renders as the
+  one thing it was written as instead of two broken fragments, and a link
+  destination named twice in one message gets one number and one reference
+  line. Anything that is not assistant prose — reasoning, a tool call, command
+  output — ends the message, and prose after it starts the next.
+- **A pane you have scrolled away from keeps its place.** Resizing the
+  terminal, changing the verbosity level, toggling the raw view, and output old
+  enough to be dropped from the window used to move a paused reader somewhere
+  else. The output pane and the chat body now hold the block at the top of the
+  view across all four, in both workspaces. Following the tail is unchanged.
+- **The copy picker's rows name a message rather than a snapshot of it.**
+  Picking a message that is still being written copies the whole message as it
+  stands at that moment; a finished one is unaffected, and a row whose records
+  have since been dropped from the window still copies what it offered, so a
+  pick can never fail.
+
 - **A chat can now hand its worktree and branch to a task.** An idle chat gains
   one action — `hand off` — that creates a task adopting the chat's worktree
   path, branch, base branch and base SHA *exactly as they are*. Nothing is

--- a/docs/features.md
+++ b/docs/features.md
@@ -227,7 +227,7 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   picker that puts a message, its plain text, or a single fenced code block on
   the clipboard — built from the source, so the pane's width is never baked
   into what you paste. Consecutive assistant records are read as one message,
-  so structure an agent split across records renders whole, and a pane you have
+  so structure that an agent split across records renders whole, and a pane you have
   scrolled away from keeps its place across a resize, a level change, the raw
   toggle and output dropping off the front of the window.
 - Guided task creation exposes project, workflow, declared fields, git and

--- a/docs/features.md
+++ b/docs/features.md
@@ -226,7 +226,10 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   view for the stored Markdown when a render surprises you, and another opens a
   picker that puts a message, its plain text, or a single fenced code block on
   the clipboard — built from the source, so the pane's width is never baked
-  into what you paste.
+  into what you paste. Consecutive assistant records are read as one message,
+  so structure an agent split across records renders whole, and a pane you have
+  scrolled away from keeps its place across a resize, a level change, the raw
+  toggle and output dropping off the front of the window.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -357,6 +357,14 @@ colour alone would not survive. There are no timestamps: on an 80-column pane
 they would spend nine columns of every line answering a question the timeline
 already answers per attempt.
 
+**A message is a message, however it arrived.** An agent sometimes delivers one
+answer as several records. Consecutive assistant records are read as one
+Markdown document, so a table, a list or a fenced block spread across them is
+the one thing it was written as, and its link references are numbered once for
+the whole message. Anything that is not assistant prose — reasoning, a tool
+call, command output — ends the message, and what comes after it starts the
+next.
+
 **What the agent said is rendered as Markdown.** Headings, emphasis, strong
 text, ordered and unordered lists, nested lists, blockquotes, inline code,
 fenced code and horizontal rules become terminal structure instead of literal
@@ -395,6 +403,12 @@ already drawn.
 
 The chat workspace's conversation body is this same pane, at the same level.
 
+**Scrolling away from the tail keeps your place.** A pane that is not following
+holds onto the block at the top of it, so resizing the terminal, changing the
+level with `v` or `ctrl+r`, toggling `ctrl+o`, and output old enough to be
+dropped from the window all leave you looking at the same thing. Press `f`
+(`ctrl+g` in a chat) to go back to following the tail.
+
 ### Seeing the source, and taking it away
 
 `ctrl+o` swaps the rendered view for the **stored Markdown**, exactly as the
@@ -416,7 +430,9 @@ the assistant prose on screen, newest message first.
 
 Payloads come from the source, not from what is drawn, so the pane's width never
 ends up baked into what you paste, and nothing that arrives after you open the
-picker moves the row you are pointing at. Escape sequences and control
+picker moves the row you are pointing at. A row names a message rather than a
+position in it, so picking one that is still being written copies the whole
+message as it stands at that moment. Escape sequences and control
 characters are stripped on the way out for the same reason they are stripped on
 the way in: a clipboard gets pasted into a terminal.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6782,6 +6782,37 @@ every other record stays literal.
   and Markdown must never make prose look like a tool event. Command output and
   tool summaries contain Markdown punctuation constantly, and none of it was
   meant as formatting.
+- **A run of consecutive `agent.output` records is one document** *(added
+  2026-09-01, issue #291)*. The unit of parsing is the run, not the record: an
+  adapter that delivers a message in several records must not turn a table, a
+  list or a fence spanning two of them into two broken documents. Any other
+  record — reasoning, tool use, tool result, command output, `agent.raw`, a
+  result line — closes the document, and prose after it opens the next; so does
+  a run or turn boundary, since each pane renders one attempt's or one turn's
+  records. The rule is independent of the verbosity level: a level that hides a
+  record must not change how the prose around it parses. The blank-line rule
+  between a document and a record that is not prose is unchanged. Two records
+  that each carry part of one paragraph therefore reflow into that paragraph
+  rather than staying two lines, which is the same change seen from the other
+  side.
+  - **The bound on reflow, and what is deliberately not built.** No part of
+    this classifies an unfinished Markdown tail. `agent.output` never carries a
+    partial document: claude runs message-level `stream-json` with no
+    `--include-partial-messages` (the T1.7 decision), codex emits
+    `agent_message` only on `item.completed`, and cursor delivers assistant
+    content blocks whole. A record is present whole or is not present. Joining
+    does mean a *record* boundary can fall inside a block — a table header in
+    one record and its delimiter row in the next renders as a paragraph and
+    then becomes a table — and the guarantee is the weaker, true one: a record
+    boundary is a message boundary, the parse is deterministic from the
+    accumulated source, and **nothing above the last block of the previous
+    document moves** when a record arrives. Token-level deltas would need the
+    classifier; reopening T1.7 is what would build it.
+  - **Rendering is memoized per document**, keyed on the source's digest, the
+    pane width, the verbosity level and the raw toggle. A live chunk re-renders
+    the document it extended rather than every record in the pane. There is no
+    client-side throttle and no second timer: §13.3's daemon-side coalescing is
+    the rate limit.
 - **The subset is a written-down list**, not CommonMark: headings, paragraphs,
   emphasis, strong, ordered and unordered lists, nested lists, blockquotes,
   inline code, fenced code, horizontal rules, and — *amended 2026-09-01 (task
@@ -6841,7 +6872,10 @@ every other record stays literal.
   *(added 2026-09-01, task 075)*. An inline link's label renders as ordinary
   prose carrying a dim `[n]`, and the message ends with a block of `[n] dest`
   lines — one per distinct destination, numbered per rendered message,
-  identical destinations sharing a number. Those lines are preformatted, so a
+  identical destinations sharing a number. *Amended 2026-09-01 (issue #291):*
+  the message is the **document** above, so a destination named in two records
+  of one run gets one number and one line, and the reference block closes the
+  document rather than each record. Those lines are preformatted, so a
   destination is never word-collapsed and a long one hard-wraps at the cell
   boundary. An image renders its **alt text** as the link-shaped item and its
   source as the reference; nothing is fetched, and there is no fetch in this
@@ -6892,10 +6926,22 @@ persisted, sent to the daemon or written to a transcript.
   markers, blockquotes prefixed, fences dropped), plus one row per **fenced code
   block** (its interior, no fence and no info string, whitespace kept). Every
   payload is built from the source, never from rendered lines, so a copy made at
-  width 40 and one made at width 200 are byte-identical. Each row captures its
-  text **when the popup is built**, which is what keeps a target stable across a
-  resize, a transcript reload and incremental rendering: there is no index left
-  to drift.
+  width 40 and one made at width 200 are byte-identical. *Amended 2026-09-01
+  (issue #291):* a row is one per **document**, and it is a **reference to that
+  document, resolved when it is picked**, carrying the text captured when the
+  popup was built as its fallback. A reference rather than an index, because an
+  index drifts the moment a chunk arrives or the record cap prunes the front of
+  the window. Two consequences, both intended: picking a document that has
+  grown since the popup opened copies it as it is now, because "copy this
+  message" means the whole message; and a reference whose records the prune
+  took copies the captured text, so a pick can never fail.
+- **A paused pane keeps its place across a rebuild** *(added 2026-09-01, issue
+  #291)*. Records carry no id on the wire and none is added; identity is
+  client-assigned on ingest and is not an index, so it survives the record cap.
+  A pane that is not following captures the identity of its topmost visible
+  block and restores it after any rebuild — a resize, a front-prune, a
+  verbosity change, a raw toggle. Following is untouched: its anchor is the
+  bottom.
 - **The clipboard has two transports, and the notice says which ran.** The
   system clipboard is tried first because its answer can be trusted; when it
   refuses, the text is handed to the terminal over OSC 52, which is the correct

--- a/docs/tasks/077-stable-assistant-markdown-while-streaming.md
+++ b/docs/tasks/077-stable-assistant-markdown-while-streaming.md
@@ -144,6 +144,20 @@ memo). Changed: `outputlines.go`, `markdown.go`, `detail.go`,
 `detailrender.go`, `chatview.go`, `chatrender.go`, `readerpicker.go`,
 `root.go`.
 
+## Tasks
+
+- [x] **077.1** The document model, the client-assigned identities, the paused
+  anchor, the picker's references and the render memo ✓ 2026-09-01
+
+**Done when:** a table, list or fence an adapter split across consecutive
+`agent.output` records renders as the one thing it was written as in both
+workspaces; any other record closes the document; a link destination named
+twice in one document gets one number and one reference line; a paused pane
+holds its topmost block across a resize, a prune, a level cycle and a raw
+toggle while follow mode still lands on the bottom; a picked row copies the
+document as it stands, falling back to the captured text; and §15,
+`docs/guides/tui.md` and `docs/features.md` say so.
+
 ## Tests
 
 `internal/tui` is covered by no gate script, so the hermetic tests are the

--- a/docs/tasks/077-stable-assistant-markdown-while-streaming.md
+++ b/docs/tasks/077-stable-assistant-markdown-while-streaming.md
@@ -1,0 +1,186 @@
+# 077 — Keep assistant Markdown stable while output streams
+
+**Status:** ✅ done (1/1)
+**Issue:** #291
+**Amends:** §15's task 073, 075 and 076 amendments
+**Follow-up to:** [076](076-reader-actions-on-assistant-markdown.md), whose
+decision 6 shipped no identity model and named this issue as the one that
+brings one
+
+The issue asked for a stable-prefix parser: classify the assistant document
+into a settled prefix and an unfinished tail, render the prefix, and promote
+the tail at a block boundary. Three things underneath that ask are real, and
+one of them is work task 076 parked here by name. The mechanism itself is not,
+and this task does not build it.
+
+## Decisions
+
+### 1. The stable-prefix parser is not built
+
+`agent.output` never carries a partial Markdown document. Assistant text
+reaches a client one whole message at a time, on every adapter:
+
+- **claude** runs message-level `stream-json` with **no
+  `--include-partial-messages`** — the T1.7 decision, recorded at
+  `docs/history/v0-tasks.md:142` ("message-level only … token-level deltas
+  revisited at T3.3 if the tail feels chunky") and cited in
+  `internal/agent/claude/claude.go`. T3.3 never revisited it. `parseAssistant`
+  joins a message's `text` blocks into one `EventOutput`.
+- **codex** emits an `agent_message` only on `item.completed`
+  (`internal/agent/codex/stream.go`).
+- **cursor** delivers assistant content blocks whole — "not as deltas"
+  (`internal/agent/cursor/stream.go`). Only *thinking* arrives as deltas, and
+  the adapter accumulates those before emitting anything.
+
+So the pane is never holding half a fence, a table missing its delimiter row
+or a dangling emphasis run in an `agent.output` record. The classifier would
+have no stream shape to run against, and its tests could only assert against
+splits the daemon cannot emit. If token-level deltas are ever wanted,
+reopening T1.7 is its own issue, and this issue's mechanism is what that issue
+would build.
+
+Several of the issue's acceptance criteria were already true and already held
+by tests — the `X-Next-Offset` seam, one renderer for live and cold, one
+renderer for both workspaces, reparse from source rather than from ANSI, and
+§16's sanitize chokepoint. They become regression tests here, not new
+machinery.
+
+### 2. Consecutive assistant records are one document
+
+`outputLines` treated one `agent.output` record as one Markdown document.
+Consecutive records already rendered with no blank line between them, so they
+*looked* like one message and parsed as several: a table, list or fence split
+across two of them rendered as two broken documents.
+
+A run of consecutive `agent.output` records now accumulates into one document,
+joined at the newline a record ends on. Any other record — reasoning, tool
+use, tool result, command output, `agent.raw`, a result line — closes it, and
+prose after it opens the next. A run or turn boundary closes it too, which
+falls out for free: the task pane's `outputLines` is called with one attempt's
+records and the chat's is called per turn. The rule is independent of the
+verbosity level, so a level that hides a record cannot change how the prose
+around it parses.
+
+This is a parse-scope change, not a change to the blank-line rule between a
+document and a record that is not prose. It does have one visible consequence
+for ordinary prose, and it is the same change seen from the other side: two
+records that each carry part of a paragraph now reflow into that paragraph
+rather than staying two lines. `TestTurnSeparation` pins it.
+
+Two shipped decisions follow the document rather than the record:
+
+- **Link reference numbering.** Task 075 numbers destinations "per rendered
+  message"; the message is now the joined document, so one destination named
+  in two records of one run gets one number and one `[n] dest` line, and the
+  reference block closes the document.
+- **Copy-picker rows.** `copyDocsFromRecords` offered one document per record;
+  it offers one per joined document, and "message 1" is the newest document.
+
+### 3. A joined document re-parses whole, and its reflow is bounded rather than eliminated
+
+Joining reintroduces a growing tail at *record* granularity: a live run is a
+concatenation whose last record is the newest, so a table header in one record
+and its delimiter in the next renders as a paragraph and then becomes a table.
+That is accepted, and the bound is asserted instead of the classifier decision
+1 refused being built.
+
+The property held by test is the weaker, true one: a record boundary is a
+message boundary, the parse is deterministic from the accumulated source, and
+**nothing above the last block of the previous document moves** when a record
+arrives. Mid-block splits across two assistant messages are possible and rare;
+guaranteeing more would mean rendering the newest record one record late, or
+re-deriving the classifier under another name.
+
+### 4. Documents and blocks get identities, and the anchor and picker use them
+
+Task 076 decision 6 shipped no identity model on purpose — the picker captured
+a row's text when the popup opened — and named this issue as the one that
+brings one. `apiclient.TranscriptRecord` carries no id and no offset, and the
+wire format does not change, so identity is client-assigned on ingest: a
+monotonic `seq` stamped when a record is fetched or appended from a chunk —
+**not** an index into the slice, so it survives the `maxRecords` front-prune. A
+document is identified by the seq of its first record; a block is its ordinal
+within the document.
+
+- **Paused scrolling** captures the identity of the topmost visible block and
+  restores it after any rebuild. That fixes the four things that actually move
+  a paused reader, none of which is streaming reflow: a resize re-wraps, a
+  front-prune shifts every line up, and the verbosity and raw toggles rebuild
+  wholesale. Follow mode is untouched — `d.following`/`v.following` and
+  `GotoBottom` keep the bottom anchor. `anchorIndex` resolves in three tiers,
+  exact line then block then document, which is what carries a reader across
+  the raw toggle, where the rendered block ordinals do not exist.
+- **The copy picker's rows become references** to a document, resolved at pick
+  time. One behaviour change falls out and is deliberate: picking a document
+  that has grown since the popup opened copies it as it is now, because "copy
+  this message" should yield the whole message. A finished document — the
+  common case — is unaffected. A reference that no longer resolves, because
+  the prune took its records, falls back to the text captured when the popup
+  was built, so a pick can never fail. `TestCopyPickerCapturesAtPickTime`'s
+  assertion is amended to that rule rather than deleted.
+
+### 5. Rendering is memoized per document
+
+Every chunk re-rendered every record: `appendChunk` set `outputDirty` and
+`renderOutputPane` re-ran `outputLines` over up to 5000 records, at the
+daemon's ~10 Hz coalescing rate (§13.3). The cache key is **(digest of the
+document's source, width, verbosity level, raw)** — the issue's "theme" and
+"completion state" are dropped, because this TUI has no theme concept and,
+with whole records, no partial state to key on. A chunk re-renders one
+document instead of the whole pane; a growing document re-renders itself,
+which is O(document) rather than O(pane) and is the correct cost of decision
+3. No client-side throttle and no second timer: the daemon already coalesces.
+The memo is swept per render pass rather than bounded by count — what a pane
+holds is already bounded by `maxRecords`, and an entry no pass touched belongs
+to a document that left the screen.
+
+## Shape
+
+Entirely client-side, in `internal/tui` alone — the shape tasks 073, 075 and
+076 each argued for, and for the same reason. **No daemon package, no API
+route, no store migration, no wire change.** New: `assistantdoc.go` (the
+document model, `seq` stamping, anchors) and `markdowncache.go` (the keyed
+memo). Changed: `outputlines.go`, `markdown.go`, `detail.go`,
+`detailrender.go`, `chatview.go`, `chatrender.go`, `readerpicker.go`,
+`root.go`.
+
+## Tests
+
+`internal/tui` is covered by no gate script, so the hermetic tests are the
+whole assurance — task 073's position, unchanged.
+
+- A document split at every line boundary, across two records and three,
+  renders identically to the same source arriving in one record — paragraphs,
+  nested lists, blockquotes, tables and fences.
+- Nothing above the last block of the previous document changes when a record
+  arrives — decision 3's bound, asserted line for line.
+- A reasoning, tool, command, raw or result record between two prose records
+  keeps them two documents; a window boundary does the same.
+- One destination named in two records of one run gets one number and one
+  `[n] dest` line.
+- An unclosed fence, an incomplete table delimiter, a dangling emphasis marker
+  and multibyte text across a split produce no panic, no ESC, no C0/C1 and no
+  line wider than the pane, rendered and raw.
+- The paused anchor survives a resize, a `maxRecords` prune, a level cycle and
+  a raw toggle, in both workspaces; follow mode still lands on the bottom.
+- The cache: identical source at one width, level and raw renders once; each
+  of the three invalidates; a chunk extending one document re-renders one
+  document. Renders are counted, not timed.
+- A live regression test streams a table whose header, delimiter and body
+  arrive as three chunks against the real store, broker, handlers and client,
+  and asserts the pane renders the table and the seam neither duplicates a
+  record nor loses one. It needed an agent registry on the board harness so a
+  step run that names an agent has its transcript normalized out of the
+  agent's own dialect (§13.2) rather than surfacing as `agent.raw`.
+
+## Left open
+
+- **Token-level deltas.** Reopening T1.7 is its own issue. If it ever lands,
+  the classifier this task declines is what it needs, and decision 3's bound
+  is what it would tighten.
+- **Link reader actions** remain task 076 decision 1's follow-up. This task
+  gives them the thing they were waiting for — a document and block identity a
+  reference can be named against — but binds no key and adds no picker row for
+  them.
+- **No new screenshot.** Nothing here changes a panel's shape; what changed is
+  what a split message parses as, which no capture would show.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -90,6 +90,7 @@ the living engineering specification records implementation contracts.
 | [074](074-chat-handoff.md) | Hand off a chat's worktree and branch to a task | ✅ done (1/1) |
 | [075](075-rich-markdown-blocks.md) | Tables, links and code blocks in the output pane | ✅ done (1/1) |
 | [076](076-reader-actions-on-assistant-markdown.md) | Rendered/raw toggle and copy actions for assistant Markdown | ✅ done (1/1) |
+| [077](077-stable-assistant-markdown-while-streaming.md) | Consecutive assistant records as one Markdown document, with identities, a paused anchor and a render memo | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/assistantdoc.go
+++ b/internal/tui/assistantdoc.go
@@ -1,0 +1,190 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The assistant document model (#291).
+//
+// Task 073 read one `agent.output` record as one Markdown document. That is
+// wrong for a message the adapter split across records: consecutive records
+// already render with no blank line between them, so they *look* like one
+// message, and a table, list or fence spanning two of them parsed as two
+// broken documents. Here a run of consecutive `agent.output` records is one
+// document instead.
+//
+// What closes a document is any other record — reasoning, tool use, tool
+// result, command output, `agent.raw`, a result line — and a run or turn
+// boundary, which falls out for free because the task pane renders one
+// attempt's records and the chat renders one turn's. The rule is deliberately
+// independent of the verbosity level: a level that hides a record must not
+// also change how the prose around it parses.
+//
+// This is a parse-scope change. The blank-line rule between a document and a
+// record that is not prose is untouched, which is what keeps the pane's shape
+// the same everywhere a message was never split.
+//
+// What is **not** here is the stable-prefix classifier #291 proposed. This
+// wire never carries a partial Markdown document: claude runs message-level
+// `stream-json` with no `--include-partial-messages` (the T1.7 decision,
+// `docs/history/v0-tasks.md:142`), codex emits `agent_message` only on
+// `item.completed`, and cursor delivers content blocks whole. A record is
+// present whole or is not present, so there is no unfinished tail to
+// classify. Joining does reintroduce a growing tail at *record* granularity,
+// and the bound this file guarantees instead is the weaker, true one: a
+// record boundary is a message boundary, the parse is deterministic from the
+// accumulated source, and nothing above the last block of the previous
+// document moves when a record arrives.
+
+// assistantDoc is one run of consecutive `agent.output` records, read as a
+// single Markdown document.
+type assistantDoc struct {
+	// seq is the document's identity: the client-assigned identity of its
+	// first record. It is not an index — see seqStamp — so it survives the
+	// maxRecords front-prune.
+	seq  int64
+	text string
+	// first and last bound the run in the record window it was derived
+	// from. They are render-time positions and are not identity.
+	first, last int
+}
+
+// assistantDocs splits a record window into the documents it contains, in
+// order. seqs is the window's parallel identity slice; a caller that has none
+// (a test rendering a literal window) passes nil and gets positional
+// identities, which is enough for one render but not across a prune.
+func assistantDocs(recs []apiclient.TranscriptRecord, seqs []int64) []assistantDoc {
+	out := make([]assistantDoc, 0, 4)
+	for i := 0; i < len(recs); i++ {
+		if recs[i].Type != recTypeOutput {
+			continue
+		}
+		j := i
+		var b strings.Builder
+		for j < len(recs) && recs[j].Type == recTypeOutput {
+			if j > i {
+				// A record ends at a line: joining with a newline is what
+				// reconstructs the source a splitting adapter started with,
+				// so a table header in one record and its delimiter row in
+				// the next parse as the one table they were written as.
+				b.WriteByte('\n')
+			}
+			b.WriteString(recs[j].Text)
+			j++
+		}
+		out = append(out, assistantDoc{seq: seqAt(seqs, i), text: b.String(), first: i, last: j - 1})
+		i = j - 1
+	}
+	return out
+}
+
+// recTypeOutput is the one record type ever read as Markdown (task 073
+// decision 5).
+const recTypeOutput = "agent.output"
+
+// seqStamp hands out the client-side identities records arrive without.
+//
+// apiclient.TranscriptRecord carries no id and no offset, and #291 changes no
+// wire format, so identity is assigned on ingest instead. It is monotonic and
+// never an index into the record slice: the whole point is that it survives
+// the maxRecords front-prune, which shifts every index down.
+type seqStamp struct{ next int64 }
+
+// take returns n fresh identities.
+func (s *seqStamp) take(n int) []int64 {
+	out := make([]int64, n)
+	for i := range out {
+		s.next++
+		out[i] = s.next
+	}
+	return out
+}
+
+// fit returns seqs stamped to cover exactly n records. The common paths stamp
+// on ingest and this is a no-op; a window installed by any other route — a
+// test, a path that has not been through applyTranscript — is stamped whole on
+// first use, which costs that window its anchor and nothing else.
+func (s *seqStamp) fit(seqs []int64, n int) []int64 {
+	if len(seqs) == n {
+		return seqs
+	}
+	return s.take(n)
+}
+
+// seqAt is the identity of record i, or a positional stand-in when the caller
+// passed no identities at all.
+func seqAt(seqs []int64, i int) int64 {
+	if i < len(seqs) {
+		return seqs[i]
+	}
+	return int64(i) + 1
+}
+
+// lineAnchor is what one rendered pane line came from, which is what lets a
+// paused reader keep their place across a rebuild.
+//
+// Four things move a paused reader today, and none of them is streaming
+// reflow: a resize re-wraps every line, a front-prune shifts them all up, and
+// the verbosity and raw toggles rebuild the pane wholesale. Capturing the
+// topmost visible block and restoring it afterwards fixes all four. Follow
+// mode is untouched — it keeps the bottom anchor.
+type lineAnchor struct {
+	// rec is the identity of the record the line came from; for assistant
+	// prose it is the document's seq, which is its first record's. Zero
+	// means the line belongs to no record (a truncation note, an
+	// unrecognized-line count) and cannot be anchored to.
+	rec int64
+	// block is the ordinal of the Markdown block within the document, and 0
+	// for every other line.
+	block int
+	// off is the line's ordinal within that block.
+	off int
+}
+
+// anchorAt is the anchor of the line at the given viewport offset.
+func anchorAt(anchors []lineAnchor, y int) lineAnchor {
+	if y < 0 || y >= len(anchors) {
+		return lineAnchor{}
+	}
+	return anchors[y]
+}
+
+// anchorIndex finds where a captured anchor landed in a freshly built pane.
+//
+// It resolves in three tiers, which is what makes it survive a rebuild that
+// changed the block structure rather than only the wrapping: the exact line,
+// then the block's first line, then the document's first line. The last tier
+// is what carries a paused reader across the raw toggle, where the rendered
+// blocks a captured ordinal names do not exist.
+func anchorIndex(anchors []lineAnchor, want lineAnchor) (int, bool) {
+	if want.rec == 0 {
+		return 0, false
+	}
+	block, doc := -1, -1
+	for i, a := range anchors {
+		if a.rec != want.rec {
+			continue
+		}
+		if doc < 0 {
+			doc = i
+		}
+		if a.block != want.block {
+			continue
+		}
+		if block < 0 {
+			block = i
+		}
+		if a.off == want.off {
+			return i, true
+		}
+	}
+	switch {
+	case block >= 0:
+		return block, true
+	case doc >= 0:
+		return doc, true
+	}
+	return 0, false
+}

--- a/internal/tui/assistantdoc_test.go
+++ b/internal/tui/assistantdoc_test.go
@@ -1,0 +1,393 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// splitDoc breaks a document into n records at line boundaries, which is
+// where an adapter that split a message would have broken it. Rejoining the
+// pieces with a newline reconstructs the source exactly, which is the
+// property every test below leans on.
+func splitDoc(text string, n int) []apiclient.TranscriptRecord {
+	lines := strings.Split(text, "\n")
+	out := make([]apiclient.TranscriptRecord, 0, n)
+	per := max(len(lines)/n, 1)
+	for i := 0; i < len(lines); i += per {
+		end := min(i+per, len(lines))
+		out = append(out, apiclient.TranscriptRecord{
+			Type: "agent.output", Text: strings.Join(lines[i:end], "\n"),
+		})
+		if len(out) == n {
+			if end < len(lines) {
+				out[len(out)-1].Text += "\n" + strings.Join(lines[end:], "\n")
+			}
+			break
+		}
+	}
+	return out
+}
+
+// splitDocAt breaks a document into exactly two records at one line boundary.
+func splitDocAt(text string, line int) []apiclient.TranscriptRecord {
+	lines := strings.Split(text, "\n")
+	return []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: strings.Join(lines[:line], "\n")},
+		{Type: "agent.output", Text: strings.Join(lines[line:], "\n")},
+	}
+}
+
+// docFixtures are documents whose interesting boundaries are the ones a
+// record split can land on: inside a paragraph, between a list and its nested
+// items, inside a quote, between a table's header, delimiter and rows, and at
+// a fence's open, interior and close.
+var docFixtures = map[string]string{
+	"paragraph":   "The first sentence.\nThe second one.\n\nA new paragraph.\n",
+	"nested list": "Steps:\n\n- outer one\n  - inner one\n  - inner two\n- outer two\n",
+	"blockquote":  "As it says:\n\n> a quoted line\n> and its continuation\n\nafter.\n",
+	"table":       "Before.\n\n| Step | State |\n|---|---|\n| build | ok |\n| test | ok |\n\nAfter.\n",
+	"fence":       "Run it:\n\n```sh\ngo test ./...\ngo run mage.go lint\n```\n\nThen read it.\n",
+	"headings":    "# Title\n\nbody one\n\n## Sub\n\nbody two\n\n---\n\nlast\n",
+}
+
+// TestSplitDocumentRendersLikeWholeOne is #291's central property: a message
+// an adapter delivered as several records renders exactly as the same source
+// delivered as one. Every structurally interesting boundary is tried, across
+// two records and three.
+func TestSplitDocumentRendersLikeWholeOne(t *testing.T) {
+	const width = 60
+	for name, doc := range docFixtures {
+		whole := strings.Join(plainLines(outputLines(
+			[]apiclient.TranscriptRecord{{Type: "agent.output", Text: doc}},
+			levelNormal, width, lineOpts{expandKey: "v"})), "\n")
+		for line := 1; line < len(strings.Split(doc, "\n")); line++ {
+			got := strings.Join(plainLines(outputLines(
+				splitDocAt(doc, line), levelNormal, width, lineOpts{expandKey: "v"})), "\n")
+			if got != whole {
+				t.Fatalf("%s split at line %d rendered differently:\n%s\n--- want ---\n%s",
+					name, line, got, whole)
+			}
+		}
+		got := strings.Join(plainLines(outputLines(
+			splitDoc(doc, 3), levelNormal, width, lineOpts{expandKey: "v"})), "\n")
+		if got != whole {
+			t.Fatalf("%s split across three records rendered differently:\n%s\n--- want ---\n%s",
+				name, got, whole)
+		}
+	}
+}
+
+// TestRecordArrivalMovesNothingAboveTheLastBlock is decision 3's bound,
+// asserted line for line rather than claimed.
+//
+// Joining reintroduces a growing tail at *record* granularity — a table
+// header in one record and its delimiter in the next renders as a paragraph
+// and then becomes a table — and the guarantee is the weaker, true one:
+// nothing above the last block of the document that was already on screen
+// moves when the next record arrives.
+func TestRecordArrivalMovesNothingAboveTheLastBlock(t *testing.T) {
+	const width = 60
+	cases := []struct{ before, arriving string }{
+		{"A paragraph.\n\n- one\n- two\n", "- three\n"},
+		{"Before.\n\n| Step | State |", "|---|---|\n| build | ok |"},
+		{"Text.\n\n```go\nx := 1", "y := 2\n```"},
+		{"# Title\n\nbody", "\n\nmore body"},
+	}
+	for _, tc := range cases {
+		before, at := markdownBlockLines(tc.before, width)
+		head := 0
+		for i, b := range at {
+			if b == at[len(at)-1] {
+				head = i
+				break
+			}
+		}
+		after, _ := markdownBlockLines(tc.before+"\n"+tc.arriving, width)
+		if len(after) < head {
+			t.Fatalf("%q shrank below the previous document's last block", tc.before)
+		}
+		for i := range head {
+			if plainLines(before[i : i+1])[0] != plainLines(after[i : i+1])[0] {
+				t.Fatalf("line %d moved when a record arrived:\n%q\nbecame\n%q",
+					i, plainLines(before)[i], plainLines(after)[i])
+			}
+		}
+	}
+}
+
+// TestOnlyProseAccumulates: any other record closes a document, and so does a
+// run or turn boundary.
+func TestOnlyProseAccumulates(t *testing.T) {
+	prose := func(text string) apiclient.TranscriptRecord {
+		return apiclient.TranscriptRecord{Type: "agent.output", Text: text}
+	}
+	closers := []apiclient.TranscriptRecord{
+		{Type: "agent.thinking", Text: "thinking"},
+		{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{{Name: "Bash", CallID: "t1"}}},
+		{Type: "agent.tool_result", Results: []apiclient.TranscriptToolResult{{CallID: "t1"}}},
+		{Type: "agent.command_output", Output: "hello"},
+		{Type: "agent.raw", Line: "{}"},
+		{Type: "agent.result", ResultText: "done"},
+	}
+	for _, closer := range closers {
+		recs := []apiclient.TranscriptRecord{prose("| Step |"), closer, prose("|---|")}
+		docs := assistantDocs(recs, nil)
+		if len(docs) != 2 {
+			t.Fatalf("%s left %d document(s), want 2", closer.Type, len(docs))
+		}
+		if docs[0].text != "| Step |" || docs[1].text != "|---|" {
+			t.Fatalf("%s joined across the closer: %#v", closer.Type, docs)
+		}
+	}
+	// A run or turn boundary is the edge of the window itself: each pane
+	// renders one attempt's or one turn's records, so two windows are two
+	// documents by construction.
+	first := assistantDocs([]apiclient.TranscriptRecord{prose("| Step |")}, nil)
+	second := assistantDocs([]apiclient.TranscriptRecord{prose("|---|")}, nil)
+	if len(first) != 1 || len(second) != 1 || first[0].text == second[0].text {
+		t.Fatal("a window boundary did not close the document")
+	}
+}
+
+// TestLinkReferencesAreNumberedPerDocument: task 075 numbers destinations per
+// rendered message, and #291 makes the joined document the message. One
+// destination named in two records of one run gets one number and one line.
+func TestLinkReferencesAreNumberedPerDocument(t *testing.T) {
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "See [the spec](https://example.test/spec)."},
+		{Type: "agent.output", Text: "And [it again](https://example.test/spec)."},
+	}
+	got := strings.Join(plainLines(outputLines(recs, levelNormal, 80, lineOpts{expandKey: "v"})), "\n")
+	if n := strings.Count(got, "https://example.test/spec"); n != 1 {
+		t.Fatalf("the destination is listed %d times, want once:\n%s", n, got)
+	}
+	if !strings.Contains(got, "[1] https://example.test/spec") {
+		t.Fatalf("the reference block did not close the document:\n%s", got)
+	}
+	if strings.Contains(got, "[2]") {
+		t.Fatalf("one destination took two numbers:\n%s", got)
+	}
+}
+
+// TestSplitDocumentStaysInsideTheSubset: a split that lands mid-structure
+// produces a document the parser has never seen whole. §16's guarantees hold
+// on it anyway — no panic, no escape out of the pane, no control character
+// and no line wider than the pane.
+func TestSplitDocumentStaysInsideTheSubset(t *testing.T) {
+	const width = 24
+	halves := [][2]string{
+		{"```go", "x := 1"},                       // an unclosed fence
+		{"| a | b |", "|--"},                      // an incomplete delimiter row
+		{"some **bold", "text that never closes"}, // a dangling emphasis run
+		{"héllo wörld ", "and a — dash"},          // multibyte either side
+		{"> quote", ">> deeper"},                  // a quote that changes depth
+		{"- item", "  continuation of the item"},  // a list item's continuation
+	}
+	for _, h := range halves {
+		recs := []apiclient.TranscriptRecord{
+			{Type: "agent.output", Text: h[0]},
+			{Type: "agent.output", Text: h[1]},
+		}
+		for _, raw := range []bool{false, true} {
+			lines := outputLines(recs, levelNormal, width, lineOpts{expandKey: "v", raw: raw})
+			for _, line := range plainLines(lines) {
+				for _, r := range line {
+					if isTerminalControl(r) {
+						t.Fatalf("%q kept control %#U", line, r)
+					}
+				}
+				if cols(line) > width {
+					t.Fatalf("%q is %d cells wide, pane is %d", line, cols(line), width)
+				}
+			}
+		}
+	}
+}
+
+// splitAcrossMultibyte is the one split a byte-oriented join could corrupt: a
+// rune's bytes divided between two records. Records carry text, not bytes, so
+// this can only be built by hand — and the join must still produce the two
+// halves as they were, not a replacement character.
+func TestSplitDoesNotCorruptMultibyteText(t *testing.T) {
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "日本語の"},
+		{Type: "agent.output", Text: "テキスト"},
+	}
+	docs := assistantDocs(recs, nil)
+	if len(docs) != 1 || docs[0].text != "日本語の\nテキスト" {
+		t.Fatalf("the join corrupted multibyte text: %#v", docs)
+	}
+}
+
+// TestPausedAnchorSurvivesRebuilds is the anchor's whole point: the four
+// things that actually move a paused reader — a resize, a maxRecords prune, a
+// level cycle and a raw toggle — leave the topmost visible block where it was.
+func TestPausedAnchorSurvivesRebuilds(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 4
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	recs := make([]apiclient.TranscriptRecord, 0, 40)
+	for i := range 20 {
+		recs = append(recs,
+			apiclient.TranscriptRecord{Type: "agent.output", Text: "paragraph " + string(rune('a'+i))},
+			apiclient.TranscriptRecord{Type: "agent.thinking", Text: "thought"},
+		)
+	}
+	d.applyTranscript(detailTranscriptMsg{runID: d.displayRun, records: recs})
+	d.width, d.height = 80, 20
+	d.renderOutputPane(10)
+
+	// Scroll away from the tail and note what is at the top.
+	d.following = false
+	d.vp.SetYOffset(12)
+	topOf := func() lineAnchor { return anchorAt(d.anchors, d.vp.YOffset()) }
+	want := topOf()
+	if want.rec == 0 {
+		t.Fatal("the paused reader is looking at nothing anchorable")
+	}
+
+	for _, step := range []struct {
+		name string
+		do   func()
+	}{
+		{"resize", func() { d.width = 50 }},
+		{"level cycle", func() { d.cycleLevel(); d.outputDirty = true }},
+		{"raw toggle", func() { d.toggleRaw(); d.outputDirty = true }},
+		{"prune", func() {
+			d.appendChunk(apiclient.OutputNote{
+				Type: "agent.output", RunID: d.displayRun, Offset: 99,
+				Payload: []byte(`{"text":"a later message"}`),
+			})
+			d.outputDirty = true
+		}},
+	} {
+		step.do()
+		d.renderOutputPane(10)
+		if got := topOf(); got.rec != want.rec {
+			t.Fatalf("a %s moved the paused reader off document %d, onto %d",
+				step.name, want.rec, got.rec)
+		}
+	}
+
+	// Following is untouched: it keeps the bottom anchor across the same
+	// rebuilds.
+	d.following = true
+	d.width = 70
+	d.renderOutputPane(10)
+	if !d.vp.AtBottom() {
+		t.Fatal("a resize left a following pane off the bottom")
+	}
+}
+
+// TestChatPausedAnchorSurvivesRebuilds is the same property in the other
+// workspace, which shares the renderer and now shares the anchor.
+func TestChatPausedAnchorSurvivesRebuilds(t *testing.T) {
+	v := chatViewFixture()
+	for seq := 1; seq <= 6; seq++ {
+		v.turns = append(v.turns, apiclient.ChatTurn{
+			ID: int64(seq), Seq: seq, State: "done", Prompt: "ask " + string(rune('a'+seq)),
+		})
+		v.applyTranscript(chatTranscriptMsg{chatID: v.chatID, seq: seq, records: []apiclient.TranscriptRecord{
+			{Type: "agent.output", Text: "# Answer\n\nbody of turn " + string(rune('a'+seq))},
+			{Type: "agent.output", Text: "\nand its second half"},
+		}})
+	}
+	v.bodyView(80, 10)
+	v.following = false
+	v.vp.SetYOffset(8)
+	want := anchorAt(v.anchors, v.vp.YOffset())
+	if want.rec == 0 {
+		t.Fatal("the paused reader is looking at nothing anchorable")
+	}
+
+	for _, step := range []struct {
+		name  string
+		do    func()
+		width int
+	}{
+		{"resize", func() {}, 50},
+		{"level cycle", func() { v.level.cycle(); v.bodyDirty = true }, 50},
+		{"raw toggle", func() { v.raw.toggle(); v.bodyDirty = true }, 50},
+	} {
+		step.do()
+		v.bodyView(step.width, 10)
+		if got := anchorAt(v.anchors, v.vp.YOffset()); got.rec != want.rec {
+			t.Fatalf("a %s moved the paused reader off document %d, onto %d",
+				step.name, want.rec, got.rec)
+		}
+	}
+
+	v.following = true
+	v.bodyDirty = true
+	v.bodyView(70, 10)
+	if !v.vp.AtBottom() {
+		t.Fatal("a rebuild left a following conversation off the bottom")
+	}
+}
+
+// TestMarkdownCacheKeysOnEverythingThatChangesTheResult: identical source at
+// one width, level and raw setting renders once; each of the three
+// invalidates. Renders are counted, not timed — a timing assertion would make
+// the suite a benchmark.
+func TestMarkdownCacheKeysOnEverythingThatChangesTheResult(t *testing.T) {
+	c := &mdCache{}
+	const doc = "# Title\n\nbody\n"
+	render := func(width int, level outputLevel, raw bool) {
+		c.begin()
+		c.lines(doc, width, level, raw)
+		c.sweep()
+	}
+	render(80, levelNormal, false)
+	render(80, levelNormal, false)
+	if c.renders != 1 {
+		t.Fatalf("identical source rendered %d times, want 1", c.renders)
+	}
+	render(40, levelNormal, false)
+	render(40, levelVerbose, false)
+	render(40, levelVerbose, true)
+	if c.renders != 4 {
+		t.Fatalf("width, level and raw did not each invalidate: %d renders, want 4", c.renders)
+	}
+	// A pass that does not touch an entry drops it, which is what bounds the
+	// memo without a size limit.
+	c.begin()
+	c.sweep()
+	if len(c.entries) != 0 {
+		t.Fatalf("the sweep kept %d untouched entries", len(c.entries))
+	}
+}
+
+// TestChunkRerendersOneDocument: a chunk extending one document re-renders
+// that document and no other. That is the whole point of keying on the
+// document — the pane was re-rendering every record on every chunk, at the
+// daemon's coalescing rate.
+func TestChunkRerendersOneDocument(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 4
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	d.applyTranscript(detailTranscriptMsg{runID: d.displayRun, records: []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "first document"},
+		{Type: "agent.thinking", Text: "thought"},
+		{Type: "agent.output", Text: "second document"},
+	}})
+	d.width = 80
+	d.outputLines()
+	before := d.mdcache.renders
+	if before != 2 {
+		t.Fatalf("the first pass rendered %d documents, want 2", before)
+	}
+	d.outputLines()
+	if d.mdcache.renders != before {
+		t.Fatalf("an unchanged pane re-rendered %d document(s)", d.mdcache.renders-before)
+	}
+	d.appendChunk(apiclient.OutputNote{
+		Type: "agent.output", RunID: d.displayRun, Offset: 9,
+		Payload: []byte(`{"text":"and its second half"}`),
+	})
+	d.outputLines()
+	if got := d.mdcache.renders - before; got != 1 {
+		t.Fatalf("a chunk re-rendered %d documents, want 1", got)
+	}
+}

--- a/internal/tui/boardlive_test.go
+++ b/internal/tui/boardlive_test.go
@@ -14,6 +14,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/agent/claude"
 	"github.com/lezli01/vincent/internal/api"
 	"github.com/lezli01/vincent/internal/apiclient"
 	"github.com/lezli01/vincent/internal/config"
@@ -76,6 +78,10 @@ func newBoardLiveHarnessConfig(t *testing.T, cfg func() config.Config) *boardLiv
 		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Store:       st,
 		Broker:      broker,
+		// An agent registry so a step run that names one has its transcript
+		// normalized out of the agent's own dialect (§13.2), which is what
+		// puts assistant prose rather than agent.raw in front of the pane.
+		Agents: agent.NewRegistry(claude.New(func() string { return "" })),
 	})
 	ts := httptest.NewServer(s.Handler())
 	t.Cleanup(ts.Close)

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -29,16 +29,19 @@ const chatExpandKey = "ctrl+r"
 // A turn whose transcript has gone to retention contributes its ResultText
 // instead (§17), which is what the pane is drawing for it: the picker offers
 // what is on screen, not what is on disk.
-func (v *chatView) copyDocs() []string {
-	docs := make([]string, 0, len(v.turns))
+func (v *chatView) copyDocs() []copyDoc {
+	docs := make([]copyDoc, 0, len(v.turns))
 	for i := len(v.turns) - 1; i >= 0; i-- {
 		t := &v.turns[i]
 		if recs := v.turnRecords[t.Seq]; len(recs) > 0 {
-			docs = append(docs, copyDocsFromRecords(recs)...)
+			docs = append(docs, copyDocsFromRecords(recs, v.recordSeqs(t.Seq))...)
 			continue
 		}
 		if t.ResultText != "" {
-			docs = append(docs, t.ResultText)
+			// A retained-away answer has no record and so no identity: it
+			// is offered as the captured text, which is what the pane is
+			// drawing for it.
+			docs = append(docs, copyDoc{text: t.ResultText})
 		}
 	}
 	return docs
@@ -77,11 +80,21 @@ func (v *chatView) bodyView(width, height int) string {
 	v.vp.SetWidth(max(width, 1))
 	v.vp.SetHeight(max(height, 1))
 	if v.bodyDirty || v.builtWidth != width {
-		v.vp.SetContent(strings.Join(v.bodyLines(width), "\n"))
+		// The paused anchor, as in the task workspace (#291): a resize, the
+		// maxRecords cap and the level and raw toggles all rebuild the body,
+		// and a reader who scrolled away from the tail keeps their place
+		// across every one of them.
+		keep := anchorAt(v.anchors, v.vp.YOffset())
+		lines, anchors := v.bodyLinesAt(width)
+		v.vp.SetContent(strings.Join(lines, "\n"))
+		v.anchors = anchors
 		v.bodyDirty = false
 		v.builtWidth = width
-		if v.following {
+		switch y, ok := anchorIndex(anchors, keep); {
+		case v.following:
 			v.vp.GotoBottom()
+		case ok:
+			v.vp.SetYOffset(y)
 		}
 	}
 	return v.vp.View()
@@ -129,23 +142,45 @@ func (v *chatView) headerLine(width int) string {
 // It also records where each turn starts, which is what lets a scroll say
 // which turns are on screen and fetch the transcripts they need (decision 6).
 func (v *chatView) bodyLines(width int) []string {
+	lines, _ := v.bodyLinesAt(width)
+	return lines
+}
+
+// bodyLinesAt is bodyLines with the per-line provenance the paused anchor
+// needs, and is where the conversation's render pass opens and closes — one
+// pass over every turn, so the memo sweeps what left the screen and keeps
+// what did not.
+func (v *chatView) bodyLinesAt(width int) ([]string, []lineAnchor) {
 	lines := make([]string, 0, len(v.turns)*4)
+	anchors := make([]lineAnchor, 0, len(v.turns)*4)
+	pad := func(n int) {
+		for range n {
+			anchors = append(anchors, lineAnchor{})
+		}
+	}
 	v.turnAt = make(map[int]int, len(v.turns))
 	if v.truncated {
 		lines = append(lines, styleDim.Render(gutterNone+
 			"… earlier output truncated — the transcripts on disk are whole"))
+		pad(1)
 	}
 	level := v.level.get()
 	raw := v.raw.get()
+	v.mdcache.begin()
+	defer v.mdcache.sweep()
 	for i := range v.turns {
 		t := &v.turns[i]
 		v.turnAt[t.Seq] = len(lines)
 		lines = append(lines, styleDim.Render(fmt.Sprintf(" ── turn %d ──", t.Seq)))
-		lines = append(lines, wrapCellLines("› "+t.Prompt, width-2, 6)...)
+		prompt := wrapCellLines("› "+t.Prompt, width-2, 6)
+		lines = append(lines, prompt...)
+		pad(1 + len(prompt))
 		switch recs := v.turnRecords[t.Seq]; {
 		case len(recs) > 0:
-			lines = append(lines, outputLines(recs, level, width,
-				lineOpts{expandKey: chatExpandKey, raw: raw})...)
+			body, at := outputLinesAt(recs, v.recordSeqs(t.Seq), level, width,
+				lineOpts{expandKey: chatExpandKey, raw: raw, cache: &v.mdcache})
+			lines = append(lines, body...)
+			anchors = append(anchors, at...)
 		case t.State == "running":
 			// Nothing has arrived yet; the tail fills in as it does.
 		case t.ResultText != "":
@@ -164,17 +199,21 @@ func (v *chatView) bodyLines(width int) []string {
 			// It follows the rendered/raw toggle too (task 076 decision 2):
 			// a retained-away answer is still assistant prose, and the
 			// mode is the session's, not the record's.
-			lines = append(lines, assistantLines(t.ResultText, width, raw)...)
+			body, _ := v.mdcache.lines(t.ResultText, width, level, raw)
+			lines = append(lines, body...)
+			pad(len(body))
 		}
 		if t.FailReason != "" {
 			lines = append(lines, " "+styleBad.Render(
 				strings.TrimSpace(t.FailReason+" "+t.ErrorMessage)))
+			pad(1)
 		}
 	}
 	if len(lines) == 0 {
 		lines = append(lines, styleDim.Render("  Nothing said yet. Type below and press enter."))
+		pad(1)
 	}
-	return lines
+	return lines, anchors
 }
 
 func (v *chatView) footerLines(width int) []string {

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -101,6 +101,15 @@ type chatView struct {
 	vp        viewport.Model
 	following bool
 	bodyDirty bool
+	// turnSeqs is the client-assigned identity of each record in
+	// turnRecords, keyed the same way and pruned with it, and stamp is where
+	// they come from (#291). anchors is the last build's per-line
+	// provenance, which is what a paused conversation restores from, and
+	// mdcache memoizes the rendered documents.
+	stamp    seqStamp
+	turnSeqs map[int][]int64
+	anchors  []lineAnchor
+	mdcache  mdCache
 	// turnAt is each turn's first body line, rebuilt on every render. It is
 	// what makes "which turns are on screen" answerable, and so what drives
 	// the lazy transcript fetch.
@@ -133,6 +142,7 @@ func newChatView(level *levelHolder, raw *rawHolder) *chatView {
 		vp:          viewport.New(),
 		following:   true,
 		turnRecords: map[int][]apiclient.TranscriptRecord{},
+		turnSeqs:    map[int][]int64{},
 		fetched:     map[int]bool{},
 	}
 }
@@ -343,6 +353,8 @@ const eagerTurns = 5
 // and on send: the next load rebuilds it.
 func (v *chatView) resetRecords() {
 	v.turnRecords = map[int][]apiclient.TranscriptRecord{}
+	v.turnSeqs = map[int][]int64{}
+	v.anchors = nil
 	v.fetched = map[int]bool{}
 	v.truncated = false
 	v.liveFrom, v.liveTurn = 0, 0
@@ -459,6 +471,7 @@ func (v *chatView) applyTranscript(msg chatTranscriptMsg) {
 		v.liveTurn, v.liveFrom = turn.ID, msg.next
 	}
 	v.turnRecords[msg.seq] = msg.records
+	v.turnSeqs[msg.seq] = v.stamp.take(len(msg.records))
 	v.capRecords()
 	v.bodyDirty = true
 }
@@ -483,10 +496,14 @@ func (v *chatView) capRecords() {
 		if len(recs) <= over {
 			over -= len(recs)
 			delete(v.turnRecords, seq)
+			delete(v.turnSeqs, seq)
 			continue
 		}
 		// Keep the end of the turn: the newest lines are the ones being read.
 		v.turnRecords[seq] = recs[over:]
+		if seqs := v.turnSeqs[seq]; len(seqs) >= over {
+			v.turnSeqs[seq] = seqs[over:]
+		}
 		over = 0
 	}
 }
@@ -619,7 +636,7 @@ func (v *chatView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		v.bodyDirty = true
 		return v, nil
 	case copyPickKey:
-		return v, openCopyPicker(v.copyDocs())
+		return v, openCopyPicker(v.copyDocs(), v.resolveDoc)
 	case "pgup":
 		v.vp.PageUp()
 		v.syncFollowToViewport()
@@ -699,4 +716,26 @@ func (v *chatView) cancelCmd() tea.Cmd {
 		defer cancel()
 		return chatCanceledMsg{chatID: id, err: client.CancelChat(ctx, id)}
 	}
+}
+
+// recordSeqs is one turn's identity slice, stamped if some path installed its
+// records without going through applyTranscript.
+func (v *chatView) recordSeqs(seq int) []int64 {
+	seqs := v.stamp.fit(v.turnSeqs[seq], len(v.turnRecords[seq]))
+	if v.turnSeqs == nil {
+		v.turnSeqs = map[int][]int64{}
+	}
+	v.turnSeqs[seq] = seqs
+	return seqs
+}
+
+// resolveDoc answers a copy pick from the conversation as it stands now.
+func (v *chatView) resolveDoc(seq int64) (string, bool) {
+	for i := range v.turns {
+		t := v.turns[i].Seq
+		if text, ok := resolveDocs(v.turnRecords[t], v.recordSeqs(t), seq); ok {
+			return text, true
+		}
+	}
+	return "", false
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -152,6 +152,15 @@ type detail struct {
 	// next frame rather than on every appended chunk.
 	outputDirty bool
 	builtWidth  int
+	// seqs is the client-assigned identity of each record in d.records,
+	// stamped on ingest and pruned with it, and stamp is where they come
+	// from (#291). anchors is the last build's per-line provenance, which is
+	// what a paused pane restores its position from.
+	stamp   seqStamp
+	seqs    []int64
+	anchors []lineAnchor
+	// mdcache memoizes rendered assistant documents for this pane.
+	mdcache mdCache
 
 	notes      <-chan apiclient.Note
 	stopStream context.CancelFunc
@@ -359,6 +368,8 @@ func (d *detail) deselect() {
 // to another attempt.
 func (d *detail) resetOutput() {
 	d.records = nil
+	d.seqs = nil
+	d.anchors = nil
 	d.nextOffset = 0
 	d.fetching = false
 	d.fetchErr = nil
@@ -511,6 +522,7 @@ func (d *detail) applyTranscript(msg detailTranscriptMsg) {
 	}
 	d.fetchErr = nil
 	d.records = msg.records
+	d.seqs = d.stamp.take(len(msg.records))
 	d.nextOffset = msg.next
 	d.drainBuffer()
 	d.outputDirty = true
@@ -540,8 +552,10 @@ func (d *detail) drainBuffer() {
 func (d *detail) appendChunk(note apiclient.OutputNote) {
 	rec := recordFromChunk(note)
 	d.records = append(d.records, rec)
+	d.seqs = append(d.seqs, d.stamp.take(1)...)
 	if len(d.records) > maxRecords {
 		d.records = d.records[len(d.records)-maxRecords:]
+		d.seqs = d.seqs[len(d.seqs)-maxRecords:]
 		d.truncated = true
 	}
 	if note.Offset > d.nextOffset {
@@ -708,7 +722,10 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	case rawToggleKey:
 		return d.toggleRaw()
 	case copyPickKey:
-		return openCopyPicker(copyDocsFromRecords(d.records))
+		return openCopyPicker(copyDocsFromRecords(d.records, d.recordSeqs()),
+			func(seq int64) (string, bool) {
+				return resolveDocs(d.records, d.recordSeqs(), seq)
+			})
 	}
 
 	// Action keys work from any focus: they act on the task, not on a pane.
@@ -936,4 +953,11 @@ func (d *detail) toggleTab() tea.Cmd {
 	d.tab = tabDiff
 	d.diff.openTask(d.taskID)
 	return d.diff.fetch(d.client, true)
+}
+
+// recordSeqs is the pane's identity slice, stamped if some path installed
+// records without going through applyTranscript or appendChunk.
+func (d *detail) recordSeqs() []int64 {
+	d.seqs = d.stamp.fit(d.seqs, len(d.records))
+	return d.seqs
 }

--- a/internal/tui/detaillive_test.go
+++ b/internal/tui/detaillive_test.go
@@ -127,3 +127,95 @@ func appendTranscript(t *testing.T, path string, texts ...string) int64 {
 	}
 	return fi.Size()
 }
+
+// TestLiveSplitDocumentMatchesTheColdTranscript is #291's regression test for
+// the two criteria that were already true and now have a document model
+// underneath them: an assistant message an adapter delivered as several
+// records renders the same live as it does from the persisted transcript, and
+// the X-Next-Offset seam still neither duplicates a record nor loses one.
+//
+// It streams a table whose header, delimiter and body arrive as three
+// separate chunks — the split that used to render as three broken documents —
+// and compares the pane against a cold render of the same source.
+func TestLiveSplitDocumentMatchesTheColdTranscript(t *testing.T) {
+	h := newBoardLiveHarness(t)
+	task := h.createTask(t, "split-document task")
+	ctx := context.Background()
+
+	path := filepath.Join(t.TempDir(), "0-1.jsonl")
+	appendAssistant(t, path, "Here is the table:\n")
+
+	if _, _, err := h.st.TransitionTask(ctx, task.ID,
+		store.TaskQueued, store.TaskRunning, store.TaskChange{}); err != nil {
+		t.Fatalf("transition to running: %v", err)
+	}
+	run := &store.StepRun{
+		TaskID: task.ID, StepIndex: 0, StepID: "one", StepType: "agent",
+		Agent:   "claude",
+		Attempt: 1, State: store.StepRunning, TranscriptPath: path,
+		StartedAt: time.Now(),
+	}
+	if err := h.st.CreateStepRun(ctx, run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+
+	_, cmd := h.m.Update(selectTaskMsg{id: task.ID})
+	h.p.push(cmd)
+	_, cmd = h.m.Update(tea.KeyPressMsg{Code: '3', Text: "3"})
+	h.p.push(cmd)
+	h.p.until(20*time.Second, "the transcript window to render", func() bool {
+		return strings.Contains(content(h.m), "Here is the table:")
+	})
+	h.p.until(10*time.Second, "the per-task subscription to attach", func() bool {
+		return h.broker.OutputSubscribers(task.ID) > 0
+	})
+
+	// The rest of the one message, record by record, transcript first and
+	// then the chunk past it — exactly the runner's order.
+	rest := []string{"| Step | State |", "|---|---|", "| build | ok |"}
+	for _, text := range rest {
+		offset := appendAssistant(t, path, text)
+		h.broker.PublishOutput(task.ID, events.Chunk{
+			Type:    "agent.output",
+			Payload: map[string]any{"run_id": run.ID, "offset": offset, "text": text},
+		})
+	}
+	h.p.until(20*time.Second, "the live table to render", func() bool {
+		return strings.Contains(content(h.m), "build")
+	})
+
+	got := content(h.m)
+	if strings.Count(got, "| Step | State |") != 0 {
+		t.Errorf("the delimiter row never joined its header — the table stayed source:\n%s", got)
+	}
+	if strings.Count(got, "build") != 1 {
+		t.Errorf("the seam duplicated a record:\n%s", got)
+	}
+	if !strings.Contains(got, "Here is the table:") {
+		t.Errorf("the fetched window lost its first record:\n%s", got)
+	}
+}
+
+// appendAssistant is appendTranscript for assistant prose: one agent.output
+// record per call, returning the offset the daemon would stamp on the chunk
+// it publishes next.
+func appendAssistant(t *testing.T, path string, text string) int64 {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	// The transcript on disk holds the agent's own dialect (§13.2); the
+	// server normalizes it on the way out, exactly as it does for a real run.
+	if _, err := fmt.Fprintf(f,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":%q}]}}`+"\n",
+		text); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatalf("stat transcript: %v", err)
+	}
+	return fi.Size()
+}

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -950,11 +950,22 @@ func (d *detail) renderOutputPane(height int) string {
 	d.vp.SetWidth(max(d.width, 1))
 	d.vp.SetHeight(height)
 	if d.outputDirty || d.builtWidth != d.width {
-		d.vp.SetContent(strings.Join(d.outputLines(), "\n"))
+		// A paused reader keeps their place across the rebuild (#291): the
+		// topmost visible block is captured before the rebuild and restored
+		// after it, which is what a resize, a maxRecords prune and the level
+		// and raw toggles used to take away. Following is untouched — the
+		// bottom is its anchor.
+		keep := anchorAt(d.anchors, d.vp.YOffset())
+		lines, anchors := d.outputLinesAt()
+		d.vp.SetContent(strings.Join(lines, "\n"))
+		d.anchors = anchors
 		d.outputDirty = false
 		d.builtWidth = d.width
-		if d.following {
+		switch y, ok := anchorIndex(anchors, keep); {
+		case d.following:
 			d.vp.GotoBottom()
+		case ok:
+			d.vp.SetYOffset(y)
 		}
 	}
 	return d.vp.View()
@@ -982,6 +993,13 @@ func (d *detail) outputEmptyState() (string, bool) {
 // outputLines renders the pane's records at the pane's level. The rendering
 // itself is outputlines.go's, shared with the chat workspace (task 071).
 func (d *detail) outputLines() []string {
+	lines, _ := d.outputLinesAt()
+	return lines
+}
+
+// outputLinesAt is outputLines with the per-line provenance the paused anchor
+// needs, and is where the pane's render pass opens and closes.
+func (d *detail) outputLinesAt() ([]string, []lineAnchor) {
 	note := ""
 	if d.truncated {
 		// Naming the key here is the whole point of T4.11: this line is the
@@ -989,8 +1007,10 @@ func (d *detail) outputLines() []string {
 		// it is where the way to the rest of it belongs.
 		note = "… earlier output truncated — press e for the whole transcript"
 	}
-	return outputLines(d.records, d.level.get(), max(d.width, 1),
-		lineOpts{expandKey: "v", truncatedNote: note, raw: d.raw.get()})
+	d.mdcache.begin()
+	defer d.mdcache.sweep()
+	return outputLinesAt(d.records, d.recordSeqs(), d.level.get(), max(d.width, 1),
+		lineOpts{expandKey: "v", truncatedNote: note, raw: d.raw.get(), cache: &d.mdcache})
 }
 
 // plain is a record with the blank gutter: assistant prose and command

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -132,24 +132,50 @@ func (b mdBlock) joined() string { return strings.Join(b.text, " ") }
 // rendering is derived, and the transcript on disk stays the agent's bytes
 // (decision 4).
 func markdownLines(text string, width int) []string {
+	lines, _ := markdownBlockLines(text, width)
+	return lines
+}
+
+// markdownBlockLines is markdownLines plus, for every line it returns, the
+// ordinal of the Markdown block that produced it. Those ordinals are the
+// block half of a lineAnchor (#291), which is what lets a paused reader keep
+// their place across a resize, a prune or a level change.
+//
+// A blank separator line belongs to the block *above* it, so a block's first
+// ordinal is its first line of content: an anchor that restored onto the
+// separator would put the block one line lower than the reader left it.
+func markdownBlockLines(text string, width int) ([]string, []int) {
 	refs := &mdRefs{}
 	blocks := parseMarkdown(sanitizeText(text), refs)
 	out := make([]string, 0, len(blocks)*2)
+	at := make([]int, 0, len(blocks)*2)
 	prev := mdParagraph
-	for _, b := range blocks {
+	for i, b := range blocks {
 		if len(out) > 0 && mdNeedsBlank(prev, b.kind) {
 			out = append(out, "")
+			at = append(at, max(i-1, 0))
 		}
-		out = append(out, renderMDBlock(b, width)...)
+		body := renderMDBlock(b, width)
+		out = append(out, body...)
+		for range body {
+			at = append(at, i)
+		}
 		prev = b.kind
 	}
+	// The reference block closes the document rather than each record
+	// (task 075 decision 2, amended by #291): one destination named in two
+	// records of one run gets one number and one line here.
 	if lines := renderMDRefs(refs, width); len(lines) > 0 {
 		if len(out) > 0 {
 			out = append(out, "")
+			at = append(at, max(len(blocks)-1, 0))
 		}
 		out = append(out, lines...)
+		for range lines {
+			at = append(at, len(blocks))
+		}
 	}
-	return out
+	return out, at
 }
 
 // mdRefs numbers the destinations one rendered message links to (task 075
@@ -859,18 +885,29 @@ func runLen(s string, i int, ch byte) int {
 // as Markdown *source*, not the agent's bytes as terminal input: raw mode is
 // the escape hatch for a surprising render, not a hole in the one chokepoint
 // §16 was added to guarantee.
-func rawLines(text string, width int) []string {
+// It reports per-line block ordinals the way markdownBlockLines does. Raw
+// source has no blocks, so every line reports block 0 and its own source line
+// as the offset: an anchor captured in one mode and restored in the other
+// falls to anchorIndex's document tier, which is the right answer — a raw
+// toggle keeps the document at the top of the pane, not a block ordinal that
+// mode does not have.
+func rawBlockLines(text string, width int) ([]string, []int) {
 	src := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
 	out := make([]string, 0, len(src))
+	at := make([]int, 0, len(src))
 	for _, line := range src {
-		out = append(out, wrapLine(paneLine{
+		body := wrapLine(paneLine{
 			gutter:      gutterNone,
 			gutterStyle: styleDim,
 			pre:         true,
 			segs:        []segment{{text: line, style: styleRaw}},
-		}, width)...)
+		}, width)
+		out = append(out, body...)
+		for range body {
+			at = append(at, 0)
+		}
 	}
-	return out
+	return out, at
 }
 
 // styleRaw draws raw source. It is dimmer than prose on purpose: raw mode is

--- a/internal/tui/markdowncache.go
+++ b/internal/tui/markdowncache.go
@@ -1,0 +1,83 @@
+package tui
+
+import "crypto/sha256"
+
+// The rendered-document memo (#291).
+//
+// Every live chunk marks the pane dirty, and the rebuild re-rendered every
+// record — up to maxRecords of them — at the daemon's ~10 Hz coalescing rate
+// (§13.3). Keying the render on the document instead means a chunk re-renders
+// the one document it extended: O(document) rather than O(pane), which is the
+// honest cost of reading a run of records as one document.
+//
+// The key is the source's digest plus every input that changes the result:
+// the pane width, the verbosity level and the raw toggle. The issue's "theme"
+// and "completion state" are not in it — this TUI has no theme concept, and
+// with whole records there is no partial state to key on. There is no
+// client-side throttle and no second timer either; the daemon already
+// coalesces.
+type mdCacheKey struct {
+	digest [sha256.Size]byte
+	width  int
+	level  outputLevel
+	raw    bool
+}
+
+type mdCacheEntry struct {
+	lines  []string
+	blocks []int
+	gen    uint64
+}
+
+// mdCache is one pane's memo. It is swept per render pass rather than bounded
+// by count: what a pane can hold is already bounded by maxRecords, and an
+// entry no pass touched belongs to a document that is no longer on screen.
+type mdCache struct {
+	entries map[mdCacheKey]mdCacheEntry
+	gen     uint64
+	// renders counts the renders that actually ran, which is what the tests
+	// assert on. Counting renders rather than timing them is the only way to
+	// state the property without making the suite a benchmark.
+	renders int
+}
+
+// begin opens a render pass.
+func (c *mdCache) begin() {
+	if c == nil {
+		return
+	}
+	c.gen++
+}
+
+// sweep closes one, dropping what the pass did not touch.
+func (c *mdCache) sweep() {
+	if c == nil {
+		return
+	}
+	for k, e := range c.entries {
+		if e.gen != c.gen {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// lines renders one document, from the memo when it can. A nil cache renders
+// every time, which is what the call sites that have no pane behind them want.
+func (c *mdCache) lines(text string, width int, level outputLevel, raw bool) ([]string, []int) {
+	if c == nil {
+		return assistantBlockLines(text, width, raw)
+	}
+	key := mdCacheKey{digest: sha256.Sum256([]byte(text)), width: width, level: level, raw: raw}
+	if e, ok := c.entries[key]; ok {
+		e.gen = c.gen
+		c.entries[key] = e
+		return e.lines, e.blocks
+	}
+	lines, blocks := assistantBlockLines(text, width, raw)
+	c.renders++
+	if c.entries == nil {
+		c.entries = make(map[mdCacheKey]mdCacheEntry, 8)
+	}
+	c.entries[key] = mdCacheEntry{lines: lines, blocks: blocks, gen: c.gen}
+	return lines, blocks
+}

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -644,20 +644,53 @@ type lineOpts struct {
 	// rather than as a fourth argument because it is a pane-specific
 	// display choice, which is exactly what this struct carries.
 	raw bool
+	// cache memoizes rendered documents for the pane that owns it (#291).
+	// Nil renders every document every time, which is what a caller with no
+	// pane behind it wants.
+	cache *mdCache
 }
 
 // outputLines renders the normalized records into wrapped pane lines.
 //
-// Two rules shape the result beyond the per-record rendering. Consecutive
+// Three rules shape the result beyond the per-record rendering. Consecutive
 // unrecognized lines collapse into a count — a dialect vincent does not model
 // must not be able to drown the output a human is reading — and `v` expands
-// them rather than leaving the count a dead end. And an assistant message
-// that follows anything else gets a blank line before it, which is what
-// separates one turn from the next without spending a column on it.
+// them rather than leaving the count a dead end. An assistant message that
+// follows anything else gets a blank line before it, which is what separates
+// one turn from the next without spending a column on it. And a run of
+// consecutive assistant records is one Markdown document (#291): see
+// assistantdoc.go for what closes one and why.
 func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width int, opts lineOpts) []string {
+	lines, _ := outputLinesAt(records, nil, level, width, opts)
+	return lines
+}
+
+// outputLinesAt is outputLines plus, for every line, what it came from.
+//
+// seqs is the record window's client-assigned identity slice; the anchors it
+// returns are what a paused pane restores its position from after a rebuild.
+// A caller with no identities passes nil and gets positional ones, which is
+// enough to render but not to survive a prune.
+func outputLinesAt(records []apiclient.TranscriptRecord, seqs []int64, level outputLevel, width int, opts lineOpts) ([]string, []lineAnchor) {
 	lines := make([]string, 0, len(records)+1)
+	anchors := make([]lineAnchor, 0, len(records)+1)
+	// note appends lines that belong to no record: they carry the zero
+	// anchor and are never a restore target.
+	note := func(added []string) {
+		lines = append(lines, added...)
+		for range added {
+			anchors = append(anchors, lineAnchor{})
+		}
+	}
+	// fromRecord appends a record's lines, each anchored to it.
+	fromRecord := func(seq int64, added []string) {
+		for i, l := range added {
+			lines = append(lines, l)
+			anchors = append(anchors, lineAnchor{rec: seq, off: i})
+		}
+	}
 	if opts.truncatedNote != "" {
-		lines = append(lines, styleDim.Render(gutterNone+opts.truncatedNote))
+		note([]string{styleDim.Render(gutterNone + opts.truncatedNote)})
 	}
 	// sawOutput drives the T4.16 result de-duplication: every dialect's
 	// result text repeats assistant messages already on screen — cursor's is
@@ -669,19 +702,25 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 		if rawRun == 0 {
 			return
 		}
-		lines = append(lines, styleDim.Render(fmt.Sprintf(
-			"%s… %d unrecognized line(s) (%s)", gutterNone, rawRun, opts.expandKey)))
+		note([]string{styleDim.Render(fmt.Sprintf(
+			"%s… %d unrecognized line(s) (%s)", gutterNone, rawRun, opts.expandKey))})
 		rawRun = 0
 	}
-	for _, rec := range records {
+	docs := assistantDocs(records, seqs)
+	docAt := make(map[int]int, len(docs))
+	for i, doc := range docs {
+		docAt[doc.first] = i
+	}
+	for i := 0; i < len(records); i++ {
+		rec := records[i]
 		if rec.Type == "agent.raw" {
 			if level == levelVerbose {
 				flushRaw()
-				lines = append(lines, wrapLine(paneLine{
+				fromRecord(seqAt(seqs, i), wrapLine(paneLine{
 					gutter:      gutterNone,
 					gutterStyle: styleDim,
 					segs:        []segment{{text: rec.Line, style: styleDim}},
-				}, width)...)
+				}, width))
 				lastWasOutput = false
 				continue
 			}
@@ -689,26 +728,38 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 			continue
 		}
 		flushRaw()
-		if rec.Type == "agent.output" {
+		if k, ok := docAt[i]; ok {
 			// Assistant prose is the one record type that is Markdown
 			// (task 073 decision 5), and it is handled here rather than in
-			// renderRecord because one record now yields several pane lines
-			// — the same reason agent.thinking is handled above.
-			block := assistantLines(rec.Text, width, opts.raw)
+			// renderRecord because one document now yields several pane
+			// lines — the same reason agent.thinking is handled below — and
+			// because it spans a run of records rather than one of them.
+			doc := docs[k]
+			i = doc.last
+			block, blockAt := opts.cache.lines(doc.text, width, level, opts.raw)
 			if len(block) == 0 {
 				continue
 			}
 			if !lastWasOutput && len(lines) > 0 {
-				lines = append(lines, "")
+				note([]string{""})
 			}
 			sawOutput = true
-			lines = append(lines, block...)
+			off, prev := 0, -1
+			for n, l := range block {
+				b := blockOrdinal(blockAt, n)
+				if b != prev {
+					off, prev = 0, b
+				}
+				lines = append(lines, l)
+				anchors = append(anchors, lineAnchor{rec: doc.seq, block: b, off: off})
+				off++
+			}
 			lastWasOutput = true
 			continue
 		}
 		if rec.Type == "agent.thinking" {
 			if block := thinkingBlock(rec.Text, level, width, opts.expandKey); len(block) > 0 {
-				lines = append(lines, block...)
+				fromRecord(seqAt(seqs, i), block)
 				lastWasOutput = false
 			}
 			continue
@@ -719,27 +770,38 @@ func outputLines(records []apiclient.TranscriptRecord, level outputLevel, width 
 		}
 		if pl.isOutput {
 			if !lastWasOutput && len(lines) > 0 {
-				lines = append(lines, "")
+				note([]string{""})
 			}
 			sawOutput = true
 		}
-		lines = append(lines, wrapLine(pl, width)...)
+		fromRecord(seqAt(seqs, i), wrapLine(pl, width))
 		lastWasOutput = pl.isOutput
 	}
 	flushRaw()
-	return lines
+	return lines, anchors
 }
 
-// assistantLines renders one assistant document, rendered or raw. It is the
-// single branch task 076 adds to the pane: the two call sites that draw
-// assistant prose — this one and the chat's §17 retention fallback — go
-// through it, and nothing else changes, because nothing else was ever
-// interpreted as Markdown (task 073 decision 5).
-func assistantLines(text string, width int, raw bool) []string {
-	if raw {
-		return rawLines(text, width)
+// blockOrdinal is the block a rendered line belongs to, tolerating a renderer
+// that reported none.
+func blockOrdinal(at []int, i int) int {
+	if i < len(at) {
+		return at[i]
 	}
-	return markdownLines(text, width)
+	return 0
+}
+
+// assistantBlockLines renders one assistant document, rendered or raw, and
+// reports the Markdown block each line came from.
+//
+// It is the single branch task 076 adds to the pane: the call sites that draw
+// assistant prose — the pane and the chat's §17 retention fallback — reach it
+// through the memo (see markdowncache.go), and nothing else changes, because
+// nothing else was ever interpreted as Markdown (task 073 decision 5).
+func assistantBlockLines(text string, width int, raw bool) ([]string, []int) {
+	if raw {
+		return rawBlockLines(text, width)
+	}
+	return markdownBlockLines(text, width)
 }
 
 // renderRecord maps one normalized record to a pane line. A record with

--- a/internal/tui/outputlines_test.go
+++ b/internal/tui/outputlines_test.go
@@ -252,6 +252,11 @@ func TestToolResultWithoutSummaryStillSaysWhether(t *testing.T) {
 
 // TestTurnSeparation pins the blank line: assistant prose that follows
 // anything else is a new turn, and consecutive prose is not.
+//
+// It also pins what #291 changed underneath that rule. Consecutive prose
+// records are one Markdown document, so two records that each hold part of a
+// paragraph reflow into the one paragraph they were written as, rather than
+// staying two documents on two lines.
 func TestTurnSeparation(t *testing.T) {
 	d := newTestDetail(t)
 	d.width = 80
@@ -262,7 +267,7 @@ func TestTurnSeparation(t *testing.T) {
 		{Type: "agent.output", Text: "second turn"},
 	}
 	got := plainLines(d.outputLines())
-	want := []string{"  first", "  still first", "▸ Bash", "", "  second turn"}
+	want := []string{"  first still first", "▸ Bash", "", "  second turn"}
 	if strings.Join(got, "|") != strings.Join(want, "|") {
 		t.Errorf("lines = %q, want %q", got, want)
 	}

--- a/internal/tui/readerpicker.go
+++ b/internal/tui/readerpicker.go
@@ -24,16 +24,44 @@ import (
 // stays dormant until asked for, follows palette.go's shape, and owns the
 // keyboard while it is up, at the top of the §15 esc stack.
 //
-// Each row **captures its payload when the popup is built** rather than
-// holding an index into the records. That is what makes a target stable
-// across resize, transcript reload and incremental rendering: there is no
-// index left to drift when a chunk arrives, a re-render happens, or the
-// chat's maxRecords cap prunes the front of the slice. When #291 lands a
-// semantic document model the rows become references to it, and none of the
-// payloads below change.
+// Each row is a **reference to a document**, resolved when it is picked, with
+// the text captured at build time as its fallback (#291, which landed the
+// identity model task 076 decision 6 deliberately shipped without). A
+// reference rather than an index: an index would drift the moment a chunk
+// arrived or the chat's maxRecords cap pruned the front of the slice, and a
+// document's seq does neither.
+//
+// One behaviour change falls out of resolving late, and it is deliberate:
+// picking a document that has grown since the popup opened copies it as it is
+// now, because "copy this message" should yield the whole message. A finished
+// document — the common case — is unaffected. A reference that no longer
+// resolves, because the prune took its records, copies the text captured when
+// the popup was built, so a pick can never fail.
 
-// copyItem is one offer: what it is called, and the exact text a pick puts on
-// the clipboard.
+// copyKind is which payload of a document a row offers (decision 5). It is
+// kept beside the captured text so a pick can re-derive the payload from the
+// document as it stands now.
+type copyKind int
+
+const (
+	copyKindMarkdown copyKind = iota
+	copyKindPlain
+	copyKindCode
+)
+
+// copyDoc is one assistant document offered to the picker: its text as the
+// pane drew it, and the identity a pick resolves against. A document with no
+// identity — a chat turn whose transcript went to retention and contributes
+// its ResultText instead (§17) — has ref.ok false and is always copied from
+// the captured text.
+type copyDoc struct {
+	seq  int64
+	text string
+	ok   bool
+}
+
+// copyItem is one offer: what it is called, the exact text a pick puts on the
+// clipboard if the reference cannot be resolved, and the reference itself.
 type copyItem struct {
 	// group is the document the row belongs to — "message 1" is the newest.
 	// Ordinals rather than the opening words alone, because two documents
@@ -44,6 +72,11 @@ type copyItem struct {
 	// findable when a conversation has twenty of them.
 	snippet string
 	text    string
+	// ref names the document this row was built from, and kind/index say
+	// which of its payloads to re-derive at pick time.
+	ref   copyDoc
+	kind  copyKind
+	index int
 }
 
 // copyItemLabels are the three payloads (decision 5).
@@ -56,15 +89,21 @@ const (
 // copyItemsFrom lists what can be copied out of one assistant document, in
 // the order a reader would look for them: the whole thing as its source, the
 // whole thing without the punctuation, then each fenced block.
-func copyItemsFrom(group, text string) []copyItem {
-	clean := sanitizeText(text)
+func copyItemsFrom(group string, doc copyDoc) []copyItem {
+	clean := sanitizeText(doc.text)
 	if strings.TrimSpace(clean) == "" {
 		return nil
 	}
 	snippet := copySnippet(clean)
 	out := []copyItem{
-		{group: group, label: copyLabelMarkdown, snippet: snippet, text: clean},
-		{group: group, label: copyLabelPlain, snippet: snippet, text: markdownPlainText(clean)},
+		{
+			group: group, label: copyLabelMarkdown, snippet: snippet,
+			text: clean, ref: doc, kind: copyKindMarkdown,
+		},
+		{
+			group: group, label: copyLabelPlain, snippet: snippet,
+			text: markdownPlainText(clean), ref: doc, kind: copyKindPlain,
+		},
 	}
 	blocks := codeBlocks(clean)
 	for i, code := range blocks {
@@ -76,21 +115,48 @@ func copyItemsFrom(group, text string) []copyItem {
 		}
 		out = append(out, copyItem{
 			group: group, label: label, snippet: copySnippet(code), text: code,
+			ref: doc, kind: copyKindCode, index: i,
 		})
 	}
 	return out
+}
+
+// copyPayload re-derives one row's payload from a document's current source.
+// It is copyItemsFrom's body, minus the labelling, and the two must agree:
+// what a pick copies is what the row said it would, read from the document as
+// it stands now.
+func copyPayload(text string, kind copyKind, index int) (string, bool) {
+	clean := sanitizeText(text)
+	if strings.TrimSpace(clean) == "" {
+		return "", false
+	}
+	switch kind {
+	case copyKindMarkdown:
+		return clean, true
+	case copyKindPlain:
+		return markdownPlainText(clean), true
+	case copyKindCode:
+		blocks := codeBlocks(clean)
+		if index < 0 || index >= len(blocks) {
+			// The document changed shape under the popup and the block the
+			// row named is gone; the captured text is what it promised.
+			return "", false
+		}
+		return blocks[index], true
+	}
+	return "", false
 }
 
 // copyDocs collects the picker's rows from assistant documents already
 // handed to it newest-first. It is the one place the "message N" ordinals are
 // assigned, so the task pane's records and the chat's turns number the same
 // way.
-func copyDocs(docs []string) []copyItem {
+func copyDocs(docs []copyDoc) []copyItem {
 	out := make([]copyItem, 0, len(docs)*2)
 	n := 0
-	for _, text := range docs {
+	for _, doc := range docs {
 		group := fmt.Sprintf("message %d", n+1)
-		items := copyItemsFrom(group, text)
+		items := copyItemsFrom(group, doc)
 		if len(items) == 0 {
 			continue
 		}
@@ -100,18 +166,28 @@ func copyDocs(docs []string) []copyItem {
 	return out
 }
 
-// copyDocsFromRecords is the task workspace's source: the assistant prose in
-// the loaded records, newest first. Only agent.output is offered, because it
-// is the only record type that was ever read as Markdown (task 073
-// decision 5).
-func copyDocsFromRecords(records []apiclient.TranscriptRecord) []string {
-	docs := make([]string, 0, len(records))
-	for i := len(records) - 1; i >= 0; i-- {
-		if records[i].Type == "agent.output" {
-			docs = append(docs, records[i].Text)
+// copyDocsFromRecords is the task workspace's source: the assistant documents
+// in the loaded records, newest first. One row per *document* rather than per
+// record (#291), so "message 1" is the newest document and a message an
+// adapter split across records is offered once rather than in pieces.
+func copyDocsFromRecords(records []apiclient.TranscriptRecord, seqs []int64) []copyDoc {
+	found := assistantDocs(records, seqs)
+	out := make([]copyDoc, 0, len(found))
+	for i := len(found) - 1; i >= 0; i-- {
+		out = append(out, copyDoc{seq: found[i].seq, text: found[i].text, ok: true})
+	}
+	return out
+}
+
+// resolveDocs answers a pick from a record window: the current source of the
+// document a row references, if it is still there.
+func resolveDocs(records []apiclient.TranscriptRecord, seqs []int64, seq int64) (string, bool) {
+	for _, doc := range assistantDocs(records, seqs) {
+		if doc.seq == seq {
+			return doc.text, true
 		}
 	}
-	return docs
+	return "", false
 }
 
 // copySnippet is a row's preview: the first line with anything on it,
@@ -129,12 +205,35 @@ func copySnippet(text string) string {
 // than owning a popup of its own: the picker overlays the whole screen and
 // takes the keyboard, which is the root's job for the palette already — and
 // building the items in the view is what captures them at pick time.
-type openCopyPickerMsg struct{ items []copyItem }
+// resolve re-reads a document by its seq from the view that offered it, and
+// is what makes a row a reference rather than a snapshot. It closes over the
+// view, so it sees the records as they are at pick time.
+type openCopyPickerMsg struct {
+	items   []copyItem
+	resolve func(seq int64) (string, bool)
+}
 
 // openCopyPicker turns a view's collected documents into that message.
-func openCopyPicker(docs []string) tea.Cmd {
+func openCopyPicker(docs []copyDoc, resolve func(seq int64) (string, bool)) tea.Cmd {
 	items := copyDocs(docs)
-	return func() tea.Msg { return openCopyPickerMsg{items: items} }
+	return func() tea.Msg { return openCopyPickerMsg{items: items, resolve: resolve} }
+}
+
+// pickText is what a chosen row puts on the clipboard: the document as it
+// stands now, or the text captured when the popup was built.
+func pickText(it copyItem, resolve func(seq int64) (string, bool)) string {
+	if resolve == nil || !it.ref.ok {
+		return it.text
+	}
+	text, ok := resolve(it.ref.seq)
+	if !ok {
+		return it.text
+	}
+	payload, ok := copyPayload(text, it.kind, it.index)
+	if !ok {
+		return it.text
+	}
+	return payload
 }
 
 // readerPicker is the popup itself: a search line over the captured rows.

--- a/internal/tui/readerpicker_test.go
+++ b/internal/tui/readerpicker_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -171,7 +172,7 @@ func TestChatRetentionFallbackFollowsRaw(t *testing.T) {
 
 // TestCopyPayloads pins what each of the three payloads is (decision 5).
 func TestCopyPayloads(t *testing.T) {
-	items := copyDocs([]string{readerDoc})
+	items := copyDocs(literalDocs(readerDoc))
 
 	md := copyOne(t, items, copyLabelMarkdown)
 	if md != readerDoc {
@@ -210,7 +211,7 @@ func TestCopyPayloadsAreWidthIndependent(t *testing.T) {
 	for i, width := range []int{40, 200} {
 		outputLines(recs, levelNormal, width, lineOpts{expandKey: "v"})
 		var b strings.Builder
-		for _, it := range copyDocs(copyDocsFromRecords(recs)) {
+		for _, it := range copyDocs(copyDocsFromRecords(recs, nil)) {
 			b.WriteString(it.label + "\x00" + it.text + "\x00")
 		}
 		payloads[i] = b.String()
@@ -225,7 +226,7 @@ func TestCopyPayloadsAreWidthIndependent(t *testing.T) {
 func TestCopyPayloadsAreSanitized(t *testing.T) {
 	wrote := stubClipboard(t, nil)
 	evil := "# Title\x1b[2J\n\nbody\x07 and \x9bmore\n"
-	items := copyDocs([]string{evil})
+	items := copyDocs(literalDocs(evil))
 	if len(items) == 0 {
 		t.Fatal("no copy rows for a document that has text")
 	}
@@ -251,9 +252,12 @@ func TestCopyPickerLists(t *testing.T) {
 		{Type: "agent.output", Text: twin},
 		{Type: "agent.thinking", Text: "not prose"},
 		{Type: "agent.output", Text: readerDoc},
+		// A reasoning record closes a document, so the two prose records
+		// around it stay two of them (#291).
+		{Type: "agent.thinking", Text: "not prose"},
 		{Type: "agent.output", Text: twin},
 	}
-	items := copyDocs(copyDocsFromRecords(recs))
+	items := copyDocs(copyDocsFromRecords(recs, nil))
 
 	// Newest first, and two documents with identical opening text stay
 	// distinguishable by their ordinal.
@@ -279,9 +283,10 @@ func TestCopyPickerLists(t *testing.T) {
 	}
 }
 
-// TestCopyPickerCapturesAtPickTime is the "targets remain stable" criterion:
-// the rows hold text, not indices, so nothing that happens afterwards moves
-// the target (decision 6).
+// TestCopyPickerCapturesAtPickTime is the "targets remain stable" criterion,
+// under #291's amended rule: a row is a reference to a document, and a
+// reference whose records the prune took falls back to the text captured when
+// the popup was built, so a pick can never fail.
 func TestCopyPickerCapturesAtPickTime(t *testing.T) {
 	d := newTestDetail(t)
 	d.taskID = 4
@@ -295,9 +300,12 @@ func TestCopyPickerCapturesAtPickTime(t *testing.T) {
 	}
 	p := newReaderPicker(msg.items)
 
-	// The world moves on: more output arrives, the front of the slice is
-	// pruned, and the pane is resized.
-	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: "something else entirely"}}
+	// The world moves on: the window is replaced by a later fetch, which is
+	// what a prune looks like from here, and the pane is resized.
+	d.applyTranscript(detailTranscriptMsg{
+		runID:   d.displayRun,
+		records: []apiclient.TranscriptRecord{{Type: "agent.output", Text: "something else entirely"}},
+	})
 	d.width = 40
 	d.outputLines()
 
@@ -305,15 +313,63 @@ func TestCopyPickerCapturesAtPickTime(t *testing.T) {
 	if !done || run == nil {
 		t.Fatal("enter did not pick a row")
 	}
-	if run.text != readerDoc {
-		t.Fatalf("the pick copied %q, want the document that was on screen", run.text)
+	if got := pickText(*run, msg.resolve); got != readerDoc {
+		t.Fatalf("the pick copied %q, want the document that was on screen", got)
 	}
+}
+
+// TestCopyPickerResolvesGrownDocument is the other half of that rule: a
+// document still on screen that has *grown* since the popup opened copies as
+// it is now, because "copy this message" should yield the whole message.
+func TestCopyPickerResolvesGrownDocument(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 4
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	d.applyTranscript(detailTranscriptMsg{
+		runID:   d.displayRun,
+		records: []apiclient.TranscriptRecord{{Type: "agent.output", Text: "first half."}},
+	})
+	d.width = 200
+
+	msg, ok := drain(d.updateKey(tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl})).(openCopyPickerMsg)
+	if !ok {
+		t.Fatal("ctrl+y did not open the picker")
+	}
+	p := newReaderPicker(msg.items)
+
+	// The same document grows by another record while the popup is up.
+	d.appendChunk(apiclient.OutputNote{
+		Type:    "agent.output",
+		RunID:   d.displayRun,
+		Offset:  9,
+		Payload: json.RawMessage(`{"type":"agent.output","text":"second half."}`),
+	})
+
+	run, done, _ := p.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done || run == nil {
+		t.Fatal("enter did not pick a row")
+	}
+	want := "first half.\nsecond half."
+	if got := pickText(*run, msg.resolve); got != want {
+		t.Fatalf("the pick copied %q, want the whole document %q", got, want)
+	}
+}
+
+// literalDocs offers bare text with no identity behind it, which is what the
+// payload tests want: they exercise what a row carries, not what a reference
+// resolves to.
+func literalDocs(texts ...string) []copyDoc {
+	out := make([]copyDoc, 0, len(texts))
+	for _, text := range texts {
+		out = append(out, copyDoc{text: text})
+	}
+	return out
 }
 
 // TestCopyPickerFilters: the search line narrows the rows, as the palette's
 // does.
 func TestCopyPickerFilters(t *testing.T) {
-	p := newReaderPicker(copyDocs([]string{readerDoc}))
+	p := newReaderPicker(copyDocs(literalDocs(readerDoc)))
 	for _, r := range "code" {
 		p.update(tea.KeyPressMsg{Code: r, Text: string(r)})
 	}
@@ -565,7 +621,7 @@ func TestCopyPayloadsCarryTask075Blocks(t *testing.T) {
 		"| Step | State |\n" +
 		"|---|---|\n" +
 		"| build | ok |\n"
-	items := copyDocs([]string{doc})
+	items := copyDocs(literalDocs(doc))
 
 	plain := copyOne(t, items, copyLabelPlain)
 	for _, punct := range []string{"](", "|", "---"} {

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -75,6 +75,9 @@ type root struct {
 	// owns the keyboard while it is up. The two are never open together —
 	// each closes on the key that would open the other.
 	reader *readerPicker
+	// readerResolve re-reads a picked row's document from the view that
+	// offered it, and is nil while no picker is up.
+	readerResolve func(seq int64) (string, bool)
 	// mouseOn drives tea.View's mouse mode: on by default, M toggles (§15
 	// Mouse). Off restores native click-drag text selection.
 	mouseOn bool
@@ -211,6 +214,7 @@ func (m *root) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.deliver(m.active, msg)
 	case openCopyPickerMsg:
 		m.reader = newReaderPicker(msg.items)
+		m.readerResolve = msg.resolve
 		return m, nil
 	case clipboardResultMsg:
 		return m, m.updateClipboardResult(msg)
@@ -387,18 +391,20 @@ func (m *root) updatePaletteKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 // updateReaderKey routes keys into the open copy picker and puts whatever it
-// picks on the clipboard. The payload was captured when the popup was built,
-// so what is copied is what was on screen then — records that arrived since,
-// and a resize, change nothing.
+// picks on the clipboard. A row is a reference to a document, resolved here
+// against the view's records as they stand now (#291): a document that grew
+// while the popup was up copies whole, and one whose records were pruned
+// copies the text captured when the popup was built.
 func (m *root) updateReaderKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	run, done, cmd := m.reader.update(msg)
+	resolve := m.readerResolve
 	if done {
-		m.reader = nil
+		m.reader, m.readerResolve = nil, nil
 	}
 	if run == nil {
 		return m, cmd
 	}
-	return m, writeClipboardCmd(run.label, run.text)
+	return m, writeClipboardCmd(run.label, pickText(*run, resolve))
 }
 
 // openPalette builds the palette for the active surface.


### PR DESCRIPTION
## Summary

An agent sometimes delivers one answer as several `agent.output` records.
`outputLines` treated each record as its own Markdown document, and consecutive
records already rendered with no blank line between them — so they *looked*
like one message and parsed as several, and a table, a list or a fenced block
split across two of them rendered as two broken documents.

A run of consecutive `agent.output` records is now one document, joined at the
newline a record ends on. Any other record — reasoning, tool use, tool result,
command output, `agent.raw`, a result line — closes it, and prose after it
opens the next; a run or turn boundary closes it too, which falls out for free
because each pane renders one attempt's or one turn's records. The rule is
independent of the verbosity level, so a level that hides a record cannot
change how the prose around it parses.

Two shipped decisions follow the document rather than the record, which is what
they meant by "message" all along: task 075's link-reference numbering (one
destination named in two records of one run gets one number and one `[n] dest`
line) and task 076's copy-picker rows (one per document, "message 1" is the
newest).

On top of that:

- **Identities.** `apiclient.TranscriptRecord` carries no id and no offset and
  no wire format changes, so identity is client-assigned on ingest: a monotonic
  `seq` that is deliberately not an index, so it survives the `maxRecords`
  front-prune. This is the identity model task 076 decision 6 shipped without
  and named this issue as the source of.
- **A paused pane keeps its place.** It captures the identity of its topmost
  visible block and restores it after any rebuild, fixing the four things that
  actually move a paused reader — a resize, a front-prune, a level cycle, a raw
  toggle. Following is untouched; its anchor is the bottom.
- **Picker rows are references**, resolved at pick time with the captured text
  as fallback. A message still being written copies whole; a row whose records
  the prune took still copies what it offered, so a pick can never fail.
- **Rendering is memoized per document** on (source digest, width, level, raw),
  so a chunk re-renders the document it extended rather than every record in
  the pane at the daemon's ~10 Hz coalescing rate. No client-side throttle and
  no second timer.

**The stable-prefix classifier the issue proposed is deliberately not built.**
`agent.output` never carries a partial Markdown document: claude runs
message-level `stream-json` with no `--include-partial-messages` (the T1.7
decision, `docs/history/v0-tasks.md:142`), codex emits `agent_message` only on
`item.completed`, and cursor delivers assistant content blocks whole. A record
is present whole or is not present, so the classifier would have no stream
shape to run against and its tests could only assert against splits the daemon
cannot emit. Joining does reintroduce a growing tail at *record* granularity —
a table header in one record and its delimiter in the next renders as a
paragraph and then becomes a table — and the bound asserted instead is the
weaker, true one: **nothing above the last block of the previous document moves
when a record arrives.** Reopening T1.7 for token-level deltas is its own issue,
and that issue is what would build the classifier.

Entirely client-side, in `internal/tui` alone. No daemon package, no API route,
no store migration, no wire change.

**One visible behaviour change beyond the fix**, and it is the same change seen
from the other side: two records that each carry part of a paragraph now reflow
into that paragraph rather than staying two lines. `TestTurnSeparation` is
updated to pin it.

## Related

Closes #291

Recorded as [task 077](docs/tasks/077-stable-assistant-markdown-while-streaming.md),
which closes 077.1. It revisits two recorded decisions, both explicitly:

- **T1.7** (`docs/history/v0-tasks.md:142`, message-level streaming) is *not*
  revisited — it is the reason the classifier is not built, and it stands.
- **Task 076 decision 6** ("each row captures its text when the popup is
  built") is amended, as that decision itself anticipated: rows become
  references with the captured text as fallback.
  `TestCopyPickerCapturesAtPickTime`'s assertion is amended to the new rule
  rather than deleted.

`docs/spec.md` §15 is amended in place with dated notes, in this same branch:
the task-073 amendment gains the document rule and decision 3's bound, the
task-075 link paragraph's "numbered per rendered message" now names the
document as the unit, and the task-076 paragraph gains the picker's reference
model and the paused anchor. §13.3 and §16 are untouched — no chunk, offset or
payload changed, and the sanitize chokepoint is where it was.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

The documentation was audited derivation by derivation after the implementation
commit. `internal/config`, `internal/workflow`, `internal/agent` and `skills/`
are untouched here, so the configuration reference, the workflow schema page,
`docs/guides/agents.md`, spec §9.x and `skills/vincent-workflows/SKILL.md`
correctly need nothing; no key binding, cobra command, API route or `Reason*`
constant moved either. `docs/features.md`, `docs/guides/tui.md`, spec §15 and
`CHANGELOG.md` carry the change and match the code — the `f`/`ctrl+g`,
`v`/`ctrl+r` and `ctrl+o` keys the new anchor paragraph names are the ones in
`internal/tui/bindings.go`, and the security model's "stripped on the way out"
claim survives late resolution because `copyPayload` sanitizes on the pick path
too. Two gaps were found and fixed in a separate `docs:` commit: task 077's
document had no `077.1` row for the ID this PR and the index row both cite, and
one sentence in `docs/features.md` was missing a relative pronoun.
`.vincent/workflows/*.yaml` pass `vincent workflow validate` and
`vincent workflow render`.

`internal/tui` is covered by no gate script, so the hermetic tests are the whole
assurance (task 073's position, unchanged). New in
`internal/tui/assistantdoc_test.go`:

- A document split at every line boundary, across two records and three,
  renders identically to the same source arriving in one record — paragraphs,
  nested lists, blockquotes, tables, fences, headings and rules.
- Nothing above the last block of the previous document changes when a record
  arrives — decision 3's bound, asserted line for line.
- A reasoning, tool, command, raw or result record between two prose records
  keeps them two documents; a window boundary does the same.
- One destination named in two records of one run gets one number and one line.
- An unclosed fence, an incomplete table delimiter, a dangling emphasis marker
  and multibyte text across a split produce no panic, no ESC, no C0/C1 and no
  line wider than the pane, rendered and raw.
- The paused anchor survives a resize, a `maxRecords` prune, a level cycle and
  a raw toggle, in both workspaces; follow mode still lands on the bottom.
- The memo: identical source at one width, level and raw renders once; each of
  the three invalidates; a chunk extending one document re-renders one
  document; the sweep drops what a pass did not touch. Renders are counted, not
  timed.

Extended rather than duplicated, in `detaillive_test.go`: a live test streams a
table whose header, delimiter and body arrive as three chunks against the real
store, broker, handlers and client, and asserts the pane renders the table and
that the `X-Next-Offset` seam neither duplicates a record nor loses one. That
needed an agent registry on the board live harness, so a step run naming an
agent has its transcript normalized out of the agent's own dialect (§13.2)
rather than surfacing as `agent.raw`.

No new screenshot: nothing here changes a panel's shape, and what did change is
what a split message parses as, which no capture would show.

Full suite green and `golangci-lint` clean for `GOOS=darwin`, `linux` and
`windows`.
