### PR TITLE
Give repair agents the failure output they are prompted to read

### DIFF
--- a/.vincent/workflows/github-resolve-issue-dag.yaml
+++ b/.vincent/workflows/github-resolve-issue-dag.yaml
@@ -1638,7 +1638,16 @@ steps:
         # YAML comment, outside the `run:` scalar, so the braces below are not
         # rendered here — a template action in a comment *inside* the body
         # would be.)
+        # `exec 2>&1` on the first line because `repair`'s prompt quotes this
+        # step's `.Result`, which is stdout alone (§8.4). golangci-lint writes
+        # its findings there, but `go run mage.go testrace` does not write a
+        # *compile* failure there: `go test` prints test failures on stdout and
+        # sends the build error behind `FAIL ... [build failed]` to stderr. A
+        # GOOS-tagged file that stopped compiling is the commonest thing this
+        # loop exists to repair, and without this the repair session is handed
+        # the word FAIL and no reason.
         run: |
+          exec 2>&1
           set -e
           say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
           pass="pass {{.Loop.Index}}/4"
@@ -2027,7 +2036,15 @@ steps:
         # `exit 1` after the guard rather than the rebase's own code: the `if:`
         # below reads `ne … 0`, so any non-zero is equivalent, and the fetch
         # path keeps `set -e`'s code by construction.
+        # `exec 2>&1` on the first line because `resolve`'s prompt quotes this
+        # step's `.Result`, which is stdout alone (§8.4). git splits this one:
+        # `CONFLICT (content): ...` is on stdout, but `error: could not apply`
+        # and every `hint:` line are on stderr — and `git fetch` writes
+        # *everything* there. So the failed-fetch case the prompt explicitly
+        # asks the agent to tell apart from a conflict reached it as an empty
+        # block, which is the one reading that makes the agent invent a fix.
         run: |
+          exec 2>&1
           set -e
           say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
 
@@ -2443,6 +2460,13 @@ steps:
                 # job's does. Over-long lists are truncated at 256 bytes rather
                 # than refused (§5.4).
                 say "red on $short: $(awk 'NR > 1 && $1 == "fail" { $1 = ""; sub(/^ +/, ""); printf "%s; ", $0 }' .vincent-issue/checks.txt)"
+                # `repair-checks` quotes this step's `.Result`, which is
+                # stdout alone (§8.4), and this table is the whole of what that
+                # prompt is given to work from — on this path it was written to
+                # stderr only, so the session opened on two header lines and no
+                # table. The stderr copy below stays: it is the human's, in the
+                # step summary, next to the prose that explains it.
+                sed -n '2,$p' .vincent-issue/checks.txt
                 echo "a required check did not pass on $head; not merging:" >&2
                 sed -n '2,$p' .vincent-issue/checks.txt >&2
                 exit 1

--- a/.vincent/workflows/github-resolve-issue.yaml
+++ b/.vincent/workflows/github-resolve-issue.yaml
@@ -1220,7 +1220,16 @@ steps:
         # YAML comment, outside the `run:` scalar, so the braces below are not
         # rendered here — a template action in a comment *inside* the body
         # would be.)
+        # `exec 2>&1` on the first line because `repair`'s prompt quotes this
+        # step's `.Result`, which is stdout alone (§8.4). golangci-lint writes
+        # its findings there, but `go run mage.go testrace` does not write a
+        # *compile* failure there: `go test` prints test failures on stdout and
+        # sends the build error behind `FAIL ... [build failed]` to stderr. A
+        # GOOS-tagged file that stopped compiling is the commonest thing this
+        # loop exists to repair, and without this the repair session is handed
+        # the word FAIL and no reason.
         run: |
+          exec 2>&1
           set -e
           say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
           pass="pass {{.Loop.Index}}/4"
@@ -1609,7 +1618,15 @@ steps:
         # `exit 1` after the guard rather than the rebase's own code: the `if:`
         # below reads `ne … 0`, so any non-zero is equivalent, and the fetch
         # path keeps `set -e`'s code by construction.
+        # `exec 2>&1` on the first line because `resolve`'s prompt quotes this
+        # step's `.Result`, which is stdout alone (§8.4). git splits this one:
+        # `CONFLICT (content): ...` is on stdout, but `error: could not apply`
+        # and every `hint:` line are on stderr — and `git fetch` writes
+        # *everything* there. So the failed-fetch case the prompt explicitly
+        # asks the agent to tell apart from a conflict reached it as an empty
+        # block, which is the one reading that makes the agent invent a fix.
         run: |
+          exec 2>&1
           set -e
           say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
 
@@ -2025,6 +2042,13 @@ steps:
                 # job's does. Over-long lists are truncated at 256 bytes rather
                 # than refused (§5.4).
                 say "red on $short: $(awk 'NR > 1 && $1 == "fail" { $1 = ""; sub(/^ +/, ""); printf "%s; ", $0 }' .vincent-issue/checks.txt)"
+                # `repair-checks` quotes this step's `.Result`, which is
+                # stdout alone (§8.4), and this table is the whole of what that
+                # prompt is given to work from — on this path it was written to
+                # stderr only, so the session opened on two header lines and no
+                # table. The stderr copy below stays: it is the human's, in the
+                # step summary, next to the prose that explains it.
+                sed -n '2,$p' .vincent-issue/checks.txt
                 echo "a required check did not pass on $head; not merging:" >&2
                 sed -n '2,$p' .vincent-issue/checks.txt >&2
                 exit 1

--- a/.vincent/workflows/handle-dependabot.yaml
+++ b/.vincent/workflows/handle-dependabot.yaml
@@ -266,7 +266,15 @@ steps:
     # answer is the only safe direction: the cost of a wrong 1 is one agent
     # session, and the cost of a wrong 0 is a silent breaking change merged on a
     # green build.
+    # `exec 2>&1` on the first line because `assess`'s prompt quotes this
+    # step's `.Result`, which is stdout alone (§8.4). The module line below is
+    # the only thing this body puts there; every *reason* — the major change,
+    # the pre-1.0 minor, the unreadable title — is an `>&2` echo. On the
+    # grouped-update path it exits before the module line is reached at all, so
+    # "a previous step decided this is not a routine patch bump:" was followed
+    # by nothing.
     run: |
+      exec 2>&1
       set -e
       say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
       scratch=$(git rev-parse --git-path vincent-deps)

--- a/.vincent/workflows/prepare-release.yaml
+++ b/.vincent/workflows/prepare-release.yaml
@@ -775,7 +775,15 @@ steps:
         # anything new — the loop is the iteration, not the retry budget.
         allow_failure: true
         max_retries: 0
+        # `exec 2>&1` on the first line because `repair`'s prompt quotes
+        # this step's `.Result`, which is stdout alone (§8.4), and every leg
+        # here reports its failure on stderr: `go build` writes compile errors
+        # there exclusively, and `go test` sends the build error behind its
+        # `FAIL ... [build failed]` line there too. Without it the `==` headers
+        # below arrive labelling nothing, which is the whole input the repair
+        # session gets.
         run: |
+          exec 2>&1
           say() { vincent status -- "$*" >/dev/null 2>&1 || true; }
           rc=0
 


### PR DESCRIPTION
Four command steps across the project's workflows hand their `.Result` to a
downstream agent prompt as that session's entire input. `.Result` is stdout
alone (§8.4), and each of these steps reported its failure on stderr — so the
agent opened on headers labelling nothing, which is the reading that makes it
invent a fix rather than apply one.

| Step | Workflow | What was lost |
|---|---|---|
| `verify-probe` | `github-resolve-issue`, `-dag` | `go test` prints test failures on stdout but sends a *compile* failure behind `FAIL ... [build failed]` to stderr. A GOOS-tagged file that stopped compiling is the commonest thing the repair loop exists to fix, and `repair` was handed the word FAIL and no reason. |
| `rebase` | `github-resolve-issue`, `-dag` | git splits it: `CONFLICT (content): ...` on stdout, `error: could not apply` and every `hint:` on stderr — and `git fetch` writes *everything* there. The failed-fetch case the prompt explicitly asks `resolve` to tell apart from a conflict arrived as an empty block. |
| `sweep` | `prepare-release` | `go build` writes compile errors to stderr exclusively, and `go test` sends its build error there too, so the `==` section headers arrived labelling nothing. |
| `risk` | `handle-dependabot` | The module line is the only thing on stdout; every *reason* — major change, pre-1.0 minor, unreadable title — is an `>&2` echo. On the grouped-update path it exits before the module line is reached, so "a previous step decided this is not a routine patch bump:" was followed by nothing. |

Fix is `exec 2>&1` on the first line of each body, which is the idiom `build`
and `verify-final` in `handle-dependabot` already use. Each site carries a
comment saying which stream ate what, so the next edit to those bodies knows
why the line is there.

The merge-blocked check table is the one exception: it gets a stdout *copy*
rather than a merge, because its stderr copy is the human's — it sits in the
step summary next to the prose that explains it — while `repair-checks` needs
the table itself.

Nothing downstream parses these results: every reference is either an
`.ExitCode` comparison or prose quoting `.Result` into a prompt, so merging the
streams changes no control flow.

`vincent workflow validate` passes on all seven project workflows, 0 warnings.

Task 214.