### PR TITLE
Add a config switch over the automatic usage-limit wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,39 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **`usage_limit_auto_continue` — a switch over the automatic usage-limit
+  wait.** When an agent CLI reports that the account's quota for the window is
+  spent, vincent parks the task and re-runs the step by itself. That is still
+  the default and nothing changes for anyone who leaves it alone. The new
+  top-level key in `config.yaml` decides whether it happens at all:
+
+  | value | a recognized quota stop … |
+  |---|---|
+  | `always` (default) | waits the window out and re-runs the step unattended, exactly as before |
+  | `reported_only` | waits when the CLI actually named a reset time; **blocks** when the wait would be the [`usage_limit_recheck_interval`](docs/reference/configuration.md#usage_limit_recheck_interval) estimate |
+  | `never` | always blocks |
+
+  Blocking costs nothing: the task stops at the step it was on with
+  `block_reason: usage_limit`, the attempt is still recorded `interrupted`, and
+  **no retry is consumed** — press `r` once the window reopens and the step
+  re-runs with a full budget.
+
+  The reason to turn it down is that a quota wall is recognized from the CLI's
+  *wording*, and a stop recognized wrongly re-queues itself and spends money on
+  the next attempt with nobody watching. `never` stops that at the first
+  occurrence; `reported_only` blocks exactly the stops where vincent was
+  guessing at the window and keeps unattended recovery for the ones where the
+  CLI said when it reopens.
+
+  Editable everywhere the daemon's configuration is: `GET`/`PATCH /v1/config`,
+  `vincent config get|set usage_limit_auto_continue`, and the daemon view's
+  config editor as a three-way chooser. Read at the moment of the stop, so a
+  hot reload reaches the next one without a restart; a task **already** waiting
+  keeps its wait and meets the new mode at the next stop. The spent window still
+  reaches `GET /v1/agents` and the board's agent badge in every mode, so the
+  board can always say why a task stopped. Only claude recognizes a spent quota
+  at all, so the key is inert on codex and cursor.
+
 - **An in-progress indicator, for as long as the work is actually running.**
   A moving braille frame and an elapsed clock — `⠋ working… 14s` — now say that
   an agent is working, on all four surfaces that used to go silent while it did:

--- a/docs/features.md
+++ b/docs/features.md
@@ -157,6 +157,10 @@ retry. Every attempt also keeps a durable JSONL transcript.
 When Claude Code reports a usage limit, vincent treats it as a temporary wait
 instead of a failure: the task returns to the queue without consuming a retry or
 slot, shows its next admission time, and starts again when the window reopens.
+`usage_limit_auto_continue` decides whether that happens unattended — wait
+always, wait only when the CLI actually named a reset time, or stop and tell
+you. Stopping costs nothing: the attempt still consumes no retry, so a retry
+once the window reopens starts with a full budget.
 
 A step that fails on something transient can borrow the same wait. Give it
 `retry_backoff: 30s` and its retry is paced rather than immediate: the task

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -93,7 +93,7 @@ The most capable adapter, and the only one that can be interrupted mid-step.
   burning a real quota window), and vincent will not guess at one, because a
   wrong guess parks a genuinely failed task in a wait it never leaves. On those
   two, both conditions still read as `agent_error` or `nonzero_exit`. See
-  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing).
+  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing-unless-you-asked-to-be-told).
 - **Reports its remaining quota, but only by pushing.** There is no usage
   subcommand to poll; what Claude Code has is a status line, which it hands both
   usage windows on every render.
@@ -447,7 +447,7 @@ reported reading is rendered from. A reading wins where there is one, so:
 
 The warning is advisory. The form still submits, admission is unchanged, and a
 task queued against a spent window simply parks on the ordinary
-[`usage_limit` wait](troubleshooting.md#usage_limit--do-nothing) — or blocks
+[`usage_limit` wait](troubleshooting.md#usage_limit--do-nothing-unless-you-asked-to-be-told) — or blocks
 there, if
 [`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
 says not to wait. Since only claude recognizes a quota stop at all, that key is

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -84,8 +84,10 @@ The most capable adapter, and the only one that can be interrupted mid-step.
   means [`max_task_cost_usd`](../reference/configuration.md#max_task_cost_usd)
   can only stop a task that ran on claude.
 - **Recognizes a spent usage quota and a logged-out CLI** in the output of a run
-  that failed. A quota stop becomes `usage_limit` — no retry consumed, the task
-  waits and re-runs itself — and a logged-out CLI becomes
+  that failed. A quota stop becomes `usage_limit` — no retry consumed, and by
+  default the task waits and re-runs itself, though
+  [`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+  can make it block for you instead — and a logged-out CLI becomes
   `agent_unauthenticated`, which blocks with the fix named. Codex and cursor do
   neither: their wordings have not been captured from a real run (doing so means
   burning a real quota window), and vincent will not guess at one, because a
@@ -445,7 +447,11 @@ reported reading is rendered from. A reading wins where there is one, so:
 
 The warning is advisory. The form still submits, admission is unchanged, and a
 task queued against a spent window simply parks on the ordinary
-[`usage_limit` wait](troubleshooting.md#usage_limit--do-nothing). The next
+[`usage_limit` wait](troubleshooting.md#usage_limit--do-nothing) — or blocks
+there, if
+[`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+says not to wait. Since only claude recognizes a quota stop at all, that key is
+inert on the other two, exactly as the table above says. The next
 successful step on that adapter retires the **observation** — and only the
 observation, since a step completing proves the wall vincent watched has come
 down and proves nothing about a percentage a vendor reported — so an estimate is

--- a/docs/guides/scripting.md
+++ b/docs/guides/scripting.md
@@ -22,8 +22,10 @@ That loop is the answer to the failure this guide exists for. An agent
 credential expires, every task that reaches an agent step fails its retry budget
 and blocks on `agent_unauthenticated`, and no amount of waiting helps: someone
 has to fix the login and then move each task. (`usage_limit` is deliberately
-*not* this case — it is a queued reason, never a block reason, and the scheduler
-re-admits on its own.)
+*not* this case by default — it is a queued reason and the scheduler re-admits
+on its own. It reaches a loop like this one only where
+[`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+says not to wait, and then it is a block reason like any other.)
 
 The same loop with a different verb does the other batches — archiving a day's
 finished work, or running one more command in each of several finished tasks'

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -569,7 +569,7 @@ The block reason names what happened:
 | `agent_error` | The agent's own event stream reported an error |
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
 | `agent_unauthenticated` | The agent CLI is installed but not logged in (see below) |
-| `usage_limit` | The agent's usage quota for the window is spent — **not** a failure; the task waits and re-runs itself (see below) |
+| `usage_limit` | The agent's usage quota for the window is spent — **not** a failure. By default the task waits and re-runs itself; with [`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue) turned down it blocks here instead (see below) |
 | `retry_backoff` | Not a block reason: it is what a task shows while a step's [`retry_backoff`](../reference/workflow-schema.md#step-fields) paces the next attempt (see below). The failure itself keeps its own reason |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |
@@ -593,10 +593,10 @@ The block reason names what happened:
 the agent claimed was done. Read the step's transcript, then `E` to edit the
 prompt and retry with better instructions.
 
-### `usage_limit` — do nothing
+### `usage_limit` — do nothing, unless you asked to be told
 
 The agent CLI stopped because your account's usage quota for the current window
-is spent. Vincent treats this as a wait, not a failure:
+is spent. By default vincent treats this as a wait, not a failure:
 
 - the attempt is recorded `interrupted` and consumes **no** retry;
 - the task goes back to `queued` and **gives up its concurrency slot**, so other
@@ -612,6 +612,21 @@ know your plan's window, set that knob to match it.
 
 If you would rather not wait, cancel the task, or pause and resume it to try
 again immediately — any human action drops the wait.
+
+**If it is blocked here instead of waiting**, someone turned
+[`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+down from its default. `never` blocks every quota stop; `reported_only` blocks
+the ones where the CLI named no reset time and vincent would have been guessing
+at the window. Nothing is lost: the attempt is still `interrupted`, no retry was
+consumed, and the task is still on the step it stopped at — press `r` once the
+window reopens and the step re-runs with a full budget. The board's agent badge
+still names the window, so you can see what you are waiting for.
+
+The reason to turn it down: vincent recognizes a spent quota from the CLI's
+*wording*, and a stop it recognized wrongly would otherwise re-queue itself and
+spend money on the next attempt with nobody watching. If you have seen a task
+that keeps re-running against a quota that is plainly not spent, that is the
+switch.
 
 **The daemon remembers which adapter it was.** A human action drops the task's
 own wait, but the observation is per adapter and outlives it: the board header
@@ -646,7 +661,7 @@ The difference is the cost, and it is the thing to read the row for:
 | The attempt | `interrupted` | `failed`, with the reason it actually failed with |
 | Retry budget | untouched | one spent |
 | What ends the wait | the quota window reopening | the configured duration elapsing |
-| If it keeps happening | it waits again, indefinitely | the budget runs out and the task **blocks** with the step's own reason |
+| If it keeps happening | it waits again, indefinitely — unless `usage_limit_auto_continue` says to block | the budget runs out and the task **blocks** with the step's own reason |
 
 So a task that keeps reappearing on `retry_backoff` is a task on its way to
 being blocked — the transcripts of the attempts already made are what say why.

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -82,7 +82,7 @@ Three behaviors matter:
   `queued → 14:20`, the time vincent will try it again, on its own. It holds no
   slot and needs nothing from you; the detail header names the reason in full
   (`queued · usage limit → 14:20`, `queued · retry backoff → 14:20`). See
-  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing) and
+  [Troubleshooting](troubleshooting.md#usage_limit--do-nothing-unless-you-asked-to-be-told) and
   [`retry_backoff`](troubleshooting.md#retry_backoff--also-do-nothing-but-for-a-different-reason).
 - **The header badges the agent, not just the task.** An adapter vincent has
   watched run out reads `claude ⏳14:20` in place of `claude ✓`, and stays that
@@ -950,9 +950,12 @@ branch name, priority and agent — above the create action](../assets/tui-new-t
 
 The agent row warns when the adapter the task would run on is out of quota —
 `· usage limit until 14:20`, from the same quota the board header badges.
-It **warns and nothing else**: the form submits, and the task waits its turn on
-the ordinary [`usage_limit` hold](troubleshooting.md#usage_limit--do-nothing) if
-the window is still shut when it is admitted.
+It **warns and nothing else**: the form submits, and the task meets the ordinary
+[`usage_limit` stop](troubleshooting.md#usage_limit--do-nothing-unless-you-asked-to-be-told) if
+the window is still shut when it is admitted — waiting it out, or blocking
+there where
+[`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+says not to wait.
 
 The override pickers are fed by live adapter data, tagged with where each option
 came from, and always accept free text. They are windowed and filterable — you

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1995,7 +1995,9 @@ What follows from that:
 Three more bounds worth knowing when a run behaves oddly:
 `transcript_max_bytes` (512MB per attempt, then `transcript_limit`);
 `usage_limit`, which is not a failure — the task waits `queued` until the
-agent's quota window reopens, consuming no retry; and
+agent's quota window reopens, consuming no retry, unless
+[`usage_limit_auto_continue`](../reference/configuration.md#usage_limit_auto_continue)
+says to block for you instead; and
 [`max_task_cost_usd`](../reference/configuration.md#max_task_cost_usd), off by
 default, which blocks a task with `cost_limit` once its spend across every
 attempt passes a ceiling you set. That last one counts **one task**, so each

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -112,11 +112,14 @@ max_task_cost_usd: 0
 usage_limit_recheck_interval: 15m
 
 # What a recognized usage-limit stop does: always | reported_only | never.
-# always waits the window out, which is the behaviour every version before this
-# key had. reported_only waits only when the CLI actually named a reset time,
-# and blocks when the wait would be the estimate above. never always blocks.
-# Only claude recognizes a spent quota at all, so this is inert on codex and
-# cursor.
+# always holds the task — it returns to the queue, waits out the reset and
+# consumes no retry — and is today's behaviour, so leaving this alone changes
+# nothing. reported_only holds only when the CLI actually named a reset time,
+# and blocks when the wait would be the estimate above — the case where
+# vincent is guessing. never always blocks.
+#
+# Only claude reports a spent quota at all; codex and cursor recognize no such
+# wording, so this key is inert on them.
 usage_limit_auto_continue: always
 
 # Daemon log verbosity: debug | info | warn | error.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,6 +111,14 @@ max_task_cost_usd: 0
 # the queue and holds no slot while it waits.
 usage_limit_recheck_interval: 15m
 
+# What a recognized usage-limit stop does: always | reported_only | never.
+# always waits the window out, which is the behaviour every version before this
+# key had. reported_only waits only when the CLI actually named a reset time,
+# and blocks when the wait would be the estimate above. never always blocks.
+# Only claude recognizes a spent quota at all, so this is inert on codex and
+# cursor.
+usage_limit_auto_continue: always
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 
@@ -655,6 +663,52 @@ of the step's retry budget. See
 Must be positive. There is no exponential backoff; if you know your plan's
 window, set this to match it. Hot-reloaded, so a change applies to the next
 task that hits a limit.
+
+Whether the wait happens at all is
+[`usage_limit_auto_continue`](#usage_limit_auto_continue) below. This value
+keeps its meaning in every mode — it is the estimate vincent falls back to when
+the CLI named nothing — even where it no longer times a wait.
+
+### `usage_limit_auto_continue`
+
+```yaml
+usage_limit_auto_continue: always
+```
+
+Whether a recognized usage-limit stop is waited out or handed to you. One of
+three values:
+
+| value | a recognized quota stop … |
+|---|---|
+| `always` (default) | waits: the task returns to the queue, holds no slot, and is tried again when the window reopens |
+| `reported_only` | waits when the CLI actually named a reset time; **blocks** when the wait would be the [`usage_limit_recheck_interval`](#usage_limit_recheck_interval) estimate |
+| `never` | always blocks |
+
+`always` is what every version before this key did, so leaving it alone changes
+nothing.
+
+When it blocks, the task goes `blocked` with `block_reason: usage_limit` at the
+step it was on. The attempt is still recorded `interrupted`, still consumes
+**none** of the step's retry budget, and the step is not advanced past — press
+`retry` once the window reopens and it re-runs with a full budget. See
+[Task lifecycle](task-lifecycle.md#block-reasons).
+
+Turn it down when you would rather be told than waited for. vincent recognizes
+a spent quota by the CLI's wording, and a stop it recognized *wrongly* would
+otherwise re-queue itself and spend money on the next attempt, unattended.
+`never` stops that at the first occurrence. `reported_only` is the middle
+ground: it blocks exactly the stops where vincent is guessing at the window,
+and keeps the unattended recovery for the ones where the CLI said when it
+reopens.
+
+The mode is read at the moment of the stop, so a hot reload reaches the next
+one without a restart. A task **already waiting** keeps its wait: it is tried
+once more, and meets the new mode at the next stop. The spent window still
+reaches [`GET /v1/agents`](api.md) and the board's agent badge in every mode —
+that is how you see why a task just blocked.
+
+Only claude recognizes a spent quota at all, so this key is inert on codex and
+cursor. See [Agents](../guides/agents.md).
 
 ### `parallel`
 

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -84,12 +84,13 @@ Two reasons produce that wait, and they are worth telling apart:
 
 | `queued_reason` | What it means |
 |---|---|
-| `usage_limit` | The agent's usage quota for the window is spent. The attempt is recorded `interrupted` and costs **no** retry; the wait ends at the reset the CLI named, or after [`usage_limit_recheck_interval`](configuration.md#usage_limit_recheck_interval) when it named none |
+| `usage_limit` | The agent's usage quota for the window is spent. The attempt is recorded `interrupted` and costs **no** retry; the wait ends at the reset the CLI named, or after [`usage_limit_recheck_interval`](configuration.md#usage_limit_recheck_interval) when it named none. Whether there is a wait at all is [`usage_limit_auto_continue`](configuration.md#usage_limit_auto_continue) — under `never`, and under `reported_only` when the CLI named no reset, the task blocks instead |
 | `retry_backoff` | The step failed and its next attempt is being paced by [`retry_backoff`](workflow-schema.md#step-fields). The attempt is recorded `failed` with its own reason and **does** consume a retry; the wait is the configured duration. When the budget runs out the task blocks with the step's own reason, with no wait first |
 
-Both are `queued_reason` values only. Neither is ever a `block_reason`, and
-`retry_backoff` is never a step's failure reason either — the step's row keeps
-whatever actually failed.
+`retry_backoff` is a `queued_reason` only, and is never a step's failure reason
+either — the step's row keeps whatever actually failed. `usage_limit` is a
+`queued_reason` in the default mode and a `block_reason` in the modes that do
+not wait; it names the same condition either way.
 
 **`awaiting_children` holds no slot, and offers `cancel` and `retry`.** A fan-out
 parent waiting on its lanes owns no process, so keeping a slot would starve
@@ -275,7 +276,7 @@ same thing wherever it originated.
 | `agent_error` | The agent's event stream reported an error |
 | `agent_unavailable` | The adapter's CLI could not be resolved or started |
 | `agent_unauthenticated` | The agent CLI is installed but not logged in. Retries as usual, then blocks — log in and retry |
-| `usage_limit` | The agent's usage quota for the window is spent. **Not a failure:** no retry is consumed, and the task waits `queued` until the window reopens |
+| `usage_limit` | The agent's usage quota for the window is spent. **Not a failure:** no retry is consumed. In the default mode the task waits `queued` until the window reopens and this is never a `block_reason`; under [`usage_limit_auto_continue`](configuration.md#usage_limit_auto_continue) `never`, and under `reported_only` when the CLI named no reset, it blocks instead — at the step it was on, cursor unmoved, attempt still `interrupted`, so a `retry` once the window reopens re-runs the step with a full budget |
 | `retry_backoff` | Not a failure reason at all, and never appears on a step run — it is the `queued_reason` of a task waiting out a step's [`retry_backoff`](workflow-schema.md#step-fields) between two attempts. The attempt that triggered it keeps its own reason |
 | `timeout` | The attempt exceeded its `timeout` and was killed |
 | `input_timeout` | A mid-run question went unanswered past `input_timeout` |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -917,6 +917,26 @@ stdout/stderr are captured to the step transcript.
   between attempts a walled step would otherwise spend its whole budget in
   seconds. `usage_limit` is therefore a `queued_reason`, never a `block_reason`.
   Recovery needs no human: the scheduler re-admits the task when the hold expires.
+
+  *Amended 2026-09-08 (task 091).* The wait now has an off switch, so the two
+  sentences above hold only in the default mode.
+  `usage_limit_auto_continue` (§12.3) selects what a recognized quota stop
+  does: `always` — the default, and everything described above — holds and
+  re-queues; `reported_only` holds only when the CLI actually named a reset
+  time and **blocks** when the wait would be the
+  `usage_limit_recheck_interval` estimate; `never` always blocks. Where it
+  blocks, the task stops at the step it is on with `block_reason:
+  usage_limit` and waits for a human retry. `usage_limit` is therefore a
+  `queued_reason` *or* a `block_reason` depending on the mode — it names the
+  same condition either way, which is why no second reason was minted for it
+  and why the vocabulary `internal/taskrun` and `internal/worktree` share
+  stays single. Everything else in this bullet is unchanged in every mode:
+  the attempt is still recorded `interrupted`, it still consumes **no**
+  retry, the cursor does not advance, and the observation still reaches
+  §14's per-adapter record so the board can say why the task stopped. The
+  block is taken in the *interrupted* arm of the engine's outcome switch,
+  above the failed arm, so the `allow_failure` bullet below never reaches
+  it: an account out of quota is not a result a workflow may branch on.
 - **`retry_backoff` paces the retries.** *Added 2026-08-25 (task 028).* A step
   may carry `retry_backoff`, a duration, settable per step and in
   `defaults:`. Its default is **zero**, which is an immediate retry — every
@@ -3912,7 +3932,12 @@ Two consequences are handled rather than assumed away:
   §7.2's: `usage_limit`, and — *added 2026-08-25 (task 028)* — `retry_backoff`,
   the wait between two attempts of a step that asked for one. The pair of
   columns is generic, which is why the second producer cost no migration, no
-  second branch in this walk and no client change. The walk applies the three checks **in this order**:
+  second branch in this walk and no client change. *Amended 2026-09-08 (task
+  091):* `usage_limit` is a producer only in the modes that hold — under
+  `usage_limit_auto_continue: never`, and under `reported_only` when the CLI
+  named no reset, a quota stop blocks the task (§7.2) and writes no hold at
+  all. `retry_backoff` is unconditional. Either way this walk is unchanged: a
+  stop that produced no hold never reaches it. The walk applies the three checks **in this order**:
   1. **pause** — a pending pause parks the task, held or not. This runs first
      because a human asked for `paused`, and a task showing `queued` until a hold
      expired would be the same lie the cap check already avoids. It is also why
@@ -4402,6 +4427,7 @@ transcript_retention_days: 90   # transcripts of *archived* tasks older than thi
 transcript_max_bytes: 512MB     # per-run transcript cap (§18); past it the step fails `transcript_limit`
 max_task_cost_usd: 0            # per-task spend ceiling (§17, §18); 0 = no cap
 usage_limit_recheck_interval: 15m  # how long a quota-held task waits when the CLI named no reset (§11)
+usage_limit_auto_continue: always  # what a quota stop does: always | reported_only | never (§7.2)
 parallel:
   max_parallel: 4            # sub-steps of one `parallel` group at once (§7.5); the §11 caps do not see these
 log_level: info
@@ -4599,6 +4625,41 @@ resolved configuration at the moment of the wait, so it carries no per-task
 state either, and it is §7.2's concept rather than a second one beside it. It
 has no key in this file for the same reason `max_retries` has none: retry
 policy is a workflow's business, and `defaults:` here is timeouts.
+
+**`usage_limit_auto_continue` (task 091, added 2026-09-08).** Whether a
+recognized quota stop is waited out or handed to a human. One of three values,
+default `always`:
+
+| value | a recognized quota stop … |
+|---|---|
+| `always` | holds and re-queues the task, exactly as §7.2 describes. The behaviour of every version before this key, so no existing installation changes |
+| `reported_only` | holds when the adapter parsed a reset the CLI actually named; **blocks** when the wait would be the `usage_limit_recheck_interval` estimate |
+| `never` | blocks |
+
+Blocking means `blocked` with `block_reason: usage_limit` at the step the task
+is on, cursor unmoved, attempt still `interrupted`, **no** retry consumed — the
+shape `cost_limit` takes. A human retry re-runs the step with a full budget.
+
+It exists because the classification can be wrong. An adapter recognizes a
+quota wall by wording (§9.1), and a stop the daemon merely guessed at re-queues
+unattended and spends money on the next attempt; `never` stops that at the
+first occurrence, and `reported_only` stops exactly the guessed class while
+keeping the unattended recovery the feature was built for. A tri-state rather
+than a boolean for that middle value alone. Overloading
+`usage_limit_recheck_interval: 0` was rejected — zero is already invalid
+because it re-admits on the next tick, and one key would then mean both "how
+long" and "whether".
+
+The mode is read at the moment of the stop, the way the interval beside it is,
+so a hot reload reaches the next quota stop rather than the next daemon
+restart. A hold **already in flight is not converted**: the task keeps it, is
+re-admitted once, and meets the new mode at the next stop. The per-adapter
+observation (§14) is recorded in every mode, estimate included, so the board
+never disagrees with itself about a spent window — which means
+`usage_limit_recheck_interval` keeps a meaning in every mode: it is the
+estimate, even where it times no wait. Claude-only in effect, since it is the
+only adapter that recognizes the wording at all (§9.1); inert on codex and
+cursor.
 
 **`max_task_cost_usd` (task 033, added 2026-08-26).** A ceiling, in US dollars,
 on what **one task** may spend — the §17 rollup of `cost_usd` over every attempt
@@ -8792,7 +8853,7 @@ else.
 | Model/effort unknown to the catalog | Validation warning only; the CLI is the final authority — a rejected value fails the step with the CLI's error (retry policy applies) |
 | Model *in* the catalog but rejected at run time | Real, not hypothetical, on cursor (§9.7): the step fails with the stderr tail as the message, since no `result` event arrives. Catalog membership is advisory in both directions |
 | Agent CLI installed but not authenticated | `logged_in: false` where the adapter can tell (§9.5); the new-task form flags it like an unavailable agent. Where it cannot (`null`), the step runs and fails. *Amended 2026-08-14 (task 003):* where the adapter recognizes the CLI's auth wording, that failure is now named `agent_unauthenticated` instead of surfacing as `nonzero_exit`/`agent_error`. Everything else about the row is unchanged and deliberately so — the step still runs, the attempt still fails, the §7.2 budget still applies, and the task still ends up blocked. There is no pre-flight refusal on `logged_in: false`. *Amended 2026-08-15 (task 005):* the "where it cannot (`null`)" set is now **claude alone** — codex probes `login status`, cursor probes `status` (§9.5). Every other clause of this row stands untouched, task 003 decision 4 included: making the state visible is not the same as blocking on it, and `vincent doctor` is where a user sees it before a task burns its retry budget |
-| Agent stopped by a usage limit | *Added 2026-08-14 (task 003).* Where the adapter recognizes the wording, the attempt is recorded `interrupted` with reason `usage_limit`, consumes **no** retry (§7.2), and the task returns to `queued` with an admission hold (§11) — releasing its slot, so other work keeps running. The hold ends at the reset time the CLI reported, or `usage_limit_recheck_interval` after the stop when it reported none. Recovery is unattended: the scheduler re-admits and the step re-runs. The board says `queued` *with* its reason rather than `blocked` (§15). Where the adapter recognizes nothing — codex and cursor today (§9.1) — the run reads as `nonzero_exit`/`agent_error` exactly as before. *Amended 2026-08-24 (task 026):* the reset the engine acted on is additionally recorded per adapter (§14) and published on change (§13.3), so the fact outlives the hold — `admit_not_before` is cleared by the next transition out of `queued`, and until now the observation went with it. It is retired by the next successful agent step on that adapter, never by a timer. *Amended 2026-09-08:* the wording is only ever read from a run that **failed** (§9.1) — a step that succeeded while writing about quota stops is a success, not a wall |
+| Agent stopped by a usage limit | *Added 2026-08-14 (task 003).* Where the adapter recognizes the wording, the attempt is recorded `interrupted` with reason `usage_limit`, consumes **no** retry (§7.2), and the task returns to `queued` with an admission hold (§11) — releasing its slot, so other work keeps running. The hold ends at the reset time the CLI reported, or `usage_limit_recheck_interval` after the stop when it reported none. Recovery is unattended: the scheduler re-admits and the step re-runs. The board says `queued` *with* its reason rather than `blocked` (§15). Where the adapter recognizes nothing — codex and cursor today (§9.1) — the run reads as `nonzero_exit`/`agent_error` exactly as before. *Amended 2026-08-24 (task 026):* the reset the engine acted on is additionally recorded per adapter (§14) and published on change (§13.3), so the fact outlives the hold — `admit_not_before` is cleared by the next transition out of `queued`, and until now the observation went with it. It is retired by the next successful agent step on that adapter, never by a timer. *Amended 2026-09-08:* the wording is only ever read from a run that **failed** (§9.1) — a step that succeeded while writing about quota stops is a success, not a wall. *Amended 2026-09-08 (task 091):* all of the above is what `usage_limit_auto_continue: always` — the default — does. Under `never`, and under `reported_only` when the CLI named no reset, the same stop **blocks** the task instead with `block_reason: usage_limit` (§7.2, §12.3): the attempt is still `interrupted` and still costs no retry, the cursor does not advance, and a human retry re-runs the step |
 | `effort` set on a step whose agent has no effort concept | Ignored by the adapter and documented as ignored (cursor, §9.7); a claude/codex effort value on a cursor step is already an §8.2 *error* — it belongs to another adapter's catalog |
 | `restricted` step on an adapter that cannot restrict on this OS | Step fails to start with `restricted_unsupported` (cursor on Windows, §9.7), under the retry policy → typically blocked. Never downgraded to full-auto, and deliberately *not* `agent_unavailable`: the CLI is installed and healthy, so "not found" would send the user to reinstall what is already there. *Amended 2026-08-28 (task 041):* **task creation refuses these** with a `400` naming the step and the agent (§9.4), and `GET /v1/agents` publishes the `restricted_verdict` the gate uses. Reaching the engine anyway means the task and its daemon parted company — a data directory carried to Windows, or a workflow edited after the task was queued — so the reason above stays exactly as it is, as the backstop. Retries are not gated: enforcement is creation-time, and the backstop is what catches the rest |
 | Step declaring `on_input: require` on an agent that cannot ask | *Added 2026-08-17 (task 013).* A workflow pinning an adapter with no control channel (codex, cursor) fails §8.2 validation outright. Otherwise creation is refused with a `400` naming the step and the agent, and the TUI's picker will not select that agent; `GET /v1/agents` publishes the `input_verdict` the gate uses. A task that reaches the engine anyway — claude upgraded past the §9.3 ceiling, a data directory moved — fails the attempt with `input_unsupported` under the §7.2 budget, before anything is spawned. Only a positive "cannot" refuses: an absent or unprobed binary is unknown, and unknown never blocks (§9.6) |

--- a/docs/tasks/091-usage-limit-auto-continue.md
+++ b/docs/tasks/091-usage-limit-auto-continue.md
@@ -1,0 +1,157 @@
+# 091 — `usage_limit_auto_continue`: an operator control over the quota wait
+
+**Status:** ✅ done (5/5)
+**Issue:** #348
+**Amends:** §7.2 — the usage-limit bullet's "`usage_limit` is therefore a
+`queued_reason`, never a `block_reason`" becomes conditional on the mode; §11 —
+the admission-holds paragraph's "two producers", where `usage_limit` is one only
+in the modes that hold; §12.3 — the new key beside
+`usage_limit_recheck_interval`, and the generated `config.yaml` sample; §18 —
+the "Agent stopped by a usage limit" row
+**Keeps, without relitigating:** [003](003-usage-limit-classification.md)
+decision 1 — a *queued* task still never carries a `block_reason`; what changes
+is that a quota stop may produce a `blocked` task instead of a queued one, which
+is a different thing from overloading the reason on a held row.
+[003](003-usage-limit-classification.md) decision 3 and
+[028](028-retry-backoff.md)'s beat — still no exponential backoff and still no
+per-task hold state; a mode is resolved configuration read at the stop, exactly
+as the interval is. [003](003-usage-limit-classification.md) decision 2 —
+codex and cursor still recognize no quota wording, so this key is inert on them
+
+Task 003 built the wait and nothing since built a way out of it.
+`usage_limit_recheck_interval` tunes how long a task waits when the CLI named no
+reset; it is validated positive, so it cannot say "do not wait", and
+`max_task_cost_usd` defaults off and only stops a loop after the money is spent.
+
+That gap matters because the classification can be wrong. An adapter recognizes
+a quota wall by *wording* (§9.1), and the incident behind #348 was a claude run
+that succeeded and was read as a quota stop anyway: the step was drafting text
+about quota handling, quoted the marker list back in its final message, and
+matched itself. It re-queued behind a fresh estimate, re-drafted the same text,
+matched again — three attempts and roughly $2.85 before a human looked. The
+misclassification itself is a separate fix; this work is the operator control
+that would have stopped the loop at the first occurrence without patching the
+daemon.
+
+## Tasks
+
+- [x] **091.1** `usage_limit_auto_continue` in `internal/config`: the field
+  beside `UsageLimitRecheckInterval`, the `always` default, enum validation
+  modelled on `log_level`'s, and the commented entry in the generated
+  `config.yaml`.
+- [x] **091.2** The engine: `usageLimitStop` computes the effective reset,
+  records the per-adapter observation and answers hold-or-block;
+  `holdForUsageLimit` writes only the hold it was told to write, and the block
+  is the caller's `fail` with `ReasonUsageLimit`. `runRepair` takes the same
+  decision and routes to `finishRepair` where it says not to wait.
+- [x] **091.3** The clients: `GET`/`PATCH /v1/config`, the `apiclient` wire
+  types, `vincent config get|set`, and a `kindEnum` key in the TUI daemon view.
+- [x] **091.4** `scripts/m2-gate.sh` scenario 13: `never` against a CLI that
+  named no reset blocks, `reported_only` against one that did still holds.
+- [x] **091.5** The spec amendments above, the configuration, task-lifecycle,
+  troubleshooting, agents and features pages, and the changelog.
+
+## Decisions
+
+### 1. A tri-state enum, not the boolean the issue proposed
+
+*2026-09-08.* `always | reported_only | never`, default `always`.
+
+The incident that motivated the issue had **no CLI-reported reset**: prose
+matched the marker list and the hold was the 15-minute estimate.
+`reported_only` blocks exactly that class of stop — the one where vincent is
+guessing at the window — while keeping unattended recovery for the case the
+feature was built for, a CLI that names when it reopens. A boolean cannot
+express that split.
+
+The shape is cheap: `log_level` is the precedent for a validated string enum in
+`config.Validate`, `kindEnum` plus a `choices` var the precedent in
+`internal/tui/configkeys.go`, and `cmd/fakeagent` already drives both legs
+through `FAKEAGENT_USAGE_LIMIT_RESET`, so `reported_only` cost no new agent
+scenario.
+
+**Beat:** the boolean. It would have shipped a switch that is either "never
+recover unattended" or "keep the behaviour that spent the money", with nothing
+between them.
+
+**Beat:** letting `usage_limit_recheck_interval: 0` mean off. Zero is already
+invalid because it re-admits on the very next tick — the respawn loop task 003
+exists to stop — and overloading it would make one key mean both "how long" and
+"whether". A very large interval was beaten too: it leaves the task `queued`
+indefinitely under a reason that says a wait is in progress, while holding a
+queue position nobody was told about. `blocked` is the honest state for "this
+will not move without you".
+
+**Beat:** a consecutive-hold cap — block after N quota holds in a row on one
+step. It bounds a runaway without giving up auto-continue, but it is per-task
+state the row would have to carry, which is the objection decision 3 of task 003
+already raised against exponential backoff. Worth its own issue if the enum
+proves too blunt.
+
+### 2. Blocking reuses `usage_limit` rather than minting a second reason
+
+*2026-09-08.* §7.2 said `usage_limit` is "never a `block_reason`" and §11 named
+it as one of two admission-hold producers. An off switch makes it both, so one
+of those had to move: amend the two sentences, or block under a new reason.
+
+Amending is the better answer and it is what landed. The reason names the same
+condition either way — the account's window is spent — and
+`internal/taskrun` and `internal/worktree` share one reason vocabulary
+(T1.5/T1.6 decision). A second reason would make `usage_limit` mean "quota,
+waited" in one place and something else mean "quota, blocked" in another, for
+one condition, and every client that renders a reason would have to learn both.
+
+### 3. The block is taken in the *interrupted* arm, out of `allow_failure`'s reach
+
+*2026-09-08.* Both outcomes are decided in the `StepInterrupted` arm of the
+engine's outcome switch, above the `StepFailed` arm where `allowFailure` is
+consulted. §7.2's "`usage_limit` and `interrupted` are untouched by
+`allow_failure`" therefore stays literally true in every mode: a workflow must
+not be able to branch on "the account is out of quota" as though it were a test
+result.
+
+The attempt row is already `interrupted` from `finishStepRun`, so **no retry is
+consumed** in any mode — the same shape `cost_limit` takes
+([033](033-task-cost-cap.md)). The step did nothing wrong, and a human retrying
+after the window reopens starts with a full budget. The cursor does not advance
+either, so the retry re-runs the step it stopped at.
+
+### 4. The per-adapter observation is recorded in every mode
+
+*2026-09-08.* `recordUsageLimit` (task 026) runs before the hold-or-block
+decision, including for the `now + usage_limit_recheck_interval` estimate with
+`resets_at_reported: false`. That record is what puts the board badge and the
+`agent.quota_changed` event in front of the operator, and it is precisely how
+someone learns *why* a task just blocked. A config key must not be able to make
+the board disagree with itself.
+
+Consequence, accepted: `usage_limit_recheck_interval` keeps a meaning in every
+mode — it is the estimate — even where it no longer times a wait. Under
+`reported_only` that estimate is what separates a hold from a block.
+
+### 5. A quota stop during an ad-hoc repair restores the reason the task was blocked with
+
+*2026-09-08.* The issue's "`repair.go` reaches the same helper and needs no
+separate branch" is not quite true. `finishRepair` restores `req.BlockReason`
+deliberately, and the comment beside the cost cap in `runRepair` records the
+reasoning: the reason the task was blocked with says more than the reason the
+repair ran into.
+
+So the quota arm of `runRepair` gets one branch — hold in the modes that hold,
+`finishRepair` in the modes that block, request drained the way every finished
+repair drains it. The switch still does its job there: the repair does not
+re-run unattended.
+
+### 6. A mode flip does not convert holds already in flight
+
+*2026-09-08, recorded rather than fixed.* The mode is read at the moment of the
+stop, the way the interval already is, so a hot reload (§12.3) reaches the next
+quota stop rather than the next daemon restart. A task already sitting on a hold
+keeps it, is re-admitted once, and meets the new mode at the *next* stop. One
+wasted spawn — the same trade task 003 decision 1 recorded for pause-then-resume
+dropping a hold.
+
+Also recorded: **the default protects nobody by itself.** `always` is the
+default, so a fresh installation still auto-continues. What makes a runaway
+impossible is the classifier being right; this is the operator control, and it
+is not a substitute for that.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -104,6 +104,7 @@ the living engineering specification records implementation contracts.
 | [088](088-step-details-tab.md) | Record what each attempt was *given* — the rendered prompt, script, `check:`, `if:` and `for_each` list, plus the §8.6 provenance, the permission mode, the timeouts, the shell and the working directory — and read it back on a Step Details tab bound to `6`, moving Pull Request to `7` | ✅ done (3/3) |
 | [089](089-in-progress-indicator.md) | One animated in-progress indicator — a braille frame and an elapsed clock — for the chat workspace, the chats board, the task workspace's output pane and `vincent chat send` | ✅ done (1/1) |
 | [090](090-cascading-fan-out-retry.md) | One `retry` on a fan-out parent parked in `awaiting_children` re-admits every blocked descendant, without writing the parent's own row | ✅ done (5/5) |
+| [091](091-usage-limit-auto-continue.md) | `usage_limit_auto_continue`: whether a recognized quota stop waits the window out or blocks for a human | ✅ done (5/5) |
 
 ## How to add and update a task document
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -56,20 +56,24 @@ type configResponse struct {
 	// MaxTaskCostUSD is the per-task spend ceiling; 0 is no cap (task 033).
 	// Served for the same reason every other key is: the TUI reads no
 	// configuration from disk (§15).
-	MaxTaskCostUSD    float64            `json:"max_task_cost_usd"`
-	UsageLimitRecheck string             `json:"usage_limit_recheck_interval"`
-	LogLevel          string             `json:"log_level"`
-	Debug             bool               `json:"debug"`
-	Environment       configEnvironment  `json:"environment"`
-	Agents            configAgents       `json:"agents"`
-	Parallel          configParallel     `json:"parallel"`
-	FanOut            configFanOut       `json:"fan_out"`
-	Loop              configLoop         `json:"loop"`
-	Include           configInclude      `json:"include"`
-	MCP               configMCP          `json:"mcp"`
-	GitHub            configGitHub       `json:"github"`
-	Update            configUpdateStatus `json:"update"`
-	Notify            configNotify       `json:"notify"`
+	MaxTaskCostUSD    float64 `json:"max_task_cost_usd"`
+	UsageLimitRecheck string  `json:"usage_limit_recheck_interval"`
+	// UsageLimitAutoContinue is what a recognized quota stop does: hold and
+	// re-queue the task ("always"), hold only when the CLI named a reset time
+	// ("reported_only"), or block it outright ("never") — task 003.
+	UsageLimitAutoContinue string             `json:"usage_limit_auto_continue"`
+	LogLevel               string             `json:"log_level"`
+	Debug                  bool               `json:"debug"`
+	Environment            configEnvironment  `json:"environment"`
+	Agents                 configAgents       `json:"agents"`
+	Parallel               configParallel     `json:"parallel"`
+	FanOut                 configFanOut       `json:"fan_out"`
+	Loop                   configLoop         `json:"loop"`
+	Include                configInclude      `json:"include"`
+	MCP                    configMCP          `json:"mcp"`
+	GitHub                 configGitHub       `json:"github"`
+	Update                 configUpdateStatus `json:"update"`
+	Notify                 configNotify       `json:"notify"`
 	// Container is §16's container execution mode (task 061). Served like
 	// every other key: `image: ""` — the default — is what says the steps run
 	// on the host, and a client that could not see it could not tell a
@@ -240,6 +244,7 @@ func configBody(cfg config.Config) configResponse {
 		TranscriptMaxBytes:          cfg.TranscriptMaxBytes.Bytes(),
 		MaxTaskCostUSD:              cfg.MaxTaskCostUSD,
 		UsageLimitRecheck:           cfg.UsageLimitRecheckInterval.String(),
+		UsageLimitAutoContinue:      cfg.UsageLimitAutoContinue,
 		LogLevel:                    cfg.LogLevel,
 		Debug:                       cfg.Debug,
 		Environment: configEnvironment{
@@ -351,6 +356,7 @@ type configPatch struct {
 	TranscriptMaxBytes          *int64             `json:"transcript_max_bytes"`
 	MaxTaskCostUSD              *float64           `json:"max_task_cost_usd"`
 	UsageLimitRecheck           *string            `json:"usage_limit_recheck_interval"`
+	UsageLimitAutoContinue      *string            `json:"usage_limit_auto_continue"`
 	LogLevel                    *string            `json:"log_level"`
 	Debug                       *bool              `json:"debug"`
 	Environment                 *environmentPatch  `json:"environment"`
@@ -483,6 +489,7 @@ func (p configPatch) sets() []config.Set {
 		add("max_task_cost_usd", ftoa(*p.MaxTaskCostUSD))
 	}
 	addIfString(add, "usage_limit_recheck_interval", p.UsageLimitRecheck)
+	addIfString(add, "usage_limit_auto_continue", p.UsageLimitAutoContinue)
 	addIfString(add, "log_level", p.LogLevel)
 	addIfBool(add, "debug", p.Debug)
 	if e := p.Environment; e != nil {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -60,7 +60,7 @@ type configResponse struct {
 	UsageLimitRecheck string  `json:"usage_limit_recheck_interval"`
 	// UsageLimitAutoContinue is what a recognized quota stop does: hold and
 	// re-queue the task ("always"), hold only when the CLI named a reset time
-	// ("reported_only"), or block it outright ("never") — task 003.
+	// ("reported_only"), or block it outright ("never") — task 091.
 	UsageLimitAutoContinue string             `json:"usage_limit_auto_continue"`
 	LogLevel               string             `json:"log_level"`
 	Debug                  bool               `json:"debug"`

--- a/internal/api/config_patch_test.go
+++ b/internal/api/config_patch_test.go
@@ -300,7 +300,7 @@ func TestConfigPatchCoversEveryServedKey(t *testing.T) {
 }
 
 // usage_limit_auto_continue reaches a client only if it is on all three of
-// the served DTO, the response builder and the patch apply (task 003). A field
+// the served DTO, the response builder and the patch apply (task 091). A field
 // wired to two of the three still answers a GET and silently discards the
 // PATCH, so the round trip is asserted end to end rather than per field.
 func TestConfigPatchRoundTripsUsageLimitAutoContinue(t *testing.T) {

--- a/internal/api/config_patch_test.go
+++ b/internal/api/config_patch_test.go
@@ -159,6 +159,7 @@ func TestConfigPatchRejectionLeavesTheFileByteIdentical(t *testing.T) {
 		{"a host that is not loopback", `{"listen":"0.0.0.0:0"}`},
 		{"a cap below one", `{"max_parallel_tasks":0}`},
 		{"an unknown log level", `{"log_level":"chatty"}`},
+		{"a usage limit mode that is not one", `{"usage_limit_auto_continue":"sometimes"}`},
 		{"a duration that will not parse", `{"defaults":{"agent_timeout":"soon"}}`},
 		{"a branch template that does not compile", `{"branch_template":"vincent/{{.ID"}`},
 		{"a notify state that is not one", `{"notify":{"on":["exploded"]}}`},
@@ -295,6 +296,44 @@ func TestConfigPatchCoversEveryServedKey(t *testing.T) {
 	}
 	if len(missing) > 0 {
 		t.Errorf("GET /v1/config serves keys PATCH cannot change: %v", missing)
+	}
+}
+
+// usage_limit_auto_continue reaches a client only if it is on all three of
+// the served DTO, the response builder and the patch apply (task 003). A field
+// wired to two of the three still answers a GET and silently discards the
+// PATCH, so the round trip is asserted end to end rather than per field.
+func TestConfigPatchRoundTripsUsageLimitAutoContinue(t *testing.T) {
+	h := newConfigHarness(t)
+	_, getBody := doRequest(t, h.ts, http.MethodGet, "/v1/config", testToken)
+	if !strings.Contains(string(getBody), `"usage_limit_auto_continue"`) {
+		t.Fatalf("GET /v1/config does not serve the key at all: %s", getBody)
+	}
+	var served configResponse
+	if err := json.Unmarshal(getBody, &served); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if served.UsageLimitAutoContinue != config.UsageLimitAlways {
+		t.Errorf("served default = %q, want %q", served.UsageLimitAutoContinue, config.UsageLimitAlways)
+	}
+	for _, want := range []string{config.UsageLimitReportedOnly, config.UsageLimitNever, config.UsageLimitAlways} {
+		resp, body := h.patch(t, `{"usage_limit_auto_continue":"`+want+`"}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("patch %q: status = %d, want 200 (body %s)", want, resp.StatusCode, body)
+		}
+		var answered configResponse
+		if err := json.Unmarshal(body, &answered); err != nil {
+			t.Fatalf("parse patch response: %v", err)
+		}
+		if answered.UsageLimitAutoContinue != want {
+			t.Errorf("the patch response says %q, want %q", answered.UsageLimitAutoContinue, want)
+		}
+		if got := h.cur.Load().UsageLimitAutoContinue; got != want {
+			t.Errorf("the applied config says %q, want %q", got, want)
+		}
+		if !strings.Contains(string(h.bytes(t)), "usage_limit_auto_continue: "+want) {
+			t.Errorf("config.yaml does not carry %q:\n%s", want, h.bytes(t))
+		}
 	}
 }
 

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -148,19 +148,23 @@ type Config struct {
 	MaxTaskCostUSD float64 `json:"max_task_cost_usd"`
 	// UsageLimitRecheck is how long a quota-held task waits before the
 	// scheduler tries again, when the agent CLI reported no reset time (§11).
-	UsageLimitRecheck string            `json:"usage_limit_recheck_interval"`
-	LogLevel          string            `json:"log_level"`
-	Debug             bool              `json:"debug"`
-	Environment       ConfigEnvironment `json:"environment"`
-	Agents            ConfigAgents      `json:"agents"`
-	Parallel          ConfigParallel    `json:"parallel"`
-	FanOut            ConfigFanOut      `json:"fan_out"`
-	Loop              ConfigLoop        `json:"loop"`
-	Include           ConfigInclude     `json:"include"`
-	MCP               ConfigMCP         `json:"mcp"`
-	GitHub            ConfigGitHub      `json:"github"`
-	Update            ConfigUpdate      `json:"update"`
-	Notify            ConfigNotify      `json:"notify"`
+	UsageLimitRecheck string `json:"usage_limit_recheck_interval"`
+	// UsageLimitAutoContinue is what a recognized quota stop does: hold and
+	// re-queue ("always"), hold only when the CLI named a reset time
+	// ("reported_only"), or block the task ("never") — §11, task 003.
+	UsageLimitAutoContinue string            `json:"usage_limit_auto_continue"`
+	LogLevel               string            `json:"log_level"`
+	Debug                  bool              `json:"debug"`
+	Environment            ConfigEnvironment `json:"environment"`
+	Agents                 ConfigAgents      `json:"agents"`
+	Parallel               ConfigParallel    `json:"parallel"`
+	FanOut                 ConfigFanOut      `json:"fan_out"`
+	Loop                   ConfigLoop        `json:"loop"`
+	Include                ConfigInclude     `json:"include"`
+	MCP                    ConfigMCP         `json:"mcp"`
+	GitHub                 ConfigGitHub      `json:"github"`
+	Update                 ConfigUpdate      `json:"update"`
+	Notify                 ConfigNotify      `json:"notify"`
 	// Container is §16's container execution mode (task 061). Image empty is
 	// the default and means the steps run on this host.
 	Container ConfigContainer `json:"container"`
@@ -365,6 +369,7 @@ type ConfigPatch struct {
 	TranscriptMaxBytes          *int64                  `json:"transcript_max_bytes,omitempty"`
 	MaxTaskCostUSD              *float64                `json:"max_task_cost_usd,omitempty"`
 	UsageLimitRecheck           *string                 `json:"usage_limit_recheck_interval,omitempty"`
+	UsageLimitAutoContinue      *string                 `json:"usage_limit_auto_continue,omitempty"`
 	LogLevel                    *string                 `json:"log_level,omitempty"`
 	Debug                       *bool                   `json:"debug,omitempty"`
 	Environment                 *ConfigEnvironmentPatch `json:"environment,omitempty"`

--- a/internal/apiclient/daemon.go
+++ b/internal/apiclient/daemon.go
@@ -151,7 +151,7 @@ type Config struct {
 	UsageLimitRecheck string `json:"usage_limit_recheck_interval"`
 	// UsageLimitAutoContinue is what a recognized quota stop does: hold and
 	// re-queue ("always"), hold only when the CLI named a reset time
-	// ("reported_only"), or block the task ("never") — §11, task 003.
+	// ("reported_only"), or block the task ("never") — §7.2, §11, task 091.
 	UsageLimitAutoContinue string            `json:"usage_limit_auto_continue"`
 	LogLevel               string            `json:"log_level"`
 	Debug                  bool              `json:"debug"`

--- a/internal/apiclient/daemon_test.go
+++ b/internal/apiclient/daemon_test.go
@@ -97,7 +97,7 @@ func TestConfigCarriesTheSettingsInEffect(t *testing.T) {
 	}
 	// The §11 pair travels together: a client that can show the recheck
 	// interval and not the mode it applies under describes half a policy
-	// (task 003).
+	// (task 091, over task 003).
 	if cfg.UsageLimitRecheck != cfgDefault.UsageLimitRecheckInterval.String() {
 		t.Errorf("UsageLimitRecheck = %q, want %q",
 			cfg.UsageLimitRecheck, cfgDefault.UsageLimitRecheckInterval.String())

--- a/internal/apiclient/daemon_test.go
+++ b/internal/apiclient/daemon_test.go
@@ -95,4 +95,15 @@ func TestConfigCarriesTheSettingsInEffect(t *testing.T) {
 	if cfg.MCP.MaxTasks != cfgDefault.MCP.MaxTasks || cfg.FanOut.MaxDepth != cfgDefault.FanOut.MaxDepth {
 		t.Errorf("the sections the endpoint used to omit did not arrive: %+v", cfg)
 	}
+	// The §11 pair travels together: a client that can show the recheck
+	// interval and not the mode it applies under describes half a policy
+	// (task 003).
+	if cfg.UsageLimitRecheck != cfgDefault.UsageLimitRecheckInterval.String() {
+		t.Errorf("UsageLimitRecheck = %q, want %q",
+			cfg.UsageLimitRecheck, cfgDefault.UsageLimitRecheckInterval.String())
+	}
+	if cfg.UsageLimitAutoContinue != cfgDefault.UsageLimitAutoContinue {
+		t.Errorf("UsageLimitAutoContinue = %q, want %q",
+			cfg.UsageLimitAutoContinue, cfgDefault.UsageLimitAutoContinue)
+	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -214,6 +214,8 @@ func configFields() map[string]configField {
 		},
 		"usage_limit_recheck_interval": str(func(c apiclient.Config) string { return c.UsageLimitRecheck },
 			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{UsageLimitRecheck: v} }),
+		"usage_limit_auto_continue": str(func(c apiclient.Config) string { return c.UsageLimitAutoContinue },
+			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{UsageLimitAutoContinue: v} }),
 		"log_level": str(func(c apiclient.Config) string { return c.LogLevel },
 			func(v *string) apiclient.ConfigPatch { return apiclient.ConfigPatch{LogLevel: v} }),
 		"debug": boolField(func(c apiclient.Config) bool { return c.Debug },

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -61,7 +61,7 @@ func TestConfigValuesRoundTripThroughSet(t *testing.T) {
 		Listen: "127.0.0.1:0", MaxParallelTasks: 3, BranchTemplate: "vincent/{{.ID}}",
 		Defaults:                apiclient.ConfigDefaults{AgentTimeout: "1h0m0s", CommandTimeout: "15m0s", InputTimeout: "24h0m0s"},
 		TranscriptRetentionDays: 90, TranscriptMaxBytes: 512 << 20, MaxTaskCostUSD: 2.5,
-		UsageLimitRecheck: "15m0s", LogLevel: "info",
+		UsageLimitRecheck: "15m0s", UsageLimitAutoContinue: "always", LogLevel: "info",
 		Environment: apiclient.ConfigEnvironment{
 			Inherit: apiclient.ConfigInherit{Mode: "list", Names: []string{"PATH", "HOME"}},
 			Unset:   []string{"MSYSTEM"},

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -88,6 +88,17 @@ max_task_cost_usd: 0
 # the queue and holds no slot while it waits.
 usage_limit_recheck_interval: 15m
 
+# What a recognized usage-limit stop does: always | reported_only | never.
+# always holds the task — it returns to the queue, waits out the reset and
+# consumes no retry — and is today's behaviour, so leaving this alone changes
+# nothing. reported_only holds only when the CLI actually named a reset time,
+# and blocks when the wait would be the estimate above — the case where
+# vincent is guessing. never always blocks.
+#
+# Only claude reports a spent quota at all; codex and cursor recognize no such
+# wording, so this key is inert on them.
+usage_limit_auto_continue: always
+
 # Daemon log verbosity: debug | info | warn | error.
 log_level: info
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,7 +233,30 @@ type Config struct {
 	// no exponential backoff: that is per-task state the row would have to
 	// carry, and a second retry-ish concept beside §7.2's.
 	UsageLimitRecheckInterval Duration `yaml:"usage_limit_recheck_interval"`
-	LogLevel                  string   `yaml:"log_level"`
+	// UsageLimitAutoContinue decides what a recognized usage-limit stop does
+	// (task 003, §11). `always` — the default — holds the task: it returns to
+	// the queue with `usage_limit`, waits out the reset and consumes no retry,
+	// which is what every version before this key did, so no existing
+	// installation changes. `reported_only` holds only when the CLI actually
+	// named a reset time, and blocks when the wait would be the
+	// UsageLimitRecheckInterval estimate — the case where vincent is guessing
+	// rather than repeating what the agent said. `never` always blocks, for an
+	// operator who would rather see a misclassified stop than wait on it.
+	//
+	// The mode is read at the moment of the stop, not when the task was
+	// admitted, so a hot reload (§12.3) reaches the next quota stop without a
+	// restart.
+	//
+	// UsageLimitRecheckInterval keeps a meaning in every mode: it is the
+	// estimate — the wait vincent guesses at when the CLI named no reset time.
+	// Under `reported_only` that guess is exactly what separates a hold from a
+	// block; under `never` it times no wait at all.
+	//
+	// Claude-only in effect. FailureUsageLimit is produced by exactly one
+	// adapter (internal/agent/claude); codex and cursor recognize no quota
+	// wording (task 003 decision 2), so this key is inert on them.
+	UsageLimitAutoContinue string `yaml:"usage_limit_auto_continue"`
+	LogLevel               string `yaml:"log_level"`
 	// Debug records, in every step's transcript, the exact conditions the
 	// step ran under: the resolved agent/model/effort, the permission mode,
 	// the working directory, and the full argv of the process spawned.
@@ -303,6 +326,15 @@ type Config struct {
 	// and a second `vincent doctor` line for one setting.
 	TUI TUI `yaml:"tui"`
 }
+
+// The modes UsageLimitAutoContinue takes (task 003). A tri-state string
+// rather than a bool because the middle value is the interesting one: hold
+// when the agent named a reset, block when the wait would be a guess.
+const (
+	UsageLimitAlways       = "always"
+	UsageLimitReportedOnly = "reported_only"
+	UsageLimitNever        = "never"
+)
 
 // GitHub configures the GitHub integration (spec §12.3 — task 035, task 069).
 //
@@ -654,6 +686,7 @@ func Default() Config {
 		TranscriptRetentionDays:   90,
 		TranscriptMaxBytes:        512 << 20, // 512MB (§12.3)
 		UsageLimitRecheckInterval: Duration(15 * time.Minute),
+		UsageLimitAutoContinue:    UsageLimitAlways,
 		LogLevel:                  "info",
 		// Inherit everything: exactly what the daemon did before the policy
 		// existed, so nothing changes for anyone who does not ask.
@@ -792,6 +825,14 @@ func (c Config) validate() error {
 	// to stop (task 003).
 	if c.UsageLimitRecheckInterval <= 0 {
 		return fmt.Errorf("usage_limit_recheck_interval must be positive, got %s", c.UsageLimitRecheckInterval)
+	}
+	// An enum, checked the way log_level's is: an unrecognized mode is a typo,
+	// and quietly reading it as `always` would leave a switch the operator
+	// believes they turned off still holding their tasks.
+	switch c.UsageLimitAutoContinue {
+	case UsageLimitAlways, UsageLimitReportedOnly, UsageLimitNever:
+	default:
+		return fmt.Errorf("usage_limit_auto_continue must be one of always, reported_only, never; got %q", c.UsageLimitAutoContinue)
 	}
 	switch c.LogLevel {
 	case "debug", "info", "warn", "error":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,7 +234,7 @@ type Config struct {
 	// carry, and a second retry-ish concept beside §7.2's.
 	UsageLimitRecheckInterval Duration `yaml:"usage_limit_recheck_interval"`
 	// UsageLimitAutoContinue decides what a recognized usage-limit stop does
-	// (task 003, §11). `always` — the default — holds the task: it returns to
+	// (task 091, over task 003's hold; §7.2, §11). `always` — the default — holds the task: it returns to
 	// the queue with `usage_limit`, waits out the reset and consumes no retry,
 	// which is what every version before this key did, so no existing
 	// installation changes. `reported_only` holds only when the CLI actually
@@ -327,7 +327,7 @@ type Config struct {
 	TUI TUI `yaml:"tui"`
 }
 
-// The modes UsageLimitAutoContinue takes (task 003). A tri-state string
+// The modes UsageLimitAutoContinue takes (task 091). A tri-state string
 // rather than a bool because the middle value is the interesting one: hold
 // when the agent named a reset, block when the wait would be a guess.
 const (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -230,7 +230,7 @@ func TestTaskCostCapDefaultsOff(t *testing.T) {
 	}
 }
 
-// TestUsageLimitAutoContinueDefaultsToAlways pins the default task 003's hold
+// TestUsageLimitAutoContinueDefaultsToAlways pins the default task 091's key
 // rests on: a recognized usage-limit stop re-queues the task and waits, which
 // is what every version before this key did. An installation that never names
 // the key must keep it, whether the file is missing entirely or merely silent.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -91,7 +91,12 @@ agents:
 		TranscriptMaxBytes:         32 << 20,
 		MaxTaskCostUSD:             12.5,
 		UsageLimitRecheckInterval:  Duration(2 * time.Minute),
-		LogLevel:                   "warn",
+		// And the same for `usage_limit_auto_continue`: the file names it
+		// nowhere, so task 003's hold-and-requeue survives a config that
+		// overrides everything else, which is what "no installation changes"
+		// has to mean for it to be true.
+		UsageLimitAutoContinue: UsageLimitAlways,
+		LogLevel:               "warn",
 		// The file omits `environment:`, so the §12.3 default survives an
 		// otherwise fully-overriding config — which is the property that
 		// keeps T4.23 invisible to anyone who does not ask for it.
@@ -225,6 +230,60 @@ func TestTaskCostCapDefaultsOff(t *testing.T) {
 	}
 }
 
+// TestUsageLimitAutoContinueDefaultsToAlways pins the default task 003's hold
+// rests on: a recognized usage-limit stop re-queues the task and waits, which
+// is what every version before this key did. An installation that never names
+// the key must keep it, whether the file is missing entirely or merely silent.
+func TestUsageLimitAutoContinueDefaultsToAlways(t *testing.T) {
+	if got := Default().UsageLimitAutoContinue; got != UsageLimitAlways {
+		t.Errorf("usage_limit_auto_continue default = %q, want %q", got, UsageLimitAlways)
+	}
+	// A config.yaml that says something else entirely still leaves it alone.
+	cfg, err := Load(writeConfig(t, "max_parallel_tasks: 5\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.UsageLimitAutoContinue != UsageLimitAlways {
+		t.Errorf("omitted key loaded as %q, want %q", cfg.UsageLimitAutoContinue, UsageLimitAlways)
+	}
+}
+
+// TestUsageLimitAutoContinueModes walks the tri-state: each accepted value
+// survives the round trip through a file, and a fourth is refused with a
+// message naming all three — the operator has to be told what to write.
+func TestUsageLimitAutoContinueModes(t *testing.T) {
+	for _, want := range []string{UsageLimitAlways, UsageLimitReportedOnly, UsageLimitNever} {
+		cfg, err := Load(writeConfig(t, "usage_limit_auto_continue: "+want+"\n"))
+		if err != nil {
+			t.Fatalf("Load(%q): %v", want, err)
+		}
+		if cfg.UsageLimitAutoContinue != want {
+			t.Errorf("Load(%q) = %q, want %q", want, cfg.UsageLimitAutoContinue, want)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate(%q): %v", want, err)
+		}
+	}
+
+	_, err := Load(writeConfig(t, "usage_limit_auto_continue: sometimes\n"))
+	if err == nil {
+		t.Fatal("Load accepted usage_limit_auto_continue: sometimes")
+	}
+	for _, mode := range []string{UsageLimitAlways, UsageLimitReportedOnly, UsageLimitNever} {
+		if !strings.Contains(err.Error(), mode) {
+			t.Errorf("error %q does not name the accepted value %q", err, mode)
+		}
+	}
+
+	// Validate on its own says the same thing: the API's config editor reaches
+	// it without going through Load.
+	cfg := Default()
+	cfg.UsageLimitAutoContinue = "sometimes"
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate accepted mode \"sometimes\"")
+	}
+}
+
 // TestBoardGroupingDefault pins §15's default: a board is read project by
 // project, and within a project by what each task is doing.
 func TestBoardGroupingDefault(t *testing.T) {
@@ -279,11 +338,15 @@ func TestLoadRejectsInvalid(t *testing.T) {
 		// is the respawn loop the hold exists to stop (task 003).
 		"zero recheck interval":     "usage_limit_recheck_interval: 0s\n",
 		"negative recheck interval": "usage_limit_recheck_interval: -1m\n",
-		"not yaml":                  "{{{\n",
-		"wrong type for integer":    "max_parallel_tasks: many\n",
-		"unknown grouping level":    "tui:\n  board:\n    group_by: [project, agent]\n",
-		"repeated grouping level":   "tui:\n  board:\n    group_by: [project, project]\n",
-		"grouping is not a list":    "tui:\n  board:\n    group_by: project\n",
+		// A mode nobody implements must not be read as `always`: the operator
+		// asked for something and would otherwise get the opposite.
+		"unknown usage limit mode":        "usage_limit_auto_continue: sometimes\n",
+		"usage limit mode as a yaml bool": "usage_limit_auto_continue: true\n",
+		"not yaml":                        "{{{\n",
+		"wrong type for integer":          "max_parallel_tasks: many\n",
+		"unknown grouping level":          "tui:\n  board:\n    group_by: [project, agent]\n",
+		"repeated grouping level":         "tui:\n  board:\n    group_by: [project, project]\n",
+		"grouping is not a list":          "tui:\n  board:\n    group_by: project\n",
 	}
 	for name, content := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -98,9 +98,15 @@ const (
 	// ReasonUsageLimit is an agent run the CLI stopped because the account's
 	// usage quota is spent (task 003, §7.2, §18). It is the one reason in this
 	// vocabulary that is *not* a failure: the attempt is recorded
-	// `interrupted`, consumes no retry, and the task returns to `queued` with
-	// an admission hold until the window is plausibly back. It therefore
-	// appears as a `queued_reason`, never as a `block_reason`.
+	// `interrupted` and consumes no retry, whatever happens to the task next.
+	//
+	// What happens next is `usage_limit_auto_continue` (§12.3, task 091). In
+	// the default mode the task returns to `queued` with an admission hold
+	// until the window is plausibly back, and this appears as a
+	// `queued_reason`; in the modes that do not wait the task blocks at the
+	// step it is on and this appears as a `block_reason`. It is the same
+	// condition either way, which is why one reason names both rather than
+	// splitting the vocabulary this package and internal/worktree share.
 	ReasonUsageLimit = "usage_limit"
 	// ReasonAgentUnauthenticated is a run the CLI refused because it is not
 	// logged in (task 003, §18). An ordinary failure under §7.2's budget —
@@ -150,9 +156,10 @@ const (
 	// wall.
 	ReasonLoopLimit = "loop_limit"
 	// ReasonRetryBackoff is a step whose next attempt is paced by
-	// `retry_backoff` (§7.2, task 028). Like usage_limit it is a
-	// `queued_reason` and never a `block_reason` — it names why a task is
-	// waiting, not why it stopped.
+	// `retry_backoff` (§7.2, task 028). Like a usage_limit *hold* it names why
+	// a task is waiting rather than why it stopped, and unlike usage_limit it
+	// is only ever that: it is a `queued_reason` and never a `block_reason`,
+	// in every configuration.
 	//
 	// Unlike usage_limit it is *not* the attempt's failure reason: the
 	// attempt keeps whatever it actually failed with, its row stays `failed`,
@@ -1312,7 +1319,8 @@ func (r *Runner) interrupt(task *store.Task, log *slog.Logger) {
 }
 
 // usageLimitStop turns a recognized quota stop into the two facts every
-// caller needs: the effective reset, and whether to wait it out.
+// caller needs: the effective reset, and whether to wait it out (task 091,
+// over task 003's unconditional hold).
 //
 // The reset is what the CLI named, or `now + usage_limit_recheck_interval`
 // when it named nothing. Either way the observation is recorded before this

--- a/internal/taskrun/engine.go
+++ b/internal/taskrun/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lezli01/vincent/internal/agent"
+	"github.com/lezli01/vincent/internal/config"
 	"github.com/lezli01/vincent/internal/store"
 	"github.com/lezli01/vincent/internal/taskstate"
 	"github.com/lezli01/vincent/internal/workflow"
@@ -656,8 +657,25 @@ func (r *Runner) runSteps(ctx context.Context, project *store.Project, w *stepWa
 			// A quota stop is interruption-shaped — no retry consumed, the
 			// slot released — but it must not be re-admitted immediately, or
 			// the task simply walks back into the same wall (task 003).
+			// `usage_limit_auto_continue` decides between waiting the window
+			// out and stopping for a human; the observation is recorded
+			// either way.
+			//
+			// Both outcomes are taken *here*, in the interrupted arm, above
+			// the failed arm's `allow_failure`: an account running out of
+			// quota is not a result a workflow may branch on, so the block
+			// this takes is deliberately out of that flag's reach. The
+			// attempt row stays `interrupted` and no retry is consumed —
+			// the shape the cost cap takes (task 033) — so the timeline
+			// still says what the step did while block_reason says why
+			// nothing further was tried.
 			if outcome.reason == ReasonUsageLimit {
-				r.holdForUsageLimit(task, outcome.agentName, outcome.retryAfter, env.log)
+				until, hold := r.usageLimitStop(outcome.agentName, outcome.retryAfter, env.log)
+				if !hold {
+					r.fail(task, ReasonUsageLimit, env.log, "agent usage limit reached", nil)
+					return
+				}
+				r.holdForUsageLimit(task, until, outcome.retryAfter, env.log)
 				return
 			}
 			r.interrupt(task, log)
@@ -1293,30 +1311,67 @@ func (r *Runner) interrupt(task *store.Task, log *slog.Logger) {
 	}
 }
 
+// usageLimitStop turns a recognized quota stop into the two facts every
+// caller needs: the effective reset, and whether to wait it out.
+//
+// The reset is what the CLI named, or `now + usage_limit_recheck_interval`
+// when it named nothing. Either way the observation is recorded before this
+// returns, in *every* mode — recordUsageLimit is what puts the board badge
+// and the `agent.quota_changed` event in front of the operator (task 026),
+// and that is how someone learns why a task just blocked. A config key that
+// changed whether the window was recorded would let the board disagree with
+// itself.
+//
+// The mode is read at the stop rather than cached, exactly as the interval
+// beside it is, so a config hot-reload (§12.3) reaches the next stop rather
+// than the next daemon restart. A hold already in flight is not revisited:
+// the task it belongs to is re-admitted once and meets the new mode at the
+// next stop.
+func (r *Runner) usageLimitStop(
+	agentName string, retryAfter *time.Time, log *slog.Logger,
+) (until time.Time, hold bool) {
+	cfg := r.deps.Config()
+	until = r.now().Add(cfg.UsageLimitRecheckInterval.Std()).UTC()
+	if retryAfter != nil {
+		until = retryAfter.UTC()
+	}
+	// Recorded per adapter so the fact outlives this task's stop (task 026),
+	// and before any transition, because the transition is what clears
+	// `admit_not_before`'s only other copy on the next move out of `queued`.
+	r.recordUsageLimit(agentName, until, retryAfter != nil, log)
+	switch cfg.UsageLimitAutoContinue {
+	case config.UsageLimitNever:
+		hold = false
+	case config.UsageLimitReportedOnly:
+		// Wait out a window the CLI put a time on; stop for a human when the
+		// reset above is this daemon's own estimate.
+		hold = retryAfter != nil
+	default: // config.UsageLimitAlways, and the validated default.
+		hold = true
+	}
+	return until, hold
+}
+
 // holdForUsageLimit re-queues a task whose agent reported a spent usage quota
 // (task 003, §11). It is `interrupt` plus an admission hold: the same
 // running → queued transition, the same "consumes no retry" (the attempt is
 // already recorded `interrupted` by finishStepRun, so the timeline shows it
 // and the budget does not), and the slot is released by leaving `running`.
 //
+// It is one of the two branches a quota stop can take, and the one
+// `usage_limit_auto_continue` selects when it says to continue. usageLimitStop
+// above computes `until` and makes that choice, so this only ever writes a
+// hold it was told to write; the other branch blocks the task at the step it
+// is on with `block_reason: usage_limit`, which is the caller's `fail` and
+// not this.
+//
 // Nothing sleeps here. The actor ends with the admission per the phase 2
 // decision, and the scheduler picks the task up within a tick of the hold
 // expiring — a sleeping actor would hold the slot for a whole quota window,
 // which with max_parallel_tasks slots held that way means nothing runs at all.
 func (r *Runner) holdForUsageLimit(
-	task *store.Task, agentName string, retryAfter *time.Time, log *slog.Logger,
+	task *store.Task, until time.Time, retryAfter *time.Time, log *slog.Logger,
 ) {
-	// The interval is read now rather than cached, so a config hot-reload
-	// (§12.3) reaches the next hold rather than the next daemon restart.
-	until := r.now().Add(r.deps.Config().UsageLimitRecheckInterval.Std()).UTC()
-	if retryAfter != nil {
-		until = retryAfter.UTC()
-	}
-	// The same effective reset the hold acts on, recorded per adapter so it
-	// outlives this task's hold (task 026). It is written before the
-	// transition because the transition is what clears `admit_not_before`'s
-	// only other copy on the next move out of `queued`.
-	r.recordUsageLimit(agentName, until, retryAfter != nil, log)
 	reason := ReasonUsageLimit
 	ch := store.TaskChange{
 		AdmitNotBefore: &until,

--- a/internal/taskrun/repair.go
+++ b/internal/taskrun/repair.go
@@ -134,13 +134,31 @@ func (r *Runner) runRepair(
 	}
 	outcome := r.runStepWithRetries(ctx, env)
 	if outcome.state == store.StepInterrupted {
+		if outcome.reason == ReasonUsageLimit {
+			until, hold := r.usageLimitStop(outcome.agentName, outcome.retryAfter, log)
+			if hold {
+				// Waiting the window out: the request is deliberately left
+				// undrained, so the next admission runs the repair again
+				// rather than turning it into a plain retry (task 003
+				// decision 1).
+				r.holdForUsageLimit(task, until, outcome.retryAfter, log)
+				return
+			}
+			// `usage_limit_auto_continue` says not to wait. There is nothing
+			// to wait for and nothing to re-run unasked, so the repair ends
+			// the way every finished repair ends: back at `blocked` with the
+			// reason the task was blocked with, request drained. Same
+			// reasoning as the cost cap below — the reason the task was
+			// blocked with says more than the reason the repair ran into,
+			// and this path ends `blocked` whatever the run did.
+			log.Warn("repair stopped on an agent usage limit; returning the task to blocked",
+				"reason", req.BlockReason)
+			r.finishRepair(task, req, log)
+			return
+		}
 		// Crash, shutdown or cancel. The request is *not* drained, so the
 		// next admission runs a repair again rather than silently turning it
 		// into a plain retry of the blocked step (§12.4, task 025).
-		if outcome.reason == ReasonUsageLimit {
-			r.holdForUsageLimit(task, outcome.agentName, outcome.retryAfter, log)
-			return
-		}
 		r.interrupt(task, log)
 		return
 	}

--- a/internal/taskrun/usagelimit_test.go
+++ b/internal/taskrun/usagelimit_test.go
@@ -203,3 +203,286 @@ func TestUnauthenticatedBlocksUnderTheNormalBudget(t *testing.T) {
 		}
 	}
 }
+
+// quotaModeSnapshot names claude — which adapter the observation is filed
+// under is asserted below — and states a retry budget, so "a quota stop
+// spends none of it" is measured against a number rather than a default.
+const quotaModeSnapshot = `name: quota-mode
+defaults:
+  agent: claude
+steps:
+  - id: implement
+    type: agent
+    max_retries: 1
+    prompt: "Do the work"
+`
+
+// waitForBlock polls until the task is blocked, failing loudly if it settles
+// on an admission hold instead — the mistake this file's blocking half is
+// there to catch.
+func (h *engineHarness) waitForBlock(t *testing.T, id int64) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	var last *store.Task
+	for time.Now().Before(deadline) {
+		task, err := h.store.GetTask(t.Context(), id)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		last = task
+		if task.State == store.TaskBlocked {
+			return task
+		}
+		if task.State == store.TaskDone {
+			t.Fatalf("task %d reached done; want blocked on the quota wall", id)
+		}
+		if task.State == store.TaskQueued && task.AdmitNotBefore != nil {
+			t.Fatalf("task %d picked up an admission hold (%q, until %s); "+
+				"usage_limit_auto_continue said to block",
+				id, task.QueuedReason, task.AdmitNotBefore)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never blocked (state %s)", id, last.State)
+	return nil
+}
+
+// TestUsageLimitAutoContinueTruthTable walks all six squares of the key: three
+// modes × whether the CLI named a reset. `always` holds either way,
+// `reported_only` holds only where the reset is the CLI's own word, `never`
+// blocks either way.
+//
+// Every square asserts the observation too, including the blocking ones. The
+// board badge and the `agent.quota_changed` event are how an operator learns
+// *why* a task just blocked (task 026, decision 2), so a mode that suppressed
+// the recording would leave the board disagreeing with itself.
+func TestUsageLimitAutoContinueTruthTable(t *testing.T) {
+	const (
+		interval = 4 * time.Hour
+		// Seconds the fake CLI reports as its reset, well clear of the
+		// interval so which one won is never in doubt.
+		reportedIn = 30 * time.Minute
+	)
+	cases := []struct {
+		mode     string
+		reported bool
+		hold     bool
+	}{
+		{config.UsageLimitAlways, true, true},
+		{config.UsageLimitAlways, false, true},
+		{config.UsageLimitReportedOnly, true, true},
+		{config.UsageLimitReportedOnly, false, false},
+		{config.UsageLimitNever, true, false},
+		{config.UsageLimitNever, false, false},
+	}
+	for _, tc := range cases {
+		leg := "estimated"
+		if tc.reported {
+			leg = "reported"
+		}
+		t.Run(tc.mode+"/"+leg, func(t *testing.T) {
+			t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+			if tc.reported {
+				t.Setenv("FAKEAGENT_USAGE_LIMIT_RESET", "1800")
+			}
+			h := newEngineHarnessWith(t, func(c *config.Config) {
+				// Long enough that a hold cannot expire mid-test, so what is
+				// asserted is the decision and not a race with the tick.
+				c.UsageLimitRecheckInterval = config.Duration(interval)
+				c.UsageLimitAutoContinue = tc.mode
+			})
+			task := h.createTask(t, quotaModeSnapshot)
+			before := time.Now()
+			h.start(t)
+
+			if tc.hold {
+				held := h.waitForHold(t, task.ID)
+				if held.QueuedReason != ReasonUsageLimit {
+					t.Errorf("queued_reason = %q, want %s", held.QueuedReason, ReasonUsageLimit)
+				}
+				if held.BlockReason != "" {
+					t.Errorf("block_reason = %q; a held task is not blocked", held.BlockReason)
+				}
+			} else {
+				blocked := h.waitForBlock(t, task.ID)
+				if blocked.BlockReason != ReasonUsageLimit {
+					t.Errorf("block_reason = %q, want %s", blocked.BlockReason, ReasonUsageLimit)
+				}
+				// The cursor stays where it is: a blocked task is blocked
+				// *at* a step, which is what lets a retry re-run it.
+				if blocked.CurrentStep != 0 {
+					t.Errorf("current_step = %d, want 0 — a block does not advance the cursor",
+						blocked.CurrentStep)
+				}
+				if blocked.QueuedReason != "" || blocked.AdmitNotBefore != nil {
+					t.Errorf("blocked task carries a hold: %q / %v",
+						blocked.QueuedReason, blocked.AdmitNotBefore)
+				}
+			}
+
+			// The same in either branch, and the point of taking the block
+			// inside the interrupted arm: the attempt row still says what the
+			// step did, and the budget is untouched.
+			runs := h.stepRuns(t, task.ID)
+			if len(runs) != 1 {
+				t.Fatalf("attempts = %d, want 1 — a quota stop must not burn the budget", len(runs))
+			}
+			if runs[0].State != store.StepInterrupted {
+				t.Errorf("attempt state = %s, want interrupted", runs[0].State)
+			}
+			if runs[0].FailureReason != ReasonUsageLimit {
+				t.Errorf("failure_reason = %q, want %s", runs[0].FailureReason, ReasonUsageLimit)
+			}
+			attempts, err := h.store.CountStepAttempts(t.Context(),
+				store.StepRef{TaskID: task.ID, StepID: "implement"}, time.Time{})
+			if err != nil {
+				t.Fatalf("CountStepAttempts: %v", err)
+			}
+			if attempts.Failed != 0 {
+				t.Errorf("failed attempts = %d, want 0 — no retry is consumed in any mode",
+					attempts.Failed)
+			}
+
+			q := claudeQuota(t, h)
+			if q.ResetsAtReported != tc.reported {
+				t.Errorf("resets_at_reported = %v, want %v", q.ResetsAtReported, tc.reported)
+			}
+			if q.Source != store.QuotaSourceObserved {
+				t.Errorf("source = %q, want %q", q.Source, store.QuotaSourceObserved)
+			}
+			want := interval
+			if tc.reported {
+				want = reportedIn
+			}
+			if got := q.ResetsAt.Sub(before); got < want-5*time.Minute || got > want+5*time.Minute {
+				t.Errorf("resets_at is %s away, want about %s", got, want)
+			}
+		})
+	}
+}
+
+// TestUsageLimitModeIsReadAtTheStop is the hot-reload claim, mirroring the one
+// the recheck interval already carries: the mode is read when the wall is hit,
+// never cached, so a change reaches a running daemon.
+//
+// It also pins the other half of that: a hold already in flight is *not*
+// converted. Switching to `never` does not reach back and block the held task
+// — it is re-admitted once, walks into the same wall, and blocks there.
+func TestUsageLimitModeIsReadAtTheStop(t *testing.T) {
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		// Short, so the hold this starts with expires promptly and the next
+		// stop — the one that meets the new mode — happens without waiting.
+		c.UsageLimitRecheckInterval = config.Duration(time.Millisecond)
+		c.UsageLimitAutoContinue = config.UsageLimitAlways
+	})
+	task := h.createTask(t, quotaModeSnapshot)
+	h.start(t)
+
+	held := h.waitForHold(t, task.ID)
+	if held.QueuedReason != ReasonUsageLimit {
+		t.Fatalf("queued_reason = %q, want %s", held.QueuedReason, ReasonUsageLimit)
+	}
+
+	h.reload(func(c *config.Config) { c.UsageLimitAutoContinue = config.UsageLimitNever })
+
+	blocked := h.waitForState(t, task.ID, store.TaskBlocked, store.TaskDone)
+	if blocked.State != store.TaskBlocked || blocked.BlockReason != ReasonUsageLimit {
+		t.Fatalf("task = %s (%q), want blocked/%s once the mode changed",
+			blocked.State, blocked.BlockReason, ReasonUsageLimit)
+	}
+	// At least two: the stop that held under `always`, then the one that
+	// blocked under `never`. More is legal — the hold is a millisecond long,
+	// so the task can be re-admitted a few times before the reload lands —
+	// and every one of them is still an interruption that spent no retry.
+	runs := h.stepRuns(t, task.ID)
+	if len(runs) < 2 {
+		t.Fatalf("attempts = %d, want at least 2 (a hold, then a block): %+v", len(runs), runs)
+	}
+	for _, run := range runs {
+		if run.State != store.StepInterrupted || run.FailureReason != ReasonUsageLimit {
+			t.Errorf("attempt %d = %s/%q, want interrupted/%s",
+				run.Attempt, run.State, run.FailureReason, ReasonUsageLimit)
+		}
+	}
+	attempts, err := h.store.CountStepAttempts(t.Context(),
+		store.StepRef{TaskID: task.ID, StepID: "implement"}, time.Time{})
+	if err != nil {
+		t.Fatalf("CountStepAttempts: %v", err)
+	}
+	if attempts.Failed != 0 {
+		t.Errorf("failed attempts = %d, want 0", attempts.Failed)
+	}
+}
+
+// waitForDrainedRepair polls until the repair request has been drained and the
+// task has settled, which is how a repair that ends `blocked` announces it is
+// done — its row is `interrupted`, so counting finished rows never sees it.
+func (h *engineHarness) waitForDrainedRepair(t *testing.T, id int64) *store.Task {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	var last *store.Task
+	for time.Now().Before(deadline) {
+		task, err := h.store.GetTask(t.Context(), id)
+		if err != nil {
+			t.Fatalf("GetTask: %v", err)
+		}
+		last = task
+		if task.PendingRepair == nil &&
+			task.State != store.TaskQueued && task.State != store.TaskRunning {
+			return task
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("task %d never drained its repair request (state %s, pending %+v)",
+		id, last.State, last.PendingRepair)
+	return nil
+}
+
+// TestUsageLimitDuringARepairReblocksWithTheOriginalReason is decision 1's
+// other branch. A repair is not a step of the workflow, so a quota stop that
+// is not waited out cannot leave the task anywhere new: it goes back to
+// `blocked` carrying the reason it was blocked with — not `usage_limit` —
+// with the request drained, exactly as a finished repair does.
+func TestUsageLimitDuringARepairReblocksWithTheOriginalReason(t *testing.T) {
+	// The blocked step is a command step, so the wall is reached by the
+	// repair agent and by nothing else.
+	t.Setenv("FAKEAGENT_SCENARIO", "usage-limit")
+	h := newEngineHarnessWith(t, func(c *config.Config) {
+		c.UsageLimitRecheckInterval = config.Duration(time.Hour)
+		c.UsageLimitAutoContinue = config.UsageLimitNever
+	})
+	blocked := blockedOnCheck(t, h)
+
+	if _, err := h.runner.Repair(t.Context(), blocked.ID,
+		store.RepairRequest{Prompt: "try something"}); err != nil {
+		t.Fatalf("Repair: %v", err)
+	}
+
+	// Not waitForRepair: that one counts rows that finished in some state
+	// other than `interrupted`, and a quota stop's row is interrupted. What
+	// says the repair is over here is the drained request.
+	after := h.waitForDrainedRepair(t, blocked.ID)
+	if after.State != store.TaskBlocked || after.BlockReason != ReasonCheckFailed {
+		t.Fatalf("task = %s/%q, want blocked/%s — the reason the task was blocked with",
+			after.State, after.BlockReason, ReasonCheckFailed)
+	}
+	if after.PendingRepair != nil {
+		t.Errorf("the repair request survived a stop that ends blocked: %+v", after.PendingRepair)
+	}
+	if after.AdmitNotBefore != nil || after.QueuedReason != "" {
+		t.Errorf("a blocked task kept a hold: %q / %v", after.QueuedReason, after.AdmitNotBefore)
+	}
+	repairs := repairRuns(h.stepRuns(t, after.ID))
+	if len(repairs) != 1 || repairs[0].State != store.StepInterrupted {
+		t.Fatalf("repair rows = %+v, want one interrupted row", repairs)
+	}
+	if repairs[0].FailureReason != ReasonUsageLimit {
+		t.Errorf("repair failure_reason = %q, want %s", repairs[0].FailureReason, ReasonUsageLimit)
+	}
+	// The observation is still recorded — the operator has to be able to see
+	// that the account, not the repair, is what stopped.
+	if q := claudeQuota(t, h); !q.ResetsAtReported && q.Source != store.QuotaSourceObserved {
+		t.Errorf("quota row = %+v, want an observed estimate", q)
+	}
+}

--- a/internal/tui/configkeys.go
+++ b/internal/tui/configkeys.go
@@ -101,7 +101,7 @@ func (k configKey) def() string { return k.read(defaultClientConfig()) }
 var (
 	boolChoices     = []string{"false", "true"}
 	logLevelChoices = []string{"debug", "info", "warn", "error"}
-	// The three modes usage_limit_auto_continue takes (task 003), spelled here
+	// The three modes usage_limit_auto_continue takes (task 091), spelled here
 	// rather than imported from config the way every other vocabulary in this
 	// file is: the TUI reads its configuration from the API, not from disk.
 	usageLimitAutoContinueChoices = []string{"always", "reported_only", "never"}

--- a/internal/tui/configkeys.go
+++ b/internal/tui/configkeys.go
@@ -101,8 +101,12 @@ func (k configKey) def() string { return k.read(defaultClientConfig()) }
 var (
 	boolChoices     = []string{"false", "true"}
 	logLevelChoices = []string{"debug", "info", "warn", "error"}
-	groupByChoices  = []string{"project", "workflow"}
-	inheritChoices  = []string{"all", "none"}
+	// The three modes usage_limit_auto_continue takes (task 003), spelled here
+	// rather than imported from config the way every other vocabulary in this
+	// file is: the TUI reads its configuration from the API, not from disk.
+	usageLimitAutoContinueChoices = []string{"always", "reported_only", "never"}
+	groupByChoices                = []string{"project", "workflow"}
+	inheritChoices                = []string{"all", "none"}
 )
 
 // configKeys is the editable table, in the order config.yaml carries the keys
@@ -211,6 +215,15 @@ func configKeys() []configKey {
 			"how long a quota-held task waits when the CLI named no reset time",
 			func(c apiclient.Config) string { return c.UsageLimitRecheck },
 			func(s string) apiclient.ConfigPatch { return apiclient.ConfigPatch{UsageLimitRecheck: &s} }),
+		{
+			path: "usage_limit_auto_continue", label: "usage limit auto continue",
+			kind: kindEnum, choices: usageLimitAutoContinueChoices,
+			help: "what a recognized quota stop does: hold always, only when a reset time was reported, or never",
+			read: func(c apiclient.Config) string { return c.UsageLimitAutoContinue },
+			write: func(s string) (apiclient.ConfigPatch, error) {
+				return apiclient.ConfigPatch{UsageLimitAutoContinue: &s}, nil
+			},
+		},
 		{
 			path: "log_level", label: "log level", kind: kindEnum, choices: logLevelChoices,
 			help:  "daemon log verbosity",
@@ -539,6 +552,7 @@ func defaultClientConfig() apiclient.Config {
 		TranscriptMaxBytes:          d.TranscriptMaxBytes.Bytes(),
 		MaxTaskCostUSD:              d.MaxTaskCostUSD,
 		UsageLimitRecheck:           d.UsageLimitRecheckInterval.String(),
+		UsageLimitAutoContinue:      d.UsageLimitAutoContinue,
 		LogLevel:                    d.LogLevel,
 		Debug:                       d.Debug,
 		Environment: apiclient.ConfigEnvironment{

--- a/internal/tui/configlive_test.go
+++ b/internal/tui/configlive_test.go
@@ -204,7 +204,7 @@ func TestConfigEditorSaysListenNeedsARestart(t *testing.T) {
 }
 
 // usage_limit_auto_continue is a chooser, not a free-text box: the daemon
-// takes exactly three values (task 003) and a typo in a fourth is a refusal
+// takes exactly three values (task 091) and a typo in a fourth is a refusal
 // no one should have to discover by hitting enter. The vocabulary is spelled
 // in this package, so what needs proving is that it is still the one the
 // daemon accepts — which only the real handler can say.

--- a/internal/tui/configlive_test.go
+++ b/internal/tui/configlive_test.go
@@ -202,3 +202,70 @@ func TestConfigEditorSaysListenNeedsARestart(t *testing.T) {
 		t.Errorf("the listen editor does not say it needs a restart:\n%s", out)
 	}
 }
+
+// usage_limit_auto_continue is a chooser, not a free-text box: the daemon
+// takes exactly three values (task 003) and a typo in a fourth is a refusal
+// no one should have to discover by hitting enter. The vocabulary is spelled
+// in this package, so what needs proving is that it is still the one the
+// daemon accepts — which only the real handler can say.
+func TestConfigEditorOffersTheThreeUsageLimitModes(t *testing.T) {
+	h := newConfigLive(t)
+	h.open(t, "usage_limit_auto_continue")
+	if h.view.form == nil {
+		t.Fatal("enter did not open the editor")
+	}
+	want := []string{"always", "reported_only", "never"}
+	if got := strings.Join(h.view.form.key.choices, " "); got != strings.Join(want, " ") {
+		t.Errorf("choices = %q, want %q", got, strings.Join(want, " "))
+	}
+	if h.view.form.key.kind != kindEnum {
+		t.Errorf("kind = %v, want a chooser", h.view.form.key.kind)
+	}
+	// Every one of them is a value the daemon takes, and each lands in the
+	// file under the wire name.
+	for _, mode := range want {
+		h := newConfigLive(t)
+		h.open(t, "usage_limit_auto_continue")
+		for h.view.form.value() != mode {
+			h.press(t, "right")
+		}
+		h.press(t, "enter")
+		if h.view.form != nil {
+			t.Fatalf("%s: the editor stayed open after a save: %+v", mode, h.view.form)
+		}
+		if h.view.config.UsageLimitAutoContinue != mode {
+			t.Errorf("%s: the block did not adopt it: %q", mode, h.view.config.UsageLimitAutoContinue)
+		}
+		if !strings.Contains(h.file(t), "usage_limit_auto_continue: "+mode) {
+			t.Errorf("%s: config.yaml was not written:\n%s", mode, h.file(t))
+		}
+	}
+}
+
+// The write half of the key: a table entry wired to the wrong ConfigPatch
+// field edits some other key, which the round trip above cannot see because
+// the daemon would answer 200 either way.
+func TestConfigKeyUsageLimitAutoContinuePatchesItsOwnField(t *testing.T) {
+	var key configKey
+	for _, k := range configKeys() {
+		if k.path == "usage_limit_auto_continue" {
+			key = k
+		}
+	}
+	if key.path == "" {
+		t.Fatal("the config key table does not carry usage_limit_auto_continue")
+	}
+	if got := key.read(apiclient.Config{UsageLimitAutoContinue: "never"}); got != "never" {
+		t.Errorf("read = %q, want never", got)
+	}
+	patch, err := key.write("reported_only")
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if patch.UsageLimitAutoContinue == nil || *patch.UsageLimitAutoContinue != "reported_only" {
+		t.Errorf("the patch does not carry the value: %+v", patch)
+	}
+	if patch.UsageLimitRecheck != nil || patch.LogLevel != nil {
+		t.Errorf("the patch edits a neighbouring key too: %+v", patch)
+	}
+}

--- a/internal/tui/newtaskrender.go
+++ b/internal/tui/newtaskrender.go
@@ -453,9 +453,10 @@ func (n *newTask) agentSummary() string {
 // would run on is out of quota until a stated time (task 026).
 //
 // It **warns and nothing more**: the form still submits, the daemon still
-// admits, and the task will park on the same `usage_limit` hold task 003
-// already handles. That is task 003's recorded decision 4 (no pre-flight
-// refusal) unchanged — the point here is that the user finds out before
+// admits, and the task meets the same `usage_limit` stop task 003 already
+// handles — parking on its hold, or blocking on it where
+// `usage_limit_auto_continue` says not to wait (task 091). That is task 003's
+// recorded decision 4 (no pre-flight refusal) unchanged — the point here is that the user finds out before
 // queueing a batch rather than by watching it park.
 //
 // A window that has already reset says nothing: this row is a decision aid,

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -16,11 +16,13 @@
 # (scenario 10), and that a step carrying `retry_backoff` paces its retry
 # through the same admission hold — releasing its slot and recovering
 # unattended (scenario 11), and that a step can report its own status message
-# — visible on the running row and on the finished one (scenario 12).
+# — visible on the running row and on the finished one (scenario 12), and that
+# `usage_limit_auto_continue` decides whether a recognized quota stop waits the
+# window out or blocks for a human (scenario 13).
 # Runs against the committed fakeagent so CI never calls a real
 # API; run manually with VINCENT_GATE_AGENT=claude to exercise the real CLI
 # (scenario 1 only — killing a paid run and 8× cap spend prove nothing extra).
-# VINCENT_GATE_SCENARIO=1..12 runs a single scenario for debugging.
+# VINCENT_GATE_SCENARIO=1..13 runs a single scenario for debugging.
 #
 # Each scenario gets fresh config/data/repo dirs and its own daemon:
 # FAKEAGENT_SCENARIO is read from the daemon's environment, so it can only
@@ -1527,6 +1529,168 @@ YAML
   echo "=== scenario 12 PASS (task $task_id narrated itself, live and terminal)"
 }
 
+# ---------------------------------------------------------------------------
+# Scenario 13 — usage_limit_auto_continue (task 003, §12.3): the switch that
+# turns the automatic wait off. Two daemons, because both halves of the truth
+# table need their own fake-CLI environment and FAKEAGENT_* is read at daemon
+# start (PR G decision): `never` against a CLI that named no reset must block,
+# and `reported_only` against one that did must still hold.
+# ---------------------------------------------------------------------------
+scenario13() {
+  echo "=== scenario 13: usage_limit_auto_continue — never blocks, reported_only still holds"
+  scenario_dirs s13
+
+  export FAKEAGENT_SCENARIO=usage-limit
+  # Explicit, because scenario 5 exports both and `all` runs it first: this
+  # leg is the one where the CLI names no reset and the estimate decides.
+  unset FAKEAGENT_USAGE_LIMIT_RESET FAKEAGENT_USAGE_LIMIT_MARKER
+
+  # Long, deliberately: nothing here waits for a window, so the interval only
+  # feeds the estimate that reaches /v1/agents — and a 10 s estimate would
+  # have elapsed by the time the assertions below read `spent`.
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+usage_limit_recheck_interval: 30m
+usage_limit_auto_continue: never
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+
+  mkdir -p "$CONFIG_DIR/workflows"
+  # max_retries: 1 — the opposite of scenario 5's 0, and for the opposite
+  # reason. A block is the expected outcome here, so the budget is what tells
+  # the two apart: a quota stop miscounted as a failure would retry first and
+  # arrive with two failed rows.
+  cat > "$CONFIG_DIR/workflows/m2-quota-off.yaml" <<EOF
+name: m2-quota-off
+description: M2 gate — one agent step against a quota-exhausted CLI, auto-continue off.
+defaults:
+  agent: claude
+  max_retries: 1
+steps:
+  - id: work
+    type: agent
+    prompt: "Do the work for {{.Task.Title}}"
+EOF
+
+  daemon_up
+
+  local repo="$TMP/s13/repo" proj walled
+  make_repo "$repo"
+  proj="$(register_project "$repo")"
+  walled="$(api POST /tasks "{\"project_id\":$proj,\"workflow\":\"m2-quota-off\",\"title\":\"Quota walled, no waiting\"}" | jq -r .id)"
+
+  echo "== the quota stop blocks the task instead of parking it on a hold"
+  local task="" ok=0
+  for _ in $(seq 1 90); do
+    task="$(api GET "/tasks/$walled")"
+    [[ "$(jq -r .state <<<"$task")" == "blocked" ]] && { ok=1; break; }
+    [[ "$(jq -r .state <<<"$task")" == "done" ]] \
+      && { jq . <<<"$task" >&2; fail "task $walled finished; the fake CLI was meant to be walled"; }
+    [[ "$(jq -r '.queued_reason // "null"' <<<"$task")" == "usage_limit" ]] \
+      && { jq . <<<"$task" >&2; fail "task $walled was held on the window; usage_limit_auto_continue is never"; }
+    sleep 1
+  done
+  (( ok )) || { jq . <<<"$task" >&2; fail "task $walled never blocked"; }
+
+  [[ "$(jq -r '.block_reason // "null"' <<<"$task")" == "usage_limit" ]] \
+    || fail "block_reason = $(jq -r '.block_reason // "null"' <<<"$task"), want usage_limit: $task"
+  [[ "$(jq -r '.admit_not_before // "null"' <<<"$task")" == "null" ]] \
+    || fail "a blocked task kept an admission hold: $task"
+  [[ "$(jq -r '.queued_reason // "null"' <<<"$task")" == "null" ]] \
+    || fail "a blocked task kept a queued_reason: $task"
+  # The cursor stays at the step it is on, which is what lets a retry re-run
+  # it once the window reopens.
+  [[ "$(jq -r .current_step <<<"$task")" == "0" ]] \
+    || fail "current_step = $(jq -r .current_step <<<"$task"), want 0 — a block does not advance it"
+
+  echo "== the attempt is still recorded interrupted and still spent no retry"
+  local steps
+  steps="$(api GET "/tasks/$walled/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "1" ]] || fail "attempts = $(jq 'length' <<<"$steps"), want 1: $steps"
+  [[ "$(jq -r '.[0].state' <<<"$steps")" == "interrupted" ]] \
+    || fail "attempt state is $(jq -r '.[0].state' <<<"$steps"), want interrupted: $steps"
+  [[ "$(jq -r '.[0].failure_reason' <<<"$steps")" == "usage_limit" ]] \
+    || fail "attempt reason is $(jq -r '.[0].failure_reason' <<<"$steps"), want usage_limit"
+
+  echo "== the spent window still reaches /v1/agents (decision 2)"
+  local quota
+  quota="$(api GET /agents | jq -c '.agents[] | select(.name == "claude") | .quota')"
+  [[ "$quota" != "null" && -n "$quota" ]] \
+    || fail "GET /v1/agents carries no quota block for a task that blocked on one"
+  [[ "$(jq -r .source <<<"$quota")" == "observed" ]] \
+    || fail "quota.source = $(jq -r .source <<<"$quota"), want observed: $quota"
+  [[ "$(jq -r .spent <<<"$quota")" == "true" ]] \
+    || fail "quota.spent is false; the board would not say why the task blocked: $quota"
+  # This leg sets no FAKEAGENT_USAGE_LIMIT_RESET, so the reset is the
+  # interval's estimate and must not claim the CLI stated it.
+  [[ "$(jq -r .resets_at_reported <<<"$quota")" == "false" ]] \
+    || fail "quota.resets_at_reported is true for a reset the CLI never named: $quota"
+
+  "$VINCENT" daemon stop
+
+  echo "== reported_only: a reset the CLI named is still waited out"
+  scenario_dirs s13b
+  # Read at daemon start, which is why this leg gets a daemon of its own.
+  export FAKEAGENT_USAGE_LIMIT_RESET=1800
+
+  cat > "$CONFIG_DIR/config.yaml" <<EOF
+usage_limit_recheck_interval: 30m
+usage_limit_auto_continue: reported_only
+agents:
+  claude:
+    path: "$(hostpath "$FAKEAGENT")"
+EOF
+  mkdir -p "$CONFIG_DIR/workflows"
+  cat > "$CONFIG_DIR/workflows/m2-quota-off.yaml" <<EOF
+name: m2-quota-off
+description: M2 gate — one agent step against a quota-exhausted CLI, auto-continue off.
+defaults:
+  agent: claude
+  max_retries: 1
+steps:
+  - id: work
+    type: agent
+    prompt: "Do the work for {{.Task.Title}}"
+EOF
+
+  daemon_up
+
+  local repo2="$TMP/s13b/repo" proj2 held
+  make_repo "$repo2"
+  proj2="$(register_project "$repo2")"
+  held="$(api POST /tasks "{\"project_id\":$proj2,\"workflow\":\"m2-quota-off\",\"title\":\"Quota walled, reset reported\"}" | jq -r .id)"
+
+  task="" ok=0
+  for _ in $(seq 1 90); do
+    task="$(api GET "/tasks/$held")"
+    [[ "$(jq -r '.queued_reason // "null"' <<<"$task")" == "usage_limit" ]] && { ok=1; break; }
+    [[ "$(jq -r .state <<<"$task")" == "blocked" ]] \
+      && { jq . <<<"$task" >&2; fail "task $held blocked on a reset the CLI named; reported_only must wait it out"; }
+    sleep 1
+  done
+  (( ok )) || { jq . <<<"$task" >&2; fail "task $held never picked up queued_reason=usage_limit"; }
+  [[ "$(jq -r .state <<<"$task")" == "queued" ]] || fail "held task is $(jq -r .state <<<"$task"), want queued"
+  [[ "$(jq -r '.admit_not_before // "null"' <<<"$task")" != "null" ]] \
+    || fail "held task carries no admit_not_before: $task"
+  [[ "$(jq -r '.block_reason // "null"' <<<"$task")" == "null" ]] \
+    || fail "a quota-held task must not carry a block_reason: $task"
+  # The 30 m interval is still configured, so `true` here is the CLI's own
+  # 1800 s winning — which is the whole distinction reported_only draws.
+  quota="$(api GET /agents | jq -c '.agents[] | select(.name == "claude") | .quota')"
+  [[ "$(jq -r .resets_at_reported <<<"$quota")" == "true" ]] \
+    || fail "quota.resets_at_reported is false for a reset the CLI named: $quota"
+
+  steps="$(api GET "/tasks/$held/steps")"
+  [[ "$(jq 'length' <<<"$steps")" == "1" ]] || fail "attempts = $(jq 'length' <<<"$steps"), want 1: $steps"
+  [[ "$(jq -r '.[0].state' <<<"$steps")" == "interrupted" ]] \
+    || fail "attempt state is $(jq -r '.[0].state' <<<"$steps"), want interrupted: $steps"
+
+  unset FAKEAGENT_SCENARIO FAKEAGENT_USAGE_LIMIT_RESET
+  "$VINCENT" daemon stop
+  echo "=== scenario 13 PASS (task $walled blocked on the wall, task $held still waits it out)"
+}
+
 WHICH="${VINCENT_GATE_SCENARIO:-all}"
 if (( REAL_AGENT )); then
   echo "== real-agent mode: scenario 1 only (PR G decision)"
@@ -1545,8 +1709,9 @@ case "$WHICH" in
   10) scenario10 ;;
   11) scenario11 ;;
   12) scenario12 ;;
+  13) scenario13 ;;
   all) scenario1; scenario2; scenario3; scenario4; scenario5; scenario6; scenario7; scenario8
-     scenario9; scenario10; scenario11; scenario12 ;;
+     scenario9; scenario10; scenario11; scenario12; scenario13 ;;
   *) fail "unknown VINCENT_GATE_SCENARIO: $WHICH" ;;
 esac
 

--- a/scripts/m2-gate.sh
+++ b/scripts/m2-gate.sh
@@ -1530,7 +1530,7 @@ YAML
 }
 
 # ---------------------------------------------------------------------------
-# Scenario 13 — usage_limit_auto_continue (task 003, §12.3): the switch that
+# Scenario 13 — usage_limit_auto_continue (task 091, §12.3): the switch that
 # turns the automatic wait off. Two daemons, because both halves of the truth
 # table need their own fake-CLI environment and FAKEAGENT_* is read at daemon
 # start (PR G decision): `never` against a CLI that named no reset must block,


### PR DESCRIPTION
## Summary

Adds `usage_limit_auto_continue` to `config.yaml` — the switch that says
whether a recognized quota stop is waited out or handed to a human.

Task 003 built the wait and nothing since built a way out of it.
`usage_limit_recheck_interval` tunes how long a task waits when the CLI named
no reset, but it is validated positive so it cannot say "do not wait", and
`max_task_cost_usd` defaults off and only stops a runaway after the money is
spent. That gap matters because a quota wall is recognized from the CLI's
*wording* (§9.1): a stop recognized wrongly re-queues itself and spends money
on the next attempt with nobody watching, which is how #348 was found.

The key is a validated three-value string, default `always`:

| value | a recognized quota stop … |
|---|---|
| `always` (default) | holds and re-queues the task, exactly as today. No existing installation changes |
| `reported_only` | holds when the adapter parsed a reset the CLI actually named; **blocks** when the wait would be the `usage_limit_recheck_interval` estimate |
| `never` | blocks |

A tri-state rather than the boolean the issue proposed, because the middle
value is the interesting one. The incident behind #348 had **no** CLI-reported
reset — prose matched the marker list and the hold was the 15-minute estimate.
`reported_only` blocks exactly that class of stop, the one where vincent is
guessing at the window, while keeping unattended recovery for the case the
feature was built for. Recorded as decision 1 of
`docs/tasks/091-usage-limit-auto-continue.md`, along with the beaten
alternatives: overloading `usage_limit_recheck_interval: 0`, a very large
interval, and a consecutive-hold cap.

Blocking costs nothing. The task stops at the step it was on with
`block_reason: usage_limit`, the cursor does not advance, the attempt row is
still `interrupted` from `finishStepRun`, and **no retry is consumed** — the
same shape `cost_limit` takes — so a `retry` once the window reopens re-runs
the step with a full budget. The decision is taken in the `StepInterrupted`
arm of the engine's outcome switch, above the `StepFailed` arm, so
`allow_failure` never reaches it: a workflow must not be able to branch on
"the account is out of quota" as though it were a test result.

Two behaviours held deliberately constant across all three modes:

- **The per-adapter quota observation is recorded either way**, estimate
  included, with the right `resets_at_reported`. That record is what puts the
  board badge and the `agent.quota_changed` event in front of the operator,
  and it is precisely how someone learns *why* a task just blocked. A config
  key must not be able to make the board disagree with itself. As a
  consequence `usage_limit_recheck_interval` keeps a meaning in every mode —
  it is the estimate — even where it no longer times a wait.
- **An ad-hoc repair that hits a quota stop under a blocking mode returns the
  task to `blocked` carrying the reason it was blocked with**, not
  `usage_limit`, request drained the way every finished repair drains it. The
  issue expected `repair.go` to need no branch; `finishRepair` restores
  `req.BlockReason` deliberately, for the reason already recorded beside the
  cost cap there — the reason the task was blocked with says more than the one
  the repair ran into.

The mode is read at the moment of the stop, the way the interval beside it
already is, so a hot reload reaches the next quota stop rather than the next
daemon restart. A hold **already in flight is not converted**: that task keeps
it, is re-admitted once, and meets the new mode at the next stop — one wasted
spawn, the same trade task 003 recorded for pause-then-resume dropping a hold.

Editable everywhere daemon configuration is: `GET`/`PATCH /v1/config`, the
`apiclient` wire types, `vincent config get|set`, and the daemon view's config
editor as a three-way chooser. Claude-only in effect — `FailureUsageLimit` is
produced by exactly one adapter, so the key is inert on codex and cursor,
exactly as the capability table in `docs/guides/agents.md` says.

### Spec

`usage_limit` can now be a `block_reason`, which two spec sentences said it
never was. Both are amended in place with dated notes rather than a second
reason being minted for the same condition: `internal/taskrun` and
`internal/worktree` share one reason vocabulary, and splitting it would make
`usage_limit` mean "quota, waited" in one place and something else mean
"quota, blocked" in another.

- **§7.2** — the usage-limit bullet's "therefore a `queued_reason`, never a
  `block_reason`" is now conditional on the mode.
- **§11** — `usage_limit` is one of the two admission-hold producers only in
  the modes that hold; the admission walk itself is unchanged, since a stop
  that produced no hold never reaches it.
- **§12.3** — the key's own paragraph beside `usage_limit_recheck_interval`,
  and the line in the generated `config.yaml` sample.
- **§18** — the "Agent stopped by a usage limit" row.

### Testing

`go test ./...` and `go test -race` on every package this touches are green,
and `go tool golangci-lint run ./...` is clean cross-built for `linux`,
`darwin` and `windows`. `VINCENT_GATE_SCENARIO=13 ./scripts/m2-gate.sh` and
`./scripts/m11-gate.sh` both pass locally.

Beyond the units' own coverage — the config default and enum, the engine's
three-mode truth table with the observation asserted in every case, the repair
branch, the wire round trip and the TUI chooser — the new m2 scenario 13
drives both legs end to end over curl against the fake agent: `never` against
a CLI that named no reset blocks with an `interrupted` attempt and a quota
still visible on `GET /v1/agents`, and `reported_only` against one that did
still holds.

### Integration notes

Two comments elsewhere in the tree asserted what this change makes false and
were corrected rather than rewritten: `ReasonUsageLimit`'s "appears as a
`queued_reason`, never as a `block_reason`" (and the sentence in
`ReasonRetryBackoff` that compares itself to it), and the new-task quota
advisory's "the task will park on the same `usage_limit` hold". Citations that
attributed the new key to task 003 now name task 091, which is the record that
carries its reasoning.

## Related

Closes #348

Recorded as `docs/tasks/091-usage-limit-auto-continue.md` (closes 091.1–091.5).

Revisits nothing. Task 003 decision 1 beat *overloading `block_reason` on a
queued task*, which is a different thing from blocking; a queued task still
never carries one. Task 003 decision 3 and task 028's beat — no exponential
backoff, no per-task hold state — are untouched, since a mode is resolved
configuration read at the stop, exactly as the interval is. Task 003 decision
2 (codex and cursor recognize no quota wording) is what makes the key inert on
them, and task 003 decision 4 (no pre-flight refusal on the new-task form) is
unchanged.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)

`docs/reference/api.md` is deliberately **not** changed: it documents the route
table, and no route was added or altered — `GET`/`PATCH /v1/config` serve one
more key, and that page does not enumerate them. The same goes for
`docs/reference/cli.md`, which points at the configuration reference instead of
listing keys, and for `docs/reference/workflow-schema.md` and
`skills/vincent-workflows/SKILL.md`: no step type, field, validation rule or
template variable moved.

A documentation audit after the fact found five claims on pages this change had
not touched, and fixed them in a separate `docs:` commit:

- The configuration reference introduces its default file with "this is what
  first start writes, **verbatim**", and the block it grew for the new key was
  not what `internal/config/bootstrap.go` generates — the two were written
  independently. The sample now matches the template.
- Renaming troubleshooting's `usage_limit` heading to "do nothing, unless you
  asked to be told" moved its anchor, and four links still named the old one —
  two in `docs/guides/tui.md`, two in `docs/guides/agents.md`, one of them a
  line this change had already edited to mention the new key.
- `docs/guides/scripting.md` still said `usage_limit` "is a queued reason,
  never a block reason", which is the sentence §7.2 was amended for.
- The new-task quota advisory in `docs/guides/tui.md` still said the task
  "waits its turn on the ordinary `usage_limit` hold". That is the doc
  counterpart of the comment in `internal/tui/newtaskrender.go` this change
  did correct, and of the sentence in `docs/guides/agents.md` it did fix.
- The bounds list in `docs/guides/workflows.md` stated the wait
  unconditionally.

### Found, not fixed

`docs/reference/configuration.md`'s default-file sample has **older** drift from
`internal/config/bootstrap.go` than anything here, left alone because it belongs
to other work and not to this pull request. Diffing the two shows three
remaining hunks: the sample documents a `container:` block the generated file
has never carried (task 061), it still describes the GitHub integration as
read-only where the template records the one write path (task 069), and it is
missing the `input_timeout` sentence about chat turns. A separate change should
make that block generated or gated by a test, since "verbatim" is a claim
nothing currently checks.
