### PR TITLE
Make a loop's position and its earlier iterations legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **A loop says where it is, and its earlier passes open.** The loop rollup on
+  the board and in the task header names the body step the current iteration is
+  on — `3/7 green · loop 4/10 · repair 2/3` — so "where is this task, right
+  now" no longer stops at the loop's own name, which is all the outer `k/n`
+  could ever say about a step that counts a whole loop as one. A `STEP` column
+  too narrow for all of it drops clauses from the tail rather than wrapping:
+  the body step goes first, then the `for_each` item, then the counter.
+
+  In the task workspace's Steps & Attempts tab, a folded iteration is no longer
+  unreachable. `space` opens or closes the tier the cursor is in, `→` opens and
+  `←` closes it, `enter` on a folded tier's header opens it (and still opens
+  Output on a drawn attempt), and `O`/`C` open and close every tier of the task
+  — the Diff tab's two letters in the same meaning. The timeline still *opens*
+  with the latest pass showing and the rest folded, so a reader arriving at a
+  blocked task lands on the pass it stopped on; what changed is that iteration
+  1 of a loop now on iteration 7 can be opened, its attempts selected, and
+  their output and transcript read. A multi-round `fan_out` gets the same tier
+  under its own word — `round 0`, `round 1`, … , 0-based, the number its
+  transcript file and log line already use — instead of being labelled as a
+  loop's iterations with its first round missing a header entirely.
+
+  On the wire the `loop` rollup gains `total`, `body_step`, `body_index` and
+  `body_total`, `GET /v1/tasks/{id}/steps` gains `loop_total` per row, and a
+  new column records what each admission planned. See
+  [the API reference](docs/reference/api.md) and
+  [Using the TUI](docs/guides/tui.md).
+
 - **vincent shows the real usage quota, where the agent CLI reports one.** The
   `quota` block on `GET /v1/agents` and `GET /v1/info` was an observation of a
   wall vincent had already watched a task hit; now it carries a measurement of
@@ -747,6 +774,25 @@ list with the user-facing context a commit subject cannot carry.
   filesystem and the shell, and that is all it claims to bound.
 
 ### Fixed
+
+- **A `for_each` loop showed a denominator that was never its own.** With no
+  `count:` and no step-level `max_iterations:`, the loop's total was read off
+  the workflow — where a `for_each` list does not exist yet, because it is
+  rendered at run time — and fell through to the global `loop.max_iterations`
+  ceiling. A 3-item loop rendered `loop 2/10` on the board and in the detail
+  header. Each body row now records how many iterations the admission that
+  wrote it planned, so the same loop reads `loop 2/3`. `max_iterations` keeps
+  its own meaning beside it — the bound the loop would block on — and a task
+  whose rows predate the column renders exactly as it did before the upgrade.
+
+- **`↑`/`↓` in the step timeline could leave no visible cursor.** The selection
+  walked every attempt including the ones a fold had not drawn, so pressing
+  `↓` through a loop moved it onto rows that were not on screen: the highlight
+  disappeared and the window jumped to the top of the timeline. A folded tier
+  is now a single stop — its first row — and the tier's header carries the
+  highlight while it is selected, so every selection the arrow keys can reach
+  is drawn. The Output tab's `←`/`→` are unchanged and still reach every
+  attempt.
 
 - **A `for_each:` list longer than 4 KiB was cut mid-item.** `.Steps.<id>.Result`
   for a command step is documented as the last 200 lines of its stdout, and the

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -106,8 +106,10 @@ under width pressure they are dropped instead.
 comfortable width; past that the extra room goes to `STEP` and then `STATUS` —
 the two columns whose content actually outgrows them — and only what neither
 can use comes back to the title. So a 200-column board shows
-`3/7 green · loop 4/10` whole instead of spending the room on a title's
-trailing blanks.
+`3/7 green · loop 4/10 · repair 2/3` whole instead of spending the room on a
+title's trailing blanks. A loop rollup too wide for the column it is given
+drops clauses from the tail rather than wrapping — the body step goes first,
+then the `for_each` item, then the counter, which is the last thing to survive.
 
 A wide terminal also gets a **`STATUS` column**: what the task's newest step run
 said about *itself*, if it said anything —
@@ -321,8 +323,24 @@ iteration**, folded shut with the latest one open, and a `for_each` iteration's
 header names the item it ran on. Ten passes of a four-step body is forty rows,
 and the one you arrived to read is almost always the pass it stopped on.
 
+Folded is not unreachable. `space` opens or closes the tier the cursor is in,
+`→` opens it and `←` closes it, `enter` on a folded tier's header opens it
+(and on a drawn attempt still opens Output), and `O`/`C` open and close every
+tier of the task — the same two letters the Diff tab uses. Latest-open is only
+where the timeline *starts*: what you open stays open while the task refreshes,
+and opening another task starts fresh. `↑`/`↓` stop **once** on a folded tier,
+on its header, so the cursor is always somewhere you can see; the Output tab's
+`←`/`→` still walk every attempt, folded or not.
+
+A multi-round `fan_out` (§7.6) gets the same tier under a different word: its
+rounds read `round 0`, `round 1`, … — 0-based, because that is the number the
+transcript file and the log line use — and the same keys open and close them.
+
 The board's and the header's step column say the same thing more briefly: a
-task inside a loop reads `3/7 green · loop 4/10`.
+task inside a loop reads `3/7 green · loop 4/10 · repair 2/3` — the pass it is
+on out of the loop's real extent (a 3-item `for_each` reads `loop 2/3`, not the
+ceiling it is bounded by), and the body step that pass is on, which is the one
+thing the outer `3/7` cannot say because it counts the whole loop as one step.
 
 Two things on an attempt line are worth telling apart. A red word like
 `check_failed` is vincent's **failure reason** — a fixed set of constants, and
@@ -341,7 +359,10 @@ output. It is the sentence that decides whether to open the transcript.
 | `]` / `[` | Next / previous task tab |
 | `1`–`5` | Steps & Attempts / Task Details / Output / Diff / Workflow |
 | `6` | Pull Request — only when this task has a linked pull request and GitHub is on; `tab`/`shift+tab` skip it otherwise |
-| `enter` | From Steps & Attempts, open the selected attempt in Output |
+| `enter` | From Steps & Attempts, open the selected attempt in Output — or open the folded iteration/round tier the cursor is on |
+| `space` | On Steps & Attempts, open or close the iteration/round tier the cursor is in |
+| `←`/`→` | On Steps & Attempts, close / open that tier |
+| `O` / `C` | On Steps & Attempts, open / close every iteration and round tier of this task |
 | `←`/`→` or `h`/`l` | On Output, select which attempt's output to show |
 | `f` or `G` | Follow the live output again |
 | `v` | More or less detail: compact → normal → verbose (reasoning, the run's own metadata, then unrecognized lines) |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1402,21 +1402,30 @@ running: the `count:`, or the length of the `for_each` list the running
 admission derived, which the workflow does not carry because the list is
 rendered at run time. Render `total` when it is there and fall back to
 `max_iterations` when it is not, so a 3-item `for_each` under a ceiling of 10
-reads `loop 2/3` rather than `loop 2/10`. `total` is absent until a step run
-records one — before the first iteration there is nothing to report and a
-denominator would be a guess that reads like an answer — and it is absent for a
-row written before the daemon recorded extents at all.
+reads `loop 2/3` rather than `loop 2/10`. `total` is absent until the loop has
+a body row at all — before the first iteration there is nothing to report and a
+denominator would be a guess that reads like an answer. A row written before the
+daemon recorded extents carries none, and `total` is then the same bound
+`max_iterations` reports, which is the number that row's rollup gave for its
+whole life; the fallback happens on the daemon, so a client that renders `total`
+whenever it is present is right either way.
 
 `body_step` names the body step that iteration is on, with `body_index` its
 1-based place among `body_total` body steps; the outer `step k/n` counts a
 whole loop as one step, so this is the only thing on the response that says
 where inside the loop the task is. The three are absent **together**, and only
-together, when the daemon cannot place the row in a body it recognizes — a
-repair row, or any row at all once the task's workflow snapshot no longer
-parses. The rollup is on the list endpoint too, so a board can render
-`loop 4/7 · internal/store · repair 2/3` without a request per row. Like `children`, it is derived per request from the step
-rows rather than stored: a persisted loop cursor would be a second truth that
-recovery would have to reconcile. There is deliberately **no** step-lifecycle
+together, for a row whose `step_id` is not one of the body ids the task's
+workflow snapshot declares: a repair row, or a row whose step an edit-and-retry
+rewrite of the snapshot (§6) has taken out of the body. A position counted
+against a body the row did not run in is worse than no position. (A snapshot
+that no longer parses at all does not narrow the rollup, it removes it: `loop`
+is absent from the response entirely, because nothing is left to say the current
+step is a loop.) The rollup is on
+the list endpoint too, so a board can render
+`loop 4/7 · internal/store · repair 2/3` without a request per row. Like
+`children`, it is derived per request from the step rows rather than stored: a
+persisted loop cursor would be a second truth that recovery would have to
+reconcile. There is deliberately **no** step-lifecycle
 event for iterations — ten passes of a four-step body would put forty durable
 events on the stream to say what forty rows already say.
 - **`?archived=` defaults to false.** `true` selects only archived tasks, `all`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1047,7 +1047,7 @@ are **not** here — those come from [`GET /v1/agents`](#daemon).
 | `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort?, github_issue?, github_pull? }` — `branch_name` is used verbatim and wins over any template, **except** on a `github_pull` task, whose branch is the pull request's head. Accepts an optional `Idempotency-Key` header |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
-| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart. A `fan_out` step with `needs:` between its lanes puts its rounds on the same `iteration` column (0-based, so a flat lane list still reads `0`), which is the one other place a non-zero `iteration` appears — under `schedule: eager` that number is a monotonic merge counter rather than the lane's wave, and the step may write up to one merge row per lane; the two cannot be confused because a `fan_out` is not valid inside a loop body |
+| `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart — plus `loop_total`, how many iterations the admission that wrote the row planned to run (the `count:`, or the resolved `for_each` list's length; `0` outside a loop and on a row written before the daemon recorded it). A `fan_out` step with `needs:` between its lanes puts its rounds on the same `iteration` column (0-based, so a flat lane list still reads `0`), which is the one other place a non-zero `iteration` appears — under `schedule: eager` that number is a monotonic merge counter rather than the lane's wave, and the step may write up to one merge row per lane; the two cannot be confused because a `fan_out` is not valid inside a loop body |
 | `POST` | `/v1/tasks/{id}/steps/{step_id}/status` | `{ message }` → `{ message }` as stored. What the **running** step is doing, in its own words. Called by that step's own process — see [Step status](#step-status) |
 | `GET` | `/v1/tasks/{id}/workflow` | This task's own workflow **snapshot** as a full definition — what ran, not what the registry says now. See [The task's workflow](#the-tasks-workflow) |
 
@@ -1388,14 +1388,33 @@ Both the list and the detail endpoint carry `loop` while a task's **current**
 step is a `loop` (§7.8), and omit it otherwise:
 
 ```json
-"loop": { "driver": "for_each", "iteration": 4, "max_iterations": 10, "item": "internal/store" }
+"loop": {
+  "driver": "for_each", "iteration": 4, "total": 7, "max_iterations": 10,
+  "item": "internal/store",
+  "body_step": "repair", "body_index": 2, "body_total": 3
+}
 ```
 
 `iteration` is the pass in progress (0 before the first one starts) and
 `max_iterations` is the largest it could reach — the `count:` itself, or the
-ceiling a `for_each` is bounded by, whose real length is only known at run
-time. It is on the list endpoint too, so a board can render `loop 4/10` without
-a request per row. Like `children`, it is derived per request from the step
+ceiling a `for_each` is bounded by. `total` is what the loop is **actually**
+running: the `count:`, or the length of the `for_each` list the running
+admission derived, which the workflow does not carry because the list is
+rendered at run time. Render `total` when it is there and fall back to
+`max_iterations` when it is not, so a 3-item `for_each` under a ceiling of 10
+reads `loop 2/3` rather than `loop 2/10`. `total` is absent until a step run
+records one — before the first iteration there is nothing to report and a
+denominator would be a guess that reads like an answer — and it is absent for a
+row written before the daemon recorded extents at all.
+
+`body_step` names the body step that iteration is on, with `body_index` its
+1-based place among `body_total` body steps; the outer `step k/n` counts a
+whole loop as one step, so this is the only thing on the response that says
+where inside the loop the task is. The three are absent **together**, and only
+together, when the daemon cannot place the row in a body it recognizes — a
+repair row, or any row at all once the task's workflow snapshot no longer
+parses. The rollup is on the list endpoint too, so a board can render
+`loop 4/7 · internal/store · repair 2/3` without a request per row. Like `children`, it is derived per request from the step
 rows rather than stored: a persisted loop cursor would be a second truth that
 recovery would have to reconcile. There is deliberately **no** step-lifecycle
 event for iterations — ten passes of a four-step body would put forty durable

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1379,6 +1379,15 @@ does not finish until every lane is merged.
     the retry budget and the §12.2 transcript name. `.Steps["build"].Result`
     still resolves to the latest row.
 
+  *Amended 2026-09-03 (issue #317).* Because rounds ride the loop's column, the
+  TUI renders them as the loop's tier too (§15): a multi-round step's rows are
+  grouped and folded under a **`round N`** header, 0-based, opened and closed
+  with the same keys a loop's iterations are. The number is the column's value,
+  so the screen, the log line and the §12.2 transcript name all say the same
+  one. Which noun titles the tier comes from the step's type in the task's
+  workflow snapshot — the rows alone cannot tell a round from a pass — and a
+  task whose snapshot has not arrived keeps the loop's word.
+
   A step whose **selected lanes declare no `needs:`** among themselves runs as
   a barrier whatever `schedule:` says. Such a list spawns in one round under
   either mode, so eager could only change *when* the lanes merge — and merging
@@ -1572,6 +1581,30 @@ once, a loop is a **sequence** run more than once.
   `for_each` row also carries its `loop_item`. The loop has no row of its own;
   its outcome is derived. A body step's transcript is
   `{step_index}-i{iteration}-{step_id}-{attempt}.jsonl` (§12.2).
+  *Amended 2026-09-03 (issue #317):* every body row also carries `loop_total`
+  (migration 0026) — how many iterations **the admission that wrote it**
+  planned, which is the `count:` or the resolved `for_each` list's length,
+  clamp included. That is the sentence beside `loop_item` carried one word
+  further: the row already said which item iteration 3 ran on, and now says how
+  many iterations that pass was one of. It is not a cursor (task 016 decision 7
+  refused one): nothing reads it back to decide what to run next and §12.4 has
+  nothing to reconcile with it, because the position is still derived from the
+  rows. It is 0 for every row outside a loop and for every row written before
+  the column existed, and a reader falls back to the ceiling on 0.
+- **Position on the wire.** *Added 2026-09-03 (issue #317).* The `loop` rollup
+  a task carries while its current step is a loop (§13.2) reports the loop's
+  **real extent** as `total` — the newest row's `loop_total`, absent until a row
+  records one, because before the first iteration a denominator would be a
+  guess that reads like an answer — and names the body step that iteration is
+  on as `body_step` with its 1-based `body_index` of `body_total`. The outer
+  `step k/n` counts a whole loop as one step, so without that clause "where is
+  this task" stops at the loop's own name. `max_iterations` keeps its own
+  meaning beside `total`: the bound the loop would block on. They are two
+  numbers and neither stands in for the other — a 3-item `for_each` under a
+  ceiling of 10 is `total: 3`, `max_iterations: 10`, and reads `loop 2/3`. The
+  body clause is absent **whole** — no id, no index, no total — for a row whose
+  `step_id` is not one of the snapshot's body ids: a repair row, or any row at
+  all once the snapshot no longer parses.
 - **`.Loop`** (§8.4) is `Index`, `Item`, `IsFirst`, `IsLast`, with `Index: 0`
   outside any loop.
 - **`iteration` is not only a loop's.** *Added 2026-09-01 (task 080).* A
@@ -6102,6 +6135,10 @@ CREATE TABLE step_runs (
   -- from these.
   iteration           INTEGER NOT NULL DEFAULT 0, -- 1-based inside a loop; 0 outside one
   loop_item           TEXT,                   -- the `for_each` item this iteration ran on; NULL otherwise
+  -- Added 2026-09-03 (0026, issue #317). How many iterations the admission
+  -- that wrote this row planned: the `count:`, or the resolved `for_each`
+  -- list's length. Display only — never read back to decide what runs next.
+  loop_total          INTEGER NOT NULL DEFAULT 0, -- 0 outside a loop, and for pre-0026 rows
   state               TEXT NOT NULL,          -- running | succeeded | failed | interrupted
                                               -- | approved | rejected | skipped | stopped
   agent               TEXT,                   -- adapter name, agent steps only
@@ -6381,7 +6418,9 @@ stream for the live tail.
    column, and it takes the width the fixed set leaves — but only up to a
    ceiling. Past that ceiling the surplus is spent in a fixed order: `STEP`
    first, up to a maximum wide enough for a step name with a loop rollup beside
-   it (`3/7 green · loop 4/10`); then `STATUS`, up to a maximum of a couple of
+   it (`3/7 green · loop 4/10 · repair 2/3`, amended 2026-09-03 for issue #317
+   from `3/7 green · loop 4/10`, which is the same measurement taken before the
+   rollup named its body step); then `STATUS`, up to a maximum of a couple of
    the board's lines of prose; and only then does the remainder go back to the
    title. The give-back is not a softening of the ceiling — it is what stops a
    board that has shed `STATUS` leaving dead cells on the right, and the title
@@ -6389,7 +6428,12 @@ stream for the live tail.
    ceiling and the `STATUS` column's admission gate are one value, because they
    are one fact: the title has cleared a comfortable width, so there is room to
    spend elsewhere. Below that width nothing changes — the shedding ladder, the
-   minimum title and every narrow board render exactly as they did. `STATE` is
+   minimum title and every narrow board render exactly as they did. *Amended
+   2026-09-03 (issue #317): a loop rollup that does not fit the `STEP` column it
+   is given **drops clauses from the tail** — the body step first, then the
+   `for_each` item, then the counter — rather than wrapping onto a second line.
+   Three clauses outgrow every width below the ceiling, and a row grown a line
+   to finish a counter spends its height on the least of what it says.* `STATE` is
    deliberately not among the columns a surplus reaches: the recorded reasoning
    above holds, and the wrap is what makes its overflow readable.
 
@@ -6450,6 +6494,22 @@ stream for the live tail.
 	   lets the reader move that selection with `←`/`→` (or `h`/`l`) without
 	   returning to the timeline. `enter` on a Steps & Attempts row opens Output
 	   on that attempt.
+	   *Amended 2026-09-03 (issue #317):* a `loop`'s iterations and a multi-round
+	   `fan_out`'s rounds are folded tiers on the Steps & Attempts timeline, and
+	   they **open**. Latest-open stays the arrival default (task 016 decision 14
+	   — a reader arriving at a blocked task wants the pass it stopped on);
+	   `space` toggles the tier the cursor is in, `→` opens it, `←` closes it,
+	   and `O`/`C` open and close every tier of the task — the Diff tab's fold
+	   vocabulary verbatim. `enter` means both things, chosen by the row under
+	   the cursor: on a folded tier it opens the fold, and otherwise it opens
+	   Output as above. The timeline's selection stays a run id — `↑`/`↓` treat a
+	   folded tier as **one** cursor stop, its first row, and that tier's header
+	   carries the highlight while such a row is selected, so every selection
+	   they can reach is drawn. They previously walked onto rows a fold had not
+	   rendered, which left the highlight invisible and jumped the window to the
+	   top of the timeline. The Output tab's `←`/`→` are unchanged and still
+	   reach every attempt: a fold is a fact about the timeline pane, not about
+	   the task.
    **Diff** renders the task's grouped git diff. Each owns the whole task body;
    `tab`/`shift+tab` and `[`/`]` walk them, `1`–`4` select directly, and `esc`
    returns to the board. The attempt selection persists across tabs.*

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1593,9 +1593,11 @@ once, a loop is a **sequence** run more than once.
   the column existed, and a reader falls back to the ceiling on 0.
 - **Position on the wire.** *Added 2026-09-03 (issue #317).* The `loop` rollup
   a task carries while its current step is a loop (§13.2) reports the loop's
-  **real extent** as `total` — the newest row's `loop_total`, absent until a row
-  records one, because before the first iteration a denominator would be a
-  guess that reads like an answer — and names the body step that iteration is
+  **real extent** as `total` — the newest row's `loop_total`, absent until the
+  loop has a body row at all, because before the first iteration a denominator
+  would be a guess that reads like an answer, and falling back to the snapshot's
+  bound for a row that predates the column, which is the number that row's
+  rollup reported for its whole life — and names the body step that iteration is
   on as `body_step` with its 1-based `body_index` of `body_total`. The outer
   `step k/n` counts a whole loop as one step, so without that clause "where is
   this task" stops at the loop's own name. `max_iterations` keeps its own
@@ -1603,8 +1605,11 @@ once, a loop is a **sequence** run more than once.
   numbers and neither stands in for the other — a 3-item `for_each` under a
   ceiling of 10 is `total: 3`, `max_iterations: 10`, and reads `loop 2/3`. The
   body clause is absent **whole** — no id, no index, no total — for a row whose
-  `step_id` is not one of the snapshot's body ids: a repair row, or any row at
-  all once the snapshot no longer parses.
+  `step_id` is not one of the snapshot's body ids: a repair row, or a row whose
+  step an edit-and-retry rewrite of the snapshot (§6) has taken out of the body.
+  A snapshot that no longer parses is the other case and not this one: it does
+  not narrow the rollup, it removes it, because nothing is then left to say the
+  current step is a loop.
 - **`.Loop`** (§8.4) is `Index`, `Item`, `IsFirst`, `IsLast`, with `Index: 0`
   outside any loop.
 - **`iteration` is not only a loop's.** *Added 2026-09-01 (task 080).* A

--- a/docs/tasks/050-board-column-widths-and-wrapping.md
+++ b/docs/tasks/050-board-column-widths-and-wrapping.md
@@ -66,6 +66,16 @@ two names for one threshold and an invitation for them to drift apart.
 then `STATUS` to `widthStatusMax`, then the remainder back to the title.**
 *(2026-08-29)*
 
+> **Superseded in part, 2026-09-03 — [task 083](083-loop-legibility.md).** The
+> allocation order stands; the measurement it was taken against grew. The loop
+> rollup now names its body step, so the sample is
+> `3/7 green · loop 4/10 · repair 2/3` and `widthStepMax` is **34**. A rollup
+> too wide for the cell **drops clauses from the tail** — body step, then item,
+> then counter — rather than taking decision 4's uniform second line: three
+> clauses outgrow every width below the ceiling, and a whole board grown a line
+> so one cell can finish a counter spends that height on the least of what the
+> rollup says. Decision 4 still governs every other cell.
+
 `widthStepMax = 32` fits `3/7 green · loop 4/10` (21 cells) with room for a
 step name longer than the sample's; `widthStatusMax = 96` is a couple of the
 board's lines of prose, past which wrapping is the better answer than a column

--- a/docs/tasks/083-loop-legibility.md
+++ b/docs/tasks/083-loop-legibility.md
@@ -1,0 +1,126 @@
+# 083 — Make a loop's position and its earlier iterations legible
+
+**Status:** ✅ done (1/1)
+**Issue:** #317
+**Amends:** §7.6, §7.8, §14, §15
+**Extends:** [016](016-workflow-loops.md) decision 8 ("the row carries its item; the
+extent is a fact the rows hold") by one word, and leaves decision 7 ("no
+persisted loop cursor") and decision 14 ("latest iteration open on arrival")
+standing as written
+
+A task sitting on a `loop` was the one shape of work the TUI could not answer
+"where is this, right now" about. The outer `step k/n` counts a whole loop as a
+single step; the §7.8 rollup carried `{driver, iteration, max_iterations,
+item}` and so named neither the body step running nor, for a `for_each`, a
+denominator the loop was actually going to reach; and the timeline folded every
+iteration but the latest with no key that opened one. Four faults, confirmed in
+the code rather than taken on the issue's word:
+
+1. Which body step is running was nowhere on the wire.
+2. `renderTimeline` skipped folded rows and never entered their ids, while
+   `moveSelection` walked *every* row — so `↑`/`↓` moved the selection onto
+   rows that were not drawn, the highlight vanished and the window jumped to
+   the top of the timeline. The comment there ("cannot happen, because it never
+   entered ids") was true for mouse hit-testing and false for the arrow keys.
+3. `loopDefinitionOf` took the total from `count:`, else the step's
+   `max_iterations:`, else the config ceiling — so a 3-item `for_each` with
+   neither rendered `loop 2/10`.
+4. `loopIndexes` keyed off `Iteration > 0`, which a multi-round `fan_out` sets
+   too (task 080 decision 3), so its rounds were titled "iteration N" and round
+   0 got no header at all.
+
+## Decisions
+
+1. **The `for_each` extent is persisted on the row, beside its item.**
+   Migration 0026 adds `step_runs.loop_total`, written on every body row from
+   the admission's `loopPlan.total` exactly as `loop_item` is written from
+   `plan.items`. This is task 016 decision 8's sentence carried one word
+   further: the row already recorded *which item* iteration 3 ran on, and now
+   records *how many iterations that admission planned*. It is **not** a cursor
+   — decision 7 refused one and still does: nothing reads it back to decide what
+   runs next, the loop's position is still derived from the rows, and §12.4
+   recovery has nothing to reconcile with it.
+
+   Two alternatives were rejected. Asking the live `taskrun.Runner` for the
+   in-flight plan needs no migration but reports the real total only while an
+   actor exists — so a **blocked or paused** loop, the exact case a human is
+   staring at, would silently fall back to the ceiling again. Materializing the
+   resolved list into the task snapshot (task 080 decision 5's precedent) would
+   freeze a list decision 8 deliberately re-derives per admission for
+   iterations that have not started, making it a change to the loop rather than
+   to the rollup.
+
+2. **`total` and `max_iterations` are two numbers and neither is made to mean
+   the other.** `max_iterations` keeps its documented meaning — the ceiling
+   this loop is bounded by, the number it would block on. `total` is the extent
+   the running admission planned, absent (0) until a row records one, because
+   before the first iteration there is nothing to report and a guess would read
+   like an answer. The client prefers `total` when it has one, so a pre-0026
+   row keeps rendering exactly what it rendered before the upgrade.
+
+3. **The body clause is absent whole, or not at all.** A row whose `step_id` is
+   not one of the snapshot's body ids — a repair row, or any row once the
+   snapshot no longer parses — gets no `body_step`, no `body_index` and no
+   `body_total`, rather than a position counted against a body it did not run
+   in. A rollup that degrades to driver + iteration is honest; one that guesses
+   is not.
+
+4. **The timeline's selection stays a run id; a folded tier is one cursor
+   stop.** `↑`/`↓` treat a folded iteration or round as a single stop — its
+   first row — and `renderTimeline` highlights that tier's *header* while such
+   a row is selected. Every selection the arrow keys can reach is therefore
+   drawn, which is the issue's fourth acceptance criterion, and no second kind
+   of selection enters `moveSelection`, `syncOutput`, `visibleRuns` hit-testing
+   or the Output tab's `←`/`→`. Making a header its own kind of cursor stop was
+   considered and rejected on exactly that cost.
+
+   The two moves are separate entry points (`moveTimelineSelection` beside
+   `moveSelection`) rather than one function reading focus off a field: which
+   move is wanted is the caller's business, and correlating it with a field is
+   how the two came to share the wrong behaviour in the first place.
+
+5. **`enter` means both things, chosen by the row under the cursor.** On a
+   folded tier it opens the fold — the attempt it would otherwise carry the
+   reader to is one they cannot see yet — and on a drawn attempt it keeps
+   today's meaning and opens the Output tab. `space` toggles, `→` opens, `←`
+   closes, `O`/`C` open and close every tier of the task: the Diff tab's fold
+   vocabulary verbatim, because it is the same gesture on the same screen.
+
+6. **Latest-open stays the arrival default** (task 016 decision 14). The folds
+   become *openable*, not open. The fold map holds decisions only, so a tier
+   arriving mid-run opens by itself, a refresh cannot close one a reader
+   opened, and opening another task starts fresh.
+
+7. **A `fan_out`'s rounds are labelled 0-based** — "round 0", "round 1", … The
+   label is the column's value, so the screen, the log line and the §12.2
+   transcript name (`{step_index}-i{iteration}-{step_id}-{attempt}`) all say
+   the same number. Which noun titles the tier comes from the step's type in
+   the task's workflow snapshot, since the rows alone cannot tell a round from
+   a pass; `loopIndexes`' row-only derivation stays the answer for a task whose
+   snapshot has not arrived, and keeps the loop's word there.
+
+8. **A rollup too wide for the `STEP` column drops clauses from the tail** —
+   body step first, then the `for_each` item, then the counter — rather than
+   wrapping. Three clauses outgrow every width below the ceiling, and a board
+   row grown a line to finish a counter spends its height on the least of what
+   it says. `widthStepMax` rose from 32 to 34, measured off
+   `3/7 green · loop 4/10 · repair 2/3`.
+
+## What landed
+
+| Package | Change |
+|---|---|
+| `internal/store` | Migration `0026_loop_extent.sql`, `StepRun.LoopTotal`, carried through the insert and every `step_runs` read path |
+| `internal/taskrun` | `loopEnv.total` from `plan.total`, `stepEnv.loopTotal()`, written on every row that already carries `LoopItem`. `planLoop` untouched, clamp included |
+| `internal/api` | `loopDefinition.body` (the body's step ids in declaration order), `total` / `body_step` / `body_index` / `body_total` on the loop rollup, `loop_total` on `GET /v1/tasks/{id}/steps` |
+| `internal/apiclient` | The matching fields, `LoopRollup.Clauses()` in priority order with `Display()` joining them, and a live test against the real handlers |
+| `internal/tui` | Fitted board clauses and `widthStepMax` 34; the per-tier fold map, `moveTimelineSelection`, header-carries-the-cursor rendering, `round N` tiers from the snapshot's step type, and the `ctxTimeline` fold bindings |
+| `scripts/m8-gate.sh` | Scenario 4 asserts the recorded extent is the list length, read off the rows because a `done` task has no rollup |
+
+## Follow-ups
+
+None open. `scripts/screenshots.sh` seeds no workflow containing a `loop` or a
+multi-round `fan_out`, so no `docs/assets/tui-*.png` capture shows a loop
+rollup or an iteration tier and none needed re-taking. Seeding one is a new
+seed, a new tape and a new asset, and is not what this work was about — it is
+the sub-task to open if the pictures should cover loops.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -96,6 +96,7 @@ the living engineering specification records implementation contracts.
 | [080](080-fan-out-dag.md) | `needs:` between fan-out lanes, a round scheduler derived from the graph, and lanes derived from an earlier step's output | ✅ done (2/2) |
 | [081](081-eager-fan-out-scheduling.md) | `schedule: eager` on a `fan_out` step: a lane starts when its own `needs:` merge, woken by a settled-child watermark | ✅ done (1/1) |
 | [082](082-reported-agent-quota.md) | The real usage quota codex's app-server and Claude Code's status line now report, merged over the observed window on `GET /v1/agents` | ✅ done (1/1) |
+| [083](083-loop-legibility.md) | A loop's real extent and running body step on the rollup, and openable iteration/round tiers in the timeline that never lose the cursor | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/api/loop_test.go
+++ b/internal/api/loop_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"testing"
 
@@ -98,7 +100,7 @@ func TestStepRunCarriesItsPosition(t *testing.T) {
 	created := h.createTask(t, map[string]any{"title": "loops", "workflow": "adhoc"})
 	run := &store.StepRun{
 		TaskID: created.ID, StepIndex: 0, StepID: "touch", StepType: "command",
-		Attempt: 1, Iteration: 3, LoopItem: "gamma", State: store.StepSucceeded,
+		Attempt: 1, Iteration: 3, LoopItem: "gamma", LoopTotal: 4, State: store.StepSucceeded,
 	}
 	if err := h.store.CreateStepRun(t.Context(), run); err != nil {
 		t.Fatalf("create step run: %v", err)
@@ -116,6 +118,9 @@ func TestStepRunCarriesItsPosition(t *testing.T) {
 	}
 	if steps[0].LoopItem == nil || *steps[0].LoopItem != "gamma" {
 		t.Errorf("loop_item = %v, want gamma", steps[0].LoopItem)
+	}
+	if steps[0].LoopTotal != 4 {
+		t.Errorf("loop_total = %d, want 4 — the extent the admission planned", steps[0].LoopTotal)
 	}
 }
 
@@ -152,4 +157,185 @@ func (h *taskHarness) loopOf(t *testing.T, id int64) *loopResponse {
 		t.Fatalf("detail body: %v", err)
 	}
 	return detail.Loop
+}
+
+// extentSnapshotYAML is the shape issue #317 reports wrong: a `for_each` with
+// no `count:` and no step-level `max_iterations:`, so the only number the
+// snapshot has is the global ceiling — which is not this loop's. The body has
+// two steps, so a body position is something other than 1/1.
+const extentSnapshotYAML = `name: each
+steps:
+  - id: discover
+    type: command
+    run: ls
+  - id: visit
+    type: loop
+    for_each: '{{ .Steps.discover.Result }}'
+    steps:
+      - id: touch
+        type: command
+        run: echo {{ .Loop.Item }}
+      - id: verify
+        type: command
+        run: echo ok
+`
+
+// loopBodyRun is one body row of the loop at step 1 of extentSnapshotYAML,
+// recording the extent that snapshot's list has: three items, which is the
+// number the ceiling of 10 was standing in for.
+func loopBodyRun(taskID int64, stepID string, iteration int, item string) *store.StepRun {
+	return &store.StepRun{
+		TaskID: taskID, StepIndex: 1, StepID: stepID, StepType: "command",
+		Attempt: 1, Iteration: iteration, LoopItem: item, LoopTotal: 3,
+		State: store.StepSucceeded,
+	}
+}
+
+// TestLoopRollupReportsTheRealExtent is issue #317's third fault. A 3-item
+// `for_each` under a ceiling of 10 was reporting `loop 2/10`: the ceiling is
+// a bound, not a denominator. The extent comes off the row the admission
+// wrote, and the ceiling keeps reporting itself beside it — they are two
+// numbers and neither stands in for the other.
+func TestLoopRollupReportsTheRealExtent(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	task := h.seedTask(t, extentSnapshotYAML, 1)
+
+	// Nothing has run yet: the rollup exists, but it has no extent to report
+	// and no body step to name. Guessing either would read as an answer.
+	before := h.loopOf(t, task.ID)
+	if before == nil {
+		t.Fatal("loop rollup absent while the current step is a loop")
+	}
+	if before.Total != 0 || before.BodyStep != "" || before.BodyIndex != 0 || before.BodyTotal != 0 {
+		t.Errorf("rollup before the first row = %+v, want no extent and no body clause", before)
+	}
+	if before.MaxIterations != 10 {
+		t.Errorf("max_iterations = %d, want the global ceiling of 10", before.MaxIterations)
+	}
+
+	for _, run := range []*store.StepRun{
+		loopBodyRun(task.ID, "touch", 1, "alpha"),
+		loopBodyRun(task.ID, "verify", 1, "alpha"),
+		loopBodyRun(task.ID, "touch", 2, "beta"),
+		loopBodyRun(task.ID, "verify", 2, "beta"),
+	} {
+		if err := h.store.CreateStepRun(t.Context(), run); err != nil {
+			t.Fatalf("create step run: %v", err)
+		}
+	}
+
+	got := h.loopOf(t, task.ID)
+	if got.Total != 3 {
+		t.Errorf("total = %d, want 3 — the list's real length", got.Total)
+	}
+	if got.MaxIterations != 10 {
+		t.Errorf("max_iterations = %d, want 10 — the ceiling keeps its own meaning", got.MaxIterations)
+	}
+	if got.Iteration != 2 || got.Item != "beta" {
+		t.Errorf("iteration/item = %d/%q, want 2/beta", got.Iteration, got.Item)
+	}
+	// The newest row of the highest iteration is the body step in progress.
+	if got.BodyStep != "verify" || got.BodyIndex != 2 || got.BodyTotal != 2 {
+		t.Errorf("body clause = %s %d/%d, want verify 2/2",
+			got.BodyStep, got.BodyIndex, got.BodyTotal)
+	}
+
+	// The board reads the same rollup off the list endpoint.
+	if rolled := h.listLoopOf(t, task.ID); rolled == nil || rolled.Total != 3 || rolled.BodyStep != "verify" {
+		t.Errorf("list loop rollup = %+v, want the same extent and body step", rolled)
+	}
+}
+
+// TestLoopRollupFallsBackToTheBoundForALegacyRow: a row written before the
+// extent column existed carries 0. The snapshot's own bound is then the only
+// number left, and it is the one the rollup reported for that row's whole
+// life — so it is what it keeps reporting, rather than dropping the counter.
+func TestLoopRollupFallsBackToTheBoundForALegacyRow(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	task := h.seedTask(t, loopSnapshotYAML, 1)
+	if err := h.store.CreateStepRun(t.Context(), &store.StepRun{
+		TaskID: task.ID, StepIndex: 1, StepID: "touch", StepType: "command",
+		Attempt: 1, Iteration: 2, LoopItem: "beta", State: store.StepSucceeded,
+	}); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+	got := h.loopOf(t, task.ID)
+	if got.Total != 6 {
+		t.Errorf("total = %d, want the step's own max_iterations of 6", got.Total)
+	}
+}
+
+// TestLoopRollupOmitsTheBodyClauseItCannotPlace: a row whose step id is not
+// one of the snapshot's body ids — a repair row, or any row at all once the
+// snapshot no longer parses — gets no body clause. A position counted against
+// a body the row did not run in is worse than no position.
+func TestLoopRollupOmitsTheBodyClauseItCannotPlace(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	task := h.seedTask(t, extentSnapshotYAML, 1)
+	if err := h.store.CreateStepRun(t.Context(), loopBodyRun(task.ID, "repair", 1, "alpha")); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+	got := h.loopOf(t, task.ID)
+	if got.BodyStep != "" || got.BodyIndex != 0 || got.BodyTotal != 0 {
+		t.Errorf("body clause = %+v, want none — `repair` is not a body step", got)
+	}
+	// Everything else the rollup knows is still reported.
+	if got.Iteration != 1 || got.Total != 3 || got.Driver != "for_each" {
+		t.Errorf("rollup = %+v, want driver/iteration/total intact", got)
+	}
+}
+
+// TestLoopRollupWithoutBodyIDsDegrades is the same rule reached from the
+// other side: a definition carrying no body order at all, which is what a
+// snapshot the parser can no longer make sense of leaves behind. The rollup
+// degrades to driver and iteration rather than to a body position it has
+// nothing to count against.
+func TestLoopRollupWithoutBodyIDsDegrades(t *testing.T) {
+	h := newTaskHarness(t, 0, false)
+	task := h.seedTask(t, extentSnapshotYAML, 1)
+	if err := h.store.CreateStepRun(t.Context(), loopBodyRun(task.ID, "touch", 1, "alpha")); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+	srv := &Server{deps: Deps{
+		Store:  h.store,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+	summary := snapshotSummary{
+		stepTotal: 2,
+		stepNames: []string{"discover", "visit"},
+		steps: []stepDefinition{
+			{index: 0, id: "discover", stepType: "command"},
+			{index: 1, id: "visit", stepType: "loop", loop: &loopDefinition{driver: "for_each", total: 10}},
+		},
+	}
+	got := srv.loopRollup(t.Context(), task, summary)
+	if got == nil {
+		t.Fatal("loop rollup absent")
+	}
+	if got.Driver != "for_each" || got.Iteration != 1 {
+		t.Errorf("rollup = %+v, want driver for_each at iteration 1", got)
+	}
+	if got.BodyStep != "" || got.BodyIndex != 0 || got.BodyTotal != 0 {
+		t.Errorf("body clause = %+v, want none — there is no body order to place it in", got)
+	}
+}
+
+// listLoopOf is the rollup as the board reads it, off the list endpoint.
+func (h *taskHarness) listLoopOf(t *testing.T, id int64) *loopResponse {
+	t.Helper()
+	resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: %d %s", resp.StatusCode, body)
+	}
+	var list []listTaskResponse
+	if err := json.Unmarshal(body, &list); err != nil {
+		t.Fatalf("list body: %v", err)
+	}
+	for i := range list {
+		if list[i].ID == id {
+			return list[i].Loop
+		}
+	}
+	t.Fatalf("task %d not in the list", id)
+	return nil
 }

--- a/internal/api/snapcache.go
+++ b/internal/api/snapcache.go
@@ -41,6 +41,11 @@ type stepDefinition struct {
 type loopDefinition struct {
 	driver string
 	total  int
+	// body is the loop's body step ids in declaration order (§7.8). It is
+	// what turns a body row's step id into "repair 2/3": body rows carry the
+	// *loop's* step index, so a client has nothing to count a position
+	// against unless the snapshot hands it the order.
+	body []string
 }
 
 // stepName returns the display name of step index i, or "" when the index is
@@ -119,6 +124,9 @@ func loopDefinitionOf(step workflow.Step, ceiling int) *loopDefinition {
 		return nil
 	}
 	def := &loopDefinition{driver: step.Driver()}
+	for i := range step.Steps {
+		def.body = append(def.body, step.Steps[i].ID)
+	}
 	switch {
 	case step.Count != nil:
 		def.total = *step.Count

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -255,7 +255,12 @@ type stepRunResponse struct {
 	Iteration int `json:"iteration"`
 	// LoopItem is the `for_each` item that iteration ran on; null for a
 	// `count:` loop and outside a loop.
-	LoopItem      *string `json:"loop_item"`
+	LoopItem *string `json:"loop_item"`
+	// LoopTotal is how many iterations the admission that wrote this row
+	// planned to run — the `for_each` list's real length, which the snapshot
+	// does not have. 0 for a row outside a loop, and for one written before
+	// the column existed.
+	LoopTotal     int     `json:"loop_total"`
 	State         string  `json:"state"`
 	Agent         *string `json:"agent"`
 	Model         *string `json:"model"`
@@ -328,6 +333,7 @@ func toStepRunResponse(r *store.StepRun, summary snapshotSummary) stepRunRespons
 		StepType:       r.StepType,
 		Iteration:      r.Iteration,
 		LoopItem:       nilIfEmpty(r.LoopItem),
+		LoopTotal:      r.LoopTotal,
 		PromptOverride: r.PromptOverride != "",
 		RunOverride:    r.RunOverride != "",
 		Attempt:        r.Attempt,
@@ -1003,6 +1009,30 @@ type loopResponse struct {
 	// Item is the `for_each` item the current iteration is running on; empty
 	// for a `count:` loop.
 	Item string `json:"item,omitempty"`
+	// Total is the loop's *real* extent — how many iterations the admission
+	// that is running it planned. For a `for_each` that is the derived list's
+	// length, which the snapshot cannot know: the list is rendered at run
+	// time, so a snapshot-derived denominator is the ceiling and not the
+	// loop's own number. Absent (0) until a row records one, because before
+	// the first iteration there is nothing to report and a guess would read
+	// like an answer.
+	//
+	// MaxIterations keeps its own meaning beside it — the bound the loop
+	// would block on. They are two numbers and neither stands in for the
+	// other.
+	Total int `json:"total,omitempty"`
+	// BodyStep, BodyIndex and BodyTotal name the body step the current
+	// iteration is on and its 1-based place in the body. The outer `step k/n`
+	// counts a whole loop as one step, so without these "where is this task"
+	// stops at the loop's own name.
+	//
+	// All three are absent together, and only together: a row whose step id
+	// is not one of the snapshot's body ids — a repair row, or any row at all
+	// once the snapshot no longer parses — gets no clause rather than a
+	// position counted against a body that is not the one it ran in.
+	BodyStep  string `json:"body_step,omitempty"`
+	BodyIndex int    `json:"body_index,omitempty"`
+	BodyTotal int    `json:"body_total,omitempty"`
 }
 
 // loopRollup builds the §7.8 rollup for a task whose current step is a loop,
@@ -1020,9 +1050,31 @@ func (s *Server) loopRollup(ctx context.Context, t *store.Task, summary snapshot
 		s.deps.Logger.Error("loop rollup", "task", t.ID, "error", err)
 		return out
 	}
+	// The newest row of the highest iteration is the loop's current position:
+	// its iteration and item, the extent its admission planned, and the body
+	// step it is on.
+	var current *store.StepRun
 	for i := range runs {
 		if run := &runs[i]; run.Iteration >= out.Iteration {
-			out.Iteration, out.Item = run.Iteration, run.LoopItem
+			out.Iteration, out.Item, current = run.Iteration, run.LoopItem, run
+		}
+	}
+	if current == nil {
+		// No rows: the loop has not started an iteration, so there is no
+		// extent to report. Falling back to the ceiling here would put a
+		// denominator on the wire that no admission ever planned.
+		return out
+	}
+	// A row written before migration 0026 carries no extent; the snapshot's
+	// bound is the only number left, and it is the one the rollup reported
+	// for that row's whole lifetime.
+	if out.Total = current.LoopTotal; out.Total == 0 {
+		out.Total = def.total
+	}
+	for i, id := range def.body {
+		if id == current.StepID {
+			out.BodyStep, out.BodyIndex, out.BodyTotal = id, i+1, len(def.body)
+			break
 		}
 	}
 	return out

--- a/internal/apiclient/loop_live_test.go
+++ b/internal/apiclient/loop_live_test.go
@@ -1,0 +1,112 @@
+package apiclient_test
+
+import (
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// loopWorkflow is a two-step workflow whose second step is a `for_each` with
+// no bound of its own, so the snapshot's only number is the global ceiling of
+// 10 — the wrong denominator issue #317 reports. Its body has two steps, so a
+// body position is something other than 1/1.
+const loopWorkflow = `name: each
+steps:
+  - id: discover
+    type: command
+    run: ls
+  - id: visit
+    type: loop
+    for_each: '{{ .Steps.discover.Result }}'
+    steps:
+      - id: touch
+        type: command
+        run: echo one
+      - id: verify
+        type: command
+        run: echo two
+`
+
+// loopTask creates a task parked on the loop step of loopWorkflow, with one
+// body row recording the extent its admission planned.
+func loopTask(t *testing.T, h *harness) int64 {
+	t.Helper()
+	task := &store.Task{
+		ProjectID: h.projectID, Title: "looped", WorkflowName: "each",
+		WorkflowSnapshot: loopWorkflow, BaseBranch: "main",
+		BranchName: "vincent/9-looped", State: store.TaskRunning, CurrentStep: 1,
+	}
+	if err := h.st.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	if err := h.st.CreateStepRun(t.Context(), &store.StepRun{
+		TaskID: task.ID, StepIndex: 1, StepID: "verify", StepType: "command",
+		Attempt: 1, Iteration: 2, LoopItem: "beta", LoopTotal: 3,
+		State: store.StepRunning,
+	}); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	return task.ID
+}
+
+// The wire round trip, against the real handlers: the loop's real extent and
+// the body step it is on come back on the detail rollup, on the list row a
+// board reads, and — as loop_total — on the step-run DTO. This is where the
+// server's loopResponse and the client's LoopRollup would drift apart if
+// either side grew the fields alone.
+func TestLoopRollupOverTheWire(t *testing.T) {
+	h := newHarness(t)
+	c := h.client()
+	id := loopTask(t, h)
+
+	detail, err := c.GetTask(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if detail.Loop == nil {
+		t.Fatal("no loop rollup on a task parked on a loop step")
+	}
+	// The list is where a board reads it, so both call sites are proven.
+	tasks, err := c.ListTasks(t.Context(), apiclient.ListTasksOptions{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	var listed *apiclient.LoopRollup
+	for i := range tasks {
+		if tasks[i].ID == id {
+			listed = tasks[i].Loop
+		}
+	}
+	if listed == nil {
+		t.Fatal("no loop rollup on the list row")
+	}
+
+	for name, got := range map[string]*apiclient.LoopRollup{"detail": detail.Loop, "list": listed} {
+		if got.Driver != "for_each" || got.Iteration != 2 || got.Item != "beta" {
+			t.Errorf("%s rollup = %+v, want for_each at iteration 2 on beta", name, got)
+		}
+		if got.Total != 3 {
+			t.Errorf("%s total = %d, want the list's real length of 3", name, got.Total)
+		}
+		if got.MaxIterations != 10 {
+			t.Errorf("%s max_iterations = %d, want the ceiling of 10 beside it", name, got.MaxIterations)
+		}
+		if got.BodyStep != "verify" || got.BodyIndex != 2 || got.BodyTotal != 2 {
+			t.Errorf("%s body clause = %s %d/%d, want verify 2/2",
+				name, got.BodyStep, got.BodyIndex, got.BodyTotal)
+		}
+		if want := "loop 2/3 · beta · verify 2/2"; got.Display() != want {
+			t.Errorf("%s Display() = %q, want %q", name, got.Display(), want)
+		}
+	}
+
+	// The per-row extent rides the step-run DTO, which is what a client
+	// reading rows directly counts against.
+	if len(detail.Steps) != 1 {
+		t.Fatalf("steps = %d, want the one body row", len(detail.Steps))
+	}
+	if got := detail.Steps[0].LoopTotal; got != 3 {
+		t.Errorf("step run loop_total = %d, want 3", got)
+	}
+}

--- a/internal/apiclient/loop_test.go
+++ b/internal/apiclient/loop_test.go
@@ -1,0 +1,87 @@
+package apiclient_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// TestLoopRollupClauses pins the order a narrow column drops from: the
+// counter, then the `for_each` item, then the body step — so dropping from
+// the tail loses the body step first and the counter last (issue #317).
+func TestLoopRollupClauses(t *testing.T) {
+	tests := []struct {
+		name   string
+		rollup *apiclient.LoopRollup
+		want   []string
+	}{
+		{name: "absent"},
+		{
+			name:   "before the first iteration has a row",
+			rollup: &apiclient.LoopRollup{Driver: "for_each", MaxIterations: 10},
+		},
+		{
+			name: "a count loop has no item clause",
+			rollup: &apiclient.LoopRollup{
+				Driver: "count", Iteration: 4, Total: 10, MaxIterations: 10,
+				BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+			},
+			want: []string{"loop 4/10", "repair 2/3"},
+		},
+		{
+			name: "all three, in priority order",
+			rollup: &apiclient.LoopRollup{
+				Driver: "for_each", Iteration: 4, Total: 10, MaxIterations: 10,
+				Item: "alpha", BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+			},
+			want: []string{"loop 4/10", "alpha", "repair 2/3"},
+		},
+		{
+			name: "no body step, no body clause",
+			rollup: &apiclient.LoopRollup{
+				Driver: "for_each", Iteration: 2, Total: 3, MaxIterations: 10, Item: "beta",
+			},
+			want: []string{"loop 2/3", "beta"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rollup.Clauses(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Clauses() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoopRollupCountsAgainstTheExtent: the ceiling is a bound, not a
+// denominator. A 3-item `for_each` under a ceiling of 10 reads `loop 2/3`,
+// and only a rollup with no extent at all — a row written before the server
+// recorded one — counts against the bound instead.
+func TestLoopRollupCountsAgainstTheExtent(t *testing.T) {
+	derived := &apiclient.LoopRollup{Driver: "for_each", Iteration: 2, Total: 3, MaxIterations: 10}
+	if got, want := derived.Display(), "loop 2/3"; got != want {
+		t.Errorf("Display() = %q, want %q", got, want)
+	}
+	legacy := &apiclient.LoopRollup{Driver: "for_each", Iteration: 2, MaxIterations: 10}
+	if got, want := legacy.Display(), "loop 2/10"; got != want {
+		t.Errorf("Display() with no extent = %q, want %q", got, want)
+	}
+}
+
+// TestLoopRollupDisplayJoinsItsClauses: Display is the whole rollup, which is
+// what the detail header renders; the board reads Clauses instead because it
+// has a width to fit them to.
+func TestLoopRollupDisplayJoinsItsClauses(t *testing.T) {
+	r := &apiclient.LoopRollup{
+		Driver: "for_each", Iteration: 4, Total: 10, MaxIterations: 10,
+		Item: "alpha", BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+	}
+	if got, want := r.Display(), "loop 4/10 · alpha · repair 2/3"; got != want {
+		t.Errorf("Display() = %q, want %q", got, want)
+	}
+	var absent *apiclient.LoopRollup
+	if got := absent.Display(); got != "" {
+		t.Errorf("a nil rollup renders %q, want nothing at all", got)
+	}
+}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -202,7 +203,11 @@ type StepRun struct {
 	// LoopItem is the `for_each` item that iteration ran on; nil for a
 	// `count:` loop and outside a loop.
 	LoopItem *string `json:"loop_item"`
-	State    string  `json:"state"`
+	// LoopTotal is how many iterations the admission that wrote this row
+	// planned — the real extent, 0 outside a loop and 0 for a row written
+	// before the column existed.
+	LoopTotal int    `json:"loop_total"`
+	State     string `json:"state"`
 
 	Agent  *string `json:"agent"`
 	Model  *string `json:"model"`
@@ -277,24 +282,56 @@ type ChildrenRollup struct {
 // LoopRollup is the §7.8 loop rollup: where a task is inside the `loop` step
 // it is currently on.
 type LoopRollup struct {
-	Driver        string `json:"driver"`
-	Iteration     int    `json:"iteration"`
+	Driver    string `json:"driver"`
+	Iteration int    `json:"iteration"`
+	// MaxIterations is the bound the loop would block on. Total is what it is
+	// actually running: for a `for_each` the derived list's length, which the
+	// snapshot cannot know because the list is rendered at run time. They are
+	// two numbers — a 3-item list bounded by a ceiling of 10 has Total 3 and
+	// MaxIterations 10 — and the counter reports Total whenever it has one.
 	MaxIterations int    `json:"max_iterations"`
 	Item          string `json:"item,omitempty"`
+	Total         int    `json:"total,omitempty"`
+	// BodyStep names the body step the current iteration is on, with
+	// BodyIndex its 1-based place among BodyTotal body steps. Absent together
+	// when the server could not place the row in a body it recognizes.
+	BodyStep  string `json:"body_step,omitempty"`
+	BodyIndex int    `json:"body_index,omitempty"`
+	BodyTotal int    `json:"body_total,omitempty"`
 }
 
-// Display is the short form a board row shows beside the k/n step column:
-// "loop 4/10", plus the item when a `for_each` is running one. Empty before
-// the first iteration has a row, when there is nothing yet to report.
-func (r *LoopRollup) Display() string {
+// Clauses is the rollup's parts in priority order — the counter, the
+// for_each item, the body step — so a narrow column can drop from the
+// tail. Nil before the first iteration has a row, when there is nothing yet
+// to report.
+func (r *LoopRollup) Clauses() []string {
 	if r == nil || r.Iteration == 0 {
-		return ""
+		return nil
 	}
-	out := fmt.Sprintf("loop %d/%d", r.Iteration, r.MaxIterations)
+	// Total is the loop's own extent and MaxIterations only the bound it is
+	// under; the fallback is for a server that has no extent to give — an
+	// iteration whose row predates the column.
+	total := r.Total
+	if total == 0 {
+		total = r.MaxIterations
+	}
+	out := make([]string, 0, 3)
+	out = append(out, fmt.Sprintf("loop %d/%d", r.Iteration, total))
 	if r.Item != "" {
-		out += " " + r.Item
+		out = append(out, r.Item)
+	}
+	if r.BodyStep != "" {
+		out = append(out, fmt.Sprintf("%s %d/%d", r.BodyStep, r.BodyIndex, r.BodyTotal))
 	}
 	return out
+}
+
+// Display is the full short form a header shows beside the k/n step column:
+// "loop 4/10 · alpha · repair 2/3". Empty before the first iteration has a
+// row. A column too narrow for all of it reads Clauses and drops from the
+// tail rather than truncating this string.
+func (r *LoopRollup) Display() string {
+	return strings.Join(r.Clauses(), " · ")
 }
 
 // Summary is the short form a board row shows beside `awaiting_children` —

--- a/internal/store/loopextent_test.go
+++ b/internal/store/loopextent_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A body row carries the extent the admission that wrote it planned, beside
+// the item it ran on (migration 0026, issue #317). It is written once at
+// insert and read back by every path a reader reaches a row through.
+func TestStepRunLoopTotalRoundTrip(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+
+	in := &StepRun{
+		TaskID: task.ID, StepIndex: 1, StepID: "body", StepType: "command",
+		Attempt: 1, Iteration: 2, LoopItem: "beta", LoopTotal: 3,
+		State: StepRunning,
+	}
+	if err := s.CreateStepRun(ctx, in); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+
+	got, err := s.GetStepRun(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.LoopTotal != 3 {
+		t.Errorf("GetStepRun LoopTotal = %d, want 3", got.LoopTotal)
+	}
+	if got.LoopItem != "beta" {
+		t.Errorf("GetStepRun LoopItem = %q, want beta", got.LoopItem)
+	}
+
+	// Every read path selects the same column list, so a column missing from
+	// one of them is a column missing from all of them — assert through the
+	// list readers too rather than trusting the single-row scan for them.
+	runs, err := s.ListStepRuns(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	if len(runs) != 1 || runs[0].LoopTotal != 3 {
+		t.Errorf("ListStepRuns LoopTotal = %+v, want one row carrying 3", runs)
+	}
+	at, err := s.ListStepRunsAt(ctx, task.ID, 1)
+	if err != nil {
+		t.Fatalf("ListStepRunsAt: %v", err)
+	}
+	if len(at) != 1 || at[0].LoopTotal != 3 {
+		t.Errorf("ListStepRunsAt LoopTotal = %+v, want one row carrying 3", at)
+	}
+
+	// The extent is not a mutable field: UpdateStepRun writes the row's
+	// mutable columns and leaves this one exactly as the insert wrote it,
+	// the same way it leaves `loop_item`.
+	finished := time.Now()
+	got.State, got.FinishedAt, got.LoopTotal, got.LoopItem = StepSucceeded, &finished, 99, "zeta"
+	if err := s.UpdateStepRun(ctx, got); err != nil {
+		t.Fatalf("UpdateStepRun: %v", err)
+	}
+	after, err := s.GetStepRun(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun after update: %v", err)
+	}
+	if after.LoopTotal != 3 || after.LoopItem != "beta" {
+		t.Errorf("after update LoopTotal/LoopItem = %d/%q, want 3/beta — both are insert-only",
+			after.LoopTotal, after.LoopItem)
+	}
+}
+
+// A row written outside a loop records no extent, and 0 is what says so. It
+// is the same value a pre-0026 row reads, which is what lets a reader treat
+// "no extent" as one case rather than two.
+func TestStepRunLoopTotalZeroOutsideALoop(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	task := testTask(t, s)
+
+	in := &StepRun{
+		TaskID: task.ID, StepIndex: 0, StepID: "implement", StepType: "agent",
+		Attempt: 1, State: StepRunning,
+	}
+	if err := s.CreateStepRun(ctx, in); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	got, err := s.GetStepRun(ctx, in.ID)
+	if err != nil {
+		t.Fatalf("GetStepRun: %v", err)
+	}
+	if got.LoopTotal != 0 {
+		t.Errorf("LoopTotal = %d, want 0 — a row outside a loop records no extent", got.LoopTotal)
+	}
+}
+
+// A row written before migration 0026 reads back the same 0, so a loop
+// already in flight over the upgrade renders exactly as it did before rather
+// than claiming an extent nobody recorded.
+func TestMigrateLeavesLoopTotalZeroOnPreexistingRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vincent.db")
+	migrateTo(t, path, 25)
+
+	func() {
+		db, err := sql.Open("sqlite", dsn(path))
+		if err != nil {
+			t.Fatalf("reopen at 0025: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+		db.SetMaxOpenConns(1)
+		if _, err := db.Exec(`PRAGMA foreign_keys = OFF`); err != nil {
+			t.Fatalf("disable foreign keys: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO step_runs
+			(task_id, step_index, step_id, step_type, attempt, iteration, loop_item, state, started_at)
+			VALUES (1, 0, 'body', 'command', 1, 2, 'beta', 'succeeded', ?)`,
+			formatTime(time.Now())); err != nil {
+			t.Fatalf("insert legacy row: %v", err)
+		}
+		var n int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('step_runs') WHERE name = 'loop_total'`).Scan(&n); err != nil {
+			t.Fatalf("pragma_table_info: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("loop_total exists at schema 25; the fixture is not a pre-0026 database")
+		}
+	}()
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open (migrating 25 -> %d): %v", latestSchemaVersion, err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	runs, err := s.ListStepRuns(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("step runs = %d, want the legacy row", len(runs))
+	}
+	if runs[0].LoopTotal != 0 {
+		t.Errorf("legacy LoopTotal = %d, want 0 — no extent was recorded for it", runs[0].LoopTotal)
+	}
+	if runs[0].LoopItem != "beta" {
+		t.Errorf("legacy LoopItem = %q, want beta — the added column must not shift the scan",
+			runs[0].LoopItem)
+	}
+}

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -19,7 +19,7 @@ func openTest(t *testing.T) *Store {
 
 // latestSchemaVersion tracks the newest migration file; bump alongside new
 // migrations.
-const latestSchemaVersion = 25
+const latestSchemaVersion = 26
 
 func schemaVersion(t *testing.T, s *Store) int {
 	t.Helper()

--- a/internal/store/migrations/0026_loop_extent.sql
+++ b/internal/store/migrations/0026_loop_extent.sql
@@ -1,0 +1,33 @@
+-- 0026_loop_extent: how many iterations the admission that wrote a body row
+-- planned to run — the loop's extent, recorded beside the item that row ran on
+-- (§7.8, issue #317).
+--
+-- A reader asking "iteration 2 of how many?" had no answer on the row, so it
+-- reconstructed one from the definition: `count:`, else the step's
+-- `max_iterations:`, else the global `loop.max_iterations` ceiling. For a
+-- `for_each` carrying neither, that ceiling is not the loop's number at all —
+-- a three-item loop rendered `2/10`. The extent is only knowable from the
+-- resolved list, and only the admission that resolved it knows it.
+--
+-- It is recorded rather than re-asked for the same reason `loop_item` is
+-- (migration 0009, task 016 decision 8): asking the live actor works only
+-- while one exists, so a blocked or paused loop — the one a human is actually
+-- looking at — would fall back to the ceiling again. This is decision 8's
+-- sentence carried one word further: the row already says *which item*
+-- iteration 3 ran on, and now says *how many iterations that admission
+-- planned*.
+--
+-- It is **not** a cursor (decision 7 refused one): nothing reads it back to
+-- decide what to run next, and §12.4 recovery has nothing to reconcile with
+-- it. It is display only.
+--
+-- 0 means no extent was recorded: every row outside a loop, and every row
+-- written before this migration. Readers fall back to what they did before on
+-- 0, so a task already in flight renders exactly as it did before the upgrade.
+--
+-- The value written is whatever planLoop computed, *including* its clamp
+-- against the iterations already on record — which is what keeps a shrinking
+-- `for_each` source from making a later row disagree with an earlier one.
+--
+-- No index: it is read only through rows already selected by task and step.
+ALTER TABLE step_runs ADD COLUMN loop_total INTEGER NOT NULL DEFAULT 0; -- 0 = no extent recorded

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -269,7 +269,15 @@ type StepRun struct {
 	// re-derived: it is the loop's extent, not a question, and re-asking it
 	// mid-loop would re-index a resumed iteration onto different work
 	// (decision 8).
-	LoopItem      string
+	LoopItem string
+	// LoopTotal is how many iterations the admission that wrote this row
+	// planned to run: the `count:`, or the resolved `for_each` list length.
+	// 0 means no extent was recorded — every row outside a loop, and every
+	// row written before the column existed.
+	//
+	// Like LoopItem it is written once, at insert, and never updated: it is
+	// what *that* admission planned, not a running total (migration 0026).
+	LoopTotal     int
 	State         StepRunState
 	Agent         string // adapter name; agent steps only
 	Model         string // resolved model as passed to the adapter (spec §8.6); "" = CLI default

--- a/internal/store/steps.go
+++ b/internal/store/steps.go
@@ -10,6 +10,7 @@ import (
 )
 
 const stepRunColumns = `id, task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
+	loop_total,
 	state, agent, model, effort, pid,
 	proc_started_at, proc_identity, container_id, exit_code, check_exit_code, failure_reason, skip_reason,
 	result_summary,
@@ -97,13 +98,15 @@ func createStepRun(ctx context.Context, db execer, r *StepRun) error {
 	}
 	res, err := db.ExecContext(ctx, `
 		INSERT INTO step_runs (task_id, step_index, step_id, step_type, attempt, iteration, loop_item,
+			loop_total,
 			state, agent, model, effort, pid,
 			proc_started_at, proc_identity, container_id, exit_code, check_exit_code, failure_reason,
 			skip_reason,
 			result_summary, stdout_tail, status_message, prompt_override, run_override, transcript_path,
 			input_tokens, output_tokens, cost_usd, input_wait_ms, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.TaskID, r.StepIndex, r.StepID, r.StepType, r.Attempt, r.Iteration, nullString(r.LoopItem),
+		r.LoopTotal,
 		string(r.State),
 		nullString(r.Agent), nullString(r.Model), nullString(r.Effort),
 		r.PID, formatTimePtr(r.ProcStartedAt), r.ProcIdentity, r.ContainerID, r.ExitCode, r.CheckExitCode,
@@ -378,7 +381,7 @@ func scanStepRun(row rowScanner) (*StepRun, error) {
 		started                                 string
 	)
 	if err := row.Scan(&r.ID, &r.TaskID, &r.StepIndex, &r.StepID, &r.StepType, &r.Attempt,
-		&r.Iteration, &loopItem,
+		&r.Iteration, &loopItem, &r.LoopTotal,
 		(*string)(&r.State), &agent, &model, &effort, &pid, &procStarted, &procIdentity, &containerID,
 		&exitCode, &checkExit,
 		&failure, &skip, &summary, &stdoutTail, &status, &promptOv, &runOv, &transcript,

--- a/internal/taskrun/condition.go
+++ b/internal/taskrun/condition.go
@@ -72,6 +72,7 @@ func (r *Runner) recordDecisionRow(
 		// loop.
 		Iteration:     env.iteration(),
 		LoopItem:      env.loopItem(),
+		LoopTotal:     env.loopTotal(),
 		State:         state,
 		SkipReason:    skipReason,
 		FailureReason: failureReason,

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -978,6 +978,7 @@ func (r *Runner) runAttempt(ctx context.Context, env *stepEnv, attempt int, prev
 		Attempt:   attempt,
 		Iteration: env.iteration(),
 		LoopItem:  env.loopItem(),
+		LoopTotal: env.loopTotal(),
 		State:     store.StepRunning,
 	}
 	var sel agent.Selection

--- a/internal/taskrun/loop.go
+++ b/internal/taskrun/loop.go
@@ -34,8 +34,12 @@ import (
 type loopEnv struct {
 	iteration int // 1-based
 	item      string
-	isFirst   bool
-	isLast    bool
+	// total is the extent this admission planned — plan.total, recorded on
+	// every body row beside its item so a reader can say "2 of 3" without
+	// re-deriving a number the loop definition does not carry (issue #317).
+	total   int
+	isFirst bool
+	isLast  bool
 	// pos is this step's position in the body, and order maps every body
 	// step id to its own. Together they are the third component of the
 	// position comparison stepEnv.precedes makes (decision 9).
@@ -64,6 +68,15 @@ func (e *stepEnv) loopItem() string {
 		return ""
 	}
 	return e.loop.item
+}
+
+// loopTotal is the extent recorded on this step's rows: how many iterations
+// the admission that writes them planned to run. 0 outside a loop.
+func (e *stepEnv) loopTotal() int {
+	if e.loop == nil {
+		return 0
+	}
+	return e.loop.total
 }
 
 // loopPlan is a loop's extent for one admission: how many iterations it will
@@ -170,6 +183,7 @@ func (r *Runner) runIteration(
 			loop: &loopEnv{
 				iteration: iteration,
 				item:      itemAt(plan.items, iteration),
+				total:     plan.total,
 				isFirst:   iteration == 1,
 				isLast:    iteration == plan.total,
 				pos:       pos,

--- a/internal/taskrun/loopextent_test.go
+++ b/internal/taskrun/loopextent_test.go
@@ -1,0 +1,138 @@
+package taskrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// loopTotalsAt is the extent recorded on each body row of one step index, in
+// row order. Rows the loop itself owns have no iteration and are left out.
+func loopTotalsAt(runs []store.StepRun, index int, stepID string) []int {
+	var out []int
+	for _, r := range runs {
+		if r.StepIndex == index && r.Iteration > 0 && (stepID == "" || r.StepID == stepID) {
+			out = append(out, r.LoopTotal)
+		}
+	}
+	return out
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestLoopCountRecordsItsExtentOnEveryBodyRow: a `count:` loop writes how many
+// iterations it planned onto every row it produces (issue #317).
+//
+// The number was previously only knowable from the definition, which is why a
+// reader had to guess at one — and guessed the global ceiling for the driver
+// that carries no number at all. Recording it beside the item costs one column
+// and answers "2 of how many?" from the row, which is the only place a
+// blocked or paused loop still has an answer.
+func TestLoopCountRecordsItsExtentOnEveryBodyRow(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+
+	snapshot := loopSnapshot("count: 5", commandStep("tick", appendCmd("ticks.txt", "x")))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	got := loopTotalsAt(h.stepRuns(t, task.ID), 0, "tick")
+	if !equalInts(got, []int{5, 5, 5, 5, 5}) {
+		t.Errorf("loop_total column = %v, want 5 on each of five body rows", got)
+	}
+}
+
+// TestLoopForEachRecordsItsListLengthOnEveryBodyRow: the driver that opened
+// #317. A three-item `for_each` with neither `count:` nor `max_iterations:`
+// records 3 — its own number, not the ceiling that happens to bound it.
+func TestLoopForEachRecordsItsListLengthOnEveryBodyRow(t *testing.T) {
+	h := newEngineHarness(t)
+	h.start(t)
+
+	snapshot := loopSnapshot("for_each: [alpha, beta, gamma]",
+		commandStep("visit", appendCmd("items.txt", "{{ .Loop.Item }}")))
+	task := h.createTask(t, snapshot)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	runs := h.stepRuns(t, task.ID)
+	if got := loopTotalsAt(runs, 0, "visit"); !equalInts(got, []int{3, 3, 3}) {
+		t.Errorf("loop_total column = %v, want 3 on each of three body rows", got)
+	}
+	// The extent is recorded beside the item, not instead of it.
+	var items []string
+	for _, r := range runs {
+		if r.Iteration > 0 && r.StepID == "visit" {
+			items = append(items, r.LoopItem)
+		}
+	}
+	if !equalStrings(items, []string{"alpha", "beta", "gamma"}) {
+		t.Errorf("loop_item column = %v, want [alpha beta gamma]", items)
+	}
+}
+
+// TestLoopExtentOnReadmissionIsTheClampedOne: a loop re-admitted over rows it
+// already has records the extent planLoop computed, clamp included.
+//
+// planLoop never lets a re-derived `for_each` list shorten a loop below the
+// iterations already on record (§7.8, task 016 decision 8). Recording the
+// pre-clamp list length instead would let a later row disagree with an earlier
+// one about the same loop — row 1 saying "of 3", row 3 saying "of 1" — which
+// is the one way a per-row extent can be worse than the guess it replaces.
+//
+// The fixture stands in for an admission interrupted mid-body: iterations 1
+// and 2 have a finished `head` row each and no `tail` row, against a list that
+// now re-derives to a single item.
+func TestLoopExtentOnReadmissionIsTheClampedOne(t *testing.T) {
+	h := newEngineHarness(t)
+	ctx := t.Context()
+
+	snapshot := loopSnapshot("for_each: [alpha]",
+		commandStep("head", appendCmd("head.txt", "h")),
+		commandStep("tail", appendCmd("tail.txt", "t")),
+	)
+	task := h.createTask(t, snapshot)
+
+	// Seeded before the scheduler runs, so the task is admitted onto them.
+	for i, item := range []string{"alpha", "beta"} {
+		finished := time.Now()
+		if err := h.store.CreateStepRun(ctx, &store.StepRun{
+			TaskID: task.ID, StepIndex: 0, StepID: "head", StepType: "command",
+			Attempt: 1, Iteration: i + 1, LoopItem: item,
+			State: store.StepSucceeded, FinishedAt: &finished,
+		}); err != nil {
+			t.Fatalf("seed iteration %d: %v", i+1, err)
+		}
+	}
+	h.start(t)
+
+	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
+	if done.State != store.TaskDone {
+		t.Fatalf("task state = %s (block_reason %q), want done", done.State, done.BlockReason)
+	}
+	// Two iterations survive the clamp, so both `tail` rows say "of 2" — the
+	// list length of 1 is never what any row records.
+	if got := loopTotalsAt(h.stepRuns(t, task.ID), 0, "tail"); !equalInts(got, []int{2, 2}) {
+		t.Errorf("loop_total on the resumed rows = %v, want [2 2] — the clamped extent, "+
+			"not the one-item list it re-derived", got)
+	}
+	if got := countLines(t, done.WorktreePath, "tail.txt"); got != 2 {
+		t.Errorf("tail ran %d times, want 2 — the clamp keeps both recorded iterations", got)
+	}
+}

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -200,7 +200,16 @@ var bindings = []binding{
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxTimeline, hint: "tab views", priority: 1},
 	{key: "]", label: "move to the next task view ([ goes back)", scope: scopePanel, context: ctxTimeline, hint: "[/] views", priority: 2},
 	{key: "down", label: "select an attempt (↑/↓); scrollback is per attempt", scope: scopePanel, context: ctxTimeline, hint: "↑/↓ attempts", priority: 3},
-	{key: "enter", label: "open the selected attempt in the Output tab", scope: scopePanel, context: ctxTimeline, hint: "enter output", priority: 3},
+	{key: "enter", label: "open the selected attempt in the Output tab, or open the folded iteration/round tier the cursor is on", scope: scopePanel, context: ctxTimeline, hint: "enter output", priority: 3},
+	// Folding a loop's iterations and a `fan_out`'s rounds (issue #317). The
+	// Diff tab's vocabulary verbatim, because it is the same gesture on the
+	// same screen. ↑/↓ stop once on a folded tier — its first row — so every
+	// selection they reach is drawn.
+	{key: "space", label: "open or close the iteration/round tier the cursor is in (enter and →/← too)", scope: scopePanel, context: ctxTimeline, hint: "space fold", priority: 4, fold: true},
+	{key: "right", label: "open the folded tier the cursor is in", scope: scopePanel, context: ctxTimeline, priority: 5, fold: true},
+	{key: "left", label: "close the tier the cursor is in", scope: scopePanel, context: ctxTimeline, priority: 6, fold: true},
+	{key: "O", label: "open every iteration and round tier of this task", scope: scopePanel, context: ctxTimeline, hint: "O/C fold all", priority: 7, fold: true},
+	{key: "C", label: "close every one — the timeline opens with the latest pass showing", scope: scopePanel, context: ctxTimeline, priority: 8, fold: true},
 
 	// Task details.
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxTaskDetails, hint: "tab views", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -338,6 +339,52 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 			v.updateKey(registryKey(t, "enter"))
 			if v.tab != taskTabOutput || v.detail.selectedRun != selected {
 				t.Fatalf("enter opened tab %v with run %d, want Output with run %d", v.tab, v.detail.selectedRun, selected)
+			}
+		},
+		// The five fold keys (issue #317). Each drives the workspace on a
+		// task whose step 1 has three passes, where the two earlier tiers are
+		// folded shut and the cursor starts on the first of them.
+		"space": func(t *testing.T) {
+			v := tierTaskView(t, 1, 2, 3)
+			selectTier(t, v.detail, 1)
+			v.updateKey(registryKey(t, "space"))
+			if v.detail.timelineFolded() {
+				t.Fatal("space did not open the tier under the cursor")
+			}
+			v.updateKey(registryKey(t, "space"))
+			if !v.detail.timelineFolded() {
+				t.Fatal("space did not close it again")
+			}
+		},
+		"right": func(t *testing.T) {
+			v := tierTaskView(t, 1, 2, 3)
+			selectTier(t, v.detail, 1)
+			v.updateKey(registryKey(t, "right"))
+			if v.detail.timelineFolded() {
+				t.Fatal("→ did not open the folded tier")
+			}
+		},
+		"left": func(t *testing.T) {
+			v := tierTaskView(t, 1, 2, 3)
+			selectTier(t, v.detail, 3)
+			v.updateKey(registryKey(t, "left"))
+			if !v.detail.timelineFolded() {
+				t.Fatal("← did not close the tier the cursor is in")
+			}
+		},
+		"O": func(t *testing.T) {
+			v := tierTaskView(t, 1, 2, 3)
+			v.updateKey(registryKey(t, "O"))
+			if got := v.detail.renderTimeline(200); strings.Contains(got, diffFoldClosed) {
+				t.Fatalf("O left a tier folded:\n%s", got)
+			}
+		},
+		"C": func(t *testing.T) {
+			v := tierTaskView(t, 1, 2, 3)
+			v.updateKey(registryKey(t, "C"))
+			got := v.detail.renderTimeline(200)
+			if strings.Contains(got, diffFoldOpen) {
+				t.Fatalf("C left a tier open:\n%s", got)
 			}
 		},
 	},

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -999,7 +999,11 @@ type boardCell struct {
 // cellsFor is one task's cells in column order. It and boardColumns share one
 // shape — the same optional columns in the same order — and move together; a
 // row that disagrees with the column set indexes the table out of range.
-func (b *board) cellsFor(t apiclient.Task, now time.Time, indent string, set columnSet) []boardCell {
+//
+// cols is passed for the widths, not the shape: the STEP cell chooses how
+// much of a loop rollup it can say before it is laid out, because dropping a
+// clause is a better answer there than wrapping one (formatStep).
+func (b *board) cellsFor(t apiclient.Task, now time.Time, indent string, set columnSet, cols []table.Column) []boardCell {
 	cells := make([]boardCell, 0, maxBoardColumns)
 	plain := func(text string) boardCell { return boardCell{text: text} }
 	if set.mark {
@@ -1023,7 +1027,7 @@ func (b *board) cellsFor(t apiclient.Task, now time.Time, indent string, set col
 	cells = append(cells,
 		boardCell{text: t.Title, wrap: true, indent: indent},
 		boardCell{text: boardStateLabel(t), style: stateStyles[t.State], wrap: true},
-		boardCell{text: formatStep(t, set.stepName), wrap: true},
+		boardCell{text: formatStep(t, set.stepName, columnWidth(cols, "STEP")), wrap: true},
 		plain(elapsed),
 	)
 	if set.cost {
@@ -1080,7 +1084,7 @@ func (b *board) rowHeight(rows []boardRow, cols []table.Column, set columnSet) i
 		if r.header {
 			continue
 		}
-		for _, lines := range layoutCells(b.cellsFor(r.task, now, indent, set), cols) {
+		for _, lines := range layoutCells(b.cellsFor(r.task, now, indent, set, cols), cols) {
 			h = max(h, len(lines))
 		}
 		if h >= boardRowLines {
@@ -1109,7 +1113,7 @@ func (b *board) rowsFor(rows []boardRow, cols []table.Column, set columnSet) []t
 		// Continuations follow their first line, so the layout is computed
 		// once per task and read down.
 		if r.line == 0 || lines == nil {
-			lines = layoutCells(b.cellsFor(r.task, now, indent, set), cols)
+			lines = layoutCells(b.cellsFor(r.task, now, indent, set, cols), cols)
 		}
 		row := make(table.Row, 0, maxBoardColumns)
 		for _, cell := range lines {

--- a/internal/tui/board_test.go
+++ b/internal/tui/board_test.go
@@ -256,14 +256,14 @@ func TestFormatHelpers(t *testing.T) {
 		t.Errorf("cost = %q", got)
 	}
 	// An unparsable snapshot has no step count; "1/0" would be a lie.
-	if got := formatStep(apiclient.Task{StepTotal: 0}, true); got != "—" {
+	if got := formatStep(apiclient.Task{StepTotal: 0}, true, widthStepLong); got != "—" {
 		t.Errorf("stepless task = %q, want a dash", got)
 	}
-	withName := formatStep(apiclient.Task{CurrentStep: 1, StepTotal: 6, StepName: "build"}, true)
+	withName := formatStep(apiclient.Task{CurrentStep: 1, StepTotal: 6, StepName: "build"}, true, widthStepLong)
 	if withName != "2/6 build" {
 		t.Errorf("step = %q, want %q", withName, "2/6 build")
 	}
-	if noName := formatStep(apiclient.Task{CurrentStep: 1, StepTotal: 6, StepName: "build"}, false); noName != "2/6" {
+	if noName := formatStep(apiclient.Task{CurrentStep: 1, StepTotal: 6, StepName: "build"}, false, widthStepShort); noName != "2/6" {
 		t.Errorf("narrow step = %q, want %q", noName, "2/6")
 	}
 }

--- a/internal/tui/boardcols.go
+++ b/internal/tui/boardcols.go
@@ -60,13 +60,35 @@ const (
 	maxTitle = 64
 	// widthStepMax and widthStatusMax are how far a surplus may take those
 	// two columns before the rest goes back to the title (task 050 decision
-	// 3). The step's ceiling fits `3/7 green · loop 4/10` — 21 cells — with
-	// room for a step name longer than the sample's; the status' is a couple
-	// of the board's lines of prose, past which wrapping is the better answer
-	// than a column nothing else can see around.
-	widthStepMax   = 32
+	// 3). The step's ceiling is measured off its widest content, a task in a
+	// `for_each` loop reporting its body step: `3/7 green · loop 4/10 ·
+	// repair 2/3` is 34 cells, and formatStep drops clauses from the tail
+	// below that rather than wrapping. The status' is a couple of the board's
+	// lines of prose, past which wrapping is the better answer than a column
+	// nothing else can see around.
+	//
+	// Amended 2026-09-03 (issue #317): 32 was the same measurement taken
+	// against `3/7 green · loop 4/10` — 21 cells — plus room for a longer
+	// step name. The body-step clause is 13 cells more, so a ceiling of 34
+	// now buys the full sample exactly and the slack goes to the title, which
+	// is the column that always has an appetite for it.
+	widthStepMax   = 34
 	widthStatusMax = 96
 )
+
+// columnWidth is the width the current column set gave the column headed
+// title, or 0 when this board is not carrying it. cellsFor and boardColumns
+// already share one shape (the same optional columns in the same order), so
+// the heading is the one stable name a cell can find its own width by — a
+// cell's index moves with every optional column ahead of it.
+func columnWidth(cols []table.Column, title string) int {
+	for i := range cols {
+		if cols[i].Title == title {
+			return cols[i].Width
+		}
+	}
+	return 0
+}
 
 // maxBoardColumns is every column the widest board can carry — the size a row
 // is built at, so rowsFor and groupHeaderRow never grow their slice mid-loop.

--- a/internal/tui/boardloop_test.go
+++ b/internal/tui/boardloop_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The board's STEP column under a loop rollup (issue #317). formatStep's own
+// drop order is pinned in detailloop_test.go; what these prove is that a real
+// board, at the widths that actually produce each STEP width, renders that
+// order — and that a task carrying no rollup is untouched by any of it.
+
+// loopedBoard is a flat board holding one running task on step 3 of 7, in a
+// loop the caller describes.
+func loopedBoard(rollup *apiclient.LoopRollup) *board {
+	b := testBoard()
+	t := task(1, stateRunning, withStep("green", 2, 7))
+	t.Loop = rollup
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{t}})
+	return b
+}
+
+// TestBoardStepColumnDropsFromTheTail walks the three widths a flat board
+// gives the STEP column — widthStepLong, a middle tier bought with surplus,
+// and its ceiling — and pins what survives at each. The clause dropped first
+// is the body step, then the `for_each` item, then the counter.
+func TestBoardStepColumnDropsFromTheTail(t *testing.T) {
+	rollup := &apiclient.LoopRollup{
+		Driver: "for_each", Iteration: 4, Total: 10, MaxIterations: 10,
+		Item: "alpha", BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+	}
+	for _, tt := range []struct {
+		name  string
+		width int
+		want  string
+		// gone is what the width could not afford, which must not appear
+		// anywhere on the board — not wrapped onto a second line either.
+		gone []string
+	}{
+		{
+			name: "at the column's base width only k/n and the name fit",
+			// 18 cells: `3/7 green · loop 4/10` is 21, so even the counter goes.
+			width: 110, want: "3/7 green", gone: []string{"loop 4/10", "alpha", "repair"},
+		},
+		{
+			name:  "a middle tier buys the counter",
+			width: 170, want: "3/7 green · loop 4/10", gone: []string{"alpha", "repair"},
+		},
+		{
+			name:  "the ceiling buys the item too",
+			width: 190, want: "3/7 green · loop 4/10 · alpha", gone: []string{"repair"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ansi.Strip(loopedBoard(rollup).render(tt.width, 20))
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("a %d-column board does not show %q:\n%s", tt.width, tt.want, out)
+			}
+			for _, absent := range tt.gone {
+				if strings.Contains(out, absent) {
+					t.Errorf("a %d-column board shows %q, which does not fit its STEP column:\n%s",
+						tt.width, absent, out)
+				}
+			}
+		})
+	}
+
+	// A `count:` loop has no item clause, so the same ceiling reaches the
+	// body step — the tier widthStepMax is measured off.
+	out := ansi.Strip(loopedBoard(&apiclient.LoopRollup{
+		Driver: "count", Iteration: 4, Total: 10, MaxIterations: 10,
+		BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+	}).render(190, 20))
+	if want := "3/7 green · loop 4/10 · repair 2/3"; !strings.Contains(out, want) {
+		t.Errorf("a 190-column board does not show %q:\n%s", want, out)
+	}
+}
+
+// TestBoardWithoutALoopIsUnchanged: the fitting is dead code for every task
+// not in a loop, which is nearly every task. A board of them must render byte
+// for byte as it did before the clauses existed — at every width, including
+// the ones the loop tiers are bought at.
+func TestBoardWithoutALoopIsUnchanged(t *testing.T) {
+	for _, width := range []int{80, 110, 170, 190, 200} {
+		before := loopedBoard(nil).render(width, 20)
+		// A rollup with no iteration yet reports nothing, so it is the same
+		// board: that is what keeps a loop's first moments from flickering a
+		// half-built clause onto the row.
+		after := loopedBoard(&apiclient.LoopRollup{Driver: "count", MaxIterations: 10}).render(width, 20)
+		if before != after {
+			t.Errorf("width %d: a rollup with no iteration changed the board:\n%s\n---\n%s",
+				width, before, after)
+		}
+		if strings.Contains(ansi.Strip(before), "loop ") {
+			t.Errorf("width %d: a task with no loop shows a loop clause:\n%s", width, before)
+		}
+	}
+	// Guard the assertion itself: an empty render would satisfy everything
+	// above.
+	if out := ansi.Strip(loopedBoard(nil).render(110, 20)); !strings.Contains(out, "3/7 green") {
+		t.Fatalf("the fixture board renders no step cell at all:\n%s", out)
+	}
+}

--- a/internal/tui/boardrows.go
+++ b/internal/tui/boardrows.go
@@ -337,21 +337,37 @@ func wrapCellLines(text string, width, height int) []string {
 // that would not parse has no step count, so it renders a dash rather than
 // a confident "1/0".
 //
-// A task inside a `loop` gets its iteration appended — `3/7 green · loop 4/10`
-// — because k/n alone says nothing about the one number that is moving
-// (§7.8, task 016 decision 14). Every other task carries no rollup and reads
-// exactly as it did.
-func formatStep(t apiclient.Task, withName bool) string {
+// A task inside a `loop` gets its position appended — `3/7 green · loop 4/10
+// · repair 2/3` — because k/n counts the whole loop as one step and so says
+// nothing about either number that is moving (§7.8, task 016 decision 14).
+// Every other task carries no rollup and reads exactly as it did.
+//
+// Those clauses are *fitted* to the column rather than left for the cell to
+// wrap: three of them outgrow every width below widthStepMax, and a STEP
+// column spilling onto a second and third line to finish a counter is the
+// row height spent on the least of what the row says. width is the STEP
+// column's own width, so the clauses drop from the tail — the body step
+// first, then the item, then the counter — and what is left always fits on
+// one line.
+func formatStep(t apiclient.Task, withName bool, width int) string {
 	k, n, ok := t.StepDisplay()
 	if !ok {
 		return "—"
 	}
 	s := fmt.Sprintf("%d/%d", k, n)
-	if withName && t.StepName != "" {
+	if !withName {
+		// The narrow column shows k/n alone; the loop goes with the name,
+		// because a bare `loop 4/10` beside no step name names nothing.
+		return s
+	}
+	if t.StepName != "" {
 		s += " " + t.StepName
 	}
-	if loop := t.Loop.Display(); withName && loop != "" {
-		s += " · " + loop
+	for clauses := t.Loop.Clauses(); len(clauses) > 0; clauses = clauses[:len(clauses)-1] {
+		fitted := s + " · " + strings.Join(clauses, " · ")
+		if ansi.StringWidth(fitted) <= width {
+			return fitted
+		}
 	}
 	return s
 }

--- a/internal/tui/boardwrap_test.go
+++ b/internal/tui/boardwrap_test.go
@@ -84,13 +84,13 @@ func TestTitleCapSpendsTheSurplus(t *testing.T) {
 		{width: 120, g: grouped, title: 50, step: widthStepLong, wantStatusColumnGated: true},
 		// The give-back band: STATUS is gated off, STEP fills, and the rest
 		// comes back to the title rather than rendering as dead cells.
-		{width: 160, g: grouped, title: 76, step: widthStepMax, wantStatusColumnGated: true},
+		{width: 160, g: grouped, title: 74, step: widthStepMax, wantStatusColumnGated: true},
 		// STATUS admitted: the title drops to the cap and both other columns
 		// take the surplus in order.
-		{width: 200, g: grouped, title: maxTitle, step: widthStepMax, status: 50},
+		{width: 200, g: grouped, title: maxTitle, step: widthStepMax, status: 48},
 		{width: 200, g: nil, title: maxTitle, step: 22, status: widthStatus},
 		// Both ceilings reached: only now does the title exceed its cap.
-		{width: 300, g: grouped, title: 118, step: widthStepMax, status: widthStatusMax},
+		{width: 300, g: grouped, title: 116, step: widthStepMax, status: widthStatusMax},
 	} {
 		t.Run(strconv.Itoa(tc.width)+" "+tc.g.label(), func(t *testing.T) {
 			cols, _ := boardColumns(tc.width, tc.g, false)

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -179,6 +179,13 @@ type detail struct {
 	// kept so a click can name the attempt on the line it landed on.
 	timelineTop int
 	visibleRuns []int64
+	// timelineFolds records the iteration and round tiers a reader has opened
+	// or closed in the Steps & Attempts timeline. It holds *decisions only*:
+	// a tier that is absent renders at the arrival default, latest-open (task
+	// 016 decision 14), which is what lets a tier arriving mid-run open by
+	// itself while a refresh cannot close one the reader opened. `open` and
+	// `deselect` clear it, so another task starts at the default again.
+	timelineFolds map[tierKey]bool
 
 	width, height int
 }
@@ -335,6 +342,7 @@ func (d *detail) open(id int64, stateHint string) tea.Cmd {
 	d.task = apiclient.TaskDetail{}
 	d.loaded, d.loadErr = false, nil
 	d.selectedRun, d.displayRun = 0, 0
+	d.timelineFolds = nil // the folds a reader opened belong to that task
 	d.resetOutput()
 	d.buffer = nil // held output belongs to the task being left
 	d.focus = focusTimeline
@@ -355,6 +363,7 @@ func (d *detail) deselect() {
 	d.task = apiclient.TaskDetail{}
 	d.loaded, d.loadErr = false, nil
 	d.selectedRun, d.displayRun = 0, 0
+	d.timelineFolds = nil
 	d.resetOutput()
 	d.buffer = nil
 	d.actions.clear()
@@ -740,9 +749,22 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	if d.focus == focusTimeline {
 		switch msg.String() {
 		case "up", "k":
-			return d.moveSelection(-1)
+			return d.moveTimelineSelection(-1)
 		case "down", "j":
-			return d.moveSelection(1)
+			return d.moveTimelineSelection(1)
+		// The fold keys live here rather than in the workspace so the popup's
+		// timeline and the full-screen one are the same pane in the same
+		// state. ←/→ keep no alias: h/l are the Output tab's attempt walk.
+		case " ", "space":
+			return d.toggleTimelineFold()
+		case "right":
+			return d.setTimelineFold(true)
+		case "left":
+			return d.setTimelineFold(false)
+		case "O":
+			return d.setAllTimelineFolds(true)
+		case "C":
+			return d.setAllTimelineFolds(false)
 		}
 		return nil
 	}
@@ -808,6 +830,10 @@ func (d *detail) syncFollowToViewport() {
 	d.following = false
 }
 
+// moveSelection walks every attempt in timeline order, drawn or not. This is
+// the Output tab's ←/→, whose job is to reach each attempt's output in turn —
+// a fold is a fact about the timeline pane and must not hide an attempt from
+// the pane that exists to show it.
 func (d *detail) moveSelection(delta int) tea.Cmd {
 	runs := d.attempts()
 	if len(runs) == 0 {
@@ -817,9 +843,152 @@ func (d *detail) moveSelection(delta int) tea.Cmd {
 	if i < 0 {
 		i = len(runs) - 1
 	}
-	i = min(max(i+delta, 0), len(runs)-1)
-	d.selectedRun = runs[i].ID
+	return d.selectRun(runs, i+delta)
+}
+
+// moveTimelineSelection is ↑/↓ on the timeline, where a folded tier is a
+// single cursor stop — its first row — and renderTimeline highlights that
+// tier's header while such a row is selected. Every selection this can reach
+// is therefore drawn; walking onto an undrawn row left cursorLine at 0, so
+// the highlight vanished and the window jumped to the top of the timeline
+// (issue #317).
+//
+// A separate entry point rather than a flag read off d.focus: which of the
+// two moves is wanted is the caller's business — the wheel over the Steps
+// tab wants this one, the Output tab's ←/→ want the other — and correlating
+// it with a field is how the two came to share the wrong behaviour.
+func (d *detail) moveTimelineSelection(delta int) tea.Cmd {
+	runs := d.attempts()
+	if len(runs) == 0 {
+		return nil
+	}
+	stops := d.timelineStops(runs)
+	if len(stops) == 0 {
+		return nil
+	}
+	i := d.runIndex(d.selectedRun)
+	if i < 0 {
+		i = len(runs) - 1
+	}
+	// The cursor can sit on a row that is not itself a stop — `C` folds the
+	// tier under it — so a move from there steps to the neighbouring stop
+	// instead of counting from a position the list no longer has.
+	pos, exact := 0, false
+	for p, s := range stops {
+		if s == i {
+			pos, exact = p, true
+			break
+		}
+		if s < i {
+			pos = p + 1
+		}
+	}
+	switch {
+	case exact:
+		pos += delta
+	case delta < 0:
+		pos--
+	}
+	pos = min(max(pos, 0), len(stops)-1)
+	return d.selectRun(runs, stops[pos])
+}
+
+// timelineStops are the positions in `runs` that ↑/↓ may land on: every drawn
+// row, plus the first row of each folded tier, which stands for the tier its
+// header draws.
+func (d *detail) timelineStops(runs []apiclient.StepRun) []int {
+	loops := loopIndexes(runs)
+	latest := latestIterations(runs)
+	stops := make([]int, 0, len(runs))
+	seen := map[tierKey]bool{}
+	for i, r := range runs {
+		k := tierKey{r.StepIndex, r.Iteration}
+		switch {
+		case !loops[r.StepIndex], d.tierOpen(r.StepIndex, r.Iteration, latest[r.StepIndex]):
+			stops = append(stops, i)
+		case !seen[k]:
+			seen[k] = true
+			stops = append(stops, i)
+		}
+	}
+	return stops
+}
+
+func (d *detail) selectRun(runs []apiclient.StepRun, i int) tea.Cmd {
+	d.selectedRun = runs[min(max(i, 0), len(runs)-1)].ID
 	return d.syncOutput()
+}
+
+// tierKey identifies one fold tier of the timeline: an iteration of a `loop`
+// or a round of a `fan_out`, which ride the same column (task 080 decision 3).
+type tierKey struct {
+	index     int
+	iteration int
+}
+
+// tierOpen reports whether a tier renders its attempts. `latest` is the
+// highest iteration its step index has a row for — the tier that is open
+// until a reader says otherwise.
+func (d *detail) tierOpen(index, iteration, latest int) bool {
+	if open, ok := d.timelineFolds[tierKey{index, iteration}]; ok {
+		return open
+	}
+	return iteration == latest
+}
+
+// timelineTier is the tier the timeline cursor sits in, and false when the
+// selected row is at a step index that renders no tiers at all.
+func (d *detail) timelineTier() (tierKey, int, bool) {
+	runs := d.attempts()
+	sel := d.runByID(d.selectedRun)
+	if sel.ID == 0 || !loopIndexes(runs)[sel.StepIndex] {
+		return tierKey{}, 0, false
+	}
+	return tierKey{sel.StepIndex, sel.Iteration}, latestIterations(runs)[sel.StepIndex], true
+}
+
+// timelineFolded reports whether the cursor sits inside a tier that is folded
+// shut — the state in which `enter` opens the tier instead of carrying the
+// reader to the Output tab.
+func (d *detail) timelineFolded() bool {
+	k, latest, ok := d.timelineTier()
+	return ok && !d.tierOpen(k.index, k.iteration, latest)
+}
+
+// setTimelineFold opens (→) or closes (←) the tier under the cursor.
+func (d *detail) setTimelineFold(open bool) tea.Cmd {
+	if k, _, ok := d.timelineTier(); ok {
+		d.setFold(k, open)
+	}
+	return nil
+}
+
+// toggleTimelineFold is `space`, and `enter` on a folded tier.
+func (d *detail) toggleTimelineFold() tea.Cmd {
+	if k, latest, ok := d.timelineTier(); ok {
+		d.setFold(k, !d.tierOpen(k.index, k.iteration, latest))
+	}
+	return nil
+}
+
+// setAllTimelineFolds acts on every tier of the task — `O` and `C`, the Diff
+// tab's two letters in the same meaning.
+func (d *detail) setAllTimelineFolds(open bool) tea.Cmd {
+	runs := d.attempts()
+	loops := loopIndexes(runs)
+	for _, r := range runs {
+		if loops[r.StepIndex] {
+			d.setFold(tierKey{r.StepIndex, r.Iteration}, open)
+		}
+	}
+	return nil
+}
+
+func (d *detail) setFold(k tierKey, open bool) {
+	if d.timelineFolds == nil {
+		d.timelineFolds = map[tierKey]bool{}
+	}
+	d.timelineFolds[k] = open
 }
 
 // attempts returns every attempt in timeline order: by step, then by

--- a/internal/tui/detailloop_test.go
+++ b/internal/tui/detailloop_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/lezli01/vincent/internal/apiclient"
 )
 
@@ -80,9 +82,10 @@ func TestDetailTimelineGroupsLoopIterations(t *testing.T) {
 	}
 }
 
-// TestLoopRollupDisplay pins what the board renders beside k/n. A task with no
-// rollup — every task not currently in a loop — must render nothing at all,
-// or the column would grow a permanent empty suffix.
+// TestLoopRollupDisplay pins what the board and the detail header render
+// beside k/n. A task with no rollup — every task not currently in a loop —
+// must render nothing at all, or the column would grow a permanent empty
+// suffix.
 func TestLoopRollupDisplay(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -95,16 +98,36 @@ func TestLoopRollupDisplay(t *testing.T) {
 			rollup: &apiclient.LoopRollup{Driver: "count", MaxIterations: 10},
 		},
 		{
-			name:   "count",
+			name: "count",
+			rollup: &apiclient.LoopRollup{
+				Driver: "count", Iteration: 4, Total: 10, MaxIterations: 10,
+			},
+			want: "loop 4/10",
+		},
+		{
+			// A row written before the extent column existed carries none,
+			// so the bound is the only number left to count against.
+			name:   "a row with no recorded extent falls back to the bound",
 			rollup: &apiclient.LoopRollup{Driver: "count", Iteration: 4, MaxIterations: 10},
 			want:   "loop 4/10",
 		},
 		{
-			name: "for_each names its item",
+			// The whole of issue #317's third fault: the ceiling is not the
+			// loop's number, and the extent is.
+			name: "for_each counts against its real extent, not the ceiling",
 			rollup: &apiclient.LoopRollup{
-				Driver: "for_each", Iteration: 2, MaxIterations: 25, Item: "internal/store",
+				Driver: "for_each", Iteration: 2, Total: 3, MaxIterations: 25,
+				Item: "internal/store",
 			},
-			want: "loop 2/25 internal/store",
+			want: "loop 2/3 · internal/store",
+		},
+		{
+			name: "the running body step is the last clause",
+			rollup: &apiclient.LoopRollup{
+				Driver: "for_each", Iteration: 4, Total: 10, MaxIterations: 10,
+				Item: "alpha", BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
+			},
+			want: "loop 4/10 · alpha · repair 2/3",
 		},
 	}
 	for _, tt := range tests {
@@ -116,20 +139,53 @@ func TestLoopRollupDisplay(t *testing.T) {
 	}
 }
 
-// TestFormatStepAppendsTheLoop: the board's step column carries the iteration
-// only for a task that is in one, so nothing changes for every other row.
-func TestFormatStepAppendsTheLoop(t *testing.T) {
+// TestFormatStepFitsTheLoopToItsColumn: the step column carries as much of
+// the rollup as its width allows and drops the rest from the tail — the body
+// step first, then the `for_each` item, then the counter (issue #317). The
+// alternative is what the cell did before: wrap a counter onto a second and
+// third line, spending the row's whole height on the least of what it says.
+func TestFormatStepFitsTheLoopToItsColumn(t *testing.T) {
 	task := apiclient.Task{CurrentStep: 2, StepTotal: 7, StepName: "green"}
-	if got, want := formatStep(task, true), "3/7 green"; got != want {
+	if got, want := formatStep(task, true, widthStepMax), "3/7 green"; got != want {
 		t.Errorf("formatStep without a loop = %q, want %q", got, want)
 	}
-	task.Loop = &apiclient.LoopRollup{Driver: "count", Iteration: 4, MaxIterations: 10}
-	if got, want := formatStep(task, true), "3/7 green · loop 4/10"; got != want {
-		t.Errorf("formatStep in a loop = %q, want %q", got, want)
+	task.Loop = &apiclient.LoopRollup{
+		Driver: "for_each", Iteration: 4, Total: 10, MaxIterations: 10,
+		Item: "alpha", BodyStep: "repair", BodyIndex: 2, BodyTotal: 3,
 	}
+	for _, tt := range []struct {
+		name  string
+		width int
+		want  string
+	}{
+		{name: "everything fits", width: 42, want: "3/7 green · loop 4/10 · alpha · repair 2/3"},
+		{name: "one cell short of the body step", width: 41, want: "3/7 green · loop 4/10 · alpha"},
+		{name: "one cell short of the item", width: 28, want: "3/7 green · loop 4/10"},
+		{name: "one cell short of the counter", width: 20, want: "3/7 green"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatStep(task, true, tt.width); got != tt.want {
+				t.Errorf("formatStep at width %d = %q, want %q", tt.width, got, tt.want)
+			}
+		})
+	}
+
+	// widthStepMax is measured off the tier boardcols.go names, a `count:`
+	// loop reporting its body step. If this no longer fits exactly, one of
+	// the two moved without the other.
+	task.Loop.Driver, task.Loop.Item = "count", ""
+	full := formatStep(task, true, widthStepMax)
+	if want := "3/7 green · loop 4/10 · repair 2/3"; full != want {
+		t.Errorf("formatStep at widthStepMax = %q, want %q", full, want)
+	}
+	if got := ansi.StringWidth(full); got != widthStepMax {
+		t.Errorf("the widest tier is %d cells, widthStepMax is %d — boardcols.go is measured off it",
+			got, widthStepMax)
+	}
+
 	// The narrow column drops the name, and the loop with it: what survives
 	// the width budget is k/n (boardcols.go).
-	if got, want := formatStep(task, false), "3/7"; got != want {
+	if got, want := formatStep(task, false, widthStepShort), "3/7"; got != want {
 		t.Errorf("formatStep without names = %q, want %q", got, want)
 	}
 }

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -372,18 +372,30 @@ func (d *detail) renderTimeline(height int) string {
 	// members get a tier of their own beneath it. Outside both the shape is
 	// unchanged: one header, then its attempts.
 	//
-	// A loop's iterations are folded shut with the latest open. Ten passes of
-	// a four-step body is forty rows, and a reader arriving at a blocked task
-	// wants the pass it stopped on, not the nine that worked — the same
-	// judgement task 012 made about a twenty-file diff.
+	// A loop's iterations — and a multi-round `fan_out`'s rounds, which ride
+	// the same column (task 080 decision 3) — are folded shut with the latest
+	// open. Ten passes of a four-step body is forty rows, and a reader
+	// arriving at a blocked task wants the pass it stopped on, not the nine
+	// that worked — the same judgement task 012 made about a twenty-file
+	// diff. Folded is not unreachable, though: the tiers open (§15, issue
+	// #317), and d.timelineFolds carries what a reader chose.
 	groups := groupedIndexes(runs)
 	loops := loopIndexes(runs)
-	openIteration := latestIterations(runs)
+	latest := latestIterations(runs)
+	// The tier the cursor sits in, when that tier is folded shut: its rows
+	// are not drawn, so its header stands in for them and takes the
+	// highlight. Without this the selection is invisible and the window jumps
+	// to the top of the timeline, which is the fault issue #317 names.
+	selTier, selFolded := d.foldedSelection(loops, latest)
 	lines := make([]string, 0, len(runs)*2)
 	ids := make([]int64, 0, len(runs)*2)
 	cursorLine := 0
 	lastStep := -1
-	lastIteration := 0
+	// -1 rather than 0, because a `fan_out`'s rounds are 0-based (task 080
+	// decision 3) and round 0 deserves a header like every other tier. A
+	// header is only emitted on a change, so starting at the first legal
+	// value would swallow it.
+	lastIteration := -1
 	lastSub := ""
 	for _, r := range runs {
 		looped := loops[r.StepIndex]
@@ -399,20 +411,31 @@ func (d *detail) renderTimeline(height int) string {
 				ids = append(ids, 0)
 			}
 			lastStep = r.StepIndex
-			lastSub, lastIteration = "", 0
+			lastSub, lastIteration = "", -1
 			lines = append(lines, d.timelineHeader(r, round, looped, grouped))
 			ids = append(ids, 0)
 		}
+		open := looped && d.tierOpen(r.StepIndex, r.Iteration, latest[r.StepIndex])
 		if looped && r.Iteration != lastIteration {
 			lastIteration = r.Iteration
 			lastSub = ""
-			lines = append(lines, styleDim.Render("    "+iterationHeader(r, openIteration[r.StepIndex])))
+			header := "    " + iterationHeader(r, open, d.tierNoun(r.StepIndex))
+			if selFolded && selTier == (tierKey{r.StepIndex, r.Iteration}) {
+				cursorLine = len(lines)
+				header = styleSelected.Render(header)
+			} else {
+				header = styleDim.Render(header)
+			}
+			lines = append(lines, header)
 			ids = append(ids, 0)
 		}
-		if looped && r.Iteration != openIteration[r.StepIndex] {
-			// Folded: the header above stands for the whole iteration, and
-			// its attempts are not rendered. Selecting a run inside a folded
-			// iteration cannot happen, because it never entered ids.
+		if looped && !open {
+			// Folded: the header above stands for the whole tier, and its
+			// attempts are not rendered. A run inside one can still be
+			// *selected* — ↑/↓ treat a folded tier as one cursor stop, its
+			// first row (issue #317) — which is why the header above carries
+			// the cursor and no row here enters ids. A click cannot land on
+			// one: it is not on screen.
 			continue
 		}
 		// A repair is not an attempt of the blocked step and must never read
@@ -543,8 +566,9 @@ func groupedIndexes(runs []apiclient.StepRun) map[int]bool {
 }
 
 // loopIndexes reports which step indexes hold rows from more than one
-// iteration, or any row carrying an iteration at all — which is exactly the
-// `loop` steps, since every other step type writes iteration 0.
+// iteration, or any row carrying an iteration at all — the `loop` steps and
+// the multi-round `fan_out`s, since every other step type writes iteration 0.
+// What the two share is the tier: which *noun* titles it is tierNoun's job.
 //
 // Derived from the rows rather than the snapshot for the reason groupedIndexes
 // is: the timeline has to render before workflow_steps arrives, and for a task
@@ -559,8 +583,10 @@ func loopIndexes(runs []apiclient.StepRun) map[int]bool {
 	return out
 }
 
-// latestIterations is the highest iteration each loop index has a row for —
-// the one iteration that renders open.
+// latestIterations is the highest iteration each index has a row for — the
+// one tier that renders open until a reader says otherwise (task 016
+// decision 14: whoever arrives at a blocked task wants the pass it stopped
+// on).
 func latestIterations(runs []apiclient.StepRun) map[int]int {
 	out := map[int]int{}
 	for _, r := range runs {
@@ -571,32 +597,76 @@ func latestIterations(runs []apiclient.StepRun) map[int]int {
 	return out
 }
 
-// iterationHeader is one iteration's tier line, carrying the fold glyph and —
-// for a `for_each` loop — the item that pass ran on, which is the whole reason
-// a reader wants iteration headers rather than a flat list.
-func iterationHeader(r apiclient.StepRun, open int) string {
+// iterationHeader is one tier's line, carrying the fold glyph, the noun that
+// names the tier and — for a `for_each` loop — the item that pass ran on,
+// which is the whole reason a reader wants tier headers rather than a flat
+// list.
+func iterationHeader(r apiclient.StepRun, open bool, noun string) string {
 	glyph := diffFoldClosed
-	if r.Iteration == open {
+	if open {
 		glyph = diffFoldOpen
 	}
-	out := fmt.Sprintf("%s iteration %d", glyph, r.Iteration)
+	out := fmt.Sprintf("%s %s %d", glyph, noun, r.Iteration)
 	if r.LoopItem != nil && *r.LoopItem != "" {
 		out += " · " + *r.LoopItem
 	}
 	return out
 }
 
-// structureLabel names a `parallel` group or a `loop` from the task's
-// snapshot, since neither writes a step_runs row to take a name from (task
-// 014 decision 17, task 016 decision 7). A snapshot that has not loaded yet
-// falls back to the type name, which is still true.
-func (d *detail) structureLabel(index int, kind string) string {
+// structureLabel names a `parallel` group, a `loop` or a `fan_out` from the
+// task's snapshot, since none of them writes a step_runs row to take a name
+// from (task 014 decision 17, task 016 decision 7).
+//
+// The kind is the snapshot step's own type rather than the caller's guess, so
+// a multi-round `fan_out` reads as one instead of as the loop its rows look
+// like. `fallback` is what the rows imply and is used only for a task whose
+// snapshot has not arrived, or no longer parses — the row-only derivation is
+// all such a task can honestly be labelled from.
+func (d *detail) structureLabel(index int, fallback string) string {
 	for _, s := range d.task.WorkflowSteps {
-		if s.Index == index {
-			return fmt.Sprintf("%s (%s)", s.ID, kind)
+		if s.Index != index {
+			continue
+		}
+		kind := s.Type
+		if kind == "" {
+			kind = fallback
+		}
+		return fmt.Sprintf("%s (%s)", s.ID, kind)
+	}
+	return "(" + fallback + ")"
+}
+
+// tierNoun names the fold tiers at one step index. A multi-round `fan_out`
+// writes its round on the very column a `loop` writes its pass on (task 080
+// decision 3), so the rows alone cannot tell the two apart; only the
+// snapshot's step type can, and a task without one keeps the loop's word.
+//
+// The number is the column's value either way, so the screen, the log line
+// and the transcript name (`{step_index}-i{iteration}-{step_id}-{attempt}`)
+// all say the same one — which is why a round is labelled 0-based.
+func (d *detail) tierNoun(index int) string {
+	for _, s := range d.task.WorkflowSteps {
+		if s.Index == index && s.Type == stepTypeFanOut {
+			return "round"
 		}
 	}
-	return "(" + kind + ")"
+	return "iteration"
+}
+
+// stepTypeFanOut is the §7.6 step type as the task snapshot spells it.
+const stepTypeFanOut = "fan_out"
+
+// foldedSelection is the tier the timeline cursor sits in when that tier is
+// folded shut, so renderTimeline can move the highlight onto its header.
+func (d *detail) foldedSelection(loops map[int]bool, latest map[int]int) (tierKey, bool) {
+	sel := d.runByID(d.selectedRun)
+	if sel.ID == 0 || !loops[sel.StepIndex] {
+		return tierKey{}, false
+	}
+	if d.tierOpen(sel.StepIndex, sel.Iteration, latest[sel.StepIndex]) {
+		return tierKey{}, false
+	}
+	return tierKey{sel.StepIndex, sel.Iteration}, true
 }
 
 // includedFrom names the workflow step `index` was spliced in from (§7.9,

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -583,7 +583,7 @@ func (s *shell) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
 		return s.checkSelection()
 	case panelTimeline:
 		s.syncDetailFocus()
-		return s.detail.moveSelection(delta)
+		return s.detail.moveTimelineSelection(delta)
 	default:
 		// Whichever tab the pane is showing is the one that scrolls: wheeling
 		// over a diff used to move the output tail nobody could see.
@@ -636,13 +636,17 @@ func (s *shell) jumpAttention() tea.Cmd {
 // current state, so the footer never offers a press that does nothing. The
 // board's fold keys are the only ones: with `group_by: []` the table has no
 // groups at all (task 054 decision 5).
+//
+// The timeline's fold rows carry the same marker but not the same condition —
+// a loop's iterations and a `fan_out`'s rounds are tiers whatever the board is
+// grouped by — so the drop is scoped to the surface the decision was about.
 func (s *shell) liveBindings(rows []binding) []binding {
 	if len(s.board.group) > 0 {
 		return rows
 	}
 	out := make([]binding, 0, len(rows))
 	for _, b := range rows {
-		if !b.fold {
+		if !b.fold || b.context != ctxTasks {
 			out = append(out, b)
 		}
 	}

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -327,6 +327,13 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 			t.openPopup()
 			return nil
 		}
+		if t.tab == taskTabSteps && t.detail.timelineFolded() {
+			// `enter` means both things, chosen by the row under the cursor:
+			// on a folded tier it opens the fold, and there is nothing else
+			// it could usefully mean there — the attempt it would carry the
+			// reader to is one they cannot see yet (issue #317).
+			return t.detail.setTimelineFold(true)
+		}
 		if t.tab == taskTabSteps && t.detail.selectedRun != 0 {
 			return t.setTab(taskTabOutput)
 		}
@@ -352,6 +359,24 @@ func (t *taskView) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	}
 	if t.tab == taskTabPull {
 		return t.updatePullTabKey(msg)
+	}
+	if t.tab == taskTabSteps {
+		// Gated on the tab, not handled in the switch above: ←/→ already walk
+		// the Output tab's attempt selection just below, and O/C are the Diff
+		// tab's fold-all. Each pair means the fold only while Steps &
+		// Attempts has the screen.
+		switch msg.String() {
+		case " ", "space":
+			return t.detail.toggleTimelineFold()
+		case "right":
+			return t.detail.setTimelineFold(true)
+		case "left":
+			return t.detail.setTimelineFold(false)
+		case "O":
+			return t.detail.setAllTimelineFolds(true)
+		case "C":
+			return t.detail.setAllTimelineFolds(false)
+		}
 	}
 	if t.tab == taskTabOutput {
 		switch msg.String() {
@@ -552,7 +577,7 @@ func (t *taskView) updateWheel(msg tea.MouseWheelMsg) tea.Cmd {
 	}
 	switch t.tab {
 	case taskTabSteps:
-		return t.detail.moveSelection(delta)
+		return t.detail.moveTimelineSelection(delta)
 	case taskTabDetails:
 		t.details.scrollAt(msg.X, delta)
 	case taskTabOutput:

--- a/internal/tui/timelinefold_test.go
+++ b/internal/tui/timelinefold_test.go
@@ -1,0 +1,323 @@
+package tui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// tierDetail is a task whose step 1 repeats: a two-step body (`suite`, then
+// `repair`) run once per entry in `iters`, on the iteration column. kind is
+// the snapshot's type for that step — "loop", "fan_out", or "" for a task
+// whose snapshot never arrived, where the timeline has only the rows to go on.
+func tierDetail(t *testing.T, kind string, iters ...int) *detail {
+	t.Helper()
+	d := newTestDetail(t)
+	d.taskID = 41
+
+	rows := []apiclient.StepRun{attempt(1, 0, 1, "build", "succeeded", false)}
+	id := int64(2)
+	for _, it := range iters {
+		for _, name := range []string{"suite", "repair"} {
+			rows = append(rows, iteration(id, it, name, "succeeded", ""))
+			id++
+		}
+	}
+	task := apiclient.TaskDetail{
+		Task:  apiclient.Task{ID: d.taskID, Title: "tiered", State: stateRunning, StepTotal: 2},
+		Steps: rows,
+	}
+	if kind != "" {
+		task.WorkflowSteps = []apiclient.WorkflowStep{
+			{Index: 0, ID: "build", Type: "command"},
+			{Index: 1, ID: "green", Type: kind},
+		}
+	}
+	d.applyLoaded(detailLoadedMsg{id: d.taskID, task: task})
+	d.focus = focusTimeline
+	return d
+}
+
+// tierTaskView is tierDetail's loop in the full-screen workspace, on the tab
+// whose keys the folds belong to.
+func tierTaskView(t *testing.T, iters ...int) *taskView {
+	t.Helper()
+	v := newTaskView(tierDetail(t, "loop", iters...))
+	v.tab = taskTabSteps
+	return v
+}
+
+// tierStepIndex is the step every tierDetail fixture repeats on.
+const tierStepIndex = 1
+
+// firstRowOfTier is the row a folded tier's header stands for — the one row
+// of it ↑/↓ may select.
+func firstRowOfTier(d *detail, k tierKey) int64 {
+	for _, r := range d.attempts() {
+		if r.StepIndex == k.index && r.Iteration == k.iteration {
+			return r.ID
+		}
+	}
+	return 0
+}
+
+// selectTier puts the timeline cursor on a tier's first row, the way ↑/↓
+// would land on it.
+func selectTier(t *testing.T, d *detail, iteration int) {
+	t.Helper()
+	id := firstRowOfTier(d, tierKey{tierStepIndex, iteration})
+	if id == 0 {
+		t.Fatalf("no row at step %d iteration %d", tierStepIndex, iteration)
+	}
+	d.selectedRun = id
+}
+
+// TestTimelineFoldOpensAnEarlierIteration: before issue #317 the rows of a
+// pass that was not the latest were skipped by the renderer and reachable by
+// nothing, so a loop on iteration 7 hid the failure in iteration 1. The tier
+// opens now, and what it draws is attempts with output behind them.
+func TestTimelineFoldOpensAnEarlierIteration(t *testing.T) {
+	d := tierDetail(t, "loop", 1, 2)
+
+	got := d.renderTimeline(200)
+	if !strings.Contains(got, "iteration 1") {
+		t.Fatalf("the folded tier lost its header:\n%s", got)
+	}
+	if n := strings.Count(got, "· suite"); n != 1 {
+		t.Fatalf("`suite` tiers on screen = %d, want 1 — a folded tier draws no rows:\n%s", n, got)
+	}
+
+	// space, from the timeline, on the folded tier's first row.
+	selectTier(t, d, 1)
+	d.updateKey(registryKey(t, "space"))
+	got = d.renderTimeline(200)
+	if n := strings.Count(got, "· suite"); n != 2 {
+		t.Fatalf("`suite` tiers after opening = %d, want 2:\n%s", n, got)
+	}
+
+	// The attempts it drew are hit-testable and their transcripts fetchable:
+	// walking onto iteration 1's second row moves the output pane to it and
+	// puts that attempt's transcript in flight. (The fixture has no client,
+	// so the fetch is a nil command; `fetching` is what says one was asked
+	// for.)
+	d.moveTimelineSelection(1)
+	if d.displayRun != d.selectedRun {
+		t.Fatalf("output pane is showing run %d, cursor is on %d", d.displayRun, d.selectedRun)
+	}
+	if d.noTranscript || !d.fetching {
+		t.Fatalf("no transcript fetch for the newly reachable attempt (noTranscript=%v fetching=%v)",
+			d.noTranscript, d.fetching)
+	}
+	d.renderTimeline(200)
+	if !slices.Contains(d.visibleRuns, d.selectedRun) {
+		t.Fatalf("run %d is selected but not on screen (visible %v)", d.selectedRun, d.visibleRuns)
+	}
+}
+
+// TestTimelineFoldAllTiers: O and C act on every tier of the task, not on the
+// one under the cursor — the Diff tab's two letters in the Diff tab's meaning.
+func TestTimelineFoldAllTiers(t *testing.T) {
+	v := tierTaskView(t, 1, 2, 3)
+
+	v.updateKey(registryKey(t, "O"))
+	got := v.detail.renderTimeline(200)
+	if n := strings.Count(got, "· suite"); n != 3 {
+		t.Fatalf("O left %d of 3 tiers open:\n%s", n, got)
+	}
+	if strings.Contains(got, diffFoldClosed) {
+		t.Fatalf("O left a tier folded:\n%s", got)
+	}
+
+	v.updateKey(registryKey(t, "C"))
+	got = v.detail.renderTimeline(200)
+	if n := strings.Count(got, "· suite"); n != 0 {
+		t.Fatalf("C left %d tiers open, including the latest:\n%s", n, got)
+	}
+	if n := strings.Count(got, diffFoldClosed); n != 3 {
+		t.Fatalf("closed glyphs = %d, want 3:\n%s", n, got)
+	}
+}
+
+// TestTimelineFoldKeysInTheWorkspace pins the vocabulary the workspace routes:
+// → opens, ← closes, and enter means both things — the fold on a folded tier,
+// the Output tab on a drawn attempt.
+func TestTimelineFoldKeysInTheWorkspace(t *testing.T) {
+	v := tierTaskView(t, 1, 2)
+	selectTier(t, v.detail, 1)
+
+	v.updateKey(registryKey(t, "enter"))
+	if v.tab != taskTabSteps {
+		t.Fatalf("enter on a folded tier left the tab at %v, want Steps & Attempts", v.tab)
+	}
+	if v.detail.timelineFolded() {
+		t.Fatal("enter on a folded tier did not open it")
+	}
+
+	// Now that the row under the cursor is drawn, enter means what it always
+	// meant.
+	v.updateKey(registryKey(t, "enter"))
+	if v.tab != taskTabOutput {
+		t.Fatalf("enter on a drawn attempt opened %v, want the Output tab", v.tab)
+	}
+
+	v.tab = taskTabSteps
+	v.updateKey(registryKey(t, "left"))
+	if !v.detail.timelineFolded() {
+		t.Fatal("← did not close the tier the cursor is in")
+	}
+	v.updateKey(registryKey(t, "right"))
+	if v.detail.timelineFolded() {
+		t.Fatal("→ did not open the folded tier")
+	}
+
+	// ←/→ are the Output tab's attempt walk there, not folds.
+	v.tab = taskTabOutput
+	before := v.detail.selectedRun
+	v.updateKey(registryKey(t, "right"))
+	if v.detail.selectedRun == before {
+		t.Fatal("→ on the Output tab stopped moving the attempt selection")
+	}
+}
+
+// TestTimelineCursorIsNeverInvisible is the criterion that names the bug:
+// moveSelection walked every row including the ones the renderer skipped, so
+// the highlight vanished and the window jumped to the top. Driving ↓ from the
+// first row to the last and back, every selection is either a drawn row or the
+// first row of a folded tier whose header carries the highlight.
+func TestTimelineCursorIsNeverInvisible(t *testing.T) {
+	d := tierDetail(t, "loop", 1, 2, 3, 4)
+	// Not the arrival default: a reader who opened an old pass and closed the
+	// newest is exactly who walks over a fold.
+	d.setFold(tierKey{tierStepIndex, 1}, true)
+	d.setFold(tierKey{tierStepIndex, 4}, false)
+
+	runs := d.attempts()
+	d.selectedRun = runs[0].ID
+	for range len(runs) + 2 {
+		assertCursorDrawn(t, d)
+		d.moveTimelineSelection(1)
+	}
+	for range len(runs) + 2 {
+		assertCursorDrawn(t, d)
+		d.moveTimelineSelection(-1)
+	}
+	if d.selectedRun != runs[0].ID {
+		t.Fatalf("↑ came to rest on run %d, want the first row %d", d.selectedRun, runs[0].ID)
+	}
+}
+
+func assertCursorDrawn(t *testing.T, d *detail) {
+	t.Helper()
+	out := d.renderTimeline(200)
+	if slices.Contains(d.visibleRuns, d.selectedRun) {
+		return
+	}
+	runs := d.attempts()
+	k, folded := d.foldedSelection(loopIndexes(runs), latestIterations(runs))
+	if !folded {
+		t.Fatalf("run %d is selected, is not on screen, and is in no folded tier:\n%s", d.selectedRun, out)
+	}
+	if first := firstRowOfTier(d, k); first != d.selectedRun {
+		t.Fatalf("run %d is selected inside a folded tier whose first row is %d — "+
+			"↑/↓ must stop on the first row only", d.selectedRun, first)
+	}
+	header := styleSelected.Render("    " + iterationHeader(d.runByID(d.selectedRun), false, d.tierNoun(k.index)))
+	if !strings.Contains(out, header) {
+		t.Fatalf("the folded tier standing in for run %d is not highlighted:\n%s", d.selectedRun, out)
+	}
+}
+
+// TestTimelineTierNoun: a multi-round `fan_out` writes its round on the very
+// column a loop writes its pass on (task 080 decision 3), 0-based. Only the
+// snapshot's step type tells the two apart, and round 0 needs a header like
+// every other tier — it used to get none, because the renderer only emitted
+// one on a change and started counting at 0.
+func TestTimelineTierNoun(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want []string
+	}{
+		{name: "fan_out rounds are 0-based", kind: "fan_out", want: []string{"round 0", "round 1", "round 2"}},
+		{name: "a loop's are iterations", kind: "loop", want: []string{"iteration 0", "iteration 1", "iteration 2"}},
+		// No snapshot: the rows alone cannot say which it was, so the
+		// row-only derivation keeps the loop's word (structureLabel's
+		// fallback is the same judgement).
+		{name: "no snapshot keeps the row-derived word", kind: "", want: []string{"iteration 0", "iteration 1", "iteration 2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := tierDetail(t, tt.kind, 0, 1, 2)
+			got := d.renderTimeline(200)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("timeline missing %q:\n%s", want, got)
+				}
+			}
+			if n := strings.Count(got, diffFoldClosed); n != 2 {
+				t.Errorf("folded tiers = %d, want the two that are not the latest:\n%s", n, got)
+			}
+			// The step header names the structure from the snapshot's type,
+			// and falls back to the word the rows imply when there is none.
+			label := "(loop)"
+			if tt.kind != "" {
+				label = "green (" + tt.kind + ")"
+			}
+			if !strings.Contains(got, label) {
+				t.Errorf("step header missing %q:\n%s", label, got)
+			}
+		})
+	}
+}
+
+// TestTimelineFoldBindingsRegistered: the keys are only discoverable because
+// they are in the registry — that is what puts them in the footer hints and in
+// the `?` overlay.
+func TestTimelineFoldBindingsRegistered(t *testing.T) {
+	rows := bindingsFor(ctxTimeline)
+	for _, key := range []string{"space", "right", "left", "O", "C"} {
+		var found *binding
+		for i, b := range rows {
+			if b.key == key {
+				found = &rows[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("%q is not registered under ctxTimeline", key)
+			continue
+		}
+		if !found.fold {
+			t.Errorf("%q is registered without the fold marker the board's fold rows carry", key)
+		}
+	}
+
+	line := ansi.Strip(renderFooter(160, rows, &actionBar{}, taskActions{}, 0, false))
+	if !strings.Contains(line, "space fold") {
+		t.Errorf("the fold hint never reached the footer: %q", line)
+	}
+}
+
+// TestTimelineFoldsSurviveARefresh: the folds are a reader's decision, so a
+// poll that reinstalls the same task must not close what they opened, while
+// opening another task starts at the arrival default again (task 016
+// decision 14).
+func TestTimelineFoldsSurviveARefresh(t *testing.T) {
+	d := tierDetail(t, "loop", 1, 2)
+	selectTier(t, d, 1)
+	d.setTimelineFold(true)
+
+	d.applyLoaded(detailLoadedMsg{id: d.taskID, task: d.task})
+	if d.timelineFolded() {
+		t.Fatal("a refresh closed the tier the reader opened")
+	}
+
+	d.open(d.taskID+1, stateRunning)
+	if d.timelineFolds != nil {
+		t.Fatalf("opening another task kept %d fold decisions from the last one", len(d.timelineFolds))
+	}
+}

--- a/scripts/m8-gate.sh
+++ b/scripts/m8-gate.sh
@@ -147,6 +147,15 @@ iterations_ran() { # iterations_ran TASK_ID
   steps_json "$1" | jq '[.[] | select(.iteration > 0) | .iteration] | unique | length'
 }
 
+# loop_totals prints the distinct extents the rows at one step index recorded
+# (§7.8, issue #317), one per line — so a capture of `3` alone means every
+# body row of that loop agrees on 3.
+loop_totals() { # loop_totals TASK_ID STEP_INDEX
+  steps_json "$1" | jq --argjson i "$2" \
+    '[.[] | select(.step_index == $i) | .loop_total] | unique | .[]' \
+    | tr -d '\r'
+}
+
 # items_ran prints the for_each item of each iteration, in iteration order.
 items_ran() { # items_ran TASK_ID
   steps_json "$1" | jq -r '[.[] | select(.loop_item != null)]
@@ -332,6 +341,17 @@ YAML
     [[ "$(subject_count "$REPO" "$TID" "$item")" == 1 ]] \
       || fail "item $item did not get exactly one iteration's work"
   done
+  # The extent recorded on every body row is the list's length, not the
+  # ceiling (issue #317). This `for_each` declares no `max_iterations:`, so a
+  # denominator derived from the snapshot would be the global 10 — a number
+  # this loop was never going to reach.
+  #
+  # It is read off the rows rather than off the task's `loop` rollup because
+  # the task is `done`: its cursor sits past the loop step, so there is no
+  # rollup on the response at all. The rows are the deterministic answer, and
+  # they need no race against a running loop.
+  [[ "$(loop_totals "$TID" 0)" == 3 ]] \
+    || fail "body rows recorded extent $(loop_totals "$TID" 0), want 3 — the list length, not the ceiling"
   daemon_down
 fi
 


### PR DESCRIPTION
## Summary

A task sitting on a `loop` was the one shape of work the TUI could not answer
"where is this, right now" about, and the pass it had already finished could not
be read at all. This makes the loop's position legible in both places it is
watched — the board row and the task workspace — and stops three things it was
saying that were wrong.

**The rollup says where inside the loop the task is.** The outer `step k/n`
counts a whole loop as one step, so the §7.8 rollup now carries the body step
the current iteration is on and its 1-based place in the body:
`3/7 green · loop 4/10 · repair 2/3`. The board's `STEP` column is a width
budget, not an appetite, so the clauses are *fitted* to it and drop from the
tail — body step first, then the `for_each` item, then the counter — rather than
wrapping a row onto a second line to finish a counter. `widthStepMax` rose from
32 to 34, measured off the full sample rather than guessed.

**A `for_each` reports its own denominator.** With no `count:` and no
step-level `max_iterations:`, the total was read off the workflow — where a
`for_each` list does not exist yet, because it is rendered at run time — and
fell through to the global `loop.max_iterations` ceiling, so a 3-item loop
rendered `loop 2/10`. Migration 0026 adds `step_runs.loop_total` and every body
row records how many iterations the admission that wrote it planned, clamp
included; the rollup reads it and the same loop reads `loop 2/3`.

That is task 016 decision 8's sentence carried one word further — the row
already recorded *which item* iteration 3 ran on, and now records *how many
iterations that pass was one of*. It is **not** a loop cursor, which decision 7
refused and still refuses: nothing reads it back to decide what runs next, the
position is still derived from the rows, and §12.4 recovery has nothing to
reconcile with it. Asking the live `taskrun.Runner` instead needs no migration
but only answers while an actor exists, so a blocked or paused loop — the exact
case a human is staring at — would fall back to the ceiling again; materializing
the resolved list into the task snapshot would freeze a list decision 8
deliberately re-derives per admission. `max_iterations` keeps its own meaning
beside `total` (the bound the loop would block on), and a task whose rows
predate the column renders exactly as it did before the upgrade.

**Folded iterations open, and the cursor is always visible.** In Steps &
Attempts, `space` opens or closes the tier the cursor is in, `→` opens and `←`
closes it, `enter` on a folded tier's header opens it (and still opens Output on
a drawn attempt), and `O`/`C` act on every tier of the task — the Diff tab's
fold vocabulary verbatim. Latest-open stays the arrival default (task 016
decision 14): the folds become *openable*, not open, and the fold map holds
decisions only, so a refresh cannot close what a reader opened and another task
starts fresh.

`↑`/`↓` used to walk the selection onto rows a fold had not drawn, which left
`cursorLine` at 0 — the highlight vanished and the window jumped to the top of
the timeline. A folded tier is now a single cursor stop, its first row, and the
tier's *header* carries the highlight while that row is selected, so every
selection the arrow keys can reach is drawn. The selection stays a run id: no
second kind of cursor enters `moveSelection`, `syncOutput` or `visibleRuns`
hit-testing, and the Output tab's `←`/`→` still reach every attempt, because a
fold is a fact about the timeline pane and not about the task.

**A multi-round `fan_out` is labelled as one.** Rounds ride the loop's
`iteration` column (task 080 decision 3), so they were being titled "iteration
N" with round 0 getting no header at all. They now read `round 0`, `round 1`, …
— 0-based, the number the log line and the §12.2 transcript name already use —
and fold with the same keys. The noun comes from the step's type in the task's
workflow snapshot, since the rows alone cannot tell a round from a pass; the
row-only derivation stays the answer for a task whose snapshot has not arrived,
and keeps the loop's word there.

On the wire: `loop` gains `total`, `body_step`, `body_index` and `body_total`,
and `GET /v1/tasks/{id}/steps` gains `loop_total` per row. The three body fields
are absent **together** for a row the daemon cannot place in a body it
recognizes — a repair row, or a row whose step an edit-and-retry rewrite of the
snapshot (§6) has taken out of the body — so the rollup degrades to driver,
iteration and total rather than to a guess. (A snapshot that no longer *parses*
is the other case and not this one: `loopAt` returns nil, so the response
carries no `loop` at all.)

`scripts/m8-gate.sh` scenario 4 asserts the recorded extent is the list length
and not the ceiling. It reads that off the step rows rather than the rollup on
purpose: the scenario waits for `done`, and a finished task's cursor sits past
the loop step, so there is no rollup on the response at all.

Nothing here reopens a recorded decision. Task 016 decisions 7, 8 and 14 are
extended or preserved as described above and cited in `docs/tasks/083`.

## Related

Closes #317

Recorded as [083](docs/tasks/083-loop-legibility.md), which carries the
decisions and the rejected alternatives. Extends task 016 decision 8; leaves
decisions 7 and 14 standing.

**Scope note.** The issue's last acceptance criterion asks that affected
`docs/assets/tui-*.png` captures be re-taken with `scripts/screenshots.sh`. No
current capture is affected: that script seeds no workflow containing a `loop`
or a multi-round `fan_out`, so no screenshot shows a loop rollup or an iteration
tier today, and the criterion is satisfied vacuously. Seeding one is a new seed,
a new tape and a new asset — say so and it becomes a sub-task.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes — store round-trip and pre-column
      default, engine extent for `count:` / `for_each` / a re-admitted loop,
      `internal/api/loop_test.go` for the real total and the body clause's
      absence, apiclient clause order and a live test against the real handlers,
      board width tiers and the drop order, and
      `internal/tui/timelinefold_test.go` for the folds, `O`/`C`, the fan-out
      tiers and the criterion that names the bug — driving `↓` from the first
      row to the last, every selection is drawn
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — the
      rollup and folds under Added, the `for_each` denominator and the vanishing
      cursor under Fixed
- [x] Affected page under `docs/` updated — `docs/spec.md` §7.6, §7.8, §14 and
      §15 amended in place with dated notes, `docs/reference/api.md` for the
      rollup shape and `loop_total`, `docs/guides/tui.md` for the fold keys, the
      round tier and the board sample, and `docs/tasks/050` decision 3 given the
      repository's superseded-in-part note because `widthStepMax` moved from 32
      to 34 under the sample it was measured against. The config and CLI pages
      are untouched because neither `internal/config` nor the cobra tree
      changed, no `Reason*` constant was added, `internal/workflow` did not
      change so the schema page, the lifecycle page and
      `skills/vincent-workflows/SKILL.md` are all still true, no
      `docs/gates/` walkthrough covers `m8`, and this repository's five
      `.vincent/workflows/*.yaml` still both validate and render

## Notes for the reviewer

**Two doc claims in the first documentation commit were wrong and are fixed in
`bc9b947`; the code is right in both cases.**

1. `docs/reference/api.md` and `docs/spec.md` §7.8 said `total` is absent for a
   row written before the daemon recorded extents. `loopRollup` falls back to
   the snapshot's bound for such a row — `TestLoopRollupFallsBackToTheBoundForALegacyRow`
   asserts it — so `total` is present. It is absent only until the loop has a
   body row at all.
2. Both pages listed "any row once the snapshot no longer parses" as a case in
   which the body clause drops. An unparseable snapshot leaves an empty
   `snapshotSummary`, so `loopAt` returns nil and the whole `loop` object is
   absent. The reachable case beside a repair row is a snapshot rewritten by
   edit-and-retry.

   **Not fixed here, because it is outside a documentation step's reach:**
   `TestLoopRollupWithoutBodyIDsDegrades` in `internal/api/loop_test.go` carries
   the same wrong explanation in its comment ("which is what a snapshot the
   parser can no longer make sense of leaves behind"). The test itself is
   sound — it hand-builds a `loopDefinition` with no body order and asserts the
   rollup degrades — but the sentence naming what produces that state is not
   reachable from `parseSnapshot`, and a `loop` step with an empty body does not
   parse (`workflow`'s "at least one body step"). Worth re-wording to name the
   rewritten-snapshot case instead.

**No screenshot is stale.** `scripts/screenshots.sh` seeds no workflow with a
`loop` or a multi-round `fan_out`, so no `docs/assets/tui-*.png` shows a loop
rollup or an iteration tier, and none of them needs re-capturing. The images
were not touched.
