### PR TITLE
Widen the DAG resolver's build scope to root-level Go files and deletions

### DIFF
--- a/.vincent/workflows/github-resolve-issue-dag.yaml
+++ b/.vincent/workflows/github-resolve-issue-dag.yaml
@@ -1241,10 +1241,22 @@ steps:
         # unmerged, no marker left behind. `git diff` feeds `grep -E` without
         # `-q` on purpose (CLAUDE.md): an early-exiting consumer would kill the
         # producer with SIGPIPE and fail the check *because* it matched.
+        #
+        # "The packages it staged" includes two shapes the first spelling of
+        # this pipeline missed (#341): a Go file at the repository root, which
+        # has no `/` to strip and so needs the second `sed` address that emits
+        # `.` — `mage.go` and `magefile.go` live there — and a pure deletion,
+        # which `--diff-filter=ACMR` dropped even though removing a file is
+        # the edit most likely to break the siblings that stayed. `D` cannot
+        # simply be appended: the directory of a deleted file may be gone, or
+        # hold no Go file any more, and `go build` on such a path fails. So
+        # the list is filtered against what is on disk after the resolution,
+        # which turns a package the resolution emptied back into no argument
+        # at all rather than into a false failure.
         check: >
           test -z "$(git ls-files -u)" &&
           { markers=$(git diff --cached -U0 --diff-filter=ACMR | grep -E '^\+(<<<<<<<|>>>>>>>)' || true); test -z "$markers" || { echo 'conflict markers survived the resolution:' >&2; echo "$markers" >&2; false; }; } &&
-          { dirs=$(git diff --cached --name-only --diff-filter=ACMR | sed -n 's#^\(.*\)/[^/]*\.go$#./\1#p' | sort -u); test -z "$dirs" || { go build $dirs && go vet $dirs; }; }
+          { dirs=$(git diff --cached --name-only --diff-filter=ACMRD | sed -n -e 's#^\(.*\)/[^/]*\.go$#\1#p' -e 's#^[^/]*\.go$#.#p' | sort -u | while read -r p; do ls "$p"/*.go >/dev/null 2>&1 && printf './%s\n' "$p"; done); test -z "$dirs" || { go build $dirs && go vet $dirs; }; }
         check_timeout: 10m
 
   - id: integrate

--- a/internal/workflow/dagbuildscope_unix_test.go
+++ b/internal/workflow/dagbuildscope_unix_test.go
@@ -1,0 +1,219 @@
+//go:build unix
+
+package workflow
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+
+	"github.com/lezli01/vincent/internal/testrepo"
+)
+
+// The conflict resolver in github-resolve-issue-dag builds only the packages
+// the resolution staged, because a whole-repo build is red by construction
+// mid-join (#328, PR #336). Nothing exercised that extraction, and it misses
+// two shapes of staged change (issue #341): a Go file at the repository root
+// never yields a directory, and `--diff-filter=ACMR` drops pure deletions —
+// which is exactly the edit most likely to break a package's remaining files.
+//
+// Unix-only on purpose: the workflow declares `platforms: [posix]` (§8.1.1)
+// and its check bodies run under the daemon's `/bin/sh` (§8.3), so there is no
+// Windows behaviour of this pipeline to assert.
+func TestDAGResolverBuildScopeCoversStagedGoFiles(t *testing.T) {
+	scope := stagedBuildScope(t)
+
+	// The repository as the resolver finds it: two ordinary packages, a
+	// package with two files, a package with one, a Go file at the root and a
+	// file that is not Go at all.
+	base := map[string]string{
+		"internal/api/tasks.go":  "package api\n",
+		"internal/tui/board.go":  "package tui\n",
+		"internal/store/keep.go": "package store\n",
+		"internal/store/drop.go": "package store\n",
+		"internal/gone/only.go":  "package gone\n",
+		"magefile.go":            "package main\n",
+		"docs/spec.md":           "spec\n",
+	}
+
+	cases := []struct {
+		name string
+		// edit maps a path to its new content; an empty string deletes it.
+		edit map[string]string
+		want []string
+	}{
+		{
+			name: "nested packages",
+			edit: map[string]string{
+				"internal/api/tasks.go": "package api\n\n// resolved\n",
+				"internal/tui/board.go": "package tui\n\n// resolved\n",
+			},
+			want: []string{"internal/api", "internal/tui"},
+		},
+		{
+			// mage.go and magefile.go live at the root and are Go files like
+			// any other; a resolution that touches one has to build it.
+			name: "root-level go file",
+			edit: map[string]string{"magefile.go": "package main\n\n// resolved\n"},
+			want: []string{"."},
+		},
+		{
+			// Deleting one file out of a package is precisely the edit that
+			// breaks the siblings that stayed.
+			name: "deletion with siblings left behind",
+			edit: map[string]string{"internal/store/drop.go": ""},
+			want: []string{"internal/store"},
+		},
+		{
+			// The other half of the deletion case, and the reason the fix
+			// cannot simply add D to the filter: the directory is gone after
+			// the resolution, and `go build ./internal/gone` on it would fail
+			// the check for a package that no longer exists.
+			name: "package emptied by the deletion",
+			edit: map[string]string{"internal/gone/only.go": ""},
+			want: nil,
+		},
+		{
+			name: "no go files staged",
+			edit: map[string]string{"docs/spec.md": "spec\n\n## resolved\n"},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := testrepo.Init(t, "main")
+			for path, content := range base {
+				testrepo.WriteFile(t, repo, path, content)
+			}
+			testrepo.Run(t, repo, "add", "-A")
+			testrepo.Run(t, repo, "commit", "-q", "-m", "base")
+
+			for path, content := range tc.edit {
+				if content == "" {
+					if err := os.Remove(filepath.Join(repo, path)); err != nil {
+						t.Fatalf("delete %s: %v", path, err)
+					}
+					continue
+				}
+				testrepo.WriteFile(t, repo, path, content)
+			}
+			testrepo.Run(t, repo, "add", "-A")
+
+			got := runBuildScope(t, repo, scope)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(got)
+			sort.Strings(want)
+			if strings.Join(got, " ") != strings.Join(want, " ") {
+				t.Errorf("staged %v\n build scope = %v\n         want %v", stagedPaths(t, repo), got, want)
+			}
+		})
+	}
+}
+
+// runBuildScope executes the extracted assignment in repo and returns the
+// packages it would hand `go build`, split the way the unquoted `$dirs`
+// expansion in the check splits them and cleaned so that the assertion is
+// about which packages are built, not about how the pipeline spells them —
+// `./internal/api`, `internal/api`, `.` and `./.` all name one package to
+// `go build`.
+func runBuildScope(t *testing.T, repo, scope string) []string {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", scope+"\nprintf '%s\\n' $dirs\n")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run build scope: %v\n%s", err, out)
+	}
+	var dirs []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			dirs = append(dirs, path.Clean(line))
+		}
+	}
+	return dirs
+}
+
+func stagedPaths(t *testing.T, repo string) string {
+	t.Helper()
+	return strings.ReplaceAll(testrepo.Run(t, repo, "diff", "--cached", "--name-status"), "\n", ", ")
+}
+
+// stagedBuildScope pulls the `dirs=$(...)` assignment out of the shipped
+// workflow rather than restating it, so the test asserts what the resolver
+// actually runs.
+func stagedBuildScope(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", ".vincent", "workflows", "github-resolve-issue-dag.yaml")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc any
+	if err := yaml.Unmarshal(src, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var bodies []string
+	walkYAMLStrings(doc, func(s string) {
+		if strings.Contains(s, "git diff --cached --name-only") {
+			bodies = append(bodies, s)
+		}
+	})
+	if len(bodies) != 1 {
+		t.Fatalf("expected exactly one staged-name pipeline in %s, found %d", path, len(bodies))
+	}
+	return assignment(t, bodies[0], "dirs")
+}
+
+// assignment returns `name=$( … )` from body, balancing parentheses and
+// ignoring anything inside single quotes — the sed script carries `\(` and
+// `\)` of its own.
+func assignment(t *testing.T, body, name string) string {
+	t.Helper()
+	start := strings.Index(body, name+"=$(")
+	if start < 0 {
+		t.Fatalf("no %s=$(...) assignment in check body: %s", name, body)
+	}
+	depth, quoted := 0, false
+	for i := start; i < len(body); i++ {
+		switch c := body[i]; {
+		case c == '\'':
+			quoted = !quoted
+		case quoted:
+		case c == '(':
+			depth++
+		case c == ')':
+			if depth--; depth == 0 {
+				return body[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced %s=$(...) in check body: %s", name, body)
+	return ""
+}
+
+func walkYAMLStrings(v any, fn func(string)) {
+	switch n := v.(type) {
+	case string:
+		fn(n)
+	case []any:
+		for _, e := range n {
+			walkYAMLStrings(e, fn)
+		}
+	case map[string]any:
+		for _, e := range n {
+			walkYAMLStrings(e, fn)
+		}
+	case map[any]any:
+		for _, e := range n {
+			walkYAMLStrings(e, fn)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The conflict resolver in `.vincent/workflows/github-resolve-issue-dag.yaml`
(`merge.on_conflict: agent`) claims — in its `check:`, in the file header and in
its own step comment — to `go build` and `go vet` "the packages this resolution
actually staged". Two shapes of staged change produced no directory at all and
were therefore silently unbuilt.

**Root cause**, both halves in the one `dirs=` assignment at line 1247:

- The `sed` address `s#^\(.*\)/[^/]*\.go$#./\1#p` requires a literal `/` before
  the filename. A Go file at the repository root has none, so it matched
  nothing, and there was no branch that emitted `.` for the root package.
  `mage.go` and `magefile.go` live there.
- `--diff-filter=ACMR` enumerates added, copied, modified and renamed paths and
  omits `D`. A resolution whose only change to a package was deleting a `.go`
  file staged one path, that path was filtered out before `sed` saw it, and the
  package whose surviving files that deletion is most likely to break was never
  built.

Both were **missed checks, never false failures** — the check stayed honest
about what it asserted, it just asserted less than the prose around it said.
Low severity, but the resolver runs unattended inside a `fan_out` join, so
nobody is watching the gap.

The fix adds the second `sed` address that emits `.`, adds `D` to the filter,
and then filters the result against what is on disk after the resolution:

```sh
dirs=$(git diff --cached --name-only --diff-filter=ACMRD | sed -n -e 's#^\(.*\)/[^/]*\.go$#\1#p' -e 's#^[^/]*\.go$#.#p' | sort -u | while read -r p; do ls "$p"/*.go >/dev/null 2>&1 && printf './%s\n' "$p"; done)
```

The presence filter is what makes `D` safe rather than harmful, and it is the
reason `D` could not simply be appended: a deleted file's directory may no
longer exist, or may no longer hold any Go file, and `go build` on such a path
fails — turning a missed check into a false failure, which is strictly worse
than the bug. A package the resolution emptied now contributes no argument at
all instead of a red build.

The step comment gains a paragraph recording why the pipeline has that
`while`/`ls` tail, since it is not obvious from the shape.

**What this does not do:** it does not widen the check back toward
`go build ./...`. PR #336's decision (from #328, 2026-09-05) stands — a lane and
a join may not assert a whole-repo build, because a provider unit merges before
the consumer unit that updates its call sites and the repository legitimately
does not compile between the two. The build stays scoped to what the resolution
staged; `./...` keeps its only home in `integrate` (line 1393), after every unit
has merged. The sibling marker check's deliberate avoidance of `grep -q`
(CLAUDE.md's SIGPIPE rule) is untouched, and its `--diff-filter=ACMR` is
untouched on purpose — a deleted file contributes no added lines, so a conflict
marker cannot survive in one.

**How the regression test catches this coming back.**
`internal/workflow/dagbuildscope_unix_test.go` parses the shipped YAML, finds
the single `git diff --cached --name-only` pipeline, extracts the `dirs=$(…)`
assignment by balancing parentheses, and runs *that string* under `/bin/sh` in a
throwaway `internal/testrepo` repository — so it asserts what the resolver
actually executes rather than a restatement of it, and any future edit to the
check is tested by construction. Package paths are `path.Clean`ed before
comparison, so the assertion is about *which* packages get built, not how the
pipeline spells them (`./.`, `.` and `./internal/api` all pass). Five cases pin
the two reported shapes plus the caution above: nested packages, a root-level Go
file, a deletion with siblings left behind, a package emptied by the deletion
(which must stay excluded), and a staged change with no Go file in it. Before
the fix, cases 2 and 3 failed with an empty scope and nothing else failed.

It is `//go:build unix` because the workflow declares `platforms: [posix]`
(line 279) and its check bodies run under the daemon's `/bin/sh` (spec §8.3);
there is no Windows behaviour of this pipeline to assert.

**Verified:** the regression test red before the fix and green after; `go build
./...` and `go test ./...` green; `go tool golangci-lint run ./...` clean for
`GOOS=linux`, `darwin` and `windows`; `vincent workflow validate` still reports
`ok — github-resolve-issue-dag, 23 step(s), 0 warning(s), platforms: posix`; and
the folded check body passes `sh -n`.

No spec amendment: spec §8.3, §8.5, §7.2 and §7.6 govern the *mechanism* (a
`check` string run through `/bin/sh -c`, and the `fan_out` resolver this check
belongs to), not what this particular check asserts. Nothing in `docs/spec.md`
becomes untrue.

## Related

Closes #341

Builds on PR #336 / #328 without revisiting either: this is a gap in that PR's
*extraction*, not in its decision, and the decision that a lane or a join may
not assert a whole-repo build is preserved verbatim.

## Documentation audit

Audited against every derivation `CLAUDE.md` names; **nothing needed changing**,
and nothing was found that this PR leaves unfixed. The diff is one `check:`
string and its comment in a project workflow, plus one test file — it adds no
config key, cobra command, API route, TUI binding, `Reason*` constant, step
type, workflow field, validation rule, template variable or adapter capability,
so none of `docs/reference/configuration.md`, `cli.md`, `api.md`,
`docs/guides/tui.md`, the block-reason tables, `workflow-schema.md`,
`task-lifecycle.md` or `docs/guides/agents.md` carries a claim this makes false.
`docs/spec.md` needs no amendment for the reason given above. No `docs/tasks/`
row is open or advanced, and no gate walkthrough covers `.vincent/workflows/`.
`skills/vincent-workflows/SKILL.md` is runtime text spliced into the built-in
prompts, but the schema is untouched, so it stays current — and neither it nor
its `references/` carries a scoped-build recipe with the same gap.

No screenshot under `docs/assets/` is affected: this change touches no TUI
surface.

All seven of this repository's own workflows still pass `vincent workflow
validate` and `vincent workflow render` after the edit.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
      not applicable. `.vincent/workflows/` is this repository's own automation;
      nothing installs it and no user of the shipped binary can hit this. The
      built-in registry is `adhoc`, `create-workflow` and `update-workflows`,
      and no `go:embed` reaches `.vincent/`. The precedent is the same: 00708e4,
      the commit that introduced the gap, has no `CHANGELOG.md` entry either —
      no entry in the file mentions the conflict resolver at all — and the
      workflows' only entry describes their arrival as worked examples, not each
      subsequent tweak.
- [ ] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — not applicable, and audited rather than assumed; see
      **Documentation audit** above. The two pieces of prose the check was
      measured against — the file header at line 121 and the step comment above
      the check — were re-read and stay true as written, so neither needed an
      edit.
