### PR TITLE
Scroll the chat conversation with the mouse wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -674,10 +674,12 @@ list with the user-facing context a commit subject cannot carry.
   overran its frame by two rows: the hint line naming `enter send`,
   `pgup/pgdown scroll` and `ctrl+g live` was cut off entirely and the composer
   showed two of its three rows. Both are on screen now.
-- **The mouse wheel scrolled the pane behind an open task popup.** Clicks were
+- **The mouse wheel reached the tab behind an open task popup.** Clicks were
   already ignored while a question, repair or follow-up popup owns the screen;
-  the wheel was not, so a tick moved the Steps, Output, Diff or Workflow tab
-  underneath it. A popup now takes the wheel as well.
+  the wheel was not, so a tick scrolled the tab underneath it — and on the Steps
+  and Pull Request tabs, where the wheel moves a cursor rather than a viewport,
+  it changed which step or pull request was selected. A popup now takes the
+  wheel as well.
 - **Palette entries for `ctrl+`-modified keys did nothing.** Running one
   replays its direct key, and the replay had a hand-written case per ctrl key
   that had fallen a registry behind — the chat's `ctrl+r` (detail level) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ list with the user-facing context a commit subject cannot carry.
   have since been dropped from the window still copies what it offered, so a
   pick can never fail.
 
+- **The mouse wheel scrolls a chat's conversation.** The chat workspace was the
+  one scrollable pane the wheel did not reach — `pgup`/`pgdown` and `ctrl+g`
+  were the only way to move it, which matters most here because the composer
+  holds the keyboard almost always. A tick now moves the conversation one line,
+  wheeling back pauses following the live end and `ctrl+g` re-arms it, and turns
+  whose transcripts had not been fetched yet are fetched as you wheel to them
+  rather than leaving blank space. It scrolls from anywhere in the view: the
+  conversation is the only thing on that screen that scrolls, which is what the
+  TUI's rule — the wheel moves the focused panel, not the hovered one — already
+  says to do. The chats board stays keyboard-only.
+
 - **A chat can now hand its worktree and branch to a task.** An idle chat gains
   one action — `hand off` — that creates a task adopting the chat's worktree
   path, branch, base branch and base SHA *exactly as they are*. Nothing is
@@ -658,6 +669,15 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Fixed
 
+- **The chat workspace's footer hint was drawn off the bottom of the screen.**
+  The composer counted as one line while it rendered three, so the chat's body
+  overran its frame by two rows: the hint line naming `enter send`,
+  `pgup/pgdown scroll` and `ctrl+g live` was cut off entirely and the composer
+  showed two of its three rows. Both are on screen now.
+- **The mouse wheel scrolled the pane behind an open task popup.** Clicks were
+  already ignored while a question, repair or follow-up popup owns the screen;
+  the wheel was not, so a tick moved the Steps, Output, Diff or Workflow tab
+  underneath it. A popup now takes the wheel as well.
 - **Palette entries for `ctrl+`-modified keys did nothing.** Running one
   replays its direct key, and the replay had a hand-written case per ctrl key
   that had fallen a registry behind — the chat's `ctrl+r` (detail level) and

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1155,7 +1155,7 @@ them, and a composer at the bottom.
 | `ctrl+t` | Hand the worktree and branch to a new task — the chat ends |
 | `ctrl+o` | Show the assistant's original Markdown instead of the rendered view |
 | `ctrl+y` | Copy an assistant message, its plain text, or one of its code blocks |
-| `pgup` / `pgdown` | Scroll the conversation |
+| `pgup` / `pgdown` | Scroll the conversation (the mouse wheel scrolls it a line at a time) |
 | `ctrl+g` | Jump to the live end and follow it again |
 | `esc` | Back to the chats board |
 
@@ -1185,9 +1185,12 @@ model — which sit behind a `… N unrecognized line(s) (ctrl+r)` count at the
 other two levels rather than filling the screen.
 
 Scrolling away from the end pauses follow; `ctrl+g` jumps back and re-arms it.
-Finished turns are drawn from their transcripts, so raising the level shows more
-of what already happened and not only of what happens next. A turn whose
-transcript has aged out of retention still shows its answer.
+The **mouse wheel** does this too — a line per tick, from anywhere in the view,
+because the conversation is the only thing here that scrolls. Finished turns are
+drawn from their transcripts, so raising the level shows more of what already
+happened and not only of what happens next, and turns you wheel back to are
+fetched as you reach them. A turn whose transcript has aged out of retention
+still shows its answer.
 
 When the agent asks something mid-turn, the chat enters `awaiting_input` and
 **the same popup a task's question opens** appears here — same options, same

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -538,7 +538,9 @@ and one expanded to its hunk](../assets/tui-diff.png)
 | `[` | Back to the Output tab (`]` advances to Workflow) |
 
 Clicking a file's row folds it; clicking a line of code selects its file and
-leaves it open. The mouse wheel scrolls whichever tab is on screen.
+leaves it open. The mouse wheel scrolls whichever tab is on screen, unless a
+popup is open — a popup takes the mouse as well as the keyboard, so a tick
+behind it moves nothing.
 
 The counts beside each path are the added and removed lines inside that file's
 hunks, and the line above the list totals them. A **binary** file says so

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6424,6 +6424,15 @@ stream for the live tail.
    `409 chat_cap_reached` on send renders as a refusal — never a queued turn,
    never a spinner — because that is what the daemon did.
 
+   *Amended 2026-09-01 (issue #300).* The conversation body takes the **mouse
+   wheel** as well as `pgup`/`pgdown`: one line per tick, a scroll back pausing
+   follow and `ctrl+g` re-arming it, and the lazy transcript fetch running on a
+   wheel scroll exactly as it does on a paging key. It is not scoped to the
+   pointer's position — the workspace has one scrollable pane, so this section's
+   Mouse rule ("the focused panel", not the hovered one) already names it — and
+   the §7.4 popup takes the wheel out of the conversation behind it, the way it
+   already takes clicks.
+
 ### Layout
 
 The list above is also the screen contract. View 1 is the board-only home

--- a/docs/tasks/078-chat-workspace-mouse-wheel.md
+++ b/docs/tasks/078-chat-workspace-mouse-wheel.md
@@ -1,0 +1,150 @@
+# 078 — Scroll the chat workspace conversation with the mouse wheel
+
+**Status:** ✅ done (1/1)
+**Issue:** #300
+**Amends:** §15 view 9
+
+The chat workspace was the one scrollable pane in the TUI the wheel did not
+reach: `chatView.update` handled `tea.WindowSizeMsg` and `tea.KeyPressMsg` and
+no mouse message, so a conversation could only be moved with `pgup`/`pgdown`.
+It is the view where that is missed most — the composer holds the keyboard
+almost always, which is why the scroll keys had to be `ctrl`-modified in the
+first place.
+
+The body now takes `tea.MouseWheelMsg`: one line per tick, `syncFollowToViewport()`
+so a scroll back pauses follow and `ctrl+g` re-arms it, and
+`fetchVisibleTranscripts()` so wheeling back into turns whose transcripts were
+never fetched fills them in rather than scrolling into blank space (task 071
+decision 6). That is `taskTabOutput`'s arm of `taskView.updateWheel`, verbatim,
+which is the point: §15 view 9 makes this body that pane.
+
+## Decisions
+
+### 1. The wheel scrolls the conversation from anywhere in the chat view
+
+The issue as filed required the wheel to act **only** while the pointer is over
+the conversation body, with ticks over the header, footer or composer ignored,
+and asked for a `chatView` field recording the body's Y range the way
+`taskView.bodyY` does. That is not built, and the issue's own first alternative
+— scroll from anywhere — is what shipped.
+
+It contradicts a binding recorded decision. §15's Mouse section says "wheel to
+scroll the focused panel"; PR S (`../history/v0-tasks.md`) records it as *"The
+wheel scrolls the focused panel, not the hovered one — §15 verbatim. Hover
+tracking is drag-adjacent machinery for a behavior §15 does not ask for"*; and
+`TestShellWheelScrollsFocusedPanel` asserts it by name, moving the pointer over
+an unfocused table to prove the tick does not follow it. No view gates the wheel
+on pointer position today — `taskView.updateWheel` dispatches on the active tab,
+`shell.updateWheel` on `s.focus` — so the gate would have made the chat
+workspace the only position-gated surface in the TUI, the inverse of the issue's
+own stated reason for rejecting this alternative.
+
+The chat workspace has exactly one scrollable pane, so "the focused panel" is
+that pane and the rule needs no exception to cover it. The cost is accepted
+knowingly: a tick with the pointer in a draft longer than the composer's three
+rows scrolls the conversation rather than the draft. §15's Mouse section is
+therefore **unchanged** — this change makes the chat obey the rule already
+written there rather than amending it.
+
+Two alternatives are recorded so neither is re-proposed silently:
+
+- **The hover gate**, above.
+- **Hover-*routing* on the `detailsPane.scrollAt` precedent** (task 049 — over
+  the sidebar it walks sections, over the content it scrolls the body).
+  `scrollAt` is position-aware *routing* and is never a no-op; a positional
+  no-op has no precedent here, and routing the wheel into the composer's own
+  draft is behaviour nobody asked for.
+
+### 2. The pre-existing footer clip is fixed in the same work
+
+`chatView.render` computes `room := max(height-len(head)-len(foot), 1)`, but
+`footerLines` appended `v.composer.View()` as a **single** slice element and the
+composer is `SetHeight(3)`; bubbles' `viewport.View` pads its output to its
+height, so that one element rendered three rows. The footer occupied five
+rendered rows while `len(foot)` reported three, `render` returned `height+2`
+lines, and `frame` keeps only the first `h-2` — so the in-view hint line
+(`enter send · ctrl+x stop the turn · … pgup/pgdown scroll · ctrl+g live`) was
+never drawn and the composer showed two of its three rows. The same bug fed a
+string containing newlines to `render`'s per-line `ansi.Truncate` pass.
+
+`footerLines` now returns one element per rendered line. `len(foot)` is honest,
+`room` becomes `height-7`, `render` returns exactly `height` lines, and the
+truncation pass sees single lines. The body loses two rows to the footer that
+was always going to occupy them; that is the honest accounting, not a
+regression.
+
+It is in scope because the issue's fourth acceptance criterion names the footer
+as a region the wheel must respect, and it was not on screen at all.
+
+### 3. `taskView.updateWheel` gains the popup gate it was missing
+
+`taskView.updateClick` returns early on `t.popup`; `updateWheel` did not, so
+wheeling behind an open task popup scrolled the pane underneath it. PR S records
+*"the palette and the answer popup ignore clicks"*, and the issue asks the chat
+to honour the same rule for the wheel. Both have it now:
+`chatView.updateWheel` returns `nil` while `v.form != nil`,
+`taskView.updateWheel` while `t.popup`. "A popup owns the surface" is one rule
+rather than two.
+
+### 4. The tests live beside the chat's own scroll tests
+
+The issue nominated `mouse_test.go` and `diffshell_test.go`. Both are built on
+`newShellFixture`, which constructs a `shell` and cannot reach a `chatView`. The
+chat's existing scroll coverage is `chatturns_test.go` with the `finishedChat`
+fixture, which already drives `v.render(60, 14)` and a paging key, so the wheel
+tests go in a new `chatmouse_test.go` beside it. The task workspace's popup gate
+is tested there too, next to the chat gate it is the twin of.
+
+## Shape
+
+`internal/tui` alone. No daemon package, no API route, no store migration, no
+wire change, and no key binding: the wheel is not a binding, so
+`internal/tui/bindings.go` is untouched and the `ctxChat` rows for `pgup` and
+`ctrl+g` are correct as they stand.
+
+`internal/tui/root.go` is untouched as well — PR S already gives takeover
+screens wheel delegation for free, and with decision 1 the chat never reads
+`msg.Y`, so the header decrement there is irrelevant here and no geometry has to
+agree with it. The chats board (§15 view 8) stays keyboard-only, as the issue
+scopes it; it is its own issue if it is wanted.
+
+## Tasks
+
+- [x] **078.1** The wheel on the chat conversation, the footer clip and the task
+  workspace's popup gate ✓ 2026-09-01
+
+**Done when:** a wheel tick over an open chat moves the conversation one line;
+a wheel-up pauses follow and `ctrl+g` re-arms it at the end; wheeling back past
+the five turns fetched on open fetches the older ones; a tick behind either
+workspace's popup moves nothing; `chatView.render(w, h)` returns exactly `h`
+lines with the footer hint on screen; and §15 and `docs/guides/tui.md` say so.
+
+## Tests
+
+`internal/tui` is covered by no gate script, so the hermetic tests are the whole
+assurance — task 073's position, unchanged.
+
+- A tick moves `v.vp.YOffset()` by exactly one line, each way.
+- A wheel-up on a following conversation clears `v.following`, and `ctrl+g`
+  restores it with `v.vp.AtBottom()` true — the same pair `pgup` is held to.
+- Wheeling to the top fetches turn 1, mirroring
+  `TestChatFetchesOlderTurnsWhenScrolledTo` with ticks in place of pages, so the
+  two scroll routes are proven to fetch identically.
+- A tick behind the §7.4 popup leaves the offset unchanged in both workspaces,
+  and closing the popup hands the wheel back — so neither gate is a test that
+  nothing scrolls.
+- `render(80, h)` returns exactly `h` lines at four heights, and the footer hint
+  survives `frame` at the size `root.framedView` uses. Both fail against the
+  pre-fix `footerLines`.
+
+Position is deliberately **not** asserted: a test that fed a tick at composer
+coordinates and expected no scroll would encode the design decision 1 rejects.
+
+## Left open
+
+- **The chats board's wheel** (§15 view 8). Out of scope by the issue's own
+  wording.
+- **No new screenshot.** The wheel is not visible in a still, and the footer fix
+  restores a line the captures under `docs/assets/` were taken without — worth a
+  re-run of `scripts/screenshots.sh` next time it is walked, not a reason to
+  block this.

--- a/docs/tasks/078-chat-workspace-mouse-wheel.md
+++ b/docs/tasks/078-chat-workspace-mouse-wheel.md
@@ -8,8 +8,8 @@ The chat workspace was the one scrollable pane in the TUI the wheel did not
 reach: `chatView.update` handled `tea.WindowSizeMsg` and `tea.KeyPressMsg` and
 no mouse message, so a conversation could only be moved with `pgup`/`pgdown`.
 It is the view where that is missed most — the composer holds the keyboard
-almost always, which is why the scroll keys had to be `ctrl`-modified in the
-first place.
+almost always, which is why the scroll keys had to be `pgup`/`pgdown` and
+`ctrl+g` rather than the arrows in the first place.
 
 The body now takes `tea.MouseWheelMsg`: one line per tick, `syncFollowToViewport()`
 so a scroll back pauses follow and `ctrl+g` re-arms it, and
@@ -79,7 +79,9 @@ as a region the wheel must respect, and it was not on screen at all.
 ### 3. `taskView.updateWheel` gains the popup gate it was missing
 
 `taskView.updateClick` returns early on `t.popup`; `updateWheel` did not, so
-wheeling behind an open task popup scrolled the pane underneath it. PR S records
+wheeling behind an open task popup reached the tab underneath it — scrolling it,
+or on the Steps and Pull Request tabs, where the wheel moves a cursor rather
+than a viewport, changing what was selected there. PR S records
 *"the palette and the answer popup ignore clicks"*, and the issue asks the chat
 to honour the same rule for the wheel. Both have it now:
 `chatView.updateWheel` returns `nil` while `v.form != nil`,
@@ -144,7 +146,8 @@ coordinates and expected no scroll would encode the design decision 1 rejects.
 
 - **The chats board's wheel** (§15 view 8). Out of scope by the issue's own
   wording.
-- **No new screenshot.** The wheel is not visible in a still, and the footer fix
-  restores a line the captures under `docs/assets/` were taken without — worth a
-  re-run of `scripts/screenshots.sh` next time it is walked, not a reason to
-  block this.
+- **No new screenshot.** The wheel is not visible in a still, and nothing under
+  `docs/assets/` goes stale: the chat workspace is photographed by no capture —
+  `scripts/screenshots.sh` has no chat tape and there is no `tui-chat*.png` — so
+  the restored hint line appears in no existing image. A chat capture is worth
+  adding next time the script is walked, not a reason to block this.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -91,6 +91,7 @@ the living engineering specification records implementation contracts.
 | [075](075-rich-markdown-blocks.md) | Tables, links and code blocks in the output pane | ✅ done (1/1) |
 | [076](076-reader-actions-on-assistant-markdown.md) | Rendered/raw toggle and copy actions for assistant Markdown | ✅ done (1/1) |
 | [077](077-stable-assistant-markdown-while-streaming.md) | Consecutive assistant records as one Markdown document, with identities, a paused anchor and a render memo | ✅ done (1/1) |
+| [078](078-chat-workspace-mouse-wheel.md) | The mouse wheel scrolls the chat conversation, with the footer clip and the task popup's wheel gate fixed alongside | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/chatmouse_test.go
+++ b/internal/tui/chatmouse_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// wheelTick builds one wheel event. Its coordinates are arbitrary on purpose:
+// §15's Mouse rule scrolls the focused panel, not the hovered one (PR S), and
+// the chat workspace has exactly one scrollable pane. A test that fed a tick
+// at composer coordinates and expected no scroll would encode the position
+// gate this design rejects.
+func wheelTick(up bool) tea.MouseWheelMsg {
+	button := tea.MouseWheelDown
+	if up {
+		button = tea.MouseWheelUp
+	}
+	return tea.MouseWheelMsg{X: 10, Y: 4, Button: button}
+}
+
+// scrollableChat is a chat long enough that its conversation does not fit the
+// body, laid out once so the viewport has content to move over.
+func scrollableChat(t *testing.T) *chatView {
+	t.Helper()
+	v := finishedChat(t, 9)
+	v.fetchTranscripts()
+	v.bodyDirty = true
+	v.render(60, 14)
+	if v.vp.AtTop() {
+		t.Fatal("the fixture conversation fits its body; nothing here can scroll")
+	}
+	return v
+}
+
+// TestChatWheelScrollsOneLinePerTick is issue #300's first acceptance
+// criterion: the wheel reaches the conversation, at the output pane's step.
+func TestChatWheelScrollsOneLinePerTick(t *testing.T) {
+	v := scrollableChat(t)
+	before := v.vp.YOffset()
+
+	v.update(wheelTick(true))
+	if got := v.vp.YOffset(); got != before-1 {
+		t.Fatalf("a wheel-up moved the body from %d to %d, want one line back", before, got)
+	}
+	v.update(wheelTick(false))
+	if got := v.vp.YOffset(); got != before {
+		t.Fatalf("a wheel-down moved the body to %d, want it back at %d", got, before)
+	}
+}
+
+// TestChatWheelUpPausesFollowAndCtrlGReArmsIt holds the wheel to the same pair
+// pgup is held to (§15 view 9): a manual scroll pauses follow, ctrl+g re-arms
+// it and jumps to the end.
+func TestChatWheelUpPausesFollowAndCtrlGReArmsIt(t *testing.T) {
+	v := scrollableChat(t)
+	if !v.following {
+		t.Fatal("the fixture is not following; the pause has nothing to prove")
+	}
+
+	v.update(wheelTick(true))
+	if v.following {
+		t.Fatal("a wheel-up left the body following; a manual scroll pauses it")
+	}
+
+	v.updateKey(registryKey(t, "ctrl+g"))
+	if !v.following {
+		t.Fatal("ctrl+g did not re-arm follow after a wheel scroll")
+	}
+	if !v.vp.AtBottom() {
+		t.Fatalf("ctrl+g re-armed follow at offset %d without jumping to the end", v.vp.YOffset())
+	}
+}
+
+// TestChatWheelFetchesOlderTurnsWhenScrolledTo mirrors
+// TestChatFetchesOlderTurnsWhenScrolledTo with wheel ticks in place of pgup:
+// the two scroll routes fetch identically, so wheeling back into turns whose
+// transcripts were never fetched fills them in rather than scrolling into
+// blank space (task 071 decision 6).
+func TestChatWheelFetchesOlderTurnsWhenScrolledTo(t *testing.T) {
+	v := scrollableChat(t)
+	if v.fetched[1] {
+		t.Fatal("turn 1 was fetched eagerly; the lazy half has nothing to prove")
+	}
+
+	// One line per tick, so the wheel walks where pgup paged.
+	for range 200 {
+		if v.vp.AtTop() {
+			break
+		}
+		v.update(wheelTick(true))
+	}
+	if !v.vp.AtTop() {
+		t.Fatal("200 wheel ticks did not reach the top of a nine-turn conversation")
+	}
+	if !v.fetched[1] {
+		t.Fatalf("wheeling to the top fetched %v, never turn 1", v.fetched)
+	}
+}
+
+// TestChatWheelIgnoredBehindTheAnswerPopup: a popup owns the surface. PR S
+// gave the palette and the §7.4 popup clicks; the wheel is the same rule.
+func TestChatWheelIgnoredBehindTheAnswerPopup(t *testing.T) {
+	v := scrollableChat(t)
+	v.form = newAnswerForm(questionRequest())
+	before := v.vp.YOffset()
+
+	v.update(wheelTick(true))
+	v.update(wheelTick(false))
+	if got := v.vp.YOffset(); got != before {
+		t.Fatalf("a wheel tick behind the popup moved the body from %d to %d", before, got)
+	}
+
+	// Closing it hands the wheel back, so the gate is not simply "nothing
+	// scrolls in this fixture".
+	v.form = nil
+	v.update(wheelTick(true))
+	if got := v.vp.YOffset(); got == before {
+		t.Fatalf("the body stayed at %d with no popup open", got)
+	}
+}
+
+// TestTaskWheelIgnoredBehindAPopup is the same rule on the task workspace,
+// which had the gate on clicks (updateClick) and not on the wheel.
+func TestTaskWheelIgnoredBehindAPopup(t *testing.T) {
+	v := popupTaskView(t, func(d *detail) { d.form = newAnswerForm(questionRequest()) })
+	v.tab = taskTabOutput
+	v.detail.vp.SetWidth(60)
+	v.detail.vp.SetHeight(5)
+	v.detail.vp.SetContent(strings.Repeat("a line of output\n", 40))
+	v.detail.vp.GotoBottom()
+	before := v.detail.vp.YOffset()
+
+	v.updateWheel(wheelTick(true))
+	if got := v.detail.vp.YOffset(); got != before {
+		t.Fatalf("a wheel tick behind the popup moved the output pane from %d to %d", before, got)
+	}
+
+	v.popup = false
+	v.updateWheel(wheelTick(true))
+	if got := v.detail.vp.YOffset(); got != before-1 {
+		t.Fatalf("the output pane moved from %d to %d with no popup, want one line back", before, got)
+	}
+}
+
+// TestChatRenderFillsExactlyItsHeight is the regression test for the footer
+// clip: footerLines appended the composer as one element while bubbles pads
+// its View to SetHeight(3), so render returned height+2 lines, the frame kept
+// the first h-2, and the in-view hint line was never drawn.
+func TestChatRenderFillsExactlyItsHeight(t *testing.T) {
+	for _, height := range []int{10, 14, 24, 40} {
+		v := finishedChat(t, 9)
+		v.bodyDirty = true
+		got := strings.Count(v.render(80, height), "\n") + 1
+		if got != height {
+			t.Errorf("render(80, %d) produced %d lines", height, got)
+		}
+	}
+}
+
+// TestChatFooterHintIsOnScreen is the other half of it: the hint naming the
+// scroll keys is what the clip cost, and it is drawn inside the frame.
+func TestChatFooterHintIsOnScreen(t *testing.T) {
+	v := finishedChat(t, 9)
+	v.bodyDirty = true
+	// Framed the way root.framedView does it, because that is where the clip
+	// happened: render was asked for h-2 lines, returned h, and frame kept
+	// h-2 — dropping the hint off the bottom of the screen.
+	const w, h = 200, 24
+	got := ansi.Strip(frame(v.title(), v.render(w-2, h-2), w, h, true))
+	for _, want := range []string{"enter send", "pgup/pgdown scroll", "ctrl+g live"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the footer hint lost %q on screen:\n%s", want, got)
+		}
+	}
+}

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -225,7 +225,14 @@ func (v *chatView) footerLines(width int) []string {
 		}
 		out = append(out, " "+style.Render(v.note))
 	}
-	out = append(out, v.composer.View())
+	// One element per rendered line, not one per widget: the composer is
+	// SetHeight(3) and bubbles' viewport pads its View to that height, so a
+	// joined string would report a height of 1 and render 3. render's
+	// `room := height - len(head) - len(foot)` would then overrun the frame
+	// by two lines — the frame keeps the first h-2 — and the hint line below
+	// would never be drawn. It would also feed a multi-line string to
+	// render's per-line ansi.Truncate pass.
+	out = append(out, strings.Split(v.composer.View(), "\n")...)
 	hint := " enter send · ctrl+x stop the turn · ctrl+r detail · " +
 		rawToggleKey + " raw · " + copyPickKey + " copy · " +
 		"pgup/pgdown scroll · ctrl+g live · esc back to the chats board"

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -295,8 +295,40 @@ func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
 		return v, v.applyCanceled(msg)
 	case tea.KeyPressMsg:
 		return v.updateKey(msg)
+	case tea.MouseWheelMsg:
+		return v, v.updateWheel(msg)
 	}
 	return v, nil
+}
+
+// updateWheel scrolls the conversation, one line per tick — the step and the
+// follow semantics the output pane's arm of taskView.updateWheel uses, because
+// §15 view 9 makes this body that pane.
+//
+// It is not gated on where the pointer is. §15's Mouse section says the wheel
+// scrolls "the focused panel", and PR S recorded that as the focused panel and
+// not the hovered one (docs/history/v0-tasks.md) — hover tracking being
+// drag-adjacent machinery for a behaviour §15 does not ask for. This workspace
+// has exactly one scrollable pane, so that pane is the focused panel and the
+// rule needs no exception; the cost, knowingly taken, is that a tick with the
+// pointer in a long draft scrolls the conversation rather than the draft.
+//
+// The §7.4 popup takes the wheel out of the conversation behind it, the way
+// updateKey and taskView.updateClick already take the keyboard and clicks.
+func (v *chatView) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
+	if v.form != nil {
+		return nil
+	}
+	if msg.Button == tea.MouseWheelUp {
+		v.vp.ScrollUp(1)
+	} else {
+		v.vp.ScrollDown(1)
+	}
+	v.syncFollowToViewport()
+	// The lazy half of task 071 decision 6 runs on a wheel scroll exactly as
+	// it does on pgup/pgdown: without it, wheeling back into turns whose
+	// transcripts were never fetched scrolls into blank space.
+	return v.fetchVisibleTranscripts()
 }
 
 func (v *chatView) applyLoaded(msg chatLoadedMsg) {

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -540,6 +540,12 @@ func (t *taskView) updateClick(msg tea.MouseClickMsg) tea.Cmd {
 }
 
 func (t *taskView) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
+	// A popup owns the surface: PR S gave the palette and the answer popup
+	// clicks, and updateClick honours it. The wheel is the same rule — a tick
+	// behind an open popup must not scroll the pane under it.
+	if t.popup {
+		return nil
+	}
 	delta := 1
 	if msg.Button == tea.MouseWheelUp {
 		delta = -1


### PR DESCRIPTION
## Summary

The chat workspace was the one scrollable pane in the TUI the mouse wheel did
not reach: `chatView.update` handled `tea.WindowSizeMsg` and `tea.KeyPressMsg`
and no mouse message. It is the view where that is missed most — the composer
holds the keyboard almost always, which is why the scroll keys had to be
`pgup`/`pgdown`/`ctrl+g` in the first place.

The conversation body now takes `tea.MouseWheelMsg`, through
`taskTabOutput`'s arm of `taskView.updateWheel` verbatim, because §15 view 9
makes this body that pane:

- one line per tick — `v.vp.ScrollUp(1)` / `v.vp.ScrollDown(1)`;
- `syncFollowToViewport()`, so a scroll back pauses follow and `ctrl+g` re-arms
  it, the same pair `pgup` is held to;
- `fetchVisibleTranscripts()`, so wheeling back into turns whose transcripts
  were never fetched fills them in rather than scrolling into blank space
  (task 071 decision 6).

**The wheel is not gated on the pointer's position, and the issue's own first
alternative is what shipped.** §15's Mouse section says "wheel to scroll the
focused panel"; PR S (`docs/history/v0-tasks.md`) records it as *"the focused
panel, not the hovered one — §15 verbatim. Hover tracking is drag-adjacent
machinery for a behavior §15 does not ask for"*, and
`TestShellWheelScrollsFocusedPanel` asserts it by name. No view gates the wheel
on position today — `taskView.updateWheel` dispatches on the active tab,
`shell.updateWheel` on `s.focus` — so the gate the issue asked for would have
made the chat the only position-gated surface in the TUI, the inverse of the
issue's own stated reason for rejecting this alternative. The workspace has
exactly one scrollable pane, so "the focused panel" is that pane and the rule
needs no exception. The cost is taken knowingly: a tick with the pointer in a
draft longer than the composer's three rows scrolls the conversation rather
than the draft. §15's Mouse section is therefore **unchanged** — this makes the
chat obey the rule already written there. Task 078 decision 1 records the
rejected hover gate and the rejected `detailsPane.scrollAt`-style hover
*routing* so neither is re-proposed silently.

Two things land with it, both in scope through the issue's acceptance criteria:

- **The chat's footer hint was drawn off the bottom of the screen.**
  `footerLines` appended `v.composer.View()` as a *single* slice element while
  the composer is `SetHeight(3)` and bubbles pads a viewport's `View` to its
  height. `len(foot)` reported three where five rows rendered, `render`
  returned `height+2` lines, and `frame` keeps only the first `h-2` — so the
  hint naming `enter send · … · pgup/pgdown scroll · ctrl+g live` was never
  drawn and the composer showed two of its three rows. The same element also
  fed a string containing newlines to `render`'s per-line `ansi.Truncate` pass.
  `footerLines` now returns one element per rendered line; `room` becomes
  `height-7` and `render` returns exactly `height` lines. The body loses two
  rows to a footer that was always going to occupy them.
- **`taskView.updateWheel` gains the popup gate `updateClick` already had.**
  Wheeling behind an open task popup scrolled the pane underneath it. PR S
  records "the palette and the answer popup ignore clicks"; both workspaces now
  apply that to the wheel, so "a popup owns the surface" is one rule rather
  than two.

Scope is `internal/tui` alone — no daemon package, API route, migration or wire
change. `internal/tui/bindings.go` is untouched (the wheel is not a binding),
`internal/tui/root.go` is untouched (PR S already delegates the wheel to
takeover screens, and the chat never reads `msg.Y`), and the chats board (§15
view 8) stays keyboard-only as the issue scopes it.

Verified with `go run mage.go test` (green) and the cross-platform lint sweep
from `CLAUDE.md` — `golangci-lint` built for the host and run under
`GOOS=darwin`, `GOOS=linux` and `GOOS=windows`, 0 issues each. No gate script
covers the TUI.

## Noted, not fixed here

The chat's footer hint line — on screen for the first time now that the clip is
fixed — omits `ctrl+t hand off`. It is hardcoded in `footerLines`
(`internal/tui/chatrender.go`) rather than generated from `bindings.go`, whose
`ctxChat` rows carry that hint at priority 6 (task 074). The guide's key table
lists `ctrl+t`, so the documentation is right and the screen is one binding
short. Pre-existing, invisible until this PR drew the line; out of scope for a
documentation commit.

## Related

Closes #300 · closes 078.1

`docs/tasks/078-chat-workspace-mouse-wheel.md` is new, with the index row in
the same edit. Decision 1 **declines the issue's stated requirement** that the
wheel act only over the conversation body, because it contradicts PR S's
recorded decision in `docs/history/v0-tasks.md` and the test that asserts it;
the reasoning and both rejected alternatives are written down there rather than
left in a PR thread. §15 view 9 carries a dated amendment for the wheel; §15's
Mouse section is deliberately not amended, since this change obeys the rule it
already states.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — `internal/tui/chatmouse_test.go`:
      a tick moves the offset by exactly one line each way; a wheel-up clears
      `following` and `ctrl+g` restores it `AtBottom`; wheeling to the top
      fetches turn 1, mirroring `TestChatFetchesOlderTurnsWhenScrolledTo` with
      ticks in place of pages; a tick behind the popup moves nothing in either
      workspace, and closing it hands the wheel back; `render(80, h)` returns
      exactly `h` lines and the footer hint survives `frame`. The last two fail
      against the pre-fix `footerLines`, checked by reverting it.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — the
      wheel under **Added**, the footer clip and the task popup's wheel under
      **Fixed**.
- [x] Affected page under `docs/` updated — `docs/guides/tui.md`'s chat
      workspace section and its key table, plus the §15 view 9 amendment and the
      new task document. No key binding changed, so `bindings.go`'s tables and
      the pages generated from them are untouched. A documentation audit
      followed and corrected four claims in a `docs:` commit of its own: the
      guide's "the mouse wheel scrolls whichever tab is on screen", which the
      task workspace's popup gate makes false while a popup is up; the CHANGELOG
      entry for that gate, which named four of the six tabs it covers and missed
      that on Steps and Pull Request the wheel moves a cursor, so a tick behind a
      popup changed what was selected; and two in task 078 — that the chat's
      scroll keys are `ctrl`-modified (`pgup`/`pgdown` are not) and that the
      footer fix restores a line the captures under `docs/assets/` were taken
      without (the chat workspace is in no capture: `scripts/screenshots.sh` has
      no chat tape and there is no `tui-chat*.png`, so no image goes stale and
      none was regenerated). Everything else was already true: `internal/config`,
      the cobra tree, `internal/api`'s route table, the `Reason*` constants,
      `internal/workflow`/`internal/taskrun`'s step types and `internal/agent`
      are all untouched by a change confined to `internal/tui`, so the
      configuration, CLI, API, block-reason, workflow-schema, task-lifecycle and
      agents pages derive from unchanged sources;
      `skills/vincent-workflows/SKILL.md` is unchanged because no step type,
      field, validation rule, template variable or human-interaction mechanism
      moved; the repository's three `.vincent/workflows/*.yaml` still `validate`
      and `render` clean; and no gate walkthrough changed — `m3-gate.md`'s S14
      walks the wheel over the board and task panels, which behave as before,
      and its L8 drives the answer popup from the keyboard only.
