### PR TITLE
Add a quiet output level, a distinct user turn, and a bordered composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **A `quiet` level, below `compact`, for reading a chat as a conversation.**
+  The verbosity cycle `v` walks in the task workspace's output pane and
+  `ctrl+r` walks in the chat workspace is four levels now —
+  `quiet → compact → normal → verbose` — and `quiet` is the one that shows what
+  the agent *said* and what went wrong, and nothing it narrated about its own
+  machinery. Relative to `compact` it drops the `▸` tool calls and their
+  outcomes, the `✓ done · …` line of a run that succeeded, and unrecognized
+  lines entirely: not even the `… N unrecognized line(s)` count, because a
+  count is an offer to expand and `quiet` is the level that makes no offers. A
+  two-sentence answer arrives as two sentences instead of buried in file reads
+  and greps.
+
+  A failure is never hidden by a display level: `agent.error`, an `agent.result`
+  that failed, a turn's own fail reason and the `── turn N ──` separators all
+  render at `quiet`, and so does the result *text* of a turn that produced no
+  prose at all — a codex turn with no `agent_message` — which would otherwise
+  leave a turn header with nothing under it. A command step's pane is byte for
+  byte the same at `quiet` as at `compact`: `quiet` is a rule about what the
+  agent narrated, and a command step narrates nothing.
+
+  It is still **one level for the session**, shared by both panes and persisted
+  nowhere, and the default is still `normal` — no existing screen moves until
+  you press the key. The pane title and the chat header name `quiet` while it is
+  on, which matters most for this level, since it is the one whose effect can be
+  to hide the only thing a turn produced. `compact`, `normal` and `verbose`
+  render exactly what they rendered before. See
+  [Using the TUI](docs/guides/tui.md#what-v-adds).
+
 - **A loop says where it is, and its earlier passes open.** The loop rollup on
   the board and in the task header names the body step the current iteration is
   on — `3/7 green · loop 4/10 · repair 2/3` — so "where is this task, right
@@ -759,6 +787,28 @@ list with the user-facing context a commit subject cannot carry.
   See [Using the TUI](docs/guides/tui.md#what-v-adds).
 
 ### Changed
+
+- **The chat workspace reads as a conversation: a user turn you can find, and a
+  composer with an edge.** Your own message is drawn as a right-aligned bubble —
+  shrink-to-fit, capped at about two thirds of the pane, wrapped inside itself
+  and marked with `›` on *every* line rather than only the first. The agent's
+  half is untouched, flush left at the full width, so scrolling back through a
+  long chat no longer reads as one undifferentiated column. The distinction is
+  an accent foreground and bold, never a background band: right alignment and
+  the per-line marker carry it on a monochrome terminal or under `NO_COLOR`,
+  where a tint carries nothing.
+
+  A prompt's own line breaks now survive into the bubble, and a long prompt is
+  no longer cut off after six lines with an ellipsis. The composer is multi-line
+  by design, so a pasted snippet or a numbered list is content you wrote, not
+  incidental whitespace — and truncating it put the tail of your own question
+  out of reach on a body that already scrolls.
+
+  The composer sits inside a titled border, so the field you type into stops
+  looking like one more row of the conversation. The border is spent out of the
+  height budget rather than added after it: the frame is exactly as tall as the
+  terminal at every size, the hint line is still the last row, and nothing is
+  pushed off the bottom.
 
 - **The new-chat form uses the same list every other create form uses.**
   Project, agent, model and effort are now `picker` rows: `enter` opens the

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -169,7 +169,7 @@ live agent output on the right, with a **Diff** tab beside it.
 | `↑`/`↓` | Move the selection |
 | `enter` | Open the selected task |
 | `]` | Switch the output pane between Output and Diff |
-| `v` | Show more or less detail (compact → normal → verbose) |
+| `v` | Show more or less detail (quiet → compact → normal → verbose) |
 | `:` | Command palette — everything reachable by name |
 | `?` | Every key, in context |
 | `q` | Quit (the daemon and any running task keep going) |

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -365,7 +365,7 @@ output. It is the sentence that decides whether to open the transcript.
 | `O` / `C` | On Steps & Attempts, open / close every iteration and round tier of this task |
 | `←`/`→` or `h`/`l` | On Output, select which attempt's output to show |
 | `f` or `G` | Follow the live output again |
-| `v` | More or less detail: compact → normal → verbose (reasoning, the run's own metadata, then unrecognized lines) |
+| `v` | More or less detail: quiet → compact → normal → verbose (tool lines, then reasoning, the run's own metadata, then unrecognized lines) |
 | `ctrl+o` | Show the assistant's original Markdown instead of the rendered view |
 | `ctrl+y` | Copy an assistant message, its plain text, or one of its code blocks |
 | `e` | Open this attempt's **whole** transcript in `$EDITOR` |
@@ -469,6 +469,21 @@ Copying a link's destination is not here yet: links still render as the
 characters the agent sent, so there is no destination for the picker to offer.
 
 ### What `v` adds
+
+`quiet` is what the agent **said**, and whatever went wrong. Below compact it
+drops the `▸` tool calls and the outcomes under them, the `✓ done · …` line of a
+run that succeeded, and the lines vincent's parsers do not model — not even
+their count, because a count is an offer to expand and this is the level that
+makes no offers. It is the level for reading an answer rather than watching a
+run: a two-sentence reply arrives as two sentences instead of buried in file
+reads and greps.
+
+A failure is never hidden by a level. An `✗` result, an error line and a turn's
+own fail reason all render at `quiet`, and so does the result *text* of an
+attempt that printed nothing else — a codex turn with no assistant message —
+which would otherwise leave a turn header with nothing under it. A command
+step's pane is identical at `quiet` and `compact`: `quiet` is a rule about what
+the *agent* narrated, and a command step narrates nothing.
 
 `compact` is what the agent **said and did**, and nothing else. Reasoning is
 hidden, and so is everything about the run itself.
@@ -1262,11 +1277,25 @@ the draft alone; a second press discards the draft and returns you to the board.
 One conversation: the finished turns above, the running turn's live output below
 them, and a composer at the bottom.
 
+Your own messages are easy to find in it. A prompt is drawn as a right-aligned
+bubble — as wide as it needs to be, up to about two thirds of the pane, wrapping
+inside itself and marked with `›` on *every* line, not just the first. The
+agent's half of a turn is untouched: flush left, full width. The distinction is
+alignment and the marker as much as it is the colour, so it survives a
+monochrome terminal, `NO_COLOR` and an SSH session that lost the palette. Line
+breaks you typed are line breaks in the bubble, and a long prompt is not cut
+short — the tail of what you asked stays readable.
+
+The composer sits inside a titled `message` box, so the field you type into does
+not read as one more row of the conversation. The border comes out of the pane's
+height rather than being added on top of it: the screen is the same height it
+always was, and the hint line is still the last row of it.
+
 | Key | Does |
 |---|---|
 | `enter` | Send the message |
 | `ctrl+x` | Stop the running turn — its process tree is killed |
-| `ctrl+r` | How much of the conversation to show: compact → normal → verbose |
+| `ctrl+r` | How much of the conversation to show: quiet → compact → normal → verbose |
 | `ctrl+t` | Hand the worktree and branch to a new task — the chat ends |
 | `ctrl+o` | Show the assistant's original Markdown instead of the rendered view |
 | `ctrl+y` | Copy an assistant message, its plain text, or one of its code blocks |
@@ -1288,16 +1317,19 @@ a merge or rebase is refused with the operation named.
 
 The body is the task workspace's [output pane](#task-detail), same records
 and same marks: `▸` a tool call, the outcome indented under it, `·` reasoning,
-`#` the run header, `✓`/`✗` the result. `ctrl+r` cycles the same three levels
+`#` the run header, `✓`/`✗` the result. `ctrl+r` cycles the same four levels
 `v` cycles there, and it is the **same level** — set it in either place and the
 other is on it too. `ctrl+r` rather than `v` because the composer owns every
 printable key: a letter would be typed into your draft.
 
+At `quiet` you get the agent's prose and anything that went wrong, with the
+tool calls, the closing outcome line and the unrecognized-line count all gone.
 At `compact` you get what the agent said and did and nothing else. At `normal`
 reasoning is truncated to its first lines and the run header appears. At
 `verbose` you get everything, including the dialect lines vincent does not
-model — which sit behind a `… N unrecognized line(s) (ctrl+r)` count at the
-other two levels rather than filling the screen.
+model — which sit behind a `… N unrecognized line(s) (ctrl+r)` count at
+`compact` and `normal`, and leave no trace at all at `quiet`, rather than
+filling the screen.
 
 Scrolling away from the end pauses follow; `ctrl+g` jumps back and re-arms it.
 The **mouse wheel** does this too — a line per tick, from anywhere in the view,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -7065,6 +7065,35 @@ stream for the live tail.
    the §7.4 popup takes the wheel out of the conversation behind it, the way it
    already takes clicks.
 
+   *Amended 2026-09-03 (issue #321).* `ctrl+r` cycles **four** levels here, as
+   `v` does there — `quiet → compact → normal → verbose` — and `quiet` is the
+   level this view exists to have: a chat read as a conversation, with the tool
+   calls, the success outcome line and the unrecognized-line count gone and the
+   prose left. It is not a chat dialect of `compact`: the task workspace's
+   output pane hides exactly the same records at exactly the same level, because
+   the whole point of task 071's amendment above is that the two panes are one
+   vocabulary. Nothing else in that amendment moves — the level is still one
+   shared session value, and the header still names it when it is not `normal`.
+
+   Two pieces of chrome are this view's own, and are what "the output pane's
+   line model" was never a claim about. The **human's half of a turn is a
+   right-aligned bubble**: shrink-to-fit, capped at about two thirds of the
+   pane, wrapping inside itself, with the `›` marker on every line of it and an
+   accent foreground rather than a background band — this section's Colour rule
+   requires the palette to degrade under `NO_COLOR` and at 16 colours, and right
+   alignment plus a per-line marker are what survive that. The prompt's own line
+   breaks survive into the bubble and there is no line cap, for the reason task
+   073 decision 5 dropped the §17 fallback's: a truncated prompt puts the tail of
+   what a human asked out of reach on a body that scrolls. The agent's half is
+   untouched — flush left, full width, the output pane's renderer verbatim — and
+   a §17 retained-away turn still renders its `ResultText` as assistant prose.
+   The **composer wears a titled border**, drawn with this section's one
+   box-drawing routine, so the field reads as a field rather than as one more
+   row of the conversation. The border is spent out of the height budget, not
+   added after the join: the #299 amendment below governs it verbatim — a
+   composer that grew is a body that shrank — and the footer still carries one
+   element per *rendered* line, the border's two rows included.
+
 ### Layout
 
 The list above is also the screen contract. View 1 is the board-only home
@@ -7423,7 +7452,13 @@ on an error, where it is the error and may be the only content there is.
   columns saying nothing, and the whole point of the field is to distinguish
   "the model finished" from "it hit a limit". `verbose` adds the API-time split
   and, on wrapped continuation lines of the same record, the cache read/write
-  split and the per-model breakdown.
+  split and the per-model breakdown. *Amended 2026-09-03 (issue #321):* the
+  line does not shrink below compact — at `quiet` it is **absent**. Only the
+  success outcome is: the `✗ ` error form and the fallback that prints the
+  result *text* when the attempt rendered nothing else both still render at
+  `quiet`, because those two are meanings of the record rather than level
+  rules, and a level that erased them would hide a failure outright or leave a
+  turn's separator with nothing under it.
 
 *Amended 2026-08-31 (task 070).* One more gutter mark, and one record with no
 mark at all:
@@ -7881,6 +7916,26 @@ where they are read, so a chat says `(ctrl+r)` and never `(v)`. `e` opens `$EDIT
 re-reads a registry or the daemon blocks. One key jumps to the next task needing a
 human, surfaced in the footer only when that count is non-zero — the board has
 always pinned and belled those tasks without offering any way to *go* to one.
+
+*Amended 2026-09-03 (issue #321).* That cycle is **four levels, not three**:
+`quiet → compact → normal → verbose`, wrapping from verbose back to quiet, so
+one press is still "one louder, wrap to the quietest" and the gesture is
+unchanged. `quiet` sits below compact and is what the agent **said**, plus
+anything that went wrong: relative to compact it drops `agent.tool_use` and
+`agent.tool_result`, the success outcome of the result line, and unrecognized
+lines altogether. That last one amends the sentence above rather than adding
+below it — unrecognized lines stay behind their count at **compact and normal**,
+not at every level below verbose, because a count is an offer to expand and
+quiet is the level that makes no offers. `agent.error`, a chat turn's own fail
+reason and the `── turn N ──` separators render at every level including this
+one: a display level is not allowed to hide a failure. `command.output` and
+`vincent.output` are untouched, so a command step's pane is byte for byte the
+same at quiet as at compact — quiet is a rule about what the *agent* narrated,
+and a command step narrates nothing. Everything else here holds verbatim: the
+level is still one value for the session shared by both panes, still persisted
+nowhere, the default is still `normal`, and the pane title still names any level
+but the default — which matters most for this one, since it is the level whose
+effect can be to hide the only thing a turn produced.
 
 *Amended 2026-08-31 (task 067).* The chats board and the chat workspace carry
 their own rows in the registry (`internal/tui/bindings.go`), which is what the

--- a/docs/tasks/085-chat-workspace-ux.md
+++ b/docs/tasks/085-chat-workspace-ux.md
@@ -1,0 +1,162 @@
+# 085 — A quieter level, a distinct user turn, and a bounded composer
+
+**Status:** ✅ done (1/1)
+**Issue:** #321
+**Amends:** §15 (the `v` paragraph, the task 066 result-line amendment, view 9)
+
+Task 071 put the chat workspace's body through the output pane's own renderer,
+and that was the right call for fidelity: an `agent.tool_use` reads the same in
+a chat as in a task, and there is one verbosity vocabulary rather than two. It
+left three things wrong for *reading a conversation*, and this task fixes all
+three without reopening that decision.
+
+**There was no level quiet enough.** `compact` already means "what the agent
+said and did, nothing else" — and tool calls are what it *did*, so they stay.
+In a chat that put a two-sentence answer behind a column of file reads, greps
+and a count of lines nobody asked about. `quiet` goes in **below** compact
+rather than redefining it.
+
+**The user's own words looked like the agent's.** A prompt was
+`wrapCellLines("› "+t.Prompt, width-2, 6)`: default foreground, flush left at
+the assistant's own margin, with the `›` on the first line only and gone on
+every wrapped line after it. It now renders as a right-aligned bubble.
+
+**The composer had no boundary.** The last line of an answer and the first line
+of a draft were two adjacent rows of the same colour. It now sits in a titled
+box drawn with `shell.go`'s `frame`.
+
+## Decisions
+
+### 1. A fourth level, not a redefinition of `compact`, and not a chat-only one
+
+*2026-09-03.* `outputLevel` gains `levelQuiet` as the new zero value and the
+other three shift up. Three alternatives were rejected in the issue and are
+recorded here because each would have superseded a task 071 decision:
+
+- **Redefining `compact`** contradicts §15's stated meaning of that level and
+  silently changes the task output pane for every existing user.
+- **A chat-only level** would supersede task 071 decision 3 and §15's amendment
+  that the level is one session value visible in both panes: walking from a chat
+  to a task workspace would reset what a reader chose to see.
+- **A chat-only *rendering* of a shared value** — the value cycles four ways but
+  the task pane draws `quiet` as `compact` — is two panes rendering one named
+  level differently, which is the second vocabulary task 071 decision 2 removed.
+
+`newLevelHolder()` still starts at `levelNormal`, so no existing first screen
+moves; the level is still persisted nowhere (no `tui.json` entry, no `tui:`
+key), which is precisely why renumbering the constants costs nothing. `next()`
+is a four-cycle wrapping verbose → quiet, so one press is still "one louder,
+wrap to the quietest" and the gesture did not change.
+
+The renumbering made every `level == levelCompact` guard a decision rather than
+a constant: a guard meaning "compact only" (`resultOutcome`'s short form) and one
+meaning "compact and below" (`agent.run_header`, `agent.plan`, `thinkingBlock`)
+are now different expressions, and the second became `level <= levelCompact`.
+Getting one wrong is a silent regression at an existing level, which is why the
+tests compare whole rendered output at `compact`, `normal` and `verbose` rather
+than spot-checking a line.
+
+### 2. `quiet` suppresses the result line's outcome branch and only that branch
+
+*2026-09-03.* `renderResult` has three branches. The issue's prose ("a failure
+is never hidden by a display level") and its acceptance criterion ("no
+`agent.result` line") disagreed about two of them; settled in favour of the
+prose, and §15 amended to say where `quiet` sits.
+
+- `rec.IsError` (`✗ …`) still renders. In a step run there is no other line
+  carrying the failure — the chat has its own fail-reason line, a step run does
+  not — so a display level that hid it would erase a failure outright.
+- `!sawOutput` (`✓ <result text>`) still renders. It is the fallback for a turn
+  that produced no assistant prose at all, which is what a codex turn with no
+  `agent_message` looks like; suppressing it would draw such a turn as a bare
+  `── turn N ──` with nothing under it.
+- the `✓ done · …` outcome is what `quiet` drops.
+
+§15 records the first two as meanings of the record rather than as level rules,
+which is the reason they survive a level that is otherwise about hiding. And
+`sawOutput` is set only by the assistant-document path — no `renderRecord` arm
+sets `isOutput` — so hiding the tool lines cannot perturb which branch is taken:
+the fallback fires at `quiet` exactly when it fires everywhere else.
+Mechanically `renderResult` grew a `bool` return and `renderRecord`'s
+`case "agent.result"` stopped returning an unconditional `true`.
+
+### 3. An unrecognized line leaves no trace at `quiet`
+
+*2026-09-03.* This is the one written rule the task **changes** rather than adds
+below, so it is amended in §15 in place rather than quietly outgrown.
+`levelCompact`'s doc comment said unrecognized lines "stay behind their count at
+every level below verbose". That is now true of `compact` and `normal`.
+Everywhere else the count is an offer — *there are lines here, `v` shows them* —
+and `quiet` is the level that makes no offers, so `flushRaw` resets its run and
+appends nothing rather than drawing a row of arithmetic about itself.
+
+### 4. A foreground accent and a per-line `›`, not a background band
+
+*2026-09-03.* The issue asked for a "tinted band … in an accent colour". Drawn
+instead as an existing 16-colour **foreground**, bold, with `›` on every line of
+the bubble.
+
+Every style in `internal/tui` is a 16-colour foreground; the package's only
+background is `styleSelected`'s 256-colour grey 237, which means "this row is
+selected" and collapses to nothing on a 16-colour terminal. §15's Colour section
+requires the palette to degrade under `NO_COLOR` and at 16 colours, and the
+issue's own requirement is that the distinction survive monochrome. Right
+alignment plus a per-line marker carry it with the colour stripped entirely; a
+band would either reuse the selection colour for something unselected or invent a
+palette role §15 does not have. `stylePrompt` is composed from `styleFocus`'s
+colour 6 rather than given a colour of its own: the accent already in the
+palette is the accent.
+
+### 5. The prompt wraps in full and keeps its own line breaks
+
+*2026-09-03.* The old call collapsed `\n`/`\r`/`\t` into spaces and capped the
+prompt at six lines with an ellipsis. Both are gone.
+
+The composer is multi-line by design — task 071 decision 4 keeps `↑`/`↓` for
+editing a draft — so a pasted snippet or a numbered list is prompt content, not
+incidental whitespace. And a truncated prompt puts the tail of what a *human*
+asked out of reach on a body that already scrolls, which is the same call task
+073 decision 5 made when it dropped the 40-line cap from the §17 retention
+fallback, and the same posture §15's #299 amendment states for fields being
+typed into. Tabs are expanded to four spaces so every remaining cell is one the
+width arithmetic can count.
+
+The bubble pads by its *actual* height, so prompt lines still carry the zero
+anchor and `v.turnAt[t.Seq]` still points at the turn separator: `lineAnchor` /
+`anchorIndex` restore behaviour is unchanged.
+
+### 6. The border is spent out of the height budget
+
+*2026-09-03.* `footerLines` reuses `frame(title, content, w, h, focused)` from
+`shell.go` — the package has exactly one box-drawing routine and a second would
+be a second answer to the same question. Titled `message`, `focused=false`: the
+chat composer holds the keyboard nearly always, so a permanently lit focus glyph
+would say nothing.
+
+`footerLines` returns **one element per rendered line**, so `frame`'s output is
+split on `\n` the way the composer's own `View()` already is. This is issue
+#299's regression and the standing comment in `footerLines` is its warning: a
+joined multi-line string makes `render`'s `room := height - len(head) -
+len(foot)` arithmetic wrong *and* feeds the per-line `ansi.Truncate` pass a
+string it measures as the sum of its rows — `ansi.StringWidth` treats `\n` as
+zero-width and never resets — which collapses the box to its top edge. The
+comment was extended to cover the frame rather than restated somewhere else, and
+`TestPaneWidthChatComposerKeepsEveryWrappedRow` grew widths and heights rather
+than gaining a sibling.
+
+The two rows the frame costs come out of the body, which §15's #299 amendment
+already sanctions: "a composer that grew is a body that shrank, not a frame that
+overflowed." `chatComposerWidth` is one function because two callers size the
+composer — `footerLines` on every render and `chatview.go`'s `WindowSizeMsg`
+handler — and two copies of that arithmetic drift.
+
+## Not done here
+
+- **No chat screenshot.** `scripts/screenshots.sh` seeds no chat and has no chat
+  tape, the gap task 071 recorded under its own "Not done here", so no
+  `docs/assets/tui-*.png` shows this view and none went stale. No existing
+  capture shows a non-default level either: the pane title names a level only
+  when it is not the default, and every tape runs at `normal`.
+- **No gate.** The level is client-only session state that never crosses the
+  wire, and the chrome is client-side layout, so `scripts/m14-gate.sh` is
+  unaffected and no new script is warranted.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -98,6 +98,7 @@ the living engineering specification records implementation contracts.
 | [082](082-reported-agent-quota.md) | The real usage quota codex's app-server and Claude Code's status line now report, merged over the observed window on `GET /v1/agents` | ✅ done (1/1) |
 | [083](083-loop-legibility.md) | A loop's real extent and running body step on the rollup, and openable iteration/round tiers in the timeline that never lose the cursor | ✅ done (1/1) |
 | [084](084-fan-out-observability.md) | Make a fan-out run observable: lanes as expandable board rows, `l`/`U`/`esc` through the workspace, `?by=lane` diff attribution, and the lane DAG drawn | ✅ done (5/5) |
+| [085](085-chat-workspace-ux.md) | A fourth output level, `quiet`, below `compact`; the chat's user turn as a right-aligned bubble; the composer inside a titled border | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -233,7 +233,7 @@ var bindings = []binding{
 	{key: "tab", label: "move between Steps & Attempts, Task Details, Output and Diff (shift+tab goes back; 1–4 jump directly)", scope: scopePanel, context: ctxOutput, hint: "tab views", priority: 1},
 	{key: "]", label: "move to the next task view ([ goes back)", scope: scopePanel, context: ctxOutput, hint: "[/] views", priority: 2},
 	{key: "f", label: "follow the live output again (f/G)", scope: scopePanel, context: ctxOutput, hint: "f follow", priority: 2},
-	{key: "v", label: "show more or less: compact → normal → verbose (reasoning, then unrecognized lines)", scope: scopePanel, context: ctxOutput, hint: "v detail", priority: 3},
+	{key: "v", label: "show more or less: quiet → compact → normal → verbose (tool lines, then reasoning, then unrecognized lines)", scope: scopePanel, context: ctxOutput, hint: "v detail", priority: 3},
 	{key: rawToggleKey, label: "show the assistant's original Markdown instead of the rendered view", scope: scopePanel, context: ctxOutput, hint: "ctrl+o raw", priority: 6},
 	{key: copyPickKey, label: "copy an assistant message, its plain text, or one of its code blocks", scope: scopePanel, context: ctxOutput, hint: "ctrl+y copy", priority: 7},
 	{key: "e", label: "open this attempt's whole transcript in $EDITOR (the pane holds only the end of it)", scope: scopePanel, context: ctxOutput, hint: "e transcript", priority: 5},
@@ -280,7 +280,7 @@ var bindings = []binding{
 	{key: "ctrl+x", label: "stop the running turn (its process tree is killed)", scope: scopePanel, context: ctxChat, hint: "ctrl+x stop", priority: 2},
 	// ctrl+r rather than `v` (task 071 decision 4): the composer owns every
 	// printable key, so a letter would be typed into the message.
-	{key: "ctrl+r", label: "how much of the conversation to show (compact → normal → verbose)", scope: scopePanel, context: ctxChat, hint: "ctrl+r detail", priority: 3},
+	{key: "ctrl+r", label: "how much of the conversation to show (quiet → compact → normal → verbose)", scope: scopePanel, context: ctxChat, hint: "ctrl+r detail", priority: 3},
 	{key: "pgup", label: "scroll the conversation back (pgdown goes forward)", scope: scopePanel, context: ctxChat, hint: "pgup/pgdown scroll", priority: 4},
 	{key: "ctrl+g", label: "jump to the live end and follow it again", scope: scopePanel, context: ctxChat, hint: "ctrl+g live", priority: 5},
 	// ctrl+t rather than `h`, for the reason ctrl+r is a combination: the

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -1775,3 +1775,39 @@ func TestOutputTabKeysWorkFromEitherFocus(t *testing.T) {
 		}
 	}
 }
+
+// TestLevelKeysNameEveryLevel: the two rows that spell the cycle out are the
+// only place the help says what the key does, so a level missing from a label
+// is a level a reader has no way to know exists. Both rows are checked
+// because the two panes cycle one shared holder — a label naming three levels
+// beside one naming four would describe two different keys.
+func TestLevelKeysNameEveryLevel(t *testing.T) {
+	rows := map[bindingContext]string{ctxOutput: "v", ctxChat: "ctrl+r"}
+	found := map[bindingContext]bool{}
+	for _, b := range bindings {
+		key, ok := rows[b.context]
+		if !ok || b.key != key {
+			continue
+		}
+		found[b.context] = true
+		for _, l := range []outputLevel{levelQuiet, levelCompact, levelNormal, levelVerbose} {
+			if !strings.Contains(b.label, l.String()) {
+				t.Errorf("the %s row for %q does not name %s: %q",
+					b.context, key, l, b.label)
+			}
+		}
+		// Named in the order the key walks them, so the label is a promise
+		// about the next press rather than a list of the levels that exist.
+		want := levelQuiet.String() + " → " + levelCompact.String() +
+			" → " + levelNormal.String() + " → " + levelVerbose.String()
+		if !strings.Contains(b.label, want) {
+			t.Errorf("the %s row for %q does not spell the cycle %q: %q",
+				b.context, key, want, b.label)
+		}
+	}
+	for ctx, key := range rows {
+		if !found[ctx] {
+			t.Errorf("no %s row for %q in the registry", ctx, key)
+		}
+	}
+}

--- a/internal/tui/chatprompt.go
+++ b/internal/tui/chatprompt.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// The chat workspace's user turn: a right-aligned bubble, so a conversation
+// reads as two voices rather than as one undifferentiated column.
+//
+// stylePrompt is a foreground accent, not a background band, which is what
+// the original report asked for. Every style in this package is a 16-colour
+// foreground; the one background here — styleSelected's grey 237 — means
+// "this row is selected" and collapses to nothing at 16 colours. §15's Colour
+// section requires the palette to degrade under NO_COLOR and at 16 colours,
+// and the point of the bubble is a distinction that survives monochrome.
+// Right alignment plus the marker on every line carry it with the colour
+// stripped entirely; a band would either reuse the selection colour for
+// something unselected or invent a palette role §15 does not have.
+//
+// It is composed from styleFocus's colour 6, bolded, rather than declared
+// with a colour of its own: the accent already in the palette is the accent.
+var stylePrompt = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+
+// promptMarker opens every line of the bubble, not just the first — it is the
+// half of the distinction that survives with no colour at all, and a wrapped
+// prompt whose continuations were unmarked would be indistinguishable from
+// agent prose that happened to be indented.
+const promptMarker = "› "
+
+// promptBubbleNum and promptBubbleDen cap the bubble at two thirds of the
+// pane. Wide enough that an ordinary question is not shredded into a column,
+// narrow enough that the gutter on the left is unmistakably a gutter — a
+// bubble allowed the full width is not a bubble.
+const (
+	promptBubbleNum = 2
+	promptBubbleDen = 3
+)
+
+// promptBubbleLines draws a turn's prompt as a right-aligned bubble: shrink-
+// to-fit, capped at promptBubbleNum/promptBubbleDen of the pane, wrapped
+// inside itself, with promptMarker on every line. Agent output is untouched
+// by this — it stays flush left at the full width.
+//
+// The prompt's own line breaks survive. The composer is multi-line by design
+// (task 071 decision 4 keeps ↑/↓ for editing a draft), so a pasted snippet or
+// a numbered list is prompt content, not incidental whitespace, and there is
+// no line cap either: a truncated prompt puts the tail of what a human asked
+// out of reach on a body that already scrolls. That is the call task 073
+// decision 5 made when it dropped the 40-line cap from the §17 fallback.
+//
+// The text is plain while it is wrapped and measured, and each produced line
+// is styled afterwards (task 050 decision 8, v0 T4.16): no break can land
+// inside an escape sequence and no measurement ever sees one.
+func promptBubbleLines(prompt string, width int) []string {
+	if width <= 0 {
+		return nil
+	}
+	marker := cols(promptMarker)
+	// The bubble is at most the pane, however narrow the pane is: the cap is
+	// a share of the width, and a share of a small width is smaller still.
+	limit := min(width*promptBubbleNum/promptBubbleDen, width)
+	inner := max(limit-marker, 1)
+
+	wrapped := make([]string, 0, 4)
+	for _, para := range strings.Split(normalizeBreaks(prompt), "\n") {
+		if cols(para) <= inner {
+			// An empty line stays an empty line: a blank between paragraphs
+			// is how the human spaced what they wrote.
+			wrapped = append(wrapped, para)
+			continue
+		}
+		wrapped = append(wrapped, strings.Split(ansi.Wrap(para, inner, "-"), "\n")...)
+	}
+
+	// Shrink to fit: the bubble is as wide as its widest line, not as wide as
+	// it was allowed to be.
+	widest := 0
+	for _, line := range wrapped {
+		widest = max(widest, cols(line))
+	}
+	left := max(width-marker-widest, 0)
+	pad := strings.Repeat(" ", left)
+
+	out := make([]string, len(wrapped))
+	for i, line := range wrapped {
+		out[i] = pad + stylePrompt.Render(promptMarker+line)
+	}
+	return out
+}
+
+// normalizeBreaks folds the line endings a prompt can arrive with into "\n"
+// and expands tabs, so every break the human typed becomes a line of the
+// bubble and every remaining cell is one the width arithmetic can count. A
+// literal tab is the one character whose rendered width is the terminal's
+// business rather than ours.
+func normalizeBreaks(s string) string {
+	return strings.NewReplacer("\r\n", "\n", "\r", "\n", "\t", "    ").Replace(s)
+}

--- a/internal/tui/chatprompt_test.go
+++ b/internal/tui/chatprompt_test.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The chat workspace's user turn is a right-aligned bubble and the agent's
+// turn is not, which is the whole of the distinction: a conversation that
+// drew both halves flush left at the full width read as one column of text
+// with a `›` somewhere in it.
+//
+// Every assertion here is against ANSI-stripped output, because that is the
+// requirement rather than a convenience: §15's Colour section has the palette
+// degrading under NO_COLOR and at 16 colours, so the alignment and the marker
+// have to carry the distinction on their own.
+
+// bubbleBox is a bubble's left column, right column and marked-line count,
+// measured in cells off the stripped lines.
+func bubbleBox(t *testing.T, lines []string) (left, right, marked int) {
+	t.Helper()
+	left = -1
+	for i, line := range plainLines(lines) {
+		trimmed := strings.TrimLeft(line, " ")
+		if !strings.HasPrefix(trimmed, promptMarker) {
+			t.Errorf("bubble line %d is not marked with %q: %q", i, promptMarker, line)
+			continue
+		}
+		marked++
+		l := ansi.StringWidth(line) - ansi.StringWidth(trimmed)
+		if left < 0 || l < left {
+			left = l
+		}
+		right = max(right, ansi.StringWidth(line))
+	}
+	return left, right, marked
+}
+
+// TestChatPromptBubbleIsRightAlignedBoldAndMarked is the shape of the thing:
+// flush against the right edge of the pane, bold, and carrying the marker on
+// every line rather than only the first.
+func TestChatPromptBubbleIsRightAlignedBoldAndMarked(t *testing.T) {
+	const width = 60
+	lines := promptBubbleLines("what changed in the scheduler?", width)
+	if len(lines) != 1 {
+		t.Fatalf("a prompt that fits produced %d lines: %q", len(lines), plainLines(lines))
+	}
+	left, right, marked := bubbleBox(t, lines)
+	if right != width {
+		t.Errorf("the bubble's right edge is at column %d in a %d-column pane, so it is not right-aligned: %q",
+			right, width, plainLines(lines)[0])
+	}
+	if left <= 0 {
+		t.Errorf("the bubble starts at column %d: there is no gutter left of it and nothing distinguishes it from agent prose", left)
+	}
+	if marked != len(lines) {
+		t.Errorf("%d of %d bubble lines carry the marker", marked, len(lines))
+	}
+	// Bold as well as coloured: the colour is the part NO_COLOR takes away.
+	if !strings.Contains(lines[0], "\x1b[1") {
+		t.Errorf("the bubble is not bold: %q", lines[0])
+	}
+	if plain := plainLines(lines)[0]; !strings.Contains(plain, "what changed in the scheduler?") {
+		t.Errorf("the prompt did not survive stripping: %q", plain)
+	}
+}
+
+// TestChatPromptBubbleShrinksToFitAndCapsAtTwoThirds holds both halves of
+// "shrink-to-fit, capped": a short prompt is as wide as it is, and a long one
+// wraps inside the cap instead of growing to the pane.
+func TestChatPromptBubbleShrinksToFitAndCapsAtTwoThirds(t *testing.T) {
+	const width = 90
+	limit := width * promptBubbleNum / promptBubbleDen
+
+	short := "hi"
+	lines := promptBubbleLines(short, width)
+	left, right, _ := bubbleBox(t, lines)
+	if got := right - left; got != ansi.StringWidth(promptMarker+short) {
+		t.Errorf("a two-character prompt drew a %d-column bubble; it should shrink to fit, not stretch to the cap", got)
+	}
+
+	long := strings.Repeat("scheduler admission ", 12)
+	lines = promptBubbleLines(long, width)
+	if len(lines) < 2 {
+		t.Fatalf("a %d-cell prompt in a %d-column pane produced %d lines: it did not wrap",
+			ansi.StringWidth(long), width, len(lines))
+	}
+	left, right, marked := bubbleBox(t, lines)
+	if got := right - left; got > limit {
+		t.Errorf("the bubble is %d columns wide, past the %d-column cap in a %d-column pane", got, limit, width)
+	}
+	if right != width {
+		t.Errorf("the wrapped bubble's right edge is at column %d, want the pane's %d", right, width)
+	}
+	if marked != len(lines) {
+		t.Errorf("%d of %d wrapped lines carry the marker: a continuation with no marker is indistinguishable from agent prose", marked, len(lines))
+	}
+	for i, line := range plainLines(lines) {
+		if w := ansi.StringWidth(line); w > width {
+			t.Errorf("bubble line %d is %d columns in a %d-column pane: %q", i, w, width, line)
+		}
+	}
+	// Nothing was dropped on the way in.
+	var joined strings.Builder
+	for _, line := range plainLines(lines) {
+		joined.WriteString(strings.TrimPrefix(strings.TrimLeft(line, " "), promptMarker))
+		joined.WriteString(" ")
+	}
+	if !strings.Contains(joined.String(), "admission") {
+		t.Errorf("the wrapped prompt lost its words: %q", joined.String())
+	}
+}
+
+// TestChatPromptBubbleKeepsItsOwnLineBreaks is the composer being multi-line
+// by design (task 071 decision 4): a pasted snippet or a numbered list is
+// prompt content, and the old call folded every break into a space.
+func TestChatPromptBubbleKeepsItsOwnLineBreaks(t *testing.T) {
+	lines := plainLines(promptBubbleLines("one\ntwo\n\nthree", 60))
+	if len(lines) != 4 {
+		t.Fatalf("a prompt with three breaks produced %d lines, want 4: %q", len(lines), lines)
+	}
+	for i, want := range []string{"one", "two", "", "three"} {
+		got := strings.TrimPrefix(strings.TrimLeft(lines[i], " "), promptMarker)
+		if got != want {
+			t.Errorf("line %d is %q, want %q — the prompt's own breaks did not survive", i, got, want)
+		}
+	}
+}
+
+// TestChatPromptBubbleHasNoLineCap is the other half of the old call: six
+// lines and an ellipsis put the tail of what a human asked out of reach on a
+// body that already scrolls. Task 073 decision 5 made the same call for §17's
+// retention fallback.
+func TestChatPromptBubbleHasNoLineCap(t *testing.T) {
+	rows := make([]string, 20)
+	for i := range rows {
+		rows[i] = "step " + strings.Repeat("x", i+1)
+	}
+	lines := plainLines(promptBubbleLines(strings.Join(rows, "\n"), 60))
+	if len(lines) != len(rows) {
+		t.Fatalf("a %d-line prompt rendered as %d lines", len(rows), len(lines))
+	}
+	last := strings.TrimPrefix(strings.TrimLeft(lines[len(lines)-1], " "), promptMarker)
+	if last != rows[len(rows)-1] {
+		t.Errorf("the last line of the prompt is %q, want %q", last, rows[len(rows)-1])
+	}
+	if strings.Contains(strings.Join(lines, "\n"), "…") {
+		t.Errorf("a twenty-line prompt was cut with an ellipsis:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+// TestChatAgentOutputStaysFlushLeftAndFullWidth is the control: only the
+// prompt half of a turn changed.
+func TestChatAgentOutputStaysFlushLeftAndFullWidth(t *testing.T) {
+	const width = 60
+	v := finishedChat(t, 1)
+	v.applyTranscript(chatTranscriptMsg{chatID: 1, seq: 1, records: []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: strings.Repeat("word ", 40)},
+	}})
+	limit := width * promptBubbleNum / promptBubbleDen
+	var flushLeft, wide int
+	for _, line := range plainLines(v.bodyLines(width)) {
+		if strings.Contains(line, "word word") {
+			// The output pane's own gutter, not an alignment: a couple of
+			// columns, nowhere near the third of the pane a bubble sits past.
+			if indent := ansi.StringWidth(line) - ansi.StringWidth(strings.TrimLeft(line, " ")); indent <= 2 {
+				flushLeft++
+			}
+			if ansi.StringWidth(line) > limit {
+				wide++
+			}
+		}
+	}
+	if flushLeft == 0 {
+		t.Error("no agent output line is flush left: the bubble's alignment leaked onto the agent's half of the turn")
+	}
+	if wide == 0 {
+		t.Errorf("no agent output line is wider than %d columns: the agent's half was capped like the prompt's", limit)
+	}
+}
+
+// TestChatPromptBubbleKeepsAPausedReadersPlace is the anchor claim. Prompt
+// lines carry the zero anchor and cannot be anchored *to*; what matters is
+// that the pad is by the bubble's actual height, so every record line below a
+// prompt keeps the anchor it had and a growing prompt above the reader does
+// not slide the pane out from under them (#291).
+func TestChatPromptBubbleKeepsAPausedReadersPlace(t *testing.T) {
+	const width, height = 60, 20
+	v := finishedChat(t, 3)
+	for seq := 1; seq <= 3; seq++ {
+		recs := make([]apiclient.TranscriptRecord, 6)
+		for i := range recs {
+			recs[i] = apiclient.TranscriptRecord{
+				Type: "agent.output",
+				Text: "turn " + string(rune('0'+seq)) + " line " + string(rune('0'+i)),
+			}
+		}
+		v.applyTranscript(chatTranscriptMsg{chatID: 1, seq: seq, records: recs})
+	}
+	v.render(width, height)
+	v.updateKey(registryKey(t, "pgup"))
+	if v.following {
+		t.Fatal("pgup did not pause the pane")
+	}
+	top := func() string {
+		body := plainLines(strings.Split(v.bodyView(width, height-8), "\n"))
+		return strings.TrimSpace(body[0])
+	}
+	before := top()
+
+	// A multi-line prompt above the reader: the bubble grows by four lines,
+	// and a pad that still counted one would shift every anchor below it.
+	v.turns[0].Prompt = "one\ntwo\nthree\nfour\nfive"
+	v.bodyDirty = true
+	v.render(width, height)
+	if after := top(); after != before {
+		t.Errorf("the paused pane moved from %q to %q when a prompt above it grew", before, after)
+	}
+
+	// And across a plain rebuild at the same width, which is what a level or
+	// raw toggle is.
+	v.bodyDirty = true
+	v.render(width, height)
+	if after := top(); after != before {
+		t.Errorf("a rebuild moved the paused pane from %q to %q", before, after)
+	}
+}

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -176,7 +176,11 @@ func (v *chatView) bodyLinesAt(width int) ([]string, []lineAnchor) {
 		t := &v.turns[i]
 		v.turnAt[t.Seq] = len(lines)
 		lines = append(lines, styleDim.Render(fmt.Sprintf(" ── turn %d ──", t.Seq)))
-		prompt := wrapCellLines("› "+t.Prompt, width-2, 6)
+		// The human's half of the turn is a right-aligned bubble; the agent's
+		// half below is untouched, flush left at the full width. The pad is
+		// by the bubble's *actual* height, so the prompt keeps carrying the
+		// zero anchor and v.turnAt[t.Seq] still points at the separator.
+		prompt := promptBubbleLines(t.Prompt, width)
 		lines = append(lines, prompt...)
 		pad(1 + len(prompt))
 		switch recs := v.turnRecords[t.Seq]; {
@@ -220,6 +224,12 @@ func (v *chatView) bodyLinesAt(width int) ([]string, []lineAnchor) {
 	return lines, anchors
 }
 
+// chatComposerWidth is how many columns the composer gets inside its border:
+// the pane's, less the frame's two. It is one function because two callers
+// size the composer — footerLines on every render and the WindowSizeMsg
+// handler in chatview.go — and two copies of the arithmetic drift.
+func chatComposerWidth(pane int) int { return max(pane-2, 10) }
+
 func (v *chatView) footerLines(width int) []string {
 	out := []string{""}
 	if v.note != "" {
@@ -231,21 +241,34 @@ func (v *chatView) footerLines(width int) []string {
 	}
 	// One element per rendered line, not one per widget (issue #299): the
 	// composer is SetHeight(3) and bubbles' viewport pads its View to that
-	// height, so a joined string would report a height of 1 and render 3.
-	// render's `room := height - len(head) - len(foot)` would then overrun the
-	// frame by two lines — the frame keeps the first h-2 — and the hint line
-	// below would never be drawn. It would also feed a multi-line string to
-	// render's per-line ansi.Truncate pass, which measures the whole thing as
-	// the *sum* of its rows — ansi.StringWidth treats the `\n`s as zero-width
-	// and never resets — so once that sum passes the pane width the tail is cut
-	// and the composer collapses to its first row. newtaskrender.go does the
-	// same split for the description textarea.
+	// height, and the border around it adds two more, so a joined string would
+	// report a height of 1 and render 5. render's
+	// `room := height - len(head) - len(foot)` would then overrun the frame by
+	// four lines — the frame keeps the first h-4 — and the hint line below
+	// would never be drawn. It would also feed a multi-line string to render's
+	// per-line ansi.Truncate pass, which measures the whole thing as the *sum*
+	// of its rows — ansi.StringWidth treats the `\n`s as zero-width and never
+	// resets — so once that sum passes the pane width the tail is cut and the
+	// box collapses to its top edge. That is why the frame is split here the
+	// same way the composer's own View is, and why the border is spent out of
+	// the budget rather than added after the join: §15's #299 amendment, "a
+	// composer that grew is a body that shrank, not a frame that overflowed".
 	//
 	// The width is the pane's, not the terminal's: render is what knows how
 	// many columns the composer actually has, and a composer sized from the
-	// whole terminal has its rows cut by the Truncate pass above.
-	v.composer.SetWidth(max(width-4, 10))
-	out = append(out, strings.Split(v.composer.View(), "\n")...)
+	// whole terminal has its rows cut by the Truncate pass above. Two of them
+	// go to the border, which is what shell.go's frame draws in.
+	v.composer.SetWidth(chatComposerWidth(width))
+	rows := strings.Split(v.composer.View(), "\n")
+	// focused=false on purpose: the composer holds the keyboard nearly always
+	// here, so a permanently lit focus glyph would say nothing.
+	box := frame("message", v.composer.View(), width, len(rows)+2, false)
+	if box == "" {
+		// Narrower or shorter than a box can be drawn in; the rows still are.
+		out = append(out, rows...)
+	} else {
+		out = append(out, strings.Split(box, "\n")...)
+	}
 	hint := " enter send · ctrl+x stop the turn · ctrl+r detail · " +
 		rawToggleKey + " raw · " + copyPickKey + " copy · " +
 		"pgup/pgdown scroll · ctrl+g live · esc back to the chats board"

--- a/internal/tui/chatturns_test.go
+++ b/internal/tui/chatturns_test.go
@@ -52,9 +52,16 @@ func TestChatFetchesOlderTurnsWhenScrolledTo(t *testing.T) {
 	v.fetchTranscripts()
 	v.bodyDirty = true
 	v.render(60, 14)
-	v.updateKey(registryKey(t, "pgup"))
-	v.updateKey(registryKey(t, "pgup"))
-	v.updateKey(registryKey(t, "pgup"))
+	// Paged to the top, not paged a fixed number of times: how many pages a
+	// conversation is depends on how many rows the body has, and the body is
+	// whatever the header and the framed composer left it.
+	for range 20 {
+		before := v.vp.YOffset()
+		v.updateKey(registryKey(t, "pgup"))
+		if v.vp.YOffset() == before {
+			break
+		}
+	}
 	if !v.fetched[1] {
 		t.Fatalf("scrolling to the top fetched %v, never turn 1", v.fetched)
 	}

--- a/internal/tui/chatverbosity_test.go
+++ b/internal/tui/chatverbosity_test.go
@@ -112,17 +112,21 @@ func TestChatLevelIsTheOutputPanesLevel(t *testing.T) {
 	if d.level.get() != levelVerbose {
 		t.Fatalf("the task pane is on %s, want the level the chat cycled to", d.level.get())
 	}
-	// And back the other way.
+	// And back the other way. Verbose wraps to the quietest level, which is
+	// quiet since issue #321.
 	d.cycleLevel()
-	if v.level.get() != levelCompact {
-		t.Fatalf("cycling in the task pane left the chat on %s, want compact", v.level.get())
+	if v.level.get() != levelQuiet {
+		t.Fatalf("cycling in the task pane left the chat on %s, want quiet", v.level.get())
 	}
-	// compact → normal → verbose → compact, three presses back to the start.
-	for range 3 {
+	// quiet → compact → normal → verbose → quiet, four presses back to the
+	// start, and the two panes agree at every stop along the way.
+	want := []outputLevel{levelCompact, levelNormal, levelVerbose, levelQuiet}
+	for _, w := range want {
 		v.updateKey(registryKey(t, "ctrl+r"))
-	}
-	if v.level.get() != levelCompact {
-		t.Fatalf("three presses landed on %s, want compact again", v.level.get())
+		if v.level.get() != w || d.level.get() != w {
+			t.Fatalf("a press landed on %s (chat) and %s (task), want %s",
+				v.level.get(), d.level.get(), w)
+		}
 	}
 	// Leaving and reopening the chat keeps it: the holder outlives the view's
 	// per-chat state.
@@ -142,7 +146,7 @@ func TestChatHeaderNamesANonDefaultLevel(t *testing.T) {
 	if strings.Contains(header(), "normal") {
 		t.Error("the header names the default level, which is noise")
 	}
-	for _, l := range []outputLevel{levelCompact, levelVerbose} {
+	for _, l := range []outputLevel{levelQuiet, levelCompact, levelVerbose} {
 		v.level.set(l)
 		if !strings.Contains(header(), l.String()) {
 			t.Errorf("the header does not name the %s level", l)
@@ -229,7 +233,7 @@ func TestChatLiveAndRefetchedAgree(t *testing.T) {
 	for _, note := range live {
 		streamed = append(streamed, recordFromChunk(note))
 	}
-	for _, level := range []outputLevel{levelCompact, levelNormal, levelVerbose} {
+	for _, level := range []outputLevel{levelQuiet, levelCompact, levelNormal, levelVerbose} {
 		opts := lineOpts{expandKey: chatExpandKey}
 		want := plainLines(outputLines(fetched, level, 80, opts))
 		got := plainLines(outputLines(streamed, level, 80, opts))
@@ -256,7 +260,7 @@ func TestChatAndTaskPaneRenderMarkdownIdentically(t *testing.T) {
 		{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{{Name: "Edit", CallID: "c1"}}},
 		{Type: "agent.output", Text: mdFixture},
 	}
-	for _, level := range []outputLevel{levelCompact, levelNormal, levelVerbose} {
+	for _, level := range []outputLevel{levelQuiet, levelCompact, levelNormal, levelVerbose} {
 		for _, width := range []int{40, 80} {
 			d := newTestDetail(t)
 			d.width = width

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -267,7 +267,7 @@ func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		v.width, v.height = msg.Width, msg.Height
-		v.composer.SetWidth(max(msg.Width-4, 10))
+		v.composer.SetWidth(chatComposerWidth(msg.Width))
 		return v, nil
 	case openChatMsg:
 		return v, v.open(msg.id)

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -1134,20 +1134,35 @@ func toolUsePane(tools []apiclient.TranscriptTool) paneLine {
 	}
 }
 
-// renderResult renders the terminal record. On success it shows the outcome
-// and nothing else: every dialect's result text repeats assistant messages
-// already on screen — cursor's is the entire turn concatenated — so printing
-// it again is the same words twice. The text is kept when nothing else
-// rendered, which is what a codex turn with no agent_message looks like, and
-// always on error, where it is the error and may be the only content there is.
-func renderResult(rec apiclient.TranscriptRecord, sawOutput bool, level outputLevel) paneLine {
+// renderResult renders the terminal record, reporting whether it produced a
+// line at all. On success it shows the outcome and nothing else: every
+// dialect's result text repeats assistant messages already on screen —
+// cursor's is the entire turn concatenated — so printing it again is the same
+// words twice. The text is kept when nothing else rendered, which is what a
+// codex turn with no agent_message looks like, and always on error, where it
+// is the error and may be the only content there is.
+//
+// levelQuiet suppresses the outcome branch and only that branch. The other
+// two are meanings of the record rather than level rules — §15 states them as
+// such — and a display level is not allowed to hide a failure, which in a
+// step run has no other line carrying it, nor to reduce a turn that produced
+// no prose at all to a bare `── turn N ──` with nothing under it.
+//
+// sawOutput is unperturbed by what quiet hides: it is set only by the
+// assistant-document path, so dropping the tool lines cannot change which
+// branch is taken, and the !sawOutput fallback fires at quiet exactly when it
+// fires everywhere else.
+func renderResult(rec apiclient.TranscriptRecord, sawOutput bool, level outputLevel) (paneLine, bool) {
 	if rec.IsError {
-		return marked("✗ ", firstNonEmpty(rec.Message, rec.ResultText, "run failed"), styleBad)
+		return marked("✗ ", firstNonEmpty(rec.Message, rec.ResultText, "run failed"), styleBad), true
 	}
 	if !sawOutput {
-		return marked("✓ ", firstNonEmpty(rec.ResultText, "run finished"), styleOK)
+		return marked("✓ ", firstNonEmpty(rec.ResultText, "run finished"), styleOK), true
 	}
-	return marked("✓ ", resultOutcome(rec, level), styleOK)
+	if level == levelQuiet {
+		return paneLine{}, false
+	}
+	return marked("✓ ", resultOutcome(rec, level), styleOK), true
 }
 
 // resultOutcome is the one-line summary that replaces a repeated result text.
@@ -1160,7 +1175,9 @@ func renderResult(rec apiclient.TranscriptRecord, sawOutput bool, level outputLe
 // said and did, nothing else", and how long a run took is neither. From
 // normal up it carries what the run said about itself, and the per-model and
 // cache breakdown — the part that is several lines, not several words — is
-// verbose only.
+// verbose only. levelQuiet does not reach here at all: it drops the outcome
+// line rather than shortening it further (see renderResult), which is why the
+// short form below is `== levelCompact` and not "compact and below".
 func resultOutcome(rec apiclient.TranscriptRecord, level outputLevel) string {
 	if level == levelCompact {
 		if rec.CostUSD != nil {

--- a/internal/tui/outputlines.go
+++ b/internal/tui/outputlines.go
@@ -87,13 +87,27 @@ func isTerminalControl(r rune) bool {
 // outputLevel is how much of a record the pane shows. One key cycles it
 // (§15 `v`); the level is session state, so switching attempts does not
 // silently reset what a reader is looking at.
+//
+// Four levels, quietest first, so `l < levelNormal` reads as "quieter than
+// the default" and a guard meaning "compact and below" is spelled
+// `level <= levelCompact`. Nothing outside this file may depend on the
+// numbers: they renumbered once already, when quiet was added underneath,
+// and nothing persists them (see levelHolder).
 type outputLevel int
 
 const (
+	// levelQuiet is the reading level: the agent's prose and anything that
+	// went wrong, and nothing it narrated about its own machinery. Below
+	// compact it drops the tool calls and their outcomes, the `done · …`
+	// outcome of a run that succeeded, and unrecognized lines entirely —
+	// not even their count, since a count is an offer to expand and quiet
+	// is the level that makes no offers.
+	levelQuiet outputLevel = iota
 	// levelCompact hides reasoning: what the agent said and did, nothing
-	// else. Unrecognized lines stay behind their count at every level below
-	// verbose — the count is the affordance that says there is more.
-	levelCompact outputLevel = iota
+	// else. Unrecognized lines stay behind their count at compact and at
+	// normal — the count is the affordance that says there is more, and
+	// quiet is the one level that does not show even that.
+	levelCompact
 	// levelNormal is the default — reasoning truncated to its first lines.
 	levelNormal
 	// levelVerbose shows everything, including the lines vincent's parsers
@@ -103,6 +117,8 @@ const (
 
 func (l outputLevel) String() string {
 	switch l {
+	case levelQuiet:
+		return "quiet"
 	case levelCompact:
 		return "compact"
 	case levelVerbose:
@@ -112,10 +128,12 @@ func (l outputLevel) String() string {
 	}
 }
 
-// next cycles compact → normal → verbose → compact.
+// next cycles quiet → compact → normal → verbose → quiet. One press is still
+// "one louder, wrap to the quietest", so the gesture did not change when the
+// fourth level went in underneath.
 func (l outputLevel) next() outputLevel {
 	if l >= levelVerbose {
-		return levelCompact
+		return levelQuiet
 	}
 	return l + 1
 }
@@ -128,6 +146,9 @@ func (l outputLevel) next() outputLevel {
 // dies with the process, exactly as §15 already reasons for the task pane.
 type levelHolder struct{ level outputLevel }
 
+// newLevelHolder starts at levelNormal, which since issue #321 is no longer
+// the zero value: a session must be constructed through here rather than as a
+// bare levelHolder{}, which would open every pane at quiet.
 func newLevelHolder() *levelHolder { return &levelHolder{level: levelNormal} }
 
 func (h *levelHolder) get() outputLevel { return h.level }
@@ -600,10 +621,10 @@ func toolResultLine(r apiclient.TranscriptToolResult) paneLine {
 }
 
 // thinkingBlock renders a reasoning block at the given level: hidden at
-// compact, truncated at normal, whole at verbose. Truncation is applied
-// after wrapping, so "3 lines" means three lines of the pane.
+// compact and below, truncated at normal, whole at verbose. Truncation is
+// applied after wrapping, so "3 lines" means three lines of the pane.
 func thinkingBlock(text string, level outputLevel, width int, expandKey string) []string {
-	if level == levelCompact || text == "" {
+	if level <= levelCompact || text == "" {
 		return nil
 	}
 	lines := wrapLine(paneLine{
@@ -700,6 +721,14 @@ func outputLinesAt(records []apiclient.TranscriptRecord, seqs []int64, level out
 	rawRun := 0
 	flushRaw := func() {
 		if rawRun == 0 {
+			return
+		}
+		// Quiet is the level below the count. Everywhere else the count is
+		// an offer — "there are lines here, `v` shows them" — and quiet is
+		// the level that makes no offers, so an unparsed line leaves no
+		// trace at all rather than a row of arithmetic about itself.
+		if level == levelQuiet {
+			rawRun = 0
 			return
 		}
 		note([]string{styleDim.Render(fmt.Sprintf(
@@ -812,12 +841,15 @@ func assistantBlockLines(text string, width int, raw bool) ([]string, []int) {
 func renderRecord(rec apiclient.TranscriptRecord, sawOutput bool, level outputLevel) (paneLine, bool) {
 	switch rec.Type {
 	case "agent.tool_use":
-		if len(rec.Tools) == 0 {
+		// levelQuiet is "what the agent said, and what went wrong". A tool
+		// call is what it *did*, which is exactly the half compact keeps
+		// and quiet drops.
+		if level == levelQuiet || len(rec.Tools) == 0 {
 			return paneLine{}, false
 		}
 		return toolUsePane(rec.Tools), true
 	case "agent.tool_result":
-		if len(rec.Results) == 0 {
+		if level == levelQuiet || len(rec.Results) == 0 {
 			return paneLine{}, false
 		}
 		// One record can report several outcomes; the first owns the line
@@ -825,16 +857,18 @@ func renderRecord(rec apiclient.TranscriptRecord, sawOutput bool, level outputLe
 		return toolResultLine(rec.Results[0]), true
 	case "agent.run_header":
 		// levelCompact is "what the agent said and did, nothing else"; the
-		// run header is neither, so it appears from normal up (task 066).
-		if level == levelCompact {
+		// run header is neither, so it appears from normal up (task 066) —
+		// and so is hidden at quiet for the same reason, one level down.
+		if level <= levelCompact {
 			return paneLine{}, false
 		}
 		return runHeaderLine(rec), true
 	case "agent.plan":
 		// levelCompact is "what the agent said and did, nothing else". A
 		// plan is neither — it is what the agent intends — so it appears
-		// from normal up, where the run header does (task 070).
-		if level == levelCompact || len(rec.Items) == 0 {
+		// from normal up, where the run header does (task 070), and stays
+		// hidden at everything below compact too.
+		if level <= levelCompact || len(rec.Items) == 0 {
 			return paneLine{}, false
 		}
 		return planLine(rec.Items), true
@@ -854,7 +888,10 @@ func renderRecord(rec apiclient.TranscriptRecord, sawOutput bool, level outputLe
 	case "agent.error":
 		return marked("✗ ", rec.Message, styleBad), true
 	case "agent.result":
-		return renderResult(rec, sawOutput, level), true
+		// The only arm that decides for itself whether it has a line: quiet
+		// suppresses the success outcome and keeps the other two forms, so
+		// the answer is not "always" (see renderResult).
+		return renderResult(rec, sawOutput, level)
 	case "command.output", "vincent.output":
 		if rec.Stream == "stderr" {
 			return plain(rec.Text, styleStderr, false), true

--- a/internal/tui/outputlines_test.go
+++ b/internal/tui/outputlines_test.go
@@ -123,8 +123,10 @@ func TestWrapLineJoinsGutterToFirstWord(t *testing.T) {
 func TestThinkingLevels(t *testing.T) {
 	text := strings.Repeat("reasoning words ", 30)
 
-	if got := thinkingBlock(text, levelCompact, 40, "v"); got != nil {
-		t.Errorf("compact rendered %d lines, want none", len(got))
+	for _, level := range []outputLevel{levelQuiet, levelCompact} {
+		if got := thinkingBlock(text, level, 40, "v"); got != nil {
+			t.Errorf("%s rendered %d lines, want none", level, len(got))
+		}
 	}
 
 	normal := plainLines(thinkingBlock(text, levelNormal, 40, "v"))
@@ -148,17 +150,30 @@ func TestThinkingLevels(t *testing.T) {
 	}
 }
 
-// TestOutputLevelCycle pins the order the key advances through.
+// TestOutputLevelCycle pins the order the key advances through: four levels
+// since issue #321, and one press is still "one louder, wrap to the
+// quietest", so the gesture did not change when quiet went in underneath.
 func TestOutputLevelCycle(t *testing.T) {
-	got := []outputLevel{levelNormal}
-	for range 3 {
+	got := []outputLevel{levelQuiet}
+	for range 4 {
 		got = append(got, got[len(got)-1].next())
 	}
-	want := []outputLevel{levelNormal, levelVerbose, levelCompact, levelNormal}
+	want := []outputLevel{levelQuiet, levelCompact, levelNormal, levelVerbose, levelQuiet}
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("cycle = %v, want %v", got, want)
 		}
+	}
+	names := []string{"quiet", "compact", "normal", "verbose"}
+	for i, name := range names {
+		if l := outputLevel(i); l.String() != name {
+			t.Errorf("level %d names itself %q, want %q", i, l.String(), name)
+		}
+	}
+	// A fifth value would mean a level with no name, since String falls back
+	// to "normal" rather than reporting one.
+	if outputLevel(len(names)).next() != levelQuiet {
+		t.Error("the cycle does not close after the four named levels")
 	}
 }
 
@@ -199,7 +214,7 @@ func TestUsageOnlyAtVerbose(t *testing.T) {
 	d.records = []apiclient.TranscriptRecord{
 		{Type: "agent.usage", Raw: json.RawMessage(`{"input_tokens":10}`)},
 	}
-	for _, level := range []outputLevel{levelCompact, levelNormal} {
+	for _, level := range []outputLevel{levelQuiet, levelCompact, levelNormal} {
 		d.level.set(level)
 		if got := d.outputLines(); len(got) != 0 {
 			t.Errorf("%s rendered usage: %q", level, got)
@@ -372,9 +387,11 @@ func TestRunHeaderLevels(t *testing.T) {
 		AvailableTools: []string{"Task", "Bash", "Write"},
 	}}
 
-	d.level.set(levelCompact)
-	if got := d.outputLines(); len(got) != 0 {
-		t.Errorf("compact rendered the run header: %q", got)
+	for _, level := range []outputLevel{levelQuiet, levelCompact} {
+		d.level.set(level)
+		if got := d.outputLines(); len(got) != 0 {
+			t.Errorf("%s rendered the run header: %q", level, got)
+		}
 	}
 
 	var atNormal string
@@ -564,10 +581,12 @@ func TestPlanFromNormalUp(t *testing.T) {
 	}
 	d.records = []apiclient.TranscriptRecord{{Type: "agent.output", Text: "working"}, plan}
 
-	d.level.set(levelCompact)
-	compact := plainLines(d.outputLines())
-	if len(compact) != 1 || strings.TrimSpace(compact[0]) != "working" {
-		t.Errorf("compact = %q, want only the agent's own words", compact)
+	for _, level := range []outputLevel{levelQuiet, levelCompact} {
+		d.level.set(level)
+		got := plainLines(d.outputLines())
+		if len(got) != 1 || strings.TrimSpace(got[0]) != "working" {
+			t.Errorf("%s = %q, want only the agent's own words", level, got)
+		}
 	}
 	for _, level := range []outputLevel{levelNormal, levelVerbose} {
 		d.level.set(level)
@@ -621,7 +640,7 @@ func TestCommandOutputOnlyAtVerbose(t *testing.T) {
 	d.records = []apiclient.TranscriptRecord{
 		{Type: "agent.command_output", CallID: "item_2", Output: "total 8\n", Truncated: true},
 	}
-	for _, level := range []outputLevel{levelCompact, levelNormal} {
+	for _, level := range []outputLevel{levelQuiet, levelCompact, levelNormal} {
 		d.level.set(level)
 		if got := d.outputLines(); len(got) != 0 {
 			t.Errorf("%s rendered a command's output body: %q", level, got)

--- a/internal/tui/panewidth_test.go
+++ b/internal/tui/panewidth_test.go
@@ -28,39 +28,76 @@ func countRune(frame string, r rune) int { return strings.Count(ansi.Strip(frame
 // message longer than the composer is wide wraps inside the textarea, and
 // the chat pane draws exactly one row of it.
 //
-// chatrender.go:228 appends `v.composer.View()` — three rows, `ta.SetHeight(3)`
-// at chatview.go:136 — as a single element of a slice whose every other
-// element is one line. render (chatrender.go:49-63) then counts it as one
-// line in `room`, so the frame is two lines taller than the terminal it was
-// given, and runs `ansi.Truncate(line, width, "…")` over all three rows at
-// once: `ansi.StringWidth` never resets across the `\n`s, so the composer is
+// footerLines appended `v.composer.View()` — three rows, `ta.SetHeight(3)` at
+// chatview.go:136 — as a single element of a slice whose every other element
+// is one line. render then counts it as one line in `room`, so the frame is
+// two lines taller than the terminal it was given, and runs
+// `ansi.Truncate(line, width, "…")` over all three rows at once:
+// `ansi.StringWidth` never resets across the `\n`s, so the composer is
 // measured as the sum of its rows and everything past the pane width — the
 // remaining rows, newlines included — is dropped.
+//
+// The claim covers the border the composer now wears: a frame is two more
+// rows in the same slice, and a joined box would collapse to its top edge for
+// exactly the reason a joined textarea collapsed to its first row. What the
+// frame costs, the body gives up — "a composer that grew is a body that
+// shrank, not a frame that overflowed" (§15's #299 amendment) — so the drawn
+// height is unchanged at any terminal size.
 func TestPaneWidthChatComposerKeepsEveryWrappedRow(t *testing.T) {
-	const (
-		width  = 80
-		height = 24
-	)
-	v := chatViewFixture()
-	v.update(tea.WindowSizeMsg{Width: width, Height: height})
+	for _, tc := range []struct{ width, height int }{
+		{80, 24}, {80, 12}, {40, 20}, {120, 40}, {24, 10},
+	} {
+		v := chatViewFixture()
+		v.update(tea.WindowSizeMsg{Width: tc.width, Height: tc.height})
 
-	// Long enough to wrap, short enough to still fit the composer's three
-	// rows: what is asserted is that the wrapped rows are drawn, not that an
-	// over-full composer scrolls.
-	msg := strings.Repeat("Z", width+panePad)
-	v.composer.SetValue(msg)
+		// Long enough to wrap, short enough to still fit the composer's three
+		// rows: what is asserted is that the wrapped rows are drawn, not that
+		// an over-full composer scrolls.
+		msg := strings.Repeat("Z", tc.width+panePad)
+		v.composer.SetValue(msg)
 
-	frame := v.render(width, height)
+		// What the composer drew is the yardstick, not what was typed: at a
+		// narrow width a textarea three rows tall scrolls its own value, and
+		// that is the widget's business. The claim is that every row it drew
+		// reaches the pane.
+		drew := countRune(v.composer.View(), 'Z')
+		var wrappedRows int
+		for _, row := range strings.Split(v.composer.View(), "\n") {
+			if strings.ContainsRune(ansi.Strip(row), 'Z') {
+				wrappedRows++
+			}
+		}
+		if wrappedRows < 2 {
+			t.Fatalf("%dx%d: the value did not wrap onto a second row, so the test has nothing to catch", tc.width, tc.height)
+		}
 
-	if got := len(strings.Split(frame, "\n")); got != height {
-		t.Errorf("the chat frame is %d lines at height %d: the composer's rows are not counted in room, so its tail falls off the bottom of the terminal", got, height)
-	}
-	if got := countRune(frame, 'Z'); got != len(msg) {
-		t.Errorf("%d of the %d typed characters reached the screen: the composer is truncated to its first row and the rest is typed blind", got, len(msg))
-	}
-	for i, line := range strings.Split(frame, "\n") {
-		if w := ansi.StringWidth(line); w > width {
-			t.Errorf("line %d is %d columns wide in a %d-column pane: %q", i, w, width, ansi.Strip(line))
+		frame := v.render(tc.width, tc.height)
+		lines := strings.Split(frame, "\n")
+
+		if got := len(lines); got != tc.height {
+			t.Errorf("%dx%d: the chat frame is %d lines: the composer's rows are not counted in room, so its tail falls off the bottom of the terminal",
+				tc.width, tc.height, got)
+		}
+		if got := countRune(frame, 'Z'); got != drew {
+			t.Errorf("%dx%d: %d of the %d drawn characters reached the screen: the composer is truncated to its first row and the rest is typed blind",
+				tc.width, tc.height, got, drew)
+		}
+		for i, line := range lines {
+			if w := ansi.StringWidth(line); w > tc.width {
+				t.Errorf("%dx%d: line %d is %d columns wide: %q", tc.width, tc.height, i, w, ansi.Strip(line))
+			}
+		}
+		// The composer is a field, not more conversation: a titled box around
+		// it, and the hint still below the box and last on the pane.
+		plain := ansi.Strip(frame)
+		if !strings.Contains(plain, "─ message ") {
+			t.Errorf("%dx%d: the composer is not framed:\n%s", tc.width, tc.height, plain)
+		}
+		if !strings.Contains(plain, "└") || !strings.Contains(plain, "┐") {
+			t.Errorf("%dx%d: the frame lost a corner, so it collapsed to an edge:\n%s", tc.width, tc.height, plain)
+		}
+		if last := ansi.Strip(lines[len(lines)-1]); !strings.Contains(last, "enter send") {
+			t.Errorf("%dx%d: the last line of the pane is %q, want the hint below the frame", tc.width, tc.height, last)
 		}
 	}
 }

--- a/internal/tui/quietlevel_test.go
+++ b/internal/tui/quietlevel_test.go
@@ -1,0 +1,342 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The fourth output level (issue #321). `quiet` sits below `compact` and is
+// the reading level: assistant prose and anything that went wrong, with
+// nothing the agent narrated about its own machinery.
+//
+// Two things are under test here. What quiet drops, in *both* panes — the
+// level is one holder shared by pointer, so a rule that held in a task
+// workspace and not in a chat would be a second vocabulary. And what quiet
+// did *not* disturb: the constants renumbered underneath the other three, so
+// the loud levels are held to a golden of their whole rendered output rather
+// than to a spot check, because an off-by-one in a `==` guard is exactly the
+// regression that would otherwise pass unnoticed.
+
+var quietCost = 0.0125
+
+// levelFixture covers every record type §15 gives a per-level rule for, plus
+// the ones it gives none — command output and the vincent.* frame — so the
+// golden below says something about each.
+var levelFixture = []apiclient.TranscriptRecord{
+	{Type: "agent.run_header", WorkDir: "/w/tree", AvailableTools: []string{"Edit", "Bash"}},
+	{Type: "agent.plan", Items: []apiclient.TranscriptPlanItem{
+		{Text: "read the file", Completed: true},
+		{Text: "write the fix"},
+	}},
+	{Type: "agent.thinking", Text: strings.Repeat("reasoning words ", 20)},
+	{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{
+		{Name: "Edit", Summary: "main.go", CallID: "c1"},
+	}},
+	{Type: "agent.tool_result", Results: []apiclient.TranscriptToolResult{
+		{CallID: "c1", Verb: "wrote", Summary: "main.go"},
+	}},
+	{Type: "agent.command_output", Output: "ok\n"},
+	{Type: "agent.usage", Raw: json.RawMessage(`{"input_tokens":10}`)},
+	{Type: "agent.raw", Line: `{"type":"stream_event"}`},
+	{Type: "agent.raw", Line: `{"type":"system","subtype":"compact_boundary"}`},
+	{Type: "agent.output", Text: "here is the **answer**"},
+	{Type: "vincent.command_started", Raw: json.RawMessage(`{"command":"go test ./..."}`)},
+	{Type: "command.output", Text: "PASS"},
+	{Type: "command.output", Text: "a warning", Stream: "stderr"},
+	{Type: "agent.error", Message: "the model refused"},
+	{
+		Type:          "agent.result",
+		ResultText:    "here is the answer",
+		DurationMS:    1200,
+		APIDurationMS: 900,
+		NumTurns:      3,
+		StopReason:    "end_turn",
+		CostUSD:       &quietCost,
+	},
+}
+
+// levelGolden is levelFixture rendered at eighty columns, one entry per
+// level. The three loud ones were captured from the code as it stood before
+// quiet existed and must not move; quiet's is the new rule.
+var levelGolden = map[outputLevel]string{
+	// Nothing the agent narrated about itself: no tool call, no outcome for
+	// it, no arithmetic about lines vincent could not parse, and no `done ·`
+	// summary of a run that succeeded. The failure stays, and so does the
+	// command step's own output — a command step narrates nothing, so its
+	// pane is byte-identical to compact's.
+	levelQuiet: "  here is the answer\n" +
+		"$ go test ./...\n" +
+		"  PASS\n" +
+		"  a warning\n" +
+		"✗ the model refused",
+
+	levelCompact: "▸ Edit main.go\n" +
+		"    ✓ wrote · main.go\n" +
+		"  … 2 unrecognized line(s) (v)\n" +
+		"\n" +
+		"  here is the answer\n" +
+		"$ go test ./...\n" +
+		"  PASS\n" +
+		"  a warning\n" +
+		"✗ the model refused\n" +
+		"✓ done · $0.01",
+
+	levelNormal: "# /w/tree · 2 tools: Edit, Bash\n" +
+		"☰ ✓ read the file · ○ write the fix\n" +
+		"· reasoning words reasoning words reasoning words reasoning words reasoning\n" +
+		"  words reasoning words reasoning words reasoning words reasoning words\n" +
+		"  reasoning words reasoning words reasoning words reasoning words reasoning\n" +
+		"  … +2 lines (v)\n" +
+		"▸ Edit main.go\n" +
+		"    ✓ wrote · main.go\n" +
+		"  … 2 unrecognized line(s) (v)\n" +
+		"\n" +
+		"  here is the answer\n" +
+		"$ go test ./...\n" +
+		"  PASS\n" +
+		"  a warning\n" +
+		"✗ the model refused\n" +
+		"✓ done · 1.2s · 3 turns · $0.01",
+
+	levelVerbose: "# /w/tree · 2 tools: Edit, Bash\n" +
+		"☰ ✓ read the file · ○ write the fix\n" +
+		"· reasoning words reasoning words reasoning words reasoning words reasoning\n" +
+		"  words reasoning words reasoning words reasoning words reasoning words\n" +
+		"  reasoning words reasoning words reasoning words reasoning words reasoning\n" +
+		"  words reasoning words reasoning words reasoning words reasoning words\n" +
+		"  reasoning words reasoning words\n" +
+		"▸ Edit main.go\n" +
+		"    ✓ wrote · main.go\n" +
+		"  ok\n" +
+		"  {\"input_tokens\":10}\n" +
+		"  {\"type\":\"stream_event\"}\n" +
+		"  {\"type\":\"system\",\"subtype\":\"compact_boundary\"}\n" +
+		"\n" +
+		"  here is the answer\n" +
+		"$ go test ./...\n" +
+		"  PASS\n" +
+		"  a warning\n" +
+		"✗ the model refused\n" +
+		"✓ done · 1.2s (0.9s api) · 3 turns · $0.01",
+}
+
+// renderAt is levelFixture through the task workspace's own pane.
+func renderAt(t *testing.T, level outputLevel) string {
+	t.Helper()
+	d := newTestDetail(t)
+	d.width = 80
+	d.records = levelFixture
+	d.level.set(level)
+	return strings.Join(plainLines(d.outputLines()), "\n")
+}
+
+// TestLoudLevelsRenderWhatTheyAlwaysDid is the renumbering's regression net.
+// Adding a level below compact shifted every constant up by one, so a guard
+// that meant "compact only" and a guard that meant "compact and quieter" are
+// now different code — and a whole-output golden is what tells them apart,
+// which a spot check for one substring would not.
+func TestLoudLevelsRenderWhatTheyAlwaysDid(t *testing.T) {
+	for _, level := range []outputLevel{levelCompact, levelNormal, levelVerbose} {
+		if got := renderAt(t, level); got != levelGolden[level] {
+			t.Errorf("%s moved\n got:\n%s\nwant:\n%s", level, got, levelGolden[level])
+		}
+	}
+}
+
+// TestQuietRendersOnlyProseAndFailures holds the new level's whole output in
+// the task workspace.
+func TestQuietRendersOnlyProseAndFailures(t *testing.T) {
+	got := renderAt(t, levelQuiet)
+	if got != levelGolden[levelQuiet] {
+		t.Fatalf("quiet\n got:\n%s\nwant:\n%s", got, levelGolden[levelQuiet])
+	}
+	for _, gone := range []string{"▸ Edit", "wrote", "unrecognized line(s)", "done ·"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("quiet still shows %q:\n%s", gone, got)
+		}
+	}
+}
+
+// TestQuietInAChatHidesTheSameThings is the pointer-shared holder's other
+// half: the chat body is the output pane, so quiet has to mean there exactly
+// what it means in a task workspace.
+func TestQuietInAChatHidesTheSameThings(t *testing.T) {
+	v := chatWithRecords(t)
+	v.level.set(levelQuiet)
+	body := strings.Join(plainLines(v.bodyLines(80)), "\n")
+
+	hidden := []string{
+		"Edit", "wrote", "unrecognized line(s)", "done ·",
+		"/w/tree", "reasoning words", "hook_created",
+	}
+	for _, gone := range hidden {
+		if strings.Contains(body, gone) {
+			t.Errorf("quiet in a chat still shows %q:\n%s", gone, body)
+		}
+	}
+	// The turn frame and the answer are what is left.
+	for _, want := range []string{"── turn 1 ──", "here is the answer"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("quiet in a chat dropped %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestQuietLeavesNoTraceOfAnUnrecognizedLine is the one rule quiet changes
+// rather than adds below: everywhere else an unparsed line leaves a count,
+// because the count is the offer to expand. Quiet makes no offers, so an
+// agent.raw record contributes nothing whatsoever — not the line, not a
+// number, not a blank row where it would have gone.
+func TestQuietLeavesNoTraceOfAnUnrecognizedLine(t *testing.T) {
+	recs := []apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "before"},
+		{Type: "agent.raw", Line: `{"type":"stream_event"}`},
+		{Type: "agent.raw", Line: `{"type":"system"}`},
+	}
+	without := []apiclient.TranscriptRecord{{Type: "agent.output", Text: "before"}}
+
+	for _, opts := range []lineOpts{{expandKey: "v"}, {expandKey: chatExpandKey}} {
+		got := plainLines(outputLines(recs, levelQuiet, 80, opts))
+		want := plainLines(outputLines(without, levelQuiet, 80, opts))
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Errorf("%s: the raw records left a trace\n got: %q\nwant: %q",
+				opts.expandKey, got, want)
+		}
+	}
+}
+
+// TestQuietKeepsFailuresAndSilentTurns pins the settled decision about
+// renderResult: only the success outcome goes. A display level does not hide
+// a failure — in a step run there is no other line carrying it — and it does
+// not reduce a turn that produced no prose at all to a bare separator.
+func TestQuietKeepsFailuresAndSilentTurns(t *testing.T) {
+	body := func(recs []apiclient.TranscriptRecord) string {
+		return strings.Join(plainLines(
+			outputLines(recs, levelQuiet, 80, lineOpts{expandKey: "v"})), "\n")
+	}
+
+	if got := body([]apiclient.TranscriptRecord{
+		{Type: "agent.error", Message: "context deadline exceeded"},
+	}); !strings.Contains(got, "context deadline exceeded") {
+		t.Errorf("quiet hid an agent.error: %q", got)
+	}
+
+	// A failed result, with nothing else in the run to carry the reason.
+	if got := body([]apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "working on it"},
+		{Type: "agent.result", IsError: true, Message: "the run failed hard"},
+	}); !strings.Contains(got, "the run failed hard") {
+		t.Errorf("quiet hid a failed result: %q", got)
+	}
+
+	// A codex turn with no agent_message: the result text is the only thing
+	// the turn ever said, and hiding it would leave the turn blank.
+	if got := body([]apiclient.TranscriptRecord{
+		{Type: "agent.tool_use", Tools: []apiclient.TranscriptTool{{Name: "Edit"}}},
+		{Type: "agent.result", ResultText: "all done, nothing to report"},
+	}); !strings.Contains(got, "all done, nothing to report") {
+		t.Errorf("quiet hid the fallback result text: %q", got)
+	}
+
+	// And the outcome form, which is the one that goes.
+	if got := body([]apiclient.TranscriptRecord{
+		{Type: "agent.output", Text: "the answer"},
+		{Type: "agent.result", ResultText: "the answer", DurationMS: 1200},
+	}); strings.Contains(got, "done") {
+		t.Errorf("quiet kept the success outcome: %q", got)
+	}
+}
+
+// TestQuietKeepsAChatTurnsFailureLine covers the other place a chat says
+// something went wrong: the turn row's own FailReason, drawn beside the
+// records rather than among them. It survives quiet for the reason a failed
+// result does.
+func TestQuietKeepsAChatTurnsFailureLine(t *testing.T) {
+	v := chatViewFixture()
+	v.level.set(levelQuiet)
+	v.turns = []apiclient.ChatTurn{{
+		ID: 9, Seq: 1, State: "failed", Prompt: "ask",
+		FailReason: "agent_error", ErrorMessage: "cursor-agent exited 1",
+	}}
+	body := strings.Join(plainLines(v.bodyLines(80)), "\n")
+	for _, want := range []string{"agent_error", "cursor-agent exited 1"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("quiet hid a turn's failure line, want %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestQuietDoesNotTouchACommandStep: quiet is a rule about what the *agent*
+// narrated, and a command step narrates nothing, so its pane is the same
+// bytes at quiet as at compact.
+func TestQuietDoesNotTouchACommandStep(t *testing.T) {
+	recs := []apiclient.TranscriptRecord{
+		{Type: "vincent.command_started", Raw: json.RawMessage(`{"command":"go build ./..."}`)},
+		{Type: "command.output", Text: "building"},
+		{Type: "command.output", Text: "vet: bad news", Stream: "stderr"},
+		{Type: "vincent.output", Text: "done"},
+	}
+	quiet := plainLines(outputLines(recs, levelQuiet, 80, lineOpts{expandKey: "v"}))
+	compact := plainLines(outputLines(recs, levelCompact, 80, lineOpts{expandKey: "v"}))
+	if strings.Join(quiet, "\n") != strings.Join(compact, "\n") {
+		t.Errorf("a command step differs by level\nquiet:   %q\ncompact: %q", quiet, compact)
+	}
+	if !strings.Contains(strings.Join(quiet, "\n"), "vet: bad news") {
+		t.Errorf("quiet dropped a command step's stderr: %q", quiet)
+	}
+}
+
+// TestBothPanesOpenAtNormalAndNameQuiet: the default did not move — a fourth
+// level below the old floor must not change what anyone's first screen shows
+// — and quiet, being a level other than the default, is named where compact
+// and verbose already are.
+func TestBothPanesOpenAtNormalAndNameQuiet(t *testing.T) {
+	d := newTestDetail(t)
+	v := chatViewFixture()
+	if d.level.get() != levelNormal || v.level.get() != levelNormal {
+		t.Fatalf("panes opened at %s (task) and %s (chat), want normal",
+			d.level.get(), v.level.get())
+	}
+	title := func() string { return plainLines([]string{d.outputTitle()})[0] }
+	header := func() string { return plainLines([]string{v.headerLine(80)})[0] }
+	if strings.Contains(title(), "quiet") || strings.Contains(header(), "quiet") {
+		t.Fatal("a pane named quiet while on normal")
+	}
+	d.level.set(levelQuiet)
+	v.level.set(levelQuiet)
+	if !strings.Contains(title(), "quiet") {
+		t.Errorf("the output pane's title does not name quiet: %q", title())
+	}
+	if !strings.Contains(header(), "quiet") {
+		t.Errorf("the chat header does not name quiet: %q", header())
+	}
+}
+
+// TestCopyDocsIgnoreTheLevel: what a reader may copy is the assistant
+// documents in the window, and that has never depended on how much of them
+// is on screen (task 076). Quiet, which hides more than any other level,
+// is the strongest statement of it.
+func TestCopyDocsIgnoreTheLevel(t *testing.T) {
+	d := newTestDetail(t)
+	d.width = 80
+	d.records = levelFixture
+	var want []copyItem
+	for _, level := range []outputLevel{levelQuiet, levelCompact, levelNormal, levelVerbose} {
+		d.level.set(level)
+		_ = d.outputLines()
+		got := copyDocs(copyDocsFromRecords(d.records, d.recordSeqs()))
+		if len(got) == 0 {
+			t.Fatalf("%s: no assistant document is offered for copying", level)
+		}
+		if want == nil {
+			want = got
+			continue
+		}
+		if len(got) != len(want) {
+			t.Errorf("%s offers %d documents, want %d", level, len(got), len(want))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The chat workspace renders a conversation with the task output pane's renderer,
verbatim — task 071 decision 2, and still the right call. This makes that
conversation readable as one: a level quiet enough to see only the answer, a
user turn you can pick out of the column, and a composer with an edge. All of it
is client-side in `internal/tui`; there is no daemon, API, store or wire change.

**A fourth level, `quiet`, below `compact`.** The verbosity cycle `v` walks in
the output pane and `ctrl+r` walks in the chat is four levels now —
`quiet → compact → normal → verbose`, wrapping back to quiet — so one press is
still "one louder, wrap to the quietest" and the gesture is unchanged. Relative
to `compact`, `quiet` drops `agent.tool_use` and `agent.tool_result`, the
`✓ done · …` outcome of a run that succeeded, and unrecognized lines entirely:
not even the `… N unrecognized line(s)` count, because a count is an offer to
expand and `quiet` is the level that makes no offers.

A display level is not allowed to hide a failure, so `agent.error`, an
`agent.result` that failed, a turn's own fail reason and the `── turn N ──`
separators all render at `quiet` — and so does the result *text* of an attempt
that rendered nothing else, which is what a codex turn with no `agent_message`
looks like and would otherwise be a turn separator with nothing under it. §15
records those two as meanings of the record rather than as level rules, which is
why they survive. `command.output` and `vincent.output` are untouched, so a
command step's pane is byte for byte the same at `quiet` as at `compact`.

`quiet` is a real level in **both** panes, not a chat dialect of `compact`: it is
still one shared session value, still persisted nowhere, and the default is still
`normal`, so nothing on an existing user's first screen moves. The three
alternatives — redefining `compact`, a chat-only level, a chat-only *rendering*
of a shared value — each would have superseded a task 071 decision and are
recorded as rejected in `docs/tasks/085-chat-workspace-ux.md`.

**A user turn that looks like one.** A prompt was
`wrapCellLines("› "+t.Prompt, width-2, 6)`: default foreground, flush left at the
assistant's own margin, with the `›` on the first line and gone on every wrapped
line after it. It is now a right-aligned bubble — shrink-to-fit, capped at about
two thirds of the pane, wrapping inside itself, with the marker on **every** line.
The agent's half is untouched, flush left at the full width. The tint is a
16-colour foreground and bold rather than the background band the issue asked
for: every style in this package is a foreground, its one background means "this
row is selected", and §15's Colour section requires the palette to degrade under
`NO_COLOR` and at 16 colours — right alignment plus a per-line marker are what
survive that. The prompt's own line breaks now reach the bubble and the six-line
ellipsis cap is gone, the same call task 073 decision 5 made for the §17
retention fallback: truncating puts the tail of what a human asked out of reach
on a body that already scrolls.

**A composer with a boundary.** It sits inside a titled `message` box drawn with
`shell.go`'s existing `frame`, unfocused on purpose — the composer holds the
keyboard nearly always here, so a lit focus glyph would say nothing. The border
is spent out of the height budget rather than added after the join: `footerLines`
returns one element per *rendered* line, frame rows included, which is issue
#299's regression and the reason its comment in that function was extended to
cover the box rather than restated elsewhere. What the frame costs, the body
gives up — §15's #299 amendment, "a composer that grew is a body that shrank, not
a frame that overflowed".

The renumbering of the level constants made every `level == levelCompact` guard a
decision: "compact only" (`resultOutcome`'s short form) and "compact and below"
(`agent.run_header`, `agent.plan`, `thinkingBlock`) are now different
expressions. The tests compare whole rendered output at `compact`, `normal` and
`verbose` rather than spot-checking lines, because an off-by-one in one of those
guards is a silent regression at a level nobody asked to change.

No screenshot went stale and none is added: `scripts/screenshots.sh` seeds no
chat and has no chat tape, so no `docs/assets/tui-*.png` shows this view, and no
capture shows a non-default level either — the pane title names a level only when
it is not the default, and every tape runs at `normal`. No gate script is
affected: the level is client-only session state that never crosses the wire.

`go run mage.go test`, `testrace` and `lint` are green, with `golangci-lint`
built for the host and run under `GOOS=darwin`, `GOOS=linux` and `GOOS=windows`
(0 issues each).

## Related

Closes #321

Task [085](docs/tasks/085-chat-workspace-ux.md) carries the six decisions.

This does not revisit a recorded decision. It **extends** three and amends one
written rule in place:

- Task 071 decision 2 (the chat uses the output pane's renderer) and decision 3
  (one shared, unpersisted session level) are both preserved literally — `quiet`
  goes into the shared cycle and renders identically in both panes, and the
  chrome added here is around the records, not in the renderer.
- Task 071 decision 4 (`↑`/`↓` edit a multi-line draft) is the reason the
  prompt's own newlines now survive into the bubble.
- Task 073 decision 5 (drop the §17 fallback's 40-line cap, "the cap hid its
  tail") is the precedent for dropping the prompt's six-line cap.
- **Amended, not outgrown:** §15 said unrecognized lines "stay behind their count
  at every level below verbose". That is now true of `compact` and `normal`. The
  sentence is amended in place with a dated note rather than left to be
  contradicted by the code.

Spec §15 is amended in three places, all dated 2026-09-03 and all in this PR: the
`v` paragraph, the task 066 "result line grows by level" amendment, and view 9.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
      — `feat(tui)` for the two behaviour commits, `docs` for the records; the
      two lane merges are merge commits and carry no prefix by nature.
- [x] Tests added/updated for behavior changes — `internal/tui`'s
      `quietlevel_test.go` (new), `chatprompt_test.go` (new), and updates to
      `outputlines_test.go`, `chatverbosity_test.go`, `bindings_test.go`,
      `chatturns_test.go` and `panewidth_test.go`. The level tests are golden
      comparisons of whole rendered output at `compact`/`normal`/`verbose`, not
      spot checks; `TestPaneWidthChatComposerKeepsEveryWrappedRow` grew widths
      and heights to cover the border rather than gaining a sibling.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` — the
      new level under **Added**, the chat chrome under **Changed**.
- [x] Affected page under `docs/` updated — `docs/guides/tui.md`: both key tables
      (derived from `internal/tui/bindings.go`, whose `v` and `ctrl+r` labels
      changed), the "What `v` adds" level prose, and the chat workspace section.
      `docs/getting-started/quickstart.md` carries its own short key table off
      the same registry and its `v` row still named three levels; the
      documentation audit caught it and it is fixed here. `docs/spec.md` is
      amended in three places and `docs/tasks/085-chat-workspace-ux.md` plus its
      index row are in. Nothing here touches config, the cobra tree, the API
      route table, the `Reason*` constants, the workflow schema or an adapter's
      capabilities, so those pages — and
      `skills/vincent-workflows/SKILL.md`, which is runtime text for the
      `create-workflow` built-in rather than documentation — are unchanged.
