### PR TITLE
fix(tui): wrap text fields at the pane width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -680,6 +680,20 @@ list with the user-facing context a commit subject cannot carry.
   and Pull Request tabs, where the wheel moves a cursor rather than a viewport,
   it changed which step or pull request was selected. A popup now takes the
   wheel as well.
+- **The chat composer hid what you typed whenever its pane was narrower than
+  the terminal.** The composer was sized from the whole terminal rather than
+  from the pane it is drawn in, so each of its wrapped rows was cut off with an
+  ellipsis at the pane's right edge and everything past that was typed blind.
+  It is sized from the pane now. The answer form a chat can put up is counted
+  in the same height budget as the rest of the frame too, instead of being
+  appended past it where it pushed the chat's bottom rows off the screen.
+- **Every other text field ran off the right edge of the pane.** A title, a
+  branch, a filter, a palette query or a config value longer than its pane was
+  drawn on one row past the edge, taking the cursor with it, and the host either
+  cut the tail off with an ellipsis or let the terminal reflow it and push the
+  rest of the form down. Text fields now wrap onto further rows of their pane
+  and the form reflows around them, which is what the boards and rendered
+  Markdown have always done.
 - **Palette entries for `ctrl+`-modified keys did nothing.** Running one
   replays its direct key, and the replay had a hand-written case per ctrl key
   that had fallen a registry behind — the chat's `ctrl+r` (detail level) and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6485,6 +6485,18 @@ design, so `git push -u origin` on one either fails or lands a copy of a
 contributor's branch in the user's own repository. It is never a force-push and
 destroys nothing.
 
+**Text fields wrap (added 2026-09-01, issue #299).** A field being typed into
+is bound by the same rule the boards and the rendered Markdown already carry: a
+value too long for the pane it is in **wraps onto further rows of that pane**.
+It is never drawn past the right edge, and it is never cut with an ellipsis —
+truncating a field puts the tail of the value *and the cursor* out of reach,
+which is worse than it is on any read-only surface. The field's height is
+therefore a property of its value, and the form hosting it recomputes its line
+budget from the rows the field actually drew rather than assuming one. That
+holds for the multi-line chat composer of view 9 as much as for the single-value
+rows: a view is given a width and a height and draws inside both of them, so a
+composer that grew is a body that shrank, not a frame that overflowed.
+
 **Opening a URL (task 052.6, added 2026-08-29).** The two screens above hand a
 URL to the platform's own opener — `open` on macOS, `xdg-open` on the other
 unixes, the shell's protocol handler on Windows — and to nothing else. Only

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/table"
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -117,7 +116,7 @@ type board struct {
 	dataDir     string
 	foldsLoaded bool
 
-	filter    textinput.Model
+	filter    textField
 	filtering bool
 
 	// group is the grouping the table is rendering (boardgroup.go);
@@ -157,9 +156,9 @@ type board struct {
 }
 
 func newBoard() *board {
-	fi := textinput.New()
-	fi.Placeholder = "filter by id, title, project or state"
-	fi.Prompt = "/"
+	fi := newTextField()
+	fi.SetPlaceholder("filter by id, title, project or state")
+	fi.SetPrompt("/")
 	b := &board{
 		now:         time.Now,
 		filter:      fi,
@@ -913,7 +912,7 @@ func (b *board) render(width, height int) string {
 	var sb strings.Builder
 	sb.WriteString(b.headerLine())
 	sb.WriteString("\n")
-	if line := b.statusLine(); line != "" {
+	for _, line := range b.statusLines() {
 		sb.WriteString(line)
 		sb.WriteString("\n")
 	}
@@ -963,10 +962,7 @@ func (b *board) actionLine() string {
 
 func (b *board) chromeLines() int {
 	n := 3 // header + the action line + a blank the shell leaves
-	if b.statusLine() != "" {
-		n++
-	}
-	return n
+	return n + len(b.statusLines())
 }
 
 // firstRowLine is the board-content line the table's first data row lands
@@ -978,10 +974,7 @@ func (b *board) chromeLines() int {
 // (M3 gate finding, macOS).
 func (b *board) firstRowLine() int {
 	n := 2 // the header line, then the table's column header
-	if b.statusLine() != "" {
-		n++
-	}
-	return n
+	return n + len(b.statusLines())
 }
 
 // boardCell is one cell of a task row before it is laid out: the plain text,
@@ -1216,18 +1209,22 @@ func (b *board) agentsSummary() string {
 // typed — a committed filter moves to the panel title (§15). A refresh that
 // failed says so and says how old the rows are, rather than the board
 // quietly showing yesterday's truth.
-func (b *board) statusLine() string {
+// It is lines rather than a line because the filter is a wrapping field
+// (issue #299): a long filter grows the row it is typed on, and the two line
+// budgets below have to count what it actually drew.
+func (b *board) statusLines() []string {
 	switch {
 	case b.filtering:
-		line := " " + b.filter.View()
+		b.filter.SetWidth(max(b.width-1, 10))
+		rows := fieldRows(" ", b.filter)
 		if b.loadErr != nil {
-			line += styleBad.Render("  ⚠ " + b.staleNote())
+			rows[len(rows)-1] += styleBad.Render("  ⚠ " + b.staleNote())
 		}
-		return line
+		return rows
 	case b.loadErr != nil:
-		return styleBad.Render(" ⚠ " + b.staleNote())
+		return []string{styleBad.Render(" ⚠ " + b.staleNote())}
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -56,19 +56,23 @@ func (v *chatView) render(width, height int) string {
 	}
 	head := []string{v.headerLine(width), ""}
 	foot := v.footerLines(width)
-	room := max(height-len(head)-len(foot), 1)
-	lines := make([]string, 0, len(head)+room+len(foot))
+	// The form is part of the budget, not something added after it (issue
+	// #299): appended past the join it pushed the same number of lines off the
+	// bottom of the terminal that the unsplit composer did.
+	var form []string
+	if v.form != nil {
+		form = strings.Split(v.form.render(width, min(v.form.height(width), height/2)), "\n")
+	}
+	room := max(height-len(head)-len(foot)-len(form), 1)
+	lines := make([]string, 0, len(head)+room+len(foot)+len(form))
 	lines = append(lines, head...)
 	lines = append(lines, strings.Split(v.bodyView(width, room), "\n")...)
 	lines = append(lines, foot...)
+	lines = append(lines, form...)
 	for i, line := range lines {
 		lines[i] = ansi.Truncate(line, width, "…")
 	}
-	out := strings.Join(lines, "\n")
-	if v.form != nil {
-		return out + "\n" + v.form.render(width, min(v.form.height(width), height/2))
-	}
-	return out
+	return strings.Join(lines, "\n")
 }
 
 // bodyView lays the conversation into the viewport. The window is bottom-
@@ -225,13 +229,22 @@ func (v *chatView) footerLines(width int) []string {
 		}
 		out = append(out, " "+style.Render(v.note))
 	}
-	// One element per rendered line, not one per widget: the composer is
-	// SetHeight(3) and bubbles' viewport pads its View to that height, so a
-	// joined string would report a height of 1 and render 3. render's
-	// `room := height - len(head) - len(foot)` would then overrun the frame
-	// by two lines — the frame keeps the first h-2 — and the hint line below
-	// would never be drawn. It would also feed a multi-line string to
-	// render's per-line ansi.Truncate pass.
+	// One element per rendered line, not one per widget (issue #299): the
+	// composer is SetHeight(3) and bubbles' viewport pads its View to that
+	// height, so a joined string would report a height of 1 and render 3.
+	// render's `room := height - len(head) - len(foot)` would then overrun the
+	// frame by two lines — the frame keeps the first h-2 — and the hint line
+	// below would never be drawn. It would also feed a multi-line string to
+	// render's per-line ansi.Truncate pass, which measures the whole thing as
+	// the *sum* of its rows — ansi.StringWidth treats the `\n`s as zero-width
+	// and never resets — so once that sum passes the pane width the tail is cut
+	// and the composer collapses to its first row. newtaskrender.go does the
+	// same split for the description textarea.
+	//
+	// The width is the pane's, not the terminal's: render is what knows how
+	// many columns the composer actually has, and a composer sized from the
+	// whole terminal has its rows cut by the Truncate pass above.
+	v.composer.SetWidth(max(width-4, 10))
 	out = append(out, strings.Split(v.composer.View(), "\n")...)
 	hint := " enter send · ctrl+x stop the turn · ctrl+r detail · " +
 		rawToggleKey + " raw · " + copyPickKey + " copy · " +

--- a/internal/tui/chats.go
+++ b/internal/tui/chats.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -81,7 +80,7 @@ type chatsView struct {
 	cursor     int
 	selectedID int64
 
-	filter    textinput.Model
+	filter    textField
 	filtering bool
 
 	folds   foldSet
@@ -100,9 +99,9 @@ type chatsView struct {
 }
 
 func newChatsView() *chatsView {
-	fi := textinput.New()
-	fi.Placeholder = "filter by title, agent or branch"
-	fi.Prompt = "/"
+	fi := newTextField()
+	fi.SetPlaceholder("filter by title, agent or branch")
+	fi.SetPrompt("/")
 	return &chatsView{now: time.Now, filter: fi, names: map[int64]string{}}
 }
 

--- a/internal/tui/chatsrender.go
+++ b/internal/tui/chatsrender.go
@@ -19,7 +19,8 @@ func (v *chatsView) render(width, height int) string {
 	lines := make([]string, 0, height)
 	lines = append(lines, v.headerLine(width))
 	if v.filtering || v.filter.Value() != "" {
-		lines = append(lines, " "+v.filter.View())
+		v.filter.SetWidth(max(width-1, 10))
+		lines = append(lines, fieldRows(" ", v.filter)...)
 	}
 	lines = append(lines, "")
 

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -38,7 +37,7 @@ type configForm struct {
 	// choice indexes key.choices for kindBool and kindEnum; input holds the
 	// text for every other kind.
 	choice int
-	input  textinput.Model
+	input  textField
 	// confirming is the second step a dangerous key needs. It is entered on
 	// save and left by y (apply) or esc (back to the field).
 	confirming bool
@@ -56,10 +55,9 @@ func newConfigForm(k configKey, cur apiclient.Config) *configForm {
 	case kindBool, kindEnum:
 		f.choice = indexOf(k.choices, value)
 	default:
-		in := textinput.New()
-		in.Prompt = ""
+		in := newTextField()
+		in.SetPrompt("")
 		in.SetValue(value)
-		in.SetWidth(48)
 		in.Focus()
 		// The cursor lands at the end, on the value someone is about to edit,
 		// rather than at column zero in front of it.
@@ -158,7 +156,7 @@ func (f *configForm) save(client *apiclient.Client) tea.Cmd {
 // default beside it, and the line that says what happens when it applies. The
 // width is the caller's business: every line here is short by construction, so
 // nothing wraps and nothing has to be elided.
-func (f *configForm) render(_ int) []string {
+func (f *configForm) render(width int) []string {
 	out := []string{
 		" " + styleTitle.Render("edit "+f.key.path),
 		"",
@@ -172,7 +170,8 @@ func (f *configForm) render(_ int) []string {
 	case kindBool, kindEnum:
 		out = append(out, "   "+f.renderChoices())
 	default:
-		out = append(out, "   "+f.input.View())
+		f.input.SetWidth(max(width-3, 10))
+		out = append(out, fieldRows("   ", f.input)...)
 		if len(f.key.choices) > 0 {
 			out = append(out, "   "+styleDim.Render("accepted: "+strings.Join(f.key.choices, " ")))
 		}

--- a/internal/tui/newchat.go
+++ b/internal/tui/newchat.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -67,8 +66,8 @@ type newChatForm struct {
 	model  string
 	effort string
 
-	title textinput.Model
-	base  textinput.Model
+	title textField
+	base  textField
 
 	// pick is the list the focused row expands into, nil while navigating.
 	pick *picker
@@ -82,10 +81,10 @@ type newChatForm struct {
 
 func newNewChatForm(client *apiclient.Client, hintProject int64) *newChatForm {
 	f := &newChatForm{client: client, projectID: hintProject}
-	f.title = textinput.New()
-	f.title.Placeholder = "what is this conversation about"
-	f.base = textinput.New()
-	f.base.Placeholder = f.baseHint()
+	f.title = newTextField()
+	f.title.SetPlaceholder("what is this conversation about")
+	f.base = newTextField()
+	f.base.SetPlaceholder(f.baseHint())
 	f.focus = ncTitle
 	f.title.Focus()
 	return f
@@ -152,7 +151,7 @@ func (f *newChatForm) applyFields(msg newChatFieldsMsg) {
 	if f.projectID == 0 && len(f.projects) > 0 {
 		f.projectID = f.projects[0].ID
 	}
-	f.base.Placeholder = f.baseHint()
+	f.base.SetPlaceholder(f.baseHint())
 }
 
 // resumableAgents is the agent picker's contents: only adapters that can hold
@@ -287,7 +286,7 @@ func (f *newChatForm) setRow(row ncRow, value string) {
 // row's hint: it names that project's real default branch.
 func (f *newChatForm) setProject(id int64) {
 	f.projectID = id
-	f.base.Placeholder = f.baseHint()
+	f.base.SetPlaceholder(f.baseHint())
 }
 
 // setAgent selects an adapter by name and drops the model and effort chosen
@@ -517,16 +516,22 @@ func (f *newChatForm) projectName() string {
 }
 
 func (f *newChatForm) render(width, height int) string {
+	// ncIndent is the marker plus the padded label every row carries, and so
+	// what the two text fields have left of the pane (issue #299).
+	const ncIndent = 2 + 9
+	f.title.SetWidth(max(width-ncIndent, 10))
+	f.base.SetWidth(max(width-ncIndent, 10))
 	rows := []struct {
-		row          ncRow
-		label, value string
+		row   ncRow
+		label string
+		value []string
 	}{
-		{ncProject, "project", f.projectName() + stepHint()},
-		{ncTitle, "title", f.title.View()},
-		{ncAgent, "agent", f.agentLabel()},
-		{ncModel, "model", f.overrideValue(f.model, f.defaultModel())},
-		{ncEffort, "effort", f.overrideValue(f.effort, f.defaultEffort())},
-		{ncBase, "base", f.base.View()},
+		{ncProject, "project", []string{f.projectName() + stepHint()}},
+		{ncTitle, "title", f.title.rows()},
+		{ncAgent, "agent", []string{f.agentLabel()}},
+		{ncModel, "model", []string{f.overrideValue(f.model, f.defaultModel())}},
+		{ncEffort, "effort", []string{f.overrideValue(f.effort, f.defaultEffort())}},
+		{ncBase, "base", f.base.rows()},
 	}
 	lines := []string{" " + styleTitle.Render("new chat"), ""}
 	for _, r := range rows {
@@ -534,9 +539,10 @@ func (f *newChatForm) render(width, height int) string {
 		if r.row == f.focus && f.pick == nil {
 			marker = "▸ "
 		}
-		lines = append(lines, marker+padRight(r.label, 9)+r.value)
+		lines = append(lines, indentRows(marker+padRight(r.label, 9), r.value)...)
 	}
 	if f.pick != nil {
+		f.pick.setWidth(width)
 		lines = append(lines, f.pick.renderBody()...)
 	}
 	lines = append(lines, "")
@@ -551,8 +557,11 @@ func (f *newChatForm) render(width, height int) string {
 	default:
 		lines = append(lines, " "+styleDim.Render("enter choose · ctrl+s create · esc cancel"))
 	}
-	_ = width
-	_ = height
+	// A form that grew past its pane keeps its cursor row on screen rather
+	// than drawing off the bottom.
+	if height > 0 && len(lines) > height {
+		lines = window(lines, int(f.focus)+2, height)
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/tui/newchat_test.go
+++ b/internal/tui/newchat_test.go
@@ -272,12 +272,12 @@ func TestNewChatFormArrowsStepInPlace(t *testing.T) {
 // project row, while the value stays empty so the daemon resolves it.
 func TestNewChatFormBaseRowNamesTheProjectDefault(t *testing.T) {
 	f := chatFormWithCatalogs()
-	if got := f.base.Placeholder; got != "main (the project's default)" {
+	if got := f.base.Placeholder(); got != "main (the project's default)" {
 		t.Fatalf("the base row reads %q, want the first project's default branch", got)
 	}
 	f.focus = ncProject
 	f.update(registryKey(t, "right"), nil)
-	if got := f.base.Placeholder; got != "trunk (the project's default)" {
+	if got := f.base.Placeholder(); got != "trunk (the project's default)" {
 		t.Fatalf("after changing project the base row reads %q, want the new project's default branch", got)
 	}
 

--- a/internal/tui/newtask.go
+++ b/internal/tui/newtask.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/textarea"
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -180,15 +179,15 @@ type newTask struct {
 	// re-derived when the project-scoped catalog lands; a deliberate pick
 	// must survive it.
 	workflowPicked bool
-	titleIn        textinput.Model
+	titleIn        textField
 	desc           textarea.Model
 	fields         []kv
-	branch         textinput.Model
+	branch         textField
 	// branchName is the task's own branch, distinct from branch above, which is
 	// the *base* it forks from. Two adjacent rows about branches need labels that
 	// cannot be misread as one having been renamed (task 001).
-	branchName textinput.Model
-	priority   textinput.Model
+	branchName textField
+	priority   textField
 	agent      string
 	model      string
 	effort     string
@@ -248,23 +247,27 @@ type newTask struct {
 }
 
 func newNewTask() *newTask {
-	title := textinput.New()
-	title.Placeholder = "what should the agent do?"
-	branch := textinput.New()
-	branch.Placeholder = "base branch"
-	priority := textinput.New()
-	priority.Placeholder = "0"
+	title := newTextField()
+	title.SetPlaceholder("what should the agent do?")
+	branch := newTextField()
+	branch.SetPlaceholder("base branch")
+	priority := newTextField()
+	priority.SetPlaceholder("0")
 	priority.SetValue("0")
 	desc := textarea.New()
 	desc.Placeholder = "describe the task (markdown); e opens $EDITOR"
 	desc.SetHeight(5)
 	return &newTask{
-		exec:     tea.ExecProcess,
-		titleIn:  title,
-		branch:   branch,
-		priority: priority,
-		desc:     desc,
-		rowErr:   map[ntRow]string{},
+		exec:    tea.ExecProcess,
+		titleIn: title,
+		branch:  branch,
+		// Constructed here rather than left as a zero value: a text field owns
+		// a viewport, so it has to be built before anything sizes or types
+		// into it (issue #299).
+		branchName: newTextField(),
+		priority:   priority,
+		desc:       desc,
+		rowErr:     map[ntRow]string{},
 	}
 }
 

--- a/internal/tui/newtaskpicker.go
+++ b/internal/tui/newtaskpicker.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -55,12 +54,12 @@ type picker struct {
 	cursor    int // index into matches, not into options
 	top       int // first visible match; the window scrolls to follow cursor
 	allowFree bool
-	input     textinput.Model
+	input     textField
 	editing   bool
 	// filter narrows the list incrementally. matches holds the indices of
 	// options passing it, so the full catalog is never mutated and clearing
 	// the filter is free.
-	filter    textinput.Model
+	filter    textField
 	filtering bool
 	matches   []int
 	err       string
@@ -69,13 +68,20 @@ type picker struct {
 	// picking three reviewers is one visit rather than three (§8.1.2, task
 	// 058).
 	multi bool
+	// width is the pane the owning form is drawing into, so the picker's own
+	// two fields wrap at it rather than running off it (issue #299). Forms set
+	// it before renderBody.
+	width int
 }
 
+// setWidth hands the picker the pane width its rows share.
+func (p *picker) setWidth(w int) { p.width = w }
+
 func newPicker(row int, heading string, options []pickerOption, allowFree bool, current string) *picker {
-	in := textinput.New()
-	in.Placeholder = "type a value"
-	fl := textinput.New()
-	fl.Placeholder = "filter"
+	in := newTextField()
+	in.SetPlaceholder("type a value")
+	fl := newTextField()
+	fl.SetPlaceholder("filter")
 	p := &picker{row: row, heading: heading, options: options, allowFree: allowFree, input: in, filter: fl}
 	p.applyFilter()
 	for i, idx := range p.matches {
@@ -248,7 +254,8 @@ func (p *picker) renderBody() []string {
 	}
 	out := []string{styleDim.Render(heading)}
 	if p.filtering {
-		out = append(out, "      "+p.filter.View())
+		p.filter.SetWidth(max(p.width-6, 10))
+		out = append(out, fieldRows("      ", p.filter)...)
 	}
 	end := min(p.top+pickerWindow, len(p.matches))
 	if p.top > 0 {
@@ -296,7 +303,8 @@ func (p *picker) renderBody() []string {
 		out = append(out, "    "+marker+styleDim.Render("type a value not listed…"))
 	}
 	if p.editing {
-		out = append(out, "      "+p.input.View())
+		p.input.SetWidth(max(p.width-6, 10))
+		out = append(out, fieldRows("      ", p.input)...)
 	}
 	if p.err != "" {
 		out = append(out, styleBad.Render("    ⚠ "+p.err))
@@ -623,12 +631,12 @@ type fieldsEditor struct {
 	cursor int
 	// editing is 0 for none, 1 for the key, 2 for the value.
 	editing int
-	input   textinput.Model
+	input   textField
 	err     string
 }
 
 func newFieldsEditor(rows []kv) *fieldsEditor {
-	in := textinput.New()
+	in := newTextField()
 	return &fieldsEditor{rows: append([]kv(nil), rows...), input: in}
 }
 

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -125,7 +125,7 @@ func (n *newTask) renderCompact(height int) string {
 		if row == n.cursor {
 			cursorLine = len(lines)
 		}
-		lines = append(lines, n.renderRow(row))
+		lines = append(lines, strings.Split(n.renderRow(row), "\n")...)
 		lines = append(lines, n.renderExpansion(row)...)
 	}
 	lines = append(lines, "")
@@ -219,7 +219,7 @@ func (n *newTask) renderStage(stage ntStage) ([]string, int) {
 		if row == n.cursor {
 			cursorLine = len(lines)
 		}
-		lines = append(lines, n.renderRow(row))
+		lines = append(lines, strings.Split(n.renderRow(row), "\n")...)
 		lines = append(lines, n.renderExpansion(row)...)
 	}
 	lines = append(lines, "", styleDim.Render("  ↑/↓ or tab moves · enter changes the focused field"))
@@ -250,7 +250,7 @@ func (n *newTask) renderReview(lines []string) ([]string, int) {
 		}, styleDim.Render(" · "))),
 	)
 	cursorLine := len(lines)
-	lines = append(lines, n.renderRow(ntCreate))
+	lines = append(lines, strings.Split(n.renderRow(ntCreate), "\n")...)
 	lines = append(lines, n.statusLines()...)
 	return lines, cursorLine
 }
@@ -259,7 +259,21 @@ func (n *newTask) reviewLine(label, value string) string {
 	return "  " + styleDim.Render(fmt.Sprintf("%-13s", label)) + " " + value
 }
 
+// ntRowIndent is the cursor plus the padded label every row carries, and so
+// what a text row has left of the pane (issue #299).
+const ntRowIndent = 2 + 12 + 1
+
+// sizeFields hands the four text rows the width they wrap at.
+func (n *newTask) sizeFields() {
+	w := max(n.width-ntRowIndent, 10)
+	n.titleIn.SetWidth(w)
+	n.branch.SetWidth(w)
+	n.branchName.SetWidth(w)
+	n.priority.SetWidth(w)
+}
+
 func (n *newTask) renderRow(row ntRow) string {
+	n.sizeFields()
 	cursor := "  "
 	if row == n.cursor && n.mode != ntConfirming {
 		cursor = styleFocus.Render("› ")
@@ -275,7 +289,11 @@ func (n *newTask) renderRow(row ntRow) string {
 		return cursor + styleKey.Render("[ "+label+" ]") + "  " +
 			styleDim.Render("enter · ctrl+s from anywhere")
 	}
-	line := fmt.Sprintf("%s%-12s %s", cursor, ntLabels[row], n.rowValue(row))
+	// indentRows, not a plain concatenation: an edited text row wraps, and its
+	// further rows line up under the first rather than under the label.
+	line := strings.Join(indentRows(
+		fmt.Sprintf("%s%-12s ", cursor, ntLabels[row]),
+		strings.Split(n.rowValue(row), "\n")), "\n")
 	// An inherited row is drawn like any other and marked as what it is: the
 	// worktree it names exists, so this is a fact being confirmed rather than
 	// a choice being offered (task 074).
@@ -524,6 +542,7 @@ func (n *newTask) renderExpansion(row ntRow) []string {
 	}
 	switch {
 	case n.mode == ntPicking && n.pick != nil && ntRow(n.pick.row) == row:
+		n.pick.setWidth(n.width)
 		return n.renderPicker()
 	case (n.mode == ntFieldsOpen || n.mode == ntFieldPicking) && row == ntFields:
 		return n.renderFields()
@@ -604,6 +623,10 @@ func (n *newTask) renderWorkflowDetail(name string) []string {
 
 func (n *newTask) renderFields() []string {
 	f := n.fieldsEd
+	// 6 is the row's own indent and marker; the label in front of the value is
+	// the definition's, and the pane truncates a row whose label runs long the
+	// way it always has.
+	f.input.SetWidth(max(n.width-6, 10))
 	out := []string{styleDim.Render("    task fields — available to templates as .Task.Fields:")}
 	for i, r := range f.rows {
 		marker := "  "
@@ -645,7 +668,10 @@ func (n *newTask) renderFields() []string {
 				}
 			}
 		}
-		out = append(out, "    "+marker+name+meta+" = "+firstNonEmpty(value, placeholder))
+		// Split: the key/value field wraps, and a row carrying newlines would
+		// otherwise be one element of a slice the caller counts in lines.
+		out = append(out, strings.Split(
+			"    "+marker+name+meta+" = "+firstNonEmpty(value, placeholder), "\n")...)
 		if i == f.cursor && r.declared {
 			if r.definition.Description != "" {
 				out = append(out, styleDim.Render("        "+r.definition.Description))
@@ -662,6 +688,7 @@ func (n *newTask) renderFields() []string {
 			}
 		}
 		if i == f.cursor && n.mode == ntFieldPicking && n.pick != nil {
+			n.pick.setWidth(n.width)
 			out = append(out, n.pick.renderBody()...)
 			hint := "    enter select · esc cancel"
 			if r.definition.Multiple {

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -16,7 +15,7 @@ import (
 // replacing them. Invalid task actions are omitted, not greyed: an action
 // that cannot happen is never on screen.
 type palette struct {
-	input   textinput.Model
+	input   textField
 	entries []paletteEntry
 	cursor  int
 }
@@ -32,9 +31,9 @@ type paletteEntry struct {
 }
 
 func newPalette(entries []paletteEntry) *palette {
-	in := textinput.New()
-	in.Placeholder = "type to search commands"
-	in.Prompt = ": "
+	in := newTextField()
+	in.SetPlaceholder("type to search commands")
+	in.SetPrompt(": ")
 	in.Focus()
 	return &palette{input: in, entries: entries}
 }
@@ -152,7 +151,8 @@ func (p *palette) paste(text string) tea.Cmd {
 func (p *palette) render(w, h int) string {
 	inner := max(w-2, 10)
 	lines := make([]string, 0, h)
-	lines = append(lines, " "+p.input.View())
+	p.input.SetWidth(max(inner-1, 1))
+	lines = append(lines, fieldRows(" ", p.input)...)
 
 	m := p.matches()
 	if len(m) == 0 {

--- a/internal/tui/panewidth_test.go
+++ b/internal/tui/panewidth_test.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The two halves of issue #299, both of them the same claim: a value longer
+// than the pane is wide belongs on further rows of the pane, never off the
+// side of it and never off the bottom. §15's row-height rule (task 052) and
+// its code-block rule already say that for the surfaces that read text — "a
+// cell too long for its column wraps onto further lines of the same row
+// rather than being truncated away", "not truncation, which would put the
+// tail of a long line out of reach of the TUI entirely" — and a field being
+// typed into is the one surface where losing the tail also loses the cursor.
+
+// panePad is the padding a value gets so it is unambiguously longer than the
+// pane, whatever chrome the field draws around itself.
+const panePad = 40
+
+// countRune is how many times r survives into the drawn frame, ANSI stripped.
+func countRune(frame string, r rune) int { return strings.Count(ansi.Strip(frame), string(r)) }
+
+// TestPaneWidthChatComposerKeepsEveryWrappedRow is the reported symptom: a
+// message longer than the composer is wide wraps inside the textarea, and
+// the chat pane draws exactly one row of it.
+//
+// chatrender.go:228 appends `v.composer.View()` — three rows, `ta.SetHeight(3)`
+// at chatview.go:136 — as a single element of a slice whose every other
+// element is one line. render (chatrender.go:49-63) then counts it as one
+// line in `room`, so the frame is two lines taller than the terminal it was
+// given, and runs `ansi.Truncate(line, width, "…")` over all three rows at
+// once: `ansi.StringWidth` never resets across the `\n`s, so the composer is
+// measured as the sum of its rows and everything past the pane width — the
+// remaining rows, newlines included — is dropped.
+func TestPaneWidthChatComposerKeepsEveryWrappedRow(t *testing.T) {
+	const (
+		width  = 80
+		height = 24
+	)
+	v := chatViewFixture()
+	v.update(tea.WindowSizeMsg{Width: width, Height: height})
+
+	// Long enough to wrap, short enough to still fit the composer's three
+	// rows: what is asserted is that the wrapped rows are drawn, not that an
+	// over-full composer scrolls.
+	msg := strings.Repeat("Z", width+panePad)
+	v.composer.SetValue(msg)
+
+	frame := v.render(width, height)
+
+	if got := len(strings.Split(frame, "\n")); got != height {
+		t.Errorf("the chat frame is %d lines at height %d: the composer's rows are not counted in room, so its tail falls off the bottom of the terminal", got, height)
+	}
+	if got := countRune(frame, 'Z'); got != len(msg) {
+		t.Errorf("%d of the %d typed characters reached the screen: the composer is truncated to its first row and the rest is typed blind", got, len(msg))
+	}
+	for i, line := range strings.Split(frame, "\n") {
+		if w := ansi.StringWidth(line); w > width {
+			t.Errorf("line %d is %d columns wide in a %d-column pane: %q", i, w, width, ansi.Strip(line))
+		}
+	}
+}
+
+// TestPaneWidthNewChatTitleWraps is the other half: every single-line row in
+// the TUI is a `textinput.Model` that is never given a width, and bubbles/v2
+// turns horizontal scrolling off entirely when `Width() <= 0`
+// (textinput.go:356, `handleOverflow` returns early). The field draws its
+// whole value on one row, so the row runs past the right edge of the pane —
+// carrying the cursor with it — and whatever hosts the form either truncates
+// it with `…` or lets the terminal reflow it.
+//
+// newchat.go's `title` is the field the reproduction names, and its render
+// discards the width it is handed outright (`_ = width`, newchat.go:554).
+func TestPaneWidthNewChatTitleWraps(t *testing.T) {
+	const (
+		width  = 80
+		height = 24
+	)
+	f := newNewChatForm(nil, 0)
+	title := strings.Repeat("Z", width+panePad)
+	f.title.SetValue(title)
+
+	frame := f.render(width, height)
+
+	for i, line := range strings.Split(frame, "\n") {
+		if w := ansi.StringWidth(line); w > width {
+			t.Errorf("line %d is %d columns wide in a %d-column pane, so its tail and the cursor are off screen: %q",
+				i, w, width, ansi.Strip(line))
+		}
+	}
+	if got := countRune(frame, 'Z'); got != len(title) {
+		t.Errorf("%d of the %d typed characters reached the screen, want the whole value wrapped onto further rows", got, len(title))
+	}
+	if got := len(strings.Split(frame, "\n")); got > height {
+		t.Errorf("the form is %d lines at height %d", got, height)
+	}
+}

--- a/internal/tui/projectform.go
+++ b/internal/tui/projectform.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -61,10 +60,10 @@ type projectForm struct {
 	// resent — a resend would stomp a concurrent edit.
 	original *apiclient.Project
 
-	path     textinput.Model
-	name     textinput.Model
-	branch   textinput.Model
-	cap      textinput.Model
+	path     textField
+	name     textField
+	branch   textField
+	cap      textField
 	workflow string
 	// workflowSet records that the workflow row was touched, so clearing it
 	// on an edit sends null rather than being mistaken for "unchanged".
@@ -85,16 +84,16 @@ func newProjectForm(client *apiclient.Client, p *apiclient.Project) *projectForm
 	f := &projectForm{
 		client:   client,
 		original: p,
-		path:     textinput.New(),
-		name:     textinput.New(),
-		branch:   textinput.New(),
-		cap:      textinput.New(),
+		path:     newTextField(),
+		name:     newTextField(),
+		branch:   newTextField(),
+		cap:      newTextField(),
 		rowErr:   map[pfRow]string{},
 	}
-	f.path.Placeholder = "path to a git repository"
-	f.name.Placeholder = "(the directory name)"
-	f.branch.Placeholder = "(detected from the repository)"
-	f.cap.Placeholder = "(no project cap)"
+	f.path.SetPlaceholder("path to a git repository")
+	f.name.SetPlaceholder("(the directory name)")
+	f.branch.SetPlaceholder("(detected from the repository)")
+	f.cap.SetPlaceholder("(no project cap)")
 	if p != nil {
 		f.path.SetValue(p.Path)
 		f.name.SetValue(p.Name)

--- a/internal/tui/projectrender.go
+++ b/internal/tui/projectrender.go
@@ -22,7 +22,7 @@ func (p *projectsView) render(width, height int) string {
 		if guidedTakeover(p.width, p.height) {
 			return p.renderGuided(rows)
 		}
-		return p.form.render()
+		return p.form.render(p.width)
 	}
 	p.syncTable(rows)
 	if guidedTakeover(p.width, p.height) {
@@ -72,7 +72,7 @@ func (p *projectsView) renderGuided(rows []apiclient.Project) string {
 	var main string
 	if p.form != nil {
 		mainTitle = p.form.heading()
-		main = p.form.renderFocused(p.height - 2)
+		main = p.form.renderFocused(p.width/2, p.height-2)
 	} else if pr, ok := p.current(); ok {
 		mainTitle = "Overview · " + pr.Name
 		main = p.renderProjectOverview(pr, p.height-2)
@@ -321,7 +321,8 @@ func (p *projectsView) rowsFor(projects []apiclient.Project, set projectColSet) 
 func (p *projectsView) statusLines() []string {
 	var out []string
 	if p.filtering || p.filter.Value() != "" {
-		out = append(out, " "+p.filter.View())
+		p.filter.SetWidth(max(p.width-1, 10))
+		out = append(out, fieldRows(" ", p.filter)...)
 	}
 	if p.loadErr != nil {
 		note := " ⚠ refresh failed: " + errString(p.loadErr)
@@ -362,17 +363,25 @@ func (f *projectForm) heading() string {
 	return "Edit project"
 }
 
-func (f *projectForm) render() string {
-	lines, _ := f.renderLines(true)
+func (f *projectForm) render(width int) string {
+	lines, _ := f.renderLines(width, true)
 	return strings.Join(lines, "\n")
 }
 
-func (f *projectForm) renderFocused(height int) string {
-	lines, cursorLine := f.renderLines(false)
+func (f *projectForm) renderFocused(width, height int) string {
+	lines, cursorLine := f.renderLines(width, false)
 	return strings.Join(window(lines, cursorLine, height), "\n")
 }
 
-func (f *projectForm) renderLines(includeHeading bool) ([]string, int) {
+func (f *projectForm) renderLines(width int, includeHeading bool) ([]string, int) {
+	// pfRowIndent is the two-space gutter, the marker and the padded label
+	// every row carries, and so what a text row has left of the pane (#299).
+	const pfRowIndent = 2 + 2 + 20
+	w := max(width-pfRowIndent, 10)
+	f.path.SetWidth(w)
+	f.name.SetWidth(w)
+	f.branch.SetWidth(w)
+	f.cap.SetWidth(w)
 	var lines []string
 	if includeHeading {
 		lines = append(lines, " "+styleTitle.Render(strings.ToLower(f.heading())), "")
@@ -382,11 +391,12 @@ func (f *projectForm) renderLines(includeHeading bool) ([]string, int) {
 		if row == f.cursor {
 			cursorLine = len(lines)
 		}
-		lines = append(lines, f.renderRow(row))
+		lines = append(lines, strings.Split(f.renderRow(row), "\n")...)
 		if msg, ok := f.rowErr[row]; ok {
 			lines = append(lines, styleBad.Render("      ⚠ "+msg))
 		}
 		if row == pfWorkflow && f.pick != nil {
+			f.pick.setWidth(width)
 			lines = append(lines, f.pick.renderBody()...)
 			lines = append(lines, styleDim.Render("    enter select · esc cancel"))
 		}
@@ -418,7 +428,7 @@ func (f *projectForm) renderRow(row pfRow) string {
 	if row == pfSave {
 		return "  " + marker + styleTitle.Render("save")
 	}
-	return "  " + marker + label + f.rowValue(row)
+	return strings.Join(indentRows("  "+marker+label, strings.Split(f.rowValue(row), "\n")), "\n")
 }
 
 func (f *projectForm) rowValue(row pfRow) string {

--- a/internal/tui/projects.go
+++ b/internal/tui/projects.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/table"
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -77,7 +76,7 @@ type projectsView struct {
 	tbl        table.Model
 	selectedID int64
 
-	filter    textinput.Model
+	filter    textField
 	filtering bool
 
 	form    *projectForm
@@ -91,9 +90,9 @@ type projectsView struct {
 }
 
 func newProjectsView() *projectsView {
-	fi := textinput.New()
-	fi.Placeholder = "filter by name or path"
-	fi.Prompt = "/"
+	fi := newTextField()
+	fi.SetPlaceholder("filter by name or path")
+	fi.SetPrompt("/")
 	p := &projectsView{
 		now:    time.Now,
 		filter: fi,

--- a/internal/tui/pullrequests.go
+++ b/internal/tui/pullrequests.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -165,7 +164,7 @@ type pullRequestsView struct {
 
 	cursor int
 
-	filter    textinput.Model
+	filter    textField
 	filtering bool
 
 	// picker is the link picker, scoped to the row's own project: POST takes
@@ -194,9 +193,9 @@ type pullRequestsView struct {
 }
 
 func newPullRequestsView() *pullRequestsView {
-	fi := textinput.New()
-	fi.Placeholder = "filter by number, title, branch or project"
-	fi.Prompt = "/"
+	fi := newTextField()
+	fi.SetPlaceholder("filter by number, title, branch or project")
+	fi.SetPrompt("/")
 	return &pullRequestsView{now: time.Now, filter: fi, state: pullStates[0]}
 }
 

--- a/internal/tui/pullrequestsrender.go
+++ b/internal/tui/pullrequestsrender.go
@@ -30,7 +30,8 @@ func (v *pullRequestsView) render(width, height int) string {
 	lines := make([]string, 0, height)
 	lines = append(lines, v.headerLine(width))
 	if v.filtering || v.filter.Value() != "" {
-		lines = append(lines, " "+v.filter.View())
+		v.filter.SetWidth(max(width-1, 10))
+		lines = append(lines, fieldRows(" ", v.filter)...)
 	}
 	lines = append(lines, "")
 

--- a/internal/tui/readerpicker.go
+++ b/internal/tui/readerpicker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 
@@ -238,15 +237,15 @@ func pickText(it copyItem, resolve func(seq int64) (string, bool)) string {
 
 // readerPicker is the popup itself: a search line over the captured rows.
 type readerPicker struct {
-	input  textinput.Model
+	input  textField
 	items  []copyItem
 	cursor int
 }
 
 func newReaderPicker(items []copyItem) *readerPicker {
-	in := textinput.New()
-	in.Placeholder = "type to search what can be copied"
-	in.Prompt = ": "
+	in := newTextField()
+	in.SetPlaceholder("type to search what can be copied")
+	in.SetPrompt(": ")
 	in.Focus()
 	return &readerPicker{input: in, items: items}
 }
@@ -312,7 +311,8 @@ func (p *readerPicker) paste(text string) tea.Cmd {
 func (p *readerPicker) render(w, h int) string {
 	inner := max(w-2, 10)
 	lines := make([]string, 0, h)
-	lines = append(lines, " "+p.input.View())
+	p.input.SetWidth(max(inner-1, 1))
+	lines = append(lines, fieldRows(" ", p.input)...)
 
 	m := p.matches()
 	if len(m) == 0 {

--- a/internal/tui/textfield.go
+++ b/internal/tui/textfield.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// textField is the TUI's single-value text row (issue #299).
+//
+// It is a textarea rather than a `textinput` because the wanted behaviour is a
+// field that *wraps*. bubbles/v2 turns horizontal scrolling off entirely while
+// `Width() <= 0` — `handleOverflow` returns early — so an unsized textinput
+// draws its whole value on one row, which runs past the right edge of the pane
+// and takes the cursor with it. Giving each field a width and letting it scroll
+// horizontally instead is the smaller change and was rejected: §15 already says
+// a value too long for its column wraps onto further lines rather than being
+// truncated away (task 052's row height, and the code-block rule), and a field
+// being typed into is the one surface where losing the tail also loses the
+// cursor.
+//
+// It is a *field*, not an editor. The prompt gutter and the line numbers are
+// off so a wrapped field reads as the single row it replaces, the newline key
+// is disabled and a pasted newline becomes a space, so `Value` is always the
+// one line the caller stored. Its height follows its content, which is why a
+// host asks `rows` for the lines to lay out rather than assuming one.
+type textField struct {
+	ta textarea.Model
+	// prompt is drawn by the field rather than by the textarea, which repeats
+	// its own prompt on every row: a wrapped filter row must not grow a second
+	// `/`. It is the row's prefix, so the wrapped rows indent past it.
+	prompt string
+	width  int
+}
+
+// newTextField is the constructor every text row in the TUI goes through.
+func newTextField() textField {
+	ta := textarea.New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.DynamicHeight = true
+	ta.MinHeight = 1
+	ta.KeyMap.InsertNewline.SetEnabled(false)
+	// The cursor line's background would draw a full-width bar across a form
+	// row; a field is one row of a form, not a document being edited.
+	s := ta.Styles()
+	s.Focused.CursorLine = lipgloss.NewStyle()
+	s.Blurred.CursorLine = lipgloss.NewStyle()
+	ta.SetStyles(s)
+	ta.SetHeight(1)
+	return textField{ta: ta, width: textareaDefaultWidth}
+}
+
+// textareaDefaultWidth is what bubbles gives a fresh textarea, kept so a field
+// nobody sized still wraps somewhere rather than not at all.
+const textareaDefaultWidth = 40
+
+// SetPlaceholder sets the dim text shown while the field is empty.
+func (f *textField) SetPlaceholder(s string) { f.ta.Placeholder = s }
+
+// Placeholder is that text.
+func (f textField) Placeholder() string { return f.ta.Placeholder }
+
+// SetWidth sets how many columns the field's rows may use, prompt included.
+// Callers pass the room left in the pane after whatever prefix the row carries,
+// so the widest wrapped row plus that prefix is exactly the pane width.
+func (f *textField) SetWidth(w int) {
+	f.width = w
+	f.applyWidth()
+}
+
+// SetPrompt sets the marker the first row carries — `/` for a filter, `: ` for
+// a palette.
+func (f *textField) SetPrompt(s string) {
+	f.prompt = s
+	f.applyWidth()
+}
+
+func (f *textField) applyWidth() {
+	f.ta.SetWidth(max(f.width-ansi.StringWidth(f.prompt), 1))
+}
+
+// Width is the field's current column budget, prompt included.
+func (f textField) Width() int { return f.width }
+
+// CursorEnd puts the cursor after the last character.
+func (f *textField) CursorEnd() { f.ta.CursorEnd() }
+
+func (f textField) Value() string   { return f.ta.Value() }
+func (f textField) Focused() bool   { return f.ta.Focused() }
+func (f *textField) Blur()          { f.ta.Blur() }
+func (f *textField) Focus() tea.Cmd { return f.ta.Focus() }
+
+// SetValue stores a value. Newlines collapse to spaces: this is a field, and a
+// value that grew a second logical line would stop round-tripping through
+// Value.
+func (f *textField) SetValue(s string) {
+	f.ta.SetValue(fieldOneLine(s))
+	f.ta.CursorEnd()
+}
+
+// Update runs the field's own key handling. A paste is flattened first, for the
+// reason SetValue flattens.
+func (f textField) Update(msg tea.Msg) (textField, tea.Cmd) {
+	if p, ok := msg.(tea.PasteMsg); ok {
+		msg = tea.PasteMsg{Content: fieldOneLine(p.Content)}
+	}
+	var cmd tea.Cmd
+	f.ta, cmd = f.ta.Update(msg)
+	return f, cmd
+}
+
+// View is the field's rows joined, which is what a host that has a whole line
+// to itself wants. A host laying the field out beside a label wants rows.
+func (f textField) View() string { return strings.Join(f.rows(), "\n") }
+
+// rows is the field as it will be drawn: one entry per wrapped row, each no
+// wider than the width it was given.
+func (f textField) rows() []string {
+	out := strings.Split(f.ta.View(), "\n")
+	// The textarea pads every row out to its full width. That is invisible on
+	// its own but it is not free to a host that puts something after the
+	// field, or that is counting columns against the pane.
+	for i, r := range out {
+		out[i] = strings.TrimRight(r, " ")
+	}
+	return indentRows(f.prompt, out)
+}
+
+// fieldOneLine flattens a value to the single line a field holds.
+func fieldOneLine(s string) string {
+	return strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
+}
+
+// fieldRows lays a field out under a fixed prefix: the first row carries the
+// prefix, and every wrapped row after it is indented to the same column so the
+// field still reads as the one row it grew out of.
+func fieldRows(prefix string, f textField) []string {
+	return indentRows(prefix, f.rows())
+}
+
+// indentRows is fieldRows for anything already split into rows.
+func indentRows(prefix string, rows []string) []string {
+	pad := strings.Repeat(" ", ansi.StringWidth(prefix))
+	out := make([]string, 0, len(rows))
+	for i, r := range rows {
+		if i == 0 {
+			out = append(out, prefix+r)
+			continue
+		}
+		out = append(out, pad+r)
+	}
+	return out
+}
+
+// truncateRows cuts every row of a laid-out field to the pane width.
+func truncateRows(rows []string, width int) []string {
+	for i, r := range rows {
+		rows[i] = ansi.Truncate(r, width, "…")
+	}
+	return rows
+}

--- a/internal/tui/workflowcreate.go
+++ b/internal/tui/workflowcreate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -25,7 +24,7 @@ type wfCreateForm struct {
 	// sourceProject scopes the lookup of source.
 	sourceProject int64
 
-	name textinput.Model
+	name textField
 	// scopes are the destinations, in registry order: global first, then
 	// each project. A fork of a global entry into the global scope would
 	// shadow nothing, so it is still offered — the daemon refuses the
@@ -55,8 +54,8 @@ const (
 // source; a plain create takes only the scope list. It issues no command:
 // everything it needs is already in the loaded blocks.
 func (w *workflowsView) openCreate(fork bool) {
-	f := &wfCreateForm{fork: fork, name: textinput.New()}
-	f.name.Placeholder = "file name (lowercase, no spaces)"
+	f := &wfCreateForm{fork: fork, name: newTextField()}
+	f.name.SetPlaceholder("file name (lowercase, no spaces)")
 	if fork {
 		line, ok := w.currentLine()
 		if !ok {

--- a/internal/tui/workfloweditor.go
+++ b/internal/tui/workfloweditor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -82,7 +81,7 @@ type wfEditorLayer struct {
 	cursor int
 
 	// input is the focused text row, nil when the list has the keyboard.
-	input   *textinput.Model
+	input   *textField
 	editing int
 
 	loading bool

--- a/internal/tui/workfloweditorkeys.go
+++ b/internal/tui/workfloweditorkeys.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/lezli01/vincent/internal/apiclient"
@@ -99,7 +98,7 @@ func (w *workflowsView) editorActivate() tea.Cmd {
 		}
 		return w.commitRow(row, next)
 	}
-	in := textinput.New()
+	in := newTextField()
 	in.SetValue(row.value)
 	in.Focus()
 	e.input = &in

--- a/internal/tui/workfloweditorrender.go
+++ b/internal/tui/workfloweditorrender.go
@@ -3,8 +3,6 @@ package tui
 import (
 	"fmt"
 	"strings"
-
-	"github.com/charmbracelet/x/ansi"
 )
 
 // The editor's rendering. It draws rows, never YAML: the whole argument for a
@@ -66,6 +64,8 @@ func (w *workflowsView) renderEditorRows(width int) []string {
 			value = unsetMarker
 		}
 		if e.input != nil && i == e.editing {
+			// 21 is the mark and the padded label the value sits after.
+			e.input.SetWidth(max(width-21, 10))
 			value = e.input.View()
 		}
 		if row.descend != "" {
@@ -76,9 +76,9 @@ func (w *workflowsView) renderEditorRows(width int) []string {
 			line += " " + styleBad.Render("required")
 		}
 		if width > 0 {
-			line = ansi.Truncate(line, width, "…")
+			line = strings.Join(truncateRows(strings.Split(line, "\n"), width), "\n")
 		}
-		rows = append(rows, line)
+		rows = append(rows, strings.Split(line, "\n")...)
 		if i == e.cursor && row.field.Help != "" {
 			rows = append(rows, "    "+styleDim.Render(row.field.Help))
 		}
@@ -87,7 +87,7 @@ func (w *workflowsView) renderEditorRows(width int) []string {
 }
 
 // renderCreate draws the create/fork prompt: a scope row and a file-name row.
-func (w *workflowsView) renderCreate(_, height int) string {
+func (w *workflowsView) renderCreate(width, height int) string {
 	f := w.create
 	title := "New workflow"
 	if f.fork {
@@ -113,8 +113,11 @@ func (w *workflowsView) renderCreate(_, height int) string {
 		styleTitle.Render("  " + title),
 		"",
 		rowMark(wfCreateRowScope) + styleDim.Render(fmt.Sprintf("%-10s", "scope")) + " " + strings.Join(scope, " "),
-		rowMark(wfCreateRowName) + styleDim.Render(fmt.Sprintf("%-10s", "file name")) + " " + f.name.View(),
 	}
+	f.name.SetWidth(max(width-13, 10))
+	out = append(out, indentRows(
+		rowMark(wfCreateRowName)+styleDim.Render(fmt.Sprintf("%-10s", "file name"))+" ",
+		f.name.rows())...)
 	if f.fork {
 		out = append(out, "", styleDim.Render(
 			"  the copy keeps "+f.source+"'s own name:, which is what makes it shadow the original"))


### PR DESCRIPTION
## Summary

A value longer than the pane is wide now goes onto further **rows** of the pane
— not off the side of it, and not off the bottom.

**The reported symptom: the chat composer.** `footerLines` appended
`v.composer.View()` as a single element of a slice whose every other element is
exactly one line. The composer is three rows (`ta.SetHeight(3)`), and
`chatView.render` does two things to that slice that both assume one element is
one line:

- `room := max(height-len(head)-len(foot), 1)` counted the composer as **one**
  line, so the frame was built two lines taller than the height it was handed
  and its bottom rows fell off the terminal.
- `ansi.Truncate(line, width, "…")` ran over all three rows at once.
  `ansi.StringWidth` treats `\n` as a zero-width execute action and never
  resets its running total, so the composer measured as the **sum** of its rows
  — 228 columns for a 3×76 composer. Once that sum passed the pane width,
  `Truncate` cut at the width, appended `…` and dropped every remaining byte,
  the newlines with it. The composer collapsed to one visible row and the rest
  of the message was typed blind.

The root cause is the unsplit `.View()`, and that is what changed:
`chatrender.go` now splits the composer into its rows the way
`newtaskrender.go` already splits the description textarea, so `room` counts
its real height and `Truncate` sees one row at a time. The composer's width now
comes from the pane width `render` is handed rather than only from
`tea.WindowSizeMsg` (which is the whole terminal), and the answer form a chat
can put up is counted in the same height budget instead of being appended past
the join — it overflowed by exactly the same arithmetic.

**The second half: every other text field.** Every single-line row in the TUI
was a `textinput.Model` that was never given a width, and bubbles/v2 disables
horizontal scrolling entirely while `Width() <= 0` (`handleOverflow` returns
early), so the field drew its whole value on one row running past the right
edge of the pane and taking the cursor with it. `newChatForm.render(80, 24)`
with a 120-character title drew a row 134 columns wide, and its `render`
discarded the width it was handed outright (`_ = width`).

Those rows are now a shared `textField`: a textarea with the prompt gutter and
the line numbers off, the newline key disabled and pasted newlines flattened,
so it reads and round-trips as the single row it replaces while its height
follows its content. Each host sizes it from the pane it is drawing into and
recomputes its own line budget from the rows the field actually drew —
`board.statusLine` becomes `statusLines`, and the two counters that measured
the board's chrome (`chromeLines`, `firstRowLine`) now count what it drew
rather than assuming one. `configform.go`'s fixed `SetWidth(48)`, which did not
track the terminal and overflowed in any pane narrower than 48 columns plus its
indent, becomes width-derived like the rest.

The alternative — giving each `textinput` an explicit width and letting it
scroll horizontally with the cursor — is the smaller change and was rejected by
the report's author before this branch existed. The wanted behaviour is a
wrapped field.

**How the regression test catches this coming back.**
`internal/tui/panewidth_test.go` is hermetic — no daemon, no network, no agent
CLI — and asserts the claim rather than the implementation:

- `TestPaneWidthChatComposerKeepsEveryWrappedRow` renders the chat fixture at
  80×24 with 120 typed characters and asserts the frame is exactly 24 lines,
  that all 120 characters reach the screen, and that no line exceeds 80
  columns. Against the unfixed code it reported **25 lines** and **70 of 120**
  characters. Re-appending any multi-row `.View()` unsplit, or dropping the
  form from the height budget, fails the line count; re-truncating across rows
  fails the character count.
- `TestPaneWidthNewChatTitleWraps` renders the new-chat form at 80×24 with a
  120-character title and asserts no line exceeds 80 columns, that every
  character is on screen, and that the form fits the height. Against the
  unfixed code it drew a **134-column** line. Removing a `SetWidth` from a host
  form, or going back to an unsized `textinput`, fails the width assertion.

Neither assertion was weakened. The one change to an existing test is
mechanical: `newchat_test.go` reads the base row's placeholder, which moved
from an exported struct field to a `Placeholder()` method when the field type
changed. Same value, same assertion.

`go test ./...` and `go tool golangci-lint run ./...` are green, the linter run
for `GOOS=darwin`, `linux` and `windows`. The change is pure rendering
arithmetic in `internal/tui` with no build-tagged files and no platform-specific
path.

**One thing found on the way past and deliberately not fixed here:** the
fields editor's key/value input (`fieldsEditor.input`, `newtaskpicker.go`) is
not in the diagnosed table and its row is assembled from a label whose width is
the workflow definition's, not the pane's. It is sized from the pane and its
row is split so it can no longer corrupt the frame, but a declared field with a
very long label can still push that row's *first* line past the pane, where the
host truncates it as it always has. Worth its own issue rather than a wider
change here.

## Related

Closes #299

Amends `docs/spec.md` §15 with a dated note (2026-09-01) stating the field rule
positively: a text field wraps at the pane width and its form reflows around
it. §15 already said wrap-not-truncate for boards (task 052's row height) and
for rendered code blocks ("not truncation, which would put the tail of a long
line out of reach of the TUI entirely") but said nothing about fields, which
are the one surface where losing the tail also loses the cursor. The spec was
silent, not wrong — no recorded decision in `docs/spec.md`, `docs/tasks/` or
`docs/history/v0-tasks.md` contradicts this, and task 067's chat workspace and
§15's chat rows are silent on field sizing. §15 view 9 already specified the
composer as multi-line (`shift+enter` inserts a newline, "the composer keeps
`↑`/`↓` for editing a multi-line message"), which a composer that could only
ever show one row contradicted: the code was the side that was wrong.

## Checklist

- [ ] PR title is plain language (no Conventional Commit prefix) — the title
      was asked for in Conventional Commits style, which this box contradicts.
      Flagging rather than silently picking one: the `PR title` workflow
      enforces plain language, so `Wrap TUI text fields at the pane width` is
      what should go in the GitHub title field if that check is to pass.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [ ] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — **audited, and none of them needed a change.** The diff is
      `internal/tui` plus `CHANGELOG.md` and `docs/spec.md`, so every derived
      page is derived from a package this branch does not touch: no config key
      (`internal/config`), no cobra command, no route in
      `internal/api/server.go`, no `Reason*` constant, no step type in
      `internal/workflow`/`internal/taskrun`, no adapter capability under
      `internal/agent`. `internal/tui/bindings.go` is untouched and every host
      still intercepts its navigation keys before the field sees them
      (`palette.update` handles `up`/`down` first, and the forms handle
      `tab`/`enter` first), so `docs/guides/tui.md`'s key tables stay true —
      `enter` in a field never inserted a newline before and does not now.
      `docs/guides/tui.md`'s wrap claims are about board cells (task 052), the
      answer field and the graph's step popup, all of which already wrapped and
      still do; its `truncated` mentions are the output pane, the reasoning
      level and the workflow header, none of them a field. `docs/features.md`
      makes no claim about field sizing. No task document: this is a bug fix
      whose reasoning lives in the spec amendment and `textfield.go`'s header,
      and `docs/tasks/README.md` reserves a task record for work whose
      reasoning must outlive the pull request — the standalone `fix(...)`
      commits on `master` set the same precedent. `docs/gates/m3-gate.md`'s
      S15 resize walkthrough asserts nothing the fix makes false.
      `skills/vincent-workflows/SKILL.md` and `.vincent/workflows/*.yaml` are
      untouched because the workflow schema is.
- [x] `docs/spec.md` §15 amended in place with a dated note (2026-09-01), in
      this pull request, per the repository's separate rule for the spec.

## Screenshots

`docs/assets/tui-board.png` (the filter row), `tui-new-task.png` (the four text
rows) and `tui-workflow-editor.png` (the key input) all photograph fields this
change converts, and **none of them is stale**: for a value that fits the pane
the new `textField` emits the same text at the same column as the `textinput`
it replaces — same prompt, same label padding, trailing pad trimmed — and the
layout only diverges once a value overflows, which none of the seeded shots do.
Nothing was re-captured, and `scripts/screenshots.sh` was not run.
