### PR TITLE
Archived boards for tasks and chats, with permanent delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,13 @@ jobs:
       - name: M14 gate (chats end to end)
         shell: bash
         run: ./scripts/m14-gate.sh
+
+      # M15: archived listings and the permanent delete (task 092, issue #350;
+      # §10, §13.2, §13.3). The matrix matters here because the delete reaches
+      # the filesystem and git on the host: a transcript directory has to be
+      # gone on all three, and §10's "a branch with commits is kept" is a
+      # `git rev-list` answer read back through the platform's own line
+      # endings.
+      - name: M15 gate (archived boards and delete)
+        shell: bash
+        run: ./scripts/m15-gate.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **Archived boards, and a permanent delete.** Archiving a task or a chat kept
+  every row it ever wrote, and nothing in vincent could reach that history or
+  discard any of it — retention removes transcript *files* and never a row. Two
+  new screens, reached from the command palette (`:`), are where it is read
+  back: **Archived tasks** and **Archived chats**, the boards you already know
+  in a second mode. Same grouping, same folding, same `/` filter, same
+  `space`/`V` selection, listing what is archived instead of what is live,
+  newest-archived first, a hundred rows at a time, inside a date window `d`
+  cycles (7 days / 30 days / all). `enter` opens the row's full workspace, which
+  is read-only for free — an archived task offers no actions.
+
+  `D` deletes permanently: the row, its step attempts (or its turns) and its
+  transcripts, with `b` on the confirmation also deleting the branch. It is
+  `DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}` over the API, and
+  `vincent task delete` / `vincent chat delete` (aliased `rm`) from a shell,
+  which take `--branch`, `--json` and `--before 30d` to sweep the archive by
+  age. **A branch carrying commits past its base is never deleted**, whichever
+  way it was asked — vincent's standing rule, unchanged — and the remote branch
+  is never touched. A delete refuses rather than cascading, naming the row that
+  is holding on: a live row, a fan-out parent whose lanes still exist, a chat
+  handed off to a task, or a task such a chat points at. Neither route is an MCP
+  tool, so an agent cannot discard history a human archived. `GET /v1/tasks` and
+  `GET /v1/chats` grew `archived_before` and `archived_since`, and
+  `GET /v1/chats` grew `limit` and `offset`.
+
 - **`usage_limit_auto_continue` — a switch over the automatic usage-limit
   wait.** When an agent CLI reports that the account's quota for the window is
   spent, vincent parks the task and re-runs the step by itself. That is still

--- a/docs/features.md
+++ b/docs/features.md
@@ -149,6 +149,19 @@ every other one — approve, reject, retry, repair, skip, pause, resume, answer,
 archive — is a subcommand now too, so a board full of blocked tasks can be
 cleared from a shell loop.
 
+Archiving keeps the history. **Archived boards** — one for tasks, one for chats,
+both reached from the command palette — are where it is read back: the live
+boards you already know, listing what is archived instead of what is running,
+newest-archived first, in pages and inside a date window. Opening a row from
+there opens its full workspace, read-only because an archived task offers no
+actions rather than because a flag says so. It is also the one place anything is
+**permanently deleted**: `D` (or `vincent task delete` / `vincent chat delete`)
+removes the row, its attempts and its transcripts for good, optionally with its
+branch — never a branch carrying commits past its base, which stays vincent's
+standing rule wherever it is asked. A delete refuses rather than cascading:
+a fan-out parent whose lanes still exist, or a task a handed-off chat points
+at, is named as what is holding on.
+
 Every state transition is persisted before execution. If the daemon dies
 mid-step, restart recovery finalizes the interrupted attempt, verifies and
 stops orphan processes, and reruns the step without charging it as a failed

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -38,12 +38,14 @@ every human action (`task_cancel`, `task_pause`, `task_approve`, `task_answer`,
 the GitHub reads, and the read-only `health`, `info`, `config_get`,
 `agent_list`, `doctor`, `orphan_list`.
 
-Ten routes are deliberately **not** tools:
+Twelve routes are deliberately **not** tools:
 
 - `POST /v1/daemon/stop`
 - `POST /v1/agents/{name}/quota`
 - `POST /v1/daemon/backup`
 - `DELETE /v1/projects/{id}`
+- `DELETE /v1/tasks/{id}`
+- `DELETE /v1/chats/{id}`
 - `POST /v1/maintenance/gc`
 - `POST /v1/doctor/fix`
 - `PATCH /v1/config`
@@ -52,7 +54,11 @@ Ten routes are deliberately **not** tools:
 - `POST /v1/tasks/{id}/github/pull/create`
 
 An agent should not be able to stop, garbage-collect or reconfigure the daemon
-that is supervising it. Those stay CLI-and-curl only. The configuration one is
+that is supervising it. Those stay CLI-and-curl only. The two
+[permanent deletes](../reference/api.md#permanent-delete) are on the project
+delete's line: a row a human archived is history nobody else may discard.
+`task_archive` stays an ordinary tool, because the row and its transcripts
+survive an archive. The configuration one is
 the sharpest of them: a patch can change the argv the daemon spawns
 (`notify.command`, `agents.*.path`), what its children inherit (`environment`),
 and whether steps are wired to MCP at all (`mcp.wire_steps` — a step could

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1315,6 +1315,9 @@ task-only.
 | `s` | Cycle the listing between live, archived and handed-off, and all |
 | `r` | Reload the board |
 
+`s` is a peek at history from the live board; the [Archived](#archived) screen
+is where history is paged, windowed and deleted.
+
 Archived and handed-off chats are **off this board by default**, the way
 archived tasks are off the task board. `s` cycles the listing — live, then the
 terminal ones, then both — and the header names the listing whenever it is not
@@ -1468,6 +1471,41 @@ conversation and send again.
 A turn that runs past `agent_timeout`, or sits unanswered past `input_timeout`,
 fails and returns the chat to `idle` — the slot comes back rather than being
 held by a conversation nobody came back to.
+
+### Archived
+
+Two screens, one for tasks and one for chats, reached from the command palette
+(`:`). They are the boards you already know, in a second mode: the same
+grouping, the same folding, the same `/` filter and the same `space`/`V`
+selection, listing what is archived instead of what is live. There is no key of
+its own for either — the palette is how you get there, which is the pattern
+every takeover but new task follows.
+
+`enter` opens the row's workspace. It is **read-only for free**: an archived
+task offers no `available_actions`, and every action key is gated on those, so
+there is nothing to withhold and no flag saying so.
+
+| Key | Does |
+|---|---|
+| `D` | Delete permanently — asks first |
+| `d` | Cycle the window: last 7 days → last 30 days → all time |
+| `<` / `>` | Turn the page (a hundred rows at a time) |
+| `enter` | Open the row's workspace, read-only |
+| `/` | Filter, exactly as on the live board |
+| `space` / `V` | Select rows for the delete |
+
+The confirmation takes three answers: `y` deletes the row, its step attempts (or
+its turns) and its transcripts; `b` does that **and** deletes its branch; `n`
+does nothing. No other key answers it — a permanent delete is not something a
+stray press should be able to confirm or cancel. And the extra answer cannot
+destroy anything `y` would have kept: a branch carrying commits past its base is
+reported and kept whichever you pressed.
+
+Rows are listed **newest-archived first**, which is the only order an archive
+has. A selection deletes one row at a time and reports what happened — how many
+went, how many branches with them, and how many the daemon refused. A refusal
+names what is holding on: a fan-out parent still has its lanes, or a handed-off
+chat still points at the task. Delete those first and try again.
 
 ### Daemon
 

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -43,8 +43,8 @@ workspace has five full-view tabs — **Steps & Attempts**, **Task Details**,
 whole terminal. `tab` advances through them, `shift+tab` goes back, and `1`–`5`
 jump directly. `esc` returns to the board.
 
-New task, projects, workflows, daemon, and — for GitHub projects — pull
-requests are full-screen takeovers too. `esc`
+New task, projects, workflows, chats, the two archived boards, daemon, and —
+for GitHub projects — pull requests are full-screen takeovers too. `esc`
 closes one layer at a time (popup → task/screen → selection → filter) and
 **never quits**.
 
@@ -1495,11 +1495,12 @@ there is nothing to withhold and no flag saying so.
 | `space` / `V` | Select rows for the delete |
 
 The confirmation takes three answers: `y` deletes the row, its step attempts (or
-its turns) and its transcripts; `b` does that **and** deletes its branch; `n`
-does nothing. No other key answers it — a permanent delete is not something a
-stray press should be able to confirm or cancel. And the extra answer cannot
-destroy anything `y` would have kept: a branch carrying commits past its base is
-reported and kept whichever you pressed.
+its turns) and its transcripts; `b` does that **and** deletes its branch; `n` —
+or `esc`, which closes a layer everywhere — does nothing. No other key answers
+it: a permanent delete is not something a stray press should be able to confirm
+or cancel. And the extra answer cannot destroy anything `y` would have kept: a
+branch carrying commits past its base is reported and kept whichever you
+pressed.
 
 Rows are listed **newest-archived first**, which is the only order an archive
 has. A selection deletes one row at a time and reports what happened — how many

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1095,13 +1095,77 @@ are **not** here — those come from [`GET /v1/agents`](#daemon).
 
 | Method | Path | Notes |
 |---|---|---|
-| `GET` | `/v1/tasks?project_id=&state=&archived=&limit=&offset=&parent_id=&include_children=` | List. Fan-out lanes are **excluded** by default — `parent_id` lists one parent's lanes in merge order, `include_children=true` the flat everything |
+| `GET` | `/v1/tasks?project_id=&state=&archived=&archived_before=&archived_since=&limit=&offset=&parent_id=&include_children=` | List. Fan-out lanes are **excluded** by default — `parent_id` lists one parent's lanes in merge order, `include_children=true` the flat everything |
 | `POST` | `/v1/tasks` | `{ project_id, workflow, title, description?, fields?, base_branch?, branch_name?, priority?, agent?, model?, effort?, github_issue?, github_pull? }` — `branch_name` is used verbatim and wins over any template, **except** on a `github_pull` task, whose branch is the pull request's head. Accepts an optional `Idempotency-Key` header |
 | `GET` | `/v1/tasks/{id}` | Full task |
 | `PATCH` | `/v1/tasks/{id}` | `{ priority }` — queued/paused only |
+| `DELETE` | `/v1/tasks/{id}` | Permanent delete of an **archived** task. `?delete_branch=true` (or `{ "delete_branch": true }`) → `{ deleted: true, branch? }`. See [Permanent delete](#permanent-delete) |
 | `GET` | `/v1/tasks/{id}/steps` | Every step run, every attempt, in position order. `state` may be `stopped` (a `condition` step ended the run, or a `break` ended its loop), and a `skipped` row carries `skip_reason: "condition"` when a guard skipped it and `null` when you did. A row inside a `loop` (§7.8) carries `iteration` (1-based) and, for `for_each`, `loop_item` — a loop's body steps share the loop's `step_index`, so those are what tell two of them apart — plus `loop_total`, how many iterations the admission that wrote the row planned to run (the `count:`, or the resolved `for_each` list's length; `0` outside a loop and on a row written before the daemon recorded it). A `fan_out` step with `needs:` between its lanes puts its rounds on the same `iteration` column (0-based, so a flat lane list still reads `0`), which is the one other place a non-zero `iteration` appears — under `schedule: eager` that number is a monotonic merge counter rather than the lane's wave, and the step may write up to one merge row per lane; the two cannot be confused because a `fan_out` is not valid inside a loop body. A `fan_out` row appears when its round's lanes are **spawned**, not when they merge: the park opens the row `running` and that round's merge admission finalizes the same one (§7.6), so a parent whose lanes are working is on the timeline rather than missing from it. Each row also carries **what the attempt was given**: `rendered_prompt`, `rendered_run`, `rendered_check` and `rendered_if` are the substituted text the adapter, the shell and the guard actually saw — the full bytes, unlike `prompt_override`/`run_override`, which are booleans here — with `rendered_for_each` the resolved list an iteration drew its `loop_item` from, carried as a **string holding a JSON array** rather than as an array field, and `input_truncated` saying a field was cut at its 64 KiB ceiling. Beside them the resolution the attempt ran under: `agent_source`, `model_source` and `effort_source` name which level supplied each part (`step`, `task`, `workflow`, `adapter`), and `permission_mode`, `timeout_ms`, `check_timeout_ms`, `shell` and `work_dir` are the values that were in force, recorded rather than re-resolved, so they still describe the attempt after a config reload or a task patch. `null` (or `0`, or `""`) means nothing was recorded — an attempt from before the daemon recorded any of this, and every field the step type has no input for — while an empty string on a rendered field is a render that produced nothing. `rendered_if` is evidence, not a decision: a guard is re-evaluated every time it is reached |
 | `POST` | `/v1/tasks/{id}/steps/{step_id}/status` | `{ message }` → `{ message }` as stored. What the **running** step is doing, in its own words. Called by that step's own process — see [Step status](#step-status) |
 | `GET` | `/v1/tasks/{id}/workflow` | This task's own workflow **snapshot** as a full definition — what ran, not what the registry says now. See [The task's workflow](#the-tasks-workflow) |
+
+### Permanent delete
+
+`DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}` remove an **archived** row
+for good: the row, its step attempts (or its turns) and its transcript
+directory under `{data_dir}/transcripts/`. They are the only routes that delete
+a task or chat row — [retention](files.md#transcripts) removes transcript
+*files* and never a row.
+
+Delete is **not** a §6 action. It never appears in `available_actions`, the
+state check is the handler's own rather than the FSM's, and neither route is an
+[MCP tool](#the-mcp-endpoint). The precedent is `DELETE /v1/projects/{id}`,
+which is likewise no action.
+
+`?archived_before=` and `?archived_since=` on `GET /v1/tasks` and
+`GET /v1/chats` are RFC3339 instants that bound the listing to what was
+archived in a window; anything unparseable is `400 validation_failed`. An
+archived-only listing comes back **newest-archived first** rather than by id —
+recency is the only order an archive has, which is why there is no `sort=`
+parameter. Tasks measure the bound over `archived_at`; chats measure it over
+`updated_at`, which for a terminal chat is when it ended.
+
+There is no bulk delete and there is not going to be one. A sweep is one
+`DELETE` per row.
+
+```sh
+curl -sS -X DELETE "http://127.0.0.1:PORT/v1/tasks/7?delete_branch=true" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{ "deleted": true,
+  "branch": { "name": "vincent/7-add-login", "result": "has_commits" } }
+```
+
+`branch` carries archive's vocabulary unchanged — `deleted`, `has_commits`,
+`not_ours`, `unknown`, `error` — and is omitted entirely when the branch step
+did not run. `delete_branch=true` does **not** weaken §10's standing rule: a
+branch carrying any commit past its base is kept and reported `has_commits`
+whatever was asked for. The remote branch is never touched; that leg belongs to
+`delete_remote_branch_on_archive` and to archive alone.
+
+Every refusal is a `409` in the standard envelope, with `details.reason` naming
+what is holding on:
+
+| `details.reason` | Meaning |
+|---|---|
+| `not_archived` | The row is still live. Delete applies to archived rows only |
+| `has_lanes` | An archived fan-out parent whose lane rows still exist. Delete the lanes first |
+| `handoff_target` | A `handed_off` chat points at this task and would be left pointing at nothing |
+| `handed_off` | The chat was handed off to a task, which owns its worktree and branch. Delete that task |
+
+An unknown id is `404`.
+
+Two things a delete deliberately does **not** do. It does not purge the row's
+`events`: their `id` is the `Last-Event-ID` cursor every subscriber is holding,
+and one archived row going is not a project's whole history going. And it does
+not clear `created_by_task_id` on a task this one created by refusing — that
+column nulls itself, and `mcp.max_depth`'s walk simply stops one link early.
+
+A client resuming `/v1/events` from a cursor older than a delete will see events
+for an id that now `404`s. That is the same thing a project delete does to a
+stale cursor, and it is survivable: re-fetch, and drop what is gone.
 
 ### The task's workflow
 
@@ -1543,8 +1607,8 @@ separate family from tasks: they never appear in `GET /v1/tasks` or on the
 board, and tasks never appear here.
 
 ```
-GET    /v1/chats?project_id=&state=&archived=
-                                      newest first; state may repeat
+GET    /v1/chats?project_id=&state=&archived=&archived_before=&archived_since=
+                &limit=&offset=       newest first; state may repeat
 POST   /v1/chats                      create, with a worktree and a branch
 GET    /v1/chats/{id}                 { chat, turns[] } — the whole conversation
 POST   /v1/chats/{id}/send            start a turn
@@ -1552,6 +1616,8 @@ POST   /v1/chats/{id}/answer          answer a mid-run request
 POST   /v1/chats/{id}/cancel          stop the live turn
 POST   /v1/chats/{id}/archive         remove the worktree; terminal
 POST   /v1/chats/{id}/handoff         give the worktree and branch to a new task; terminal
+DELETE /v1/chats/{id}                 permanent delete of an archived chat
+                                      — see Permanent delete
 GET    /v1/chats/{id}/events          SSE: this chat's events plus its live output
 GET    /v1/chats/{id}/turns/{seq}/transcript
                                       one turn's transcript, with ?offset= / ?tail=
@@ -1852,6 +1918,7 @@ task.step_advanced      task.status_changed     task.children_changed
 task.github_pull_changed
 chat.created            chat.state_changed      chat.turn_changed
 chat.archived           chat.handed_off
+task.deleted            chat.deleted
 project.*               workflow.registry_changed
 agent.quota_changed     daemon.shutting_down
 ```
@@ -1862,6 +1929,12 @@ they need.
 - **A connection without `Last-Event-ID` starts live at the next committed
   event.** The stream never replays history unasked: catch-up is a REST snapshot
   first, then the stream.
+- `task.deleted` and `chat.deleted` carry `{ id, title }` and announce a
+  [permanent delete](#permanent-delete). They exist even though there is no
+  `task.archived` type, and for the reason there is not one: an archive *is*
+  `task.state_changed` with `to: archived`, but a delete has no state to change
+  to, so without a type no other client would ever learn the row is gone. The
+  event outlives the row it records.
 - There is no separate `task.archived` or `task.awaiting_input` type. Both are
   `task.state_changed` with the appropriate `to`; the `awaiting_input` payload
   additionally carries the request kind and a one-line summary, which is the
@@ -1953,6 +2026,8 @@ Every route on this page is a tool, with these exceptions:
 | `POST /v1/daemon/stop` | An agent must not stop the daemon supervising it |
 | `POST /v1/daemon/backup` | Destructive admin |
 | `DELETE /v1/projects/{id}` | Destructive admin |
+| `DELETE /v1/tasks/{id}` | Destructive admin, on the same line: a row a human archived is history nobody else may discard. Archive stays a tool — the row and its transcripts survive it |
+| `DELETE /v1/chats/{id}` | Same |
 | `POST /v1/maintenance/gc` | Destructive admin |
 | `POST /v1/doctor/fix` | Destructive admin |
 | `PATCH /v1/config` | An agent must not reconfigure the daemon supervising it — a patch changes the argv it spawns, what its children inherit, and whether steps get MCP at all |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -863,8 +863,9 @@ Each is exit 1 carrying the daemon's own wording, which names the row that is
 holding on. An unknown id is exit 1 with a 404.
 
 `--branch` additionally deletes the task's local branch. [§10's standing
-rule](../security-model.md) is unchanged by asking: a branch carrying **any**
-commit past its base is kept and reported `has_commits`. The remote branch is
+rule](configuration.md#delete_empty_branch_on_archive) is unchanged by asking: a
+branch carrying **any** commit past its base is kept and reported
+`has_commits`. The remote branch is
 never touched — that leg belongs to
 [`delete_remote_branch_on_archive`](configuration.md#delete_remote_branch_on_archive)
 and to archive alone.
@@ -873,8 +874,8 @@ and to archive alone.
 (`2026-01-31`, or a full RFC3339 instant) or a duration back from now (`30d`,
 `12h`). It is one `DELETE` per row, sequentially — there is no bulk endpoint —
 and it does not stop at the first refusal. `--json` emits one entry per row
-with `deleted`, `branch` and, on a refusal, `reason`. Exit is 1 if any row was
-refused or failed.
+with `id`, `deleted`, `branch` and, on a refusal, `reason` and `error`. Exit is
+1 if any row was refused or failed.
 
 ### `vincent task answer`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -838,6 +838,44 @@ Error: worktree_dirty: worktree ~/.local/share/vincent/worktrees/7 has local cha
 The first line is the daemon's, printed as it stands; the second is the
 command's own.
 
+### `vincent task delete`
+
+```sh
+vincent task delete <id>... [--branch] [--json]
+vincent task delete --before <date|duration> [--branch] [--json]
+```
+
+Aliased as `vincent task rm`. Permanently deletes an **archived** task: the
+row, its step attempts and its transcript directory. This is the only thing in
+vincent that removes a task row — [retention](files.md#transcripts) removes
+transcript *files* and never a row.
+
+It does not prompt. The command tree exists for scripting, and the daemon's
+refusals are the confirmation story:
+
+| Refusal | `details.reason` |
+| --- | --- |
+| The task is not archived | `not_archived` |
+| It is a fan-out parent whose lanes still exist — delete those first | `has_lanes` |
+| A handed-off chat points at it — that chat would be left pointing at nothing | `handoff_target` |
+
+Each is exit 1 carrying the daemon's own wording, which names the row that is
+holding on. An unknown id is exit 1 with a 404.
+
+`--branch` additionally deletes the task's local branch. [§10's standing
+rule](../security-model.md) is unchanged by asking: a branch carrying **any**
+commit past its base is kept and reported `has_commits`. The remote branch is
+never touched — that leg belongs to
+[`delete_remote_branch_on_archive`](configuration.md#delete_remote_branch_on_archive)
+and to archive alone.
+
+`--before` sweeps instead of naming ids: every task archived before a date
+(`2026-01-31`, or a full RFC3339 instant) or a duration back from now (`30d`,
+`12h`). It is one `DELETE` per row, sequentially — there is no bulk endpoint —
+and it does not stop at the first refusal. `--json` emits one entry per row
+with `deleted`, `branch` and, on a refusal, `reason`. Exit is 1 if any row was
+refused or failed.
+
 ### `vincent task answer`
 
 ```sh
@@ -1189,6 +1227,25 @@ vincent chat archive CHAT_ID [--force] [--json]
 Removes the chat's worktree and, under `delete_empty_branch_on_archive`, an
 empty branch with it — the same archive a task gets. A worktree with local
 changes is refused; `--force` is the way past it.
+
+### `vincent chat delete`
+
+```sh
+vincent chat delete CHAT_ID... [--branch] [--json]
+vincent chat delete --before <date|duration> [--branch] [--json]
+```
+
+Aliased as `vincent chat rm`. `vincent task delete` for a chat: permanently
+deletes an **archived** chat — the row, its turns and its transcript directory.
+
+A `handed_off` chat is refused (`details.reason: "handed_off"`). The task it
+was handed to owns the worktree and the branch, so that task is what to delete;
+a `--before` sweep skips handed-off rows rather than collecting a refusal it
+can see coming.
+
+`--before` measures from when the chat *ended*, which for a terminal chat is
+its `updated_at` — chats have no `archived_at` column, because the transition
+into a terminal state is the last write the row takes.
 
 ### `vincent chat handoff`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -568,7 +568,10 @@ archive time. `0` disables pruning. The pruner runs at daemon start and on a
 24-hour ticker, which is what makes retention work on a daemon that survives
 reboots rather than only on the restarts it no longer has.
 
-Task and step rows are **never** deleted — only the transcript files.
+The **pruner** deletes no rows — only the transcript files. Task and step rows
+go when a human asks for it, and only then:
+[`vincent task delete`](cli.md#vincent-task-delete) on an archived task, or
+removing the project.
 
 This covers [chats](cli.md#vincent-chat) too: an **ended** chat's turn
 transcripts under `{data_dir}/transcripts/chat-{chat_id}/` are pruned on the
@@ -577,7 +580,8 @@ endings count — `archived` and [`handed_off`](cli.md#vincent-chat-handoff) —
 a handed-off chat's transcripts are its own rather than the worktree's, so
 pruning them never reaches the task that inherited it. A chat that has not ended
 keeps its transcripts however old it is, exactly as a task does. Chat and turn
-rows are never deleted either.
+rows are the same: the pruner never touches them, and
+[`vincent chat delete`](cli.md#vincent-chat-delete) is what removes one.
 
 That same pass also drops
 [idempotency keys](api.md#transport-and-auth) older than a fixed 24 hours. This

--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -189,6 +189,14 @@ Deleting a project deletes its task rows, and retention walks rows — so those
 directories are reached by no retention pass, ever, and are reclaimed by
 [`vincent gc`](cli.md#vincent-gc) instead.
 
+[`vincent task delete`](cli.md#vincent-task-delete) and
+[`vincent chat delete`](cli.md#vincent-chat-delete) are the third way. They
+remove an archived row *and* its transcript directory, in that order: the row
+goes first, so a failed unlink cannot resurrect something already reported gone
+— and `vincent gc` treats a transcript directory with no row as its own, which
+is what closes that gap. They are the only thing in vincent that deletes a task
+or a chat row; the retention pass removes files and never a row.
+
 They contain everything the agent did. The **rendered prompt or command** an
 attempt was handed is recorded on the attempt's own row in the database instead —
 the claude adapter passes the prompt on stdin, so no transcript ever carried it —

--- a/docs/reference/task-lifecycle.md
+++ b/docs/reference/task-lifecycle.md
@@ -66,7 +66,7 @@ task's existing worktree, and returns it to the state it came from. See
 | `paused` | You asked it to hold; takes effect at the next step boundary | no |
 | `done` | Every step succeeded. Worktree and branch retained for inspection. `follow_up` runs more work in them; `archive` tears them down | no |
 | `aborted` | You cancelled, or rejected terminally. Worktree and branch retained, and open to `follow_up` on the same terms as `done` | no |
-| `archived` | Terminal. Worktree removed, record kept. The branch is kept unless it has no commits past its base, in which case it is deleted ([`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)) | no |
+| `archived` | Terminal. Worktree removed, record kept — until a human discards it with [`vincent task delete`](cli.md#vincent-task-delete), which is not an action on this page's list and is the only thing that removes the row. The branch is kept unless it has no commits past its base, in which case it is deleted ([`delete_empty_branch_on_archive`](configuration.md#delete_empty_branch_on_archive)) | no |
 
 Three of these are worth dwelling on.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -133,6 +133,7 @@ Decisions fixed during the design interview; the rest of this document elaborate
 | 27 | GitHub pull requests | **Daemon-side, and read-only until task 069**, like row 26 and through the same gate and credential. *Amended 2026-08-31 (task 068): the read side grows a live **check rollup** for a linked pull request's head commit — `GET /v1/tasks/{id}/github/pull/checks`, one normalized row per check run and per legacy commit status from either leg, never stored — and unlink gains a second home on the task workspace's Pull Request tab (§15 view 2). Task 068 decision 1 settled that merge, close, re-run and comment are written from the TUI only, human-triggered, and 068.4 is the sub-task that lands them and rewrites row 11.* A project's **open** pull requests are listed on demand, and a task is linked to the pull request whose head branch equals its own `branch_name` — by a daemon-side reconciler on a `github.poll_interval` tick, never as a side effect of a GET. Only the *link* is stored (`github_pull_json`: repo, number, source, suppressed) and it is a **pointer, not a snapshot** — the deliberate opposite of row 26, because draft, state and merged status are live by nature and a stored copy of them would read exactly like a current one while being wrong. A human may link or unlink; a human unlink is *sticky* and the reconciler never re-applies it, never overwrites a human link and never un-suppresses one. **Row 11 stands unamended**: vincent pushes nothing, opens nothing and merges nothing, and the “create a PR” affordance is a *constructed* compare URL — no request is made to GitHub when it is built — that a human clicks. `internal/github` gains no write method, no `POST` and no mutating `gh` subcommand. Task 035 decision 5's “repo identity is not stored” was revisited exactly as it predicted: the identity landed on the **task**, beside the number, and no `github_repo` column was added to projects (§5.3, §12.3, §13.2, §13.3, §14, §20; task 052, added 2026-08-29). *Narrowed 2026-08-30 (task 064):* the read-only posture holds in full — no write method, no `POST`, no mutating `gh` subcommand — and a task may now be created **from** a pull request and run on its head branch. That adds a flag to the same envelope (`branch`, `fork`) rather than a snapshot: nothing renderable is stored, so "a pointer, never a snapshot" is unchanged, and there is still no `.Pull` template variable. The consequences live in §10 (a second worktree creation mode, and archive never touching a branch vincent did not cut) and in §5.3's branch-name chain, which gains `pull` above the per-task literal. The listing above is narrowed the same way: it still **defaults** to open, but `?state=` (§13.2) makes a closed or merged pull request reachable, because acting on a merged one and redoing a reverted one are exactly what creating a task from one is for *Amended 2026-08-31 (task 069, issue #273):* the read-only posture gains **exactly one write path** — pull-request creation, from a human. `internal/github.CreatePull` is the only method here that writes, on both legs (`gh pr create`, `POST /repos/{owner}/{name}/pulls`); nothing updates, comments on, closes or merges anything, and `github.enabled` is the only gate on it (§12.3, decision 2: the consent is the keypress and the editable popup in front of it, not a second config key nobody would turn on). Every *other* half of this row is unchanged and load-bearing: the link is still a pointer and never a snapshot, the listing is still pure, the reconciler still never overwrites a human link, and the compare URL is still built by string construction with no request made — it is now the **fallback**, opened when there is no write credential or the create call fails, and the branch behind it has been pushed, so it is no longer a dead page. A create writes the link immediately as `source: human`, which is why the reconciler's poll interval does not make a just-created pull request read as unlinked |
 | 28 | MCP from the daemon | **A second protocol on the existing listener, not a second server.** `/mcp` is registered in §13.2's route table inside the same `recover → log → auth` chain, so row 4 is *added to*, not reversed: same loopback listener, same `Authorization: Bearer {token}` from `{data_dir}/token`, same `daemon.json` discovery. The tool surface **is** the route table — a call replays its arguments as an in-process request against the same handler, so the §13.1 bounds, the validation, the `409` + `details.state` envelopes and `Idempotency-Key` hold by construction — **minus five destructive-admin routes** (`daemon/stop`, `daemon/backup`, `DELETE projects/{id}`, `maintenance/gc`, `doctor/fix`), which is a design line: an agent must not be able to stop, garbage-collect or reconfigure the daemon supervising it. §13.3's SSE routes are replaced by a bounded blocking `task_wait` with a hard ceiling, whose result is complete for a client that drops every progress notification. A step parked in that wait **keeps its §11 slot** and a self-blocking wait is *refused*, not released — releasing it would create a §6 state owning a live agent process and holding no slot, which no state does today. The daemon wires its own agent steps to a **per-step endpoint** (`/mcp/step/{run_id}`, per-run secret), which is identity for the refusal and the provenance column and is explicitly **not** a security boundary (§16). Recursion is bounded by `created_by_task_id` + `mcp.max_depth`/`mcp.max_tasks`, deliberately **not** by `parent_task_id`, which the `awaiting_children` join counts (§9.1, §9.2, §9.3, §9.4, §9.7, §11, §12.3, §12.4, §13.4, §14, §16, §20; task 057, issue #243, added 2026-08-29) |
 | 29 | Free chat | **A first-class entity beside Task, never a task with a `kind` column.** A `chat` is a titled conversation with an agent, scoped to a project, running in its own git worktree and `vincent/{id}-{slug}` branch, with its own four-state lifecycle (§5.5), its own `chats`/`chat_turns` tables (§14) and its own route family (§13.2). It never appears on the task board, in `GET /v1/tasks` or in any §17 aggregate over `step_runs`, whose `task_id` stays `NOT NULL`. Continuity comes from the **agent CLI resuming its own session** — §7.3's fresh-session rule is amended *for chats only* — so turn N sees turns 1..N-1 without vincent replaying any log as prompt context. A turn is bounded by its own cap `max_parallel_chats` (default 3) and is **refused with 409, never queued**: `internal/scheduler` stays the only place `queued → running` happens because a chat turn is never `queued`, and row 28's "no live-but-uncounted agent CLI" reasoning is extended rather than excepted (§11). **No chat route is an MCP tool** — row 28's exclusion list grows by the whole chat family, because an agent must not start unqueued agent processes and `mcp.max_depth`/`mcp.max_tasks` bound tasks by walking `created_by_task_id`, a chain a chat is not in (§13.4). Only adapters that can resume may hold a chat: claude yes (§9.2), **codex and cursor are refused at creation with a typed reason, not emulated** (§9.3, §9.7). *Amended 2026-08-31 (issue #279):* `GET /v1/agents` publishes that answer as `supports_resume` (§9.6) so a client's picker offers only adapters that can hold a chat; the creation-time refusal is unchanged and stays the authority, and an absent field — an older daemon — filters nothing. A stored session the CLI no longer knows fails the turn with `session_lost` and leaves the chat usable; a turn interrupted by a daemon restart is finalized `interrupted` and is **never re-run**, because re-running would re-send the human's message into a session that died with the process (§12.4). Chat worktrees join gc's claim namespace and worktree directories are named by owner, so chat 7 and task 7 cannot collide (§10). §16 is untouched: chats are full-auto by default exactly as tasks are (§5.5, §6, §7.3, §9.1, §9.2, §9.3, §9.7, §10, §11, §12.3, §12.4, §13.2, §13.3, §13.4, §14, §15, §20; task 063, issue #255, added 2026-08-30). *Amended 2026-08-31 (task 067, issue #269, closing 063.2 and 063.3):* chats reach the TUI, as **two views of their own** — a chats board and a chat workspace — never as rows on the task board, so "it never appears on the task board" is unchanged and now literal in the client too. Attention is the chats board's own: an `awaiting_input` chat is pinned and badged there and nowhere else, and `!` and the home board's needs-attention count stay task-only. A chat turn is bounded by §7.2's `agent_timeout` and §7.4's `input_timeout` verbatim, so the slot this row says it holds is no longer held forever (§11, §12.3, §13.2, §13.3, §13.4, §15). *Amended 2026-08-31 (task 070, issue #268):* **codex resumes now**, so "codex and cursor are refused at creation with a typed reason" reads **cursor alone** — codex met the precondition task 063 decision 3 attached to it, a capture against a named build (codex-cli 0.150.1) pinning `codex exec --json resume <thread_id>`, and its `thread.started` id is read into `RunResult.SessionID` (§9.3). Nothing else in this row moves: continuity still comes from the CLI resuming its own session, vincent still replays no log as prompt context, and the refusal is still the authority for the adapters that cannot (§9.7). *Amended 2026-08-31 (task 071, issue #282):* a chat's live output is **normalized in the daemon exactly as a task's is** — §13.3's typed chunks, with the verbatim line kept as `raw` — and the chat workspace renders it with the output pane's own renderer at the session's shared verbosity level. The chat is still its own entity; what it is not is its own rendering vocabulary *Amended 2026-08-31 (task 072, issue #283):* **cursor resumes too**, pinned to a capture against cursor-agent 2026.08.11-e8db854, so "codex and cursor are refused at creation" is retired entirely and **no shipped adapter is refused**. The refusal path is unchanged and unretired — it is the contract for the next adapter — and is now proven against a stub adapter rather than a shipped one, which is what stops it asserting the opposite of the truth the day a capability lands. Two consequences are stated positively rather than worked around: a resumed codex run is always full-auto, because `codex exec resume` has no `--sandbox`, guarded structurally by chats having no requestable permission mode; and cursor cannot report a lost session at all, because it adopts an unknown `--resume` id and answers rather than refusing (§9.3, §9.7). *Amended 2026-09-01 (task 074, issue #288):* a chat has **two** terminal states, not one — an idle chat may `hand_off` its worktree and branch to a task that adopts them verbatim, and `handed_off` is terminal because reusing `archived` would run the archive path, which removes the worktree this transfers. The chat remains a separate entity and this row's "never a task with a `kind` column" is untouched: what is added is a lifecycle transition *between* the two entities, with one authoritative foreign key (`chats.handoff_task_id`) and the reverse direction served by a lookup. It is one transaction — task row, branch claim, link, transition, claim release, both events — with the scheduler notified after the commit, so the scheduler cannot admit a task before it owns a complete workspace and gc never sees the directory claimed twice or not at all. The task becomes the sole owner of that worktree and branch (§10). The new route joins this row's own MCP exclusion list rather than excepting it, which is why it is a chats-family route and not a field on `POST /v1/tasks` (§13.4). §7.3 is untouched: the chat's session is not transferred, and workflow steps still start fresh (§5.5, §10, §12.3, §13.2, §13.3, §13.4, §14, §15) |
+| 30 | Archived boards and permanent delete | *Added 2026-09-09 (task 092, issue #350).* **Archived history is a screen, and a permanent delete is a route.** Two TUI views — archived tasks, archived chats — are the live boards *in a second mode* rather than two new models (§15): the archive needs grouping, folding, `/` and the bulk selection, and a copy would drift on the first change to any of the four. They get palette rows and no keys, because task 049 retired `1..6` to stop adding memorized ones and task 067 gave chats the same treatment. `DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}` (§13.2) are the only things in vincent that delete a task or chat row — the §17 pruner removes transcript *files* and never a row, and that sentence in the retention table is amended to say so. Delete is **not a §6 action**: `taskstate` has no opinion on it and it never appears in `available_actions`, which is what makes the workspace an archived row opens read-only for free; its precedent is `DELETE /v1/projects/{id}`, likewise no action, and both routes join that route's §13.4 destructive-admin exclusion. It **refuses rather than cascading**, naming the row that is holding on: a live row (`not_archived`), an archived fan-out parent whose lanes still exist (`has_lanes` — `parent_task_id` has no `ON DELETE` clause, so without the guard it is a driver error), a `handed_off` chat (`handed_off` — the task owns the worktree, §5.5), and an archived task such a chat points at (`handoff_target`). §10's standing rule is untouched and its task 008 exception merely widens to "at archive time **and at permanent delete**": a branch carrying any commit past its base is reported `has_commits` and kept whatever was answered, and the remote leg is not offered at all. Two durable events are added, `task.deleted` and `chat.deleted` (§13.3) — PR D's "there is no separate `task.archived` type" does not reach them, because that type was redundant with `task.state_changed` and a delete has no state to change to — while the historical `events` rows are deliberately kept, their id being the `Last-Event-ID` cursor. No migration: `archived_at` has been a column since `0001_init.sql`, chats measure the same window over `updated_at` by task 074 decision 6, and every cascade this needs already exists. There is no bulk endpoint and there is not going to be one (task 011): every sweep, in the TUI and in `vincent task delete --before`, is one `DELETE` per row (§5.5, §6, §10, §13.2, §13.3, §13.4, §15, §17, §20) |
 
 ## 4. Architecture
 
@@ -572,6 +573,7 @@ talking to can edit files and make commits without colliding with any task.
 | `branch`, `base_branch`, `base_sha`, `worktree_path` | §10, exactly a task's |
 | `session_id` | **the agent CLI's own conversation id** — the whole of §7.3's chat-only amendment. Empty before the first turn finishes |
 | `pending_input` | the §7.4 request being awaited; non-null exactly in `awaiting_input` |
+| *(permanent delete)* | *Added 2026-09-09 (task 092, issue #350):* `DELETE /v1/chats/{id}` is legal from **`archived` alone**, and is refused from `handed_off` for the reason `archive` is: the task named by `handoff_task_id` owns the worktree and the branch, and a deleted row cannot say that. It is not a §5.5 transition — it removes the row rather than moving it — so the state machine above is unchanged. Its task mirror is refused too: an archived task a `handed_off` chat points at cannot be deleted while that chat exists, because `handoff_task_id` is `ON DELETE SET NULL` and the chat would be left pointing at nothing |
 | `handoff_task_id` | *Added 2026-09-01 (task 074, issue #288):* the task this chat's worktree and branch were handed to. The **one authoritative foreign key** between the two records; a task's `source_chat_id` (§13.2) is this column read backwards, one indexed query per list, never a second stored copy. Non-null exactly in `handed_off` |
 
 A **ChatTurn** is one exchange: the human's message and the agent run it
@@ -824,6 +826,16 @@ times before it is archived, and each is a **round** with its own rows (§5.4).
 | `set priority` | queued, paused | Reorders scheduler admission |
 | `archive` | done, aborted | Removes worktree (warns if dirty — uncommitted changes would be lost; requires `force` in that case); → `archived` |
 | `follow_up` | done, aborted | *Added 2026-08-25 (task 027).* Runs one more piece of work — an agent prompt, a shell command or a registry workflow — in the task's existing worktree and branch (§7.2, §8.3, §8.6, §13.2); → `queued`, and back to the state it came from when the run ends. Repeatable; it decides nothing about the task's verdict and spends none of the workflow's retry budgets |
+
+**Amended 2026-09-09 (task 092, issue #350): permanent delete is deliberately
+not in this table.** `DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}` (§13.2)
+are not §6 actions: delete is not a state transition, `taskstate` has no opinion
+on it, and it must **never** appear in `available_actions` — which is what gates
+every action key in §15. Its refusals are the handler's own check on the row's
+state, not the FSM's 409, and its precedent is `DELETE /v1/projects/{id}`, which
+is likewise no action. One consequence is load-bearing rather than incidental:
+the workspace an archived row opens in §15 is read-only **for free**, because an
+archived task offers no actions, not because a flag says so.
 
 **Amended 2026-08-24 (issue #127): an action that loses a race re-applies itself
 once, when the state it lost to still allows it.** Every action in this table is
@@ -3761,6 +3773,20 @@ Two consequences are handled rather than assumed away:
   dirty-worktree confirmation), then `git -C {project.path} worktree prune`. A branch
   that carries **any commit past its base** is never deleted by vincent.
 
+  *Amended 2026-09-09 (task 092, issue #350).* Task 008's exception below widens
+  from "at archive time" to "**at archive time and at permanent delete**", and
+  gains nothing else. `DELETE /v1/tasks/{id}?delete_branch=true` and
+  `DELETE /v1/chats/{id}?delete_branch=true` (§13.2) reuse the same judgement
+  verbatim — the same `base_sha`-or-`base_branch` fork point, the same
+  `-D`-only-with-a-recorded-`base_sha` rule, the same outcome vocabulary
+  (`deleted` / `has_commits` / `not_ours` / `unknown` / `error`) — so the
+  standing rule above is untouched: a branch carrying any commit past its base
+  is reported `has_commits` and **kept**, whatever the human answered. The
+  remote leg is **not offered** on a delete at all;
+  `delete_remote_branch_on_archive` stays honoured only by
+  `POST /v1/tasks/{id}/archive`, because deleting a branch on a forge other
+  people share is unrecoverable and a delete has no second chance to reconsider.
+
   *Amended 2026-08-16 (task 008).* This bullet used to read "the branch is **never**
   deleted by vincent". It has exactly one exception now: a branch with **no commits
   past the base recorded on its task** is deleted at archive time. A workflow that
@@ -5498,7 +5524,19 @@ GET    /v1/workflows?project_id=        merged registry view: built-in + global 
                                         task 019, added 2026-08-19). Whether those names resolve
                                         is not answered here: it depends on the project's
                                         resolved view and becomes a 400 at task creation
-GET    /v1/chats                        *Added 2026-08-30 (task 063).* Chats, newest first.
+GET    /v1/chats                        *Amended 2026-09-09 (task 092, issue #350).* Also takes
+                                        limit, offset, archived_before and archived_since —
+                                        GET /v1/tasks' parameters, spelled the same way, because
+                                        issue #298 already settled that one vocabulary covers
+                                        both entities. The chat bounds are measured over
+                                        **`updated_at`, with no new column**: a terminal
+                                        transition is the last write a chat row takes, so
+                                        `updated_at` already *is* when it ended (task 074
+                                        decision 6, task 079 decision 2), which is what
+                                        TerminalChatIDsBefore has measured retention off since.
+                                        A terminal-only listing is ordered
+                                        `updated_at DESC, id DESC`, the mirror of the task side
+                                        *Added 2026-08-30 (task 063).* Chats, newest first.
        ?project_id=&state=              `state` may repeat. Chats appear here and nowhere else:
        &archived=                       never in GET /v1/tasks and never on the board.
                                         *Amended 2026-09-01 (issue #298):*
@@ -5519,6 +5557,14 @@ POST   /v1/chats                        { project_id, title, agent?, model?, eff
                                         cannot resume is refused `400 agent_cannot_resume`
                                         (§9.3, §9.7): vincent will not replay the log as prompt
                                         context in its place
+DELETE /v1/chats/{id}                   *Added 2026-09-09 (task 092, issue #350).* Permanent
+                                        delete of an **archived** chat: the row, its chat_turns
+                                        (through the schema's cascade) and its
+                                        `transcripts/chat-{id}` directory. `DELETE /v1/tasks/{id}`
+                                        minus the fan-out clause, with one refusal of its own —
+                                        `handed_off` (409): the task named by `handoff_task_id`
+                                        owns the worktree and branch (§5.5, task 074 decision 5),
+                                        and a deleted row cannot say that; delete the task instead
 GET    /v1/chats/{id}                   { chat, turns[] } — the whole conversation, oldest turn
                                         first, each with its accounting (§5.5)
 POST   /v1/chats/{id}/send              { message } → 202 with the new turn. `409` outside
@@ -5660,7 +5706,20 @@ POST   /v1/resolve                      { workflow, project_id?, agent?, model?,
                                         since it shipped. No client re-implements the
                                         precedence.
 
-GET    /v1/tasks?project_id=&state=&archived=&limit=&offset=&parent_id=&include_children=
+GET    /v1/tasks?project_id=&state=&archived=&archived_before=&archived_since=&limit=&offset=
+                &parent_id=&include_children=
+                                        *Amended 2026-09-09 (task 092, issue #350).*
+                                        archived_before and archived_since are RFC3339 instants
+                                        over `archived_at`; anything unparseable is a 400
+                                        validation_failed. They narrow to the archive on their
+                                        own — `archived_at` is NULL on every live row and NULL
+                                        fails both comparisons. An **archived-only** listing is
+                                        ordered `archived_at DESC, id DESC` rather than
+                                        `id DESC`: recency is the only order an archive has, and
+                                        a task created last week and archived this morning must
+                                        not sort below one archived a year ago. There is
+                                        deliberately no `sort=` parameter — there is one right
+                                        answer per listing
                                         list rows additionally carry the §15 board fields:
                                         project_name, step_total, step_name, and cost_usd /
                                         input_tokens / output_tokens rolled up across every
@@ -5764,6 +5823,31 @@ GET    /v1/tasks/{id}                   full task incl. step runs summary and pe
                                         wrote
 PATCH  /v1/tasks/{id}                   { priority }               (queued/paused only);
                                         emits task.priority_changed and re-runs admission
+DELETE /v1/tasks/{id}                   *Added 2026-09-09 (task 092, issue #350).* Permanent
+                                        delete of an **archived** task: the row, its step_runs
+                                        and its `{data_dir}/transcripts/{id}` directory.
+                                        `?delete_branch=true` or `{ delete_branch }` also applies
+                                        §10's empty-branch judgement to its branch — never to a
+                                        branch with commits, and never to a remote.
+                                        200 { deleted: true, branch? }, branch carrying archive's
+                                        own shape and vocabulary. It is **not a §6 action**:
+                                        taskstate has no opinion on it, it never appears in
+                                        `available_actions`, and the state check is this
+                                        handler's own — the precedent is DELETE /v1/projects/{id},
+                                        which is likewise no action. Four refusals, each a 409
+                                        naming the row that is holding on in `details.reason`:
+                                        `not_archived`, `has_lanes` (an archived fan-out parent
+                                        whose lanes still exist — `parent_task_id` has no
+                                        ON DELETE clause, so without this it is a driver error
+                                        rather than a refusal), `handoff_target` (a `handed_off`
+                                        chat points at it and would be left pointing at nothing,
+                                        `chats.handoff_task_id` being ON DELETE SET NULL).
+                                        404 on an unknown id. `created_by_task_id` and the
+                                        idempotency rows clear themselves and need no refusal.
+                                        The `events` rows are **not** purged: their id is the
+                                        Last-Event-ID cursor (§13.3). There is no bulk delete and
+                                        there is not going to be one (task 011) — a sweep is one
+                                        DELETE per row
 POST   /v1/tasks/{id}/cancel
 POST   /v1/tasks/{id}/pause
 POST   /v1/tasks/{id}/resume
@@ -6009,7 +6093,23 @@ Two kinds of streams:
    `task.created`, `task.state_changed`, `task.priority_changed`, `task.step_advanced`,
    `task.status_changed`, `task.children_changed`, `project.*`,
    `workflow.registry_changed`, `agent.quota_changed`,
-   `task.github_pull_changed`, `daemon.shutting_down`.
+   `task.github_pull_changed`, `task.deleted`, `chat.deleted`,
+   `daemon.shutting_down`.
+   *Added 2026-09-09 (task 092, issue #350): `task.deleted` and `chat.deleted` —
+   payload `{id, title}` — announce a permanent delete (§13.2). PR D's ruling
+   that an archive needs no type of its own does **not** cover them: that type
+   was redundant with `task.state_changed`, and a delete has no state to change
+   to, so without a type no other client ever learns the row is gone. The event
+   outlives the row it records, exactly as `project.deleted` does — the events
+   table has no foreign keys. The historical rows behind the delete are
+   deliberately **not** purged: their id is the Last-Event-ID cursor every
+   subscriber is holding, and one archived row going is not a project's whole
+   history going. A client resuming from a cursor older than a delete will see
+   events for an id that now 404s, which is survivable and is what a project
+   delete has always done to a stale cursor. `task.deleted` carries no
+   `task_id` column — it is a foreign key, and the point of the event is that
+   the task is gone — so it reaches `GET /v1/events` and not the per-task
+   stream, and a chat's events never carried a chat_id column at all.*
    *Amended 2026-08-29 (task 052, issue #231): `task.github_pull_changed` —
    payload `{repo, number, source, suppressed}`, empty when the link was
    cleared — announces that a task's pull-request link changed, because the
@@ -6231,6 +6331,8 @@ is excluded too, on the same kind of line:
     POST   /v1/chats/{id}/answer
     POST   /v1/chats/{id}/cancel
     POST   /v1/chats/{id}/archive
+    DELETE /v1/tasks/{id}
+    DELETE /v1/chats/{id}
     POST   /v1/chats/{id}/handoff
 
 *(The last line added 2026-09-01, task 074, issue #288.)*
@@ -7562,6 +7664,33 @@ stream for the live tail.
    indicator draws only for a turn the daemon is holding in `running` — state
    the daemon does have and has told the client about.
 
+10. **Archived boards.** *Added 2026-09-09 (task 092, issue #350).* Two
+   screens — archived tasks and archived chats — reached from the command
+   palette with **no key of their own**: task 049 retired `1..6` and the point
+   was to stop adding memorized keys, so these get two `nav` palette rows, the
+   way chats did (task 067). `s` is skip and `A` is archive; neither was ever
+   free.
+
+   Each is the board it mirrors **in a second mode**, not a second model: the
+   same grouping, folding, `/` filter and `space`/`V` selection, listing what is
+   archived instead of what is live. What the mode adds is the three things only
+   an archive has — `d` cycles a date window (7 days / 30 days / all, resolved
+   client-side into §13.2's `archived_since`), `<`/`>` turn pages of a hundred
+   rows, and `D` deletes permanently. `D` is a `scopePanel` binding on these two
+   contexts and nowhere else, because delete is not a §6 action (§6) and every
+   action key is gated on `available_actions`.
+
+   The confirmation takes **three** answers: `y` deletes the row and its
+   transcripts, `b` deletes its branch as well, `n` does nothing, and no other
+   key answers it. The third answer cannot destroy anything `y` would have kept
+   — §10's rule keeps a branch carrying commits whichever was pressed. A
+   selection deletes one row at a time and reports done / refused, the shape
+   bulk archive already has (task 011): there is no bulk endpoint.
+
+   `enter` opens the row's existing workspace, which is **read-only for free**:
+   an archived task offers no `available_actions`, so there is nothing to
+   withhold and no flag saying so.
+
 ### Layout
 
 The list above is also the screen contract. View 1 is the board-only home
@@ -8863,7 +8992,7 @@ else.
 | A command emits a single line larger than one output record | *Added 2026-08-24 (#139).* Captured, not failed: the line becomes a run of `vincent.output` records marked `partial`, in order, on one stream, preserving phase, stream identity and live offsets. Minified JSON, a base64 blob and a `git diff` of a generated file all reach a megabyte on one line, so this is an ordinary command; failing it would only retry it into the same wall until the task blocked. It was previously a *silent success* — a line-bound reader stopped dead on the first such line, the rest of the stream went to `io.Discard`, and the attempt was judged from exit 0 alone |
 | A transcript write, encode or close fails | *Added 2026-08-24 (#139).* The failure latches on the transcript and the attempt fails `transcript_io_error` under the §7.2 budget — disk full, a revoked permission, a short write, and ENOSPC surfaced at `Close`, which is where a buffered filesystem reports it. Never swallowed by `allow_failure:` (§7.2): vincent failing to record a step is not an outcome the step produced. Only a *success* is overridden — an attempt that already failed keeps the more useful reason. `transcript_max_bytes` is unaffected and stays the only size-based failure (§12.3) |
 | An adapter cannot read its agent's stream to the end | *Added 2026-08-24 (#139).* The adapter latches its reader's error, drains the pipe so the CLI is not left blocked on it until the step timeout, and reports `agent.FailureStreamError`; the engine fails the attempt `agent_protocol_error` under the §7.2 budget. Deliberately not `agent_error`, which means "the CLI reported a failure" and would send a user to inspect a CLI that did nothing wrong — the reader that failed is vincent's. Deliberately not `input_protocol_error` either: that names a control message vincent could not render, and such a message arrived intact |
-| Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). DB rows are never deleted; retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |
+| Transcript of an archived task past retention | Deleted by the pruner at daemon start and every 24 h (§17). The **pruner** never deletes DB rows — a human's `DELETE /v1/tasks/{id}` does, and takes the transcript directory with it (§13.2, task 092, amended 2026-09-09); retention is measured from `archived_at`, so a long-running task archived yesterday is one day old. `transcript_retention_days: 0` disables pruning entirely |
 | Base branch doesn't exist | Task creation fails fast |
 | Branch already exists (or a ref hierarchy conflict blocks the name) | Rejected at creation with `400` where the name is known then; otherwise the task blocks with `branch_exists` at admission, which stays the authority. Never reused, never auto-renamed. Recover with `retry { branch_override }` (§10, task 001) |
 | A pull request's head cannot be fetched | *Added 2026-08-30 (task 064).* A task created from a pull request runs on that pull request's head branch, so the fetch has nothing to fall back to. The task blocks with `pull_fetch_failed` at admission — deliberately unlike §10's base fetch, which is silent because a local base is always a valid answer |

--- a/docs/tasks/092-archived-boards-and-delete.md
+++ b/docs/tasks/092-archived-boards-and-delete.md
@@ -1,0 +1,144 @@
+# 092 — Archived boards for tasks and chats, with permanent delete
+
+**Status:** ✅ done (7/7)
+**Issue:** #350
+**Amends:** §5.5 — delete is legal from `archived` alone and refused from
+`handed_off`; §6 — delete is not a human action and never appears in
+`available_actions`; §10 — task 008's exception widens to "at archive time
+**and at permanent delete**", the standing rule unchanged and the remote leg
+not offered; §13.2 — the two `DELETE` routes, the new query parameters on
+`GET /v1/tasks` and `GET /v1/chats`, and the archived-only ordering; §13.3 —
+`task.deleted` and `chat.deleted`; §13.4 — both routes join the
+destructive-admin exclusion; §15 — a tenth view and its palette rows; §17 —
+the retention table's "DB rows are never deleted" qualified to the *pruner*.
+Decision record row 30.
+**Keeps, without relitigating:** [008](008-empty-branch-cleanup.md) — the
+§10 rule that a branch carrying any commit past its base is never deleted, and
+[056](056-fetch-base-branch.md)'s `base_sha` fork point, both reused verbatim.
+[011](011-bulk-actions.md) — "there is no bulk endpoint and there is not going
+to be one"; every sweep here is one `DELETE` per row.
+[049](049-command-palette.md) — retiring `1..6` without substituting new
+memorized keys is the point, so the two boards get palette rows and no key,
+exactly as [067](067-chats-in-the-tui.md) gave chats one.
+[074](074-chat-handoff.md) decision 5 — `handed_off` means the task owns the
+worktree, which is why both directions of that link are a refusal.
+[074](074-chat-handoff.md) decision 6 and [079](079-chat-listing-scope.md)
+decision 2 — a chat's `updated_at` *is* when it ended, so no `archived_at`
+column is added for chats.
+
+Archived history existed and was unreachable. `board.tasksCmd` asked for
+`ListTasksOptions{}`, whose zero-value `Archived` is `ArchivedExclude`, and no
+other TUI surface asked for anything else; `store.ListTasks` had understood
+`ArchivedOnly` since it was written, and `archived_at` has been a column since
+`0001_init.sql`, written on the terminal transition and read by nothing but
+retention. Chats got half of it in task 079: an `s` scope cycle on the chats
+board, which is a peek rather than a place.
+
+And nothing deleted a task or a chat. The only hard delete in the system was
+`DELETE /v1/projects/{id}`, and the only thing that reclaimed anything on a
+clock was `TranscriptPruner`, which removes transcript *files* and never a row.
+An installation that ran for a year accumulated every row it ever created, with
+no way to discard one and no screen on which to see them.
+
+## Decisions
+
+1. **The branch is judged by task 008's rule, which is not amended.** §10's
+   standing rule keeps its full force: a branch carrying **any** commit past its
+   base is never deleted by vincent. `delete_branch=true` reuses
+   `worktree.Manager.DeleteEmptyBranch` verbatim — the same `base_sha`-or-
+   `base_branch` fork point (task 056), the same `-D`-only-with-a-recorded-
+   `base_sha` rule, the same outcome vocabulary — and a branch with commits is
+   reported `has_commits` and kept whatever the human answered. Task 008's
+   exception widens from "at archive time" to "at archive time and at permanent
+   delete" and gains nothing else. **The remote leg is not offered at all**:
+   `delete_remote_branch_on_archive` stays honoured only by
+   `POST /v1/tasks/{id}/archive`, because deleting a branch on a forge other
+   people share is unrecoverable and a delete has no second chance to
+   reconsider.
+
+2. **Refusals name the row that is holding on.** Delete applies to archived rows
+   only; anything else is a `409` in the snake_case envelope and is never
+   performed. Three further refusals, each a named `409` rather than a
+   foreign-key error leaking out of the driver:
+   - An archived fan-out parent whose lane rows still exist. `parent_task_id` is
+     a plain `REFERENCES tasks(id)` with no `ON DELETE` clause
+     (`0007_fan_out.sql`) and `PRAGMA foreign_keys` is on, so without the guard
+     the delete fails *in the driver*. The lanes go first, and the refusal says
+     so.
+   - A `handed_off` chat. The task named by `handoff_task_id` owns the worktree
+     and branch (task 074 decision 5), and `handed_off` means "that task owns
+     it" — a deleted row cannot say that.
+   - The mirror of it: an archived task that a `handed_off` chat points at.
+     `chats.handoff_task_id` is `ON DELETE SET NULL` (`0023_chat_handoff.sql`),
+     so deleting the task would leave a terminal chat pointing at nothing.
+
+   `created_by_task_id` (`ON DELETE SET NULL`) and the idempotency rows
+   (`ON DELETE CASCADE`) need no refusal — they clear themselves, and
+   `mcp.max_depth`'s walk simply stops one link early.
+
+3. **The age sweep is a client-side loop.** Task 011's decision stands verbatim:
+   there is no bulk endpoint and there is not going to be one. The sweep lists
+   the rows archived before a cutoff and sends one `DELETE` per row,
+   sequentially, reporting `done` / `refused` the way `actionBar.dispatchBulk`
+   already does for bulk archive. The same holds for the `space`/`V` selection
+   and for the CLI's `--before`.
+
+4. **Palette rows, no dedicated key.** Task 049 retired the `1..6` takeover keys
+   and the registry records why — "retiring `1..6` without substituting new
+   memorized keys is the point". Chats, the closest prior art, got a palette nav
+   row and no key (task 067). The archived boards get the same: two
+   `scopeGlobal` `nav: true` rows. The issue's premise that `s` is skip and `A`
+   is archive is right; the answer 049 gave was to stop adding keys, not to hunt
+   for a free letter.
+
+5. **One board model with an archived mode.** `internal/tui/board.go` is where
+   grouping, folding, `/` filtering and bulk selection live, and the archived
+   board needs all four. The board gains an archived mode and `viewArchived`
+   routes to the same model constructed in it; `internal/tui/chats.go` takes the
+   same treatment at a much smaller size, keeping its `s` cycle untouched.
+   Grouping, folding, the selection and the report are shared *by construction*
+   and cannot drift. `TestArchivedBoardSharesTheLiveBoardsBehaviour` is the
+   fence around that: if the `if archived` branches ever start reaching into
+   rendering, the fallback is this decision's runner-up — a view that embeds the
+   board — and that is a change of shape better made early than half-way.
+
+6. **Delete is not a §6 action.** It is not a state transition, `taskstate` has
+   no opinion on it, and it must never appear in `available_actions` — which is
+   what gates every `scopeTaskAction` binding. So the TUI's delete key is a
+   `scopePanel` binding on the two archived contexts, and the API refusal is the
+   handler's own check on `state`, not the FSM's `409`. The precedent is
+   `DELETE /v1/projects/{id}`, which is likewise no action. The payoff is that
+   the workspace `enter` opens is read-only *for free*: an archived task offers
+   no actions, so there is nothing to withhold and no flag saying so.
+
+7. **Events are not purged, and a delete emits one.** `events` has no foreign
+   keys and its `id` is the SSE `Last-Event-ID` cursor. `DeleteProjectCascade`
+   purges a project's event rows because the project's entire history is going
+   and every one of them would afterwards reference nothing at all; deleting one
+   archived row is not that. So the historical rows stay, and each delete
+   appends a durable `task.deleted` / `chat.deleted` event carrying the id. PR
+   D's "there is no separate `task.archived` type" does not reach this: that
+   type was redundant with `task.state_changed`, and a delete has no state to
+   change to, so without a type no other client ever learns the row is gone. A
+   chat's events carry no `chat_id` column at all — `chatEvent` puts the id in
+   the payload — which is a second reason not to try to purge them.
+
+8. **No migration.** Every column and cascade this needs already exists:
+   `archived_at` since `0001_init.sql`, the chat cascade since `0022_chats.sql`,
+   the idempotency cascade since `0016_idempotency.sql`, the handoff
+   `SET NULL` since `0023_chat_handoff.sql`. Chats measure their window over
+   `updated_at`, which task 074 decision 6 and task 079 decision 2 both recorded
+   as already being when a terminal chat ended; adding an `archived_at` column
+   to restate that would be relitigating a decision twice recorded.
+
+## What landed
+
+| # | Piece | Status |
+|---|---|---|
+| 092.1 | `TaskFilter`/`ChatFilter` date bounds, chat paging, archived-only ordering | ✅ |
+| 092.2 | `DeleteTaskCascade` / `DeleteChatCascade` with the four refusals and the two events | ✅ |
+| 092.3 | `DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}`, the new query parameters, the §13.4 exclusions | ✅ |
+| 092.4 | apiclient: `DeleteTask`/`DeleteChat`, `ListChatsOptions`, the two bounds | ✅ |
+| 092.5 | `vincent task delete` / `vincent chat delete`, with `--branch`, `--before` and `--json` | ✅ |
+| 092.6 | The two archived TUI boards: the mode, the window, the pages, the delete | ✅ |
+| 092.7 | `scripts/m15-gate.sh`, wired into `ci.yml` on all three platforms | ✅ |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -105,6 +105,7 @@ the living engineering specification records implementation contracts.
 | [089](089-in-progress-indicator.md) | One animated in-progress indicator — a braille frame and an elapsed clock — for the chat workspace, the chats board, the task workspace's output pane and `vincent chat send` | ✅ done (1/1) |
 | [090](090-cascading-fan-out-retry.md) | One `retry` on a fan-out parent parked in `awaiting_children` re-admits every blocked descendant, without writing the parent's own row | ✅ done (5/5) |
 | [091](091-usage-limit-auto-continue.md) | `usage_limit_auto_continue`: whether a recognized quota stop waits the window out or blocks for a human | ✅ done (5/5) |
+| [092](092-archived-boards-and-delete.md) | Archived boards for tasks and chats, with a permanent delete of an archived row | ✅ done (7/7) |
 
 ## How to add and update a task document
 

--- a/internal/api/chats.go
+++ b/internal/api/chats.go
@@ -227,6 +227,26 @@ func (s *Server) handleChatList(w http.ResponseWriter, r *http.Request) {
 			"archived must be one of: false, true, all")
 		return
 	}
+	// The same paging and the same date bounds GET /v1/tasks takes, spelled
+	// the same way (§13.2, task 092): one vocabulary covers both entities.
+	// The chat bounds are measured over `updated_at`, which is when a
+	// terminal chat ended (task 074 decision 6, task 079 decision 2).
+	for name, dst := range map[string]*int{"limit": &f.Limit, "offset": &f.Offset} {
+		if v := r.URL.Query().Get(name); v != "" {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 0 {
+				writeError(w, http.StatusBadRequest, CodeValidationFailed,
+					fmt.Sprintf("%s must be a non-negative integer", name))
+				return
+			}
+			*dst = n
+		}
+	}
+	before, since, ok := parseArchivedBounds(w, r)
+	if !ok {
+		return
+	}
+	f.ArchivedBefore, f.ArchivedSince = before, since
 	chats, err := s.deps.Store.ListChats(r.Context(), f)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/lezli01/vincent/internal/store"
+	"github.com/lezli01/vincent/internal/taskrun"
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// deleteRequest is the §13.2 body of DELETE /v1/tasks/{id} and
+// DELETE /v1/chats/{id}. `delete_branch` may also arrive as a query parameter,
+// because a `DELETE` with a body is awkward from curl and the gate scripts are
+// written in curl.
+type deleteRequest struct {
+	DeleteBranch bool `json:"delete_branch"`
+}
+
+// deleteResponse is what a permanent delete says (§13.2, task 092). `branch`
+// carries the same shape and the same snake_case vocabulary archive's does —
+// deleted | has_commits | not_ours | unknown | error — and is omitted entirely
+// when the branch step did not run.
+type deleteResponse struct {
+	Deleted bool            `json:"deleted"`
+	Branch  *branchResponse `json:"branch,omitempty"`
+}
+
+// deleteBranchWanted reads `delete_branch` from the query or the body, in that
+// order. It defaults to false: keeping a branch is the recoverable answer.
+func deleteBranchWanted(w http.ResponseWriter, r *http.Request) (bool, bool) {
+	switch v := r.URL.Query().Get("delete_branch"); v {
+	case "true":
+		return true, true
+	case "", "false":
+	default:
+		writeError(w, http.StatusBadRequest, CodeValidationFailed, "delete_branch must be true or false")
+		return false, false
+	}
+	var req deleteRequest
+	if r.ContentLength != 0 && !decodeJSON(w, r, &req) {
+		return false, false
+	}
+	return req.DeleteBranch, true
+}
+
+// handleTaskDelete permanently removes an archived task (§13.2, task 092).
+//
+// It is not a §6 action and never appears in `available_actions`: the state
+// check is this handler's own, through the store's delete transaction, not the
+// FSM's. The precedent is DELETE /v1/projects/{id}, which is likewise no
+// action. A refusal is a 409 in the snake_case envelope naming the row that is
+// holding on — see store.DeleteRefusedError for the four of them.
+func (s *Server) handleTaskDelete(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Runner == nil {
+		s.internalError(w, "task delete", errors.New("no task runner is configured"))
+		return
+	}
+	id, ok := taskIDFromPath(w, r)
+	if !ok {
+		return
+	}
+	branch, ok := deleteBranchWanted(w, r)
+	if !ok {
+		return
+	}
+	out, err := s.deps.Runner.Delete(r.Context(), id, branch)
+	if !s.writeDeleteError(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusOK, deleteResponse{Deleted: true, Branch: toBranchResponse(out)})
+}
+
+// handleChatDelete permanently removes an archived chat (§13.2, task 092). It
+// is the task handler minus the fan-out clause, and it runs here rather than
+// on a runner for the reason handleChatArchive does: the chat lifecycle's
+// worktree and branch work already lives in this package.
+func (s *Server) handleChatDelete(w http.ResponseWriter, r *http.Request) {
+	chat, ok := s.chatFromPath(w, r)
+	if !ok {
+		return
+	}
+	wantBranch, ok := deleteBranchWanted(w, r)
+	if !ok {
+		return
+	}
+	// Read the project before the delete: the row is about to stop existing
+	// and the §10 judgement needs the repository it lives in.
+	var projectPath string
+	if wantBranch && chat.Branch != "" {
+		project, err := s.deps.Store.GetProject(r.Context(), chat.ProjectID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+			return
+		}
+		projectPath = project.Path
+	}
+	if err := s.deps.Store.DeleteChatCascade(r.Context(), chat.ID); !s.writeDeleteError(w, err) {
+		return
+	}
+	// After the commit, and unable to fail the call: a failed unlink must not
+	// resurrect a row already reported gone, and `vincent gc` treats a
+	// transcript directory with no row as its own.
+	taskrun.RemoveTranscriptDir(s.deps.Dirs.Data, worktree.ChatOwner(chat.ID).Dir(), s.deps.Logger)
+	var out worktree.BranchOutcome
+	if projectPath != "" {
+		// ours is nil: a chat's branch is always one vincent cut, so there is
+		// no pull-request head to protect and nothing to say (task 064).
+		var err error
+		out, err = s.deps.Worktrees.DeleteEmptyBranch(r.Context(), projectPath,
+			chat.BaseBranch, chat.BaseSHA, chat.Branch, false, nil)
+		if err != nil {
+			s.deps.Logger.Warn("delete: branch kept",
+				"chat", chat.ID, "branch", chat.Branch, "result", out.Result, "error", err)
+		}
+	}
+	writeJSON(w, http.StatusOK, deleteResponse{Deleted: true, Branch: toBranchResponse(out)})
+}
+
+// writeDeleteError maps a delete failure onto §13.1 and reports whether the
+// handler may carry on. A nil error is the only "carry on".
+func (s *Server) writeDeleteError(w http.ResponseWriter, err error) bool {
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, store.ErrNotFound):
+		writeError(w, http.StatusNotFound, CodeNotFound, err.Error())
+	default:
+		var refused *store.DeleteRefusedError
+		if errors.As(err, &refused) {
+			writeConflict(w, refused.Message, map[string]string{
+				"action": "delete", "reason": refused.Reason,
+			})
+			return false
+		}
+		writeError(w, http.StatusInternalServerError, CodeInternal, err.Error())
+	}
+	return false
+}
+
+// parseArchivedBounds reads the `archived_before` and `archived_since` RFC3339
+// query parameters shared by GET /v1/tasks and GET /v1/chats (§13.2, task
+// 092). One vocabulary covers both entities, which issue #298 already settled
+// for `archived` itself. Anything unparseable is a 400.
+func parseArchivedBounds(w http.ResponseWriter, r *http.Request) (before, since time.Time, ok bool) {
+	q := r.URL.Query()
+	for name, dst := range map[string]*time.Time{"archived_before": &before, "archived_since": &since} {
+		v := q.Get(name)
+		if v == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, CodeValidationFailed,
+				fmt.Sprintf("%s must be an RFC3339 timestamp", name))
+			return time.Time{}, time.Time{}, false
+		}
+		*dst = t
+	}
+	return before, since, true
+}

--- a/internal/api/delete_test.go
+++ b/internal/api/delete_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// decodeDelete reads a permanent-delete response body.
+func decodeDelete(t *testing.T, body []byte) deleteResponse {
+	t.Helper()
+	var out deleteResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode delete: %v (%s)", err, body)
+	}
+	return out
+}
+
+func TestDeleteTaskRemovesAnArchivedTask(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone)
+	setState(t, h, task.ID, store.TaskArchived)
+
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/"+itoa(task.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE: %d %s", resp.StatusCode, body)
+	}
+	if got := decodeDelete(t, body); !got.Deleted {
+		t.Fatalf("the response does not report the delete: %s", body)
+	}
+	resp, _ = h.doJSON(t, http.MethodGet, "/v1/tasks/"+itoa(task.ID), nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET after delete: %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestDeleteTaskRefusesWithTheSnakeCaseEnvelope(t *testing.T) {
+	h := newActionHarness(t)
+	// Every refusal is a 409 whose details name what is holding on. The
+	// not_archived one is the gate on every other; the two structural ones are
+	// asserted in internal/store, where the rows can be built directly.
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone)
+
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/"+itoa(task.ID), nil)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("DELETE on a done task: %d %s, want 409", resp.StatusCode, body)
+	}
+	e := decodeError(t, body)
+	if e.Code != CodeInvalidState {
+		t.Fatalf("code %q, want %q", e.Code, CodeInvalidState)
+	}
+	if e.Details["reason"] != store.DeleteRefusedNotArchived {
+		t.Fatalf("details %v, want reason %q", e.Details, store.DeleteRefusedNotArchived)
+	}
+	if e.Details["action"] != "delete" {
+		t.Fatalf("details %v, want action delete", e.Details)
+	}
+	resp, _ = h.doJSON(t, http.MethodGet, "/v1/tasks/"+itoa(task.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("the refused task was deleted anyway")
+	}
+}
+
+func TestDeleteTaskIs404ForAnUnknownID(t *testing.T) {
+	h := newActionHarness(t)
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/999999", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("DELETE unknown: %d %s, want 404", resp.StatusCode, body)
+	}
+}
+
+func TestDeleteTaskLeavesABranchItNeverCutAlone(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone)
+	setState(t, h, task.ID, store.TaskArchived)
+	// The task never ran a step, so no worktree was ever made and no branch
+	// was ever cut for it — the empty step ledger is what says so after
+	// archive has cleared `worktree_path`. The branch step must not run: a
+	// task that blocked with `branch_exists` carries somebody else's branch
+	// name. The response omits `branch` entirely, which is the shape a client
+	// that predates the field sees.
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/"+itoa(task.ID)+"?delete_branch=true", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE: %d %s", resp.StatusCode, body)
+	}
+	if got := decodeDelete(t, body); got.Branch != nil {
+		t.Fatalf("a task with no branch reported one: %+v", got.Branch)
+	}
+}
+
+func TestDeleteTaskRejectsAnUnparseableDeleteBranch(t *testing.T) {
+	h := newActionHarness(t)
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/1?delete_branch=maybe", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("delete_branch=maybe: %d %s, want 400", resp.StatusCode, body)
+	}
+}
+
+func TestTaskListRejectsAnUnparseableArchivedBound(t *testing.T) {
+	h := newActionHarness(t)
+	for _, q := range []string{"archived_before=nonsense", "archived_since=nonsense"} {
+		resp, body := h.doJSON(t, http.MethodGet, "/v1/tasks?"+q, nil)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("%s: %d %s, want 400", q, resp.StatusCode, body)
+		}
+		if e := decodeError(t, body); e.Code != CodeValidationFailed {
+			t.Fatalf("%s: code %q, want %q", q, e.Code, CodeValidationFailed)
+		}
+	}
+}
+
+func TestDeleteTaskAnnouncesItselfAsADurableEvent(t *testing.T) {
+	h := newActionHarness(t)
+	task := queuedTask(t, h)
+	setState(t, h, task.ID, store.TaskDone)
+	setState(t, h, task.ID, store.TaskArchived)
+
+	resp, body := h.doJSON(t, http.MethodDelete, "/v1/tasks/"+itoa(task.ID), nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE: %d %s", resp.StatusCode, body)
+	}
+	events, err := h.store.ListEvents(t.Context(), store.EventFilter{Types: []string{store.EventTaskDeleted}})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d task.deleted events, want 1", len(events))
+	}
+	var payload struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload.ID != task.ID {
+		t.Fatalf("the event names task %d, want %d", payload.ID, task.ID)
+	}
+}

--- a/internal/api/mcp_parity_test.go
+++ b/internal/api/mcp_parity_test.go
@@ -117,6 +117,12 @@ func TestMCPExcludesDestructiveAdminByName(t *testing.T) {
 		// reporting its own adapter at 99% would paint every board and status
 		// line in the installation with a wall that does not exist.
 		{http.MethodPost, "/v1/agents/{name}/quota"},
+		// Task 092: the two permanent deletes, on the project delete's line.
+		// §13.4's surface is the route table minus destructive admin, and a
+		// row a human archived is history nobody else may discard. Archive
+		// stays a tool — the row and its transcripts survive it.
+		{http.MethodDelete, "/v1/tasks/{id}"},
+		{http.MethodDelete, "/v1/chats/{id}"},
 	}
 	if len(mcp.Excluded) != len(want) {
 		t.Fatalf("mcp.Excluded has %d entries, want %d", len(mcp.Excluded), len(want))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -287,6 +287,12 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodPost, "/v1/tasks", s.handleTaskCreate)
 	rt.handle(http.MethodGet, "/v1/tasks/{id}", s.handleTaskGet)
 	rt.handle(http.MethodPatch, "/v1/tasks/{id}", s.handleTaskPatch)
+	// Permanent delete of an archived row (§13.2, task 092). Not a §6 action
+	// and never in `available_actions`; the state check is the handler's own,
+	// exactly as DELETE /v1/projects/{id} is. Neither DELETE is an MCP tool
+	// (§13.4) — they join the destructive-admin exclusion the project delete
+	// is already on.
+	rt.handle(http.MethodDelete, "/v1/tasks/{id}", s.handleTaskDelete)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/cancel", s.handleTaskCancel)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/pause", s.handleTaskPause)
 	rt.handle(http.MethodPost, "/v1/tasks/{id}/resume", s.handleTaskResume)
@@ -313,6 +319,7 @@ func (s *Server) buildHandler() http.Handler {
 	rt.handle(http.MethodGet, "/v1/chats", s.handleChatList)
 	rt.handle(http.MethodPost, "/v1/chats", s.handleChatCreate)
 	rt.handle(http.MethodGet, "/v1/chats/{id}", s.handleChatGet)
+	rt.handle(http.MethodDelete, "/v1/chats/{id}", s.handleChatDelete)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/send", s.handleChatSend)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/answer", s.handleChatAnswer)
 	rt.handle(http.MethodPost, "/v1/chats/{id}/cancel", s.handleChatCancel)

--- a/internal/api/tasks.go
+++ b/internal/api/tasks.go
@@ -1189,6 +1189,11 @@ func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request) {
 			"archived must be one of: false, true, all")
 		return
 	}
+	before, since, ok := parseArchivedBounds(w, r)
+	if !ok {
+		return
+	}
+	filter.ArchivedBefore, filter.ArchivedSince = before, since
 	ctx := r.Context()
 	tasks, err := s.deps.Store.ListTasks(ctx, filter)
 	if err != nil {

--- a/internal/apiclient/chats.go
+++ b/internal/apiclient/chats.go
@@ -75,26 +75,60 @@ func (c *Client) CreateChat(ctx context.Context, req CreateChatRequest) (*Chat, 
 	return &out, nil
 }
 
+// ListChatsOptions narrows GET /v1/chats. It is the shape ListTasksOptions
+// has, with the same parameter names on the wire (§13.2, task 092): issue #298
+// settled that one vocabulary covers both entities, and the archived board
+// pages and date-bounds chats exactly as it does tasks.
+//
+// It replaced two bare arguments. A third and a fourth would have been two
+// more call sites to touch for every parameter after them.
+type ListChatsOptions struct {
+	ProjectID int64
+	// Archived selects how terminal chats are treated, and reuses ListTasks'
+	// ArchivedScope because the wire parameter is the same one (§13.2,
+	// amended 2026-09-01). The zero value — ArchivedExclude — leaves the
+	// parameter off and takes the server's default, which is to hide both
+	// `archived` and `handed_off`.
+	Archived ArchivedScope
+	Limit    int
+	Offset   int
+	// ArchivedBefore and ArchivedSince bound when the chat ended. The daemon
+	// measures them over `updated_at`, which for a terminal chat *is* when it
+	// ended (task 074 decision 6, task 079 decision 2).
+	ArchivedBefore time.Time
+	ArchivedSince  time.Time
+}
+
+func (o ListChatsOptions) query() string {
+	q := url.Values{}
+	if o.ProjectID > 0 {
+		q.Set("project_id", strconv.FormatInt(o.ProjectID, 10))
+	}
+	if o.Archived != ArchivedExclude {
+		q.Set("archived", string(o.Archived))
+	}
+	if o.Limit > 0 {
+		q.Set("limit", strconv.Itoa(o.Limit))
+	}
+	if o.Offset > 0 {
+		q.Set("offset", strconv.Itoa(o.Offset))
+	}
+	if !o.ArchivedBefore.IsZero() {
+		q.Set("archived_before", o.ArchivedBefore.UTC().Format(time.RFC3339))
+	}
+	if !o.ArchivedSince.IsZero() {
+		q.Set("archived_since", o.ArchivedSince.UTC().Format(time.RFC3339))
+	}
+	if len(q) == 0 {
+		return ""
+	}
+	return "?" + q.Encode()
+}
+
 // ListChats fetches chats, optionally narrowed to one project. Tasks never
 // appear here, and chats never appear in ListTasks.
-//
-// archived selects how terminal chats are treated, and reuses ListTasks'
-// ArchivedScope because the wire parameter is the same one (§13.2, amended
-// 2026-09-01). The zero value — ArchivedExclude — leaves the parameter off and
-// takes the server's default, which is to hide both `archived` and
-// `handed_off`.
-func (c *Client) ListChats(ctx context.Context, projectID int64, archived ArchivedScope) ([]Chat, error) {
-	q := url.Values{}
-	if projectID > 0 {
-		q.Set("project_id", strconv.FormatInt(projectID, 10))
-	}
-	if archived != ArchivedExclude {
-		q.Set("archived", string(archived))
-	}
-	path := "/v1/chats"
-	if len(q) > 0 {
-		path += "?" + q.Encode()
-	}
+func (c *Client) ListChats(ctx context.Context, opts ListChatsOptions) ([]Chat, error) {
+	path := "/v1/chats" + opts.query()
 	var out struct {
 		Chats []Chat `json:"chats"`
 	}

--- a/internal/apiclient/delete.go
+++ b/internal/apiclient/delete.go
@@ -1,0 +1,67 @@
+package apiclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+)
+
+// deleteResponse decodes DELETE /v1/tasks/{id} and DELETE /v1/chats/{id}
+// (§13.2, task 092). `branch` carries archive's vocabulary unchanged, so the
+// same BranchOutcome and the same Summary render both.
+type deleteResponse struct {
+	Deleted bool           `json:"deleted"`
+	Branch  *BranchOutcome `json:"branch"`
+}
+
+// DeleteTask permanently removes an archived task: the row, its step_runs and
+// its transcripts. A task in any other state is refused with a 409 naming what
+// is holding on, and so is an archived fan-out parent whose lanes still exist
+// or one a handed-off chat still points at.
+//
+// deleteBranch asks for the branch as well, and §10's standing rule is
+// unchanged by the asking: a branch carrying any commit past its base is kept
+// and reported `has_commits`. The remote branch is never touched — that leg is
+// archive's alone.
+func (c *Client) DeleteTask(ctx context.Context, id int64, deleteBranch bool) (BranchOutcome, error) {
+	return c.deleteRow(ctx, "/v1/tasks/", id, deleteBranch)
+}
+
+// DeleteChat permanently removes an archived chat: the row, its turns and its
+// transcripts. A `handed_off` chat is refused — the task it was handed to owns
+// the worktree and branch, and that task is what to delete.
+func (c *Client) DeleteChat(ctx context.Context, id int64, deleteBranch bool) (BranchOutcome, error) {
+	return c.deleteRow(ctx, "/v1/chats/", id, deleteBranch)
+}
+
+func (c *Client) deleteRow(ctx context.Context, prefix string, id int64, deleteBranch bool) (BranchOutcome, error) {
+	path := prefix + strconv.FormatInt(id, 10)
+	if deleteBranch {
+		// A query parameter rather than a body: a DELETE with a body is
+		// awkward from curl, and the gates are written in curl. The daemon
+		// accepts both.
+		path += "?delete_branch=true"
+	}
+	var out deleteResponse
+	if err := c.send(ctx, http.MethodDelete, path, nil, &out); err != nil {
+		return BranchOutcome{}, err
+	}
+	if out.Branch == nil {
+		return BranchOutcome{}, nil
+	}
+	return *out.Branch, nil
+}
+
+// DeleteRefused reports whether err is a delete the daemon refused — a 409 in
+// the §13.1 envelope naming the row that is holding on — and, if so, the
+// snake_case reason from its `details`. It exists so a client can count
+// refusals apart from failures without matching on message text: a refusal is
+// acted on by deleting whatever is named, and a failure is not.
+func DeleteRefused(err error) (string, bool) {
+	var e *Error
+	if !errors.As(err, &e) || e.Status != http.StatusConflict {
+		return "", false
+	}
+	return e.Details["reason"], true
+}

--- a/internal/apiclient/delete_live_test.go
+++ b/internal/apiclient/delete_live_test.go
@@ -1,0 +1,141 @@
+package apiclient_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/store"
+)
+
+// TestDeleteRoundTrip wires the client to the real handlers and asserts the
+// permanent delete survives the wire — the response shape, the refusal's
+// `details.reason`, and the two new listing bounds. The server DTOs are
+// unexported, so nothing but a live round-trip catches `delete_branch` or
+// `archived_since` renamed on one side.
+func TestDeleteRoundTrip(t *testing.T) {
+	h := newCreateHarness(t)
+	ctx := t.Context()
+
+	mk := func(title string, state store.TaskState) *store.Task {
+		task := &store.Task{
+			ProjectID:        h.projectID,
+			Title:            title,
+			WorkflowName:     "adhoc",
+			WorkflowSnapshot: "steps: []",
+			BaseBranch:       "main",
+			BranchName:       "vincent/" + title,
+			State:            state,
+		}
+		if err := h.store.CreateTask(ctx, task, nil); err != nil {
+			t.Fatalf("CreateTask(%s): %v", title, err)
+		}
+		return task
+	}
+	live := mk("live", store.TaskDone)
+	gone := mk("gone", store.TaskDone)
+	if _, _, err := h.store.TransitionTask(ctx, gone.ID,
+		store.TaskDone, store.TaskArchived, store.TaskChange{}); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// The archived listing, and the two bounds that narrow it.
+	archived, err := h.client.ListTasks(ctx, apiclient.ListTasksOptions{Archived: apiclient.ArchivedOnly})
+	if err != nil {
+		t.Fatalf("ListTasks archived: %v", err)
+	}
+	if len(archived) != 1 || archived[0].ID != gone.ID {
+		t.Fatalf("archived listing: %v, want just task %d", archived, gone.ID)
+	}
+	none, err := h.client.ListTasks(ctx, apiclient.ListTasksOptions{
+		Archived: apiclient.ArchivedOnly, ArchivedBefore: time.Now().AddDate(-1, 0, 0),
+	})
+	if err != nil {
+		t.Fatalf("ListTasks archived_before: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("archived_before a year ago returned %d rows", len(none))
+	}
+	since, err := h.client.ListTasks(ctx, apiclient.ListTasksOptions{
+		Archived: apiclient.ArchivedOnly, ArchivedSince: time.Now().AddDate(-1, 0, 0),
+	})
+	if err != nil {
+		t.Fatalf("ListTasks archived_since: %v", err)
+	}
+	if len(since) != 1 {
+		t.Fatalf("archived_since a year ago returned %d rows, want 1", len(since))
+	}
+
+	// The refusal, decoded as the typed 409 a client branches on.
+	if _, err := h.client.DeleteTask(ctx, live.ID, false); err == nil {
+		t.Fatal("deleting a done task succeeded")
+	} else {
+		reason, ok := apiclient.DeleteRefused(err)
+		if !ok {
+			t.Fatalf("the refusal did not decode as one: %v", err)
+		}
+		if reason != store.DeleteRefusedNotArchived {
+			t.Fatalf("reason %q, want %q", reason, store.DeleteRefusedNotArchived)
+		}
+	}
+
+	// The delete itself. The task never ran, so no branch was ever cut and
+	// the outcome is the zero value rather than a judgement.
+	branch, err := h.client.DeleteTask(ctx, gone.ID, true)
+	if err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	if branch.Result != "" {
+		t.Fatalf("a task with no branch of its own reported %q", branch.Result)
+	}
+	if _, err := h.store.GetTask(ctx, gone.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("the task survived the delete: %v", err)
+	}
+}
+
+// TestListChatsOptionsRoundTrip is the chat half: the options struct that
+// replaced two bare arguments has to reach the daemon as the same four
+// parameters GET /v1/tasks takes.
+func TestListChatsOptionsRoundTrip(t *testing.T) {
+	h := newCreateHarness(t)
+	ctx := t.Context()
+
+	c := &store.Chat{
+		ProjectID: h.projectID, Title: "ended", Agent: "claude",
+		BaseBranch: "main", Branch: "vincent/chat-1", PermissionMode: "full_auto",
+	}
+	if err := h.store.CreateChat(ctx, c); err != nil {
+		t.Fatalf("CreateChat: %v", err)
+	}
+
+	live, err := h.client.ListChats(ctx, apiclient.ListChatsOptions{})
+	if err != nil {
+		t.Fatalf("ListChats: %v", err)
+	}
+	if len(live) != 1 {
+		t.Fatalf("the default listing returned %d chats, want 1", len(live))
+	}
+	paged, err := h.client.ListChats(ctx, apiclient.ListChatsOptions{Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("ListChats paged: %v", err)
+	}
+	if len(paged) != 0 {
+		t.Fatalf("offset 1 of a one-row listing returned %d chats", len(paged))
+	}
+	bounded, err := h.client.ListChats(ctx, apiclient.ListChatsOptions{
+		ArchivedSince: time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("ListChats archived_since: %v", err)
+	}
+	if len(bounded) != 0 {
+		t.Fatalf("archived_since an hour from now returned %d chats", len(bounded))
+	}
+	// A live chat cannot be deleted, and the refusal decodes.
+	if _, err := h.client.DeleteChat(ctx, c.ID, false); err == nil {
+		t.Fatal("deleting a live chat succeeded")
+	} else if reason, ok := apiclient.DeleteRefused(err); !ok || reason != store.DeleteRefusedNotArchived {
+		t.Fatalf("reason %q (typed: %v), want %q", reason, ok, store.DeleteRefusedNotArchived)
+	}
+}

--- a/internal/apiclient/tasks.go
+++ b/internal/apiclient/tasks.go
@@ -157,6 +157,11 @@ type ListTasksOptions struct {
 	ParentID int64
 	// IncludeChildren asks for the flat everything, lanes included.
 	IncludeChildren bool
+	// ArchivedBefore and ArchivedSince bound `archived_at` (§13.2, task 092),
+	// which is what the archived board's date presets and the sweep's cutoff
+	// become on the wire. Zero means no bound.
+	ArchivedBefore time.Time
+	ArchivedSince  time.Time
 }
 
 func (o ListTasksOptions) query() string {
@@ -181,6 +186,12 @@ func (o ListTasksOptions) query() string {
 	}
 	if o.Offset > 0 {
 		q.Set("offset", strconv.Itoa(o.Offset))
+	}
+	if !o.ArchivedBefore.IsZero() {
+		q.Set("archived_before", o.ArchivedBefore.UTC().Format(time.RFC3339))
+	}
+	if !o.ArchivedSince.IsZero() {
+		q.Set("archived_since", o.ArchivedSince.UTC().Format(time.RFC3339))
 	}
 	if len(q) == 0 {
 		return ""

--- a/internal/cli/actions_e2e_test.go
+++ b/internal/cli/actions_e2e_test.go
@@ -252,6 +252,79 @@ func TestHumanActionCommands(t *testing.T) {
 		}
 	})
 
+	// Permanent delete (task 092). It follows the archive subtest because it
+	// needs a row that reached `archived`, and it asserts the thing the
+	// command was designed around: it does not prompt, so a 409 is exit 1
+	// carrying the daemon's own wording (task 048).
+	t.Run("delete an archived task, and refuse a live one", func(t *testing.T) {
+		id := addActionTask(t, dataDir, cfgDir, "deletable", "--workflow", "blocky")
+		waitForState(t, dataDir, cfgDir, id, "blocked")
+
+		// Blocked is not archived, and the refusal names the state rather
+		// than asking anything.
+		out, code := runVincent(t, dataDir, cfgDir, "task", "delete", id)
+		if code != 1 {
+			t.Fatalf("delete a blocked task: code %d, want 1 (out %q)", code, out)
+		}
+		if !strings.Contains(out, "only an archived task can be deleted") {
+			t.Errorf("the refusal is not the daemon's own wording: %q", out)
+		}
+
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "cancel", id); code != 0 {
+			t.Fatalf("cancel: code %d", code)
+		}
+		waitForState(t, dataDir, cfgDir, id, "aborted")
+		if out, code := runVincent(t, dataDir, cfgDir, "task", "archive", id); code != 0 {
+			t.Fatalf("archive: code %d, out %q", code, out)
+		}
+
+		// --json emits one entry per row, so a script can tell a deletion
+		// from a refusal without parsing prose.
+		out, code = runVincent(t, dataDir, cfgDir, "task", "delete", id, "--branch", "--json")
+		if code != 0 {
+			t.Fatalf("task delete --json: code %d, out %q", code, out)
+		}
+		var reports []struct {
+			ID      int64  `json:"id"`
+			Deleted bool   `json:"deleted"`
+			Reason  string `json:"reason"`
+		}
+		if err := json.Unmarshal([]byte(out), &reports); err != nil {
+			t.Fatalf("delete --json is not a list: %v (%q)", err, out)
+		}
+		if len(reports) != 1 || !reports[0].Deleted || strconv.FormatInt(reports[0].ID, 10) != id {
+			t.Fatalf("delete --json reported %+v", reports)
+		}
+
+		// The row is gone for good: a second delete is a 404, not a no-op.
+		if out, code := runVincent(t, dataDir, cfgDir, "task", "delete", id); code != 1 {
+			t.Errorf("deleting a deleted task: code %d, want 1 (out %q)", code, out)
+		}
+
+		// A sweep with nothing in range still succeeds and says so — an empty
+		// sweep is not a failure.
+		out, code = runVincent(t, dataDir, cfgDir, "task", "delete", "--before", "3650d")
+		if code != 0 {
+			t.Fatalf("task delete --before: code %d, out %q", code, out)
+		}
+		if !strings.Contains(out, "No archived tasks to delete.") {
+			t.Errorf("an empty sweep does not say so: %q", out)
+		}
+
+		// The two argument shapes that are not a command: neither ids nor
+		// --before, and both at once.
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "delete"); code == 0 {
+			t.Error("task delete with no ids and no --before succeeded")
+		}
+		if _, code := runVincent(t, dataDir, cfgDir, "task", "delete", "1", "--before", "30d"); code == 0 {
+			t.Error("task delete with both ids and --before succeeded")
+		}
+		// The chat half of the command tree exists and refuses an unknown id.
+		if out, code := runVincent(t, dataDir, cfgDir, "chat", "rm", "999999"); code != 1 {
+			t.Errorf("chat rm on an unknown id: code %d, want 1 (out %q)", code, out)
+		}
+	})
+
 	t.Run("answer refuses a task that is not waiting for input", func(t *testing.T) {
 		id := addActionTask(t, dataDir, cfgDir, "not asking", "--workflow", "blocky")
 		waitForState(t, dataDir, cfgDir, id, "blocked")

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -39,7 +39,7 @@ func newChatCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newChatStartCmd(), newChatSendCmd(), newChatAnswerCmd(),
 		newChatCancelCmd(), newChatListCmd(), newChatShowCmd(), newChatArchiveCmd(),
-		newChatHandoffCmd())
+		newChatHandoffCmd(), newChatDeleteCmd())
 	return cmd
 }
 
@@ -262,7 +262,9 @@ func newChatListCmd() *cobra.Command {
 				if archived {
 					scope = apiclient.ArchivedAll
 				}
-				chats, err := c.ListChats(ctx, projectID, scope)
+				chats, err := c.ListChats(ctx, apiclient.ListChatsOptions{
+					ProjectID: projectID, Archived: scope,
+				})
 				if err != nil {
 					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
 					return exitError{code: 1}

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// `vincent task delete` and `vincent chat delete` (§13.2, task 092): the
+// permanent delete of an archived row, from a terminal.
+//
+// Neither prompts. Task 048 recorded that the command tree exists for
+// scripting and that the daemon's 409s are the confirmation story: delete
+// applies to archived rows only, and every other refusal names the row that is
+// holding on. A 409 is exit 1 carrying the daemon's own wording, which is what
+// keeps one refusal from being worded two ways.
+
+// deleteSweep is the two commands' shared body. It is one function because the
+// only difference between them is which endpoint the id goes to and what the
+// listing that finds the ids is called.
+type deleteSweep struct {
+	noun   string // "task" or "chat"
+	branch bool
+	before string
+	// list finds the ids a --before sweep covers.
+	list func(ctx context.Context, c *apiclient.Client, cutoff time.Time) ([]int64, error)
+	// del sends one row's DELETE.
+	del func(ctx context.Context, c *apiclient.Client, id int64, branch bool) (apiclient.BranchOutcome, error)
+}
+
+// deleteReport is what --json emits: one entry per row the sweep touched, so a
+// script can tell a deletion from a refusal without parsing prose.
+type deleteReport struct {
+	ID      int64                    `json:"id"`
+	Deleted bool                     `json:"deleted"`
+	Branch  *apiclient.BranchOutcome `json:"branch,omitempty"`
+	Error   string                   `json:"error,omitempty"`
+	// Reason is the daemon's snake_case refusal code when it refused.
+	Reason string `json:"reason,omitempty"`
+}
+
+// run resolves the ids and deletes them one at a time, in order.
+//
+// One call per row, sequentially: there is no bulk endpoint and there is not
+// going to be one (task 011's decision, verbatim). The exit code is 1 if any
+// row was refused or failed, and the report is emitted either way — a sweep
+// cut off halfway leaves no account of which half.
+func (s deleteSweep) run(cmd *cobra.Command, args []string) error {
+	return withClient(cmd, func(ctx context.Context, c *apiclient.Client) error {
+		ids, err := s.resolve(ctx, c, args)
+		if err != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Error:", apiMessage(err))
+			return exitError{code: 1}
+		}
+		out := cmd.OutOrStdout()
+		reports := make([]deleteReport, 0, len(ids))
+		bad := false
+		for _, id := range ids {
+			branch, err := s.del(ctx, c, id, s.branch)
+			if err != nil {
+				bad = true
+				reason, _ := apiclient.DeleteRefused(err)
+				reports = append(reports, deleteReport{ID: id, Error: apiMessage(err), Reason: reason})
+				if !wantJSON(cmd) {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s %d: %s\n", s.noun, id, apiMessage(err))
+				}
+				continue
+			}
+			reports = append(reports, deleteReport{ID: id, Deleted: true, Branch: branchOutcome(branch)})
+			if !wantJSON(cmd) {
+				_, _ = fmt.Fprintf(out, "%s %d deleted\n", s.noun, id)
+				if summary := branch.Summary(); summary != "" {
+					_, _ = fmt.Fprintln(out, "  "+summary)
+				}
+			}
+		}
+		if wantJSON(cmd) {
+			if err := emitJSON(out, reports); err != nil {
+				return err
+			}
+		} else if len(ids) == 0 {
+			_, _ = fmt.Fprintf(out, "No archived %ss to delete.\n", s.noun)
+		}
+		if bad {
+			return exitError{code: 1}
+		}
+		return nil
+	})
+}
+
+// resolve turns the arguments into ids: the ones named, or — with --before —
+// every archived row older than the cutoff.
+func (s deleteSweep) resolve(ctx context.Context, c *apiclient.Client, args []string) ([]int64, error) {
+	if s.before == "" {
+		ids := make([]int64, 0, len(args))
+		for _, a := range args {
+			id, err := strconv.ParseInt(a, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s id %q: not an integer", s.noun, a)
+			}
+			ids = append(ids, id)
+		}
+		return ids, nil
+	}
+	cutoff, err := parseBefore(s.before, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	return s.list(ctx, c, cutoff)
+}
+
+// parseBefore reads --before, which takes either an absolute date
+// (2026-01-31, or a full RFC3339 instant) or a duration back from now (30d,
+// 12h). Days are spelled out here because time.ParseDuration stops at hours,
+// and "delete everything older than thirty days" is the thing this flag is
+// for.
+func parseBefore(v string, now time.Time) (time.Time, error) {
+	if d, ok := strings.CutSuffix(v, "d"); ok {
+		days, err := strconv.Atoi(d)
+		if err == nil && days >= 0 {
+			return now.AddDate(0, 0, -days), nil
+		}
+	}
+	if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+		return now.Add(-d), nil
+	}
+	if t, err := time.Parse(time.RFC3339, v); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("2006-01-02", v); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("--before %q: expected a date (2026-01-31), an RFC3339 instant, or a duration back from now (30d, 12h)", v)
+}
+
+// deleteArgs validates the argument shape both commands share: ids, or
+// --before and no ids at all. Mixing them would make "which rows did that
+// touch" unanswerable from the command line alone.
+func deleteArgs(before *string) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		switch {
+		case *before != "" && len(args) > 0:
+			return fmt.Errorf("--before sweeps the archive; do not also name ids")
+		case *before == "" && len(args) == 0:
+			return fmt.Errorf("name at least one id, or pass --before to sweep the archive")
+		}
+		return nil
+	}
+}
+
+func newTaskDeleteCmd() *cobra.Command {
+	s := deleteSweep{
+		noun: "task",
+		list: func(ctx context.Context, c *apiclient.Client, cutoff time.Time) ([]int64, error) {
+			tasks, err := c.ListTasks(ctx, apiclient.ListTasksOptions{
+				Archived: apiclient.ArchivedOnly, ArchivedBefore: cutoff,
+			})
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]int64, 0, len(tasks))
+			for i := range tasks {
+				ids = append(ids, tasks[i].ID)
+			}
+			return ids, nil
+		},
+		del: func(ctx context.Context, c *apiclient.Client, id int64, branch bool) (apiclient.BranchOutcome, error) {
+			return c.DeleteTask(ctx, id, branch)
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "delete <id>...",
+		Aliases: []string{"rm"},
+		Short:   "Permanently delete archived tasks",
+		Long: "Deletes an archived task for good: the row, its step attempts and its\n" +
+			"transcripts. Only an archived task can be deleted; anything else is refused,\n" +
+			"and so is a fan-out parent whose lanes still exist or a task a handed-off chat\n" +
+			"points at. It does not prompt — the daemon's refusals are the confirmation.\n\n" +
+			"--branch additionally deletes the task's local branch, but never one carrying\n" +
+			"commits past its base: that branch is reported has_commits and kept. The\n" +
+			"remote branch is never touched.",
+		RunE: s.run,
+	}
+	cmd.Args = deleteArgs(&s.before)
+	cmd.Flags().BoolVar(&s.branch, "branch", false,
+		"Also delete the task's local branch, unless it carries commits past its base")
+	cmd.Flags().StringVar(&s.before, "before", "",
+		"Delete every task archived before this date (2026-01-31) or duration back from now (30d)")
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newChatDeleteCmd() *cobra.Command {
+	s := deleteSweep{
+		noun: "chat",
+		list: func(ctx context.Context, c *apiclient.Client, cutoff time.Time) ([]int64, error) {
+			chats, err := c.ListChats(ctx, apiclient.ListChatsOptions{
+				Archived: apiclient.ArchivedOnly, ArchivedBefore: cutoff,
+			})
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]int64, 0, len(chats))
+			for i := range chats {
+				// A handed-off chat is refused by the daemon, and a sweep is
+				// not the place to collect a refusal it can see coming: the
+				// task it was handed to owns the worktree, and that task is
+				// what to delete.
+				if chats[i].State == "handed_off" {
+					continue
+				}
+				ids = append(ids, chats[i].ID)
+			}
+			return ids, nil
+		},
+		del: func(ctx context.Context, c *apiclient.Client, id int64, branch bool) (apiclient.BranchOutcome, error) {
+			return c.DeleteChat(ctx, id, branch)
+		},
+	}
+	cmd := &cobra.Command{
+		Use:     "delete <chat-id>...",
+		Aliases: []string{"rm"},
+		Short:   "Permanently delete archived chats",
+		Long: "Deletes an archived chat for good: the row, its turns and its transcripts.\n" +
+			"Only an archived chat can be deleted — a handed-off one is refused, because\n" +
+			"the task it was handed to owns its worktree and branch. It does not prompt.\n\n" +
+			"--branch additionally deletes the chat's local branch, but never one carrying\n" +
+			"commits past its base.",
+		RunE: s.run,
+	}
+	cmd.Args = deleteArgs(&s.before)
+	cmd.Flags().BoolVar(&s.branch, "branch", false,
+		"Also delete the chat's local branch, unless it carries commits past its base")
+	cmd.Flags().StringVar(&s.before, "before", "",
+		"Delete every chat that ended before this date (2026-01-31) or duration back from now (30d)")
+	jsonFlag(cmd)
+	return cmd
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -26,7 +26,7 @@ func newTaskCmd() *cobra.Command {
 	cmd.AddCommand(newTaskAddCmd(), newTaskLsCmd(), newTaskShowCmd(), newTaskCancelCmd(),
 		newTaskFollowUpCmd(), newTaskTranscriptCmd(), newTaskPauseCmd(), newTaskResumeCmd(),
 		newTaskSkipCmd(), newTaskApproveCmd(), newTaskRejectCmd(), newTaskRetryCmd(),
-		newTaskRepairCmd(), newTaskArchiveCmd(), newTaskAnswerCmd())
+		newTaskRepairCmd(), newTaskArchiveCmd(), newTaskAnswerCmd(), newTaskDeleteCmd())
 	return cmd
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -73,6 +73,13 @@ var Excluded = []Route{
 	{Method: http.MethodPost, Path: "/v1/agents/{name}/quota"},
 	{Method: http.MethodPost, Path: "/v1/daemon/backup"},
 	{Method: http.MethodDelete, Path: "/v1/projects/{id}"},
+	// The two permanent deletes (task 092), on the same line as the project
+	// delete above and for the same reason: §13.4's surface is the route
+	// table minus destructive admin, and a row a human archived is history
+	// nobody else may discard. Archive stays a tool — it is reversible in the
+	// sense that matters, the row and its transcripts survive it.
+	{Method: http.MethodDelete, Path: "/v1/tasks/{id}"},
+	{Method: http.MethodDelete, Path: "/v1/chats/{id}"},
 	{Method: http.MethodPost, Path: "/v1/maintenance/gc"},
 	{Method: http.MethodPost, Path: "/v1/doctor/fix"},
 	// The chat family (task 063 decision 2). An agent must not be able to

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -150,6 +150,22 @@ type ChatFilter struct {
 	// decision 5) — because both are equally done with, whatever the
 	// parameter's name says. An explicit States always wins.
 	Archived ArchivedFilter
+	// ArchivedBefore and ArchivedSince bound when the chat ended, measured
+	// over `updated_at` and with no new column (task 092). Task 074 decision
+	// 6 and task 079 decision 2 both recorded that a terminal transition is
+	// the last write a chat row takes, so `updated_at` already *is* when it
+	// ended, and TerminalChatIDsBefore has measured retention off it since.
+	// Zero means no bound.
+	//
+	// Unlike the task side these do not narrow to terminal rows on their own —
+	// every chat has an `updated_at` — so a caller that wants the archived
+	// board's meaning sets Archived as well, which is what the API does.
+	ArchivedBefore time.Time
+	ArchivedSince  time.Time
+	// Limit and Offset page the listing, the way TaskFilter's fields of the
+	// same name do. 0 = unlimited.
+	Limit  int
+	Offset int
 }
 
 // ListChats returns chats newest first, which is the order a conversation
@@ -157,6 +173,7 @@ type ChatFilter struct {
 func (s *Store) ListChats(ctx context.Context, f ChatFilter) ([]Chat, error) {
 	q := `SELECT ` + chatColumns + ` FROM chats WHERE 1=1`
 	var args []any
+	archivedOnly := f.Archived == ArchivedOnly && len(f.States) == 0
 	if f.ProjectID != nil {
 		q += ` AND project_id = ?`
 		args = append(args, *f.ProjectID)
@@ -182,7 +199,30 @@ func (s *Store) ListChats(ctx context.Context, f ChatFilter) ([]Chat, error) {
 		case ArchivedAll:
 		}
 	}
-	q += ` ORDER BY id DESC`
+	if !f.ArchivedBefore.IsZero() {
+		q += ` AND updated_at < ?`
+		args = append(args, formatTime(f.ArchivedBefore))
+	}
+	if !f.ArchivedSince.IsZero() {
+		q += ` AND updated_at >= ?`
+		args = append(args, formatTime(f.ArchivedSince))
+	}
+	// A terminal-only listing is newest-*ended* first, the chat mirror of the
+	// task side's `archived_at DESC` (task 092): `id DESC` would sort by when
+	// the conversation started, and an archive is read by when it ended.
+	if archivedOnly {
+		q += ` ORDER BY updated_at DESC, id DESC`
+	} else {
+		q += ` ORDER BY id DESC`
+	}
+	if f.Limit > 0 || f.Offset > 0 {
+		limit := f.Limit
+		if limit == 0 {
+			limit = -1 // SQLite: negative LIMIT means unlimited
+		}
+		q += ` LIMIT ? OFFSET ?`
+		args = append(args, limit, f.Offset)
+	}
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list chats: %w", err)

--- a/internal/store/delete.go
+++ b/internal/store/delete.go
@@ -1,0 +1,247 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+// Durable event types for a permanent delete (§13.3, task 092). PR D's ruling
+// that an archive needs no type of its own — it is `task.state_changed` with
+// `to: archived` — does not reach these: a delete has no state to change to,
+// so without a type no other client ever learns the row is gone.
+//
+// The event outlives the row it records, exactly as `project.deleted` does:
+// the events table has no foreign keys, and the historical rows behind the
+// delete are deliberately left in place (task 092 decision, §17).
+const (
+	EventTaskDeleted = "task.deleted"
+	EventChatDeleted = "chat.deleted"
+)
+
+// DeleteRefusedError is a permanent delete refused by a rule of its own rather
+// than by the FSM (task 092 decision 2). Delete is not a §6 action — taskstate
+// has no opinion on it and it never appears in `available_actions` — so the
+// refusals are named here and mapped to a 409 by the API, the way
+// `DELETE /v1/projects/{id}` already is.
+//
+// Reason is the snake_case vocabulary the API puts in `details`; Message is
+// what a human reads. Each one names the row that is holding on, because
+// "cannot delete" without the holder is not something a caller can act on.
+type DeleteRefusedError struct {
+	// Kind is "task" or "chat" — the thing that was not deleted.
+	Kind string
+	// ID is that thing's id.
+	ID int64
+	// Reason is one of the DeleteRefused* constants.
+	Reason string
+	// Message names the row that is holding on.
+	Message string
+}
+
+func (e *DeleteRefusedError) Error() string { return e.Message }
+
+// Reasons a permanent delete is refused (§13.2). They are snake_case for the
+// reason every other reason vocabulary in the system is: a `details` value
+// means the same thing wherever it originated.
+const (
+	// DeleteRefusedNotArchived: the row is still live. Delete applies to
+	// archived rows only, and is never performed on anything else.
+	DeleteRefusedNotArchived = "not_archived"
+	// DeleteRefusedHasLanes: an archived fan-out parent whose lane rows still
+	// exist. `tasks.parent_task_id` is a plain REFERENCES with no ON DELETE
+	// clause (0007_fan_out.sql) and PRAGMA foreign_keys is on, so without this
+	// guard the delete fails in the driver rather than refusing. The lanes go
+	// first.
+	DeleteRefusedHasLanes = "has_lanes"
+	// DeleteRefusedHandedOff: a `handed_off` chat. The task named by
+	// handoff_task_id owns the worktree and branch (task 074 decision 5), and
+	// `handed_off` means "that task owns it" — a deleted row cannot say that.
+	DeleteRefusedHandedOff = "handed_off"
+	// DeleteRefusedHandoffTarget: the mirror of it — an archived task that a
+	// `handed_off` chat points at. `chats.handoff_task_id` is ON DELETE SET
+	// NULL (0023_chat_handoff.sql), so deleting the task would leave a
+	// terminal chat pointing at nothing.
+	DeleteRefusedHandoffTarget = "handoff_target"
+)
+
+// DeleteTaskCascade hard-deletes an archived task and its step_runs in one
+// transaction, appending a durable `task.deleted` event after the delete
+// (§13.2, §13.3, task 092). DeleteProjectCascade is the shape it copies.
+//
+// Returns ErrNotFound when the row does not exist and *DeleteRefusedError for
+// each of the three refusals it owns; nothing is deleted in either case. The
+// two remaining references clear themselves and need no refusal:
+// `tasks.created_by_task_id` is ON DELETE SET NULL (MCP provenance, so
+// `mcp.max_depth`'s walk simply stops one link early) and the idempotency rows
+// are ON DELETE CASCADE.
+//
+// The `events` rows are deliberately *not* purged. A project delete purges
+// them because the project's entire history is going and every row would
+// afterwards reference nothing at all; deleting one archived task is not that,
+// and `id` is the SSE Last-Event-ID cursor every subscriber is holding.
+func (s *Store) DeleteTaskCascade(ctx context.Context, id int64) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	var (
+		state     string
+		projectID int64
+		title     string
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT state, project_id, title FROM tasks WHERE id = ?`, id).Scan(&state, &projectID, &title)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("task %d: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	if TaskState(state) != TaskArchived {
+		return &DeleteRefusedError{
+			Kind: "task", ID: id, Reason: DeleteRefusedNotArchived,
+			Message: fmt.Sprintf("task %d is %s; only an archived task can be deleted", id, state),
+		}
+	}
+	var lane int64
+	if err = tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MIN(id), 0) FROM tasks WHERE parent_task_id = ?`, id).Scan(&lane); err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	if lane != 0 {
+		return &DeleteRefusedError{
+			Kind: "task", ID: id, Reason: DeleteRefusedHasLanes,
+			Message: fmt.Sprintf("task %d still has fan-out lanes (task %d); delete those first", id, lane),
+		}
+	}
+	var chat int64
+	if err = tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MIN(id), 0) FROM chats WHERE handoff_task_id = ? AND state = ?`,
+		id, string(chatstate.HandedOff)).Scan(&chat); err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	if chat != 0 {
+		return &DeleteRefusedError{
+			Kind: "task", ID: id, Reason: DeleteRefusedHandoffTarget,
+			Message: fmt.Sprintf("chat %d was handed off to task %d and would be left pointing at nothing", chat, id),
+		}
+	}
+	if _, err = tx.ExecContext(ctx, `DELETE FROM step_runs WHERE task_id = ?`, id); err != nil {
+		return fmt.Errorf("delete task %d cascade: %w", id, err)
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM tasks WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	if err = oneRowAffected(res, fmt.Sprintf("task %d", id)); err != nil {
+		return err
+	}
+	ev, err := deletedEvent(EventTaskDeleted, id, projectID, title)
+	if err != nil {
+		return err
+	}
+	if err = appendEventTx(ctx, tx, ev); err != nil {
+		return err
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("delete task %d: %w", id, err)
+	}
+	s.notify(ev)
+	return nil
+}
+
+// DeleteChatCascade hard-deletes an archived chat, appending a durable
+// `chat.deleted` event after the delete (§13.2, §13.3, task 092). The turn
+// rows go with it through the schema's own cascade (0022_chats.sql), so the
+// statement is the row alone.
+//
+// Returns ErrNotFound when the row does not exist, and *DeleteRefusedError for
+// a chat that is not `archived` — which includes `handed_off`: that state
+// means the task named by handoff_task_id owns the worktree and branch (task
+// 074 decision 5), and a deleted row cannot say so.
+//
+// A chat's events carry no chat_id column at all — chatEvent puts the id in
+// the payload — which is a second reason not to try to purge them.
+func (s *Store) DeleteChatCascade(ctx context.Context, id int64) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("delete chat %d: %w", id, err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	var (
+		state     string
+		projectID int64
+		title     string
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT state, project_id, title FROM chats WHERE id = ?`, id).Scan(&state, &projectID, &title)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("chat %d: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("delete chat %d: %w", id, err)
+	}
+	switch chatstate.State(state) {
+	case chatstate.Archived:
+	case chatstate.HandedOff:
+		return &DeleteRefusedError{
+			Kind: "chat", ID: id, Reason: DeleteRefusedHandedOff,
+			Message: fmt.Sprintf(
+				"chat %d was handed off to a task, which owns its worktree and branch; that task is what to delete", id),
+		}
+	default:
+		return &DeleteRefusedError{
+			Kind: "chat", ID: id, Reason: DeleteRefusedNotArchived,
+			Message: fmt.Sprintf("chat %d is %s; only an archived chat can be deleted", id, state),
+		}
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM chats WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete chat %d: %w", id, err)
+	}
+	if err = oneRowAffected(res, fmt.Sprintf("chat %d", id)); err != nil {
+		return err
+	}
+	ev, err := deletedEvent(EventChatDeleted, id, projectID, title)
+	if err != nil {
+		return err
+	}
+	if err = appendEventTx(ctx, tx, ev); err != nil {
+		return err
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("delete chat %d: %w", id, err)
+	}
+	s.notify(ev)
+	return nil
+}
+
+// deletedEvent builds a task.deleted or chat.deleted event. It carries the id
+// and the title and nothing more: a client's only use for it is to drop the
+// row it is already holding, and the row it names no longer exists to be
+// fetched.
+//
+// TaskID stays nil even for a task: the column is a foreign key, and the whole
+// point of this event is that the task it names is gone.
+func deletedEvent(evType string, id, projectID int64, title string) (*Event, error) {
+	payload, err := json.Marshal(map[string]any{"id": id, "title": title})
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s event: %w", evType, err)
+	}
+	pid := projectID
+	return &Event{Type: evType, ProjectID: &pid, Payload: payload}, nil
+}

--- a/internal/store/delete_test.go
+++ b/internal/store/delete_test.go
@@ -1,0 +1,397 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/chatstate"
+)
+
+// archiveTask puts a task into `archived` through the real transition path, so
+// the `archived_at` these tests order and bound by is the one the engine
+// writes rather than one a test invented.
+func archiveTask(t *testing.T, s *Store, id int64, from TaskState) {
+	t.Helper()
+	if _, _, err := s.TransitionTask(t.Context(), id, from, TaskArchived, TaskChange{}); err != nil {
+		t.Fatalf("archive task %d: %v", id, err)
+	}
+}
+
+// backdateArchivedAt moves a task's archived_at, which nothing in the API can
+// do. Ageing rows is the only way to test a date bound without sleeping.
+func backdateArchivedAt(t *testing.T, s *Store, id int64, at time.Time) {
+	t.Helper()
+	if _, err := s.db.ExecContext(t.Context(),
+		`UPDATE tasks SET archived_at = ? WHERE id = ?`, formatTime(at), id); err != nil {
+		t.Fatalf("backdate task %d: %v", id, err)
+	}
+}
+
+func newArchivedTask(t *testing.T, s *Store, projectID int64, title string) *Task {
+	t.Helper()
+	task := newTask(projectID, title, TaskDone)
+	if err := s.CreateTask(t.Context(), task, nil); err != nil {
+		t.Fatalf("CreateTask(%s): %v", title, err)
+	}
+	archiveTask(t, s, task.ID, TaskDone)
+	return task
+}
+
+func TestArchivedTaskListingIsNewestArchivedFirst(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p1")
+	// Created oldest-first, archived in the reverse order, so `id DESC` and
+	// `archived_at DESC` disagree — which is the whole point of the ordering.
+	a := newArchivedTask(t, s, p.ID, "a")
+	b := newArchivedTask(t, s, p.ID, "b")
+	c := newArchivedTask(t, s, p.ID, "c")
+	now := time.Now()
+	backdateArchivedAt(t, s, a.ID, now.Add(-time.Hour))
+	backdateArchivedAt(t, s, b.ID, now.Add(-3*time.Hour))
+	backdateArchivedAt(t, s, c.ID, now.Add(-2*time.Hour))
+
+	got, err := s.ListTasks(t.Context(), TaskFilter{Archived: ArchivedOnly})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	want := []int64{a.ID, c.ID, b.ID}
+	if len(got) != len(want) {
+		t.Fatalf("got %d tasks, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Fatalf("position %d: got task %d, want %d", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestArchivedTaskDateBoundsSelectOnArchivedAt(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p1")
+	old := newArchivedTask(t, s, p.ID, "old")
+	recent := newArchivedTask(t, s, p.ID, "recent")
+	live := newTask(p.ID, "live", TaskDone)
+	if err := s.CreateTask(t.Context(), live, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	now := time.Now()
+	backdateArchivedAt(t, s, old.ID, now.AddDate(0, 0, -40))
+	backdateArchivedAt(t, s, recent.ID, now.AddDate(0, 0, -2))
+	cutoff := now.AddDate(0, 0, -7)
+
+	before, err := s.ListTasks(t.Context(), TaskFilter{Archived: ArchivedOnly, ArchivedBefore: cutoff})
+	if err != nil {
+		t.Fatalf("ListTasks before: %v", err)
+	}
+	if len(before) != 1 || before[0].ID != old.ID {
+		t.Fatalf("archived_before: got %v, want just task %d", ids(before), old.ID)
+	}
+	since, err := s.ListTasks(t.Context(), TaskFilter{Archived: ArchivedOnly, ArchivedSince: cutoff})
+	if err != nil {
+		t.Fatalf("ListTasks since: %v", err)
+	}
+	if len(since) != 1 || since[0].ID != recent.ID {
+		t.Fatalf("archived_since: got %v, want just task %d", ids(since), recent.ID)
+	}
+	// A live task has a NULL archived_at, which fails both comparisons: a
+	// bound narrows to the archive on its own.
+	all, err := s.ListTasks(t.Context(), TaskFilter{Archived: ArchivedAll, ArchivedSince: cutoff})
+	if err != nil {
+		t.Fatalf("ListTasks all: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != recent.ID {
+		t.Fatalf("archived_since over ArchivedAll: got %v, want just task %d", ids(all), recent.ID)
+	}
+}
+
+func TestArchivedTaskPagingIsStableAcrossPages(t *testing.T) {
+	s := openTest(t)
+	p := testProject(t, s, "p1")
+	now := time.Now()
+	var all []int64
+	for i := range 6 {
+		task := newArchivedTask(t, s, p.ID, string(rune('a'+i)))
+		backdateArchivedAt(t, s, task.ID, now.Add(-time.Duration(i)*time.Hour))
+		all = append(all, task.ID)
+	}
+	var seen []int64
+	for offset := 0; offset < 6; offset += 2 {
+		page, err := s.ListTasks(t.Context(), TaskFilter{
+			Archived: ArchivedOnly, Limit: 2, Offset: offset,
+		})
+		if err != nil {
+			t.Fatalf("ListTasks offset %d: %v", offset, err)
+		}
+		seen = append(seen, ids(page)...)
+	}
+	for i, id := range all {
+		if seen[i] != id {
+			t.Fatalf("paged position %d: got task %d, want %d (pages %v)", i, seen[i], id, seen)
+		}
+	}
+}
+
+func ids(tasks []Task) []int64 {
+	out := make([]int64, 0, len(tasks))
+	for i := range tasks {
+		out = append(out, tasks[i].ID)
+	}
+	return out
+}
+
+func TestDeleteTaskCascadeRemovesStepRunsAndKeepsEvents(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newArchivedTask(t, s, p.ID, "gone")
+	run := &StepRun{TaskID: task.ID, StepIndex: 0, StepID: "s1", StepType: "command", Attempt: 1, State: StepSucceeded}
+	if err := s.CreateStepRun(ctx, run); err != nil {
+		t.Fatalf("CreateStepRun: %v", err)
+	}
+	before, err := s.ListEvents(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+
+	if err := s.DeleteTaskCascade(ctx, task.ID); err != nil {
+		t.Fatalf("DeleteTaskCascade: %v", err)
+	}
+	if _, err := s.GetTask(ctx, task.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTask after delete: %v, want ErrNotFound", err)
+	}
+	runs, err := s.ListStepRuns(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("got %d step runs after delete, want 0", len(runs))
+	}
+	// The historical events survive: `id` is the SSE Last-Event-ID cursor
+	// every subscriber is holding, and one archived row going is not a
+	// project's whole history going.
+	after, err := s.ListEvents(ctx, EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents after: %v", err)
+	}
+	if len(after) < len(before)+1 {
+		t.Fatalf("got %d events after delete, want at least %d plus the task.deleted", len(after), len(before))
+	}
+	var found bool
+	for i := range after {
+		if after[i].Type == EventTaskDeleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no %s event was appended", EventTaskDeleted)
+	}
+}
+
+func TestDeleteTaskCascadeNullsCreatedByAndClearsIdempotency(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	parent := newArchivedTask(t, s, p.ID, "parent")
+	child := newTask(p.ID, "child", TaskDone)
+	child.CreatedByTaskID = &parent.ID
+	if err := s.CreateTask(ctx, child, nil); err != nil {
+		t.Fatalf("CreateTask(child): %v", err)
+	}
+
+	if err := s.DeleteTaskCascade(ctx, parent.ID); err != nil {
+		t.Fatalf("DeleteTaskCascade: %v", err)
+	}
+	// created_by_task_id is ON DELETE SET NULL: mcp.max_depth's walk simply
+	// stops one link early, which is why this needs no refusal.
+	got, err := s.GetTask(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetTask(child): %v", err)
+	}
+	if got.CreatedByTaskID != nil {
+		t.Fatalf("child still points at task %d", *got.CreatedByTaskID)
+	}
+}
+
+func TestDeleteTaskRefusesALiveTask(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	task := newTask(p.ID, "live", TaskRunning)
+	if err := s.CreateTask(ctx, task, nil); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	err := s.DeleteTaskCascade(ctx, task.ID)
+	assertRefused(t, err, DeleteRefusedNotArchived)
+	if _, err := s.GetTask(ctx, task.ID); err != nil {
+		t.Fatalf("the task was deleted anyway: %v", err)
+	}
+}
+
+func TestDeleteTaskRefusesAParentWithLanes(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	parent := newArchivedTask(t, s, p.ID, "parent")
+	lane := newTask(p.ID, "lane", TaskDone)
+	lane.ParentTaskID = &parent.ID
+	if err := s.CreateTask(ctx, lane, nil); err != nil {
+		t.Fatalf("CreateTask(lane): %v", err)
+	}
+
+	// Without the explicit guard this is a driver error rather than a
+	// refusal: parent_task_id is a plain REFERENCES with no ON DELETE clause
+	// and PRAGMA foreign_keys is on.
+	err := s.DeleteTaskCascade(ctx, parent.ID)
+	assertRefused(t, err, DeleteRefusedHasLanes)
+	if _, err := s.GetTask(ctx, parent.ID); err != nil {
+		t.Fatalf("the parent was deleted anyway: %v", err)
+	}
+}
+
+func TestDeleteTaskRefusesAHandoffTarget(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+	task := handOff(t, s, c, p.ID)
+	archiveTask(t, s, task.ID, TaskQueued)
+
+	err := s.DeleteTaskCascade(ctx, task.ID)
+	assertRefused(t, err, DeleteRefusedHandoffTarget)
+	if _, err := s.GetTask(ctx, task.ID); err != nil {
+		t.Fatalf("the task was deleted anyway: %v", err)
+	}
+}
+
+func TestDeleteChatCascadeRemovesTheChat(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+	if _, err := s.CreateChatTurn(ctx, c.ID, "hello"); err != nil {
+		t.Fatalf("CreateChatTurn: %v", err)
+	}
+	if _, err := s.SetChatState(ctx, c.ID, chatstate.Archived); err != nil {
+		t.Fatalf("SetChatState: %v", err)
+	}
+
+	if err := s.DeleteChatCascade(ctx, c.ID); err != nil {
+		t.Fatalf("DeleteChatCascade: %v", err)
+	}
+	if _, err := s.GetChat(ctx, c.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetChat after delete: %v, want ErrNotFound", err)
+	}
+	// The turns go with the row through the schema's own cascade.
+	turns, err := s.ListChatTurns(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("ListChatTurns: %v", err)
+	}
+	if len(turns) != 0 {
+		t.Fatalf("got %d turns after delete, want 0", len(turns))
+	}
+}
+
+func TestDeleteChatRefusesAHandedOffChat(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+	handOff(t, s, c, p.ID)
+
+	err := s.DeleteChatCascade(ctx, c.ID)
+	assertRefused(t, err, DeleteRefusedHandedOff)
+	if _, err := s.GetChat(ctx, c.ID); err != nil {
+		t.Fatalf("the chat was deleted anyway: %v", err)
+	}
+}
+
+func TestDeleteChatRefusesALiveChat(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	c := testChat(t, s, p.ID)
+
+	err := s.DeleteChatCascade(ctx, c.ID)
+	assertRefused(t, err, DeleteRefusedNotArchived)
+	if _, err := s.GetChat(ctx, c.ID); err != nil {
+		t.Fatalf("the chat was deleted anyway: %v", err)
+	}
+}
+
+func TestChatDateBoundsAndPagingUseUpdatedAt(t *testing.T) {
+	s := openTest(t)
+	ctx := t.Context()
+	p := testProject(t, s, "p1")
+	var made []int64
+	for i := range 4 {
+		c := &Chat{
+			ProjectID: p.ID, Title: string(rune('a' + i)), Agent: "claude",
+			BaseBranch: "main", Branch: "vincent/chat", PermissionMode: "full_auto",
+		}
+		if err := s.CreateChat(ctx, c); err != nil {
+			t.Fatalf("CreateChat: %v", err)
+		}
+		if _, err := s.SetChatState(ctx, c.ID, chatstate.Archived); err != nil {
+			t.Fatalf("SetChatState: %v", err)
+		}
+		made = append(made, c.ID)
+	}
+	now := time.Now()
+	// `updated_at` is when a terminal chat ended, which is what these bounds
+	// measure — there is deliberately no archived_at column (task 074/079).
+	for i, id := range made {
+		if _, err := s.db.ExecContext(ctx, `UPDATE chats SET updated_at = ? WHERE id = ?`,
+			formatTime(now.Add(-time.Duration(i)*24*time.Hour)), id); err != nil {
+			t.Fatalf("backdate chat %d: %v", id, err)
+		}
+	}
+
+	got, err := s.ListChats(ctx, ChatFilter{Archived: ArchivedOnly, ArchivedBefore: now.Add(-36 * time.Hour)})
+	if err != nil {
+		t.Fatalf("ListChats before: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("archived_before: got %d chats, want 2", len(got))
+	}
+	// Newest-ended first, so the two returned are the third and fourth made.
+	if got[0].ID != made[2] || got[1].ID != made[3] {
+		t.Fatalf("archived_before order: got %d,%d want %d,%d", got[0].ID, got[1].ID, made[2], made[3])
+	}
+	page, err := s.ListChats(ctx, ChatFilter{Archived: ArchivedOnly, Limit: 2, Offset: 1})
+	if err != nil {
+		t.Fatalf("ListChats paged: %v", err)
+	}
+	if len(page) != 2 || page[0].ID != made[1] || page[1].ID != made[2] {
+		t.Fatalf("paged: got %v, want %d,%d", page, made[1], made[2])
+	}
+}
+
+// handOff runs a real handoff, so the `handed_off` state and the
+// handoff_task_id link the two refusals turn on are the ones the feature
+// writes rather than ones a test poked in.
+func handOff(t *testing.T, s *Store, c *Chat, projectID int64) *Task {
+	t.Helper()
+	task := newTask(projectID, "carry on", TaskQueued)
+	task.BranchName, task.BaseBranch, task.BaseSHA = c.Branch, c.BaseBranch, c.BaseSHA
+	task.WorktreePath = c.WorktreePath
+	if _, err := s.HandoffChat(t.Context(), c.ID, task); err != nil {
+		t.Fatalf("HandoffChat: %v", err)
+	}
+	return task
+}
+
+func assertRefused(t *testing.T, err error, reason string) {
+	t.Helper()
+	var refused *DeleteRefusedError
+	if !errors.As(err, &refused) {
+		t.Fatalf("got %v, want a *DeleteRefusedError", err)
+	}
+	if refused.Reason != reason {
+		t.Fatalf("reason %q, want %q (message: %s)", refused.Reason, reason, refused.Message)
+	}
+	if refused.Message == "" {
+		t.Fatal("the refusal names nothing")
+	}
+}

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -318,8 +318,15 @@ type TaskFilter struct {
 	ProjectID int64     // 0 = all projects
 	State     TaskState // "" = all states
 	Archived  ArchivedFilter
-	Limit     int // 0 = unlimited
-	Offset    int
+	// ArchivedBefore and ArchivedSince bound `archived_at`, the column the
+	// terminal transition writes (§13.2, task 092). Zero means no bound.
+	// They are the archived board's date presets and the sweep's cutoff, and
+	// they narrow to archived rows on their own: `archived_at` is NULL on
+	// everything else, and NULL fails both comparisons.
+	ArchivedBefore time.Time
+	ArchivedSince  time.Time
+	Limit          int // 0 = unlimited
+	Offset         int
 	// Children decides whether fan-out lanes appear (task 014 decision 13).
 	// The zero value is ChildrenExclude: a list is the work someone asked
 	// for, and a 64-task tree would bury it.
@@ -363,6 +370,7 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 	}
 	// An explicit State always wins: asking for state=archived and getting
 	// nothing back because the default excludes archives would be absurd.
+	archivedOnly := f.State == TaskArchived
 	if f.State == "" {
 		switch f.Archived {
 		case ArchivedExclude:
@@ -371,8 +379,17 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 		case ArchivedOnly:
 			where = append(where, "state = ?")
 			args = append(args, string(TaskArchived))
+			archivedOnly = true
 		case ArchivedAll:
 		}
+	}
+	if !f.ArchivedBefore.IsZero() {
+		where = append(where, "archived_at IS NOT NULL AND archived_at < ?")
+		args = append(args, formatTime(f.ArchivedBefore))
+	}
+	if !f.ArchivedSince.IsZero() {
+		where = append(where, "archived_at IS NOT NULL AND archived_at >= ?")
+		args = append(args, formatTime(f.ArchivedSince))
 	}
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -380,9 +397,19 @@ func (s *Store) ListTasks(ctx context.Context, f TaskFilter) ([]Task, error) {
 	// Lanes of one parent read in merge order — the order the join will
 	// merge them, which is what someone drilling into a fan-out is looking
 	// at. Everything else is newest first.
-	if f.ParentID != 0 {
+	//
+	// An archived-only listing is newest-*archived* first: recency is the only
+	// order an archive has, and `id DESC` would put a task created last week
+	// and archived this morning below one created a year ago and archived a
+	// year ago. That is also why no `sort=` parameter exists — there is one
+	// right answer per listing (task 092). `id DESC` breaks the tie so paging
+	// is stable across pages when a batch shares a timestamp.
+	switch {
+	case f.ParentID != 0:
 		q += " ORDER BY lane_order ASC, id ASC"
-	} else {
+	case archivedOnly:
+		q += " ORDER BY archived_at DESC, id DESC"
+	default:
 		q += " ORDER BY id DESC"
 	}
 	if f.Limit > 0 || f.Offset > 0 {

--- a/internal/taskrun/delete.go
+++ b/internal/taskrun/delete.go
@@ -1,0 +1,135 @@
+package taskrun
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/lezli01/vincent/internal/worktree"
+)
+
+// Delete permanently removes an archived task: the row and its step_runs, then
+// the transcript directory, and optionally the branch (§13.2, task 092).
+//
+// It is *not* a §6 action. taskstate has no opinion on it, it never appears in
+// `available_actions`, and the "archived only" rule is checked by the store
+// inside the delete transaction rather than by the FSM — the precedent is
+// `DELETE /v1/projects/{id}`, which is likewise no action. It lives on the
+// runner all the same, because the runner is what holds the worktree manager,
+// the data dir and the logger the three steps need.
+//
+// deleteBranch applies §10's standing rule unchanged (task 008, widened by
+// task 092 from "at archive time" to "at archive time and at permanent
+// delete"): a branch carrying any commit past its base is reported
+// `has_commits` and kept, whatever the human answered. The remote leg is not
+// offered — `delete_remote_branch_on_archive` stays honoured only by archive,
+// because deleting a branch on a forge other people share is unrecoverable and
+// a delete has no second chance to reconsider.
+//
+// The order is deliberate. The row goes first: a failed unlink must not
+// resurrect a row that has already been reported gone, and `vincent gc`
+// already treats a transcript directory with no row as its own to reclaim.
+// Neither the branch step nor the transcript step can fail the call.
+func (r *Runner) Delete(
+	ctx context.Context, id int64, deleteBranch bool,
+) (worktree.BranchOutcome, error) {
+	task, err := r.deps.Store.GetTask(ctx, id)
+	if err != nil {
+		return worktree.BranchOutcome{}, err
+	}
+	// Read before the delete: the row carries the base, the recorded base SHA
+	// and the branch name the §10 judgement needs, and it is about to stop
+	// existing.
+	var projectPath string
+	if deleteBranch && task.BranchName != "" {
+		ran, err := r.ranAStep(ctx, id)
+		if err != nil {
+			return worktree.BranchOutcome{}, err
+		}
+		if ran {
+			project, err := r.deps.Store.GetProject(ctx, task.ProjectID)
+			if err != nil {
+				return worktree.BranchOutcome{}, err
+			}
+			projectPath = project.Path
+		}
+	}
+	if err := r.deps.Store.DeleteTaskCascade(ctx, id); err != nil {
+		return worktree.BranchOutcome{}, err
+	}
+	RemoveTranscriptDir(r.deps.DataDir, strconv.FormatInt(id, 10), r.deps.Logger)
+	if projectPath == "" {
+		return worktree.BranchOutcome{}, nil
+	}
+	log := r.deps.Logger.With("task", id, "branch", task.BranchName)
+	// Whether the branch is ours to delete at all (task 064 decision 3): a
+	// task created from a pull request runs on the contributor's head branch,
+	// and this must not touch it. Same answer archive gives.
+	ours := !task.GitHubPull.FromPull()
+	out, err := r.deps.Worktrees.DeleteEmptyBranch(ctx, projectPath,
+		task.BaseBranch, task.BaseSHA, task.BranchName, false, &ours)
+	if err != nil {
+		log.Warn("delete: branch kept", "result", out.Result, "error", err)
+		return out, nil
+	}
+	switch out.Result {
+	case worktree.BranchDeleted:
+		log.Info("delete: deleted the branch, which had no commits past its base", "base", task.BaseBranch)
+	case worktree.BranchHasCommits:
+		log.Info("delete: kept the branch, which has commits past its base", "base", task.BaseBranch)
+	case worktree.BranchNotOurs:
+		log.Info("delete: kept the branch, which came from a pull request and was not cut by vincent")
+	}
+	return out, nil
+}
+
+// ranAStep reports whether the task ever executed a step, which is this
+// path's answer to "is this branch one vincent cut for this task".
+//
+// Archive asks it as `worktree_path != ""` and cannot be asked here: archive
+// *clears* that column on the way into `archived`, so by the time a delete
+// runs it is empty on every task. The question still has to be answered,
+// because a task that blocked with `branch_exists` (§10, task 001) carries a
+// branch_name naming **somebody else's** branch, and nothing may delete that.
+//
+// A step run is the surviving evidence. `ensureWorktree` runs before the first
+// step executor, so a task blocked at worktree creation has no step_run row at
+// all, while a task that ran anything necessarily had a worktree — and
+// `git worktree add -b` makes a worktree and a branch or neither. It fails
+// conservatively in the one case it is imprecise: a task whose worktree was
+// made and which was cancelled before its first step keeps its branch, which
+// is the safe direction. The rows are read before the delete, which is the
+// only time they exist.
+func (r *Runner) ranAStep(ctx context.Context, id int64) (bool, error) {
+	runs, err := r.deps.Store.ListStepRuns(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return len(runs) > 0, nil
+}
+
+// RemoveTranscriptDir removes one directory under {data_dir}/transcripts,
+// best-effort and logged, reusing the pruner's containment shape: the name is
+// joined onto the root rather than taken from a caller, so nothing outside
+// that root is reachable. Already gone is the common case — a task pruned by
+// retention, or one that never produced a transcript — and is not a log line.
+//
+// It is exported and takes the directory name rather than an id because the
+// API's chat delete calls it too: chats keep their transcripts under the same
+// root as `chat-{id}` (worktree.ChatOwner(id).Dir()), and duplicating the
+// containment would be duplicating the part that matters.
+func RemoveTranscriptDir(dataDir, name string, log *slog.Logger) {
+	if dataDir == "" || name == "" {
+		// No data dir means no transcript root to be inside, and a relative
+		// join would reach whatever the process's working directory is.
+		return
+	}
+	dir := filepath.Join(dataDir, "transcripts", name)
+	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		log.Warn("delete: transcript directory kept", "dir", name, "error", err)
+	}
+}

--- a/internal/tui/archived.go
+++ b/internal/tui/archived.go
@@ -1,0 +1,220 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The archived boards (§15 view 10, task 092). They are the live boards in a
+// second mode rather than two new screens: `internal/tui/board.go` is where
+// grouping, folding, `/` filtering and the bulk selection live, and an archive
+// needs every one of them. A copy would drift on the first change to any of
+// the four (decision 5).
+//
+// What the mode adds is the three things only an archive has: a date window,
+// pages, and a permanent delete. Delete is not a §6 action — it never appears
+// in `available_actions`, which is what gates every scopeTaskAction binding —
+// so its key is a scopePanel binding on these two contexts and nowhere else.
+
+// archivedPageSize is how many rows one page of an archived board asks for.
+// An archive grows without bound, which is the whole reason the live boards
+// exclude it; a page is what keeps the first paint bounded.
+const archivedPageSize = 100
+
+// archivedWindow is one of the date presets `d` cycles. Days of 0 means "all",
+// which sends no bound at all.
+type archivedWindow struct {
+	days  int
+	label string
+}
+
+// archivedWindows are the presets, in the order `d` walks them. Seven days is
+// the opening window because the row a human wants to delete is nearly always
+// one they archived this week; "all" is last because it is the expensive one.
+var archivedWindows = []archivedWindow{
+	{days: 7, label: "last 7 days"},
+	{days: 30, label: "last 30 days"},
+	{days: 0, label: "all time"},
+}
+
+// since turns a preset into the ArchivedSince bound, or the zero time for
+// "all". The arithmetic is client-side: the daemon takes an absolute RFC3339
+// instant, and a relative window resolved on the server would move under a
+// board that is paging through it.
+func (w archivedWindow) since(now time.Time) time.Time {
+	if w.days == 0 {
+		return time.Time{}
+	}
+	return now.AddDate(0, 0, -w.days)
+}
+
+// archivedPager is the date window and the page offset the two archived
+// boards share. Both boards embed it so the two `d`/`<`/`>` implementations
+// cannot disagree about what a press means.
+type archivedPager struct {
+	window int
+	page   int
+}
+
+func (p *archivedPager) activeWindow() archivedWindow { return archivedWindows[p.window] }
+
+// cycleWindow advances the preset and returns to page 1: the page number is an
+// offset into a listing that just changed length, so keeping it would page
+// into a window the human never looked at.
+func (p *archivedPager) cycleWindow() {
+	p.window = (p.window + 1) % len(archivedWindows)
+	p.page = 0
+}
+
+// nextPage advances only when the page that is on screen was full. A short
+// page is the end of the listing, and there is no count to compare against —
+// the endpoint answers with rows, not with a total.
+func (p *archivedPager) nextPage(shown int) bool {
+	if shown < archivedPageSize {
+		return false
+	}
+	p.page++
+	return true
+}
+
+func (p *archivedPager) prevPage() bool {
+	if p.page == 0 {
+		return false
+	}
+	p.page--
+	return true
+}
+
+// label is the one line the board writes above the rows: which window it is
+// showing and, once past the first, which page.
+func (p *archivedPager) label() string {
+	s := p.activeWindow().label
+	if p.page > 0 {
+		s += fmt.Sprintf(" · page %d", p.page+1)
+	}
+	return s
+}
+
+// rowDeletePrompt is the archived boards' confirmation. It is its own type rather
+// than an actionBar pending action for the reason the whole feature is: delete
+// is not a §6 action, and actionBar's pending state is keyed on one.
+//
+// Three answers, not two. `y` deletes the rows; `b` deletes them *and* asks
+// for their branches; `n` and esc do nothing. The branch answer is a third key
+// rather than a second prompt because a human who meant "and the branch" has
+// already decided, and §10's rule means the extra answer cannot destroy
+// anything a bare `y` would have kept: a branch carrying commits is reported
+// and kept whatever was pressed.
+type rowDeletePrompt struct {
+	ids   []int64
+	chats bool
+}
+
+// question is what the prompt reads on screen. It names the consequence — and
+// names the one thing the answer cannot do — the way confirmPrompt does.
+func (p *rowDeletePrompt) question() string {
+	noun := "task"
+	if p.chats {
+		noun = "chat"
+	}
+	what := fmt.Sprintf("%d %s", len(p.ids), plural(len(p.ids), noun, noun+"s"))
+	if len(p.ids) == 1 {
+		what = fmt.Sprintf("%s %d", noun, p.ids[0])
+	}
+	return fmt.Sprintf(
+		"delete %s permanently? [y] row and transcripts · [b] and its branch (one with commits is kept) · [n] no",
+		what)
+}
+
+// deleteResultMsg is the outcome of one sweep: one thing a human asked for and
+// one answer, the shape bulkResultMsg has and for the same reason.
+type deleteResultMsg struct {
+	chats bool
+	total int
+	// done are the ids the daemon deleted; refused are the ones it answered
+	// 409 for, which on an archived board means a lane or a handoff is
+	// holding on; failed is everything else.
+	done     []int64
+	refused  []bulkFailure
+	failed   []bulkFailure
+	branches int
+}
+
+// summary is the line the board shows afterwards. Refusals are counted
+// separately from failures because they are not the same news: a refusal names
+// a row that is holding on and is acted on by deleting that row first.
+func (m deleteResultMsg) summary() string {
+	parts := []string{fmt.Sprintf("delete · %d of %d", len(m.done), m.total)}
+	if m.branches > 0 {
+		parts = append(parts, fmt.Sprintf("%s deleted", plural(m.branches, "branch", "branches")))
+	}
+	if len(m.refused) > 0 {
+		parts = append(parts, fmt.Sprintf("%d refused: %s",
+			len(m.refused), errString(m.refused[0].err)))
+	}
+	if len(m.failed) > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed: %s",
+			len(m.failed), errString(m.failed[0].err)))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// bad reports whether the report should be shown as a problem.
+func (m deleteResultMsg) bad() bool { return len(m.refused) > 0 || len(m.failed) > 0 }
+
+// dispatchDelete sends one DELETE per row, sequentially, in the order the
+// board handed them over.
+//
+// One call per row, because there is no bulk endpoint and there is not going
+// to be one (task 011's decision, verbatim): §13.2 lives in the API, and a
+// second definition of what a delete means is a second thing to keep in step.
+// Sequential for the reason dispatchBulk is — the line a human reads afterwards
+// has to be built from outcomes that actually happened.
+func dispatchDelete(client *apiclient.Client, ids []int64, branch, chats bool) tea.Cmd {
+	if client == nil || len(ids) == 0 {
+		return nil
+	}
+	ids = slices.Clone(ids) // the selection may change while the sweep runs
+	return func() tea.Msg {
+		msg := deleteResultMsg{chats: chats, total: len(ids)}
+		for _, id := range ids {
+			out, err := deleteWithTimeout(client, id, branch, chats)
+			switch {
+			case err == nil:
+				msg.done = append(msg.done, id)
+				if out.Result == apiclient.BranchDeleted {
+					msg.branches++
+				}
+			case refusedDelete(err):
+				msg.refused = append(msg.refused, bulkFailure{id: id, err: err})
+			default:
+				msg.failed = append(msg.failed, bulkFailure{id: id, err: err})
+			}
+		}
+		return msg
+	}
+}
+
+// refusedDelete is a 409 from the daemon: a lane or a handoff is holding on,
+// or the row was not archived after all — which a board can race into when a
+// row was un-archived under it.
+func refusedDelete(err error) bool {
+	_, ok := apiclient.DeleteRefused(err)
+	return ok
+}
+
+func deleteWithTimeout(client *apiclient.Client, id int64, branch, chat bool) (apiclient.BranchOutcome, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+	defer cancel()
+	if chat {
+		return client.DeleteChat(ctx, id, branch)
+	}
+	return client.DeleteTask(ctx, id, branch)
+}

--- a/internal/tui/archived_test.go
+++ b/internal/tui/archived_test.go
@@ -1,0 +1,233 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// testArchivedBoard is the archived board with three archived rows loaded. It
+// is the *same* model the live board is (decision 5), so every assertion here
+// about grouping, folding and filtering is a fence around that sharing rather
+// than a second copy of the live board's tests.
+func testArchivedBoard() *board {
+	b := newArchivedBoard()
+	b.now = func() time.Time { return testNow }
+	b.bell = func() {}
+	b.loaded = true
+	b.group, b.configGroup = nil, nil
+	b.updateLoaded(boardLoadedMsg{tasks: []apiclient.Task{
+		task(3, stateArchived), task(2, stateArchived), task(1, stateArchived),
+	}})
+	return b
+}
+
+func TestArchivedBoardAsksForArchivedRowsAndTheLiveBoardDoesNot(t *testing.T) {
+	live := newBoard()
+	if live.archived {
+		t.Fatal("the live board is in archived mode")
+	}
+	arch := newArchivedBoard()
+	arch.now = func() time.Time { return testNow }
+	if !arch.archived {
+		t.Fatal("newArchivedBoard did not set archived mode")
+	}
+	// The listing options are what the daemon actually sees, so they are what
+	// this asserts: the live board's zero value excludes archived rows, and
+	// the archived board's asks for exactly them, paged and windowed.
+	opts := arch.listOptions()
+	if opts.Archived != apiclient.ArchivedOnly {
+		t.Fatalf("archived board asked for %q, want %q", opts.Archived, apiclient.ArchivedOnly)
+	}
+	if opts.Limit != archivedPageSize || opts.Offset != 0 {
+		t.Fatalf("paging: limit %d offset %d, want %d and 0", opts.Limit, opts.Offset, archivedPageSize)
+	}
+	if got, want := opts.ArchivedSince, testNow.AddDate(0, 0, -7); !got.Equal(want) {
+		t.Fatalf("opening window: archived_since %s, want %s", got, want)
+	}
+	if live.listOptions().Archived != apiclient.ArchivedExclude {
+		t.Fatal("the live board asked for archived rows")
+	}
+}
+
+func TestArchivedBoardDatePresetsTranslateToBounds(t *testing.T) {
+	b := testArchivedBoard()
+	want := []time.Time{
+		testNow.AddDate(0, 0, -30), // after one press: 30 days
+		{},                         // after two: all time, no bound at all
+		testNow.AddDate(0, 0, -7),  // and back round to the opening window
+	}
+	for i, w := range want {
+		b.updateKey(registryKey(t, "d"))
+		got := b.listOptions().ArchivedSince
+		if !got.Equal(w) {
+			t.Fatalf("press %d: archived_since %v, want %v (window %q)", i+1, got, w, b.label())
+		}
+	}
+}
+
+func TestArchivedBoardPagesForwardOnlyWhileThePageWasFull(t *testing.T) {
+	b := testArchivedBoard()
+	// Three rows is a short page, which is the end of the listing: there is
+	// no total to compare against, so a short page is the only signal.
+	b.updateKey(registryKey(t, ">"))
+	if b.page != 0 {
+		t.Fatalf("a short page advanced to page %d", b.page+1)
+	}
+	full := make([]apiclient.Task, archivedPageSize)
+	for i := range full {
+		full[i] = task(int64(i+1), stateArchived)
+	}
+	b.updateLoaded(boardLoadedMsg{tasks: full})
+	b.updateKey(registryKey(t, ">"))
+	if b.page != 1 {
+		t.Fatalf("a full page did not advance (page %d)", b.page+1)
+	}
+	if got, want := b.listOptions().Offset, archivedPageSize; got != want {
+		t.Fatalf("offset %d, want %d", got, want)
+	}
+	b.updateKey(registryKey(t, "<"))
+	if b.page != 0 {
+		t.Fatalf("< did not go back (page %d)", b.page+1)
+	}
+	b.updateKey(registryKey(t, "<"))
+	if b.page != 0 {
+		t.Fatal("< walked off the front of the listing")
+	}
+}
+
+func TestArchivedBoardCannotDeleteWithoutAnAnswer(t *testing.T) {
+	b := testArchivedBoard()
+	_, cmd := b.updateKey(registryKey(t, "D"))
+	if b.delPrompt == nil {
+		t.Fatal("D did not ask before deleting")
+	}
+	if cmd != nil {
+		t.Fatal("D sent something before it was answered")
+	}
+	// A key that is not one of the three answers leaves the prompt up: a
+	// permanent delete must not be cancelled *or* confirmed by a stray press.
+	if _, cmd := b.updateKey(registryKey(t, "g")); cmd != nil {
+		t.Fatal("a stray key confirmed the delete")
+	}
+	if b.delPrompt == nil {
+		t.Fatal("a stray key dismissed the confirmation")
+	}
+	if _, cmd := b.updateKey(registryKey(t, "n")); cmd != nil {
+		t.Fatal("n sent a delete")
+	}
+	if b.delPrompt != nil {
+		t.Fatal("n left the confirmation up")
+	}
+}
+
+func TestArchivedBoardConfirmationNamesTheConsequence(t *testing.T) {
+	b := testArchivedBoard()
+	b.updateKey(registryKey(t, "D"))
+	q := b.delPrompt.question()
+	for _, want := range []string{"permanently", "transcripts", "branch", "commits"} {
+		if !strings.Contains(q, want) {
+			t.Fatalf("the confirmation never says %q: %s", want, q)
+		}
+	}
+}
+
+func TestArchivedBoardBulkReportCountsRefusalsAndDeletions(t *testing.T) {
+	b := testArchivedBoard()
+	b.update(deleteResultMsg{
+		total: 3,
+		done:  []int64{1, 2},
+		refused: []bulkFailure{{id: 3, err: &apiclient.Error{
+			Status: 409, Code: "invalid_state", Message: "task 3 still has fan-out lanes (task 9)",
+		}}},
+		branches: 1,
+	})
+	if !strings.Contains(b.delNote, "2 of 3") {
+		t.Fatalf("the report does not count the deletions: %s", b.delNote)
+	}
+	if !strings.Contains(b.delNote, "1 refused") {
+		t.Fatalf("the report does not count the refusals: %s", b.delNote)
+	}
+	if !strings.Contains(b.delNote, "branch deleted") {
+		t.Fatalf("the report does not say what happened to the branch: %s", b.delNote)
+	}
+	if !b.delNoteBad {
+		t.Fatal("a report carrying a refusal is not marked as a problem")
+	}
+}
+
+// TestArchivedBoardSharesTheLiveBoardsBehaviour is decision 5's fence: the
+// archived board is the live board in a second mode, so grouping, folding and
+// `/` must behave identically. A regression here means the mode has grown a
+// branch it should not have.
+func TestArchivedBoardSharesTheLiveBoardsBehaviour(t *testing.T) {
+	b := testArchivedBoard()
+	b.group, b.configGroup = defaultGrouping(), defaultGrouping()
+	b.updateKey(registryKey(t, "g"))
+	if b.group.equal(defaultGrouping()) {
+		t.Fatal("g did not change the grouping on the archived board")
+	}
+	b.updateKey(registryKey(t, "/"))
+	if !b.filtering {
+		t.Fatal("/ did not open the filter on the archived board")
+	}
+	b.updateKey(registryKey(t, "esc"))
+	b.updateKey(registryKey(t, "space"))
+	if len(b.marks) != 1 {
+		t.Fatalf("space marked %d rows, want 1", len(b.marks))
+	}
+}
+
+func TestArchivedChatsBoardIsTerminalOnlyAndPaged(t *testing.T) {
+	v := newArchivedChatsView()
+	v.now = func() time.Time { return testNow }
+	opts := v.listOptions()
+	if opts.Archived != apiclient.ArchivedOnly {
+		t.Fatalf("archived chats asked for %q, want %q", opts.Archived, apiclient.ArchivedOnly)
+	}
+	if opts.Limit != archivedPageSize {
+		t.Fatalf("limit %d, want %d", opts.Limit, archivedPageSize)
+	}
+	if got, want := opts.ArchivedSince, testNow.AddDate(0, 0, -7); !got.Equal(want) {
+		t.Fatalf("archived_since %s, want %s", got, want)
+	}
+	// The live chats board keeps its `s` cycle and its own default, untouched.
+	live := newChatsView()
+	if live.archived || live.listOptions().Archived != apiclient.ArchivedExclude {
+		t.Fatal("the live chats board changed")
+	}
+}
+
+func TestArchivedChatsBoardRefusesToAskAboutAHandedOffChat(t *testing.T) {
+	v := newArchivedChatsView()
+	v.now = func() time.Time { return testNow }
+	v.applyLoaded(chatsLoadedMsg{
+		chats: []apiclient.Chat{testChat(1, "handed_off", "given away")},
+		names: map[int64]string{7: "repo"},
+	})
+	v.updateKey(registryKey(t, "D"))
+	if v.delPrompt != nil {
+		t.Fatal("the board asked about deleting a handed-off chat")
+	}
+	if !v.noteBad || !strings.Contains(v.note, "handed off") {
+		t.Fatalf("the refusal does not name what is holding on: %q", v.note)
+	}
+}
+
+// archivedChatsFixture is the chats board in archived mode with two archived
+// rows loaded, and a client so `r` has something to reload with.
+func archivedChatsFixture() *chatsView {
+	v := newArchivedChatsView()
+	v.now = func() time.Time { return testNow }
+	v.client = &apiclient.Client{}
+	v.applyLoaded(chatsLoadedMsg{
+		chats: []apiclient.Chat{
+			testChat(1, "archived", "first"),
+			testChat(2, "archived", "second"),
+		},
+		names: map[int64]string{7: "repo"},
+	})
+	return v
+}

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -73,11 +73,18 @@ const (
 	// The chat surfaces (task 067). Three contexts for two views: the
 	// new-chat form is a layer over the chats board with its own keyboard,
 	// which is exactly what a bindingContext names.
-	ctxChats   bindingContext = "chats"
-	ctxChat    bindingContext = "chat"
-	ctxNewChat bindingContext = "new chat"
-	ctxDaemon  bindingContext = "daemon"
-	ctxForm    bindingContext = "answer form"
+	//
+	// The two archived boards (§15 view 10, task 092). Their own contexts
+	// rather than more ctxTasks/ctxChats rows: they carry keys the live
+	// boards do not (delete, the date window, the pages) and none of the §6
+	// action keys, which an archived row offers none of anyway.
+	ctxArchived      bindingContext = "archived tasks"
+	ctxArchivedChats bindingContext = "archived chats"
+	ctxChats         bindingContext = "chats"
+	ctxChat          bindingContext = "chat"
+	ctxNewChat       bindingContext = "new chat"
+	ctxDaemon        bindingContext = "daemon"
+	ctxForm          bindingContext = "answer form"
 	// ctxRepairForm is the §6 repair popup (task 025). Its own context
 	// rather than more ctxForm rows: the two popups share a shape and
 	// nothing else — one picks from what an agent asked, the other types a
@@ -171,6 +178,12 @@ var bindings = []binding{
 	// but new task follows. `n` is not shared: on the chats board it makes a
 	// chat, everywhere else it still makes a task.
 	{label: "chats — conversations with an agent, each in its own worktree", scope: scopeGlobal, nav: true, navTarget: viewChats},
+	// The two archived boards get palette rows and no keys, for the reason
+	// task 049 retired 1..6 and task 067 gave chats a row: retiring memorized
+	// keys without substituting new ones is the point. `s` is skip and `A` is
+	// archive, and neither was ever going to be free.
+	{label: "archived tasks — history, with a permanent delete", scope: scopeGlobal, nav: true, navTarget: viewArchived},
+	{label: "archived chats — ended conversations, with a permanent delete", scope: scopeGlobal, nav: true, navTarget: viewArchivedChats},
 
 	// Task actions, gated on available_actions. `p` appears twice because
 	// pause and resume are distinct actions behind one key; the palette
@@ -268,6 +281,27 @@ var bindings = []binding{
 	{key: "+", label: "nudge the priority (+/-; higher runs first)", scope: scopePanel, context: ctxNewTask, hint: "+/- priority", priority: 4},
 	{key: "R", label: "re-probe the adapters (the list is otherwise cache-served)", scope: scopePanel, context: ctxNewTask, hint: "R re-probe", priority: 5},
 	{key: "ctrl+s", label: "create the task", scope: scopePanel, context: ctxNewTask, hint: "ctrl+s create", priority: 1},
+
+	// Archived tasks (§15 view 10, task 092). The board's own keys — ↑/↓,
+	// enter, /, g, space, V and the fold keys — work here unchanged and are
+	// listed under ctxTasks; these are the three the mode adds. There is no
+	// §6 action key: an archived task offers no `available_actions`, which is
+	// what makes the workspace `enter` opens read-only for free.
+	{key: "enter", label: "open the archived task's workspace — read-only, because an archived task offers no actions", scope: scopePanel, context: ctxArchived, hint: "enter open", priority: 1},
+	{key: "D", label: "delete permanently (asks first — the row, its step attempts and its transcripts go; optionally its branch, unless the branch has commits)", scope: scopePanel, context: ctxArchived, hint: "D delete", priority: 2},
+	{key: "d", label: "cycle the window: last 7 days → last 30 days → all time", scope: scopePanel, context: ctxArchived, hint: "d window", priority: 3},
+	{key: ">", label: "next page of the archive (< goes back)", scope: scopePanel, context: ctxArchived, hint: "</> page", priority: 4},
+	{key: "/", label: "filter by id, title, project or state", scope: scopePanel, context: ctxArchived, priority: 5},
+	{key: "space", label: "select this task for the bulk delete (V selects every row the filter is showing)", scope: scopePanel, context: ctxArchived, priority: 6},
+
+	// Archived chats. The same three keys, on the same reasoning: a chat that
+	// ended is history, and this is the only place it can be discarded.
+	{key: "enter", label: "open the archived chat's workspace — read-only, the conversation as it ended", scope: scopePanel, context: ctxArchivedChats, hint: "enter open", priority: 1},
+	{key: "D", label: "delete permanently (asks first — the row, its turns and its transcripts go; optionally its branch, unless the branch has commits)", scope: scopePanel, context: ctxArchivedChats, hint: "D delete", priority: 2},
+	{key: "d", label: "cycle the window: last 7 days → last 30 days → all time", scope: scopePanel, context: ctxArchivedChats, hint: "d window", priority: 3},
+	{key: ">", label: "next page of the archive (< goes back)", scope: scopePanel, context: ctxArchivedChats, hint: "</> page", priority: 4},
+	{key: "/", label: "filter by title, agent or branch", scope: scopePanel, context: ctxArchivedChats, priority: 5},
+	{key: "r", label: "reload the board", scope: scopePanel, context: ctxArchivedChats, priority: 6},
 
 	// Chats board.
 	{key: "enter", label: "open the chat's workspace", scope: scopePanel, context: ctxChats, hint: "enter open", priority: 1},

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -553,6 +553,111 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 	// The chat surfaces (task 067). Every probe drives the real view with
 	// the key the registry publishes and asserts the effect the label
 	// promises.
+	// The archived boards (task 092). Their keys are proved against the same
+	// models the live boards are, in archived mode — which is the point of
+	// decision 5: one model, so a probe here is a probe of the real screen.
+	ctxArchived: {
+		"enter": func(t *testing.T) {
+			b := testArchivedBoard()
+			b.updateKey(registryKey(t, "enter"))
+			// The board itself does not open the workspace; the shell routes
+			// it. What this proves is that the key is not swallowed by the
+			// archived-mode switch above it.
+			if b.delPrompt != nil {
+				t.Fatal("enter opened the delete confirmation")
+			}
+		},
+		"D": func(t *testing.T) {
+			b := testArchivedBoard()
+			b.updateKey(registryKey(t, "D"))
+			if b.delPrompt == nil {
+				t.Fatal("D did not ask before deleting")
+			}
+		},
+		"d": func(t *testing.T) {
+			b := testArchivedBoard()
+			before := b.label()
+			b.updateKey(registryKey(t, "d"))
+			if b.label() == before {
+				t.Fatalf("d did not change the window (still %s)", before)
+			}
+		},
+		">": func(t *testing.T) {
+			b := testArchivedBoard()
+			full := make([]apiclient.Task, archivedPageSize)
+			for i := range full {
+				full[i] = task(int64(i+1), stateArchived)
+			}
+			b.updateLoaded(boardLoadedMsg{tasks: full})
+			b.updateKey(registryKey(t, ">"))
+			if b.page != 1 {
+				t.Fatal("> did not turn the page")
+			}
+		},
+		"/": func(t *testing.T) {
+			b := testArchivedBoard()
+			b.updateKey(registryKey(t, "/"))
+			if !b.filtering {
+				t.Fatal("/ did not open the filter on the archived board")
+			}
+		},
+		"space": func(t *testing.T) {
+			b := testArchivedBoard()
+			b.updateKey(registryKey(t, "space"))
+			if len(b.marks) != 1 {
+				t.Fatalf("space marked %d rows, want 1", len(b.marks))
+			}
+		},
+	},
+	ctxArchivedChats: {
+		"enter": func(t *testing.T) {
+			v := archivedChatsFixture()
+			_, cmd := v.updateKey(registryKey(t, "enter"))
+			if _, ok := drain(cmd).(openChatMsg); !ok {
+				t.Fatalf("enter produced %T, want openChatMsg", drain(cmd))
+			}
+		},
+		"D": func(t *testing.T) {
+			v := archivedChatsFixture()
+			v.updateKey(registryKey(t, "D"))
+			if v.delPrompt == nil {
+				t.Fatal("D did not ask before deleting")
+			}
+		},
+		"d": func(t *testing.T) {
+			v := archivedChatsFixture()
+			before := v.label()
+			v.updateKey(registryKey(t, "d"))
+			if v.label() == before {
+				t.Fatalf("d did not change the window (still %s)", before)
+			}
+		},
+		">": func(t *testing.T) {
+			v := archivedChatsFixture()
+			full := make([]apiclient.Chat, archivedPageSize)
+			for i := range full {
+				full[i] = testChat(int64(i+1), "archived", "c")
+			}
+			v.applyLoaded(chatsLoadedMsg{chats: full, names: map[int64]string{7: "repo"}})
+			v.updateKey(registryKey(t, ">"))
+			if v.page != 1 {
+				t.Fatal("> did not turn the page")
+			}
+		},
+		"/": func(t *testing.T) {
+			v := archivedChatsFixture()
+			v.updateKey(registryKey(t, "/"))
+			if !v.filtering {
+				t.Fatal("/ did not open the filter on the archived chats board")
+			}
+		},
+		"r": func(t *testing.T) {
+			v := archivedChatsFixture()
+			if _, cmd := v.updateKey(registryKey(t, "r")); cmd == nil {
+				t.Fatal("r did not reload the board")
+			}
+		},
+	},
 	ctxChats: {
 		"enter": func(t *testing.T) {
 			v := chatsFixture()

--- a/internal/tui/board.go
+++ b/internal/tui/board.go
@@ -33,22 +33,33 @@ const (
 )
 
 // Board messages.
+//
+// Every one of them carries `archived`, and every board drops the ones that do
+// not match its own mode (task 092). Two instances of this model are alive at
+// once — the live board and the archived one — and the root broadcasts
+// background messages to every view, so an untagged fetch response lands on
+// both: the archived listing would paint the live board, and each board's
+// `seq` guard would silently discard the other's newer answer. A tick is worse
+// than wrong — both boards re-arm on every tick they see, so an untagged one
+// doubles the timer population on every beat.
 type (
 	// boardRefreshMsg fires when the debounce window closes.
-	boardRefreshMsg struct{}
+	boardRefreshMsg struct{ archived bool }
 	// boardLoadedMsg carries a completed task fetch. seq orders concurrent
 	// fetches: commands run on their own goroutines, so an older response
 	// can land after a newer one and must not clobber it (zero = untracked,
 	// for tests that build the message directly).
 	boardLoadedMsg struct {
-		seq   uint64
-		tasks []apiclient.Task
-		err   error
+		archived bool
+		seq      uint64
+		tasks    []apiclient.Task
+		err      error
 	}
 	// boardInfoMsg carries the daemon info the header renders. thenLoad is
 	// set on the fetch a closing debounce window issues, and is what makes
 	// the task list follow it rather than race it (boardRefreshMsg).
 	boardInfoMsg struct {
+		archived bool
 		info     apiclient.Info
 		err      error
 		thenLoad bool
@@ -58,12 +69,16 @@ type (
 	// the task table's grouping comes from — and, since issue #316, how deep
 	// an expanded fan-out is allowed to nest (§7.6 `fan_out.max_depth`).
 	boardConfigMsg struct {
+		archived  bool
 		board     apiclient.ConfigBoard
 		laneDepth int
 		err       error
 	}
 	// boardTickMsg drives the elapsed column.
-	boardTickMsg time.Time
+	boardTickMsg struct {
+		archived bool
+		at       time.Time
+	}
 	// selectTaskMsg asks the root to select a task on the board and open its
 	// full-screen workspace. State is the board snapshot hint used to subscribe
 	// to a running task before the authoritative detail fetch lands.
@@ -133,6 +148,20 @@ type board struct {
 	configGroup grouping
 	groupPinned bool
 
+	// archived puts the board in its archived mode (§15 view 10, task 092):
+	// it lists `archived` rows newest-archived first, in pages and inside a
+	// date window, and it offers the one thing only an archive offers — a
+	// permanent delete. Everything else about the board is unchanged, which
+	// is the point of a mode rather than a second model (decision 5).
+	archived bool
+	archivedPager
+	// delPrompt is the delete confirmation, and delNote is what the sweep
+	// reported. They are the board's own rather than the action bar's,
+	// because delete is not a §6 action (task 092).
+	delPrompt  *rowDeletePrompt
+	delNote    string
+	delNoteBad bool
+
 	// actions drives §15's action keys against the row under the cursor.
 	// The shell shares one instance between board and detail — a pending
 	// confirmation is the same question wherever the eye lands — and the
@@ -177,6 +206,14 @@ func newBoard() *board {
 	return b
 }
 
+// newArchivedBoard is the same model in archived mode (§15 view 10, task 092).
+func newArchivedBoard() *board {
+	b := newBoard()
+	b.archived = true
+	b.filter.SetPlaceholder("filter by id, title, project or state")
+	return b
+}
+
 // applyStyles sets the table styling. Selection is a background, not a
 // foreground: renderRow wraps the whole row in the Selected style and
 // lipgloss does not rewrite the per-cell colour sequences nested inside it,
@@ -202,7 +239,23 @@ func ringBell() {
 	_, _ = os.Stdout.WriteString("\a")
 }
 
-func (b *board) title() string { return "Board" }
+func (b *board) title() string {
+	if b.archived {
+		return "Archived"
+	}
+	return "Board"
+}
+
+// bindingContext names the surface for the registry. The archived board is its
+// own context because it has keys the live one does not and lacks the §6
+// action keys entirely — an archived task offers no `available_actions`, which
+// is what gates them.
+func (b *board) bindingContext() bindingContext {
+	if b.archived {
+		return ctxArchived
+	}
+	return ctxTasks
+}
 
 // setDataDir hands the board the resolved data dir and reads the fold set out
 // of it (task 054 decision 1). It is called again on every reconnect, which
@@ -223,13 +276,15 @@ func (b *board) setClient(c *apiclient.Client) tea.Cmd {
 	cmds := []tea.Cmd{b.loadCmd(), b.infoCmd(), b.configCmd()}
 	if !b.ticking {
 		b.ticking = true
-		cmds = append(cmds, tickCmd())
+		cmds = append(cmds, tickCmd(b.archived))
 	}
 	return tea.Batch(cmds...)
 }
 
-func tickCmd() tea.Cmd {
-	return tea.Tick(elapsedTick, func(t time.Time) tea.Msg { return boardTickMsg(t) })
+func tickCmd(archived bool) tea.Cmd {
+	return tea.Tick(elapsedTick, func(t time.Time) tea.Msg {
+		return boardTickMsg{archived: archived, at: t}
+	})
 }
 
 // loadCmd refetches the board: its own task list, plus one lane fetch per
@@ -257,11 +312,31 @@ func (b *board) tasksCmd() tea.Cmd {
 	}
 	b.loadSeq++
 	seq := b.loadSeq
+	archived := b.archived
+	opts := b.listOptions()
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		tasks, err := client.ListTasks(ctx, apiclient.ListTasksOptions{})
-		return boardLoadedMsg{seq: seq, tasks: tasks, err: err}
+		tasks, err := client.ListTasks(ctx, opts)
+		return boardLoadedMsg{archived: archived, seq: seq, tasks: tasks, err: err}
+	}
+}
+
+// listOptions is what the board asks GET /v1/tasks for. It is a method rather
+// than three lines inside tasksCmd so a test can assert the request the daemon
+// would see, which is the only place the two modes actually differ.
+func (b *board) listOptions() apiclient.ListTasksOptions {
+	if !b.archived {
+		return apiclient.ListTasksOptions{}
+	}
+	// Archived-only, paged, and inside the date window `d` is on. The daemon
+	// orders an archived-only listing newest-archived first, so the pages walk
+	// backwards through history in the order it happened.
+	return apiclient.ListTasksOptions{
+		Archived:      apiclient.ArchivedOnly,
+		Limit:         archivedPageSize,
+		Offset:        b.page * archivedPageSize,
+		ArchivedSince: b.activeWindow().since(b.now()),
 	}
 }
 
@@ -278,11 +353,12 @@ func (b *board) infoFetch(thenLoad bool) tea.Cmd {
 	if client == nil {
 		return nil
 	}
+	archived := b.archived
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		info, err := client.Info(ctx)
-		return boardInfoMsg{info: info, err: err, thenLoad: thenLoad}
+		return boardInfoMsg{archived: archived, info: info, err: err, thenLoad: thenLoad}
 	}
 }
 
@@ -292,6 +368,7 @@ func (b *board) infoFetch(thenLoad bool) tea.Cmd {
 // no event for it (§13.3), so there is nothing to subscribe to.
 func (b *board) configCmd() tea.Cmd {
 	client := b.client
+	archived := b.archived
 	if client == nil {
 		return nil
 	}
@@ -299,7 +376,10 @@ func (b *board) configCmd() tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		cfg, err := client.Config(ctx)
-		return boardConfigMsg{board: cfg.TUI.Board, laneDepth: cfg.FanOut.MaxDepth, err: err}
+		return boardConfigMsg{
+			archived: archived, board: cfg.TUI.Board,
+			laneDepth: cfg.FanOut.MaxDepth, err: err,
+		}
 	}
 }
 
@@ -323,10 +403,16 @@ func (b *board) scheduleRefresh() tea.Cmd {
 		return nil
 	}
 	b.refreshPending = true
-	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg { return boardRefreshMsg{} })
+	archived := b.archived
+	return tea.Tick(refreshDebounce, func(time.Time) tea.Msg {
+		return boardRefreshMsg{archived: archived}
+	})
 }
 
 func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
+	if !b.addressed(msg) {
+		return b, nil
+	}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		b.width, b.height = msg.Width, msg.Height
@@ -366,7 +452,7 @@ func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
 	case boardTickMsg:
 		// Render-only: the elapsed column advances without asking the daemon
 		// anything.
-		return b, tickCmd()
+		return b, tickCmd(b.archived)
 	case noteMsg:
 		return b, b.updateNote(msg.note)
 	case actionResultMsg:
@@ -382,10 +468,41 @@ func (b *board) update(msg tea.Msg) (panel, tea.Cmd) {
 		b.marks = b.marks.drop(msg.done...)
 		b.refreshPending = false
 		return b, b.loadCmd()
+	case deleteResultMsg:
+		b.delNote, b.delNoteBad = msg.summary(), msg.bad()
+		// What the daemon deleted leaves the selection; what it refused stays
+		// marked, so acting on the named holder and retrying needs no
+		// re-selection (task 011's shape).
+		b.marks = b.marks.drop(msg.done...)
+		b.refreshPending = false
+		return b, b.loadCmd()
 	case tea.KeyPressMsg:
 		return b.updateKey(msg)
 	}
 	return b, nil
+}
+
+// addressed reports whether a broadcast message belongs to this board. The
+// root hands every background message to every view, and there are two boards
+// (task 092): each takes only the messages stamped with its own mode. Anything
+// that is not one of the board's own message types is for everyone.
+func (b *board) addressed(msg tea.Msg) bool {
+	switch m := msg.(type) {
+	case boardLoadedMsg:
+		return m.archived == b.archived
+	case boardInfoMsg:
+		return m.archived == b.archived
+	case boardConfigMsg:
+		return m.archived == b.archived
+	case boardRefreshMsg:
+		return m.archived == b.archived
+	case boardTickMsg:
+		return m.archived == b.archived
+	case boardLanesMsg:
+		return m.archived == b.archived
+	default:
+		return true
+	}
 }
 
 // target is what the action bar acts on: the row under the cursor, carrying
@@ -552,10 +669,39 @@ func (b *board) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return b, cmd
 	}
 
+	// The delete confirmation owns the keyboard until it is answered — it
+	// cannot be walked past, and no key but its three answers reaches the
+	// board while it is up.
+	if b.delPrompt != nil {
+		return b, b.answerDelete(msg.String())
+	}
+
 	// A confirmation owns the keyboard until it is answered.
 	if b.actions.capturing() {
 		cmd, _ := b.actions.handleKey(msg.String(), b.client, b.target())
 		return b, cmd
+	}
+
+	if b.archived {
+		switch msg.String() {
+		case "D":
+			b.askDelete()
+			return b, nil
+		case "d":
+			b.cycleWindow()
+			b.delNote = ""
+			return b, b.loadCmd()
+		case ">":
+			if b.nextPage(len(b.tasks)) {
+				return b, b.loadCmd()
+			}
+			return b, nil
+		case "<":
+			if b.prevPage() {
+				return b, b.loadCmd()
+			}
+			return b, nil
+		}
 	}
 
 	switch msg.String() {
@@ -1275,7 +1421,7 @@ func (b *board) headerLine() string {
 
 	var tail []string
 	if attention > 0 {
-		tail = append(tail, styleWarn.Render(
+		tail = append(tail, styleAsk.Render(
 			fmt.Sprintf("%s %d need attention", attentionBadge, attention)))
 	} else {
 		tail = append(tail, styleDim.Render("0 need attention"))
@@ -1309,14 +1455,14 @@ func (b *board) agentsSummary() string {
 		case a.NotAuthenticated():
 			// Present but unable to run a step (§9.5) — the board's one-glance
 			// summary must not read as healthy.
-			parts = append(parts, styleWarn.Render(a.Name+" ⚠"))
+			parts = append(parts, styleAsk.Render(a.Name+" ⚠"))
 		case a.QuotaSpent(now):
 			// Installed, authenticated, and out of quota until a stated time
 			// (task 026). It ranks below the other two because it is
 			// temporary and self-clearing, and it ranks above ✓ because a
 			// tick here is the answer to "why is nothing running" being wrong.
 			// Admission is untouched: this warns, it does not withhold.
-			parts = append(parts, styleWarn.Render(a.Name+" "+quotaBadge(a.Quota, now)))
+			parts = append(parts, styleAsk.Render(a.Name+" "+quotaBadge(a.Quota, now)))
 		default:
 			parts = append(parts, styleOK.Render(a.Name+" ✓"))
 		}
@@ -1331,7 +1477,65 @@ func (b *board) agentsSummary() string {
 // It is lines rather than a line because the filter is a wrapping field
 // (issue #299): a long filter grows the row it is typed on, and the two line
 // budgets below have to count what it actually drew.
+// askDelete opens the confirmation over the marked rows, or the row under the
+// cursor when nothing is marked — the same target rule every §6 key on this
+// board follows.
+func (b *board) askDelete() {
+	ids := slices.Clone([]int64(b.marks))
+	if len(ids) == 0 {
+		id, ok := b.selected()
+		if !ok {
+			return
+		}
+		ids = []int64{id}
+	}
+	b.delPrompt = &rowDeletePrompt{ids: ids}
+	b.delNote = ""
+}
+
+// answerDelete resolves the confirmation. Anything that is not one of the
+// three answers is ignored rather than dismissing the prompt: a permanent
+// delete must not be cancelled *or* confirmed by a stray key.
+func (b *board) answerDelete(key string) tea.Cmd {
+	p := b.delPrompt
+	switch key {
+	case "y", "b":
+		b.delPrompt = nil
+		b.delNote, b.delNoteBad = "deleting…", false
+		return dispatchDelete(b.client, p.ids, key == "b", false)
+	case "n", "esc":
+		b.delPrompt = nil
+		b.delNote, b.delNoteBad = "", false
+	}
+	return nil
+}
+
 func (b *board) statusLines() []string {
+	if b.archived {
+		if line := b.archivedStatus(); line != "" {
+			return append([]string{line}, b.liveStatusLines()...)
+		}
+	}
+	return b.liveStatusLines()
+}
+
+// archivedStatus is the archived board's own line: the confirmation while one
+// is up, then the sweep's report, then the window and page it is showing.
+func (b *board) archivedStatus() string {
+	switch {
+	case b.delPrompt != nil:
+		return styleAsk.Render(" " + b.delPrompt.question())
+	case b.delNote != "":
+		if b.delNoteBad {
+			return styleBad.Render(" " + b.delNote)
+		}
+		return " " + b.delNote
+	default:
+		return styleDim.Render(" archived · " + b.label())
+	}
+}
+
+func (b *board) liveStatusLines() []string {
 	switch {
 	case b.filtering:
 		b.filter.SetWidth(max(b.width-1, 10))

--- a/internal/tui/boardlanes.go
+++ b/internal/tui/boardlanes.go
@@ -45,6 +45,8 @@ const laneDepthDefault = 3
 // can land after a newer one and must not clobber it (zero = untracked, for
 // tests that build the message directly).
 type boardLanesMsg struct {
+	// archived tags the board instance this answer belongs to (task 092).
+	archived bool
 	seq      uint64
 	parentID int64
 	lanes    []apiclient.Task
@@ -209,11 +211,12 @@ func (b *board) laneCmd(parentID int64) tea.Cmd {
 		return nil
 	}
 	seq := b.lanes.next(parentID)
+	archived := b.archived
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		lanes, err := client.ListTasks(ctx, apiclient.ListTasksOptions{ParentID: parentID})
-		return boardLanesMsg{seq: seq, parentID: parentID, lanes: lanes, err: err}
+		return boardLanesMsg{archived: archived, seq: seq, parentID: parentID, lanes: lanes, err: err}
 	}
 }
 

--- a/internal/tui/chats.go
+++ b/internal/tui/chats.go
@@ -27,12 +27,14 @@ import (
 
 // Chats board messages.
 type (
-	chatsRefreshMsg struct{}
+	chatsRefreshMsg struct{ archived bool }
 	// chatsLoadedMsg is one whole board: every chat, plus the project names
 	// the headings read from.
 	chatsLoadedMsg struct {
-		chats []apiclient.Chat
-		names map[int64]string
+		// archived tags the board instance this answer belongs to (task 092).
+		archived bool
+		chats    []apiclient.Chat
+		names    map[int64]string
 		// projectsListed reports that the load reached the project
 		// registry, so an empty names map means "none registered" rather
 		// than "not asked yet" or "the listing failed".
@@ -54,7 +56,10 @@ type (
 	// already renders now - UpdatedAt, and UpdatedAt is only written on a
 	// state change, so for a running chat it is time-since-the-turn-started
 	// and was simply never redrawn.
-	chatsTickMsg time.Time
+	chatsTickMsg struct {
+		archived bool
+		at       time.Time
+	}
 )
 
 // archivePrompt is the inline confirmation an archive takes. force is set on
@@ -97,6 +102,15 @@ type chatsView struct {
 	// is the server's default — terminal chats hidden — and `s` cycles it.
 	scope apiclient.ArchivedScope
 
+	// archived puts the board in archived mode (§15 view 10, task 092): the
+	// terminal chats only, in pages and inside a date window, with a
+	// permanent delete. `s` is untouched on the live board — it is still the
+	// way a reader peeks at history from there — and absent here, where the
+	// scope is what the screen is.
+	archived bool
+	archivedPager
+	delPrompt *rowDeletePrompt
+
 	// create is the new-chat form, a layer over this board rather than a
 	// seventh view: it is opened from here, it returns here, and it has no
 	// meaning anywhere else. `n` on the chats board makes a chat; `n`
@@ -124,7 +138,21 @@ func newChatsView() *chatsView {
 	return &chatsView{now: time.Now, filter: fi, names: map[int64]string{}}
 }
 
-func (v *chatsView) title() string { return "Chats" }
+// newArchivedChatsView is the same model in archived mode (§15 view 10, task
+// 092). The scope is fixed rather than cycled: a board whose whole purpose is
+// the archive has nothing to say about the live listing.
+func newArchivedChatsView() *chatsView {
+	v := newChatsView()
+	v.archived, v.scope = true, apiclient.ArchivedOnly
+	return v
+}
+
+func (v *chatsView) title() string {
+	if v.archived {
+		return "Archived Chats"
+	}
+	return "Chats"
+}
 
 func (v *chatsView) setClient(c *apiclient.Client) tea.Cmd {
 	v.client = c
@@ -160,6 +188,9 @@ func (v *chatsView) paste(text string) tea.Cmd {
 func (v *chatsView) bindingContext() bindingContext {
 	if v.create != nil {
 		return ctxNewChat
+	}
+	if v.archived {
+		return ctxArchivedChats
 	}
 	return ctxChats
 }
@@ -203,10 +234,34 @@ func (v *chatsView) armTick() tea.Cmd {
 		return nil
 	}
 	v.ticking = true
-	return tea.Tick(SpinnerTick, func(t time.Time) tea.Msg { return chatsTickMsg(t) })
+	archived := v.archived
+	return tea.Tick(SpinnerTick, func(t time.Time) tea.Msg {
+		return chatsTickMsg{archived: archived, at: t}
+	})
+}
+
+// addressed reports whether a broadcast message belongs to this board. Two
+// chats boards are alive at once — the live one and the archived one (task
+// 092) — and the root hands every background message to every view, so each
+// takes only the messages stamped with its own mode. An untagged tick would be
+// worse than an untagged fetch: both boards re-arm on every tick they see.
+func (v *chatsView) addressed(msg tea.Msg) bool {
+	switch m := msg.(type) {
+	case chatsLoadedMsg:
+		return m.archived == v.archived
+	case chatsRefreshMsg:
+		return m.archived == v.archived
+	case chatsTickMsg:
+		return m.archived == v.archived
+	default:
+		return true
+	}
 }
 
 func (v *chatsView) updateMsg(msg tea.Msg) (panel, tea.Cmd) {
+	if !v.addressed(msg) {
+		return v, nil
+	}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		v.width, v.height = msg.Width, msg.Height
@@ -273,14 +328,15 @@ func (v *chatsView) loadCmd() tea.Cmd {
 	if client == nil {
 		return nil
 	}
-	scope := v.scope
+	opts := v.listOptions()
+	archived := v.archived
 	v.loading = true
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), loadTimeout)
 		defer cancel()
-		chats, err := client.ListChats(ctx, 0, scope)
+		chats, err := client.ListChats(ctx, opts)
 		if err != nil {
-			return chatsLoadedMsg{err: err}
+			return chatsLoadedMsg{archived: archived, err: err}
 		}
 		names := map[int64]string{}
 		listed := false
@@ -292,8 +348,23 @@ func (v *chatsView) loadCmd() tea.Cmd {
 				names[p.ID] = p.Name
 			}
 		}
-		return chatsLoadedMsg{chats: chats, names: names, projectsListed: listed}
+		return chatsLoadedMsg{archived: archived, chats: chats, names: names, projectsListed: listed}
 	}
+}
+
+// listOptions is what the board asks GET /v1/chats for — a method for the
+// reason board.listOptions is one.
+func (v *chatsView) listOptions() apiclient.ListChatsOptions {
+	opts := apiclient.ListChatsOptions{Archived: v.scope}
+	if v.archived {
+		// Paged and date-bounded, the task board's archived mode exactly. The
+		// daemon measures the bounds over `updated_at`, which for a terminal
+		// chat is when it ended (task 074 decision 6).
+		opts.Limit = archivedPageSize
+		opts.Offset = v.page * archivedPageSize
+		opts.ArchivedSince = v.activeWindow().since(v.now())
+	}
+	return opts
 }
 
 func (v *chatsView) applyLoaded(msg chatsLoadedMsg) {
@@ -448,10 +519,40 @@ func (v *chatsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 	if v.confirm != nil {
 		return v, v.updateConfirm(msg)
 	}
+	// The delete confirmation owns the keyboard until it is answered.
+	if v.delPrompt != nil {
+		return v, v.answerDelete(msg.String())
+	}
 	if v.filtering {
 		return v, v.updateFilter(msg)
 	}
 	v.note = ""
+	if v.archived {
+		switch msg.String() {
+		case "D":
+			v.askDelete()
+			return v, nil
+		case "d":
+			v.cycleWindow()
+			return v, v.loadCmd()
+		case ">":
+			if v.nextPage(len(v.chats)) {
+				return v, v.loadCmd()
+			}
+			return v, nil
+		case "<":
+			if v.prevPage() {
+				return v, v.loadCmd()
+			}
+			return v, nil
+		case "a", "n", "s":
+			// Archive, new chat and the scope cycle have no meaning here: the
+			// rows are already terminal, this board makes nothing, and the
+			// scope is what the screen is. Swallowed rather than left to fall
+			// through to the live board's handler below.
+			return v, nil
+		}
+	}
 	switch msg.String() {
 	case "esc":
 		if v.filter.Value() != "" {
@@ -512,6 +613,40 @@ func (v *chatsView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		return v, v.loadCmd()
 	}
 	return v, nil
+}
+
+// askDelete opens the confirmation over the chat under the cursor. The chats
+// board has no bulk selection, so it is always one row — which is also why the
+// prompt names the chat rather than a count.
+func (v *chatsView) askDelete() {
+	c, ok := v.current()
+	if !ok {
+		return
+	}
+	if chatstate.State(c.State) == chatstate.HandedOff {
+		// The daemon refuses this too (409). Saying so here is what stops the
+		// question being asked at all — the same shape `a` takes above.
+		v.note, v.noteBad = "this chat was handed off to a task, which owns its worktree and branch; delete that task", true
+		return
+	}
+	v.delPrompt = &rowDeletePrompt{ids: []int64{c.ID}, chats: true}
+}
+
+// answerDelete resolves the confirmation. Anything that is not one of the
+// three answers is ignored rather than dismissing it: a permanent delete must
+// not be cancelled *or* confirmed by a stray key.
+func (v *chatsView) answerDelete(key string) tea.Cmd {
+	p := v.delPrompt
+	switch key {
+	case "y", "b":
+		v.delPrompt = nil
+		v.note, v.noteBad = "deleting…", false
+		return dispatchDelete(v.client, p.ids, key == "b", true)
+	case "n", "esc":
+		v.delPrompt = nil
+		v.note, v.noteBad = "", false
+	}
+	return nil
 }
 
 // chatScopes is the cycle `s` walks (issue #298): the default listing, then

--- a/internal/tui/palette_test.go
+++ b/internal/tui/palette_test.go
@@ -31,6 +31,7 @@ func TestPaletteReachesEveryRegistryEntry(t *testing.T) {
 		ctxTaskWorkflow, ctxTaskStepDetails, ctxTaskPull,
 		ctxDaemon, ctxPullRequests,
 		ctxChats, ctxChat, ctxNewChat,
+		ctxArchived, ctxArchivedChats,
 	}
 	for _, b := range bindings {
 		if b.noPalette {
@@ -99,11 +100,12 @@ func TestPaletteDisconnectedKeepsNavigation(t *testing.T) {
 	if actions != 0 {
 		t.Errorf("palette offers %d task actions while disconnected, want 0", actions)
 	}
-	// Six: the five takeovers plus the chats board (task 067). Navigation
-	// survives a disconnect because reaching a screen is not an action on
-	// the daemon.
-	if nav != 6 {
-		t.Errorf("palette lists %d navigation entries while disconnected, want all 6", nav)
+	// Eight: the five takeovers, the chats board (task 067) and the two
+	// archived boards (task 092). Navigation survives a disconnect because
+	// reaching a screen is not an action on the daemon — an archived board
+	// shows what it last fetched, the way every other one does.
+	if nav != 8 {
+		t.Errorf("palette lists %d navigation entries while disconnected, want all 8", nav)
 	}
 }
 

--- a/internal/tui/progress_test.go
+++ b/internal/tui/progress_test.go
@@ -184,7 +184,7 @@ func TestChatsBoardArmsTickOnlyWhileRunning(t *testing.T) {
 		t.Fatalf("a running chat armed no tick (cmd=%v ticking=%v)", cmd != nil, v.ticking)
 	}
 	v.chats[0].State = "idle"
-	if _, cmd := v.update(chatsTickMsg(v.now())); cmd != nil || v.ticking {
+	if _, cmd := v.update(chatsTickMsg{at: v.now()}); cmd != nil || v.ticking {
 		t.Fatalf("a tick after the last running chat stopped armed another (cmd=%v)", cmd != nil)
 	}
 

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -471,6 +471,10 @@ func (m *root) activeContext() bindingContext {
 		return ctxDaemon
 	case viewPullRequests:
 		return ctxPullRequests
+	case viewArchived:
+		return ctxArchived
+	case viewArchivedChats:
+		return ctxArchivedChats
 	case viewChats:
 		return m.views[viewChats].(*chatsView).bindingContext()
 	case viewChat:

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -344,7 +344,7 @@ func TestBackgroundMessagesReachTheirOwnView(t *testing.T) {
 
 	// The elapsed ticker survives a takeover for the same reason: an
 	// unre-armed tea.Tick never comes back.
-	if _, cmd = m.Update(boardTickMsg(testNow)); cmd == nil {
+	if _, cmd = m.Update(boardTickMsg{at: testNow}); cmd == nil {
 		t.Fatal("the elapsed ticker died while a takeover was on screen")
 	}
 }

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -26,6 +26,12 @@ const (
 	// because that is the shape of the thing, not because chats are tasks.
 	viewChats
 	viewChat
+	// The two archived boards (§15 view 10, task 092). Each routes to the
+	// board model it mirrors, constructed in archived mode: the archive needs
+	// grouping, folding, `/` and the bulk selection, and a second copy of all
+	// four would drift on the first change to any of them (decision 5).
+	viewArchived
+	viewArchivedChats
 	viewCount
 )
 
@@ -130,8 +136,10 @@ func newViews(ctx context.Context) [viewCount]panel {
 		// reached only when at least one project's §13.2 probe says yes: it
 		// is the *nav row* that is withheld, not the screen, so nothing here
 		// has to know the answer before the probes land.
-		viewPullRequests: newPullRequestsView(),
-		viewChats:        newChatsView(),
-		viewChat:         newChatView(level, raw),
+		viewPullRequests:  newPullRequestsView(),
+		viewChats:         newChatsView(),
+		viewChat:          newChatView(level, raw),
+		viewArchived:      newArchivedBoard(),
+		viewArchivedChats: newArchivedChatsView(),
 	}
 }

--- a/scripts/m15-gate.sh
+++ b/scripts/m15-gate.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# M15 phase gate (task 092; spec §10, §13.2, §13.3, §17): prove over the wire
+# that an archived row can be permanently deleted, that the delete refuses
+# rather than cascading, and that §10's branch rule survives being asked to
+# break it.
+#
+#   1. a task runs to done, is archived, and is listed by archived=true —
+#      newest-archived first, and absent from the default listing
+#   2. archived_before / archived_since bound that listing, and garbage is 400
+#   3. DELETE on a *live* task is refused 409 with `reason: not_archived`,
+#      and the row is still there afterwards
+#   4. DELETE on the archived task removes the row (404 afterwards) and its
+#      transcript directory
+#   5. delete_branch=true against a branch that carries commits reports
+#      has_commits and *keeps* the branch — §10's standing rule, unchanged by
+#      the asking
+#   6. delete_branch=true against a branch with no commits past its base
+#      deletes it, and the delete reports `deleted`
+#   7. a task.deleted event reaches GET /v1/events
+#   8. DELETE on an unknown id is 404
+#   9. neither DELETE is an MCP tool (§13.4)
+#
+# The agent is cmd/fakeagent unless VINCENT_GATE_AGENT names a real one.
+#
+# Requirements: bash, go, git, curl, jq.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+
+VINCENT="$BIN/vincent"
+FAKEAGENT="$BIN/fakeagent"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+  VINCENT+=".exe"
+  FAKEAGENT+=".exe"
+fi
+
+fail() { echo "GATE FAIL: $*" >&2; exit 1; }
+
+cleanup() {
+  "$VINCENT" daemon stop --force >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+hostpath() {
+  if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s\n' "$1"; fi
+}
+
+echo "== build vincent and the fake agent"
+(cd "$ROOT" && go build -o "$(hostpath "$BIN")/" ./cmd/vincent ./cmd/fakeagent)
+
+CONFIG_DIR="$TMP/config"
+DATA_DIR="$TMP/data"
+mkdir -p "$CONFIG_DIR" "$DATA_DIR"
+export VINCENT_CONFIG_DIR
+VINCENT_CONFIG_DIR="$(hostpath "$CONFIG_DIR")"
+export VINCENT_DATA_DIR
+VINCENT_DATA_DIR="$(hostpath "$DATA_DIR")"
+
+AGENT="${VINCENT_GATE_AGENT:-claude}"
+# delete_empty_branch_on_archive is off deliberately: it defaults on, and an
+# archive that had already deleted the empty branch would leave scenario 6
+# asserting nothing. With it off, the branch survives the archive and the
+# *delete* is what judges it — which is the thing under test.
+{
+  echo "delete_empty_branch_on_archive: false"
+  if [[ -z "${VINCENT_GATE_AGENT:-}" ]]; then
+    echo "agents:"
+    echo "  claude:"
+    echo "    path: $(hostpath "$FAKEAGENT")"
+  fi
+} > "$CONFIG_DIR/config.yaml"
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email gate@example.com
+git -C "$REPO" config user.name "M15 Gate"
+git -C "$REPO" commit -q --allow-empty -m "root"
+
+# Two workflows: one whose step commits (so its branch carries something past
+# its base) and one whose step does not. `run:` bodies execute under the
+# daemon's shell — /bin/sh on POSIX, pwsh on Windows (§8.3) — so they are
+# spelled in the intersection of the two: `git ...` and nothing else.
+mkdir -p "$CONFIG_DIR/workflows"
+cat > "$CONFIG_DIR/workflows/gate-commits.yaml" <<'YAML'
+name: gate-commits
+description: One step that leaves a commit on the task's branch.
+steps:
+  - id: work
+    type: command
+    run: git commit --allow-empty -m "work the gate can see"
+YAML
+cat > "$CONFIG_DIR/workflows/gate-empty.yaml" <<'YAML'
+name: gate-empty
+description: One step that writes nothing, so the branch stays empty.
+steps:
+  - id: work
+    type: command
+    run: git status
+YAML
+
+echo "== start the daemon"
+"$VINCENT" daemon start
+PORT="$(jq -r .port "$DATA_DIR/daemon.json")"
+TOKEN="$(cat "$DATA_DIR/token")"
+BASE="http://127.0.0.1:$PORT/v1"
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -X "$method" -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" "$@" "$BASE$path"
+}
+
+api_status() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -o "$TMP/body.json" -w '%{http_code}' -X "$method" \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "$@" "$BASE$path"
+}
+
+PROJECT="$(api POST /projects -d "{\"name\":\"gate\",\"path\":\"$(hostpath "$REPO")\"}")" \
+  || fail "POST /v1/projects failed"
+PROJECT_ID="$(printf '%s' "$PROJECT" | jq -r .id)"
+
+# create_task WORKFLOW TITLE -> the new task's id
+create_task() {
+  local wf="$1" title="$2" body
+  body="$(api POST /tasks -d "{\"project_id\":$PROJECT_ID,\"workflow\":\"$wf\",\"title\":\"$title\",\"agent\":\"$AGENT\"}")" \
+    || fail "POST /v1/tasks failed for $title"
+  printf '%s' "$body" | jq -r .id
+}
+
+# wait_state ID STATE — poll until the task reaches STATE.
+wait_state() {
+  local id="$1" want="$2" i state
+  for i in $(seq 1 120); do
+    state="$(api GET "/tasks/$id" | jq -r .state)"
+    [[ "$state" == "$want" ]] && return 0
+    if [[ "$state" == "aborted" || "$state" == "blocked" ]] && [[ "$want" != "$state" ]]; then
+      fail "task $id went $state waiting for $want"
+    fi
+    sleep 1
+  done
+  fail "task $id never reached $want (stuck in $state)"
+}
+
+echo "== 1. a task runs, archives, and appears only in the archived listing"
+COMMITS_ID="$(create_task gate-commits "carries a commit")"
+wait_state "$COMMITS_ID" done
+BRANCH="$(api GET "/tasks/$COMMITS_ID" | jq -r .branch_name)"
+api POST "/tasks/$COMMITS_ID/archive" >/dev/null || fail "archive failed"
+
+LIVE="$(api GET /tasks | jq -r '[.[].id] | join(",")')"
+case ",$LIVE," in
+  *",$COMMITS_ID,"*) fail "the archived task is still on the default listing" ;;
+esac
+ARCHIVED="$(api GET "/tasks?archived=true" | jq -r '[.[].id] | join(",")')"
+case ",$ARCHIVED," in
+  *",$COMMITS_ID,"*) ;;
+  *) fail "the archived task is not in archived=true ($ARCHIVED)" ;;
+esac
+
+echo "== 2. the date bounds narrow the archive, and garbage is 400"
+FUTURE="2099-01-01T00:00:00Z"
+PAST="2000-01-01T00:00:00Z"
+N_BEFORE_FUTURE="$(api GET "/tasks?archived=true&archived_before=$FUTURE" | jq 'length')"
+[[ "$N_BEFORE_FUTURE" -ge 1 ]] || fail "archived_before=$FUTURE returned nothing"
+N_BEFORE_PAST="$(api GET "/tasks?archived=true&archived_before=$PAST" | jq 'length')"
+[[ "$N_BEFORE_PAST" -eq 0 ]] || fail "archived_before=$PAST returned $N_BEFORE_PAST rows"
+N_SINCE_PAST="$(api GET "/tasks?archived=true&archived_since=$PAST" | jq 'length')"
+[[ "$N_SINCE_PAST" -ge 1 ]] || fail "archived_since=$PAST returned nothing"
+CODE="$(api_status GET "/tasks?archived_before=nonsense")"
+[[ "$CODE" == "400" ]] || fail "an unparseable archived_before answered $CODE, want 400"
+jq -e '.error.code == "validation_failed"' "$TMP/body.json" >/dev/null \
+  || fail "the 400 is not the §13.1 envelope: $(cat "$TMP/body.json")"
+# GET /v1/chats takes the same four parameters, spelled the same way.
+CODE="$(api_status GET "/chats?archived_since=nonsense")"
+[[ "$CODE" == "400" ]] || fail "GET /v1/chats accepted an unparseable archived_since ($CODE)"
+api GET "/chats?limit=1&offset=0&archived=true" >/dev/null || fail "GET /v1/chats rejected paging"
+
+echo "== 3. a live task is refused 409, and survives it"
+LIVE_ID="$(create_task gate-empty "still alive")"
+wait_state "$LIVE_ID" done
+CODE="$(api_status DELETE "/tasks/$LIVE_ID")"
+[[ "$CODE" == "409" ]] || fail "deleting a done task answered $CODE, want 409"
+jq -e '.error.details.reason == "not_archived"' "$TMP/body.json" >/dev/null \
+  || fail "the refusal does not name the reason: $(cat "$TMP/body.json")"
+api GET "/tasks/$LIVE_ID" >/dev/null || fail "the refused task was deleted anyway"
+
+echo "== 4/5. delete_branch against a branch that carries commits keeps it"
+TRANSCRIPTS="$DATA_DIR/transcripts/$COMMITS_ID"
+[[ -d "$TRANSCRIPTS" ]] || fail "no transcript directory at $TRANSCRIPTS to reclaim"
+OUT="$(api DELETE "/tasks/$COMMITS_ID?delete_branch=true")" || fail "DELETE failed"
+printf '%s' "$OUT" | jq -e '.deleted == true' >/dev/null || fail "the delete did not report itself: $OUT"
+printf '%s' "$OUT" | jq -e '.branch.result == "has_commits"' >/dev/null \
+  || fail "a branch with commits was not reported has_commits: $OUT"
+REFS="$(git -C "$REPO" for-each-ref --format='%(refname:short)' refs/heads)"
+grep -qx "$BRANCH" <<<"$REFS" || fail "the branch carrying commits was deleted: $REFS"
+CODE="$(api_status GET "/tasks/$COMMITS_ID")"
+[[ "$CODE" == "404" ]] || fail "the deleted task still answers $CODE"
+[[ -d "$TRANSCRIPTS" ]] && fail "the transcript directory survived the delete"
+
+echo "== 6. delete_branch against an empty branch deletes it"
+EMPTY_ID="$(create_task gate-empty "writes nothing")"
+wait_state "$EMPTY_ID" done
+EMPTY_BRANCH="$(api GET "/tasks/$EMPTY_ID" | jq -r .branch_name)"
+api POST "/tasks/$EMPTY_ID/archive" >/dev/null || fail "archive failed"
+OUT="$(api DELETE "/tasks/$EMPTY_ID?delete_branch=true")" || fail "DELETE failed"
+printf '%s' "$OUT" | jq -e '.branch.result == "deleted"' >/dev/null \
+  || fail "an empty branch was not deleted: $OUT"
+REFS="$(git -C "$REPO" for-each-ref --format='%(refname:short)' refs/heads)"
+if grep -qx "$EMPTY_BRANCH" <<<"$REFS"; then
+  fail "the empty branch survived: $REFS"
+fi
+
+echo "== 7. the delete is announced as a durable event"
+# GET /v1/events is a stream that never ends by itself, and it never replays
+# history unasked (PR D decision): `Last-Event-ID: 0` is *no cursor* — the
+# handler's replay is gated on `cursor > 0` — so a stream opened here, after
+# the delete, would sit idle until --max-time and prove nothing. Resume from 1
+# instead, which is every event this daemon has ever written but the first,
+# and narrow it with ?types= so the replay is the one type under test rather
+# than the whole run. `head` caps the follow that comes after the replay; it
+# is inside the substitution, so pipefail's SIGPIPE 141 is caught by the
+# `|| true` there and not read as a gate failure.
+DELETED="$(curl -sS --max-time 5 -H "Authorization: Bearer $TOKEN" \
+  -H "Last-Event-ID: 1" -N "$BASE/events?types=task.deleted" 2>/dev/null \
+  | tr -d '\r' | head -c 200000 || true)"
+grep -q 'event: task.deleted' <<<"$DELETED" \
+  || fail "no task.deleted event reached GET /v1/events: $DELETED"
+grep -q "\"id\":$COMMITS_ID" <<<"$DELETED" \
+  || fail "task.deleted does not name the deleted task $COMMITS_ID: $DELETED"
+
+echo "== 8. an unknown id is 404"
+CODE="$(api_status DELETE "/tasks/999999")"
+[[ "$CODE" == "404" ]] || fail "deleting an unknown task answered $CODE, want 404"
+CODE="$(api_status DELETE "/chats/999999")"
+[[ "$CODE" == "404" ]] || fail "deleting an unknown chat answered $CODE, want 404"
+
+echo "== 9. neither DELETE is an MCP tool"
+TOOLS="$(curl -sS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  "http://127.0.0.1:$PORT/mcp" | tr -d '\r')"
+for forbidden in task_delete chat_delete; do
+  if grep -q "\"$forbidden\"" <<<"$TOOLS"; then
+    fail "$forbidden is an MCP tool; §13.4 excludes both deletes"
+  fi
+done
+
+echo "GATE PASS: m15 (archived listings and permanent delete)"


### PR DESCRIPTION
## Summary

Archiving a task or a chat kept every row it ever wrote, and nothing in vincent
could reach that history or discard any of it. `board.tasksCmd` asked for
`ListTasksOptions{}`, whose zero-value `Archived` is `ArchivedExclude`, and no
other TUI surface asked for anything else; retention removes transcript *files*
and never a row; the only hard delete in the system was
`DELETE /v1/projects/{id}`. This adds the screen the history is read on and the
route it is discarded by.

**Two archived boards** — tasks and chats — reached from the command palette
(`:`). Each is the board it mirrors **in a second mode**, not a second model
(task 092 decision 5): `internal/tui/board.go` is where grouping, folding, the
`/` filter and the `space`/`V` selection live, and an archive needs every one of
them; a copy would drift on the first change to any of the four. What the mode
adds is the three things only an archive has — `d` cycles a date window (7 days
/ 30 days / all, resolved client-side into an absolute bound), `<`/`>` turn
pages of a hundred rows, and `D` deletes. Rows come back newest-archived first,
which is the only order an archive has. Neither board gets a key of its own:
task 049 retired `1..6` and the point was to stop adding memorized keys, so they
get two `nav` palette rows the way chats did (task 067).

`enter` opens the row's existing workspace, **read-only for free** — an archived
task offers no `available_actions`, and every action key is gated on those, so
there is nothing to withhold and no flag saying so.

**Permanent delete.** `DELETE /v1/tasks/{id}` and `DELETE /v1/chats/{id}`, with
`vincent task delete` / `vincent chat delete` (alias `rm`, matching `project
rm`) over them, taking `--branch`, `--json` and `--before 30d`. Delete is **not
a §6 action**: `taskstate` has no opinion on it and it never appears in
`available_actions`, so the TUI key is a `scopePanel` binding on the two
archived contexts and the API refusal is the handler's own check on `state`. The
precedent is `DELETE /v1/projects/{id}`, likewise no action, and both routes
join that route's §13.4 destructive-admin exclusion — an agent cannot discard
history a human archived.

It **refuses rather than cascading**, naming the row that is holding on:
`not_archived`, `has_lanes` (a fan-out parent whose lanes still exist —
`parent_task_id` has no `ON DELETE` clause, so without the guard this is a
driver error rather than a refusal), `handed_off`, and `handoff_target`.

**§10 is untouched.** `delete_branch=true` reuses
`worktree.Manager.DeleteEmptyBranch` verbatim, including task 056's
`base_sha`-or-`base_branch` fork point and the whole outcome vocabulary: a
branch carrying any commit past its base is reported `has_commits` and **kept**
whichever way it was asked. The remote leg is not offered at all —
`delete_remote_branch_on_archive` stays honoured only by the archive route.

There is no bulk endpoint and there is not going to be one (task 011, verbatim):
every sweep — the TUI selection, the `--before` sweep — is one `DELETE` per row,
sequentially, reporting done / refused the way `dispatchBulk` already does.

`GET /v1/tasks` and `GET /v1/chats` gain `archived_before` / `archived_since`;
`GET /v1/chats` gains `limit` / `offset` (it had neither). Chats measure that
window over `updated_at` rather than a new column, because task 074 decision 6
and task 079 decision 2 both recorded that a terminal transition is the last
write a chat row takes. `task.deleted` and `chat.deleted` are new §13.3 types;
the historical `events` rows are deliberately **kept**, their id being the
`Last-Event-ID` cursor every subscriber holds. **No migration** — every column
and cascade this needs already exists.

`scripts/m15-gate.sh` drives it end to end over curl against the fake agent and
is wired into `ci.yml`'s `gates` job on all three platforms.

### Notes for the reviewer

- **The PR title is deliberately plain language, not Conventional Commits.** The
  `PR title` workflow rejects a conventional prefix, and `CLAUDE.md` records
  why: GitHub copies the title into the merge commit, which would make Release
  Please record the change twice. The *commits* are conventional.
- A client resuming `/v1/events` from a `Last-Event-ID` older than a delete will
  see events for an id that now `404`s. A project delete already does this to a
  stale cursor, so it is survivable — but it is the one behaviour worth checking
  rather than assuming.
- The `ci.yml` hunk needs a local push: a cloud session's token has no
  `workflow` scope and cannot write `.github/workflows/` by any route (#120,
  #122, #125).
- No screenshot was added. `docs/guides/tui.md` describes the archived boards in
  prose and references no image, so nothing under `docs/assets/` is stale —
  but the brief did ask for a capture, and writing the VHS tape for it is left
  undone. Documentation never draws a screen, so this is a gap to fill by
  running `scripts/screenshots.sh`, not by hand.
- **Found and not fixed — a stray visual change on the *live* board.**
  `internal/tui/board.go` swaps `styleWarn` for `styleAsk` in `headerLine` and
  `agentsSummary`. The two differ: `styleWarn` is colour 3, `styleAsk` is colour
  3 **bold** (`root.go:31`, `detailrender.go:22`). So the header's "N need
  attention" badge and the adapter `⚠` / quota badges are now bold, on the live
  board as well as the archived one, with no comment saying why and nothing in
  issue #350 asking for it. `styleAsk` is genuinely the right style for the new
  delete confirmation; these three call sites look like collateral. Either
  revert them or say why they moved — and if they stay, `docs/assets/tui-board.png`
  is a capture of the header that changed and wants re-running through
  `scripts/screenshots.sh`. Left alone here: this step's commits are
  documentation commits.
- **Found and not fixed — `CLAUDE.md`'s gate list is behind.** It documents
  `m1`–`m13` and says "All ten of those run in `ci.yml`'s `gates` job". The
  repository has `m14` (task 067) and now `m15`, both wired into that job on all
  three platforms. `CLAUDE.md` is outside the paths a documentation step may
  touch, so it is reported rather than edited.

## Related

Closes #350

Task document: [`docs/tasks/092-archived-boards-and-delete.md`](docs/tasks/092-archived-boards-and-delete.md)
(closes 092.1–092.7), with the index row updated in the same edit.

Decisions this **keeps** rather than revisits, each cited in the task document:
task 008 and task 056 (the §10 branch rule and its fork point, reused verbatim —
008's exception merely widens from "at archive time" to "at archive time and at
permanent delete"), task 011 ("there is no bulk endpoint and there is not going
to be one"), task 049 and task 067 (palette rows, no new memorized keys), task
074 decision 5 (`handed_off` means the task owns the worktree, which is why both
directions of that link are a refusal), task 074 decision 6 and task 079
decision 2 (a chat's `updated_at` *is* when it ended, so no `archived_at` column
is added for chats).

One recorded ruling is explicitly **not** followed here, with the reason stated
in the spec: PR D's "there is no separate `task.archived` type" does not reach
`task.deleted`. That type was redundant with `task.state_changed`; a delete has
no state to change to, so without a type no other client ever learns the row is
gone.

Spec amended in this branch, dated 2026-09-09: §5.5, §6, §10, §13.2, §13.3,
§13.4, §15 (a tenth view), §17/§20 (the retention table's "DB rows are never
deleted" qualified — the *pruner* never deletes rows; a human's delete does),
and decision-record row 30.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
      — `internal/store/delete_test.go` (each refusal as a typed error with the
      row still present, the cascade, the untouched `events` rows, the date
      bounds and the archived-only ordering), `internal/api/delete_test.go`
      (every refusal as a `409` in the snake_case envelope, `404`, the branch
      outcomes, the `task.deleted` event reaching a subscriber),
      `internal/apiclient/delete_live_test.go` (against the real handlers, which
      is what keeps the wire types from drifting), `internal/tui/archived_test.go`
      and the `bindings_test.go` additions (`TestEveryPanelKeyIsHandled` covers
      the two new contexts), and `internal/cli/actions_e2e_test.go` for both
      commands, `--json`, `--before` and exit 1 carrying the daemon's wording.
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md`
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block reasons)
      — `docs/reference/api.md` (the two routes and the four query parameters),
      `docs/reference/cli.md` (both commands), `docs/guides/tui.md` (the key
      table for the new screens), `docs/reference/files.md` (what a delete
      reclaims), `docs/features.md`. No block-reason change: the refusals are
      `409` `details` reasons, not `Reason*` constants.

      A documentation audit over the derivations then found five more pages
      carrying a claim this change made false, fixed in a separate `docs:`
      commit:

      - `docs/reference/configuration.md` — `transcript_retention_days` said
        "task and step rows are **never** deleted" and "chat and turn rows are
        never deleted either". That is now the *pruner*'s property alone, which
        is precisely how spec §20's retention table was amended in this branch;
        the page derived from it was not. (So this **is** a config page change,
        despite adding no config key.)
      - `docs/guides/mcp.md` — "Ten routes are deliberately **not** tools",
        listing ten. `internal/mcp/tools.go` now has twelve.
      - `docs/reference/cli.md` — the new `--branch` paragraph linked "§10's
        standing rule" to `security-model.md`, which does not state it; it lives
        in `configuration.md#delete_empty_branch_on_archive`. The `--json` field
        list also omitted `id` and `error`, which is what a script keys the
        report on.
      - `docs/guides/tui.md` — the new Archived section said no key but `y`/`b`/
        `n` answers the confirmation; `esc` cancels it too (`board.answerDelete`).
        The page's Layout paragraph also still enumerated the takeover screens as
        they stood before task 067: chats *and* the two new archived boards were
        missing from it.
      - `docs/reference/task-lifecycle.md` — the `archived` row read "record
        kept" with nothing saying a human can now discard it.

## Verification

Run on macOS from this branch:

- `go build ./...`, `go vet ./...` — clean.
- `go test ./...` — **pass** (exit 0, whole suite).
- `go run mage.go lint` — **0 issues**; also cross-linted with
  `GOOS=windows` and `GOOS=linux` (0 issues each), per `CLAUDE.md`'s rule that a
  host-only lint hides findings in build-tagged files.
- `./scripts/m15-gate.sh` — **GATE PASS**, all nine scenarios. The gate is
  committed executable (`100755` in the index).

Not run here: `go run mage.go testrace` and the Windows and Linux legs — CI
covers all three platforms. The gate's first run on this machine caught a real
bug in the gate itself: it opened `/v1/events` with `Last-Event-ID: 0`, which is
*no cursor* — `startStream`'s replay is gated on `cursor > 0` and the stream
never replays history unasked (PR D decision) — so it sat idle until
`--max-time` and proved nothing. It now resumes from `1` and narrows with
`?types=task.deleted`.
