### PR TITLE
Show an in-progress indicator while a turn or attempt is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ Release Please creates release entries from Conventional Commit history. Its
 release pull request is the review point for replacing the mechanical commit
 list with the user-facing context a commit subject cannot carry.
 
+## [Unreleased]
+
+### Added
+
+- **An in-progress indicator, for as long as the work is actually running.**
+  A moving braille frame and an elapsed clock — `⠋ working… 14s` — now say that
+  an agent is working, on all four surfaces that used to go silent while it did:
+  the chat workspace, the chats board, the task workspace's output pane and
+  `vincent chat send`.
+
+  It is shown for the **whole** time a turn or an attempt is in `running`, not
+  only until the first chunk arrives. That is the part that matters: at the
+  `quiet` level the output pane drops tool calls and their results, so a turn
+  busy running tools for minutes used to render nothing new the whole time, and
+  a running chat turn that had produced no records yet rendered as literally
+  blank space under your own message. The elapsed clock is load-bearing beside
+  the animation — a number that advances is proof of life in a screenshot or in
+  scrollback, and it answers "how long has this been going" without a second
+  affordance.
+
+  In the **chat workspace** it sits above the composer, so it is there at every
+  scroll position, including after you have scrolled up and paused follow. It
+  disappears the moment the turn reaches `done`, `failed`, `interrupted` or
+  `awaiting_input` — a turn waiting on you is not working, and the header
+  already says so. On the **chats board** the frame appears beside a running
+  row's `running` label, and that row's "last activity" cell now advances
+  instead of standing still. In the **task workspace** it rides in the output
+  pane's border title while the attempt on screen is live — for a `command`
+  step as much as an `agent` one, since both are silent for the same reason.
+
+  A screen with nothing running repaints no more often than it did before: the
+  animation is armed only while something is actually running, and stops when it
+  ends.
+
+- **`vincent chat send` no longer waits in silence**, and prints exactly the
+  same bytes as before when you are not watching it. The indicator goes to
+  **stderr** only — the agent's answer is stdout and only stdout — and it is
+  suppressed entirely under `--json` and whenever stderr is not a terminal, so a
+  piped or redirected send is byte-for-byte what it always was. The line is
+  erased before anything else is written, so no spinner residue can land in
+  front of the answer or an error.
+
 ## [0.8.0](https://github.com/lezli01/vincent/compare/v0.7.0...v0.8.0) (2026-09-04)
 
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -244,6 +244,15 @@ Running `vincent` opens a Bubble Tea interface for active agent workloads:
   so structure that an agent split across records renders whole, and a pane you have
   scrolled away from keeps its place across a resize, a level change, the raw
   toggle and output dropping off the front of the window.
+- Nothing waits in silence. While a chat turn or a step attempt is running, a
+  turning glyph and an elapsed clock — `⠋ working… 14s` — say so above the chat
+  composer, beside a running row on the chats board, and in the output pane's
+  title, for the whole time it runs rather than only until its first chunk
+  arrives — which is what makes it useful at the `quiet` level, where a
+  tool-heavy turn renders nothing new for minutes. `vincent chat send` draws the
+  same indicator while it blocks, on stderr and never under `--json` or into a
+  redirect. A screen with nothing running repaints no more often than it did
+  before.
 - Guided task creation exposes project, workflow, declared fields, git and
   priority settings, agent overrides, and a final review stage.
 - Project and workflow workspaces keep navigation visible beside contextual

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -298,6 +298,14 @@ unlinking lives there and on the Pull Request tab.
 **Output** gives the selected attempt's live tail or historical transcript the
 entire view. Its selector names the attempt and its position in the task; use
 `←`/`→` (or `h`/`l`) to show another attempt without returning to the timeline.
+While the attempt on screen is still running, the pane's title carries the same
+in-progress indicator the [chat workspace](#chat-workspace) draws — a turning
+glyph and an elapsed clock, `⠋ working… 14s` — beside the level and the follow
+state, so an attempt that is thinking rather than printing is told apart from a
+screen that has stopped repainting. It is on Output only, never on Diff, and it
+follows the attempt being *live* rather than its step being an `agent` step: a
+long `command` step's pane goes quiet for exactly the same reason.
+
 **Step Details** answers the question the other tabs cannot: what this attempt
 was actually *given*. Task Details shows the workflow's template; this shows the
 substitution — the rendered prompt an agent step handed its CLI, the rendered
@@ -1312,6 +1320,14 @@ last-activity cell shows *when* the chat ended rather than a duration that keeps
 counting; and `a` on such a row declines with a note instead of asking to remove
 a worktree that is already gone, or that a handoff gave to a task.
 
+A `running` row moves. Its state cell carries a turning glyph **beside** the
+`running` label rather than instead of it — the cell is a fixed-width column in
+the same state vocabulary every other row uses — and its last-activity cell
+counts up while the turn runs instead of standing still. Nothing else animates:
+an `awaiting_input` chat is waiting on you rather than working, and the header
+already badges it. A board with no running chat repaints no more often than it
+did before.
+
 `n` is the one key whose meaning depends on where you are: on this board it
 starts a chat, everywhere else it opens the new-task form. The create form takes
 project, title, agent, model, effort and base branch; `ctrl+s` creates and drops
@@ -1374,6 +1390,19 @@ The composer sits inside a titled `message` box, so the field you type into does
 not read as one more row of the conversation. The border comes out of the pane's
 height rather than being added on top of it: the screen is the same height it
 always was, and the hint line is still the last row of it.
+
+**While a turn runs, an in-progress indicator sits just above that box** — a
+turning glyph and an elapsed clock, `⠋ working… 14s` — for the whole time the
+turn is in `running`, not only until its first chunk arrives. That is the point
+of it: at `quiet` a turn that spends minutes running tools renders no new line
+in the conversation at all, and this is the only thing on the screen that moves.
+It is above the composer rather than inline at the end of the turn, because the
+conversation scrolls and a reader who has scrolled up — follow paused, `⏸` in
+the header — is exactly the reader who needs telling that waiting is still the
+right thing to do. It is gone the moment the turn reaches `done`, `failed`,
+`interrupted` or `awaiting_input`; a turn waiting on you is not working, and the
+header already says `waiting on you`. A chat with no running turn causes no
+periodic repaint.
 
 | Key | Does |
 |---|---|

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1090,6 +1090,15 @@ and not one vincent can fix: it never refuses an unknown session id — it
 starts a fresh chat under it and answers — so a cursor chat whose session has
 aged out replies without remembering rather than failing.
 
+While it waits, an in-progress indicator — a moving glyph and an elapsed clock,
+`⠋ working… 14s` — is drawn on **stderr**, so a long turn never looks wedged.
+It is suppressed entirely in the two cases where anything extra would be wrong:
+under `--json`, and whenever stderr is not a terminal. A piped or redirected
+`vincent chat send` therefore emits exactly the bytes it would have emitted
+without it, on both streams. The answer itself is always stdout and only stdout,
+and the indicator's line is erased before anything else is written, so no
+residue can precede the answer or an error.
+
 If the agent asks a question mid-turn the chat enters `awaiting_input` and the
 send keeps waiting, because the turn has not ended. Answer it from another
 terminal with [`vincent chat answer`](#vincent-chat-answer).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -7028,6 +7028,17 @@ stream for the live tail.
      parent's own section — branch, linked pull request and its state, from one
      project listing. Lane rows carry **no checks**: checks stay one call for
      one task, and `l` opens the lane, whose own tab has them.
+
+   *Amended 2026-09-05 (task 089, issue #330).* The **Output** tab's border
+   title carries the view 9 in-progress indicator while the attempt it is
+   showing is still live — beside the tab strip, the level and the follow state,
+   which is where this workspace already keeps its live state and the one spot
+   visible at every scroll position. It draws on Output only, never on Diff, and
+   the gate is that the attempt is **live** rather than that its step is an
+   `agent` step: a long `command` step's pane is silent for exactly the same
+   reason and for exactly as long. A workspace whose displayed attempt has
+   finished arms no repaint.
+
 3. **New task.** Project picker → workflow picker (shows description + step list;
    flags steps whose agent is unavailable) → *(GitHub issue, conditional)* →
    title → description (inline or
@@ -7330,6 +7341,20 @@ stream for the live tail.
    left to remove, or — after a handoff — the task owns it, and the daemon's
    own refusal (§13.2) says the same thing from the other side.
 
+   *Amended 2026-09-05 (task 089, issue #330).* A `running` row's state cell
+   carries the view 9 in-progress indicator's moving frame **beside** the
+   `running` label, never instead of it: the cell is a fixed-width column
+   rendered through this board's shared state vocabulary, and swapping one
+   state's word for a glyph would break that vocabulary for that state alone.
+   The repaint it drives is also what makes the **last-activity cell advance**
+   while a chat is running — that cell already rendered `now - updated_at`, and
+   `updated_at` is written only on a state change, so for a running chat it was
+   already time-since-the-turn-started and was simply never redrawn. No column,
+   DTO or endpoint changes. `idle`, `awaiting_input`, `archived` and
+   `handed_off` rows do not animate, `awaiting_input` for view 9's reason — it
+   is waiting on a human, not working, and this header already badges it — and a
+   board with nothing running arms no repaint.
+
 9. **Chat workspace.** *Added 2026-08-31 (task 067, closing 063.2 and 063.3).*
    One conversation: the finished turns above, the running turn's live tail
    below them, and a composer at the bottom. `enter` sends, `ctrl+x` stops the
@@ -7410,6 +7435,29 @@ stream for the live tail.
    added after the join: the #299 amendment below governs it verbatim — a
    composer that grew is a body that shrank — and the footer still carries one
    element per *rendered* line, the border's two rows included.
+
+   *Amended 2026-09-05 (task 089, issue #330).* A running turn carries an
+   **in-progress indicator** — one moving glyph and an elapsed clock,
+   `⠋ working… 14s` — for the **whole** time it is in `running`, not only until
+   its first chunk arrives. It sits in the footer, above the composer and beside
+   the note line, and not inline at the end of the turn's body: the body
+   scrolls, and a reader who has scrolled up is exactly the reader who needs to
+   be told that waiting is still the right thing to do. The frame advances every
+   120 ms; the clock is derived from the client's own clock on each render and
+   is spelled in this section's one duration vocabulary (`14s`, `2m03s`,
+   `1h04m`). The elapsed half is load-bearing on its own: a number that advances
+   is proof of life in a screenshot or a scrollback, where an animation is not.
+   It is gone the moment the turn reaches `done`, `failed`, `interrupted` or
+   `awaiting_input` — an `awaiting_input` turn is waiting on the human, not
+   working, and the header already says `waiting on you` — and a chat with no
+   running turn arms **no** repaint at all.
+
+   This does **not** contradict the "never a spinner" rule four paragraphs
+   above, and the two are never in force for the same turn. That rule is about a
+   send the daemon **refused**: a `409 chat_cap_reached` produces no turn, and a
+   client must not draw a pending anything for work that will never happen. This
+   indicator draws only for a turn the daemon is holding in `running` — state
+   the daemon does have and has told the client about.
 
 ### Layout
 

--- a/docs/tasks/089-in-progress-indicator.md
+++ b/docs/tasks/089-in-progress-indicator.md
@@ -1,0 +1,187 @@
+# 089 — An in-progress indicator while a turn or an attempt is running
+
+**Status:** ✅ done (1/1)
+**Issue:** #330
+**Amends:** §15 (view 2, view 8, view 9)
+
+While an agent produces a turn, vincent's clients could go completely silent.
+The chat workspace was the sharpest case: a `running` turn with no records yet
+rendered as *literally nothing* — the reader's own prompt bubble and then blank
+space — and `chatView` had no `tea.Tick` at all, so with the stream quiet the
+frame was genuinely frozen. That is indistinguishable from a wedged TUI.
+
+The gap was never only the pre-first-chunk window, which is why the fix is not
+the one the issue's own rejected alternative describes. At `quiet` the output
+pane drops tool calls and results, so a turn busy running tools for minutes
+renders nothing new the whole time; even at `normal`, a long tool stretch
+between two pieces of prose is a silent gap. The same silence existed on the
+chats board (a static `running` label, no tick), in the task workspace (a
+running attempt's output pane, with no elapsed clock anywhere on the screen)
+and in `vincent chat send`, which polled every 500 ms and printed nothing at
+all until the turn ended.
+
+## Tasks
+
+- [x] **089.1** — One shared indicator across the chat workspace, the chats
+  board, the task workspace and `vincent chat send`. ✓ 2026-09-05
+
+## What was already true
+
+Three facts made this smaller than the issue assumed, and all three are worth
+recording because each removed a seam somebody would otherwise have built:
+
+1. **All three views already had an injectable clock.** `chatView`, `chatsView`
+   and `detail` each carry `now func() time.Time`, pinned by their tests. The
+   elapsed half needed no new seam.
+2. **The chats board already had the right number on screen.** `chatActivity`
+   renders `formatElapsed(now - chat.UpdatedAt)`, and the store touches
+   `chats.updated_at` only on a state change — never per output chunk — so for a
+   `running` chat that cell already *was* time-since-the-turn-started. It simply
+   never advanced, because nothing repainted. No DTO, endpoint or column
+   changed.
+3. **The wire already carried the rest.** `apiclient.ChatTurn` has `StartedAt`;
+   `apiclient.StepRun` has `StartedAt` and a `Live()` predicate.
+
+## Decisions
+
+### 1. One tick at 120 ms; the clock is derived, not ticked
+
+*2026-09-05.* A single `SpinnerTick = 120ms` advances the frame, and the
+elapsed string is computed from the view's `now()` on each render, so it still
+reads in whole seconds.
+
+The issue proposed a 1 s tick, matching `board.go`'s `elapsedTick`. Rejected: a
+glyph that moves once per second **is** the frozen screen this feature exists to
+rule out. The cost is affordable precisely because the expensive work is already
+gated — `chatView.bodyView` rebuilds only on `bodyDirty || builtWidth != width`,
+and `detail.renderOutputPane` only on `outputDirty` — so an indicator-only tick
+repaints the frame without re-rendering any Markdown.
+
+### 2. One pure renderer, not `bubbles/spinner`
+
+*2026-09-05.* `internal/tui/progress.go` exports a function of
+`(frame int, since time.Duration) string`: no `tea.Model`, no tick of its own,
+no message identity to route.
+
+`bubbles`' spinner is a model with its own ticker, so three surfaces would mean
+three models and three tick identities. A pure function is how `outputlines.go`,
+`formatElapsed` and every other renderer in this package are built, and it is
+table-testable without running a program. It is exported for one caller outside
+the package — `vincent chat send` — rather than copied there; `cli` → `tui` is
+the sanctioned direction and the alternative was a second frame table and a
+second spelling of the duration.
+
+### 3. Elapsed reuses `formatElapsed`, not the issue's `0:14`
+
+*2026-09-05.* The TUI has one duration vocabulary — `14s`, `2m03s`, `1h04m` —
+and a second spelling of the same fact, three views over, is worth more than
+matching an illustrative `e.g.` in an issue body. A negative duration clamps to
+zero rather than printing `-1s`: the client's clock and the daemon's are two
+clocks.
+
+### 4. Ticking stops by not re-arming, and every view clears its guard
+
+*2026-09-05.* `tea.Tick` cannot be cancelled (recorded in
+`docs/history/v0-tasks.md` and honoured by `internal/tui/daemon.go`'s log poll),
+so a stray tick always outlives the state that armed it and must be a no-op.
+Each of the three views clears its `ticking` guard on the tick and re-arms only
+from one place — `update`'s trailing `armTick()` — so a send, a load, a stream
+note and a cancel cannot each miss a site.
+
+**`board.go` is deliberately not copied.** Its `b.ticking` is set once and never
+cleared, which is correct *there*: the task board always has an elapsed column to
+advance. A chat with no running turn has nothing moving, and issue #330's own
+acceptance criterion demands it arm no tick. The divergence is intentional and is
+commented in all four files, so a later reader does not "unify" it.
+
+### 5. Placements: the chat footer, the board's state cell, the pane title
+
+*2026-09-05.* Three placements, each chosen for the same property — visible at
+every scroll position:
+
+- **Chat workspace:** in `footerLines`, above the composer and beside the note.
+  Not inline at the end of the running turn's body, which scrolls: a reader who
+  has scrolled up is exactly the reader who needs to be told to keep waiting.
+  This also puts it outside the `bodyDirty` gate, which is what makes it work at
+  `quiet`.
+- **Chats board:** *beside* the `running` label, not instead of it. The state
+  cell is a fixed-width column rendered through the shared `chatStateLabel`
+  vocabulary, and replacing the word with a glyph breaks that vocabulary for one
+  state only. The issue left this open.
+- **Task workspace:** in `detail.outputTitle`, beside the `output│diff` tab
+  strip, the level and the follow state. That title is already this view's home
+  for live state and the only place in the workspace visible at every scroll
+  position. Output tab only, never `tabDiff`.
+
+### 6. The detail gate is `StepRun.Live()`, not the step's type
+
+*2026-09-05.* The issue says "a running agent step". A long `command:` step is
+silent for exactly the same reason and for exactly as long, so what earns the
+indicator is that the attempt is still producing output. A deliberate, small
+widening of the issue's letter in service of its stated purpose.
+
+### 7. Only `running` animates on the chats board
+
+*2026-09-05.* The issue's list of non-animating states omitted
+`awaiting_input`; it does not animate. By this workspace's own criterion an
+`awaiting_input` chat is waiting on the human rather than working, and the
+header already badges it. This matches the chat workspace, where the indicator
+is gone at `done`, `failed`, `interrupted` **and** `awaiting_input`.
+
+### 8. Braille everywhere, no ASCII fallback
+
+*2026-09-05.* `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`, unconditionally on all three platforms. The
+issue's "plain-ASCII fallback if the braille frames do not render" is dropped as
+**undetectable**: a program can probe whether it is attached to a terminal, never
+whether that terminal has a glyph. This TUI already ships `⏸`, `▸`, `▾` and
+box-drawing on the same terms, and a terminal that cannot draw braille cannot
+draw the frame around it either.
+
+### 9. TTY detection promotes `github.com/charmbracelet/x/term`
+
+*2026-09-05.* There was no TTY detection anywhere in this repository, so the
+issue was right that this was worth deciding rather than falling into.
+`golang.org/x/term` as a new direct module was rejected: `charmbracelet/x/term`
+is **already** in `go.sum` via `charm.land/bubbletea/v2`, so promoting it to the
+direct require block adds no module to the graph and no new supply-chain
+surface, and it is the library the TUI already leans on transitively for exactly
+this question. It owns the platform difference, so `internal/cli/tty.go` needs no
+`_windows.go` twin.
+
+The predicate is `*os.File` **and** `term.IsTerminal`. The type assertion is
+load-bearing on its own: cobra's test writers are `*bytes.Buffer`, so every
+command test is non-TTY *structurally* rather than by mocking, which is what
+makes "a redirected send is byte-identical" a property of the code.
+
+### 10. The CLI leg stays single-goroutine
+
+*2026-09-05.* `runChatTurn`'s `select` over `ctx.Done()` and a 500 ms
+`time.After` becomes a select over `ctx.Done()`, a 500 ms poll ticker and a
+120 ms frame ticker, both `defer`-stopped. A writer goroutine drawing frames
+while the main one prints the answer would race on stderr for no gain; three
+channels in one `select` cost nothing and leave `-race` nothing to find. With
+the indicator suppressed the frame channel is left nil, so a redirected send
+arms no ticker at all.
+
+The line is erased before **every** exit path — the answer, both error returns
+and `ctx.Err()` — with `\r`, spaces and `\r` rather than an ANSI
+erase-to-end-of-line: a Windows console without
+`ENABLE_VIRTUAL_TERMINAL_PROCESSING` prints escape bytes literally, and garbage
+on the line this exists to keep clean is worse than a few spaces.
+
+## Not done here
+
+- **No screenshots were regenerated, and none went stale.** `scripts/screenshots.sh`
+  seeds no chat and has no chat tape — the gap task 071 recorded and task 085
+  re-recorded — so no `docs/assets/tui-*.png` shows view 8 or view 9. The one
+  task-workspace capture, `tui-diff.png`, is of the **Diff** tab, where this
+  indicator deliberately does not draw. If a chat tape or an Output-tab tape is
+  ever added, it will show one arbitrary spinner frame, which is why the elapsed
+  clock beside it is what such a picture would actually prove.
+- **No gate.** The indicator is client-side rendering over data already on the
+  wire: no endpoint, DTO, column or block reason changed, so no gate script has
+  anything new to assert.
+- **No "show it only after N seconds of silence".** The issue lists it as worth
+  revisiting if the always-on version reads as noisy in practice. It is not
+  implemented: it needs a threshold to tune and a state machine to explain, and
+  neither is worth carrying before anyone has found the always-on version noisy.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -102,6 +102,7 @@ the living engineering specification records implementation contracts.
 | [086](086-editor-and-graph-misreport.md) | Make the workflow editor's value column a schema-keyed table with a coverage test, carry `lane:`/`max_lanes:` through to the client, and draw a fan-out derived from a lane template | ✅ done (2/2) |
 | [087](087-editor-cannot-write.md) | Give the workflow editor a multi-line pane, descents into every block, `a`/`d`/`K`/`J` structural edits and pickers for the closed sets | ✅ done (4/4) |
 | [088](088-step-details-tab.md) | Record what each attempt was *given* — the rendered prompt, script, `check:`, `if:` and `for_each` list, plus the §8.6 provenance, the permission mode, the timeouts, the shell and the working directory — and read it back on a Step Details tab bound to `6`, moving Pull Request to `7` | ✅ done (3/3) |
+| [089](089-in-progress-indicator.md) | One animated in-progress indicator — a braille frame and an elapsed clock — for the chat workspace, the chats board, the task workspace's output pane and `vincent chat send` | ✅ done (1/1) |
 
 ## How to add and update a task document
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.8
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/gofrs/flock v0.13.1
@@ -67,7 +68,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.11 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260903151058-ae99b731b8c5 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/ckaznocha/intrange v0.3.1 // indirect

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -3,13 +3,16 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/tui"
 )
 
 // newChatCmd is `vincent chat` (spec §5.5, §12.1, task 063): the CLI half of
@@ -104,6 +107,70 @@ func newChatSendCmd() *cobra.Command {
 	return cmd
 }
 
+// chatPollInterval is how often `vincent chat send` asks whether the turn has
+// ended. It is unchanged by the in-progress indicator: the frame moves ten
+// times faster than this, and it moves without asking the daemon anything.
+const chatPollInterval = 500 * time.Millisecond
+
+// turnSpinner is the in-progress indicator `vincent chat send` draws while it
+// waits for a turn (task 089, issue #330).
+//
+// The rules are requirements, not decoration. It writes to stderr and never to
+// stdout, because stdout carries the agent's answer and is what a script
+// consumes. It is off entirely under --json and when stderr is not a terminal,
+// so a piped or redirected send emits exactly the bytes it emitted before this
+// existed. And the line is erased before anything else is written, on every
+// exit path, so no residue can precede the answer or an error.
+type turnSpinner struct {
+	w     io.Writer
+	on    bool
+	start time.Time
+	frame int
+	// width is how many columns the drawn line occupies, and zero when
+	// nothing is drawn. It is what erase blanks and what a shrinking clock
+	// would otherwise leave behind.
+	width int
+}
+
+func newTurnSpinner(cmd *cobra.Command, start time.Time) *turnSpinner {
+	w := cmd.ErrOrStderr()
+	return &turnSpinner{w: w, on: !wantJSON(cmd) && isTTY(w), start: start}
+}
+
+// draw repaints the indicator in place.
+//
+// Erasing with spaces and a carriage return rather than an ANSI erase-to-
+// end-of-line is the cross-platform choice: a Windows console without
+// ENABLE_VIRTUAL_TERMINAL_PROCESSING prints the escape bytes literally, and
+// garbage on the line this exists to keep clean is worse than a few spaces.
+// A rune count is the right measure of the line's width here because every
+// rune in it — the braille frame, the ellipsis, the digits and letters — is
+// single-width.
+func (s *turnSpinner) draw(now time.Time) {
+	if !s.on {
+		return
+	}
+	line := tui.ProgressLabel(s.frame, now.Sub(s.start))
+	s.frame++
+	n := utf8.RuneCountInString(line)
+	pad := ""
+	if s.width > n {
+		pad = strings.Repeat(" ", s.width-n)
+	}
+	_, _ = fmt.Fprint(s.w, "\r"+line+pad)
+	s.width = n
+}
+
+// erase takes the indicator off the line. It is idempotent, so the deferred
+// call after an explicit one writes nothing.
+func (s *turnSpinner) erase() {
+	if !s.on || s.width == 0 {
+		return
+	}
+	_, _ = fmt.Fprint(s.w, "\r"+strings.Repeat(" ", s.width)+"\r")
+	s.width = 0
+}
+
 // runChatTurn sends a message and polls the chat until the turn ends, then
 // prints the agent's answer or the reason the turn failed.
 //
@@ -111,20 +178,45 @@ func newChatSendCmd() *cobra.Command {
 // send` is one round trip a human waits on, and a poll has no reconnect
 // semantics to get wrong. The TUI, which renders the turn as it arrives, uses
 // the stream.
+//
+// The two tickers live in this one goroutine on purpose (task 089 decision).
+// A writer goroutine drawing frames while this one prints the answer would
+// race on stderr for no gain; a select over three channels costs nothing and
+// leaves `-race` nothing to find.
 func runChatTurn(ctx context.Context, cmd *cobra.Command, c *apiclient.Client, id int64, message string) error {
 	turn, err := c.SendChat(ctx, id, message)
 	if err != nil {
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 		return exitError{code: 1}
 	}
+	// Elapsed is measured from here rather than from turn.StartedAt: this is
+	// how long the human at the terminal has been waiting, and it needs no
+	// agreement between two machines' clocks to be true.
+	spin := newTurnSpinner(cmd, time.Now())
+	defer spin.erase()
+	poll := time.NewTicker(chatPollInterval)
+	defer poll.Stop()
+	// A nil channel blocks forever, so a suppressed indicator arms no ticker
+	// at all rather than waking this loop ten times a second to do nothing.
+	var frameC <-chan time.Time
+	if spin.on {
+		frames := time.NewTicker(tui.SpinnerTick)
+		defer frames.Stop()
+		frameC = frames.C
+	}
 	for {
 		select {
 		case <-ctx.Done():
+			spin.erase()
 			return ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case now := <-frameC:
+			spin.draw(now)
+			continue
+		case <-poll.C:
 		}
 		_, turns, err := c.GetChat(ctx, id)
 		if err != nil {
+			spin.erase()
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 			return exitError{code: 1}
 		}
@@ -133,6 +225,7 @@ func runChatTurn(ctx context.Context, cmd *cobra.Command, c *apiclient.Client, i
 			if t.ID != turn.ID || t.State == "running" {
 				continue
 			}
+			spin.erase()
 			if wantJSON(cmd) {
 				if err := emitJSON(cmd.OutOrStdout(), t); err != nil {
 					return err

--- a/internal/cli/chat_test.go
+++ b/internal/cli/chat_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/daemon"
+	"github.com/lezli01/vincent/internal/tui"
+)
+
+// `vincent chat send` grew an in-progress indicator (task 089, issue #330),
+// and the point of these tests is the half of that feature that is a promise
+// about what it does *not* print: a piped or redirected send, and every send
+// under --json, must emit exactly the bytes it emitted before the indicator
+// existed. Cobra's writers here are *bytes.Buffer, which isTTY refuses on the
+// type assertion alone, so that promise is structural rather than mocked.
+
+// chatSendStub serves the two endpoints `chat send` calls. The turn is
+// running on the first GET and settled on the second, so the command spends a
+// real poll interval in the window the indicator would draw in.
+func chatSendStub(t *testing.T, state, result string) http.HandlerFunc {
+	t.Helper()
+	var polls atomic.Int32
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/v1/health":
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.URL.Path == "/v1/chats/3/send" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":11,"chat_id":3,"seq":1,"state":"running",
+				"started_at":"2026-09-05T10:00:00Z"}`))
+		case r.URL.Path == "/v1/chats/3" && r.Method == http.MethodGet:
+			turn := `{"id":11,"chat_id":3,"seq":1,"state":"running",
+				"started_at":"2026-09-05T10:00:00Z"}`
+			if polls.Add(1) > 1 {
+				turn = `{"id":11,"chat_id":3,"seq":1,"state":"` + state + `",
+					"fail_reason":"agent_error","error_message":"boom",
+					"result_text":` + strconv.Quote(result) + `,
+					"started_at":"2026-09-05T10:00:00Z"}`
+			}
+			_, _ = w.Write([]byte(`{"chat":{"id":3,"state":"running"},"turns":[` + turn + `]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+// runChatSend runs the command against a stub daemon with stdout and stderr
+// kept apart, which is the whole question here.
+func runChatSend(t *testing.T, h http.HandlerFunc, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	dataDir := t.TempDir()
+	t.Setenv(config.EnvDataDir, dataDir)
+	t.Setenv(config.EnvConfigDir, t.TempDir())
+
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse stub URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("stub port: %v", err)
+	}
+	if _, err := daemon.EnsureToken(dataDir); err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if err := daemon.WriteRuntimeInfo(dataDir, daemon.RuntimeInfo{
+		Port: port, PID: os.Getpid(), StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("daemon.json: %v", err)
+	}
+
+	var out, errb bytes.Buffer
+	root := newRootCmd()
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs(args)
+	code = asExitCode(root.ExecuteContext(context.Background()))
+	return out.String(), errb.String(), code
+}
+
+// TestChatSendWritesNothingExtraWhenRedirected is the acceptance criterion
+// that a redirected send is byte-identical: the answer alone on stdout, and
+// stderr untouched — no frame, and no erase sequence either.
+func TestChatSendWritesNothingExtraWhenRedirected(t *testing.T) {
+	stdout, stderr, code := runChatSend(t, chatSendStub(t, "done", "the answer"),
+		"chat", "send", "3", "hello")
+	if code != 0 {
+		t.Fatalf("exit code %d, want 0 (stderr %q)", code, stderr)
+	}
+	if stdout != "the answer\n" {
+		t.Fatalf("stdout = %q, want the answer alone", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want nothing at all when it is not a terminal", stderr)
+	}
+}
+
+// TestChatSendJSONIsUnchanged holds the --json suppression: the indicator is
+// off whether or not stderr is a terminal, so a script's parse is safe.
+func TestChatSendJSONIsUnchanged(t *testing.T) {
+	stdout, stderr, code := runChatSend(t, chatSendStub(t, "done", "the answer"),
+		"chat", "send", "3", "hello", "--json")
+	if code != 0 {
+		t.Fatalf("exit code %d, want 0 (stderr %q)", code, stderr)
+	}
+	if !strings.HasPrefix(stdout, "{") || !strings.Contains(stdout, `"result_text": "the answer"`) {
+		t.Fatalf("stdout is not the turn's JSON: %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want nothing under --json", stderr)
+	}
+}
+
+// TestChatSendFailureIsUnchanged covers the third exit path: a failed turn
+// still reports on stderr and exits 1, with nothing before the message.
+func TestChatSendFailureIsUnchanged(t *testing.T) {
+	stdout, stderr, code := runChatSend(t, chatSendStub(t, "failed", ""),
+		"chat", "send", "3", "hello")
+	if code != 1 {
+		t.Fatalf("exit code %d, want 1", code)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want nothing on a failed turn", stdout)
+	}
+	// A prefix, not an equality: cobra appends its own "Error: exit code 1"
+	// for the returned exitError, which predates this change. What is being
+	// held is that nothing — no frame, no erase — precedes the failure line.
+	if !strings.HasPrefix(stderr, "turn 1 failed: agent_error boom\n") {
+		t.Fatalf("stderr = %q, want the failure line first and nothing before it", stderr)
+	}
+}
+
+// TestIsTTYRefusesEverythingButATerminal pins the predicate's two rejections.
+// A *bytes.Buffer fails the type assertion, which is what makes every command
+// test above non-TTY; os.DevNull is a real *os.File and still not a terminal,
+// on all three platforms.
+func TestIsTTYRefusesEverythingButATerminal(t *testing.T) {
+	if isTTY(&bytes.Buffer{}) {
+		t.Fatal("a bytes.Buffer reported as a terminal")
+	}
+	f, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	if isTTY(f) {
+		t.Fatalf("%s reported as a terminal", os.DevNull)
+	}
+}
+
+// TestNewTurnSpinnerIsOffWithoutATerminal covers the constructor's two gates
+// against a cobra command wired the way the tests above wire it.
+func TestNewTurnSpinnerIsOffWithoutATerminal(t *testing.T) {
+	for _, json := range []bool{false, true} {
+		cmd := &cobra.Command{Use: "send"}
+		jsonFlag(cmd)
+		if json {
+			if err := cmd.Flags().Set("json", "true"); err != nil {
+				t.Fatalf("set --json: %v", err)
+			}
+		}
+		cmd.SetErr(&bytes.Buffer{})
+		if s := newTurnSpinner(cmd, time.Now()); s.on {
+			t.Fatalf("the indicator is on with json=%v and a buffer for stderr", json)
+		}
+	}
+}
+
+// TestTurnSpinnerDrawsErasesAndClearsBeforeTheAnswer is the frame-writing
+// itself, with the TTY predicate forced true. It pins the three properties the
+// terminal depends on: the line is redrawn in place, a shrinking clock leaves
+// no tail behind, and the erase precedes whatever is written next.
+func TestTurnSpinnerDrawsErasesAndClearsBeforeTheAnswer(t *testing.T) {
+	var buf bytes.Buffer
+	start := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	s := &turnSpinner{w: &buf, on: true, start: start}
+
+	s.draw(start.Add(2 * time.Minute))
+	long := buf.String()
+	if !strings.HasPrefix(long, "\r") || !strings.Contains(long, "working… 2m00s") {
+		t.Fatalf("first frame = %q, want a carriage return and the label", long)
+	}
+	if s.frame != 1 {
+		t.Fatalf("frame counter = %d after one draw, want 1", s.frame)
+	}
+
+	buf.Reset()
+	s.draw(start.Add(14 * time.Second))
+	short := buf.String()
+	if !strings.Contains(short, "working… 14s") {
+		t.Fatalf("second frame = %q, want the shorter label", short)
+	}
+	if !strings.HasSuffix(short, "  ") {
+		t.Fatalf("a shorter label left its tail on screen: %q", short)
+	}
+
+	buf.Reset()
+	s.erase()
+	erased := buf.String()
+	if !strings.HasPrefix(erased, "\r") || !strings.HasSuffix(erased, "\r") ||
+		strings.TrimSpace(erased) != "" {
+		t.Fatalf("erase wrote %q, want a blanked line between carriage returns", erased)
+	}
+	// Idempotent: the deferred erase after an explicit one writes nothing, so
+	// a cleared line cannot be blanked twice into the answer's first row.
+	buf.Reset()
+	s.erase()
+	if buf.String() != "" {
+		t.Fatalf("a second erase wrote %q", buf.String())
+	}
+
+	// And off, it writes nothing at all — the redirected case, at the level
+	// of the writer rather than the command.
+	buf.Reset()
+	off := &turnSpinner{w: &buf, on: false, start: start}
+	off.draw(start.Add(time.Second))
+	off.erase()
+	if buf.String() != "" {
+		t.Fatalf("a suppressed indicator wrote %q", buf.String())
+	}
+}
+
+// TestChatSendPollAndFrameCadences pins the two intervals against each other:
+// the frame must move several times inside one poll window, or the screen
+// reads as frozen between polls — which is the whole feature.
+func TestChatSendPollAndFrameCadences(t *testing.T) {
+	if tui.SpinnerTick >= chatPollInterval {
+		t.Fatalf("frame tick %v is not faster than the poll %v", tui.SpinnerTick, chatPollInterval)
+	}
+	if chatPollInterval/tui.SpinnerTick < 3 {
+		t.Fatalf("only %d frames per poll window; the indicator would read as static",
+			chatPollInterval/tui.SpinnerTick)
+	}
+}

--- a/internal/cli/tty.go
+++ b/internal/cli/tty.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"io"
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// isTTY reports whether a writer is attached to a terminal.
+//
+// It is the repository's only TTY test, and it exists for one caller: the
+// in-progress indicator `vincent chat send` draws while it waits (task 089),
+// which must not appear when stderr is a pipe or a file.
+//
+// The *os.File assertion is load-bearing on its own, before term.IsTerminal is
+// consulted at all. Cobra's test writers are *bytes.Buffer, so every command
+// test is non-TTY structurally rather than by mocking a predicate — which is
+// what makes "redirected output is byte-identical" a property of the code
+// rather than of the test setup.
+//
+// term is github.com/charmbracelet/x/term rather than golang.org/x/term: it is
+// already in the module graph via bubbletea, so this adds no module and no new
+// supply-chain surface, and it is the library the TUI already leans on for
+// exactly this question. It owns the platform difference, so this file needs
+// no _windows.go twin.
+func isTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(f.Fd())
+}

--- a/internal/tui/chatrender.go
+++ b/internal/tui/chatrender.go
@@ -239,6 +239,23 @@ func (v *chatView) footerLines(width int) []string {
 		}
 		out = append(out, " "+style.Render(v.note))
 	}
+	// The in-progress indicator (task 089), here and not inline at the end of
+	// the running turn's body: the body scrolls, and a reader who has scrolled
+	// up — follow off, `⏸` in the header — is exactly the reader who needs to
+	// be told that waiting is still the right thing to do. The footer is drawn
+	// at every scroll position and it is next to where they type.
+	//
+	// It also survives the bodyDirty gate, which is what makes it useful at
+	// levelQuiet: a turn that spends minutes running tools renders no new body
+	// lines at all, and the frame here is the only thing that moves.
+	//
+	// This is not the "never a spinner" case §15 rules out. That rule is about
+	// a send the daemon *refused* — a 409 chat_cap_reached, a turn that will
+	// never exist and must not be drawn as pending. This draws only for a turn
+	// the daemon has in `running`, so the two never apply to the same turn.
+	if turn := v.runningTurn(); turn != nil {
+		out = append(out, " "+styleDim.Render(ProgressLabel(v.frame, v.now().Sub(turn.StartedAt))))
+	}
 	// One element per rendered line, not one per widget (issue #299): the
 	// composer is SetHeight(3) and bubbles' viewport pads its View to that
 	// height, and the border around it adds two more, so a joined string would

--- a/internal/tui/chats.go
+++ b/internal/tui/chats.go
@@ -49,6 +49,12 @@ type (
 	// the root rather than straight to the view because the view is not
 	// active yet, and an inactive view receives nothing.
 	openChatMsg struct{ id int64 }
+	// chatsTickMsg advances the in-progress indicator's frame (task 089) and,
+	// as a consequence of the repaint, the "last activity" column: that cell
+	// already renders now - UpdatedAt, and UpdatedAt is only written on a
+	// state change, so for a running chat it is time-since-the-turn-started
+	// and was simply never redrawn.
+	chatsTickMsg time.Time
 )
 
 // archivePrompt is the inline confirmation an archive takes. force is set on
@@ -96,6 +102,14 @@ type chatsView struct {
 	// meaning anywhere else. `n` on the chats board makes a chat; `n`
 	// everywhere else still makes a task.
 	create *newChatForm
+
+	// ticking guards the in-progress indicator's tick loop, and frame is the
+	// glyph it is on (task 089). It is cleared on every tick and re-armed
+	// only while some chat is running — a board of idle chats must not
+	// repaint forever. board.go arms once and never clears, which is right
+	// there and wrong here; see chatView.ticking for the argument.
+	ticking bool
+	frame   int
 
 	note    string
 	noteBad bool
@@ -158,7 +172,41 @@ func (v *chatsView) hintedProject() int64 {
 	return 0
 }
 
+// update handles the message and then re-arms the in-progress indicator if
+// any chat on the board is still running. One arming site, for the reason
+// chatView.update gives.
 func (v *chatsView) update(msg tea.Msg) (panel, tea.Cmd) {
+	p, cmd := v.updateMsg(msg)
+	return p, tea.Batch(cmd, v.armTick())
+}
+
+// anyRunning reports whether the board has a chat worth animating.
+//
+// Only `running` counts. `awaiting_input` does not: by this board's own
+// reading it is waiting on the human rather than working, and the header
+// already badges it (issue #330 left it off its list of non-animating states,
+// which is the omission this decides).
+func (v *chatsView) anyRunning() bool {
+	for i := range v.chats {
+		if v.chats[i].State == "running" {
+			return true
+		}
+	}
+	return false
+}
+
+// armTick starts the tick loop if something is running and one is not already
+// in flight. It stops by not re-arming; a stray tick is a no-op, the rule
+// tea.Tick's un-cancellability forces.
+func (v *chatsView) armTick() tea.Cmd {
+	if v.ticking || !v.anyRunning() {
+		return nil
+	}
+	v.ticking = true
+	return tea.Tick(SpinnerTick, func(t time.Time) tea.Msg { return chatsTickMsg(t) })
+}
+
+func (v *chatsView) updateMsg(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		v.width, v.height = msg.Width, msg.Height
@@ -175,6 +223,12 @@ func (v *chatsView) update(msg tea.Msg) (panel, tea.Cmd) {
 		return v, v.loadCmd()
 	case chatsLoadedMsg:
 		v.applyLoaded(msg)
+		return v, nil
+	case chatsTickMsg:
+		// Render-only: no fetch, and update's armTick decides whether there
+		// is still anything to animate.
+		v.ticking = false
+		v.frame++
 		return v, nil
 	case newChatFieldsMsg:
 		// The new-chat form's own fetch landing. The form is a layer over

--- a/internal/tui/chatsrender.go
+++ b/internal/tui/chatsrender.go
@@ -110,9 +110,17 @@ func (v *chatsView) rowLine(r chatRow, selected bool, width int) string {
 	// that can usefully be truncated.
 	// The activity cell is wide enough for the absolute stamp a terminal chat
 	// shows instead of a duration (issue #298).
+	// A running row carries the moving frame *beside* the word, never instead
+	// of it (task 089): the state cell is a fixed-width column rendered
+	// through the shared chatStateLabel vocabulary, and swapping one state's
+	// word for a glyph breaks that vocabulary for that state alone.
+	state := chatStateLabel(c.State)
+	if c.State == "running" {
+		state += " " + spinnerFrame(v.frame)
+	}
 	fixed := fmt.Sprintf("%-5s %-15s %-8s %5s %11s  ",
 		"#"+strconv.FormatInt(c.ID, 10),
-		applyStateStyle(c.State, chatStateLabel(c.State)),
+		applyStateStyle(c.State, state),
 		c.Agent,
 		"", // the turn count is not on the list DTO; see chatTurnsCell
 		chatActivity(*c, v.now()))

--- a/internal/tui/chatview.go
+++ b/internal/tui/chatview.go
@@ -58,6 +58,9 @@ type (
 		chatID int64
 		err    error
 	}
+	// chatTickMsg advances the in-progress indicator's frame (task 089). It
+	// asks the daemon nothing: the footer redraws, the body does not.
+	chatTickMsg time.Time
 )
 
 // chatView is the workspace.
@@ -122,6 +125,16 @@ type chatView struct {
 	// stream is the per-chat SSE subscription's cancel, held so opening a
 	// second chat does not leave the first one's stream running.
 	streamStop context.CancelFunc
+
+	// ticking guards the in-progress indicator's tick loop, and frame is the
+	// glyph it is on (task 089). Unlike board.go's b.ticking this one is
+	// *cleared*, and the divergence is deliberate rather than an oversight to
+	// unify later: the task board always has an elapsed column to advance, so
+	// arming once and ticking forever is right there, while a chat with no
+	// running turn has nothing moving and must arm no tick at all (issue
+	// #330's own acceptance criterion).
+	ticking bool
+	frame   int
 
 	note    string
 	noteBad bool
@@ -263,7 +276,30 @@ func readNextChatNote(id int64, ch <-chan apiclient.Note) tea.Cmd {
 	}
 }
 
+// update handles the message and then re-arms the in-progress indicator if a
+// turn is still running. Arming in one place rather than at every site that
+// can start or end a turn is what makes the guard hold: a send, a load, a
+// stream note and a cancel all change whether something is running, and a
+// missed site would leave the indicator either frozen or ticking forever.
 func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
+	p, cmd := v.updateMsg(msg)
+	return p, tea.Batch(cmd, v.armTick())
+}
+
+// armTick starts the tick loop if a turn is running and one is not already in
+// flight. It stops by not re-arming: tea.Tick cannot be cancelled (recorded in
+// docs/history/v0-tasks.md and honoured by daemon.go's log poll), so the only
+// way a ticker ends is that the tick which arrives after the turn finished
+// finds nothing running and returns no command.
+func (v *chatView) armTick() tea.Cmd {
+	if v.ticking || v.runningTurn() == nil {
+		return nil
+	}
+	v.ticking = true
+	return tea.Tick(SpinnerTick, func(t time.Time) tea.Msg { return chatTickMsg(t) })
+}
+
+func (v *chatView) updateMsg(msg tea.Msg) (panel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		v.width, v.height = msg.Width, msg.Height
@@ -293,6 +329,13 @@ func (v *chatView) update(msg tea.Msg) (panel, tea.Cmd) {
 		return v, v.applyAnswered(msg)
 	case chatCanceledMsg:
 		return v, v.applyCanceled(msg)
+	case chatTickMsg:
+		// Render-only, and a no-op for a stray tick: clearing the guard is
+		// all this does, and update's armTick re-arms only while a turn is
+		// still running.
+		v.ticking = false
+		v.frame++
+		return v, nil
 	case tea.KeyPressMsg:
 		return v.updateKey(msg)
 	case tea.MouseWheelMsg:

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -73,6 +73,9 @@ type (
 	}
 	// taskStreamDoneMsg reports the per-task note channel closed.
 	taskStreamDoneMsg struct{}
+	// detailTickMsg advances the in-progress indicator's frame (task 089).
+	// Render-only: it asks the daemon nothing.
+	detailTickMsg time.Time
 	// viewActivatedMsg and viewDeactivatedMsg tell a view it came on or off
 	// screen. The shell translates them for the detail sub-model, whose live
 	// subscription must not stay open for a task nobody is watching.
@@ -149,6 +152,13 @@ type detail struct {
 
 	following bool
 	newLines  int
+	// ticking guards the in-progress indicator's tick loop, and frame is the
+	// glyph it is on (task 089). Cleared on every tick and re-armed only
+	// while the displayed attempt is live, so a workspace on a finished task
+	// arms nothing — the opposite of board.go's arm-once ticker, which is
+	// right there because its elapsed column always has something to count.
+	ticking bool
+	frame   int
 	// outputDirty marks the rendered content stale; the pane rebuilds on the
 	// next frame rather than on every appended chunk.
 	outputDirty bool
@@ -223,7 +233,34 @@ func (d *detail) setClient(c *apiclient.Client) tea.Cmd {
 	return tea.Batch(d.loadCmd(), d.syncStream())
 }
 
+// update handles the message and then re-arms the in-progress indicator if
+// the attempt on screen is still live. One arming site, for the reason
+// chatView.update gives: a load, a stream note and a cursor move all change
+// whether something is running.
 func (d *detail) update(msg tea.Msg) tea.Cmd {
+	cmd := d.updateMsg(msg)
+	return tea.Batch(cmd, d.armTick())
+}
+
+// armTick starts the tick loop if the displayed attempt is live and one is not
+// already in flight.
+//
+// The gate is liveness, not step type. The issue says "a running agent step",
+// but a long `command:` step is silent for exactly the same reason and for
+// exactly as long, so what earns the indicator is that the attempt is still
+// producing output — which is what StepRun.Live() already means.
+//
+// It stops by not re-arming; a stray tick is a no-op, since tea.Tick cannot be
+// cancelled.
+func (d *detail) armTick() tea.Cmd {
+	if d.ticking || !d.runByID(d.displayRun).Live() {
+		return nil
+	}
+	d.ticking = true
+	return tea.Tick(SpinnerTick, func(t time.Time) tea.Msg { return detailTickMsg(t) })
+}
+
+func (d *detail) updateMsg(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		d.width, d.height = msg.Width, msg.Height
@@ -245,6 +282,12 @@ func (d *detail) update(msg tea.Msg) tea.Cmd {
 		return nil
 	case detailTranscriptMsg:
 		d.applyTranscript(msg)
+		return nil
+	case detailTickMsg:
+		// Render-only: update's armTick decides whether the attempt is still
+		// live enough to keep animating.
+		d.ticking = false
+		d.frame++
 		return nil
 	case detailRefreshMsg:
 		if msg.id != d.taskID {

--- a/internal/tui/detailrender.go
+++ b/internal/tui/detailrender.go
@@ -183,6 +183,15 @@ func (d *detail) outputTitle() string {
 	if d.raw.get() {
 		level += styleDim.Render(" · raw")
 	}
+	// The in-progress indicator (task 089). The border title is where this
+	// view already keeps its live state — the tab strip, the level, the follow
+	// state — and it is the only spot in the workspace visible at every scroll
+	// position, which is the same argument that put the chat's indicator above
+	// the composer. It draws on the output tab only: the diff tab is not
+	// showing the attempt's output, so nothing there is waiting on it.
+	if run := d.runByID(d.displayRun); run.Live() {
+		level += styleDim.Render(" · " + ProgressLabel(d.frame, d.now().Sub(run.StartedAt)))
+	}
 	return strip + level + d.followIndicator()
 }
 

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -1,0 +1,64 @@
+package tui
+
+import "time"
+
+// The in-progress indicator (issue #330, task 089): one moving glyph and one
+// advancing clock, shown for as long as a chat turn or a step attempt is in
+// `running`.
+//
+// It is a pure renderer and not a `bubbles/spinner`: that widget is a
+// tea.Model with a ticker and a message identity of its own, so the three
+// views that want this would each need one of each, and routing three tick
+// identities is more machinery than a frame table deserves. A function of
+// (frame, elapsed) is how outputlines.go, formatElapsed and every other
+// renderer in this package are built, and it is table-testable without
+// running a program.
+//
+// It is exported for exactly one caller outside this package —
+// `vincent chat send`, which waits on the same running turn and must not
+// carry a second copy of the frames or a second spelling of the duration
+// (internal/cli/chat.go). `cli` → `tui` is the sanctioned direction.
+
+// SpinnerTick is how often the frame advances.
+//
+// It is deliberately not the board's one-second elapsedTick: a glyph that
+// moves once per second is the frozen screen this indicator exists to rule
+// out. The cost is affordable because the expensive work is already gated —
+// chatView.bodyView rebuilds only on bodyDirty or a width change, and
+// detail.renderOutputPane only on outputDirty — so a tick that changes
+// nothing but the frame repaints without re-rendering any Markdown.
+const SpinnerTick = 120 * time.Millisecond
+
+// spinnerFrames is the braille cycle, used unconditionally on all three
+// platforms. There is no ASCII fallback because there is nothing to switch on:
+// a program can probe whether it is attached to a terminal, never whether that
+// terminal has a glyph. This TUI already draws `⏸`, `▸`, `▾` and the box
+// characters around this indicator on the same terms.
+var spinnerFrames = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// spinnerFrame is the glyph for a frame counter, which wraps and tolerates a
+// negative value rather than panicking on one.
+func spinnerFrame(frame int) string {
+	n := len(spinnerFrames)
+	return spinnerFrames[((frame%n)+n)%n]
+}
+
+// ProgressLabel renders the indicator: the frame, the word, and how long the
+// turn or attempt has been running.
+//
+// The elapsed half is load-bearing on its own. A number that advances is proof
+// of life in a screenshot or a scrollback, where an animation is not, and it
+// answers "how long has this been going" without a second affordance. It is
+// spelled with formatElapsed — `14s`, `2m03s`, `1h04m` — because this TUI has
+// one duration vocabulary and a second spelling of the same fact across three
+// views is worth more than matching the `0:14` in the issue body.
+//
+// A negative duration clamps to zero: `now` and the daemon's clock are two
+// clocks, and a turn that appears to have started in the future must read as
+// having just started, not as `-1s`.
+func ProgressLabel(frame int, since time.Duration) string {
+	if since < 0 {
+		since = 0
+	}
+	return spinnerFrame(frame) + " working… " + formatElapsed(since)
+}

--- a/internal/tui/progress_test.go
+++ b/internal/tui/progress_test.go
@@ -1,0 +1,254 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// TestSpinnerFramesCycle holds the frame table's contract: consecutive frames
+// differ, the cycle wraps, and a counter that has gone negative — which no
+// caller does today, and which a future one must not be able to panic on —
+// still yields a glyph.
+func TestSpinnerFramesCycle(t *testing.T) {
+	n := len(spinnerFrames)
+	if n < 2 {
+		t.Fatalf("the frame table has %d frames; nothing would move", n)
+	}
+	if spinnerFrame(0) == spinnerFrame(1) {
+		t.Fatalf("frames 0 and 1 are both %q; the indicator would not move", spinnerFrame(0))
+	}
+	for i := range n {
+		if got, want := spinnerFrame(i+n), spinnerFrame(i); got != want {
+			t.Fatalf("frame %d wrapped to %q, want %q", i+n, got, want)
+		}
+	}
+	if got := spinnerFrame(-1); got != spinnerFrames[n-1] {
+		t.Fatalf("frame -1 = %q, want the last frame %q", got, spinnerFrames[n-1])
+	}
+}
+
+// TestProgressLabelSpellsElapsedLikeTheRestOfTheTUI pins the second half of
+// the indicator to formatElapsed at the boundaries where the spelling changes,
+// and pins the clamp: a daemon clock ahead of this one must read as "just
+// started", never as `-1s`.
+func TestProgressLabelSpellsElapsedLikeTheRestOfTheTUI(t *testing.T) {
+	cases := []struct {
+		since time.Duration
+		want  string
+	}{
+		{0, "0s"},
+		{59 * time.Second, "59s"},
+		{time.Minute, "1m00s"},
+		{59*time.Minute + 59*time.Second, "59m59s"},
+		{time.Hour, "1h00m"},
+		{-5 * time.Second, "0s"},
+	}
+	for _, c := range cases {
+		got := ProgressLabel(3, c.since)
+		if !strings.HasPrefix(got, spinnerFrame(3)+" working… ") {
+			t.Errorf("ProgressLabel(3, %v) = %q, want the frame and the word first", c.since, got)
+		}
+		if !strings.HasSuffix(got, c.want) {
+			t.Errorf("ProgressLabel(3, %v) = %q, want it to end in %q", c.since, got, c.want)
+		}
+	}
+}
+
+// runningTurnAt builds one running chat turn that started `ago` before the
+// fixture's pinned clock.
+func runningTurnAt(v *chatView, ago time.Duration) apiclient.ChatTurn {
+	return apiclient.ChatTurn{ID: 9, Seq: 1, State: "running", StartedAt: v.now().Add(-ago)}
+}
+
+// TestChatViewIndicatorSurvivesQuietAndScroll is issue #330's sharpest
+// criterion: a running turn that has produced *no records at all*, read at
+// levelQuiet, still says something is happening — and says it above the
+// composer, so a reader who scrolled up has not lost it.
+func TestChatViewIndicatorSurvivesQuietAndScroll(t *testing.T) {
+	v := chatViewFixture()
+	v.level.set(levelQuiet)
+	v.turns = []apiclient.ChatTurn{runningTurnAt(v, 14*time.Second)}
+
+	if body := plainLines(v.bodyLines(80)); strings.Contains(strings.Join(body, "\n"), "working…") {
+		t.Fatalf("the indicator leaked into the scrolling body:\n%s", strings.Join(body, "\n"))
+	}
+	foot := strings.Join(plainLines(v.footerLines(80)), "\n")
+	if !strings.Contains(foot, "working… 14s") {
+		t.Fatalf("a running turn with no records shows no indicator:\n%s", foot)
+	}
+
+	// Follow off — the reader has scrolled up — must change nothing.
+	v.following = false
+	if foot := strings.Join(plainLines(v.footerLines(80)), "\n"); !strings.Contains(foot, "working…") {
+		t.Fatalf("the indicator vanished with follow off:\n%s", foot)
+	}
+}
+
+// TestChatViewIndicatorOnlyWhileRunning holds the other half: every state a
+// turn can leave `running` for stops it, `awaiting_input` included — that turn
+// is waiting on the human, not working, and the header already says so.
+func TestChatViewIndicatorOnlyWhileRunning(t *testing.T) {
+	for _, state := range []string{"done", "failed", "interrupted", "awaiting_input"} {
+		v := chatViewFixture()
+		turn := runningTurnAt(v, time.Minute)
+		turn.State = state
+		v.turns = []apiclient.ChatTurn{turn}
+		if foot := strings.Join(plainLines(v.footerLines(80)), "\n"); strings.Contains(foot, "working…") {
+			t.Errorf("a %s turn still animates:\n%s", state, foot)
+		}
+	}
+}
+
+// TestChatViewArmsTickOnlyWhileRunning covers both halves of the guard: a
+// running turn arms exactly one tick, a chat with nothing running arms none,
+// and a stray tick — tea.Tick cannot be cancelled, so one always survives the
+// turn that armed it — is a no-op rather than a fresh ticker.
+func TestChatViewArmsTickOnlyWhileRunning(t *testing.T) {
+	v := chatViewFixture()
+	_, cmd := v.update(chatLoadedMsg{id: 1, chat: v.chat, turns: []apiclient.ChatTurn{runningTurnAt(v, 0)}})
+	if cmd == nil || !v.ticking {
+		t.Fatalf("a running turn armed no tick (cmd=%v ticking=%v)", cmd != nil, v.ticking)
+	}
+	// A second message while one tick is already in flight must not arm a
+	// second: two tickers would double the repaint rate for good.
+	if _, cmd := v.update(tea.WindowSizeMsg{Width: 80, Height: 24}); cmd != nil {
+		t.Fatal("a second message armed a second ticker")
+	}
+	// The turn ends, then the tick armed before it ended arrives.
+	v.turns[0].State = "done"
+	_, cmd = v.update(chatTickMsg(v.now()))
+	if v.ticking {
+		t.Fatal("a stray tick left the guard set")
+	}
+	if cmd != nil {
+		t.Fatal("a tick delivered after the turn ended armed another")
+	}
+
+	idle := chatViewFixture()
+	_, cmd = idle.update(chatLoadedMsg{
+		id: 1, chat: idle.chat,
+		turns: []apiclient.ChatTurn{{ID: 9, Seq: 1, State: "done"}},
+	})
+	if cmd != nil || idle.ticking {
+		t.Fatalf("a chat with no running turn armed a tick (cmd=%v ticking=%v)", cmd != nil, idle.ticking)
+	}
+}
+
+// TestChatsBoardAnimatesOnlyRunningRows covers the board's row: `running`
+// carries the frame beside its label, nothing else does, and the repaint the
+// tick causes is what makes the existing "last activity" cell advance.
+func TestChatsBoardAnimatesOnlyRunningRows(t *testing.T) {
+	v := chatsFixture()
+	row := func(state string) string {
+		c := testChat(3, state, "third")
+		return strings.Join(plainLines([]string{v.rowLine(chatRow{chat: &c}, false, 120)}), "")
+	}
+	running := row("running")
+	if !strings.Contains(running, "running "+spinnerFrame(v.frame)) {
+		t.Fatalf("a running row carries no frame beside its label: %q", running)
+	}
+	for _, state := range []string{"idle", "awaiting_input", "archived", "handed_off"} {
+		line := row(state)
+		for _, f := range spinnerFrames {
+			if strings.Contains(line, f) {
+				t.Errorf("a %s row animates: %q", state, line)
+			}
+		}
+	}
+
+	// The activity cell is time-since-the-turn-started for a running chat and
+	// was only ever missing a repaint.
+	c := testChat(3, "running", "third")
+	before := chatActivity(c, v.now())
+	after := chatActivity(c, v.now().Add(time.Minute))
+	if before == after {
+		t.Fatalf("the activity cell did not advance across a simulated minute: %q", before)
+	}
+}
+
+// TestChatsBoardArmsTickOnlyWhileRunning is the board's half of the arming
+// contract, including the stray tick.
+func TestChatsBoardArmsTickOnlyWhileRunning(t *testing.T) {
+	v := newChatsView()
+	v.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	_, cmd := v.update(chatsLoadedMsg{
+		chats: []apiclient.Chat{testChat(1, "running", "first")},
+		names: map[int64]string{7: "repo"},
+	})
+	if cmd == nil || !v.ticking {
+		t.Fatalf("a running chat armed no tick (cmd=%v ticking=%v)", cmd != nil, v.ticking)
+	}
+	v.chats[0].State = "idle"
+	if _, cmd := v.update(chatsTickMsg(v.now())); cmd != nil || v.ticking {
+		t.Fatalf("a tick after the last running chat stopped armed another (cmd=%v)", cmd != nil)
+	}
+
+	idle := newChatsView()
+	idle.now = v.now
+	_, cmd = idle.update(chatsLoadedMsg{
+		chats: []apiclient.Chat{testChat(1, "idle", "first"), testChat(2, "awaiting_input", "second")},
+		names: map[int64]string{7: "repo"},
+	})
+	if cmd != nil || idle.ticking {
+		t.Fatalf("a board with nothing running armed a tick (cmd=%v ticking=%v)", cmd != nil, idle.ticking)
+	}
+}
+
+// TestDetailIndicatorOnOutputTabOnly covers the task workspace: the border
+// title carries the indicator for a live attempt on the output tab, and
+// nowhere else. The gate is StepRun.Live() and not the step's type — a long
+// `command:` step is silent for the same reason and for as long.
+func TestDetailIndicatorOnOutputTabOnly(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 5
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	title := func() string { return plainLines([]string{d.outputTitle()})[0] }
+	if !strings.Contains(title(), "working… 1m00s") {
+		t.Fatalf("a live attempt shows no indicator in the pane title: %q", title())
+	}
+
+	run := attempt(1, 0, 1, "implement", "running", true)
+	run.StepType = "command"
+	d.task.Steps = []apiclient.StepRun{run}
+	if !strings.Contains(title(), "working…") {
+		t.Fatalf("a live command step shows no indicator: %q", title())
+	}
+
+	d.tab = tabDiff
+	if strings.Contains(title(), "working…") {
+		t.Fatalf("the diff tab draws the output pane's indicator: %q", title())
+	}
+
+	d.tab = tabOutput
+	d.task.Steps = []apiclient.StepRun{attempt(1, 0, 1, "implement", "succeeded", false)}
+	if strings.Contains(title(), "working…") {
+		t.Fatalf("a finished attempt still animates: %q", title())
+	}
+}
+
+// TestDetailArmsTickOnlyWhileLive is the task workspace's half of the arming
+// contract, including the stray tick.
+func TestDetailArmsTickOnlyWhileLive(t *testing.T) {
+	d := newTestDetail(t)
+	d.taskID = 5
+	loadDetail(d, []apiclient.StepRun{attempt(1, 0, 1, "implement", "running", true)})
+	if cmd := d.update(tea.WindowSizeMsg{Width: 120, Height: 30}); cmd == nil || !d.ticking {
+		t.Fatalf("a live attempt armed no tick (cmd=%v ticking=%v)", cmd != nil, d.ticking)
+	}
+	d.task.Steps = []apiclient.StepRun{attempt(1, 0, 1, "implement", "succeeded", false)}
+	if cmd := d.update(detailTickMsg(fixedNow)); cmd != nil || d.ticking {
+		t.Fatalf("a tick after the attempt finished armed another (cmd=%v)", cmd != nil)
+	}
+
+	done := newTestDetail(t)
+	done.taskID = 5
+	loadDetail(done, []apiclient.StepRun{attempt(1, 0, 1, "implement", "succeeded", false)})
+	if cmd := done.update(tea.WindowSizeMsg{Width: 120, Height: 30}); cmd != nil || done.ticking {
+		t.Fatalf("a finished task armed a tick (cmd=%v ticking=%v)", cmd != nil, done.ticking)
+	}
+}

--- a/internal/workflow/edit.go
+++ b/internal/workflow/edit.go
@@ -744,11 +744,9 @@ func WriteFile(path string, b []byte) (err error) {
 		return fmt.Errorf("write workflow: %w", err)
 	}
 	// A rename keeps the temporary file's own mode, so it is set on the
-	// replacement rather than inherited from the target.
-	if err = os.Chmod(tmp, perm); err != nil {
-		return fmt.Errorf("write workflow: %w", err)
-	}
-	if err = os.Rename(tmp, path); err != nil {
+	// replacement rather than inherited from the target — which is why the
+	// chmod and the rename are one step (replace_unix.go, replace_windows.go).
+	if err = replaceFile(tmp, path, perm); err != nil {
 		return fmt.Errorf("write workflow: %w", err)
 	}
 	return nil

--- a/internal/workflow/replace_unix.go
+++ b/internal/workflow/replace_unix.go
@@ -1,0 +1,19 @@
+//go:build unix
+
+package workflow
+
+import "os"
+
+// replaceFile puts tmp in place of path with mode perm, completing the atomic
+// write WriteFile started.
+//
+// On unix this is one attempt and nothing else: a rename operates on the name,
+// not on the file, so another process holding the target open — the registry's
+// own reload, an editor, a backup — cannot stand in the way of replacing it.
+// Windows is the platform where that is not true; see replace_windows.go.
+func replaceFile(tmp, path string, perm os.FileMode) error {
+	if err := os.Chmod(tmp, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/workflow/replace_windows.go
+++ b/internal/workflow/replace_windows.go
@@ -1,0 +1,75 @@
+package workflow
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// replaceFile puts tmp in place of path with mode perm, completing the atomic
+// write WriteFile started — retrying while another handle stands in the way.
+//
+// Windows is the platform where a rename is not purely an operation on a name.
+// Replacing an open file needs every other handle on it to have been opened
+// with FILE_SHARE_DELETE, and Go's own `os.Open` does not pass that flag
+// (`syscall.Open` shares read and write only), so an ordinary reader of the
+// target blocks the replacement with ERROR_SHARING_VIOLATION or
+// ERROR_ACCESS_DENIED. `os.Chmod` is narrower still — it opens for
+// FILE_WRITE_ATTRIBUTES sharing only writes — so a plain reader fails it too.
+// The daemon supplies those readers itself: writing a workflow makes the
+// scope directory's watcher fire, the registry reloads, and the reload reads
+// every `*.yaml` in the directory including the one being replaced. A virus
+// scanner opening the freshly closed temporary file does the same to the
+// source side of the rename.
+//
+// None of those handles is held for long, so the fix is to wait for them
+// rather than to fail the write: the caller is an API request whose only other
+// answer is a 500 for a file that is about to become writable. A failure that
+// outlasts the window is still returned, so a genuinely locked file is still
+// an error rather than a hang.
+func replaceFile(tmp, path string, perm os.FileMode) error {
+	deadline := time.Now().Add(replaceWaitFor)
+	delay := replaceFirstDelay
+	for {
+		err := replaceOnce(tmp, path, perm)
+		if err == nil || !contended(err) {
+			return err
+		}
+		if !time.Now().Before(deadline) {
+			return err
+		}
+		time.Sleep(delay)
+		if delay *= 2; delay > replaceMaxDelay {
+			delay = replaceMaxDelay
+		}
+	}
+}
+
+// The wait is bounded generously because the cost of exhausting it is a 500 on
+// a save the user has to redo, while the cost of waiting is a request that
+// takes a moment longer. The first delay is short so the common case — a
+// reader that has already returned — costs one sleep.
+const (
+	replaceWaitFor    = 2 * time.Second
+	replaceFirstDelay = 5 * time.Millisecond
+	replaceMaxDelay   = 100 * time.Millisecond
+)
+
+func replaceOnce(tmp, path string, perm os.FileMode) error {
+	if err := os.Chmod(tmp, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// contended reports whether err is Windows saying another handle is in the
+// way, rather than saying the caller may not do this at all. The three codes
+// are indistinguishable from a real permission problem at this level, which is
+// why the retry is bounded rather than open-ended.
+func contended(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION) ||
+		errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}

--- a/internal/workflow/replace_windows_test.go
+++ b/internal/workflow/replace_windows_test.go
@@ -1,0 +1,86 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestWriteFileWaitsOutAReaderOfTheTarget: a Windows rename cannot replace a
+// file another handle has open unless that handle passed FILE_SHARE_DELETE,
+// which `os.Open` does not. The daemon opens its own workflow files that way
+// on every registry reload, so a save that raced one used to answer 500.
+func TestWriteFileWaitsOutAReaderOfTheTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "blocks.yaml")
+	if err := os.WriteFile(path, []byte("name: blocks\n"), FilePerm); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open the target: %v", err)
+	}
+	// The handle closes while the write is retrying, which is the shape of
+	// the real contention: a reload that is already on its way out.
+	closed := make(chan struct{})
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_ = f.Close()
+		close(closed)
+	}()
+
+	want := []byte("name: blocks\ndescription: replaced\n")
+	if err := WriteFile(path, want); err != nil {
+		t.Fatalf("WriteFile with a reader on the target: %v", err)
+	}
+	<-closed
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(path + ".vincent-tmp"); !os.IsNotExist(err) {
+		t.Errorf("the temporary file survived the write: %v", err)
+	}
+}
+
+// TestReplaceFileDoesNotRetryAnErrorNobodyWillClear: the wait is for a handle
+// that is about to close, so an error that says something else is returned on
+// the first attempt rather than after the window.
+func TestReplaceFileDoesNotRetryAnErrorNobodyWillClear(t *testing.T) {
+	dir := t.TempDir()
+	start := time.Now()
+	err := replaceFile(filepath.Join(dir, "absent.vincent-tmp"), filepath.Join(dir, "absent.yaml"), FilePerm)
+	if err == nil {
+		t.Fatal("replaceFile succeeded with no source file")
+	}
+	if waited := time.Since(start); waited >= replaceWaitFor {
+		t.Errorf("waited %s on an error that is not contention", waited)
+	}
+}
+
+func TestContended(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"sharing violation", windows.ERROR_SHARING_VIOLATION, true},
+		{"lock violation", windows.ERROR_LOCK_VIOLATION, true},
+		{"access denied", windows.ERROR_ACCESS_DENIED, true},
+		{"wrapped in a LinkError", &os.LinkError{Err: windows.ERROR_SHARING_VIOLATION}, true},
+		{"file not found", windows.ERROR_FILE_NOT_FOUND, false},
+		{"disk full", windows.ERROR_DISK_FULL, false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := contended(tc.err); got != tc.want {
+				t.Errorf("contended(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

While an agent produced a turn, every vincent client could go completely
silent. The chat workspace was the sharpest case: a `running` turn that had
produced no records yet rendered as *literally nothing*, and `chatView` had no
`tea.Tick` at all — so with the stream quiet the frame was genuinely frozen,
which is exactly what a wedged TUI looks like.

This adds one animated in-progress indicator — a braille frame and an elapsed
clock, `⠋ working… 14s` — shown for the **whole** time a turn or a step attempt
is in `running`, not only until the first chunk arrives. That distinction is the
feature: at `quiet` the output pane drops tool calls and results, so a
tool-heavy turn used to render nothing new for minutes.

One shared renderer, `internal/tui/progress.go` — a pure function of
`(frame int, since time.Duration) string`. Not `bubbles/spinner`, which is a
`tea.Model` with its own ticker and message identity, so three surfaces would
have meant three models and three tick identities to route.

Four surfaces:

- **Chat workspace** — in `footerLines`, above the composer. Not inline in the
  body, which scrolls: a reader who has scrolled up is exactly the one who needs
  to be told to keep waiting. This also puts it outside the `bodyDirty` gate.
- **Chats board** — beside a `running` row's label, never instead of it (the
  state cell is a fixed-width column in a shared vocabulary). The repaint is
  also what makes the existing "last activity" cell advance; no DTO, endpoint or
  column changed.
- **Task workspace** — in `detail.outputTitle`, output tab only. The gate is
  `StepRun.Live()` rather than the step's type: a long `command` step is silent
  for exactly the same reason and for exactly as long.
- **`vincent chat send`** — on **stderr** only, suppressed under `--json` and
  whenever stderr is not a terminal, and erased before every exit path.

Each of the three views clears its `ticking` guard on the tick and re-arms from
a single place, so a view with nothing running arms no repaint at all and a
stray tick is a no-op — `tea.Tick` cannot be cancelled. `board.go`'s arm-once
ticker is deliberately *not* copied, and all four files say why.

`github.com/charmbracelet/x/term` moves to the direct require block for the TTY
predicate. It was already in the graph via `charm.land/bubbletea/v2`, so no
module is added and no supply-chain surface is new; `golang.org/x/term` as a new
direct module was rejected on that basis. The `*os.File` assertion inside `isTTY`
is load-bearing: cobra's test writers are `*bytes.Buffer`, so every command test
is non-TTY *structurally*, which makes "a redirected send is byte-identical" a
property of the code rather than of the test setup.

Cross-platform notes: no platform-specific file is added — `term.IsTerminal`
owns that difference — and the CLI's erase is `\r`, spaces and `\r` rather than
an ANSI erase-to-end-of-line, which a Windows console without
`ENABLE_VIRTUAL_TERMINAL_PROCESSING` would print literally.

## Related

Closes #330
Closes 088.1

Amends `docs/spec.md` §15 views 2, 8 and 9 with dated notes. View 9's states the
boundary against the existing "never a spinner" sentence four paragraphs above
it: that rule is about a send the daemon **refused** (`409 chat_cap_reached` —
a turn that will never exist), while this indicator draws only for a turn the
daemon holds in `running`. The two are never in force for the same turn.

Two decisions in the issue were deliberately not taken, and are recorded in
`docs/tasks/088-in-progress-indicator.md` with the alternatives they beat: the
1 s tick (a glyph that moves once per second *is* the frozen screen this exists
to rule out — 120 ms instead, with the clock derived per render rather than
ticked), and the plain-ASCII fallback (undetectable — a program can probe
whether it is attached to a terminal, never whether that terminal has a glyph,
and this TUI already ships `⏸`, `▸`, `▾` and box-drawing unconditionally).

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

**On the last two boxes, what was and was not touched.** `docs/reference/cli.md`
gained the `vincent chat send` paragraph; `docs/spec.md` §15 gained the three
dated amendments; `docs/tasks/088-in-progress-indicator.md` and its index row are
new. A follow-up documentation commit added the two derived pages that describe
what a user sees: `docs/guides/tui.md` — the Output tab's title, the chats
board's running row and the chat workspace's composer — and one bullet in
`docs/features.md`'s TUI section. The config reference, the API page and the TUI
key tables are **unchanged on purpose**: no setting, no route and no binding was
added — the indicator is rendering over data already on the wire, and it is
driven by a timer rather than by a key. No block reason changed either.

One existing sentence became true rather than stale: the chats board guide
already said a *terminal* chat shows when it ended "rather than a duration that
keeps counting", which implied a live one counts. It did not, because nothing
repainted. It does now.

The "never a spinner" sentences in `docs/reference/configuration.md`
(`max_parallel_chats`) and `docs/reference/api.md` (`POST /v1/chats/{id}/send`)
were checked and left alone: both describe a **refused** send — a turn that
never exists — which is exactly the boundary spec §15 view 9's amendment draws.
Neither says anything about what a `running` turn renders.

**No screenshots were regenerated, and none went stale.** `scripts/screenshots.sh`
seeds no chat and has no chat tape (the gap task 071 recorded and task 085
re-recorded), so no `docs/assets/tui-*.png` shows the chats board or the chat
workspace. The one task-workspace capture, `tui-diff.png`, is of the **Diff**
tab, where this indicator deliberately does not draw.

**No gate script.** Nothing crossed the wire that a gate could assert: no
endpoint, DTO, column or block reason changed.

## Tests

New — `internal/tui/progress_test.go` and `internal/cli/chat_test.go`:

- the frame table cycles, wraps, and tolerates a negative counter; the elapsed
  string matches `formatElapsed` at every boundary; a negative duration clamps
  to `0s` rather than printing `-1s`;
- **arming, per view** — a tick is armed exactly when something is running, a
  second message does not arm a second ticker, a view with nothing running arms
  none, and a tick delivered *after* the state that armed it ended returns no
  command (the `tea.Tick`-cannot-be-cancelled rule, tested on all three views);
- **chat workspace** — the indicator is in the footer for a `running` turn with
  **zero records at `levelQuiet`**, it is still there with `following == false`,
  it never leaks into the scrolling body, and it is absent at `done`, `failed`,
  `interrupted` and `awaiting_input`;
- **chats board** — a `running` row carries the frame beside its label; `idle`,
  `awaiting_input`, `archived` and `handed_off` rows carry no frame at all; and
  the activity cell advances across a simulated minute on a pinned clock;
- **task workspace** — `outputTitle` carries it for a live attempt (`agent` and
  `command` alike), not on `tabDiff`, not for a finished attempt;
- **`vincent chat send`** — against a stub daemon with stdout and stderr kept
  apart: the plain path prints the answer alone on stdout with stderr *empty*,
  `--json` likewise, and the failure path still leads with its failure line. The
  frame-writing itself is unit-tested against a buffer with the predicate forced
  true, covering the in-place redraw, the padding a shrinking clock needs, the
  idempotent erase, and that the erase precedes whatever is written next.

`go test ./...`, `go run mage.go lint`, and `go tool golangci-lint run ./...`
under `GOOS=windows`, `GOOS=darwin` and `GOOS=linux` are all green, as is
`go test -race ./internal/tui ./internal/cli` — the CLI leg's single-goroutine
design is a decision, not something the type system holds.
