### PR TITLE
Stop asserting a whole-repo build inside a fan-out lane

### DIFF
--- a/.vincent/workflows/github-resolve-issue-dag.yaml
+++ b/.vincent/workflows/github-resolve-issue-dag.yaml
@@ -115,11 +115,13 @@
 # verbatim and `grep -f` / `sh <file>` never parse it as shell. This is the same
 # move `confirm-red` already makes with `green.sh`.
 #
-# Conflicts that survive all that are handled by `merge.on_conflict: agent`, and
-# its check is `go build ./...` and `go vet ./...` for the reason above — the
-# suite is not available as a bar mid-join on the bug path. A resolver that does
-# not resolve leaves the conflict blocked for a human, which is the default
-# behaviour and the right one.
+# Conflicts that survive all that are handled by `merge.on_conflict: agent`. Its
+# check asserts what is true mid-join and nothing more: nothing left unmerged, no
+# conflict marker staged, and `go build`/`go vet` over the packages this
+# resolution touched — not `./...`, which is red mid-join for both reasons above,
+# the seeded regression test on the bug path and a consumer unit that has not
+# merged yet on any path. A resolver that does not resolve leaves the conflict
+# blocked for a human, which is the default behaviour and the right one.
 #
 # ## Why the plan is a step's stdout, and why a human reads it
 #
@@ -1188,10 +1190,26 @@ steps:
         # branch carries a committed failing regression test until the unit
         # that fixes it merges, so the suite is red by construction mid-join
         # and would fail every resolution. The suite's bar is `integrate`,
-        # after the join. Build and vet are what can honestly be asserted here.
+        # after the join.
+        #
+        # `go build ./...` and `go vet ./...` are absent for the second
+        # structural reason, the one the lane check ran into on #328
+        # (2026-09-05): a provider unit merges before the consumer unit that
+        # updates its call sites — that is what `needs` means — so between
+        # those two merges the repository legitimately does not compile, and
+        # the red package is one this resolution never touched.
+        #
+        # So the build is scoped to the packages this resolution actually
+        # staged. Those are honest to assert: a package the merge touched can
+        # only depend on units that already merged, because `needs` put them
+        # first. Around it are the resolution's own bar — nothing left
+        # unmerged, no marker left behind. `git diff` feeds `grep -E` without
+        # `-q` on purpose (CLAUDE.md): an early-exiting consumer would kill the
+        # producer with SIGPIPE and fail the check *because* it matched.
         check: >
-          go build ./... &&
-          go vet ./...
+          test -z "$(git ls-files -u)" &&
+          { markers=$(git diff --cached -U0 --diff-filter=ACMR | grep -E '^\+(<<<<<<<|>>>>>>>)' || true); test -z "$markers" || { echo 'conflict markers survived the resolution:' >&2; echo "$markers" >&2; false; }; } &&
+          { dirs=$(git diff --cached --name-only --diff-filter=ACMR | sed -n 's#^\(.*\)/[^/]*\.go$#./\1#p' | sort -u); test -z "$dirs" || { go build $dirs && go vet $dirs; }; }
         check_timeout: 10m
 
   - id: integrate

--- a/.vincent/workflows/github-resolve-issue-dag.yaml
+++ b/.vincent/workflows/github-resolve-issue-dag.yaml
@@ -74,12 +74,23 @@
 # the full suite as its bar: `go run mage.go test` is red by construction there,
 # and a lane check that ran it would fail every lane for the same reason.
 #
-# Inside the fan-out the bar is therefore `go build ./...` plus the **unit's
-# own** `check` command, which the planner writes and which is scoped to what
-# that unit changed. The suite is `integrate`'s bar, after the join, where it is
-# meant to be green — and `verify` is still the cross-platform one after that.
-# That is not a weaker workflow than the sequential file; it is the same two
-# assertions in the same order, with the units' own checks added in front.
+# Inside the fan-out the bar is therefore the **unit's own** `check` command,
+# which the planner writes and which is scoped to what that unit changed. The
+# suite is `integrate`'s bar, after the join, where it is meant to be green —
+# and `verify` is still the cross-platform one after that. That is not a weaker
+# workflow than the sequential file; it is the same two assertions in the same
+# order, with the units' own checks added in front.
+#
+# `go build ./...` is not a lane bar either, for a structurally identical
+# reason. A unit that changes a signature and the unit that updates its call
+# sites are two units, the second `needs` the first and lands after it, and
+# between the two commits the repository does not compile. The first lane
+# cannot repair that — the call site is inside another unit's `files`
+# expression, so touching it fails the ownership clause below — so a whole-repo
+# build as its bar is a deadlock with no exit but `blocked`. It ran into
+# exactly that on #328 (2026-09-05), where the engine lane's `Runner.Retry`
+# signature change was consumed by a later `internal/api` lane. `integrate`
+# runs `go build ./...` once, after every unit has merged.
 #
 # ## What keeps lanes from fighting over the same file
 #
@@ -1316,13 +1327,17 @@ steps:
     # one would only fail at `gh pr create`, after you had already approved it
     # at the gate), the PR artifacts exist. Then — on the bug path only — the
     # narrow regression test, which is the fastest signal that the fix works.
-    # Then the real bar.
+    # Then the real bar — and `go build ./...` leads it, because this is the
+    # first point at which the whole repository is expected to compile: a lane
+    # that changed an interface and the lane that updated its call sites have
+    # both merged by now, which is exactly why neither of them could assert it.
     check: >
       ! git ls-files .vincent-issue | grep -q . &&
       test "$(git rev-list --count {{.Task.BaseBranch}}..HEAD)" -gt 0 &&
       test -s .vincent-issue/pr-title.txt &&
       test -s .vincent-issue/pr.md &&
       {{if eq (index .Steps "is-bug").ExitCode 0}}sh .vincent-issue/green.sh &&{{end}}
+      go build ./... &&
       go run mage.go test &&
       go run mage.go lint
     check_timeout: 15m

--- a/.vincent/workflows/github-resolve-issue-unit.yaml
+++ b/.vincent/workflows/github-resolve-issue-unit.yaml
@@ -42,15 +42,27 @@
 # An `env:` mapping would be the other way, and it is not available: `env:` is a
 # command-step field (§8.5), and the step that needs these is an agent.
 #
-# ## Why the check is not the test suite
+# ## Why the check is not the test suite, and not `go build ./...` either
 #
 # On the bug path the parent branch carries a **committed, failing** regression
 # test from the moment the fan-out starts until the unit that fixes it merges.
 # `go run mage.go test` is therefore red by construction inside a lane, and a
 # lane check that ran it would fail every lane for a reason that has nothing to
-# do with the lane. The bar here is `go build ./...` plus the unit's own scoped
-# `check` command; the suite is the parent's `integrate` step's bar, after the
-# join, and the cross-platform legs are `verify`'s after that.
+# do with the lane.
+#
+# `go build ./...` is red by construction in a lane too, and for the same
+# structural reason: a unit that changes a signature and a unit that updates its
+# call sites are different units — the second `needs` the first, so it lands
+# *after* it — and between the two commits the repository does not compile. The
+# lane that changed the signature cannot fix that: the call site is in another
+# unit's `files` expression, and touching it fails the ownership clause below.
+# A whole-repo build as the lane's bar is therefore a deadlock, not a gate: the
+# lane can neither pass it nor repair it, and its only exit is `blocked`.
+#
+# The bar here is the unit's own scoped `check` command, which the planner
+# writes and which compiles and tests what the unit actually changed. The
+# whole-repo build and the suite are the parent's `integrate` step's bar, after
+# every unit has merged, and the cross-platform legs are `verify`'s after that.
 #
 # ## Why the diff is three-dot
 #
@@ -275,7 +287,13 @@ steps:
       ## The bar
 
       `.vincent-issue/unit-check.sh` is the command the plan says proves this
-      unit. Run it. It has to pass, along with `go build ./...`.
+      unit. Run it. It has to pass, and it is the whole bar.
+
+      **Do not run `go build ./...` as your bar either.** Another unit may own
+      the call sites of an interface you changed, and it lands after you — so
+      the repository legitimately does not compile between your commit and
+      theirs. Build and vet what you own; the whole-repo build runs once, after
+      every unit has merged.
 
       **Do not run the whole test suite as your bar.** If this is a bug fix, a
       failing regression test is committed on this branch on purpose and stays
@@ -332,7 +350,6 @@ steps:
       git diff --cached --quiet &&
       test "$(git rev-list --count {{.Task.BaseBranch}}..HEAD)" -gt 0 &&
       { stray=$(git diff --name-only {{.Task.BaseBranch}}...HEAD | grep -vEf .vincent-issue/unit-files.re || true); test -z "$stray" || { echo 'this unit committed paths the plan did not give it:' >&2; echo "$stray" >&2; echo 'owned paths (ERE):' >&2; cat .vincent-issue/unit-files.re >&2; false; }; } &&
-      go build ./... &&
       sh .vincent-issue/unit-check.sh
     check_timeout: 15m
 


### PR DESCRIPTION
## Problem

`github-resolve-issue-unit.yaml`'s `unit-implement` check ran `go build ./...`.
Inside a DAG fan-out that is a deadlock, not a gate: a unit that changes a
signature and the unit that updates its call sites are two units — the second
`needs` the first, so it lands *after* — and between the two commits the
repository does not compile. The first lane cannot repair it either, because
the call site is inside another unit's `files` expression and touching it fails
the ownership clause in the same check.

Issue #328 walked into it. The `engine-cascade` lane changed `Runner.Retry` to
return three values; its only in-tree caller is in `internal/api`, owned by a
lane that `needs` it. The lane failed `check_failed` four times on that one
line while `go test ./internal/taskstate/... ./internal/taskrun/...` was green,
and ended `blocked` — with its parent parked in `awaiting_children`, which is
the very state #328 is about.

## Change

- The lane's bar is the unit's own scoped `check` command alone. The ownership
  clause, the clean-tree and commit-count assertions are unchanged.
- `integrate` gains an explicit `go build ./...` at the head of its check — the
  first point after the join where the whole repository is expected to compile.
- Both files' header comments and the `unit-implement` prompt record why a lane
  may assert neither the suite nor a whole-repo build.

Validated with `vincent workflow validate` on both files: `ok`, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)