### PR TITLE
Take terminal chats off the chats board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -694,6 +694,26 @@ list with the user-facing context a commit subject cannot carry.
   rest of the form down. Text fields now wrap onto further rows of their pane
   and the form reflows around them, which is what the boards and rendered
   Markdown have always done.
+- **Archived chats now leave the chats board.** Archiving a chat took it off
+  nothing: the row stayed, and then behaved as though the conversation were
+  still alive. Three things are fixed together. `GET /v1/chats`,
+  `vincent chat list` and the chats board had no way to exclude a terminal
+  chat — nothing between the store and the TUI could express the idea — so
+  every chat that had ever existed piled up forever. There is now an
+  `archived=false|true|all` filter, spelled and defaulted exactly as
+  `GET /v1/tasks`' is, covering **both** terminal states (`archived` and
+  `handed_off` alike, since both are equally done with); `vincent chat list
+  --archived` brings them back, and `s` on the chats board cycles the listing
+  the way `s` cycles a pull-request listing. A terminal chat's last-activity
+  cell no longer counts up second by second like a live conversation: it shows
+  *when* the chat ended. And archiving a chat that is already archived, or one
+  that was handed off, is no longer refused with "a chat with a live turn
+  cannot be archived" — a sentence about a process neither state can hold, and
+  which contradicted the state the error's own details reported. The refusal
+  now names the real reason on both sides: the API says which state blocked it,
+  and `a` on a terminal row declines with a note instead of asking you to
+  confirm removing a worktree that is already gone, or that a handoff gave to a
+  task.
 - **Palette entries for `ctrl+`-modified keys did nothing.** Running one
   replays its direct key, and the replay had a hand-written case per ctrl key
   that had fallen a registry behind — the chat's `ctrl+r` (detail level) and

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1098,7 +1098,16 @@ task-only.
 | `a` | Archive the chat — asks first, and re-offers with the force when the worktree is dirty |
 | `/` | Filter by title, agent or branch |
 | `←` / `→` | Collapse or expand a project group |
+| `s` | Cycle the listing between live, archived and handed-off, and all |
 | `r` | Reload the board |
+
+Archived and handed-off chats are **off this board by default**, the way
+archived tasks are off the task board. `s` cycles the listing — live, then the
+terminal ones, then both — and the header names the listing whenever it is not
+the default, so an empty board is never mistaken for no chats. A terminal chat's
+last-activity cell shows *when* the chat ended rather than a duration that keeps
+counting; and `a` on such a row declines with a note instead of asking to remove
+a worktree that is already gone, or that a handoff gave to a task.
 
 `n` is the one key whose meaning depends on where you are: on this board it
 starts a chat, everywhere else it opens the new-task form. The create form takes

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1376,7 +1376,8 @@ separate family from tasks: they never appear in `GET /v1/tasks` or on the
 board, and tasks never appear here.
 
 ```
-GET    /v1/chats?project_id=&state=   newest first; state may repeat
+GET    /v1/chats?project_id=&state=&archived=
+                                      newest first; state may repeat
 POST   /v1/chats                      create, with a worktree and a branch
 GET    /v1/chats/{id}                 { chat, turns[] } — the whole conversation
 POST   /v1/chats/{id}/send            start a turn
@@ -1394,6 +1395,16 @@ excluded, the stream and the transcript included. `handoff` is on that list for
 a reason worth stating: it creates a task, and `task_create`'s bounds
 (`mcp.max_depth`, `mcp.max_tasks`) are walked over `created_by_task_id`, which
 a chat is not in.
+
+`archived=false|true|all` is `GET /v1/tasks`' parameter, spelled and defaulted
+the same way: terminal chats are hidden unless you ask for them. It covers
+**both** terminal states — `archived` and `handed_off` alike — which its name
+does not say; an explicit `state=` wins over it, and anything but
+`false|true|all` is a `400 validation_failed`.
+
+`POST /v1/chats/{id}/archive` is legal from `idle` alone, so its `409` names
+the state that blocked it: an already-archived chat is told so, and a
+handed-off one that the task owns its worktree now.
 
 `POST /v1/chats/{id}/handoff` takes `POST /v1/tasks`' body and is validated by
 the same code, so it accepts exactly the task the create route accepts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1096,10 +1096,14 @@ interrupted.
 ### `vincent chat list`
 
 ```sh
-vincent chat list [--project ID] [--json]
+vincent chat list [--project ID] [--archived] [--json]
 ```
 
 One line per chat: id, state, agent, title. `--json` emits the chat objects.
+
+Archived and handed-off chats are hidden unless you pass `--archived`, the way
+`vincent task list --archived` works. Both terminal states come back under the
+one flag: a handed-off chat is as done with as an archived one.
 
 ### `vincent chat show`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -519,7 +519,7 @@ chats too — the same objection that kept a `kind` column off `tasks`.
 | `running` | a live turn: an agent process is up, owned by the chat's runner goroutine |
 | `awaiting_input` | a turn holding its process while the agent waits on a §7.4 request. It **holds** its cap slot, for §6's reason: the process is alive on its stdin. *Amended 2026-08-31 (task 067, issue #269): that hold is now **bounded** by `defaults.input_timeout` — the wait expires, the turn fails `input_timeout`, the process tree is killed and the chat returns to `idle`, releasing the slot* |
 | `archived` | terminal. The worktree is gone; nothing further can run in it. *Amended 2026-09-01 (task 074, issue #288): this was "the only terminal state"; there are now two* |
-| `handed_off` | *Added 2026-09-01 (task 074, issue #288):* terminal. The worktree and branch belong to the task named by `handoff_task_id`, which is the **sole owner** of their cleanup and lifecycle from then on (§10). `worktree_path` is cleared in the handoff transaction — that is what transferring the §10 claim means concretely — while `branch`, `base_branch` and `base_sha` stay on the row as history. Reusing `archived` was rejected on mechanism, not taste: archiving *removes* the worktree and may delete the branch, which is exactly the state a handoff transfers, so "archiving a handed-off chat must never remove task-owned workspace state" is true by construction — `archive` is simply not legal from here |
+| `handed_off` | *Added 2026-09-01 (task 074, issue #288):* terminal. The worktree and branch belong to the task named by `handoff_task_id`, which is the **sole owner** of their cleanup and lifecycle from then on (§10). `worktree_path` is cleared in the handoff transaction — that is what transferring the §10 claim means concretely — while `branch`, `base_branch` and `base_sha` stay on the row as history. Reusing `archived` was rejected on mechanism, not taste: archiving *removes* the worktree and may delete the branch, which is exactly the state a handoff transfers, so "archiving a handed-off chat must never remove task-owned workspace state" is true by construction — `archive` is simply not legal from here. *Amended 2026-09-01 (issue #298): that refusal now **says so**. `POST /v1/chats/{id}/archive` on a `handed_off` chat answers `409` naming the handoff — the task owns the worktree now — and on an `archived` one that it is already archived, rather than the single sentence "a chat with a live turn cannot be archived" that both terminal states used to get and neither could be true of (§11, §13.2)* |
 
 Human actions: `send` (idle → running), `answer` (awaiting_input → running),
 `cancel` (running/awaiting_input → idle), `archive` (idle → archived) and
@@ -4821,7 +4821,16 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         resolved view and becomes a 400 at task creation
 GET    /v1/chats                        *Added 2026-08-30 (task 063).* Chats, newest first.
        ?project_id=&state=              `state` may repeat. Chats appear here and nowhere else:
-                                        never in GET /v1/tasks and never on the board
+       &archived=                       never in GET /v1/tasks and never on the board.
+                                        *Amended 2026-09-01 (issue #298):*
+                                        `archived=false|true|all`, default `false` — spelled and
+                                        defaulted exactly as GET /v1/tasks' parameter is, so one
+                                        vocabulary covers both entities (`terminal=` was the
+                                        rejected alternative). It hides **both** terminal states,
+                                        `archived` and `handed_off` alike (§5.5, task 074
+                                        decision 5), which its name does not say and this
+                                        sentence does. An explicit `state=` wins over it, as it
+                                        does for tasks. Anything else is `400 validation_failed`
 POST   /v1/chats                        { project_id, title, agent?, model?, effort?,
                                           base_branch? } → 201 with the chat, its
                                         `vincent/{id}-{slug}` branch and its worktree (§10).
@@ -4854,7 +4863,13 @@ POST   /v1/chats/{id}/answer            the §7.4 answer flow verbatim: same nor
 POST   /v1/chats/{id}/cancel            stops the live turn and kills its process tree
 POST   /v1/chats/{id}/archive           removes the worktree and deletes the branch when it
                                         received nothing (§10, task 008 semantics), `?force=`
-                                        for the dirty-worktree refusal. Terminal
+                                        for the dirty-worktree refusal. Terminal.
+                                        *Amended 2026-09-01 (issue #298):* archiving is legal from
+                                        `idle` alone, so the `409` **names the state that actually
+                                        blocked it** rather than asserting a live turn: an
+                                        `archived` chat is told it is already archived and a
+                                        `handed_off` one that the task owns its worktree now
+                                        (§5.5). The message and `details.state` had disagreed
 POST   /v1/chats/{id}/handoff           *Added 2026-09-01 (task 074, issue #288).* Takes
                                         `POST /v1/tasks`' body, **validated by the same code** so
                                         the two routes accept exactly the same task; `project_id`,
@@ -6381,6 +6396,29 @@ stream for the live tail.
    re-renders the board with no keypress, and a `task.*` event does not — the
    separation runs both ways.
 
+   *Amended 2026-09-01 (issue #298).* **Terminal chats are off this board by
+   default**, and there is a key back to them. The board lists
+   `GET /v1/chats?archived=false` (§13.2) rather than everything, so an
+   `archived` or `handed_off` chat leaves it the way an archived task leaves
+   view 1; `s` cycles the listing — live, then archived and handed-off, then
+   both — the way view 7's `s` cycles a pull-request listing (task 064
+   decision 9), and the header names the listing whenever it is not the
+   default, so an empty board is never mistaken for "no chats". Hiding them
+   with no route back was rejected: an archived chat's transcript is still
+   worth reading. The terminal band survives, because it still orders the rows
+   the toggle brings back.
+
+   Two consequences of a chat being done with, on the same board. The
+   **last-activity cell stops**: for a terminal chat it renders *when* the chat
+   ended — an absolute stamp from `updated_at`, which is the moment of the last
+   write a chat row can take — instead of a duration that ticks up second by
+   second and reads exactly like a live conversation. No column is added to
+   `chats` for it and task 074 decision 6 is not reopened. And **`a` declines
+   on a terminal row** with a note naming the state, instead of opening the
+   "archive %q and remove its worktree? (y/n)" prompt: there is no worktree
+   left to remove, or — after a handoff — the task owns it, and the daemon's
+   own refusal (§13.2) says the same thing from the other side.
+
 9. **Chat workspace.** *Added 2026-08-31 (task 067, closing 063.2 and 063.3).*
    One conversation: the finished turns above, the running turn's live tail
    below them, and a composer at the bottom. `enter` sends, `ctrl+x` stops the
@@ -7214,7 +7252,10 @@ nothing here to decide. The issue row is hidden — the chat is the source
 already. Submitting posts to the chat's own route, not to `POST /v1/tasks`
 (§13.4), and lands on the created task. A handed-off chat's header carries a
 **permanent** link to that task; the state renders as "handed off" and the chat
-sorts into the board's terminal band beside archived ones. It is a ctrl
+sorts into the board's terminal band beside archived ones — *amended 2026-09-01
+(issue #298): and, like an archived one, is off the board's default listing
+altogether, reachable by cycling it with `s`. The band is what orders the two
+terminal states once the toggle brings them back.* It is a ctrl
 combination for the reason `ctrl+r` is: the composer owns every printable key.
 
 *Amended 2026-08-31 (issue #279).* The new-chat form's project and agent

--- a/docs/tasks/079-terminal-chats-leave-the-board.md
+++ b/docs/tasks/079-terminal-chats-leave-the-board.md
@@ -1,0 +1,89 @@
+# 079 — Terminal chats leave the chats board
+
+**Status:** ✅ done (1/1)
+**Issue:** #298
+**Amends:** §13.2's `GET /v1/chats` and `POST /v1/chats/{id}/archive` rows,
+§5.5's `handed_off` row, §15's chats board and its task 074 amendment
+**Follow-up to:** [067](067-chats-in-the-tui.md), which built the board, and
+[074](074-chat-handoff.md), which gave it a second terminal state
+
+Archiving a chat took it off nothing. The row stayed on the board, its last
+column kept counting up like a live conversation, and pressing `a` on it again
+was refused with `a chat with a live turn cannot be archived` — a sentence
+about a process neither terminal state can hold.
+
+Three defects with one symptom, two of them the code doing exactly what the
+spec said, which is why this is a spec amendment and code rather than code
+alone.
+
+## Decisions
+
+### 1. The wire parameter is `?archived=false|true|all`
+
+Verbatim parity with §13.2's task filter — same spelling, same three values,
+same default of exclusion — and it hides **both** terminal states, `archived`
+and `handed_off` alike, even though its name says only the first. §13.2's row
+therefore says so explicitly, because the name alone does not.
+
+`?terminal=` was considered and rejected. It is the more literal name for what
+the parameter does, but one vocabulary across both entities is worth more than
+a second, more accurate one: a client that knows how to hide archived tasks
+now knows how to hide terminal chats without being told.
+
+### 2. A terminal chat's cell renders an absolute stamp, not a duration
+
+The last column means "how long ago this row was last written", which is the
+right reading for an idle chat and a misleading one for a chat that can never
+be written again. For `archived` and `handed_off` it renders *when* the chat
+ended instead. Nothing ticks, and the cell keeps its information.
+
+**No schema change, and task 074 decision 6 is not reopened.** The issue
+suggested the row might need an `archived_at` or `finished_at` column. It does
+not: a terminal transition is the last write a chat row takes, so `updated_at`
+already *is* the moment the chat ended, which is what task 074 decision 6 rests
+on. The stamp is date and time, never a relative word like "today" — a cell
+that depended on `now` at all would still be a clock, only a slower one.
+
+### 3. The default exclusion lives in the store
+
+`ChatFilter` gains an archived filter — `store.ArchivedFilter`, the task
+filter's own type — whose zero value excludes both terminal states, exactly as
+`TaskFilter.Archived` does. `ChatFilter`'s doc comment recorded the opposite
+decision ("the zero value lists every chat, archived ones included — the caller
+decides") and is rewritten to say why it changed rather than quietly deleted.
+The reasoning it carried was that a listing which hid archived rows would make
+`vincent chat list --all` a lie; the lie it produced instead was the board,
+where the caller that was supposed to decide had no way to.
+
+### 4. The refusal names the state, on both sides
+
+Archiving is legal from `idle` alone (§5.5), so every other state reaches the
+refusal, and one hardcoded sentence could not be true of all of them. The API
+now names the state that actually blocked it, so the message and
+`details.state` agree; the three sibling handlers already did this, which is
+what makes it a plain bug rather than a design question.
+
+The TUI declines `a` on a terminal row with the same distinction rather than
+opening the `archive %q and remove its worktree? (y/n)` prompt. Both halves,
+not just the server's: the prompt asks a human to confirm removing a worktree
+that is already gone — or, after a handoff, one the task owns now — and a
+question that cannot be answered usefully should not be asked.
+
+Two existing tests, `TestChatActionsIn409WhenTheFSMSaysNo` and
+`TestHandoffIsTerminal`, exercise this exact path and assert only the status
+code. That is how a wrong sentence survived both, and the regression test reads
+the sentence.
+
+### 5. The terminal band stays
+
+`sortChats` still sorts `archived` and `handed_off` into the board's last band
+(task 067, task 074). Hiding them by default does not make the band dead code:
+it is what orders the rows the `s` toggle brings back.
+
+### 6. `s` is the toggle, and hiding with no way back was rejected
+
+`s` cycles the listing — live, then archived and handed-off, then both — which
+is view 7's key for the same idea (task 064 decision 9). An archived chat's
+transcript is still worth reading, so a filter with no route back would trade
+one lost affordance for another. The header names the listing whenever it is
+not the default, so an empty board is never mistaken for "no chats".

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -92,6 +92,7 @@ the living engineering specification records implementation contracts.
 | [076](076-reader-actions-on-assistant-markdown.md) | Rendered/raw toggle and copy actions for assistant Markdown | ✅ done (1/1) |
 | [077](077-stable-assistant-markdown-while-streaming.md) | Consecutive assistant records as one Markdown document, with identities, a paused anchor and a render memo | ✅ done (1/1) |
 | [078](078-chat-workspace-mouse-wheel.md) | The mouse wheel scrolls the chat conversation, with the footer clip and the task popup's wheel gate fixed alongside | ✅ done (1/1) |
+| [079](079-terminal-chats-leave-the-board.md) | Terminal chats leave the chats board: an `archived` filter, a stopped clock and a truthful archive refusal | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -210,6 +210,23 @@ func (s *Server) handleChatList(w http.ResponseWriter, r *http.Request) {
 		}
 		f.States = append(f.States, chatstate.State(st))
 	}
+	// `archived` is GET /v1/tasks' parameter, spelled the same and defaulting
+	// the same way (§13.2, amended 2026-09-01): terminal chats are excluded
+	// unless asked for. It hides `handed_off` as well as `archived` — both are
+	// terminal (§5.5, task 074 decision 5) — which the name alone does not
+	// say. An explicit `state=` wins over it.
+	switch v := r.URL.Query().Get("archived"); v {
+	case "", "false":
+		f.Archived = store.ArchivedExclude
+	case "true":
+		f.Archived = store.ArchivedOnly
+	case "all":
+		f.Archived = store.ArchivedAll
+	default:
+		writeError(w, http.StatusBadRequest, CodeValidationFailed,
+			"archived must be one of: false, true, all")
+		return
+	}
 	chats, err := s.deps.Store.ListChats(r.Context(), f)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
@@ -330,6 +347,23 @@ func (s *Server) handleChatCancel(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// archiveRefusal says which state actually blocked an archive. Archiving is
+// legal from `idle` alone (§5.5), so every other state reaches this — and the
+// one sentence that used to serve all of them, "a chat with a live turn cannot
+// be archived", was true of `running` and `awaiting_input` and false of both
+// terminal states, which hold no process at all (§11, issue #298). The
+// message now agrees with the `state` the details already carried.
+func archiveRefusal(st chatstate.State) string {
+	switch st {
+	case chatstate.Archived:
+		return "this chat is already archived"
+	case chatstate.HandedOff:
+		return "this chat was handed off to a task, which owns its worktree now"
+	default:
+		return "a chat with a live turn cannot be archived"
+	}
+}
+
 // handleChatArchive archives a chat: the worktree goes and the branch may go
 // with it, exactly as task 008 archives a task (§10). A dirty worktree is
 // refused unless `force` is set — the same refusal, and the same way out.
@@ -339,7 +373,7 @@ func (s *Server) handleChatArchive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !chatstate.Allowed(chat.State, chatstate.Archive) {
-		writeConflict(w, "a chat with a live turn cannot be archived", map[string]string{"state": string(chat.State), "action": "archive"})
+		writeConflict(w, archiveRefusal(chat.State), map[string]string{"state": string(chat.State), "action": "archive"})
 		return
 	}
 	force := r.URL.Query().Get("force") == "true"

--- a/internal/api/chats_test.go
+++ b/internal/api/chats_test.go
@@ -368,3 +368,138 @@ func waitUntil(t *testing.T, cond func() bool) {
 	}
 	t.Fatal("condition never became true")
 }
+
+// TestChatArchiveRefusalNamesTheRealState is issue #298's third defect.
+// `handleChatArchive` consults `chatstate.Allowed(state, Archive)` — legal
+// from `idle` alone — and then writes one hardcoded sentence, "a chat with a
+// live turn cannot be archived", for every state that is not `idle`. Both
+// terminal states are among them (§5.5, task 074 decision 5), and for both the
+// sentence asserts something false: an `archived` or `handed_off` chat holds
+// no process at all (§11), so there is no live turn to name. The `state` in
+// the error details carries the truth the message contradicts.
+//
+// Statuses are already pinned by TestChatActionsIn409WhenTheFSMSaysNo and
+// TestHandoffIsTerminal, which is how a wrong message survived both: this
+// reads the sentence a human is shown.
+func TestChatArchiveRefusalNamesTheRealState(t *testing.T) {
+	h := newChatHarness(t)
+
+	archived, _ := handoffFixture(t, h)
+	if resp, body := h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/archive", archived), nil); resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive = %d %s", resp.StatusCode, body)
+	}
+
+	handed, _ := handoffFixture(t, h)
+	if code, body := h.handoff(t, handed, map[string]any{"title": "finish it"}); code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+
+	for _, tc := range []struct {
+		id    int64
+		state string
+		// names is vocabulary the refusal must use to be about this state
+		// rather than about a running turn; the exact sentence is the fix's
+		// to choose.
+		names string
+	}{
+		{archived, "archived", "archiv"},
+		{handed, "handed_off", "hand"},
+	} {
+		resp, raw := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/chats/%d/archive", tc.id), nil)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("archive on a %s chat = %d %s, want 409", tc.state, resp.StatusCode, raw)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("decode %s refusal: %v", tc.state, err)
+		}
+		errObj, _ := out["error"].(map[string]any)
+		msg, _ := errObj["message"].(string)
+		details, _ := errObj["details"].(map[string]any)
+		if got := details["state"]; got != tc.state {
+			t.Fatalf("details.state = %v, want %q", got, tc.state)
+		}
+		low := strings.ToLower(msg)
+		if strings.Contains(low, "live turn") {
+			t.Errorf("archive on a %s chat says %q — it claims a live turn it never checked for, and none can be running in a terminal state", tc.state, msg)
+		}
+		if !strings.Contains(low, tc.names) {
+			t.Errorf("archive on a %s chat says %q — the message never names the state that actually blocked it, which details.state = %q reports", tc.state, msg, tc.state)
+		}
+	}
+}
+
+// TestChatListArchivedParam is issue #298's first defect. `store.ChatFilter`
+// carries only ProjectID and States and `handleChatList` reads only
+// `project_id` and repeated `state`, so nothing anywhere can ask for a chat
+// listing without its terminal rows — which is why they accumulate on the
+// chats board forever (§15). Tasks have had `?archived=false|true|all`,
+// defaulting to exclusion, since §13.2; chats get the same parameter and the
+// same default, and it covers **both** terminal states, `archived` and
+// `handed_off` alike (§5.5, task 074 decision 5). An explicit `state=` still
+// wins, exactly as it does for tasks.
+func TestChatListArchivedParam(t *testing.T) {
+	h := newChatHarness(t)
+
+	live, _ := handoffFixture(t, h)
+	gone, _ := handoffFixture(t, h)
+	if resp, body := h.doJSON(t, http.MethodPost,
+		fmt.Sprintf("/v1/chats/%d/archive", gone), nil); resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive = %d %s", resp.StatusCode, body)
+	}
+	handed, _ := handoffFixture(t, h)
+	if code, body := h.handoff(t, handed, map[string]any{"title": "finish it"}); code != http.StatusCreated {
+		t.Fatalf("handoff = %d (%v)", code, body)
+	}
+
+	ids := func(query string) []int64 {
+		t.Helper()
+		resp, raw := h.doJSON(t, http.MethodGet, "/v1/chats"+query, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /v1/chats%s = %d %s", query, resp.StatusCode, raw)
+		}
+		var out struct {
+			Chats []struct {
+				ID int64 `json:"id"`
+			} `json:"chats"`
+		}
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("decode listing: %v", err)
+		}
+		got := make([]int64, 0, len(out.Chats))
+		for _, c := range out.Chats {
+			got = append(got, c.ID)
+		}
+		return got
+	}
+	has := func(got []int64, want int64) bool {
+		for _, id := range got {
+			if id == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, q := range []string{"", "?archived=false"} {
+		got := ids(q)
+		if len(got) != 1 || got[0] != live {
+			t.Errorf("GET /v1/chats%q = %v, want only the idle chat %d — archived %d and handed-off %d must be excluded by default",
+				q, got, live, gone, handed)
+		}
+	}
+	if got := ids("?archived=true"); len(got) != 2 || !has(got, gone) || !has(got, handed) {
+		t.Errorf("archived=true = %v, want both terminal chats %d and %d", got, gone, handed)
+	}
+	if got := ids("?archived=all"); len(got) != 3 {
+		t.Errorf("archived=all = %v, want all three", got)
+	}
+	if got := ids("?state=archived"); len(got) != 1 || got[0] != gone {
+		t.Errorf("state=archived = %v, want %d — an explicit state must win", got, gone)
+	}
+	resp, raw := h.doJSON(t, http.MethodGet, "/v1/chats?archived=yes", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("archived=yes = %d %s, want 400", resp.StatusCode, raw)
+	}
+}

--- a/internal/apiclient/chats.go
+++ b/internal/apiclient/chats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -76,10 +77,23 @@ func (c *Client) CreateChat(ctx context.Context, req CreateChatRequest) (*Chat, 
 
 // ListChats fetches chats, optionally narrowed to one project. Tasks never
 // appear here, and chats never appear in ListTasks.
-func (c *Client) ListChats(ctx context.Context, projectID int64) ([]Chat, error) {
-	path := "/v1/chats"
+//
+// archived selects how terminal chats are treated, and reuses ListTasks'
+// ArchivedScope because the wire parameter is the same one (§13.2, amended
+// 2026-09-01). The zero value — ArchivedExclude — leaves the parameter off and
+// takes the server's default, which is to hide both `archived` and
+// `handed_off`.
+func (c *Client) ListChats(ctx context.Context, projectID int64, archived ArchivedScope) ([]Chat, error) {
+	q := url.Values{}
 	if projectID > 0 {
-		path += fmt.Sprintf("?project_id=%d", projectID)
+		q.Set("project_id", strconv.FormatInt(projectID, 10))
+	}
+	if archived != ArchivedExclude {
+		q.Set("archived", string(archived))
+	}
+	path := "/v1/chats"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
 	}
 	var out struct {
 		Chats []Chat `json:"chats"`

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -155,13 +155,21 @@ func runChatTurn(ctx context.Context, cmd *cobra.Command, c *apiclient.Client, i
 
 func newChatListCmd() *cobra.Command {
 	var projectID int64
+	var archived bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List chats",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
-				chats, err := c.ListChats(ctx, projectID)
+				// Terminal chats are hidden by default, the way archived
+				// tasks are (§13.2): `archived` and `handed_off` alike, since
+				// both are done with (§5.5, task 074 decision 5).
+				scope := apiclient.ArchivedExclude
+				if archived {
+					scope = apiclient.ArchivedAll
+				}
+				chats, err := c.ListChats(ctx, projectID, scope)
 				if err != nil {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}
@@ -188,6 +196,8 @@ func newChatListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Int64Var(&projectID, "project", 0, "only this project's chats")
+	cmd.Flags().BoolVar(&archived, "archived", false,
+		"Include archived and handed-off chats")
 	jsonFlag(cmd)
 	return cmd
 }

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -131,12 +131,25 @@ func (s *Store) GetChat(ctx context.Context, id int64) (*Chat, error) {
 	return c, nil
 }
 
-// ChatFilter narrows ListChats. The zero value lists every chat, archived
-// ones included — the caller decides, since a chat list that silently hid
-// archived rows would make `vincent chat list --all` a lie.
+// ChatFilter narrows ListChats. Zero values mean "no filter", except
+// Archived, whose zero value excludes both terminal states.
+//
+// That default reverses task 074's: the original comment here reasoned that a
+// listing which hid archived rows would make `vincent chat list --all` a lie,
+// but the lie it produced instead was the chats board, where every chat that
+// ever existed piles up forever and a `handed_off` row sits beside a live
+// conversation (issue #298). The caller still decides — it just says so with
+// ArchivedOnly or ArchivedAll rather than by being the only party that could
+// filter, which no caller ever was.
 type ChatFilter struct {
 	ProjectID *int64
 	States    []chatstate.State
+	// Archived selects how terminal chats are treated, the way TaskFilter's
+	// field of the same name and type does (§13.2). It covers *both*
+	// terminal states — `archived` and `handed_off` alike (§5.5, task 074
+	// decision 5) — because both are equally done with, whatever the
+	// parameter's name says. An explicit States always wins.
+	Archived ArchivedFilter
 }
 
 // ListChats returns chats newest first, which is the order a conversation
@@ -153,6 +166,20 @@ func (s *Store) ListChats(ctx context.Context, f ChatFilter) ([]Chat, error) {
 		q += ` AND state IN ` + placeholders(len(f.States))
 		for _, st := range f.States {
 			args = append(args, string(st))
+		}
+	} else {
+		// An explicit States always wins, for the reason an explicit State
+		// wins over TaskFilter.Archived: asking for state=archived and
+		// getting nothing back because the default excludes archives would
+		// be absurd.
+		switch f.Archived {
+		case ArchivedExclude:
+			q += ` AND state NOT IN (?, ?)`
+			args = append(args, string(chatstate.Archived), string(chatstate.HandedOff))
+		case ArchivedOnly:
+			q += ` AND state IN (?, ?)`
+			args = append(args, string(chatstate.Archived), string(chatstate.HandedOff))
+		case ArchivedAll:
 		}
 	}
 	q += ` ORDER BY id DESC`

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -248,7 +248,11 @@ var bindings = []binding{
 	{key: "/", label: "filter by title, agent or branch", scope: scopePanel, context: ctxChats, hint: "/ filter", priority: 4},
 	{key: "left", label: "collapse the project group", scope: scopePanel, context: ctxChats, hint: "← fold", priority: 5},
 	{key: "right", label: "expand the project group", scope: scopePanel, context: ctxChats, hint: "→ unfold", priority: 6},
-	{key: "r", label: "reload the board", scope: scopePanel, context: ctxChats, hint: "r reload", priority: 7},
+	// `s` is the pull-request board's key for the same idea (task 064
+	// decision 9): terminal chats are hidden by default (issue #298), and
+	// this is the way back to them.
+	{key: "s", label: "cycle the listing between live, archived and handed-off, and all", scope: scopePanel, context: ctxChats, hint: "s listing", priority: 7},
+	{key: "r", label: "reload the board", scope: scopePanel, context: ctxChats, hint: "r reload", priority: 8},
 
 	// Chat workspace.
 	{key: "enter", label: "send the message", scope: scopePanel, context: ctxChat, hint: "enter send", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -442,6 +442,16 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("right did not expand the project group")
 			}
 		},
+		"s": func(t *testing.T) {
+			v := chatsFixture()
+			v.client = nil
+			if _, cmd := v.updateKey(registryKey(t, "s")); cmd != nil {
+				drain(cmd)
+			}
+			if v.scope != apiclient.ArchivedOnly {
+				t.Fatalf("s left the listing at %q, want the archived one", v.scope)
+			}
+		},
 		"r": func(t *testing.T) {
 			v := chatsFixture()
 			v.client = nil

--- a/internal/tui/chats.go
+++ b/internal/tui/chats.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/chatstate"
 )
 
 // The chats board (§15, task 067, closing task 063.2).
@@ -85,6 +86,10 @@ type chatsView struct {
 
 	folds   foldSet
 	confirm *archivePrompt
+
+	// scope is which listing the board asks for (issue #298). Its zero value
+	// is the server's default — terminal chats hidden — and `s` cycles it.
+	scope apiclient.ArchivedScope
 
 	// create is the new-chat form, a layer over this board rather than a
 	// seventh view: it is opened from here, it returns here, and it has no
@@ -214,11 +219,12 @@ func (v *chatsView) loadCmd() tea.Cmd {
 	if client == nil {
 		return nil
 	}
+	scope := v.scope
 	v.loading = true
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
 		defer cancel()
-		chats, err := client.ListChats(ctx, 0)
+		chats, err := client.ListChats(ctx, 0, scope)
 		if err != nil {
 			return chatsLoadedMsg{err: err}
 		}
@@ -431,15 +437,73 @@ func (v *chatsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return v, v.create.init()
 	case "a":
 		if c, ok := v.current(); ok {
+			// A terminal chat has nothing left to archive and no worktree to
+			// remove, so the prompt would ask a human to confirm removing
+			// something that is already gone — or, for a handed-off chat, one
+			// the task owns now (§5.5). The daemon refuses it too (409); this
+			// is what stops the question being asked at all (issue #298).
+			if chatstate.Terminal(chatstate.State(c.State)) {
+				v.note, v.noteBad = chatArchiveDecline(c.State), true
+				return v, nil
+			}
 			v.confirm = &archivePrompt{
 				id: c.ID, title: c.Title,
 				text: fmt.Sprintf("archive %q and remove its worktree? (y/n)", c.Title),
 			}
 		}
+	case "s":
+		v.cycleScope()
+		return v, v.loadCmd()
 	case "r":
 		return v, v.loadCmd()
 	}
 	return v, nil
+}
+
+// chatScopes is the cycle `s` walks (issue #298): the default listing, then
+// the terminal chats it hides, then both. It is the pull-request board's `s`
+// for a different entity (task 064 decision 9), and it is the way back that
+// makes hiding terminal chats safe at all — an archived chat's transcript is
+// still worth reading.
+var chatScopes = []apiclient.ArchivedScope{
+	apiclient.ArchivedExclude, apiclient.ArchivedOnly, apiclient.ArchivedAll,
+}
+
+// chatScopeLabel names a listing as the header and the note read it. The wire
+// parameter is spelled `archived` for parity with tasks, but it covers
+// `handed_off` too (§5.5, task 074 decision 5), so the human-readable form
+// says both rather than repeating the parameter's name.
+func chatScopeLabel(s apiclient.ArchivedScope) string {
+	switch s {
+	case apiclient.ArchivedOnly:
+		return "archived and handed-off chats"
+	case apiclient.ArchivedAll:
+		return "every chat, terminal ones included"
+	default:
+		return "live chats"
+	}
+}
+
+func (v *chatsView) cycleScope() {
+	for i, sc := range chatScopes {
+		if sc == v.scope {
+			v.scope = chatScopes[(i+1)%len(chatScopes)]
+			v.note, v.noteBad = "listing "+chatScopeLabel(v.scope)+"…", false
+			return
+		}
+	}
+	v.scope = chatScopes[0]
+}
+
+// chatArchiveDecline is the board's half of the refusal the daemon would send
+// back. It names the state, for the reason the API's does: a chat that is
+// already archived and one that was handed off are refused for two different
+// reasons, and neither of them is a live turn.
+func chatArchiveDecline(state string) string {
+	if state == string(chatstate.HandedOff) {
+		return "this chat was handed off to a task, which owns its worktree now"
+	}
+	return "this chat is already archived"
 }
 
 func (v *chatsView) updateConfirm(msg tea.KeyPressMsg) tea.Cmd {

--- a/internal/tui/chats_test.go
+++ b/internal/tui/chats_test.go
@@ -113,3 +113,31 @@ func TestChatsArchiveOffersForceOnDirtyWorktree(t *testing.T) {
 		t.Fatalf("a dirty worktree did not re-offer the archive with the force: %+v", v.confirm)
 	}
 }
+
+// TestChatActivityStopsForTerminalChats is issue #298's second defect.
+// chatActivity is `now - UpdatedAt` with no upper bound, so an archived or
+// handed-off chat's last column ticks up second by second and reads exactly
+// like a live one — the task board's equivalent clamps at FinishedAt
+// (apiclient.Task.Elapsed). No stored timestamp is missing: a terminal
+// transition is the last write a chat row takes, so `updated_at` already *is*
+// the moment it ended (internal/store/chats.go:557, task 074 decision 6).
+// Only the rendering has to stop, which it does by showing terminal rows when
+// they ended rather than how long ago that was.
+func TestChatActivityStopsForTerminalChats(t *testing.T) {
+	ended := time.Date(2026, 9, 1, 14, 2, 0, 0, time.UTC)
+	for _, state := range []string{"archived", "handed_off"} {
+		c := apiclient.Chat{ID: 1, State: state, UpdatedAt: ended}
+		soon := chatActivity(c, ended.Add(time.Minute))
+		later := chatActivity(c, ended.Add(9*time.Hour))
+		if soon != later {
+			t.Errorf("chatActivity(%s) = %q one minute on and %q nine hours on — a terminal chat's clock keeps running",
+				state, soon, later)
+		}
+	}
+	// An idle chat is still "how long ago", which is what the column means
+	// for a conversation that can be resumed.
+	idle := apiclient.Chat{ID: 2, State: "idle", UpdatedAt: ended}
+	if a, b := chatActivity(idle, ended.Add(time.Minute)), chatActivity(idle, ended.Add(9*time.Hour)); a == b {
+		t.Errorf("chatActivity(idle) = %q at both one minute and nine hours — the live reading must not be frozen too", a)
+	}
+}

--- a/internal/tui/chatsrender.go
+++ b/internal/tui/chatsrender.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
 )
 
 // The chats board's rendering, split from the view for the reason every other
@@ -51,6 +53,12 @@ func (v *chatsView) headerLine(width int) string {
 		left += styleDim.Render("  ·  loading…")
 	default:
 		left += styleDim.Render("  ·  " + plural(len(v.chats), "chat", "chats"))
+		// Which listing is on, named only when it is not the default: a
+		// board hiding terminal chats must say so once `s` has been pressed,
+		// or an empty board reads as no chats at all (issue #298).
+		if v.scope != apiclient.ArchivedExclude {
+			left += styleDim.Render(" · " + chatScopeLabel(v.scope))
+		}
 		if n := countChatsAwaiting(v.chats); n > 0 {
 			left += styleDim.Render(" · ") +
 				styleWarn.Render(fmt.Sprintf("%d waiting on you", n))
@@ -100,7 +108,9 @@ func (v *chatsView) rowLine(r chatRow, selected bool, width int) string {
 	// Columns: id, state, agent, turns, last activity, then the title with
 	// whatever width is left. The title is last because it is the only cell
 	// that can usefully be truncated.
-	fixed := fmt.Sprintf("%-5s %-15s %-8s %5s %8s  ",
+	// The activity cell is wide enough for the absolute stamp a terminal chat
+	// shows instead of a duration (issue #298).
+	fixed := fmt.Sprintf("%-5s %-15s %-8s %5s %11s  ",
 		"#"+strconv.FormatInt(c.ID, 10),
 		applyStateStyle(c.State, chatStateLabel(c.State)),
 		c.Agent,

--- a/internal/tui/chatsrows.go
+++ b/internal/tui/chatsrows.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/chatstate"
 )
 
 // Row shaping for the chats board (§15, task 067). It is boardrows.go's job
@@ -167,9 +168,24 @@ func pruneChatFolds(f foldSet, chats []apiclient.Chat, names map[int64]string) f
 
 // chatActivity is the "last activity" column: how long ago the chat's row was
 // last written, which for a chat is the last turn boundary or state change.
+//
+// For a terminal chat it is when instead of how long ago (issue #298). A
+// duration that keeps growing reads as a running conversation, which is
+// exactly what an `archived` or `handed_off` chat is not; the task board's
+// equivalent stops for the same reason, by clamping at FinishedAt
+// (apiclient.Task.Elapsed). No stored timestamp is missing here: a terminal
+// transition is the last write a chat row takes, so UpdatedAt already *is* the
+// moment it ended (internal/store/chats.go, task 074 decision 6) — only the
+// rendering had to stop.
 func chatActivity(c apiclient.Chat, now time.Time) string {
 	if c.UpdatedAt.IsZero() {
 		return "—"
+	}
+	if chatstate.Terminal(chatstate.State(c.State)) {
+		// Date and time, never "today"/"yesterday": the cell must not depend
+		// on now at all, or it would tick over a day boundary — a slower
+		// clock, but still a clock.
+		return c.UpdatedAt.Local().Format("01-02 15:04")
 	}
 	d := now.Sub(c.UpdatedAt)
 	if d < 0 {

--- a/scripts/m14-gate.sh
+++ b/scripts/m14-gate.sh
@@ -15,6 +15,9 @@
 #      never queued — and leaves no turn row behind
 #   7. cancel stops a live turn; archive removes the worktree
 #   8. chats never appear in GET /v1/tasks
+#   9. handoff: a task adopts the chat's worktree and branch (task 074)
+#  10. the listing excludes both terminal states by default and ?archived=
+#      brings them back, an explicit ?state= still winning (task 079)
 #
 # The `agent_cannot_resume` refusal is deliberately *not* here. Since task 070
 # no shipped adapter is refused, so a real daemon has no subject to reach it
@@ -418,5 +421,37 @@ done
 # And the ownership claim gc sees: the inherited directory is not an orphan.
 ORPHANS="$(api GET /info | jq -r '.orphans // 0')"
 [[ "$ORPHANS" == "0" ]] || fail "the handoff left $ORPHANS orphan(s) behind"
+
+echo "== 10. the listing hides terminal chats, and ?archived= brings them back (issue #298)"
+# Two terminal chats exist by now and neither may be in the default listing:
+# $CAP_ID was archived in leg 7 and $HAND_ID was handed off in leg 9. Each
+# capture is a single line of jq output, so no `tr -d '\r'` is needed here.
+listed() { # listed QUERY ID -> true|false
+  api GET "/chats$1" | jq -r --argjson id "$2" 'any(.chats[]; .id == $id)'
+}
+for ID in "$CAP_ID" "$HAND_ID"; do
+  for QUERY in "" "?archived=false"; do
+    [[ "$(listed "$QUERY" "$ID")" == "false" ]] \
+      || fail "GET /v1/chats$QUERY still lists terminal chat $ID"
+  done
+  [[ "$(listed "?archived=true" "$ID")" == "true" ]] \
+    || fail "archived=true does not list terminal chat $ID"
+  [[ "$(listed "?archived=all" "$ID")" == "true" ]] \
+    || fail "archived=all does not list terminal chat $ID"
+done
+# A live chat is the other half: the default listing keeps it, and asking for
+# the terminal ones alone does not.
+LIVE="$(api POST /chats \
+  -d "{\"project_id\": $PROJECT_ID, \"title\": \"still talking\", \"agent\": \"claude\"}")" \
+  || fail "creating the live chat failed"
+LIVE_ID="$(printf '%s' "$LIVE" | jq -r .id)"
+[[ "$(listed "" "$LIVE_ID")" == "true" ]] || fail "the default listing dropped idle chat $LIVE_ID"
+[[ "$(listed "?archived=true" "$LIVE_ID")" == "false" ]] \
+  || fail "archived=true lists idle chat $LIVE_ID"
+# An explicit state wins over the default, exactly as it does for tasks.
+[[ "$(listed "?state=archived" "$CAP_ID")" == "true" ]] \
+  || fail "state=archived does not list archived chat $CAP_ID"
+CODE="$(api_status GET "/chats?archived=yes")"
+[[ "$CODE" == "400" ]] || fail "GET /v1/chats?archived=yes is $CODE, want 400"
 
 echo "GATE PASS: m14"


### PR DESCRIPTION
## Summary

Archiving a chat took it off nothing. The row stayed on the chats board, and
then behaved as though the conversation were still alive: its last column kept
counting up, and pressing `a` on it again was refused with `a chat with a live
turn cannot be archived`. Three defects with one symptom.

**1. Nothing between the store and the TUI could exclude a terminal chat.**
`store.ChatFilter` carried only `ProjectID` and `States`, `handleChatList` read
only `project_id` and repeated `state`, and `Client.ListChats` took a project id
and nothing else — so `internal/tui/chats.go` asked for every chat that had ever
existed and `sortChats` could only sort the terminal ones into a band rather
than remove them. Tasks have had `?archived=false|true|all`, defaulting to
exclusion, since §13.2; chats now have the same parameter with the same default
and the same "an explicit `state=` wins" rule, `400 validation_failed` on
anything else. It hides **both** terminal states — `archived` and `handed_off`
alike, since both are equally done with — which its name does not say and the
spec row now does. `?terminal=` was the rejected alternative: one vocabulary
across both entities beats a second, more literal one. `vincent chat list
--archived` and `s` on the chats board are the ways back; hiding them with no
route back was rejected, an archived chat's transcript still being worth
reading.

**2. A terminal chat's clock never stopped.** `chatActivity` was
`now - UpdatedAt` with a floor at zero and no upper bound, so an archived row
ticked up second by second and was indistinguishable from a live one — the task
board's equivalent clamps at `FinishedAt`. It now renders *when* the chat ended.
No storage decision was reopened and no column added: a terminal transition is
the last write a chat row takes, so `updated_at` already *is* that moment, which
is what task 074 decision 6 rests on. The stamp is date and time, never a
relative word — a cell that depended on `now` at all would still be a clock,
only a slower one.

**3. The archive refusal named a reason it never checked.**
`handleChatArchive` asked `chatstate.Allowed(state, Archive)` — legal from
`idle` alone — and then wrote one hardcoded sentence for every state that failed
it. Both terminal states are among them, and neither can hold a process (§11),
so the message asserted something false and contradicted the `state` its own
`details` carried. It now names the state. The board declines `a` on a terminal
row with the same distinction instead of opening the `archive %q and remove its
worktree? (y/n)` prompt — the prompt asked a human to confirm removing a
worktree that is already gone, or that a handoff gave to a task.

### Root cause, in one line each

- Defect 1: a filter field that was never added when the chat entity was built —
  the fix is on `ChatFilter`/`ListChats`, not a post-filter at the callers.
- Defect 2: a rendering function with no upper bound, fixed in `chatActivity`.
- Defect 3: a message hardcoded under a guard that tests several states, fixed
  by deriving it from the state the guard actually rejected.

### How the regression tests catch it coming back

- `TestChatListArchivedParam` (`internal/api`) drives the real handlers against
  an idle, an archived and a handed-off chat, and asserts the default and
  `?archived=false` return only the idle one, `true` returns both terminal ones,
  `all` returns three, an explicit `?state=archived` wins over the default, and
  `?archived=yes` is a 400. Reverting the store field or the parsing fails it.
- `TestChatActivityStopsForTerminalChats` (`internal/tui`) calls `chatActivity`
  twice with `now` one minute and nine hours after the chat ended, and requires
  the two to be equal for both terminal states — and *unequal* for `idle`, so
  freezing the whole column passes nothing. It asserts stability rather than a
  format, so it holds whatever stamp is chosen.
- `TestChatArchiveRefusalNamesTheRealState` (`internal/api`) reads the sentence
  a human is shown: it fails if the message says "live turn", and fails if it
  never names the state that `details.state` reports.

The three were run against the unfixed code and observed to fail; nothing about
them was weakened to make them pass. The `internal/tui` probe added in
`bindings_test.go` is new coverage for the new `s` key, not a relaxed
assertion — `TestEveryPanelKeyIsHandled` requires one for every registry row.

`scripts/m14-gate.sh` grows a tenth leg asserting the same listing behaviour
over curl against a real daemon; the whole gate passes locally.

### Not fixed here

`chatBand` (`internal/tui/chatsrows.go`) still spells the chat states as string
literals while `chatActivity` beside it now asks `chatstate.Terminal`. That is
untidy rather than wrong — both agree today — and unifying it is a refactor this
bug fix is not the place for.

## Related

Closes #298
Closes 078 (`docs/tasks/078-terminal-chats-leave-the-board.md`).

This reverses one recorded decision and leaves two standing, deliberately:

- **Reversed:** `ChatFilter`'s doc comment recorded that its zero value lists
  every chat, "archived ones included — the caller decides, since a chat list
  that silently hid archived rows would make `vincent chat list --all` a lie".
  The comment is rewritten to say why it changed rather than deleted: the lie it
  produced instead was the board, where the caller that was supposed to decide
  had no way to. Decision 3 in task 078 records this.
- **Untouched:** task 074 decision 6 — no `archived_at` column — which the
  stopped clock is built on rather than around. And task 067's terminal band,
  which still orders the rows the toggle brings back.

Spec amended in place, dated 2026-09-01: §13.2's `GET /v1/chats` and
`POST /v1/chats/{id}/archive` rows, §5.5's `handed_off` row, §15's chats board
and its task 074 amendment (the sentence "the chat sorts into the board's
terminal band beside archived ones" was exactly what this changes).

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Documentation was audited separately against the source after the fact. Every
derivation the change could have touched was re-checked and each was already
true: the cobra tree against `docs/reference/cli.md` (`--archived` is a bool
mapping to `ArchivedAll`, exactly as `vincent task list --archived` does, so
the parity the page claims is literal), `internal/api/server.go`'s route table
against `docs/reference/api.md` (no route added or removed — the ten chat
routes still match line for line), `internal/tui/bindings.go` against the key
table in `docs/guides/tui.md` (the `s` row's label and its position in priority
order both match the registry), and `docs/spec.md`'s four amended passages plus
the §15 sentence task 074 left behind. Nothing was found stale and nothing was
changed; no documentation commit was needed. `docs/assets/` holds no picture of
the chats board — the board has never been screenshotted — so no image is out
of date, and `docs/gates/` has no `m14` walkthrough for the gate's tenth leg to
contradict.
