### PR TITLE
Cascade a retry from a parked fan-out parent to its blocked lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,26 @@ list with the user-facing context a commit subject cannot carry.
   erased before anything else is written, so no spinner residue can land in
   front of the answer or an error.
 
+### Fixed
+
+- **A fan-out whose lanes blocked is no longer a dead end.** A blocked lane
+  never settles, so the join stayed open and the parent sat in
+  `awaiting_children` — a state that offered exactly one human action, `cancel`,
+  which throws the run away. `retry` on the parent was refused with a `409`, and
+  the only way out was to retry each lane by hand, once per lane and once per
+  level of a nested fan-out. Now one `retry` on the **parent** re-admits every
+  blocked descendant beneath it at any depth: `r` in the TUI,
+  `vincent task retry <id>`, or `POST /v1/tasks/{id}/retry`, which answers with
+  `retried_descendants` — the number of lanes it woke — and both clients say how
+  many. The parent itself is not touched: it stays parked, keeps its retry
+  cursor, and the join closes on its own once the lanes finish, so fixing the
+  cause once and retrying at the root is now the whole recovery. A lane you
+  **cancelled** is still yours to deal with — nothing re-admits an aborted task,
+  and that join still fails with `lane_failed`. The three override flags
+  (`--prompt`, `--run`, `--branch`) are refused on a parked parent with a `400`,
+  and the TUI stops offering `E` there: a `fan_out` step has no text to edit, so
+  the edit belongs on the blocked lane.
+
 ## [0.8.0](https://github.com/lezli01/vincent/compare/v0.7.0...v0.8.0) (2026-09-04)
 
 ### Added

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -720,7 +720,7 @@ selected on the board it acts on all of them; see
 |---|---|---|
 | `a` | Approve the gate | `awaiting_gate` |
 | `x` | Reject the gate | `awaiting_gate` |
-| `r` | Retry the blocked step | `blocked` |
+| `r` | Retry the blocked step, or cascade the retry to every blocked lane under a parked fan-out parent | `blocked`, `awaiting_children` |
 | `R` | Repair with an agent — a one-off run in this task's worktree | `blocked` |
 | `E` | Edit the step's prompt or command in `$EDITOR`, then retry | `blocked` |
 | `s` | Skip the current step | `blocked`, `awaiting_gate` |

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -713,6 +713,14 @@ Watch the children with `vincent task ls --include-children`, or press `L` on
 the parent in the TUI. They are hidden from the board by default; the parent's
 `awaiting_children (2 blocked)` summary is how you learn one of them needs you.
 
+**When lanes block.** A blocked lane never settles, so the join stays open and
+the parent stays parked. Fix what they failed on, then retry the **parent** —
+`r` in the TUI, `vincent task retry <parent>`, `POST /v1/tasks/{id}/retry`:
+one call re-admits every blocked lane under it, at any depth for a nested
+fan-out, and the parent stays where it is until they finish. A lane you
+**cancelled** is not re-admitted by anything; that one still fails the join with
+`lane_failed`.
+
 **When every lane is guarded off**, the step chooses nothing and simply
 advances. A fan-out whose conditions all said "not this time" decided
 correctly.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1311,7 +1311,7 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 | `/cancel` | most states | |
 | `/pause` | queued, running | |
 | `/resume` | paused | |
-| `/retry` | blocked | `{ prompt_override?, run_override?, branch_override? }` — `branch_override` renames the branch before re-admission, which is how a `branch_exists` block is recovered. **`409`** on a task created from a pull request: renaming its branch would detach it from that pull request |
+| `/retry` | blocked, awaiting_children | `{ prompt_override?, run_override?, branch_override? }` — `branch_override` renames the branch before re-admission, which is how a `branch_exists` block is recovered. **`409`** on a task created from a pull request: renaming its branch would detach it from that pull request. From `awaiting_children` it means the cascade below, and all three overrides are a **`400`** |
 | `/repair` | blocked | `{ prompt, agent?, model?, effort? }` — runs one ad-hoc agent in the task's existing worktree, then returns the task to `blocked` at the same step with the same reason |
 | `/skip` | blocked, awaiting_gate | |
 | `/approve` | awaiting_gate | |
@@ -1322,6 +1322,25 @@ Human actions, all `POST /v1/tasks/{id}/…`:
 
 Anything else returns `409` with `details.state`. See
 [Task lifecycle](task-lifecycle.md).
+
+`/retry` on a `fan_out` parent parked in `awaiting_children` is a **cascade**:
+the parent has no step of its own to re-run, so the one call re-admits every
+`blocked` descendant beneath it, at any depth, and the parent's own row is not
+written — it comes back still `awaiting_children`, and the join closes on its
+own once the lanes finish. The response is the ordinary task object with one
+extra field:
+
+```json
+{ "id": 42, "state": "awaiting_children", "retried_descendants": 2 }
+```
+
+`retried_descendants` is always present — `0` for an ordinary blocked retry
+with nothing blocked under it — so a client never has to tell "no cascade" from
+"an old daemon". It is a count and not a list of ids: re-fetch
+`GET /v1/tasks?parent_id={id}` if you need them. A `blocked` parent does both,
+its own retry and then the cascade. A descendant that is `awaiting_gate`,
+`paused` or itself parked is left alone; an `aborted` lane is not re-admitted
+by anything, and is still fixed and retried by hand.
 
 `/repair` runs one throwaway agent against a blocked task's worktree — the
 escape hatch for a block that `retry` cannot clear because the worktree itself

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -757,8 +757,9 @@ vincent task retry <id> [--branch NAME] [--prompt TEXT | --prompt-file FILE]
                         [--run CMD | --run-file FILE] [--json]
 ```
 
-Re-runs the step the task blocked on. Valid from `blocked`. With no flags it is
-a plain retry; the flags change what gets re-run, and each one is a different
+Re-runs the step the task blocked on. Valid from `blocked`, and from
+`awaiting_children`, where it means something else — see below. With no flags it
+is a plain retry; the flags change what gets re-run, and each one is a different
 kind of recovery:
 
 | Flag | What it does |
@@ -776,6 +777,22 @@ The check failed because the fixture path is wrong on Windows.
 Use filepath.Join rather than a slash-separated literal.
 EOF
 ```
+
+On a fan-out parent parked in `awaiting_children` the same command **cascades**:
+the parent has no step of its own to re-run, so one call re-admits every blocked
+lane beneath it, at any depth, and the parent stays parked while they run. Fix
+the cause first — each lane's step re-runs exactly as it was — then:
+
+```console
+$ vincent task retry 42
+task 42 is now awaiting_children
+  2 blocked descendants re-admitted
+```
+
+All three flags are refused from that state: a `fan_out` step carries no prompt
+or command to edit, and `--branch` would rename the branch every live lane holds
+as its base. Edit the blocked lane itself instead. With `--json` the count is
+`retried_descendants` beside the task's own fields.
 
 ### `vincent task repair`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -791,8 +791,10 @@ task 42 is now awaiting_children
 
 All three flags are refused from that state: a `fan_out` step carries no prompt
 or command to edit, and `--branch` would rename the branch every live lane holds
-as its base. Edit the blocked lane itself instead. With `--json` the count is
-`retried_descendants` beside the task's own fields.
+as its base. Edit the blocked lane itself instead. With `--json` the count rides
+beside the task's own fields as `retried_descendants`; a retry that re-admitted
+nothing omits it and prints the plain task object, where
+[the API's own body](api.md) always carries the field and reads `0`.
 
 ### `vincent task repair`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -91,7 +91,7 @@ Both are `queued_reason` values only. Neither is ever a `block_reason`, and
 `retry_backoff` is never a step's failure reason either — the step's row keeps
 whatever actually failed.
 
-**`awaiting_children` holds no slot, and offers only `cancel`.** A fan-out
+**`awaiting_children` holds no slot, and offers `cancel` and `retry`.** A fan-out
 parent waiting on its lanes owns no process, so keeping a slot would starve
 the queue for hours — and it is what makes fan-out deadlock-free at any depth,
 since a parent releases its slot before its children need one. It is not a
@@ -104,7 +104,11 @@ The parent resumes on its own once every lane has settled — finished or ended
 soon as a further lane settles, so such a parent parks and resumes more than
 once. A lane that is `blocked`, at a gate, or paused holds the join open until you
 deal with it; the `children` rollup on `GET /v1/tasks/{id}` (and the TUI's
-`awaiting_children (2 blocked)` row) is where you see that.
+`awaiting_children (2 blocked)` row) is where you see that. For blocked lanes,
+dealing with them is one `retry` on the **parent**: it re-admits every blocked
+lane beneath it, at any depth, without touching the parent's own row, and the
+join closes itself when they finish. Fix the cause first — the retry re-runs
+each lane's step exactly as it was.
 
 **`awaiting_input` keeps its concurrency slot.** The agent process is alive
 mid-step, idle on its stdin; killing or re-queueing it would lose the very
@@ -170,8 +174,8 @@ which it was not before follow-ups existed.
 | `cancel` | queued, running, awaiting_input, awaiting_gate, awaiting_children, blocked, paused | Kills any running process — graceful termination, then a kill after 10s — and moves to `aborted`. From `awaiting_children` it cascades to every unfinished lane, whose branches and worktrees survive |
 | `pause` | queued, running | From `running`, finishes the current step then holds. The request is persisted, so it survives a daemon crash; any other action clears it |
 | `resume` | paused | → `queued` |
-| `retry` | blocked | Re-runs the failed step as a fresh attempt with the retry counter reset → `queued` |
-| `edit + retry` | blocked | Overrides the step's prompt or command **in this task's snapshot only**, then retries. The override is recorded on the step run |
+| `retry` | blocked, awaiting_children | Re-runs the failed step as a fresh attempt with the retry counter reset → `queued`. From `awaiting_children` it re-admits every blocked descendant instead and leaves the parent parked; the response says how many |
+| `edit + retry` | blocked | Overrides the step's prompt or command **in this task's snapshot only**, then retries. The override is recorded on the step run. A parked fan-out parent refuses it: its `fan_out` step has no text to edit, so edit the blocked lane instead |
 | `repair` | blocked | Runs one ad-hoc agent, prompted by you, in the task's existing worktree and branch → `queued`, and back to `blocked` at the same step with the same reason when it exits. It does not consume the blocked step's retry budget |
 | `skip` | blocked, awaiting_gate | Marks the step `skipped` and advances → `queued`. A step skipped this way carries no `skip_reason`, which is how it stays distinguishable from one an `if:` guard skipped |
 | `answer` | awaiting_input | Delivers the answer into the live agent session → `running`, and the step clock resumes |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -800,7 +800,7 @@ times before it is archived, and each is a **round** with its own rows (§5.4).
 | `running` | A step process is executing (or about to) | **yes** |
 | `awaiting_gate` | Paused at a `manual` step, waiting for approval | no |
 | `awaiting_input` | The running agent emitted a structured input request (§7.4); its live process is idle, waiting for the answer | **yes** |
-| `awaiting_children` | A `fan_out` step's lanes are running as child tasks (§7.6, *added 2026-08-17, task 014*); the parent owns no process. Cancel is the only human action — approve/reject/skip would be meaningless, which is why this is not a reuse of `awaiting_gate` | no |
+| `awaiting_children` | A `fan_out` step's lanes are running as child tasks (§7.6, *added 2026-08-17, task 014*); the parent owns no process. Cancel and retry are the only human actions — approve/reject/skip would be meaningless, which is why this is not a reuse of `awaiting_gate`. *Amended 2026-09-05 (task 090, issue #328): `retry` from here is the cascade to every blocked descendant, and writes nothing to the parent's own row* | no |
 | `blocked` | A step failed and retries are exhausted; waiting for a human decision | no |
 | `paused` | Engineer-requested soft pause (takes effect at the next step boundary) | no |
 | `done` | All steps succeeded; worktree/branch retained for inspection | no |
@@ -814,8 +814,8 @@ times before it is archived, and each is a **round** with its own rows (§5.4).
 | `cancel` (abort) | queued, running, awaiting_input, awaiting_gate, awaiting_children, blocked, paused | Kills any running process (graceful term, then kill after 10 s; `taskkill /T /F` on Windows); → `aborted`. *Amended 2026-08-17 (task 014): from `awaiting_children` it cascades to every unsettled descendant, whose branches and worktrees survive.* |
 | `pause` | queued, running | `running`: finishes the current step, then holds; → `paused`. The request is persisted, so it survives a daemon crash; every other human action clears it |
 | `resume` | paused | → `queued` |
-| `retry` | blocked | Re-runs the failed step (fresh attempt, retry counter reset); → `queued` |
-| `edit + retry` | blocked | Overrides the step's prompt/command **in this task's snapshot only**, then retries; the override is recorded on the StepRun |
+| `retry` | blocked, awaiting_children | Re-runs the failed step (fresh attempt, retry counter reset); → `queued`. *Amended 2026-09-05 (task 090, issue #328): from `awaiting_children` it is the **cascade** — every `blocked` descendant at any depth is re-admitted in one call, and the parked parent's own row is not written at all: no transition, no `task.state_changed` whose from and to are equal, and no `retry_cursor_at` stamp, because nothing was retried on the parent and stamping the cursor would hand the join a fresh §7.2 budget nobody asked for. A `blocked` parent takes both: its own `blocked → queued`, then the same cascade over anything blocked beneath it. The count is reported as `retried_descendants` (§13.2). This amends [task 014 decision 22](tasks/014-workflow-fan-out.md) in scope, not in substance — an `aborted` lane is still fixed by hand before the parent is retried, because nothing here re-admits an aborted task* |
+| `edit + retry` | blocked | Overrides the step's prompt/command **in this task's snapshot only**, then retries; the override is recorded on the StepRun. *Amended 2026-09-05 (task 090): every override is a `400` from `awaiting_children` — a parked parent's cursor is a `fan_out` step, which carries no prompt or command to rewrite, and `branch_override` would rename the branch every live lane holds as its `base_branch`* |
 | `repair` | blocked | *Added 2026-08-24 (task 025).* Runs one ad-hoc agent, prompted by the operator, in the task's existing worktree and branch (§7.2, §8.6, §13.2); → `queued`, and back to `blocked` at the same step with the same reason when it exits. It decides nothing about the blocked step and does not consume its retry budget |
 | `skip` | blocked, awaiting_gate | Marks the step `skipped`, advances to the next step; → `queued` |
 | `answer` | awaiting_input | Delivers the answer to the pending input request into the live agent session (§7.4); → `running` (step clock resumes) |
@@ -1401,7 +1401,12 @@ does not finish until every lane is merged.
   done" and block `lane_failed` on work about to run perfectly well, which
   `retry` cannot clear because the lanes are still not done. A `blocked`, `awaiting_gate`
   or `paused` lane holds the join open until a human resolves it; the §13.2
-  `children` rollup is what makes that visible.
+  `children` rollup is what makes that visible. *Amended 2026-09-05 (task 090,
+  issue #328): for a `blocked` lane that resolution is one
+  `POST /v1/tasks/{id}/retry` on the **parent** — it re-admits every blocked
+  descendant at any depth and leaves the parent parked, and the tree converges
+  from there whatever order the scheduler wakes it in, because this guard is
+  exactly what parks it again while a re-admitted lane is unsettled.*
 
   *Amended 2026-09-02 (task 081).* Under `schedule: eager` an unsettled lane is
   the ordinary case, not a lost transition, so that guard is barrier-only and a
@@ -5673,11 +5678,19 @@ POST   /v1/tasks/{id}/cancel
 POST   /v1/tasks/{id}/pause
 POST   /v1/tasks/{id}/resume
 POST   /v1/tasks/{id}/retry            { prompt_override?, run_override?, branch_override? }
-                                        (blocked only). branch_override renames the task's
-                                        branch before re-admission — the recovery path for a
-                                        branch_exists block (§10, task 001); it is validated
-                                        and collision-checked exactly as creation is, and
-                                        unlike the other two it does not touch the snapshot
+                                        (blocked, awaiting_children). branch_override renames
+                                        the task's branch before re-admission — the recovery
+                                        path for a branch_exists block (§10, task 001); it is
+                                        validated and collision-checked exactly as creation is,
+                                        and unlike the other two it does not touch the
+                                        snapshot. *Added 2026-09-05 (task 090, issue #328):*
+                                        from awaiting_children the call cascades to every
+                                        blocked descendant instead and writes nothing to the
+                                        parked parent, which comes back still
+                                        awaiting_children; all three overrides are a 400 from
+                                        that state. The response is the ordinary task object
+                                        plus retried_descendants, always present and 0 when
+                                        nothing was cascaded
 POST   /v1/tasks/{id}/repair           { prompt, agent?, model?, effort? }
                                         (blocked only; added 2026-08-24, task 025). Runs one
                                         ad-hoc agent in the task's existing worktree and

--- a/docs/tasks/014-workflow-fan-out.md
+++ b/docs/tasks/014-workflow-fan-out.md
@@ -485,6 +485,15 @@ decision 21 just refused.
 spawn path and a "which child is the current attempt at lane X" question that
 `lane_id` cannot answer without becoming versioned.
 
+*Amended in scope 2026-09-05 by
+[090](090-cascading-fan-out-retry.md) (issue #328).* The remedy above is still
+the truth for an **`aborted`** lane, and the beat still stands — nothing
+re-admits an aborted task. What 090 adds is the case this decision did not
+consider: a merely **`blocked`** lane, which never reaches `mergeSet` at all
+because the join parks rather than failing on it. `retry` is now legal from
+`awaiting_children` and cascades to every blocked descendant, so the parent's
+retry is what fixes those children instead of following them.
+
 ### 23. A child's title is `{parent title} — {lane id}`, and its branch is named the ordinary way
 
 *2026-08-17.* Nothing about child branch naming is special-cased: a child is an

--- a/docs/tasks/090-cascading-fan-out-retry.md
+++ b/docs/tasks/090-cascading-fan-out-retry.md
@@ -1,0 +1,146 @@
+# 090 — A retry on a parked fan-out parent cascades to its blocked lanes
+
+**Status:** ✅ done (5/5)
+**Issue:** #328
+**Amends:** §6 — the `awaiting_children` row's "Cancel is the only human action",
+the `retry` row's valid-from set and the `edit + retry` row's refusal; §7.6's
+"Resuming" bullet, where a blocked lane's resolution is now one retry at the
+parent; §13.2 and `docs/reference/api.md` for the `/retry` states and the
+`retried_descendants` field
+**Amends in scope, without relitigating:**
+[014](014-workflow-fan-out.md) decision 22 — its remedy ("fix the child, then
+retry the parent") remains the truth for an **`aborted`** lane, because nothing
+here re-admits an aborted task, and its beat (retry re-spawning aborted lanes as
+fresh children, which `lane_id` cannot version) stays refused. What changes is
+that the parent's retry now also re-admits the **blocked** children decision 22
+never considered
+**Keeps, without relitigating:** [014](014-workflow-fan-out.md) decision 20 —
+`blocked` is still not `Settled`, so the join still never proceeds over a blocked
+lane. This changes who issues the retry, not what the join will merge
+
+A `fan_out` lane that blocked was a dead end for the tree above it. A blocked
+task is not settled, so `Scheduler.resumeSettledParents` never returned its
+parent to the queue; the parent sat in `awaiting_children`, and §6 offered
+exactly one human action from there — `cancel`, which destroys the work. `retry`
+on the parent was a `409`. Recovery was a manual walk of the lane tree, once per
+lane and once per level down to `fan_out.max_depth`, with nothing in the product
+to walk it for you.
+
+The engine already behaved correctly under a cascade, which is what made this
+cheap. A parent re-admitted while its lanes are unsettled does not join and
+fail: under barrier scheduling `parkForUnsettled` parks it again, and under
+`schedule: eager` `mergeSet` reads an unsettled lane as "not yet". So
+re-admitting lanes beneath a parked parent converges with no new engine logic,
+whichever order the scheduler happens to run things in — which is why the whole
+change is one state-table row, one cascade walk, and the plumbing that carries a
+count out to the clients.
+
+## Tasks
+
+- [x] **090.1** The state machine and the engine: `Retry` becomes legal from
+  `awaiting_children`, and `Runner.Retry` grows the parked branch and
+  `cascadeRetry`.
+- [x] **090.2** `POST /v1/tasks/{id}/retry` answers 200 from `awaiting_children`,
+  reports `retried_descendants`, and refuses `branch_override` there.
+- [x] **090.3** The clients: `apiclient.Retry` carries the count, the TUI offers
+  `r` on a parked parent and stops offering `E` where it is now a 400, and the
+  CLI and the action bar say how many lanes were re-admitted.
+- [x] **090.4** `scripts/m6-gate.sh` scenario 12: two lanes blocked on one
+  missing repository setting, one retry on the parent, both merged.
+- [x] **090.5** The spec, the API/CLI/TUI/lifecycle pages, the workflows guide
+  and the changelog.
+
+## Decisions
+
+### 1. The parked parent's row is not written at all
+
+*2026-09-05.* The §6 table gains `Retry: {AwaitingChildren: {To:
+AwaitingChildren}}` so that `taskstate.Can` is true — the API answers 200
+instead of 409 and `available_actions` lists `retry` — but `Runner.Retry`
+branches on `awaiting_children` **before** `transitionFrom` and only cascades.
+No compare-and-swap, no `task.state_changed` whose `from` and `to` are equal,
+and above all no `retry_cursor_at` stamp.
+
+The reason is `Repair`'s, and it is stated verbatim in the code: nothing was
+retried on *this* task, and stamping the cursor would silently hand the join a
+fresh §7.2 budget nobody asked for. Skipping the CAS loses nothing else —
+`applyAction`'s pending-pause clear is moot here, because `pause` is not valid
+from `awaiting_children`, so there is never one to clear.
+
+The self-transition in the table is therefore a **legality marker**, not a swap
+any caller performs, and it says so in a comment beside the row.
+
+**Beat:** a real `awaiting_children → queued` transition on the parent. It would
+re-admit the parent, which then parks again after a full admission — work,
+events and a step run for nothing, and a `retry_cursor_at` that lies.
+
+### 2. The `blocked` path keeps everything it had, and cascades after it
+
+*2026-09-05.* A `blocked` parent still takes its own `blocked → queued` swap and
+its cursor stamp, exactly as before, and the cascade runs after the transition
+has committed — the shape `Cancel` already uses with `cascadeCancel`. Its error
+is logged rather than returned: the parent's own retry has already committed, so
+reporting a failure would tell the caller the opposite of what happened. On the
+parked path there is nothing else to report, so the cascade's error **is** the
+call's error.
+
+Both shapes cascade because both are reachable: a parent blocked for its own
+reason can have a blocked descendant under it — an eager or DAG fan-out blocked
+on `merge_conflict` in round 1 with a round-2 lane blocked, or a lane set mixing
+one aborted and one blocked lane.
+
+This replaces the rationale in the issue's fourth bullet, which claimed
+cascading from `blocked` "stops the `lane_failed` case needing the lanes fixed
+first". That is wrong: `lane_failed` is raised by `mergeSet` only for a lane that
+settled **without** finishing — `aborted` or `archived` — and `retry` is illegal
+from `aborted`, so the cascade cannot touch it. The bullet is kept; its reason is
+replaced by the case that is actually reachable.
+
+### 3. Retry gets its own response type, carrying a count and not ids
+
+*2026-09-05.* `runAction`'s shared task body has no room for a second thing to
+say, so `handleTaskRetry` stops using it and writes the task fields plus
+`retried_descendants` — the way `/repair` already leaves `runAction` to carry
+its catalog warnings. The field is **always** present, `0` for an ordinary
+blocked retry with nothing under it, so a client never has to tell "no cascade"
+from "an old daemon".
+
+A count and not the ids: §13.3's convention is that a client re-fetches what it
+decides it needs, and the ids under a wide fan-out are unbounded.
+
+### 4. Every override is refused from `awaiting_children`, with a 400
+
+*2026-09-05.* A parked parent's cursor is on a `fan_out` step, which has no
+prompt and no command to rewrite, and `branch_override` would rename the branch
+every live lane holds as its own `base_branch`. A typed error from
+`Runner.Retry` (`ParkedOverrideError`) covers `prompt_override` and
+`run_override`; `branch_override` is refused in `handleTaskRetry` **before**
+`renameBranchForRetry` runs, because that rename is committed ahead of the
+action and a refusal afterwards would leave the branch moved.
+
+The TUI's `E` gains the state check its own hint line already applied, so
+edit+retry is not offered where the daemon would answer 400.
+
+### 5. Cascaded children skip the task-013 `on_input: require` re-check
+
+*2026-09-05.* `checkRetryInput` lives in the API handler and applies to the
+addressed task only. A child that would block `input_unsupported` re-blocks on
+its own row, which is the issue's stated posture for every non-quota reason and
+is exactly what retrying that lane by hand does today. A parked parent passes the
+gate as a matter of course: it reads `on_input` off `agent` steps, and the
+parent's cursor is a `fan_out`.
+
+### 6. The walk is `ChildrenOf`'s existing recursive CTE, sorted
+
+*2026-09-05.* No store change and no migration. `store.ChildrenOf` already
+returns the `Blocked` set for the whole subtree at any depth in one recursive
+CTE, which is exactly the set to re-admit — nested fan-outs included, with no Go
+recursion and no new query. The ids are sorted before the walk because the CTE
+has no `ORDER BY`, and a deterministic order is something a gate can assert.
+
+A descendant that is itself `awaiting_children` is deliberately absent from that
+set and is left parked: it needs no help, since a re-admitted lane beneath it
+parks it again (barrier) or reads as "not yet" (eager). A lane that leaves
+`blocked` between the rollup and the write is skipped on its
+`InvalidActionError` — it moved, which is not an error for the human who asked —
+and the count excludes it.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -103,6 +103,7 @@ the living engineering specification records implementation contracts.
 | [087](087-editor-cannot-write.md) | Give the workflow editor a multi-line pane, descents into every block, `a`/`d`/`K`/`J` structural edits and pickers for the closed sets | ✅ done (4/4) |
 | [088](088-step-details-tab.md) | Record what each attempt was *given* — the rendered prompt, script, `check:`, `if:` and `for_each` list, plus the §8.6 provenance, the permission mode, the timeouts, the shell and the working directory — and read it back on a Step Details tab bound to `6`, moving Pull Request to `7` | ✅ done (3/3) |
 | [089](089-in-progress-indicator.md) | One animated in-progress indicator — a braille frame and an elapsed clock — for the chat workspace, the chats board, the task workspace's output pane and `vincent chat send` | ✅ done (1/1) |
+| [090](090-cascading-fan-out-retry.md) | One `retry` on a fan-out parent parked in `awaiting_children` re-admits every blocked descendant, without writing the parent's own row | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -73,7 +73,7 @@ type retryRequest struct {
 }
 
 // retryResponse is the task as every other action renders it, plus how many
-// blocked descendants the retry re-admitted (§13.2, task 088). The task
+// blocked descendants the retry re-admitted (§13.2, task 090). The task
 // fields stay at the top level — a retry response is still a task — and
 // `retried_descendants` is always present, 0 for an ordinary blocked retry
 // with nothing under it, so a client never has to tell "no cascade" from "an
@@ -88,7 +88,7 @@ type retryResponse struct {
 
 // handleTaskRetry re-admits a blocked task, or cascades from a parent parked
 // in `awaiting_children` to the blocked lanes holding its join open (§6, task
-// 088).
+// 090).
 //
 // Like repair it cannot go through runAction: that path's taskAction returns a
 // task and nothing else, and the cascade's count is the second thing this one
@@ -162,7 +162,7 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 }
 
 // checkRetryBranchOverride refuses `branch_override` on a parent parked in
-// `awaiting_children` (task 088). Every live lane of that parent holds its
+// `awaiting_children` (task 090). Every live lane of that parent holds its
 // branch as its own `base_branch`, so renaming it would re-base a fan-out
 // already in flight onto a name that no longer exists — and unlike a
 // `branch_exists` block there is nothing here the rename would fix.
@@ -768,7 +768,7 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 	// An `edit + retry` aimed at a parent parked in `awaiting_children`. Its
 	// cursor is on a `fan_out` step, which has neither a prompt nor a command
 	// for an override to rewrite — the edit belongs on the blocked lane (task
-	// 088).
+	// 090).
 	case isParkedOverride(err):
 		e, _ := taskrun.AsParkedOverride(err)
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -102,7 +102,7 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.runAction(w, r, func(id int64) (*store.Task, error) {
-		t, err := s.deps.Runner.Retry(r.Context(), id,
+		t, _, err := s.deps.Runner.Retry(r.Context(), id,
 			store.Override{Prompt: req.PromptOverride, Run: req.RunOverride})
 		if err == nil && (req.PromptOverride != "" || req.RunOverride != "") {
 			// edit+retry rewrote this task's snapshot (§6), which is the one

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -72,6 +72,27 @@ type retryRequest struct {
 	BranchOverride string `json:"branch_override"`
 }
 
+// retryResponse is the task as every other action renders it, plus how many
+// blocked descendants the retry re-admitted (§13.2, task 088). The task
+// fields stay at the top level — a retry response is still a task — and
+// `retried_descendants` is always present, 0 for an ordinary blocked retry
+// with nothing under it, so a client never has to tell "no cascade" from "an
+// old daemon".
+//
+// A count and not the ids: §13.3's convention is that a client re-fetches
+// what it decides it needs, and the ids under a wide fan-out are unbounded.
+type retryResponse struct {
+	taskResponse
+	RetriedDescendants int `json:"retried_descendants"`
+}
+
+// handleTaskRetry re-admits a blocked task, or cascades from a parent parked
+// in `awaiting_children` to the blocked lanes holding its join open (§6, task
+// 088).
+//
+// Like repair it cannot go through runAction: that path's taskAction returns a
+// task and nothing else, and the cascade's count is the second thing this one
+// has to say.
 func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 	var req retryRequest
 	if r.ContentLength != 0 && !decodeJSONLimit(w, r, &req, maxLargeRequestBytes) {
@@ -87,7 +108,14 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
 	if branch := strings.TrimSpace(req.BranchOverride); branch != "" {
+		if !s.checkRetryBranchOverride(w, r, id) {
+			return
+		}
 		if !s.renameBranchForRetry(w, r, branch) {
 			return
 		}
@@ -98,19 +126,66 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 	// agent, or upgrade it back inside the verified family — so the verdict
 	// is re-taken here rather than assumed from creation time. A retry that
 	// would block again identically is refused with the reason instead.
+	//
+	// It applies to the addressed task and to nothing else. A cascade's lanes
+	// deliberately skip it: a lane that would block `input_unsupported`
+	// re-blocks on its own row, which is exactly what retrying it by hand
+	// does today. A parked parent passes it as a matter of course — the gate
+	// reads `on_input` off `agent` steps only, and the cursor is on a
+	// `fan_out`.
 	if !s.checkRetryInput(w, r) {
 		return
 	}
-	s.runAction(w, r, func(id int64) (*store.Task, error) {
-		t, _, err := s.deps.Runner.Retry(r.Context(), id,
-			store.Override{Prompt: req.PromptOverride, Run: req.RunOverride})
-		if err == nil && (req.PromptOverride != "" || req.RunOverride != "") {
-			// edit+retry rewrote this task's snapshot (§6), which is the one
-			// thing that can make a cached parse wrong.
-			s.snaps.forget(id)
-		}
-		return t, err
+	// The runner is needed only from here on, which is where runAction
+	// checked it when it was the caller. Moving the check up to the top of
+	// the handler would turn every 400 above into a 500 on a server wired
+	// without one.
+	if s.deps.Runner == nil {
+		s.internalError(w, "task actions", errors.New("no task runner is configured"))
+		return
+	}
+	updated, descendants, err := s.deps.Runner.Retry(r.Context(), id,
+		store.Override{Prompt: req.PromptOverride, Run: req.RunOverride})
+	if err != nil {
+		s.writeActionError(w, err)
+		return
+	}
+	if req.PromptOverride != "" || req.RunOverride != "" {
+		// edit+retry rewrote this task's snapshot (§6), which is the one
+		// thing that can make a cached parse wrong.
+		s.snaps.forget(id)
+	}
+	writeJSON(w, http.StatusOK, retryResponse{
+		taskResponse:       toTaskResponse(updated, s.snaps.get(updated.ID, updated.WorkflowSnapshot)),
+		RetriedDescendants: descendants,
 	})
+}
+
+// checkRetryBranchOverride refuses `branch_override` on a parent parked in
+// `awaiting_children` (task 088). Every live lane of that parent holds its
+// branch as its own `base_branch`, so renaming it would re-base a fan-out
+// already in flight onto a name that no longer exists — and unlike a
+// `branch_exists` block there is nothing here the rename would fix.
+//
+// It runs ahead of renameBranchForRetry because that rename is committed
+// before the action is, so a refusal afterwards would leave the branch moved.
+func (s *Server) checkRetryBranchOverride(w http.ResponseWriter, r *http.Request, id int64) bool {
+	task, err := s.deps.Store.GetTask(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, CodeNotFound, err.Error())
+		return false
+	}
+	if err != nil {
+		s.internalError(w, "get task", err)
+		return false
+	}
+	if task.State == store.TaskAwaitingChildren {
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, fmt.Sprintf(
+			"task %d is parked on a fan_out step; branch_override would rename the branch "+
+				"every live lane holds as its base_branch", id))
+		return false
+	}
+	return true
 }
 
 // repairRequest is the §13.2 body of POST /v1/tasks/{id}/repair (§6, task
@@ -690,6 +765,14 @@ func (s *Server) writeActionError(w http.ResponseWriter, err error) {
 		e, _ := taskrun.AsFollowUpOverride(err)
 		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
 
+	// An `edit + retry` aimed at a parent parked in `awaiting_children`. Its
+	// cursor is on a `fan_out` step, which has neither a prompt nor a command
+	// for an override to rewrite — the edit belongs on the blocked lane (task
+	// 088).
+	case isParkedOverride(err):
+		e, _ := taskrun.AsParkedOverride(err)
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, e.Error())
+
 	// A structurally mismatched answer is untranslatable to the live agent
 	// session; the request never reaches the task (§7.4, §13.2).
 	case isAnswerValidation(err):
@@ -730,6 +813,11 @@ func isFollowUpRequest(err error) bool {
 
 func isFollowUpOverride(err error) bool {
 	_, ok := taskrun.AsFollowUpOverride(err)
+	return ok
+}
+
+func isParkedOverride(err error) bool {
+	_, ok := taskrun.AsParkedOverride(err)
 	return ok
 }
 

--- a/internal/api/retrycascade_test.go
+++ b/internal/api/retrycascade_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// parkedParent is a task in `awaiting_children` — what a `fan_out` step
+// leaves behind while its lanes run — with `states` worth of lanes hanging
+// off it. It builds the shape rather than running a fan-out, because what is
+// under test here is the HTTP surface and not the engine.
+func parkedParent(t *testing.T, h *taskHarness, states ...store.TaskState) (taskResponse, []*store.Task) {
+	t.Helper()
+	parent := queuedTask(t, h)
+	setState(t, h, parent.ID, store.TaskAwaitingChildren)
+	stored, err := h.store.GetTask(t.Context(), parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	lanes := make([]*store.Task, 0, len(states))
+	for i, state := range states {
+		index := 0
+		child := &store.Task{
+			ProjectID:        h.projectID,
+			Title:            fmt.Sprintf("lane %d", i),
+			WorkflowName:     stored.WorkflowName,
+			WorkflowSnapshot: stored.WorkflowSnapshot,
+			BaseBranch:       stored.BranchName,
+			State:            state,
+			ParentTaskID:     &stored.ID,
+			ParentStepIndex:  &index,
+		}
+		resolve := func(id int64) (string, error) { return worktree.BranchName(id, child.Title), nil }
+		if err := h.store.CreateTask(t.Context(), child, resolve); err != nil {
+			t.Fatalf("create lane: %v", err)
+		}
+		lanes = append(lanes, child)
+	}
+	// Re-read over the API: available_actions is derived per request, and the
+	// lanes were attached after the create response was written.
+	resp, body := h.doJSON(t, http.MethodGet, fmt.Sprintf("/v1/tasks/%d", parent.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get parent: %d %s", resp.StatusCode, body)
+	}
+	return decodeTask(t, body), lanes
+}
+
+// decodeRetry reads a retry response body, which is a task plus the cascade's
+// count at the top level.
+func decodeRetry(t *testing.T, body []byte) retryResponse {
+	t.Helper()
+	var out retryResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode retry: %v (%s)", err, body)
+	}
+	return out
+}
+
+// TestRetryFromParkedParentIs200 is task 088 at the HTTP seam: the action
+// that used to be a 409 from `awaiting_children` now re-admits the blocked
+// lanes holding the join open, and says how many it reached.
+func TestRetryFromParkedParentIs200(t *testing.T) {
+	h := newActionHarness(t)
+	parent, lanes := parkedParent(t, h,
+		store.TaskBlocked, store.TaskBlocked, store.TaskRunning)
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/retry", parent.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("retry from awaiting_children: %d %s, want 200", resp.StatusCode, body)
+	}
+	got := decodeRetry(t, body)
+	if got.RetriedDescendants != 2 {
+		t.Errorf("retried_descendants = %d, want 2 — the count the runner returned",
+			got.RetriedDescendants)
+	}
+	// The parent's row is deliberately not written, so the body's task fields
+	// are the parent as it stands.
+	if got.ID != parent.ID {
+		t.Errorf("id = %d, want the addressed task %d", got.ID, parent.ID)
+	}
+	if got.State != string(store.TaskAwaitingChildren) {
+		t.Errorf("state = %s, want awaiting_children — the join is still open", got.State)
+	}
+	for _, lane := range lanes[:2] {
+		if s := laneState(t, h, lane.ID); s != store.TaskQueued {
+			t.Errorf("lane %d state = %s, want queued", lane.ID, s)
+		}
+	}
+	if s := laneState(t, h, lanes[2].ID); s != store.TaskRunning {
+		t.Errorf("running lane %d state = %s, want running — only blocked lanes cascade", lanes[2].ID, s)
+	}
+}
+
+func laneState(t *testing.T, h *taskHarness, id int64) store.TaskState {
+	t.Helper()
+	task, err := h.store.GetTask(t.Context(), id)
+	if err != nil {
+		t.Fatalf("GetTask %d: %v", id, err)
+	}
+	return task.State
+}
+
+// TestRetryReportsRetriedDescendantsAlways: the field is on every retry
+// response, so a client never has to tell "no cascade" from a daemon that
+// predates the field. An ordinary blocked retry with nothing under it is 0.
+func TestRetryReportsRetriedDescendantsAlways(t *testing.T) {
+	h := newActionHarness(t)
+	task := blockedTask(t, h, taskrun.ReasonTimeout)
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/retry", task.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("retry: %d %s", resp.StatusCode, body)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("decode: %v (%s)", err, body)
+	}
+	if _, ok := raw["retried_descendants"]; !ok {
+		t.Fatalf("body %s has no retried_descendants; it is always present", body)
+	}
+	// The task fields stay at the top level, flat, exactly as before.
+	if _, ok := raw["state"]; !ok {
+		t.Errorf("body %s nested the task; a retry response is still a task", body)
+	}
+	got := decodeRetry(t, body)
+	if got.RetriedDescendants != 0 {
+		t.Errorf("retried_descendants = %d, want 0 for a blocked task with no lanes",
+			got.RetriedDescendants)
+	}
+	if got.State != string(store.TaskQueued) {
+		t.Errorf("state = %s, want queued", got.State)
+	}
+}
+
+// TestParkedParentOffersRetry: `available_actions` is derived from §6, so the
+// endpoint and the bar a client renders cannot disagree about what is on
+// offer while a join is open.
+func TestParkedParentOffersRetry(t *testing.T) {
+	h := newActionHarness(t)
+	parent, _ := parkedParent(t, h, store.TaskBlocked)
+	if !hasAction(parent.AvailableActions, "retry") {
+		t.Errorf("awaiting_children actions = %v, must offer retry", parent.AvailableActions)
+	}
+}
+
+// TestRetryFromParkedParentRefusesBranchOverride: renaming a parked parent's
+// branch would move the name every live lane holds as its `base_branch`, so
+// it is a 400 in front of the rename rather than a fan-out re-based onto a
+// branch that no longer exists.
+func TestRetryFromParkedParentRefusesBranchOverride(t *testing.T) {
+	h := newActionHarness(t)
+	parent, _ := parkedParent(t, h, store.TaskBlocked)
+
+	resp, body := h.doJSON(t, http.MethodPost, fmt.Sprintf("/v1/tasks/%d/retry", parent.ID),
+		map[string]any{"branch_override": "vincent/renamed"})
+	wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+	if !strings.Contains(string(body), "base_branch") {
+		t.Errorf("message %s does not say what the rename would break", body)
+	}
+	stored, err := h.store.GetTask(t.Context(), parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.BranchName != parent.BranchName {
+		t.Errorf("branch_name = %q, want %q — a refused override renamed the branch anyway",
+			stored.BranchName, parent.BranchName)
+	}
+}
+
+// TestRetryFromParkedParentRefusesPromptOverride is the ParkedOverrideError
+// mapping: a parked parent's cursor is on a `fan_out` step, which has neither
+// a prompt nor a command for an override to rewrite.
+func TestRetryFromParkedParentRefusesPromptOverride(t *testing.T) {
+	for _, field := range []string{"prompt_override", "run_override"} {
+		t.Run(field, func(t *testing.T) {
+			h := newActionHarness(t)
+			parent, lanes := parkedParent(t, h, store.TaskBlocked)
+
+			resp, body := h.doJSON(t, http.MethodPost,
+				fmt.Sprintf("/v1/tasks/%d/retry", parent.ID),
+				map[string]any{field: "do it differently"})
+			wantError(t, resp, body, http.StatusBadRequest, CodeValidationFailed)
+			if s := laneState(t, h, lanes[0].ID); s != store.TaskBlocked {
+				t.Errorf("lane %d state = %s, want blocked — a refused retry cascaded anyway",
+					lanes[0].ID, s)
+			}
+		})
+	}
+}

--- a/internal/api/retrycascade_test.go
+++ b/internal/api/retrycascade_test.go
@@ -63,7 +63,7 @@ func decodeRetry(t *testing.T, body []byte) retryResponse {
 	return out
 }
 
-// TestRetryFromParkedParentIs200 is task 088 at the HTTP seam: the action
+// TestRetryFromParkedParentIs200 is task 090 at the HTTP seam: the action
 // that used to be a 409 from `awaiting_children` now re-admits the blocked
 // lanes holding the join open, and says how many it reached.
 func TestRetryFromParkedParentIs200(t *testing.T) {

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -74,7 +74,7 @@ func (c *Client) Resume(ctx context.Context, id int64) (Task, error) {
 // From `awaiting_children` it means something else: the task is a fan_out
 // parent parked on a join no lane will ever close, and the retry cascades to
 // every blocked descendant instead of touching the parent's own row, which
-// comes back still `awaiting_children` (task 088). The second return is how
+// comes back still `awaiting_children` (task 090). The second return is how
 // many descendants were re-admitted — always reported, 0 when nothing was
 // cascaded. An override from that state is a 400: a parked parent's cursor is
 // a `fan_out` step, which carries no text to edit.

--- a/internal/apiclient/actions.go
+++ b/internal/apiclient/actions.go
@@ -70,11 +70,36 @@ func (c *Client) Resume(ctx context.Context, id int64) (Task, error) {
 
 // Retry re-runs the failed step. A zero Override is a plain retry; either
 // field set is edit+retry, which rewrites this task's snapshot (§6).
-func (c *Client) Retry(ctx context.Context, id int64, ov Override) (Task, error) {
-	if ov == (Override{}) {
-		return c.action(ctx, id, ActionRetry, nil)
+//
+// From `awaiting_children` it means something else: the task is a fan_out
+// parent parked on a join no lane will ever close, and the retry cascades to
+// every blocked descendant instead of touching the parent's own row, which
+// comes back still `awaiting_children` (task 088). The second return is how
+// many descendants were re-admitted — always reported, 0 when nothing was
+// cascaded. An override from that state is a 400: a parked parent's cursor is
+// a `fan_out` step, which carries no text to edit.
+func (c *Client) Retry(ctx context.Context, id int64, ov Override) (Task, int, error) {
+	// An empty Override posts no body at all, rather than an object of empty
+	// strings the daemon would have to read as "no override" anyway.
+	var body any
+	if ov != (Override{}) {
+		body = ov
 	}
-	return c.action(ctx, id, ActionRetry, ov)
+	var out retryResponse
+	path := fmt.Sprintf("/v1/tasks/%d/%s", id, ActionRetry)
+	if err := c.post(ctx, path, body, &out); err != nil {
+		return Task{}, 0, err
+	}
+	return out.Task, out.RetriedDescendants, nil
+}
+
+// retryResponse decodes the retry body, whose task fields sit at the top level
+// beside `retried_descendants` — the shape archive's response uses for
+// `branch`, so the task is decoded from the same object rather than a nested
+// one.
+type retryResponse struct {
+	Task
+	RetriedDescendants int `json:"retried_descendants"`
 }
 
 // RepairInput is the body of POST /v1/tasks/{id}/repair (§6, task 025).

--- a/internal/apiclient/actions_test.go
+++ b/internal/apiclient/actions_test.go
@@ -216,7 +216,7 @@ func TestRepairStepIDMatchesTheEngine(t *testing.T) {
 }
 
 // TestRetryFromParkedParentCarriesTheCount: `retry` on a fan_out parent
-// parked in `awaiting_children` is the cascade (task 088), and the client
+// parked in `awaiting_children` is the cascade (task 090), and the client
 // reads how many blocked lanes it re-admitted out of the same flat object the
 // task comes from. Without it the only thing a human would see is a parent in
 // the state it was already in.

--- a/internal/apiclient/actions_test.go
+++ b/internal/apiclient/actions_test.go
@@ -3,6 +3,7 @@ package apiclient_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -60,7 +61,7 @@ func TestRetryOverrideReachesTheWire(t *testing.T) {
 	h.setState(t, id, store.TaskBlocked)
 
 	const edited = "do it differently"
-	if _, err := h.client().Retry(ctx, id, apiclient.Override{Prompt: edited}); err != nil {
+	if _, _, err := h.client().Retry(ctx, id, apiclient.Override{Prompt: edited}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	task, err := h.client().GetTask(ctx, id)
@@ -211,5 +212,91 @@ func TestRepairStepIDMatchesTheEngine(t *testing.T) {
 	if apiclient.RepairStepID != taskrun.RepairStepID {
 		t.Errorf("apiclient.RepairStepID = %q, engine says %q",
 			apiclient.RepairStepID, taskrun.RepairStepID)
+	}
+}
+
+// TestRetryFromParkedParentCarriesTheCount: `retry` on a fan_out parent
+// parked in `awaiting_children` is the cascade (task 088), and the client
+// reads how many blocked lanes it re-admitted out of the same flat object the
+// task comes from. Without it the only thing a human would see is a parent in
+// the state it was already in.
+func TestRetryFromParkedParentCarriesTheCount(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	parent := h.parkedParent(t)
+	h.lane(t, parent, store.TaskBlocked)
+	h.lane(t, parent, store.TaskBlocked)
+
+	got, retried, err := h.client().Retry(ctx, parent, apiclient.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if retried != 2 {
+		t.Errorf("retried_descendants = %d, want 2", retried)
+	}
+	if got.State != string(store.TaskAwaitingChildren) {
+		t.Errorf("state = %q, want awaiting_children — the join is still open", got.State)
+	}
+}
+
+// TestRetryFromBlockedReportsNoCascade: the count is always on the wire, and
+// on the ordinary path it is 0 — a client that read a missing field as "some"
+// would announce lanes nobody re-admitted.
+func TestRetryFromBlockedReportsNoCascade(t *testing.T) {
+	h := newHarness(t)
+	id := h.snapshotTask(t)
+	h.setState(t, id, store.TaskRunning)
+	h.setState(t, id, store.TaskBlocked)
+
+	got, retried, err := h.client().Retry(context.Background(), id, apiclient.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if retried != 0 {
+		t.Errorf("retried_descendants = %d on an ordinary retry, want 0", retried)
+	}
+	if got.State != string(store.TaskQueued) {
+		t.Errorf("state = %q, want queued", got.State)
+	}
+}
+
+// TestRetryOverrideFromParkedParentIsRefused: a parked parent's cursor is a
+// `fan_out` step, which carries no text — so edit+retry is a 400 there, which
+// is why the `E` key checks stepEditable before offering itself.
+func TestRetryOverrideFromParkedParentIsRefused(t *testing.T) {
+	h := newHarness(t)
+	parent := h.parkedParent(t)
+
+	_, _, err := h.client().Retry(context.Background(), parent,
+		apiclient.Override{Prompt: "try harder"})
+	var apiErr *apiclient.Error
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusBadRequest {
+		t.Fatalf("edit+retry from awaiting_children = %v, want a 400", err)
+	}
+}
+
+// parkedParent is a task parked on a fan_out join, which is what a `retry`
+// cascades from.
+func (h *harness) parkedParent(t *testing.T) int64 {
+	t.Helper()
+	id := h.snapshotTask(t)
+	h.setState(t, id, store.TaskRunning)
+	h.setState(t, id, store.TaskAwaitingChildren)
+	return id
+}
+
+// lane is one descendant of a parked parent, in whatever state the fan_out
+// left it — what the cascade walks.
+func (h *harness) lane(t *testing.T, parent int64, state store.TaskState) {
+	t.Helper()
+	index := 0
+	child := &store.Task{
+		ProjectID: h.projectID, Title: "lane", WorkflowName: "three",
+		WorkflowSnapshot: snapshotWorkflow, BaseBranch: "main",
+		State: state, ParentTaskID: &parent, ParentStepIndex: &index,
+	}
+	if err := h.st.CreateTask(t.Context(), child,
+		func(id int64) (string, error) { return fmt.Sprintf("vincent/%d-lane", id), nil }); err != nil {
+		t.Fatalf("create lane: %v", err)
 	}
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -715,7 +715,11 @@ func newTaskRetryCmd() *cobra.Command {
 			"--prompt and --run are edit+retry: the text replaces that step's prompt or\n" +
 			"command in this task's workflow snapshot, and in no other task's. --branch\n" +
 			"renames the task's branch before the retry re-admits it, which is how a\n" +
-			"branch_exists block is cleared without losing the task or its transcripts.",
+			"branch_exists block is cleared without losing the task or its transcripts.\n" +
+			"On a fan-out parent parked in awaiting_children it cascades instead: every\n" +
+			"blocked descendant is re-admitted in one call and the parent stays parked,\n" +
+			"and the three override flags are refused, since a fan_out step carries no\n" +
+			"text to edit.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := taskID(args[0])
@@ -730,12 +734,37 @@ func newTaskRetryCmd() *cobra.Command {
 				return err
 			}
 			return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
-				t, err := c.Retry(ctx, id, ov)
+				t, retried, err := c.Retry(ctx, id, ov)
 				if err != nil {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}
 				}
-				return printTaskAction(cmd, t)
+				if retried == 0 {
+					// The ordinary retry: nothing happened that the task's own
+					// state does not already say.
+					return printTaskAction(cmd, t)
+				}
+				if wantJSON(cmd) {
+					// The daemon's own shape: the task's fields at the top
+					// level beside the count, so a script reads the cascade
+					// here rather than only from the human line.
+					return emitJSON(cmd.OutOrStdout(), struct {
+						apiclient.Task
+						RetriedDescendants int `json:"retried_descendants,omitempty"`
+					}{Task: t, RetriedDescendants: retried})
+				}
+				out := cmd.OutOrStdout()
+				if _, err := fmt.Fprintf(out, "task %d is now %s\n", t.ID, t.State); err != nil {
+					return err
+				}
+				// A cascade leaves the parent where it was, so the lanes it
+				// re-admitted are the only part of it worth printing.
+				noun := "descendants"
+				if retried == 1 {
+					noun = "descendant"
+				}
+				_, err = fmt.Fprintf(out, "  %d blocked %s re-admitted\n", retried, noun)
+				return err
 			})
 		},
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -153,7 +153,7 @@ var routes = []Route{
 	{http.MethodPost, "/v1/tasks/{id}/cancel", "task_cancel", "Cancel a task (§6). Kills its live agent process if it has one."},
 	{http.MethodPost, "/v1/tasks/{id}/pause", "task_pause", "Request a pause at the next step boundary (§6)."},
 	{http.MethodPost, "/v1/tasks/{id}/resume", "task_resume", "Resume a paused task (§6)."},
-	{http.MethodPost, "/v1/tasks/{id}/retry", "task_retry", "Retry a blocked task's failed step (§6)."},
+	{http.MethodPost, "/v1/tasks/{id}/retry", "task_retry", "Retry a blocked task's failed step, or cascade a retry to every blocked descendant of a fan-out parent parked in awaiting_children (§6). Body: {prompt_override|run_override|branch_override}, none of which a parked parent accepts."},
 	{http.MethodPost, "/v1/tasks/{id}/repair", "task_repair", "Re-run a blocked task's step with a repair prompt (§6). Body: {prompt}."},
 	{http.MethodPost, "/v1/tasks/{id}/skip", "task_skip", "Skip a blocked task's failed step and continue (§6)."},
 	{http.MethodPost, "/v1/tasks/{id}/approve", "task_approve", "Approve a task waiting at a human gate (§7.3)."},

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -79,6 +79,23 @@ func (e *FollowUpOverrideError) Error() string {
 			"retry without an override, or start another follow-up", e.TaskID)
 }
 
+// ParkedOverrideError reports an `edit + retry` aimed at a parent parked in
+// `awaiting_children`. The API answers 400.
+//
+// A parked parent's cursor is on its `fan_out` step, which has neither a
+// prompt nor a command to rewrite (task 088). The retry it does accept is a
+// cascade to its blocked lanes, and each lane's own step is what an override
+// would have to name — so the edit belongs on the lane, not here.
+type ParkedOverrideError struct {
+	TaskID int64
+}
+
+func (e *ParkedOverrideError) Error() string {
+	return fmt.Sprintf(
+		"task %d is parked on a fan_out step, which has no prompt or command to rewrite: "+
+			"retry without an override, or edit the blocked lane itself", e.TaskID)
+}
+
 // Cancel aborts a task and stops any process it is running (§6). The task
 // reaches `aborted` first, so a client that observes the state knows the
 // decision is final even while the process tree is still winding down.
@@ -163,13 +180,41 @@ func (r *Runner) Resume(ctx context.Context, id int64) (*store.Task, error) {
 // the retry budget reset (§6). A non-empty override rewrites that step in
 // this task's snapshot — the snapshot stays the single execution truth
 // (§5.3) — and is handed to the actor for the attempt it creates.
-func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store.Task, error) {
+//
+// From `awaiting_children` it means something else: the parked parent has no
+// step of its own to re-run, so the retry cascades to every blocked
+// descendant instead (task 088). Both shapes cascade — a parent blocked for
+// its own reason can have a blocked lane under it too — and the middle return
+// value is how many descendants this call re-admitted.
+func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store.Task, int, error) {
 	task, err := r.deps.Store.GetTask(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if !taskstate.Can(task.State, taskstate.Retry) {
-		return nil, &InvalidActionError{TaskID: id, Action: taskstate.Retry, State: task.State}
+		return nil, 0, &InvalidActionError{TaskID: id, Action: taskstate.Retry, State: task.State}
+	}
+	if task.State == store.TaskAwaitingChildren {
+		if !ov.Empty() {
+			// The cursor is on the `fan_out` step: no prompt, no command,
+			// nothing an override could rewrite.
+			return nil, 0, &ParkedOverrideError{TaskID: id}
+		}
+		// The parent's row is not written at all — no transition, no
+		// `task.state_changed` whose from and to are equal, and above all no
+		// `retry_cursor_at`. The reason is Repair's: nothing was retried on
+		// *this* task, and stamping the cursor would silently hand the join a
+		// fresh §7.2 budget the human did not ask for. (applyAction's
+		// pending-pause clear is moot here: `pause` is not valid from
+		// `awaiting_children`, so there is none to clear.)
+		//
+		// A cascade error is returned rather than logged, because nothing
+		// else happened on this path — reporting success would be a lie.
+		n, err := r.cascadeRetry(ctx, id)
+		if err != nil {
+			return nil, n, err
+		}
+		return task, n, nil
 	}
 	now := time.Now()
 	ch := store.TaskChange{RetryCursorAt: &now}
@@ -178,20 +223,37 @@ func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store
 			// The follow-up survives the retry (task 027 decision 6), so a
 			// plain retry re-runs it from its cursor. An override has nowhere
 			// to land: the follow-up is not a step of the snapshot.
-			return nil, &FollowUpOverrideError{TaskID: id}
+			return nil, 0, &FollowUpOverrideError{TaskID: id}
 		}
 		target, err := r.overrideTarget(ctx, task)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		snapshot, err := applyOverride(task, ov, target)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		ch.Snapshot = &snapshot
 		ch.PendingOverride = &ov
 	}
-	return r.transitionFrom(ctx, task, taskstate.Retry, ch)
+	updated, err := r.transitionFrom(ctx, task, taskstate.Retry, ch)
+	if err != nil {
+		return nil, 0, err
+	}
+	// After the parent's own transition, the shape Cancel already uses with
+	// cascadeCancel. A blocked task can have blocked descendants under it —
+	// an eager or DAG fan-out blocked on `merge_conflict` in round 1 with a
+	// round-2 lane blocked, or a lane set mixing one aborted and one blocked
+	// lane — and the human asking for a retry means all of them.
+	//
+	// The error is logged, not returned: the parent's own retry has already
+	// committed, and reporting it as a failure would tell the caller the
+	// opposite of what happened.
+	n, err := r.cascadeRetry(ctx, id)
+	if err != nil {
+		r.deps.Logger.Error("retry: cascade to lanes", "task", id, "error", err)
+	}
+	return updated, n, nil
 }
 
 // Repair launches a one-off agent in the blocked task's existing worktree
@@ -745,6 +807,14 @@ func AsFollowUpRequest(err error) (*FollowUpRequestError, bool) {
 // what it is.
 func AsFollowUpOverride(err error) (*FollowUpOverrideError, bool) {
 	var e *FollowUpOverrideError
+	ok := errors.As(err, &e)
+	return e, ok
+}
+
+// AsParkedOverride extracts a *ParkedOverrideError from err, if that is what
+// it is.
+func AsParkedOverride(err error) (*ParkedOverrideError, bool) {
+	var e *ParkedOverrideError
 	ok := errors.As(err, &e)
 	return e, ok
 }

--- a/internal/taskrun/actions.go
+++ b/internal/taskrun/actions.go
@@ -83,7 +83,7 @@ func (e *FollowUpOverrideError) Error() string {
 // `awaiting_children`. The API answers 400.
 //
 // A parked parent's cursor is on its `fan_out` step, which has neither a
-// prompt nor a command to rewrite (task 088). The retry it does accept is a
+// prompt nor a command to rewrite (task 090). The retry it does accept is a
 // cascade to its blocked lanes, and each lane's own step is what an override
 // would have to name — so the edit belongs on the lane, not here.
 type ParkedOverrideError struct {
@@ -183,7 +183,7 @@ func (r *Runner) Resume(ctx context.Context, id int64) (*store.Task, error) {
 //
 // From `awaiting_children` it means something else: the parked parent has no
 // step of its own to re-run, so the retry cascades to every blocked
-// descendant instead (task 088). Both shapes cascade — a parent blocked for
+// descendant instead (task 090). Both shapes cascade — a parent blocked for
 // its own reason can have a blocked lane under it too — and the middle return
 // value is how many descendants this call re-admitted.
 func (r *Runner) Retry(ctx context.Context, id int64, ov store.Override) (*store.Task, int, error) {

--- a/internal/taskrun/actions_test.go
+++ b/internal/taskrun/actions_test.go
@@ -124,7 +124,8 @@ func (h *actionHarness) invoke(
 	case taskstate.Resume:
 		return h.runner.Resume(ctx, id)
 	case taskstate.Retry:
-		return h.runner.Retry(ctx, id, store.Override{})
+		task, _, err := h.runner.Retry(ctx, id, store.Override{})
+		return task, err
 	case taskstate.Repair:
 		return h.runner.Repair(ctx, id, store.RepairRequest{Prompt: "fix it"})
 	case taskstate.Skip:
@@ -240,7 +241,7 @@ func TestHumanActionsClearPendingPause(t *testing.T) {
 		t.Fatalf("block: %v", err)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	if h.get(t, task.ID).PauseRequested {
@@ -351,7 +352,7 @@ func TestApproveWithoutOpenRowFabricatesNothing(t *testing.T) {
 func TestSkipClearsPendingOverride(t *testing.T) {
 	h := newActionHarness(t)
 	task := h.task(t, store.TaskBlocked)
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{Prompt: "edited"}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{Prompt: "edited"}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	// The retried attempt never drained the override (it failed before its
@@ -395,7 +396,7 @@ func TestRetryResetsBudgetCursor(t *testing.T) {
 	task := h.task(t, store.TaskBlocked)
 	before := time.Now()
 
-	got, err := h.runner.Retry(t.Context(), task.ID, store.Override{})
+	got, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{})
 	if err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
@@ -414,7 +415,7 @@ func TestRetryWithPromptOverride(t *testing.T) {
 	h := newActionHarness(t)
 	task := h.task(t, store.TaskBlocked)
 
-	got, err := h.runner.Retry(t.Context(), task.ID, store.Override{Prompt: "try harder"})
+	got, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{Prompt: "try harder"})
 	if err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
@@ -444,20 +445,20 @@ func TestRetryWithPromptOverride(t *testing.T) {
 func TestRetryOverrideMustMatchStepType(t *testing.T) {
 	h := newActionHarness(t)
 	agentStep := h.task(t, store.TaskBlocked)
-	if _, err := h.runner.Retry(t.Context(), agentStep.ID, store.Override{Run: "echo hi"}); err == nil {
+	if _, _, err := h.runner.Retry(t.Context(), agentStep.ID, store.Override{Run: "echo hi"}); err == nil {
 		t.Error("run_override accepted on an agent step")
 	} else if _, ok := AsOverrideMismatch(err); !ok {
 		t.Errorf("err = %v, want OverrideMismatchError", err)
 	}
 
 	commandStep := h.taskAtStep(t, store.TaskBlocked, 1)
-	if _, err := h.runner.Retry(t.Context(), commandStep.ID, store.Override{Prompt: "hi"}); err == nil {
+	if _, _, err := h.runner.Retry(t.Context(), commandStep.ID, store.Override{Prompt: "hi"}); err == nil {
 		t.Error("prompt_override accepted on a command step")
 	} else if _, ok := AsOverrideMismatch(err); !ok {
 		t.Errorf("err = %v, want OverrideMismatchError", err)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), commandStep.ID, store.Override{Run: "echo hi"}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), commandStep.ID, store.Override{Run: "echo hi"}); err != nil {
 		t.Errorf("run_override on a command step: %v", err)
 	}
 }

--- a/internal/taskrun/cascade.go
+++ b/internal/taskrun/cascade.go
@@ -122,7 +122,7 @@ func (r *Runner) cascadeArchive(ctx context.Context, id int64, force bool) error
 }
 
 // cascadeRetry re-admits every blocked descendant of a task, and reports how
-// many it re-admitted (task 088).
+// many it re-admitted (task 090).
 //
 // A parent parked in `awaiting_children` has nothing of its own to retry: the
 // join is held open by lanes below it, and before this the only action §6

--- a/internal/taskrun/cascade.go
+++ b/internal/taskrun/cascade.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskstate"
@@ -118,4 +119,54 @@ func (r *Runner) cascadeArchive(ctx context.Context, id int64, force bool) error
 		r.deps.Logger.Info("archived fan-out lane", "parent", id, "child", child.ID)
 	}
 	return nil
+}
+
+// cascadeRetry re-admits every blocked descendant of a task, and reports how
+// many it re-admitted (task 088).
+//
+// A parent parked in `awaiting_children` has nothing of its own to retry: the
+// join is held open by lanes below it, and before this the only action §6
+// offered from that state was `cancel`, which ends work instead of resuming
+// it. Recovery was a manual walk of the lane tree, once per lane and once per
+// level to `fan_out.max_depth`.
+//
+// The walk needs no new query and no recursion here. `ChildrenOf`'s recursive
+// CTE already returns the whole subtree at any depth, so `rollup.Blocked` is
+// exactly the set to re-admit — nested fan-outs included. The ids are sorted
+// first because the CTE has no ORDER BY, and a deterministic order is
+// something a gate can assert.
+//
+// A descendant in `awaiting_children` is deliberately absent from that set and
+// is left parked. It needs no help: a parent re-admitted while its own lanes
+// are unsettled parks again through parkForUnsettled under barrier mode, and
+// reads an unsettled lane as "not yet" in mergeSet under eager. Whatever order
+// the scheduler picks, the tree converges.
+func (r *Runner) cascadeRetry(ctx context.Context, id int64) (int, error) {
+	rollup, err := r.deps.Store.ChildrenOf(ctx, id)
+	if err != nil {
+		return 0, fmt.Errorf("retry: list descendants of task %d: %w", id, err)
+	}
+	blocked := slices.Clone(rollup.Blocked)
+	slices.Sort(blocked)
+	count := 0
+	for _, childID := range blocked {
+		// persistCtx per child, as cascadeCancel does: a client that
+		// disconnects mid-cascade must not leave half the tree re-admitted.
+		_, n, err := r.Retry(r.persistCtx(), childID, store.Override{})
+		if err != nil {
+			if _, invalid := AsInvalidAction(err); invalid {
+				continue // it moved between the rollup and the write
+			}
+			r.deps.Logger.Error("retry: cascade to lane", "task", id, "child", childID, "error", err)
+			continue
+		}
+		// One for the lane, plus whatever its own retry reached: a blocked
+		// lane that had itself fanned out and blocked again re-admits its own
+		// subtree. By the time this walk reaches that grandchild it is no
+		// longer blocked, and the InvalidActionError skip above keeps it from
+		// being counted twice.
+		count += 1 + n
+		r.deps.Logger.Info("retried fan-out lane", "parent", id, "child", childID)
+	}
+	return count, nil
 }

--- a/internal/taskrun/cascaderetry_test.go
+++ b/internal/taskrun/cascaderetry_test.go
@@ -44,7 +44,7 @@ func (h *actionHarness) stateEvents(t *testing.T, id int64) int {
 	return len(events)
 }
 
-// TestRetryFromParkedParentCascadesToLanes is task 088's whole point: the one
+// TestRetryFromParkedParentCascadesToLanes is task 090's whole point: the one
 // action a parked parent used to accept was `cancel`, which ends the work.
 // `retry` now re-admits every blocked lane holding the join open, in one call.
 func TestRetryFromParkedParentCascadesToLanes(t *testing.T) {

--- a/internal/taskrun/cascaderetry_test.go
+++ b/internal/taskrun/cascaderetry_test.go
@@ -1,0 +1,267 @@
+package taskrun
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// lane creates a descendant of parent in a given state — what a `fan_out`
+// step leaves behind, without running one.
+func (h *actionHarness) lane(
+	t *testing.T, parent *store.Task, state store.TaskState,
+) *store.Task {
+	t.Helper()
+	index := 0
+	child := &store.Task{
+		ProjectID: h.projectID, Title: "lane of " + parent.Title,
+		WorkflowName: "test", WorkflowSnapshot: actionSnapshot,
+		BaseBranch:   parent.BranchName,
+		State:        state,
+		ParentTaskID: &parent.ID, ParentStepIndex: &index,
+	}
+	resolve := func(id int64) (string, error) { return worktree.BranchName(id, child.Title), nil }
+	if err := h.store.CreateTask(t.Context(), child, resolve); err != nil {
+		t.Fatalf("create lane: %v", err)
+	}
+	return child
+}
+
+// stateEvents counts the `task.state_changed` events written for one task,
+// which is how a test asserts a row was never touched: a transition cannot
+// happen without one (§13.3).
+func (h *actionHarness) stateEvents(t *testing.T, id int64) int {
+	t.Helper()
+	events, err := h.store.ListEvents(t.Context(), store.EventFilter{
+		Types: []string{store.EventTaskStateChanged}, TaskID: id,
+	})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	return len(events)
+}
+
+// TestRetryFromParkedParentCascadesToLanes is task 088's whole point: the one
+// action a parked parent used to accept was `cancel`, which ends the work.
+// `retry` now re-admits every blocked lane holding the join open, in one call.
+func TestRetryFromParkedParentCascadesToLanes(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskAwaitingChildren)
+	first := h.lane(t, parent, store.TaskBlocked)
+	second := h.lane(t, parent, store.TaskBlocked)
+
+	got, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("re-admitted %d lanes, want 2", n)
+	}
+	if got.State != store.TaskAwaitingChildren {
+		t.Errorf("parent state = %s, want awaiting_children — the join is still open", got.State)
+	}
+	for _, lane := range []*store.Task{first, second} {
+		if s := h.get(t, lane.ID).State; s != store.TaskQueued {
+			t.Errorf("lane %d state = %s, want queued", lane.ID, s)
+		}
+	}
+
+	// The parent's row is not written at all. A stamped retry_cursor_at would
+	// hand the join a fresh §7.2 budget nobody asked for, and a
+	// task.state_changed whose from and to are equal is a transition that did
+	// not happen.
+	after := h.get(t, parent.ID)
+	if after.RetryCursorAt != nil {
+		t.Errorf("retry_cursor_at = %v, want unset — nothing was retried on the parent", after.RetryCursorAt)
+	}
+	if n := h.stateEvents(t, parent.ID); n != 0 {
+		t.Errorf("parent emitted %d state events, want 0", n)
+	}
+}
+
+// TestRetryFromParkedParentReachesNestedLanes covers the depth the recursive
+// CTE already walks: one retry at the root reaches a blocked lane two levels
+// down, and the parked parent in between is left alone to converge on its own.
+func TestRetryFromParkedParentReachesNestedLanes(t *testing.T) {
+	h := newActionHarness(t)
+	root := h.task(t, store.TaskAwaitingChildren)
+	mid := h.lane(t, root, store.TaskAwaitingChildren)
+	leaf := h.lane(t, mid, store.TaskBlocked)
+
+	_, n, err := h.runner.Retry(t.Context(), root.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("re-admitted %d lanes, want 1", n)
+	}
+	if s := h.get(t, leaf.ID).State; s != store.TaskQueued {
+		t.Errorf("leaf state = %s, want queued — a nested lane is still a blocked descendant", s)
+	}
+	// The mid parent is not in rollup.Blocked and must not be touched: it
+	// re-parks or reads its lane as "not yet" on its own.
+	got := h.get(t, mid.ID)
+	if got.State != store.TaskAwaitingChildren {
+		t.Errorf("mid state = %s, want awaiting_children", got.State)
+	}
+	if got.RetryCursorAt != nil {
+		t.Errorf("mid retry_cursor_at = %v, want unset", got.RetryCursorAt)
+	}
+	if n := h.stateEvents(t, mid.ID); n != 0 {
+		t.Errorf("mid emitted %d state events, want 0", n)
+	}
+}
+
+// TestRetryFromParkedParentLeavesUnblockedLanes pins the set the cascade
+// walks. Only `blocked` descendants are re-admitted: a gate is a human's
+// decision to make, a pause is a human's decision already made, and queued,
+// running and done lanes are working or finished.
+func TestRetryFromParkedParentLeavesUnblockedLanes(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskAwaitingChildren)
+	untouched := map[store.TaskState]*store.Task{}
+	for _, state := range []store.TaskState{
+		store.TaskAwaitingGate, store.TaskPaused, store.TaskRunning,
+		store.TaskQueued, store.TaskDone,
+	} {
+		untouched[state] = h.lane(t, parent, state)
+	}
+
+	_, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("re-admitted %d lanes, want 0 — none of them is blocked", n)
+	}
+	for want, lane := range untouched {
+		got := h.get(t, lane.ID)
+		if got.State != want {
+			t.Errorf("lane in %s moved to %s", want, got.State)
+		}
+		if n := h.stateEvents(t, lane.ID); n != 0 {
+			t.Errorf("lane in %s emitted %d state events, want 0", want, n)
+		}
+	}
+}
+
+// TestRetryCascadeSkipsALaneThatMoved covers the gap the rollup cannot close:
+// the CTE reads the subtree once, and a lane can leave `blocked` before the
+// walk reaches it. That is not a failure of the cascade — the rest of the tree
+// is still re-admitted — and the lane that moved is not counted.
+func TestRetryCascadeSkipsALaneThatMoved(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskAwaitingChildren)
+	first := h.lane(t, parent, store.TaskBlocked)
+	second := h.lane(t, parent, store.TaskBlocked)
+
+	// The walk is sorted ascending, so `first` is retried before `second` is
+	// read. Its commit is the moment a concurrent human cancels the other.
+	var once sync.Once
+	h.store.SetEventHook(func(e *store.Event) {
+		if e.Type != store.EventTaskStateChanged || e.TaskID == nil || *e.TaskID != first.ID {
+			return
+		}
+		once.Do(func() {
+			if _, _, err := h.store.TransitionTask(t.Context(), second.ID,
+				store.TaskBlocked, store.TaskAborted, store.TaskChange{}); err != nil {
+				t.Errorf("abort the second lane: %v", err)
+			}
+		})
+	})
+	t.Cleanup(func() { h.store.SetEventHook(nil) })
+
+	_, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("re-admitted %d lanes, want 1 — the second one had moved", n)
+	}
+	if s := h.get(t, first.ID).State; s != store.TaskQueued {
+		t.Errorf("first lane state = %s, want queued", s)
+	}
+	if s := h.get(t, second.ID).State; s != store.TaskAborted {
+		t.Errorf("second lane state = %s, want aborted — the cascade must not resurrect it", s)
+	}
+}
+
+// TestRetryFromBlockedStillCascades keeps the `blocked` path whole: the
+// parent's own retry happens exactly as it did, and the lanes come with it.
+// The reachable case is a parent blocked for its own reason — an eager or DAG
+// fan-out on `merge_conflict` — with a separately blocked lane under it.
+func TestRetryFromBlockedStillCascades(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskBlocked)
+	lane := h.lane(t, parent, store.TaskBlocked)
+	before := time.Now()
+
+	got, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if got.State != store.TaskQueued {
+		t.Errorf("parent state = %s, want queued", got.State)
+	}
+	if got.RetryCursorAt == nil || got.RetryCursorAt.Before(before.Add(-time.Second)) {
+		t.Errorf("retry_cursor_at = %v, want stamped by this retry", got.RetryCursorAt)
+	}
+	if n != 1 {
+		t.Errorf("re-admitted %d lanes, want 1", n)
+	}
+	if s := h.get(t, lane.ID).State; s != store.TaskQueued {
+		t.Errorf("lane state = %s, want queued", s)
+	}
+}
+
+// TestRetryFromParkedParentRefusesAnOverride: a parked parent's cursor is on
+// its `fan_out` step, which carries neither a prompt nor a command. There is
+// nothing for an override to rewrite, and rewriting the lanes' steps from here
+// is not what `edit + retry` means.
+func TestRetryFromParkedParentRefusesAnOverride(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskAwaitingChildren)
+	lane := h.lane(t, parent, store.TaskBlocked)
+
+	_, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{Prompt: "try harder"})
+	e, ok := AsParkedOverride(err)
+	if !ok {
+		t.Fatalf("err = %v, want *ParkedOverrideError", err)
+	}
+	if e.TaskID != parent.ID {
+		t.Errorf("reported task %d, want %d", e.TaskID, parent.ID)
+	}
+	if n != 0 {
+		t.Errorf("re-admitted %d lanes, want 0 — the call was refused", n)
+	}
+	if s := h.get(t, lane.ID).State; s != store.TaskBlocked {
+		t.Errorf("lane state = %s, want blocked — a refused retry cascades nothing", s)
+	}
+}
+
+// TestRetryCascadeCountsANestedSubtreeOnce: a blocked lane that had itself
+// fanned out and blocked again re-admits its own subtree through its own
+// Retry, and the outer walk then finds that grandchild already queued. The
+// count is the size of the set re-admitted, not of the set walked.
+func TestRetryCascadeCountsANestedSubtreeOnce(t *testing.T) {
+	h := newActionHarness(t)
+	parent := h.task(t, store.TaskAwaitingChildren)
+	mid := h.lane(t, parent, store.TaskBlocked)
+	leaf := h.lane(t, mid, store.TaskBlocked)
+
+	_, n, err := h.runner.Retry(t.Context(), parent.ID, store.Override{})
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("re-admitted %d lanes, want 2 — the leaf is counted once, by mid's own retry", n)
+	}
+	for _, task := range []*store.Task{mid, leaf} {
+		if s := h.get(t, task.ID).State; s != store.TaskQueued {
+			t.Errorf("task %d state = %s, want queued", task.ID, s)
+		}
+	}
+}

--- a/internal/taskrun/condition_test.go
+++ b/internal/taskrun/condition_test.go
@@ -322,7 +322,7 @@ func TestEngineGuardIsReEvaluatedOnRetry(t *testing.T) {
 		t.Fatalf("task = %s, want blocked on the first pass", blocked.State)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("retry: %v", err)
 	}
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)

--- a/internal/taskrun/costlimit_test.go
+++ b/internal/taskrun/costlimit_test.go
@@ -123,7 +123,7 @@ func TestEngineCostCapConsumesNoRetry(t *testing.T) {
 		t.Fatalf("attempts = %+v, want one attempt and no failure — the cap consumes no retry", attempts)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	reblocked := h.waitForState(t, task.ID, store.TaskBlocked)
@@ -283,7 +283,7 @@ func TestEngineCostCapRaisedByAReloadLetsARetryFinish(t *testing.T) {
 	}
 
 	h.reload(func(c *config.Config) { c.MaxTaskCostUSD = fakeAgentCostUSD * 100 })
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	final := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)

--- a/internal/taskrun/engine_test.go
+++ b/internal/taskrun/engine_test.go
@@ -753,7 +753,7 @@ func TestEngineHumanRetryResetsBudget(t *testing.T) {
 		t.Fatalf("attempts before retry = %d, want 2", len(runs))
 	}
 
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	reblocked := h.waitForState(t, task.ID, store.TaskBlocked)
@@ -797,7 +797,7 @@ steps:
 	if blocked.State != store.TaskBlocked {
 		t.Fatalf("task = %s, want blocked", blocked.State)
 	}
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	h.waitForState(t, task.ID, store.TaskBlocked)

--- a/internal/taskrun/followup_test.go
+++ b/internal/taskrun/followup_test.go
@@ -443,7 +443,7 @@ func TestFailedFollowUpBlocksAtItsOwnIndexAndRetryReRunsIt(t *testing.T) {
 		t.Fatalf("round 1 rows = %+v, want a failed row at the follow-up's own index", rows)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	again := h.settle(t, blocked.ID)
@@ -472,7 +472,7 @@ func TestEditRetryOnABlockedFollowUpIsRefused(t *testing.T) {
 		t.Fatalf("task = %s, want blocked", blocked.State)
 	}
 
-	_, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{Run: "git --version"})
+	_, _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{Run: "git --version"})
 	if _, ok := AsFollowUpOverride(err); !ok {
 		t.Fatalf("Retry with an override: err = %v, want FollowUpOverrideError", err)
 	}

--- a/internal/taskrun/group_test.go
+++ b/internal/taskrun/group_test.go
@@ -221,7 +221,7 @@ func TestParallelGroupRetryDoesNotRerunSucceededSubSteps(t *testing.T) {
 	if blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone); blocked.State != store.TaskBlocked {
 		t.Fatalf("task state = %s, want blocked before the retry", blocked.State)
 	}
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
@@ -322,7 +322,7 @@ func TestGroupSiblingsStayInvisibleAcrossAdmissions(t *testing.T) {
 	if blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone); blocked.State != store.TaskBlocked {
 		t.Fatalf("task state = %s, want blocked before the retry", blocked.State)
 	}
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)

--- a/internal/taskrun/loop_test.go
+++ b/internal/taskrun/loop_test.go
@@ -377,7 +377,7 @@ func TestLoopRetryResumesMidIteration(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(blocked.WorktreePath, "fixed.txt"), []byte("ok\n"), 0o600); err != nil {
 		t.Fatalf("write flag file: %v", err)
 	}
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 

--- a/internal/taskrun/repair_test.go
+++ b/internal/taskrun/repair_test.go
@@ -159,7 +159,7 @@ func TestRepairThenRetryCompletesTheWorkflow(t *testing.T) {
 	}
 	h.waitForRepair(t, blocked.ID, 1)
 
-	if _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), blocked.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	done := h.waitForState(t, blocked.ID, store.TaskDone, store.TaskBlocked)
@@ -385,7 +385,7 @@ steps:
 		t.Fatalf("Repair: %v", err)
 	}
 	h.waitForRepair(t, task.ID, 1)
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)
@@ -436,7 +436,7 @@ func TestRepairWithoutAWorktreeReblocksWithoutAnAgent(t *testing.T) {
 	if after.PendingRepair == nil {
 		t.Error("the repair request was drained by a block that never ran it")
 	}
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("Retry: %v", err)
 	}
 	retried, err := h.store.GetTask(t.Context(), task.ID)

--- a/internal/taskrun/stepinput_test.go
+++ b/internal/taskrun/stepinput_test.go
@@ -343,7 +343,7 @@ func TestStepInputGuardIsRecordedButNeverReplayed(t *testing.T) {
 		t.Fatalf("rendered_if = %v, want \"maybe\"", first[0].RenderedIf)
 	}
 
-	if _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
+	if _, _, err := h.runner.Retry(t.Context(), task.ID, store.Override{}); err != nil {
 		t.Fatalf("retry: %v", err)
 	}
 	done := h.waitForState(t, task.ID, store.TaskDone, store.TaskBlocked)

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -205,7 +205,7 @@ var table = map[Action]map[State]Transition{
 	},
 	Resume: {Paused: {To: Queued}},
 	// Retry from `awaiting_children` is a **legality marker**, not a swap any
-	// caller performs (§6, task 088). It exists so that
+	// caller performs (§6, task 090). It exists so that
 	// `Can(AwaitingChildren, Retry)` is true — the API answers 200 instead of
 	// 409, and HumanActionsFrom lists `retry` — while Runner.Retry writes
 	// nothing at all to the parked parent's row: it only cascades the retry to

--- a/internal/taskstate/taskstate.go
+++ b/internal/taskstate/taskstate.go
@@ -203,8 +203,15 @@ var table = map[Action]map[State]Transition{
 		// A running task finishes its current step first; Park completes it.
 		Running: {To: Running, Deferred: true},
 	},
-	Resume:  {Paused: {To: Queued}},
-	Retry:   {Blocked: {To: Queued}},
+	Resume: {Paused: {To: Queued}},
+	// Retry from `awaiting_children` is a **legality marker**, not a swap any
+	// caller performs (§6, task 088). It exists so that
+	// `Can(AwaitingChildren, Retry)` is true — the API answers 200 instead of
+	// 409, and HumanActionsFrom lists `retry` — while Runner.Retry writes
+	// nothing at all to the parked parent's row: it only cascades the retry to
+	// every blocked descendant. A parent that has retried nothing of its own
+	// must not be stamped as if it had.
+	Retry:   {Blocked: {To: Queued}, AwaitingChildren: {To: AwaitingChildren}},
 	Repair:  {Blocked: {To: Queued}},
 	Skip:    {Blocked: {To: Queued}, AwaitingGate: {To: Queued}},
 	Answer:  {AwaitingInput: {To: Running}},

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -53,8 +53,13 @@ var wantTransitions = map[State]map[Action]State{
 	// Notably absent is Pause — a parent owning nothing running has nothing
 	// to pause — and the approve/reject/skip trio, which is why this is not
 	// awaiting_gate.
+	// Retry's self-transition is the legality marker of task 088: it makes
+	// the action legal here so it can cascade to blocked descendants, and
+	// resolves to the state the parent is already in, because nothing on the
+	// parent's own row changes.
 	AwaitingChildren: {
 		Cancel:          Aborted,
+		Retry:           AwaitingChildren,
 		ChildrenSettled: Queued,
 	},
 	// Blocked is the only state `repair` is valid from (task 025): it is a
@@ -165,15 +170,16 @@ func TestTerminalAndSlots(t *testing.T) {
 
 func TestHumanActionsFrom(t *testing.T) {
 	tests := map[State][]Action{
-		Queued:        {Cancel, Pause},
-		Running:       {Cancel, Pause},
-		AwaitingGate:  {Approve, Cancel, Reject, Skip},
-		AwaitingInput: {Answer, Cancel},
-		Blocked:       {Cancel, Repair, Retry, Skip},
-		Paused:        {Cancel, Resume},
-		Done:          {Archive, FollowUp},
-		Aborted:       {Archive, FollowUp},
-		Archived:      nil,
+		Queued:           {Cancel, Pause},
+		Running:          {Cancel, Pause},
+		AwaitingGate:     {Approve, Cancel, Reject, Skip},
+		AwaitingInput:    {Answer, Cancel},
+		AwaitingChildren: {Cancel, Retry},
+		Blocked:          {Cancel, Repair, Retry, Skip},
+		Paused:           {Cancel, Resume},
+		Done:             {Archive, FollowUp},
+		Aborted:          {Archive, FollowUp},
+		Archived:         nil,
 	}
 	for state, want := range tests {
 		got := HumanActionsFrom(state)
@@ -242,13 +248,29 @@ func TestAwaitingChildrenHoldsNoSlot(t *testing.T) {
 	}
 }
 
-// TestAwaitingChildrenOffersOnlyCancel is the reason it is not a reuse of
+// TestAwaitingChildrenOffersCancelAndRetry is the reason it is not a reuse of
 // awaiting_gate: approve, reject and skip would be actions the API accepts
-// and the TUI renders while they mean nothing.
-func TestAwaitingChildrenOffersOnlyCancel(t *testing.T) {
+// and the TUI renders while they mean nothing. `retry` does mean something
+// (task 088) — it re-admits the blocked lanes holding the join open — and
+// `cancel`, which ends them, is the only other one.
+func TestAwaitingChildrenOffersCancelAndRetry(t *testing.T) {
 	got := HumanActionsFrom(AwaitingChildren)
-	if len(got) != 1 || got[0] != Cancel {
-		t.Errorf("HumanActionsFrom(awaiting_children) = %v, want [cancel]", got)
+	if !slices.Equal(got, []Action{Cancel, Retry}) {
+		t.Errorf("HumanActionsFrom(awaiting_children) = %v, want [cancel retry]", got)
+	}
+}
+
+// TestRetryIsLegalOnlyFromBlockedAndParked pins the whole from-set of the one
+// action task 088 widened: `blocked`, where it re-runs the failed step, and
+// `awaiting_children`, where it cascades to the blocked lanes. Nowhere else —
+// a retry from `aborted` in particular is what keeps a cascade from
+// resurrecting a lane a human ended (task 014 decision 22).
+func TestRetryIsLegalOnlyFromBlockedAndParked(t *testing.T) {
+	for _, s := range All {
+		want := s == Blocked || s == AwaitingChildren
+		if got := Can(s, Retry); got != want {
+			t.Errorf("Can(%s, retry) = %v, want %v", s, got, want)
+		}
 	}
 }
 

--- a/internal/taskstate/taskstate_test.go
+++ b/internal/taskstate/taskstate_test.go
@@ -53,7 +53,7 @@ var wantTransitions = map[State]map[Action]State{
 	// Notably absent is Pause — a parent owning nothing running has nothing
 	// to pause — and the approve/reject/skip trio, which is why this is not
 	// awaiting_gate.
-	// Retry's self-transition is the legality marker of task 088: it makes
+	// Retry's self-transition is the legality marker of task 090: it makes
 	// the action legal here so it can cascade to blocked descendants, and
 	// resolves to the state the parent is already in, because nothing on the
 	// parent's own row changes.
@@ -251,7 +251,7 @@ func TestAwaitingChildrenHoldsNoSlot(t *testing.T) {
 // TestAwaitingChildrenOffersCancelAndRetry is the reason it is not a reuse of
 // awaiting_gate: approve, reject and skip would be actions the API accepts
 // and the TUI renders while they mean nothing. `retry` does mean something
-// (task 088) — it re-admits the blocked lanes holding the join open — and
+// (task 090) — it re-admits the blocked lanes holding the join open — and
 // `cancel`, which ends them, is the only other one.
 func TestAwaitingChildrenOffersCancelAndRetry(t *testing.T) {
 	got := HumanActionsFrom(AwaitingChildren)
@@ -261,7 +261,7 @@ func TestAwaitingChildrenOffersCancelAndRetry(t *testing.T) {
 }
 
 // TestRetryIsLegalOnlyFromBlockedAndParked pins the whole from-set of the one
-// action task 088 widened: `blocked`, where it re-runs the failed step, and
+// action task 090 widened: `blocked`, where it re-runs the failed step, and
 // `awaiting_children`, where it cascades to the blocked lanes. Nowhere else —
 // a retry from `aborted` in particular is what keeps a cascade from
 // resurrecting a lane a human ended (task 014 decision 22).

--- a/internal/tui/actionbar.go
+++ b/internal/tui/actionbar.go
@@ -27,7 +27,12 @@ type actionResultMsg struct {
 	// it. It rides the result rather than an event because `archived` is
 	// terminal and this is the one place a human is waiting for the answer.
 	branch apiclient.BranchOutcome
-	err    error
+	// retried is how many blocked descendants a retry on a parked fan_out
+	// parent re-admitted (task 088). Like branch it is a consequence the
+	// task's own row does not show — the parent comes back unchanged, still
+	// `awaiting_children` — and no other action sets it.
+	retried int
+	err     error
 }
 
 // actionKeys binds §15's keys to the actions they can mean. `p` is pause or
@@ -210,41 +215,48 @@ func (a *actionBar) dispatch(client *apiclient.Client, id int64, action string, 
 	}
 	a.setStatus(action+"…", false)
 	return func() tea.Msg {
-		task, branch, err := callActionWithTimeout(client, id, action, force)
-		return actionResultMsg{taskID: id, action: action, task: task, branch: branch, err: err}
+		task, branch, retried, err := callActionWithTimeout(client, id, action, force)
+		return actionResultMsg{
+			taskID: id, action: action, task: task,
+			branch: branch, retried: retried, err: err,
+		}
 	}
 }
 
 // callAction is the one place a §6 action becomes an HTTP call, shared by the
 // single-task path and the bulk one so the two cannot drift into meaning
 // different things by the same key.
-func callAction(ctx context.Context, client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, error) {
+func callAction(ctx context.Context, client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, int, error) {
 	switch action {
 	case apiclient.ActionCancel:
 		task, err := client.Cancel(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionPause:
 		task, err := client.Pause(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionResume:
 		task, err := client.Resume(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionRetry:
-		task, err := client.Retry(ctx, id, apiclient.Override{})
-		return task, apiclient.BranchOutcome{}, err
+		// From a parked fan_out parent this is the cascade (task 088); the
+		// key is the same one, because available_actions is what says the
+		// action is on offer and the daemon is what decides it means.
+		task, retried, err := client.Retry(ctx, id, apiclient.Override{})
+		return task, apiclient.BranchOutcome{}, retried, err
 	case apiclient.ActionSkip:
 		task, err := client.Skip(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionApprove:
 		task, err := client.Approve(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionReject:
 		task, err := client.Reject(ctx, id)
-		return task, apiclient.BranchOutcome{}, err
+		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionArchive:
-		return client.Archive(ctx, id, force)
+		task, branch, err := client.Archive(ctx, id, force)
+		return task, branch, 0, err
 	default:
-		return apiclient.Task{}, apiclient.BranchOutcome{}, fmt.Errorf("unknown action %q", action)
+		return apiclient.Task{}, apiclient.BranchOutcome{}, 0, fmt.Errorf("unknown action %q", action)
 	}
 }
 
@@ -254,6 +266,12 @@ func callAction(ctx context.Context, client *apiclient.Client, id int64, action 
 func (a *actionBar) applyResult(msg actionResultMsg) {
 	if msg.err == nil {
 		status := msg.action + " · now " + msg.task.State
+		// A cascade leaves the parent exactly where it was, so "now
+		// awaiting_children" is all the task row can say about it; the lanes
+		// it re-admitted are the part a human acted for (task 088).
+		if msg.retried > 0 {
+			status += " · " + plural(msg.retried, "lane", "lanes") + " re-admitted"
+		}
 		// The branch is the one consequence of an archive that is invisible
 		// afterwards — the task row no longer names a worktree to go look in —
 		// so it is said here or nowhere (§10, task 008).

--- a/internal/tui/actionbar.go
+++ b/internal/tui/actionbar.go
@@ -28,7 +28,7 @@ type actionResultMsg struct {
 	// terminal and this is the one place a human is waiting for the answer.
 	branch apiclient.BranchOutcome
 	// retried is how many blocked descendants a retry on a parked fan_out
-	// parent re-admitted (task 088). Like branch it is a consequence the
+	// parent re-admitted (task 090). Like branch it is a consequence the
 	// task's own row does not show — the parent comes back unchanged, still
 	// `awaiting_children` — and no other action sets it.
 	retried int
@@ -238,7 +238,7 @@ func callAction(ctx context.Context, client *apiclient.Client, id int64, action 
 		task, err := client.Resume(ctx, id)
 		return task, apiclient.BranchOutcome{}, 0, err
 	case apiclient.ActionRetry:
-		// From a parked fan_out parent this is the cascade (task 088); the
+		// From a parked fan_out parent this is the cascade (task 090); the
 		// key is the same one, because available_actions is what says the
 		// action is on offer and the daemon is what decides it means.
 		task, retried, err := client.Retry(ctx, id, apiclient.Override{})
@@ -268,7 +268,7 @@ func (a *actionBar) applyResult(msg actionResultMsg) {
 		status := msg.action + " · now " + msg.task.State
 		// A cascade leaves the parent exactly where it was, so "now
 		// awaiting_children" is all the task row can say about it; the lanes
-		// it re-admitted are the part a human acted for (task 088).
+		// it re-admitted are the part a human acted for (task 090).
 		if msg.retried > 0 {
 			status += " · " + plural(msg.retried, "lane", "lanes") + " re-admitted"
 		}

--- a/internal/tui/bulkaction.go
+++ b/internal/tui/bulkaction.go
@@ -38,6 +38,10 @@ type bulkResultMsg struct {
 	// branches counts archives that deleted the task's branch (§10, task 008)
 	// — the one consequence of an archive that is invisible afterwards.
 	branches int
+	// lanes counts the blocked descendants a cascading retry re-admitted
+	// across the whole batch (task 088), for the same reason: a parked parent
+	// comes back in the state it went in, so its row says nothing about it.
+	lanes int
 }
 
 type bulkFailure struct {
@@ -66,13 +70,14 @@ func (a *actionBar) dispatchBulk(client *apiclient.Client, ids []int64, action s
 	return func() tea.Msg {
 		msg := bulkResultMsg{action: action, force: force, total: len(ids)}
 		for _, id := range ids {
-			_, branch, err := callActionWithTimeout(client, id, action, force)
+			_, branch, retried, err := callActionWithTimeout(client, id, action, force)
 			switch {
 			case err == nil:
 				msg.done = append(msg.done, id)
 				if branch.Result == apiclient.BranchDeleted {
 					msg.branches++
 				}
+				msg.lanes += retried
 			case isDirtyWorktree(action, err):
 				msg.dirty = append(msg.dirty, id)
 			default:
@@ -83,7 +88,7 @@ func (a *actionBar) dispatchBulk(client *apiclient.Client, ids []int64, action s
 	}
 }
 
-func callActionWithTimeout(client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, error) {
+func callActionWithTimeout(client *apiclient.Client, id int64, action string, force bool) (apiclient.Task, apiclient.BranchOutcome, int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 	defer cancel()
 	return callAction(ctx, client, id, action, force)
@@ -110,6 +115,9 @@ func bulkSummary(msg bulkResultMsg) string {
 	parts := []string{fmt.Sprintf("%s · %d of %d", msg.action, len(msg.done), msg.total)}
 	if msg.branches > 0 {
 		parts = append(parts, fmt.Sprintf("%s deleted", plural(msg.branches, "branch", "branches")))
+	}
+	if msg.lanes > 0 {
+		parts = append(parts, plural(msg.lanes, "lane", "lanes")+" re-admitted")
 	}
 	if n := len(msg.dirty); n > 0 {
 		parts = append(parts, fmt.Sprintf("%d need force", n))

--- a/internal/tui/bulkaction.go
+++ b/internal/tui/bulkaction.go
@@ -39,7 +39,7 @@ type bulkResultMsg struct {
 	// — the one consequence of an archive that is invisible afterwards.
 	branches int
 	// lanes counts the blocked descendants a cascading retry re-admitted
-	// across the whole batch (task 088), for the same reason: a parked parent
+	// across the whole batch (task 090), for the same reason: a parked parent
 	// comes back in the state it went in, so its row says nothing about it.
 	lanes int
 }

--- a/internal/tui/cascaderetrylive_test.go
+++ b/internal/tui/cascaderetrylive_test.go
@@ -71,7 +71,7 @@ func (h *actionLiveHarness) blockedLane(t *testing.T, parent *store.Task, n int)
 	return task
 }
 
-// TestDetailRetriesParkedParentLive is the client half of task 088: the bar
+// TestDetailRetriesParkedParentLive is the client half of task 090: the bar
 // offers `r` on a parent parked in `awaiting_children`, the one call
 // re-admits every blocked lane holding the join open, and the status line
 // says how many — because the parent's own row comes back in the state it

--- a/internal/tui/cascaderetrylive_test.go
+++ b/internal/tui/cascaderetrylive_test.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// fanOutWorkflow parks its parent on a join. The lane's own work is one
+// command, because what this file is about is the parent — a `fan_out` step
+// is structure and carries no text, which is the whole reason edit+retry has
+// nothing to offer on it.
+const fanOutWorkflow = `name: fanned
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: api
+        steps:
+          - {id: api_impl, type: command, run: git --version}
+`
+
+// laneWorkflow is what a re-admitted lane runs: one command that succeeds
+// wherever the suite runs.
+const laneWorkflow = `name: lane
+steps:
+  - id: work
+    type: command
+    run: git --version
+`
+
+// parkedParent creates a task sitting in `awaiting_children` on a fan_out
+// step, without running one — the scheduler only ever admits `queued`, so a
+// task created in this state is left alone.
+func (h *actionLiveHarness) parkedParent(t *testing.T, title string) *store.Task {
+	t.Helper()
+	task := &store.Task{
+		ProjectID: h.projectID, Title: title, WorkflowName: "fanned",
+		WorkflowSnapshot: fanOutWorkflow,
+		BaseBranch:       "main", BranchName: "vincent/live-" + title,
+		State: store.TaskAwaitingChildren,
+	}
+	if err := h.st.CreateTask(context.Background(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	return task
+}
+
+// blockedLane is one descendant holding the join open.
+func (h *actionLiveHarness) blockedLane(t *testing.T, parent *store.Task, n int) *store.Task {
+	t.Helper()
+	index := 0
+	reason := "nonzero_exit"
+	task := &store.Task{
+		ProjectID: h.projectID, Title: fmt.Sprintf("lane-%d", n), WorkflowName: "lane",
+		WorkflowSnapshot: laneWorkflow,
+		BaseBranch:       "main", BranchName: fmt.Sprintf("vincent/live-lane-%d", n),
+		State:           store.TaskBlocked,
+		BlockReason:     reason,
+		ParentTaskID:    &parent.ID,
+		ParentStepIndex: &index,
+	}
+	if err := h.st.CreateTask(context.Background(), task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	return task
+}
+
+// TestDetailRetriesParkedParentLive is the client half of task 088: the bar
+// offers `r` on a parent parked in `awaiting_children`, the one call
+// re-admits every blocked lane holding the join open, and the status line
+// says how many — because the parent's own row comes back in the state it
+// went in, and would otherwise report an action that looks like it did
+// nothing.
+//
+// `E` is *not* offered there. Its cursor is the `fan_out` step, which carries
+// no text, and the daemon answers an override from this state with a 400 —
+// so the key checks the same thing its hint always did.
+func TestDetailRetriesParkedParentLive(t *testing.T) {
+	h := newActionLiveHarness(t)
+	parent := h.parkedParent(t, "fanned-out")
+	first := h.blockedLane(t, parent, 1)
+	second := h.blockedLane(t, parent, 2)
+
+	_, cmd := h.m.Update(selectTaskMsg{id: parent.ID})
+	h.p.push(cmd)
+	h.p.until(30*time.Second, "the detail view to open the parked parent", func() bool {
+		return detailOf(h.m).taskID == parent.ID && detailOf(h.m).loaded
+	})
+
+	d := detailOf(h.m)
+	if !d.target().has(apiclient.ActionRetry) {
+		t.Fatalf("available actions = %v, want retry on a parked parent", d.target().actions)
+	}
+	if d.stepEditable() {
+		t.Error("a fan_out step reports editable text")
+	}
+	if hintsContain(d.detailHints(), "edit+retry") {
+		t.Error("the bar advertises edit+retry on a parked parent")
+	}
+
+	// The key itself, not only the hint: pressing it must not reach the
+	// editor, and must not leave the "a gate has no prompt" complaint behind.
+	h.press(t, "E")
+	if status := detailOf(h.m).actions.status; strings.Contains(status, "edit+retry") {
+		t.Errorf("E acted on a parked parent: status = %q", status)
+	}
+
+	h.press(t, "r")
+	h.p.until(30*time.Second, "both lanes to be re-admitted", func() bool {
+		return h.state(t, first.ID) != store.TaskBlocked &&
+			h.state(t, second.ID) != store.TaskBlocked
+	})
+	// The parent is where it was — the join is still open — so the count is
+	// the only account of what the key did.
+	h.p.until(30*time.Second, "the bar to report the cascade", func() bool {
+		return strings.Contains(detailOf(h.m).actions.status, "2 lanes re-admitted")
+	})
+	if got := h.state(t, parent.ID); got != store.TaskAwaitingChildren &&
+		got != store.TaskQueued && got != store.TaskRunning && got != store.TaskDone {
+		t.Errorf("parent is %s after the cascade, want it parked or converged", got)
+	}
+}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -757,7 +757,12 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "e":
 		return d.openTranscript()
 	case "E":
-		if d.target().has(apiclient.ActionRetry) {
+		// The same gate the hint line and the palette use: retry on offer
+		// *and* a step carrying text to edit. A fan_out parent parked in
+		// `awaiting_children` offers retry — as the cascade (task 088) — and
+		// its cursor step has no editable text, which the daemon answers with
+		// a 400 rather than an edited snapshot.
+		if d.target().has(apiclient.ActionRetry) && d.stepEditable() {
 			return d.editRetry()
 		}
 		return nil

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -759,7 +759,7 @@ func (d *detail) updateKey(msg tea.KeyPressMsg) tea.Cmd {
 	case "E":
 		// The same gate the hint line and the palette use: retry on offer
 		// *and* a step carrying text to edit. A fan_out parent parked in
-		// `awaiting_children` offers retry — as the cascade (task 088) — and
+		// `awaiting_children` offers retry — as the cascade (task 090) — and
 		// its cursor step has no editable text, which the daemon answers with
 		// a 400 rather than an edited snapshot.
 		if d.target().has(apiclient.ActionRetry) && d.stepEditable() {

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -232,8 +232,11 @@ func (d *detail) retryCmd(override apiclient.Override) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
 		defer cancel()
-		task, err := client.Retry(ctx, id, override)
-		return actionResultMsg{taskID: id, action: apiclient.ActionRetry, task: task, err: err}
+		task, retried, err := client.Retry(ctx, id, override)
+		return actionResultMsg{
+			taskID: id, action: apiclient.ActionRetry,
+			task: task, retried: retried, err: err,
+		}
 	}
 }
 

--- a/internal/tui/editor_test.go
+++ b/internal/tui/editor_test.go
@@ -172,7 +172,7 @@ func TestEditRetryPicksRunForCommandSteps(t *testing.T) {
 // command, so `E` is not offered and does not act.
 //
 // It is silent about it. The bar never advertised the key here — its hint has
-// always been gated on there being text to edit — and task 088 gave the key
+// always been gated on there being text to edit — and task 090 gave the key
 // itself the same check, because the other step with nothing to edit is the
 // `fan_out` a parked parent sits on, where the daemon answers an override
 // with a 400. An unadvertised key that does nothing is what every other one

--- a/internal/tui/editor_test.go
+++ b/internal/tui/editor_test.go
@@ -169,7 +169,14 @@ func TestEditRetryPicksRunForCommandSteps(t *testing.T) {
 }
 
 // TestEditRetryUnavailableOnAGate: a manual step has no prompt and no
-// command, so the key does nothing and says why.
+// command, so `E` is not offered and does not act.
+//
+// It is silent about it. The bar never advertised the key here — its hint has
+// always been gated on there being text to edit — and task 088 gave the key
+// itself the same check, because the other step with nothing to edit is the
+// `fan_out` a parked parent sits on, where the daemon answers an override
+// with a 400. An unadvertised key that does nothing is what every other one
+// in the view does.
 func TestEditRetryUnavailableOnAGate(t *testing.T) {
 	rec := &retryRecorder{}
 	d := editorDetail(t, rec.client(t), "whatever", nil)
@@ -181,8 +188,8 @@ func TestEditRetryUnavailableOnAGate(t *testing.T) {
 	if len(rec.calls) != 0 {
 		t.Fatalf("a gate was edit+retried: %v", rec.calls)
 	}
-	if !strings.Contains(d.actions.status, "gate") {
-		t.Errorf("status = %q, want it to name the reason", d.actions.status)
+	if d.actions.status != "" {
+		t.Errorf("status = %q, want the key to stay silent", d.actions.status)
 	}
 	if strings.Contains(strings.Join(d.detailHints(), " "), "edit+retry") {
 		t.Error("the bar offers edit+retry on a step with nothing to edit")

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -17,6 +17,7 @@
 #   9. both creation-time 400s: a workflow cycle and fan_out.max_tasks
 #  10. `schedule: eager` starts a lane while an unrelated sibling still runs
 #  11. the merged diff is attributed back to the lane that produced it
+#  12. one retry on a parked parent re-admits every blocked lane under it
 #
 # Every scenario uses command steps only, so no agent CLI is involved at all
 # and the gate is as fast on CI as it is locally.
@@ -713,6 +714,96 @@ YAML
 
   daemon_down
   echo "=== scenario 11 PASS"
+fi
+
+# --------------------------------------------------------------------------
+# Scenario 12: one retry on the parked parent re-admits every blocked lane.
+#
+# Both lanes fail on the same missing repository setting, so the parent parks
+# with two `blocked` children under it — `blocked` is not settled, so the join
+# stays open rather than failing `lane_failed` the way scenario 8's cancelled
+# lane does. Before task 088 that shape needed one retry per lane, walked by
+# hand; the one assertion this scenario exists for is that a single retry on
+# the *parent* clears all of them, and says how many it cleared.
+#
+# The fault is one repository setting rather than a per-worktree marker
+# because a linked worktree shares the repository's config: `git config`
+# written once on the repo is seen by both lanes, which is a human fixing one
+# root cause rather than the same cause twice. It is also a single command
+# whose own exit code is the pass/fail condition, which is what §8.3's
+# sh∩pwsh vocabulary allows — no `[ -f ]`, no `if`, no `exit` after an `&&`.
+#
+# The empty commit ahead of it is what makes the join observable. The lanes
+# write nothing, and `git merge --no-ff` of a branch that is already an
+# ancestor reports "Already up to date." and records no commit, so a join over
+# empty lanes would leave nothing on the parent's branch to assert against.
+# One `--allow-empty` commit per lane gives each merge something to do, and
+# the `Merge lane '{id}' of task {n}` subjects §7.6 fixes are then the proof
+# that both lanes actually landed.
+# --------------------------------------------------------------------------
+if run_scenario 12; then
+  echo "=== scenario 12: a retry on a parked parent cascades to its blocked lanes"
+  scenario_dirs s12
+  REPO="$TMP/s12/repo"; make_repo "$REPO"
+  write_workflow fan-cascade "$(cat <<'YAML'
+name: fan-cascade
+steps:
+  - id: build
+    type: fan_out
+    lanes:
+      - id: left
+        steps:
+          - {id: gate, type: command, max_retries: 0, run: 'git commit -q --allow-empty -m left && git config --get vincent.gate.go'}
+      - id: right
+        steps:
+          - {id: gate, type: command, max_retries: 0, run: 'git commit -q --allow-empty -m right && git config --get vincent.gate.go'}
+YAML
+)"
+  daemon_up
+  PID="$(register_project "$REPO")"
+  TID="$(create_task "$PID" fan-cascade "cascading retry")"
+
+  wait_for_state "$TID" awaiting_children 60
+  BLOCKED=""
+  for _ in $(seq 1 90); do
+    BLOCKED="$(api GET "/tasks?parent_id=$TID" \
+      | jq '[.[] | select(.state == "blocked")] | length' | tr -d '\r')"
+    [[ "$BLOCKED" == 2 ]] && break
+    sleep 1
+  done
+  [[ "$BLOCKED" == 2 ]] || fail "expected both lanes blocked, got $BLOCKED"
+  # The parent is still parked with them: a blocked lane holds the join open.
+  STATE="$(api GET "/tasks/$TID" | jq -r .state | tr -d '\r')"
+  [[ "$STATE" == "awaiting_children" ]] || fail "the parent left the join: $STATE"
+
+  # One write, on the repository both lanes' worktrees share.
+  git -C "$REPO" config vincent.gate.go 1
+
+  # One retry, on the parent — not on either lane.
+  OUT="$(api_status POST "/tasks/$TID/retry" '{}')"
+  STATUS="${OUT%%$'\n'*}"; BODY="${OUT#*$'\n'}"
+  [[ "$STATUS" == 200 ]] || fail "retry on the parked parent -> HTTP $STATUS: $BODY"
+  N="$(jq -r .retried_descendants <<<"$BODY" | tr -d '\r')"
+  [[ "$N" == 2 ]] || fail "retried_descendants = $N, want 2 — one per blocked lane"
+  # Read from the retry's own response, not from a fresh GET: the parked
+  # parent's row is deliberately not written on this path, and by the time a
+  # second request lands the re-admitted lanes may already have woken it.
+  STATE="$(jq -r .state <<<"$BODY" | tr -d '\r')"
+  [[ "$STATE" == "awaiting_children" ]] \
+    || fail "the retry moved the parked parent to $STATE; its row must not be written"
+
+  wait_for_state "$TID" done 180
+  BRANCH="$(api GET "/tasks/$TID" | jq -r .branch_name | tr -d '\r')"
+  # Several lines, so `tr -d '\r'` for the same reason scenario 11 gives, and
+  # captured before matching rather than piped into `grep -q` — see m7
+  # scenario 4's comment.
+  SUBJECTS="$(git -C "$REPO" log --format=%s "$BRANCH" | tr -d '\r')"
+  for lane in left right; do
+    grep -q "^Merge lane '$lane' of task " <<<"$SUBJECTS" \
+      || fail "the join never merged lane $lane: $SUBJECTS"
+  done
+  daemon_down
+  echo "=== scenario 12 PASS"
 fi
 
 echo "M6 GATE PASS"

--- a/scripts/m6-gate.sh
+++ b/scripts/m6-gate.sh
@@ -722,7 +722,7 @@ fi
 # Both lanes fail on the same missing repository setting, so the parent parks
 # with two `blocked` children under it — `blocked` is not settled, so the join
 # stays open rather than failing `lane_failed` the way scenario 8's cancelled
-# lane does. Before task 088 that shape needed one retry per lane, walked by
+# lane does. Before task 090 that shape needed one retry per lane, walked by
 # hand; the one assertion this scenario exists for is that a single retry on
 # the *parent* clears all of them, and says how many it cleared.
 #


### PR DESCRIPTION
## Summary

A `fan_out` whose lanes blocked was a dead end. A blocked lane is not settled,
so the scheduler never returned the parent to the queue; the parent sat in
`awaiting_children`, where §6 offered exactly one human action — `cancel`, which
throws the run away — and `retry` on it was a `409`. The only real recovery was
to retry each lane by hand, once per lane and once per level of a nested
fan-out.

`retry` is now legal from `awaiting_children`, where it means the **cascade**:
one call re-admits every `blocked` descendant beneath the parent, at any depth,
and the parent's own row is not written at all — no transition, no
`task.state_changed` whose `from` and `to` are equal, and no `retry_cursor_at`
stamp, because nothing was retried on the parent and stamping the cursor would
hand the join a fresh §7.2 budget nobody asked for. The parent stays parked and
the join closes on its own once the lanes finish. A `blocked` parent takes both:
its own `blocked → queued` swap exactly as before, then the same cascade over
anything blocked beneath it.

The engine needed nothing new to make that converge: a parent re-admitted while
its lanes are unsettled parks again under barrier scheduling and reads them as
"not yet" under `schedule: eager`, whichever order the scheduler picks. The walk
is `store.ChildrenOf`'s existing recursive CTE, sorted by id — no new query, no
migration, no Go recursion. A lane that left `blocked` between the rollup and
the write is skipped and not counted.

Surfaces:

- `POST /v1/tasks/{id}/retry` answers `200` from `awaiting_children` and its
  body carries `retried_descendants` — always present, `0` when nothing
  cascaded, so a client never has to tell "no cascade" from "an old daemon". A
  count and not ids: the ids under a wide fan-out are unbounded and §13.3's
  convention is that a client re-fetches what it needs.
- `r` in the TUI works on a parked parent with no new key — the action bar reads
  `available_actions` — and the status line says how many lanes were re-admitted,
  in both the single and the bulk path. `vincent task retry` prints the same
  count, and `--json` carries `retried_descendants`.
- Every override is refused from `awaiting_children` with a `400`: a parked
  parent's cursor is a `fan_out` step with no prompt or command to rewrite, and
  `branch_override` would rename the branch every live lane holds as its
  `base_branch`. That one is refused **before** `renameBranchForRetry` runs,
  since the rename commits ahead of the action. The TUI's `E` gains the same
  check its hint line already applied, so edit+retry is not offered where the
  daemon would refuse it.
- The MCP `task_retry` description says so; the tool replays the route
  in-process and inherits the behaviour.

An `aborted` lane is untouched by all of this — nothing re-admits an aborted
task, so that join still fails `lane_failed` and is still fixed by hand. This
narrows task 014 decision 22 in scope rather than overturning it, and decision
20 (`blocked` is not `Settled`) is untouched: this changes who issues the retry,
not what the join will merge.

One thing outside the issue's scope changed as a consequence: `E` on a step with
nothing to edit — a gate, and now a parked parent's `fan_out` — is silent rather
than setting a status saying why. The bar never advertised the key there, and an
unadvertised key that does nothing is what every other one in that view does.

## Related

Closes #328

Task [088](docs/tasks/088-cascading-fan-out-retry.md) (5/5), with the six
decisions behind it. It amends [task 014](docs/tasks/014-workflow-fan-out.md)
decision 22 **in scope only** — the remedy "fix the child, then retry the
parent" is still the truth for an `aborted` lane, and the beat it recorded
(retry re-spawning aborted lanes as fresh children, which `lane_id` cannot
version) stays refused. What 088 adds is the merely `blocked` lane decision 22
never considered. Decision 22 carries a dated pointer to it.

The issue's fourth bullet is kept with its rationale replaced, and the task
document says why: cascading from `blocked` does **not** help the `lane_failed`
case, because `lane_failed` is raised only for a lane that settled without
finishing, and `retry` is illegal from `aborted`. The bullet earns its place on
the case that is actually reachable — a parent blocked for its own reason with a
blocked descendant under it.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

Tests: `internal/taskstate` pins the whole from-set of `retry` and
`HumanActionsFrom(awaiting_children)`; `internal/taskrun` covers the parked
parent with two blocked lanes, a nested tree retried from the root, descendants
in every state that must be left alone, a lane that moved between the rollup and
the write, a nested subtree counted once, the `blocked` parent that swaps *and*
cascades, and the typed override refusal; `internal/api` covers the `200`, the
always-present count, `available_actions` on a parked parent and both `400`s;
`internal/apiclient` and `internal/tui` cover the count over the real handlers
and `r` on a parked parent. `scripts/m6-gate.sh` gains scenario 12, which drives
a real daemon: two lanes blocked on one missing repository setting, one retry on
the parent, `retried_descendants == 2`, the parent still parked in that same
response, and both lane branches merged into it. Run locally on macOS
(`VINCENT_GATE_SCENARIO=12 ./scripts/m6-gate.sh`).

Docs: `docs/spec.md` §6 (the `awaiting_children` state row, the `retry` and
`edit + retry` action rows), §7.6's Resuming bullet and §13.2's `/retry` entry
are amended in place with dated notes; `docs/reference/api.md`,
`docs/reference/cli.md`, `docs/reference/task-lifecycle.md`,
`docs/guides/tui.md` and `docs/guides/workflows.md` carry the same change on
their `/retry` row, `r` row and fan-out sections. A documentation audit over
every derivation (`internal/config`, the cobra tree, the route table,
`internal/tui/bindings.go`, the `Reason*` constants, the step types,
`internal/agent/*`, `docs/features.md`, `CHANGELOG.md`, `docs/tasks/`,
`docs/gates/`) found one stale claim and fixed it: `docs/reference/cli.md` said
`--json` carries `retried_descendants`, which the CLI omits when the count is
`0`. The workflow schema did not change, so
`skills/vincent-workflows/SKILL.md` is untouched and this repository's own
`.vincent/workflows/*.yaml` still pass `workflow validate` and
`workflow render`. No `docs/assets/tui-*.png` is stale — `scripts/screenshots.sh`
seeds no task that reaches `awaiting_children`, and the action bar renders the
action name rather than a binding label.

Two things found and **not** fixed, both code rather than documentation:

- **`vincent task retry --json` omits `retried_descendants` when it is `0`**
  (`omitempty` on the anonymous struct in `internal/cli/task.go`, plus the
  `retried == 0` fall-through to `printTaskAction`). Decision 3's reason for
  making the field unconditional on the wire — "a client never has to tell 'no
  cascade' from 'an old daemon'" — does not reach the CLI, which is the
  scripting surface where it matters most. A parked parent whose lanes are all
  at gates is the reachable case: the retry succeeds, cascades nothing, and the
  JSON has no count in it. The CLI page now documents the behaviour as it is.
- **`internal/tui/bindings.go`'s `r` row still reads "retry the blocked
  step".** The command palette shows that row whenever the daemon offers
  `retry`, which now includes a parent parked in `awaiting_children`, where
  there is no blocked step. The action bar is unaffected — it renders the
  action name — and so is the help sheet, which is a static catalogue.

Suite and linter green on this branch: `go test ./...`, and
`golangci-lint run ./...` built for the host and run under `GOOS=darwin`,
`GOOS=linux` and `GOOS=windows`.
