### PR TITLE
Drop the deprecated cask url.verified stanza

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,10 +119,11 @@ homebrew_casks:
     # An rc tag must not move the cask users install; goreleaser's `auto`
     # skips the push whenever the release is a prerelease.
     skip_upload: auto
-    url:
-      # Lets `brew audit` accept a homepage whose domain differs from the
-      # download host.
-      verified: github.com/lezli01/vincent/
+    # No `url.verified` here: Homebrew removed the stanza (Homebrew/brew#23280)
+    # and now verifies the download host by default, so goreleaser stopped
+    # writing it in v2.18.1 and `goreleaser check` fails on it. It used to be
+    # what let `brew audit` accept a homepage whose domain differs from the
+    # download host; that is the default behaviour now. Do not add it back.
     commit_author:
       name: goreleaser
       email: goreleaser@users.noreply.github.com


### PR DESCRIPTION
`packaging-config` has been red on every PR since Homebrew removed `url.verified` ([Homebrew/brew#23280](https://github.com/Homebrew/brew/pull/23280)) and GoReleaser stopped writing it into the cask in v2.18.1:

```
• DEPRECATED: homebrew_casks.url.verified should not be used anymore
• .goreleaser.yaml   error=configuration is valid, but uses deprecated properties
⨯ check failed      error=1 out of 1 configuration file(s) have issues
```

Nothing in this repository changed to cause it. The job pins `goreleaser/goreleaser-action` by SHA but asks for `version: "~> v2"`, so the binary floats to the newest v2 and picked up the new deprecation on its own. Master's last green run (f3e569f, 2026-09-05) validated the identical file.

The stanza bought exactly one thing — letting `brew audit` accept a homepage whose domain differs from the download host — and that is Homebrew's default behaviour now, so there is no replacement to write. A comment stays behind in its place so it is not reintroduced.

## Verification

`goreleaser check` is green against 2.18.0 (the deprecation is "since v2.18.1", so this only proves the YAML is still structurally valid with the `url:` key gone) and against `@latest`, which is what CI actually resolves. The latter also confirms no *second* deprecation is waiting behind this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuNh6sVGkTd11fpBCj3LCi