### PR TITLE
fix(cli): watch the daemon child and report why the API never came up

### DIFF
--- a/internal/cli/backup_e2e_test.go
+++ b/internal/cli/backup_e2e_test.go
@@ -59,7 +59,7 @@ func TestBackupRestoreRoundTripE2E(t *testing.T) {
 	// Generation one: a task that finishes, with usage the result event
 	// reports, so the restored database has costs to compare.
 	first := startDaemonProcess(t, dataDir, cfgDir, "big-usage")
-	c1 := waitDaemonAPI(t, dataDir)
+	c1 := waitDaemonAPI(t, dataDir, first)
 	if out, code := runVincent(t, dataDir, cfgDir, "project", "add", repo); code != 0 {
 		t.Fatalf("project add: code %d, out %q", code, out)
 	}
@@ -70,7 +70,7 @@ func TestBackupRestoreRoundTripE2E(t *testing.T) {
 
 	// Generation two: a task that is still running when the archive is taken.
 	second := startDaemonProcess(t, dataDir, cfgDir, "hang")
-	c2 := waitDaemonAPI(t, dataDir)
+	c2 := waitDaemonAPI(t, dataDir, second)
 	runningID := addTask(t, dataDir, cfgDir, "still running at backup time")
 	waitJournaledPID(t, c2, runningID)
 
@@ -125,8 +125,7 @@ func TestBackupRestoreRoundTripE2E(t *testing.T) {
 
 	// Generation three, on the restored installation.
 	third := startDaemonProcess(t, newData, newCfg, "success")
-	c3 := waitDaemonAPI(t, newData)
-	t.Cleanup(func() { _ = third.Process.Kill() })
+	c3 := waitDaemonAPI(t, newData, third)
 
 	var restored []e2eTask
 	c3.get(t, "/v1/tasks?archived=all", &restored)

--- a/internal/cli/crash_e2e_test.go
+++ b/internal/cli/crash_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -37,7 +38,7 @@ func TestCrashRecoveryE2E(t *testing.T) {
 
 	// Daemon #1: the agent hangs until killed, so the crash lands mid-step.
 	first := startDaemonProcess(t, dataDir, cfgDir, "hang")
-	c := waitDaemonAPI(t, dataDir)
+	c := waitDaemonAPI(t, dataDir, first)
 
 	var project struct {
 		ID int64 `json:"id"`
@@ -53,14 +54,14 @@ func TestCrashRecoveryE2E(t *testing.T) {
 	pid := waitJournaledPID(t, c, task.ID)
 
 	// Hard kill: SIGKILL / TerminateProcess. No goodbye, no cleanup.
-	if err := first.Process.Kill(); err != nil {
+	if err := first.cmd.Process.Kill(); err != nil {
 		t.Fatalf("kill daemon: %v", err)
 	}
-	_ = first.Wait()
+	<-first.exited
 
 	// Daemon #2: recovery runs before it serves; the re-run must succeed.
 	second := startDaemonProcess(t, dataDir, cfgDir, "success")
-	c2 := waitDaemonAPI(t, dataDir)
+	c2 := waitDaemonAPI(t, dataDir, second)
 
 	// The journaled process is gone, whichever mechanism reaped it.
 	gone := time.Now().Add(15 * time.Second)
@@ -124,10 +125,34 @@ func TestCrashRecoveryE2E(t *testing.T) {
 	waitExit(t, second)
 }
 
+// daemonProc is a spawned daemon child plus the one goroutine that owns its
+// exec.Cmd.Wait. Wait may be called exactly once, and these tests need the
+// child's fate from several places at once — a kill that waits for the exit,
+// a startup poll that has to notice a corpse, a cleanup that reaps whatever
+// is left — so the reaper is centralized here and nothing else calls Wait.
+type daemonProc struct {
+	cmd    *exec.Cmd
+	exited chan struct{} // closed once the child has been reaped
+	err    error         // Wait's result; read only after exited is closed
+}
+
+// status describes the child for a failure message.
+func (p *daemonProc) status() string {
+	select {
+	case <-p.exited:
+		if p.err != nil {
+			return "child exited: " + p.err.Error()
+		}
+		return "child exited: status 0"
+	default:
+		return fmt.Sprintf("child still running (pid %d)", p.cmd.Process.Pid)
+	}
+}
+
 // startDaemonProcess runs `vincent daemon` (foreground) as a real child
 // process with the fake agent's scenario in its environment, so a
 // Process.Kill is a genuine daemon crash.
-func startDaemonProcess(t *testing.T, dataDir, cfgDir, scenario string) *exec.Cmd {
+func startDaemonProcess(t *testing.T, dataDir, cfgDir, scenario string) *daemonProc {
 	t.Helper()
 	cmd := exec.Command(vincentBin, "daemon")
 	cmd.Env = append(hermeticEnv(),
@@ -138,27 +163,28 @@ func startDaemonProcess(t *testing.T, dataDir, cfgDir, scenario string) *exec.Cm
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start daemon: %v", err)
 	}
+	p := &daemonProc{cmd: cmd, exited: make(chan struct{})}
+	go func() {
+		p.err = cmd.Wait()
+		close(p.exited)
+	}()
 	t.Cleanup(func() {
-		if cmd.ProcessState == nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
+		_ = cmd.Process.Kill()
+		<-p.exited
 	})
-	return cmd
+	return p
 }
 
 // daemonExitTimeout bounds a graceful shutdown in the e2e tests: §12.4's 15 s
 // process grace plus the HTTP drain has to fit inside it.
 const daemonExitTimeout = 30 * time.Second
 
-func waitExit(t *testing.T, cmd *exec.Cmd) {
+func waitExit(t *testing.T, p *daemonProc) {
 	t.Helper()
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
 	select {
-	case <-done:
+	case <-p.exited:
 	case <-time.After(daemonExitTimeout):
-		_ = cmd.Process.Kill()
+		_ = p.cmd.Process.Kill()
 		t.Fatalf("daemon did not exit within %s", daemonExitTimeout)
 	}
 }
@@ -169,13 +195,44 @@ type apiClient struct {
 	token string
 }
 
+// daemonAPIBudget is how long waitDaemonAPI gives a freshly spawned daemon to
+// serve its API. It is not a claim about the daemon's startup cost: it is wall
+// clock on a shared runner, and the load it competes with varies by platform
+// and by build. `go test -race ./...` reaches internal/cli after internal/api
+// and internal/taskrun have run in the same job, and on Windows the fixed 30 s
+// this replaced turned out to be roughly the observed cost rather than a
+// margin (issue #340). So scale it, and take the multipliers from the build
+// rather than guessing at run time.
+//
+// This is a test-harness budget only. `daemon start`'s own startTimeout is a
+// phase 1 decision about the user-facing command and is deliberately untouched.
+func daemonAPIBudget() time.Duration {
+	budget := 30 * time.Second
+	if raceEnabled {
+		budget *= 2
+	}
+	if runtime.GOOS == "windows" {
+		budget *= 2
+	}
+	return budget
+}
+
 // waitDaemonAPI polls until the (re)started daemon serves its API and
 // returns a client for it. A stale daemon.json from a crashed predecessor
 // fails the health check and keeps the poll going.
-func waitDaemonAPI(t *testing.T, dataDir string) *apiClient {
+//
+// A daemon that died during startup will never become healthy, so the poll
+// watches the child as well and gives up the moment it exits — otherwise a
+// broken daemon costs the whole (now larger) budget on every run. Either way
+// the failure carries the evidence: the budget actually spent, the child's
+// fate, and the tail of daemon.log, which is where the daemon writes its
+// reason. `daemon start` attaches the same log tail to its own timeout.
+func waitDaemonAPI(t *testing.T, dataDir string, p *daemonProc) *apiClient {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	for time.Now().Before(deadline) {
+	budget := daemonAPIBudget()
+	start := time.Now()
+	deadline := start.Add(budget)
+	for {
 		ri, err := daemon.ReadRuntimeInfo(dataDir)
 		if err == nil {
 			if _, err := daemon.CheckHealth(t.Context(), ri.Port); err == nil {
@@ -186,9 +243,19 @@ func waitDaemonAPI(t *testing.T, dataDir string) *apiClient {
 				return &apiClient{base: fmt.Sprintf("http://127.0.0.1:%d", ri.Port), token: token}
 			}
 		}
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-p.exited:
+			t.Fatalf("daemon exited after %s without serving its API (%s)\n--- daemon.log tail ---\n%s",
+				time.Since(start).Round(time.Millisecond), p.status(), daemon.LogTail(dataDir, 20))
+		default:
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(pollInterval)
 	}
-	t.Fatal("daemon did not become healthy within 30s")
+	t.Fatalf("daemon did not become healthy within %s (%s)\n--- daemon.log tail ---\n%s",
+		budget, p.status(), daemon.LogTail(dataDir, 20))
 	return nil
 }
 

--- a/internal/cli/racebuild_norace_test.go
+++ b/internal/cli/racebuild_norace_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package cli
+
+// raceEnabled reports whether this test binary is race-instrumented. See the
+// `race` half of this pair.
+const raceEnabled = false

--- a/internal/cli/racebuild_race_test.go
+++ b/internal/cli/racebuild_race_test.go
@@ -1,0 +1,9 @@
+//go:build race
+
+package cli
+
+// raceEnabled reports whether this test binary is race-instrumented. It comes
+// from the build rather than from an environment guess, because there is no
+// environment variable that says so: `go test -race` sets the `race` build tag
+// and nothing else.
+const raceEnabled = true

--- a/internal/cli/waitdaemon_e2e_test.go
+++ b/internal/cli/waitdaemon_e2e_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/config"
+)
+
+// waitHelperEnv gates the child half of the test below. It is deliberately
+// not VINCENT_-prefixed: hermeticEnv strips that whole block (§8.5) from
+// every child this suite spawns, and the daemon the child starts must stay
+// hermetic while the flag itself survives.
+const waitHelperEnv = "E2E_WAIT_DAEMON_HELPER"
+
+// TestWaitDaemonAPIReportsWhyTheDaemonNeverCameUp is issue #340's regression
+// guard. waitDaemonAPI is the shared startup wait behind TestCrashRecoveryE2E
+// and TestBackupRestoreE2E; when its budget expires it reports only "daemon
+// did not become healthy within 30s" — no daemon log, no exit status — so a
+// timeout on CI is indistinguishable between "too slow under load" and "the
+// daemon died at startup". `daemon start` already solves this the right way
+// (internal/cli/daemon.go: the error carries daemon.LogTail(dirs.Data, 20));
+// the test helper diverged from it.
+//
+// The failure path calls t.Fatal, so it can only be observed from outside the
+// test that runs it: this re-execs the test binary against the child half and
+// reads its output. The child points the daemon at an unparseable config, so
+// the daemon logs "startup failed: invalid config" and exits within
+// milliseconds — a cause that is sitting in {data_dir}/logs/daemon.log the
+// whole time waitDaemonAPI is polling, and that the timeout throws away.
+func TestWaitDaemonAPIReportsWhyTheDaemonNeverCameUp(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWaitDaemonAPIOnADoomedDaemon$", "-test.v")
+	cmd.Env = append(hermeticEnv(), waitHelperEnv+"=1")
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("child test passed; it must fail, the daemon never serves\n%s", out)
+	}
+	if got := string(out); !strings.Contains(got, "startup failed: invalid config") {
+		t.Errorf("waitDaemonAPI gave up after %s naming no cause; the daemon log said why "+
+			"and the failure did not carry it:\n%s", elapsed, got)
+	}
+}
+
+// TestWaitDaemonAPIOnADoomedDaemon is the child half: it starts a daemon that
+// cannot come up and lets waitDaemonAPI fail. It always fails, which is why it
+// skips unless its parent asked for it.
+func TestWaitDaemonAPIOnADoomedDaemon(t *testing.T) {
+	if os.Getenv(waitHelperEnv) != "1" {
+		t.Skip("child half of TestWaitDaemonAPIReportsWhyTheDaemonNeverCameUp")
+	}
+	dataDir, cfgDir := t.TempDir(), t.TempDir()
+	// Unparseable YAML. The daemon builds its logger before it loads config
+	// (internal/daemon/daemon.go), so the reason reaches daemon.log and the
+	// process exits non-zero straight away.
+	bad := "listen: \"127.0.0.1:0\"\nagents: [unclosed\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(bad), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	startDaemonProcess(t, dataDir, cfgDir, "success")
+	waitDaemonAPI(t, dataDir)
+}

--- a/internal/cli/waitdaemon_e2e_test.go
+++ b/internal/cli/waitdaemon_e2e_test.go
@@ -64,6 +64,6 @@ func TestWaitDaemonAPIOnADoomedDaemon(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cfgDir, config.FileName), []byte(bad), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
-	startDaemonProcess(t, dataDir, cfgDir, "success")
-	waitDaemonAPI(t, dataDir)
+	p := startDaemonProcess(t, dataDir, cfgDir, "success")
+	waitDaemonAPI(t, dataDir, p)
 }


### PR DESCRIPTION
## Summary

`waitDaemonAPI` — the shared "wait for a freshly spawned daemon to serve its
API" helper behind `TestCrashRecoveryE2E` and `TestBackupRestoreRoundTripE2E` —
gave every daemon spawn a hardcoded 30 s and, when that expired, reported one
sentence carrying no evidence: not the daemon log, not the child's exit status,
not even whether the daemon process was still alive.

Two independent defects sat on the same twelve lines:

- **The budget was absolute; the load it competes with is not.** On the Windows
  `-race` leg `internal/cli` runs after `internal/api` (644 s) and
  `internal/taskrun` (614 s) in the same job, and 30 s stops being a margin —
  it was roughly the observed cost.
- **The failure was undiagnosable.** `internal/cli/daemon.go` already gets this
  right for the user-facing `daemon start`: its timeout error carries
  `daemon.LogTail(dirs.Data, 20)`. The test helper had diverged from that and
  threw the log away.

The second is why the first cost a full rerun of the slowest CI leg: nobody
could tell from the output whether the daemon was slow or dead.

### Root cause

`waitDaemonAPI` polled only `daemon.ReadRuntimeInfo` and `daemon.CheckHealth`.
It never looked at the child `*exec.Cmd` it was waiting on, so a daemon that
exited during startup — with its reason already written to
`{data_dir}/logs/daemon.log` — was polled for the full budget and then reported
as an anonymous timeout.

### What changed

All of it is in `internal/cli` test files.

- **Watch the child.** `startDaemonProcess` now returns a `daemonProc` that owns
  the single `exec.Cmd.Wait` (it is once-only, and these tests need the child's
  fate from several places at once: a kill that waits for the exit, a startup
  poll that has to notice a corpse, a cleanup that reaps whatever is left). The
  poll gives up the moment the child exits. This is not cosmetics — without it
  the regression guard below would pay the *scaled* budget on the slowest leg on
  every run, making CI worse rather than better. With it the guard takes ~1 s.
- **Report why.** Both failure paths now carry the elapsed time, the child's
  fate, and `daemon.LogTail(dataDir, 20)` — the same evidence `daemon start`
  already attaches — and print the budget actually used rather than a literal
  `30s`.
- **Scale the budget.** `daemonAPIBudget()` doubles for a race-instrumented
  build and doubles again on Windows: 30 s on Linux without `-race`, 120 s on
  the Windows race leg. `-race` is detected from a `race` build-tagged constant
  pair (`racebuild_race_test.go` / `racebuild_norace_test.go`), not from an
  environment guess — nothing in the environment reports it.

`internal/cli/daemon.go`'s `startTimeout = 10 * time.Second` is deliberately
untouched: that is a phase 1 decision about the user-facing `daemon start`
command, and the flake was in the test harness, which that decision does not
cover.

### The regression test

`internal/cli/waitdaemon_e2e_test.go` is committed first, in the form that was
run against the unfixed helper and observed to fail:

```
--- FAIL: TestWaitDaemonAPIReportsWhyTheDaemonNeverCameUp (30.66s)
    waitdaemon_e2e_test.go:47: waitDaemonAPI gave up after 30.65865925s naming
    no cause; the daemon log said why and the failure did not carry it:
        waitdaemon_e2e_test.go:68: daemon did not become healthy within 30s
```

`waitDaemonAPI` fails via `t.Fatal`, so its failure path is only observable from
outside the test that runs it: the guard re-execs the test binary against a
child test that points the daemon at unparseable YAML. The daemon builds its
logger before it loads config, so it writes `startup failed: invalid config` to
`{data_dir}/logs/daemon.log` and exits non-zero in about 100 ms. The parent
asserts that string appears in the child's output — which it can only do if the
helper's failure carries the log tail. If either half of the fix regresses (the
log tail dropped, or the child no longer watched so the poll times out
anonymously), that assertion goes red again.

Hermetic: no network, no real agent CLI, `t.TempDir()` for both dirs, and the
child half skips unless its parent sets `E2E_WAIT_DAEMON_HELPER=1`.

### Verification

- `go test ./...` — green.
- `go test -race ./internal/cli -run 'TestCrashRecoveryE2E|TestBackupRestoreRoundTripE2E|TestWaitDaemonAPI'`
  — green, which also exercises the `raceEnabled = true` branch and clears the
  new reaper goroutine's `p.err` handoff with the race detector.
- `golangci-lint run ./internal/cli/` under `GOOS=darwin`, `linux` and `windows`
  — 0 issues on each.
- The guard itself: 31.6 s red before the fix, 1.1 s green after.

Nothing here is platform-specific beyond the `runtime.GOOS` multiplier, and the
reproduction was run on macOS.

### Notes for the reviewer

- The regression test was **not** weakened. Its one assertion is unchanged. The
  second commit edits two lines of its child half — `startDaemonProcess` now
  returns a `daemonProc`, so the call site captures it and passes it to
  `waitDaemonAPI` — which is the mechanical consequence of the signature change,
  not a change to what is asserted.
- `backup_e2e_test.go` lost a `t.Cleanup(func() { _ = third.Process.Kill() })`
  rather than being adapted to the new type. `startDaemonProcess`'s own cleanup
  now kills and reaps unconditionally, so that line was a duplicate of it.
- No second bug found along the way.

## Related

Closes #340

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [ ] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
      not applicable: every line of this change is in a `_test.go` file. There
      is no behaviour a user of the binary can reach, so there is nothing for a
      changelog entry to describe.
- [ ] Affected page under `docs/` updated — not applicable: no page tracks the
      e2e test harness. The config reference, CLI page, API page, TUI key tables
      and block reasons are all untouched. `docs/spec.md` needs no amendment
      either: §12.4 (crash recovery) and §12.1 (foreground start) govern the
      behaviour under test and both remain true — the spec says nothing about
      test-harness wall-clock budgets, so this is a defect in the suite, not a
      code/spec mismatch.
