### PR TITLE
Report whether the published skills are installed, and install them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ list with the user-facing context a commit subject cannot carry.
 
 ### Added
 
+- **vincent tells you whether its workflow-authoring skill is installed, and
+  installs it.** vincent publishes an agent skill so that an agent you talk to
+  *directly* — outside a vincent run — knows how to write a vincent workflow,
+  and until now the only way to get it was to find a command in the README and
+  run it by hand. Nothing in the binary had ever looked at whether you had it,
+  and an installed copy went stale invisibly because the skill carried no
+  version at all.
+
+  Now `vincent doctor` carries a **SKILLS** group and `vincent skills ls` lists
+  the same rows: the version this binary ships, the version on disk, and which
+  agents it is linked into — `not installed`, `installed and current`, `out of
+  date` with both versions named, or `newer than this build` when you have
+  downgraded. `vincent skills install` runs the install for the agents vincent
+  found on this machine. The TUI's daemon view offers it under `S`, shows the
+  exact `npx` command before running anything, and remembers a "not now".
+
+  Detection is a filesystem read: it works with no daemon running and with no
+  node installed. Only the install needs `npx`, and its absence is a message
+  naming the dependency and printing the command to run once node is there —
+  never a crash. A missing or stale skill is a **row, not a problem**:
+  `vincent doctor` still exits 0, because the built-in `create-workflow` and
+  `update-workflows` workflows carry the skill's text in their own prompts and
+  are unaffected either way.
+
+  Two honest limits, written down rather than papered over. vincent reports the
+  links that are on disk, which can disagree with `npx skills list -g` — that
+  command's agent column is the CLI's remembered *selection*, not a fact about
+  your filesystem. And whether codex and cursor actually read the directories
+  the `skills` CLI writes to is not something this repository can confirm, so
+  it is documented rather than claimed.
+
 - **The footer fills the width it has, and says what it is hiding.** It used to
   show the focused surface's first five keys and drop the rest in silence —
   eleven of the twenty-one surfaces declare more than five, so on the board

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ list with the user-facing context a commit subject cannot carry.
   the same rows: the version this binary ships, the version on disk, and which
   agents it is linked into — `not installed`, `installed and current`, `out of
   date` with both versions named, or `newer than this build` when you have
-  downgraded. `vincent skills install` runs the install for the agents vincent
+  downgraded. A copy installed before this release carries no version marker at
+  all, so it reads `out of date: installed unversioned` — reinstalling is what
+  makes the row exact. `vincent skills install` runs the install for the agents vincent
   found on this machine. The TUI's daemon view offers it under `S`, shows the
   exact `npx` command before running anything, and remembers a "not now".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ list with the user-facing context a commit subject cannot carry.
   date` with both versions named, or `newer than this build` when you have
   downgraded. A copy installed before this release carries no version marker at
   all, so it reads `out of date: installed unversioned` — reinstalling is what
-  makes the row exact. `vincent skills install` runs the install for the agents vincent
-  found on this machine. The TUI's daemon view offers it under `S`, shows the
-  exact `npx` command before running anything, and remembers a "not now".
+  makes the row exact. `vincent skills install` runs the install for all three
+  adapters, and `--agent` narrows it. The TUI's daemon view offers the same
+  thing under `S` — for the adapters it actually found on this machine — shows
+  the exact `npx` command before running anything, and remembers a "not now".
 
   Detection is a filesystem read: it works with no daemon running and with no
   node installed. Only the install needs `npx`, and its absence is a message

--- a/README.md
+++ b/README.md
@@ -504,8 +504,19 @@ Install the portable workflow-authoring skill for Claude Code, Codex, Cursor,
 or another Agent Skills client:
 
 ```sh
+vincent skills install
+```
+
+That runs `npx skills add` for you, for the agents vincent found on this
+machine. The equivalent by hand, which prompts for the agent selection:
+
+```sh
 npx skills add lezli01/vincent --skill vincent-workflows -g
 ```
+
+`vincent skills ls` says what is installed and whether it is current, and
+`vincent doctor` carries the same rows. Neither needs a running daemon, and
+only the install needs node.
 
 It asks about human gates and cost constraints, prefers deterministic commands
 and native control flow, and validates generated workflow YAML.

--- a/README.md
+++ b/README.md
@@ -507,8 +507,9 @@ or another Agent Skills client:
 vincent skills install
 ```
 
-That runs `npx skills add` for you, for the agents vincent found on this
-machine. The equivalent by hand, which prompts for the agent selection:
+That runs `npx skills add` for you, answering its agent picker with all three
+vincent adapters — `--agent claude,codex,cursor` narrows it. The equivalent by
+hand, which prompts for the selection instead:
 
 ```sh
 npx skills add lezli01/vincent --skill vincent-workflows -g

--- a/docs/features.md
+++ b/docs/features.md
@@ -509,7 +509,9 @@ See the [pull-requests screen](guides/tui.md#pull-requests), the
 `vincent doctor` produces one report covering paths, configuration, daemon
 health, the recent log tail, the database's footprint, row counts and integrity,
 agent availability, login state and whether the installed CLI build is one
-vincent has been tested against, the GitHub integration, whether a newer vincent
+vincent has been tested against, the GitHub integration, whether the
+[workflow-authoring skill](reference/cli.md#vincent-skills) is installed and
+current for your agents, whether a newer vincent
 has been released and whether the running daemon is older than the binary you
 just ran, disk use, worktrees, and task counts. It supports JSON output for bug
 reports and automation, while `--fix` can reclaim orphans and compact the

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -34,7 +34,9 @@ workflow-snapshot bytes and how far back its event history reaches; every agent
 CLI with its path, version and
 [`logged_in`](agents.md#found-is-not-usable); whether the
 [GitHub integration](../reference/configuration.md#github) can read issues, and
-if not which piece is missing; whether a newer vincent has been
+if not which piece is missing; whether the
+[skills vincent publishes](../reference/cli.md#vincent-skills) are installed and
+current for your agents; whether a newer vincent has been
 [released](../reference/cli.md#vincent-update) and whether the running daemon is
 older than the binary you just ran; free disk, worktree count and bytes, and any
 orphaned worktrees; and task counts by state — so "12 blocked" is visible

--- a/docs/guides/tui.md
+++ b/docs/guides/tui.md
@@ -1553,6 +1553,7 @@ the editor says so before you apply it.
 | `R` | Re-read the daemon info, the config and the log |
 | `f` / `G` | Follow the end of the log again |
 | `i` | Make vincent claude's status line, or remove it — the exact JSON is shown first |
+| `S` | Install the agent skills vincent publishes — the exact command is shown first |
 
 And inside the editor:
 
@@ -1588,6 +1589,22 @@ you the exact JSON first. Whatever status line you had is run by vincent and
 printed unchanged, pressing `i` again puts the file back the way it was, and
 declining is remembered so the offer does not come back. See
 [`vincent statusline`](../reference/cli.md#vincent-statusline).
+
+A line under the adapters says how many of the
+[skills vincent publishes](../reference/cli.md#vincent-skills) are not installed
+for your agents, and `S` opens the offer: what is on this machine, and the exact
+`npx skills add` command each install runs, spelled out before anything happens.
+`enter` runs it, `n` is a "not now" that is remembered in `{data_dir}/tui.json`
+so the line stops advertising itself, and `esc` closes without installing
+anything. Once everything is current the line still says so — that is where `S`
+stays discoverable, the same way the status-line line works.
+
+Two things differ from `i`. vincent does not write these files itself: it runs
+`npx skills add`, which needs node on `PATH` and, on its first run, the network
+to download the package — so the install happens off the event loop and the
+screen says what is running rather than freezing. And the state the line reports
+comes off the same `vincent doctor` report this view already fetches, so the TUI
+still holds no state the daemon does not; only the "not now" is local.
 
 The row also trails with what vincent knows about the build itself: `untested`
 and the builds the adapter was judged against, `incompatible version` for a

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -39,9 +39,10 @@ vincent skills install
 ```
 
 That shells out to `npx skills add lezli01/vincent --skill vincent-workflows
---agent <your agents> --yes --global`, which is the published command with the
-interactive agent picker answered from the adapters vincent detected. Running
-it by hand works too:
+--agent claude-code,codex,cursor --yes --global`, which is the published command
+with the interactive agent picker answered. `--agent` narrows the selection to
+some of `claude`, `codex`, `cursor`; the TUI's `S` offer answers it with the
+adapters vincent actually detected instead. Running it by hand works too:
 
 ```sh
 npx skills add lezli01/vincent --skill vincent-workflows -g

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -35,8 +35,23 @@ The portable [vincent Workflows skill](../../skills/vincent-workflows/SKILL.md)
 helps supporting coding agents design and validate these files:
 
 ```sh
+vincent skills install
+```
+
+That shells out to `npx skills add lezli01/vincent --skill vincent-workflows
+--agent <your agents> --yes --global`, which is the published command with the
+interactive agent picker answered from the adapters vincent detected. Running
+it by hand works too:
+
+```sh
 npx skills add lezli01/vincent --skill vincent-workflows -g
 ```
+
+`vincent skills ls` reports whether the skill is installed, whether it is the
+version this binary ships, and which agents it is linked into; `vincent doctor`
+shows the same rows, and the TUI's daemon view offers the install under `S`.
+Detection is a filesystem read — it works with no daemon and with no node
+installed. Only the install needs `npx`.
 
 It asks only for decisions that change the workflow, including possible human
 gates and interaction needs. It prefers deterministic command steps and native

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -433,7 +433,10 @@ daemon running.
 - **`skills[]` is one row per published skill**, never one per agent. The
   `skills` CLI keeps a single copy in a global store, `~/.agents/skills/`, and
   links it into each agent's directory, so a per-agent version would be the same
-  string on every row. `state` is one of `absent`, `current`, `older`, `newer`,
+  string on every row. `installed_version` is absent for a copy that carries no
+  `metadata.version` — every copy installed before that marker existed — and
+  such a copy is `older`, not `unreadable`. `state` is one of `absent`,
+  `current`, `older`, `newer`,
   `differs` (unequal and at least one side is not semver, so no direction is
   claimed) and `unreadable`. `links[]` is what is on disk and can name agents
   vincent does not drive. Nothing here ever reaches `problems[]` — see

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -381,6 +381,14 @@ daemon running.
                   "supports_input": false, "version_verdict": "tested",
                   "tested_versions": "0.142.5, 0.147.0, 0.150.1",
                   "restricted_verdict": "supported" } ],
+  "skills":   [ { "name": "vincent-workflows",
+                  "description": "Create, edit, review, and validate vincent workflow YAML…",
+                  "shipped_version": "1.0.0", "installed_version": "1.0.0",
+                  "state": "current",
+                  "store_path": "/home/you/.agents/skills/vincent-workflows",
+                  "links": [ { "agent": "claude", "adapter": "claude",
+                               "path": "/home/you/.claude/skills/vincent-workflows",
+                               "symlink": true } ] } ],
   "storage":  { "worktrees_dir": "…", "disk_free_bytes": 127310651392,
                 "disk_total_bytes": 494384795648,
                 "worktree_count": 3, "worktree_bytes": 8412736,
@@ -422,6 +430,14 @@ daemon running.
   `/v1/agents` uses instead: it is for a caller that is not in that loop and
   wants the rest of the report cheaply — the TUI's daemon panel, which opens on
   a keypress, is the one in the tree. `vincent doctor` always forces.
+- **`skills[]` is one row per published skill**, never one per agent. The
+  `skills` CLI keeps a single copy in a global store, `~/.agents/skills/`, and
+  links it into each agent's directory, so a per-agent version would be the same
+  string on every row. `state` is one of `absent`, `current`, `older`, `newer`,
+  `differs` (unequal and at least one side is not semver, so no direction is
+  claimed) and `unreadable`. `links[]` is what is on disk and can name agents
+  vincent does not drive. Nothing here ever reaches `problems[]` — see
+  [`vincent skills`](cli.md#vincent-skills).
 - **The database group measures growth** and changes nothing about it.
   `total_bytes` is the file plus its WAL and SHM sidecars, which is the honest
   figure: the store runs in WAL mode, so `size_bytes` alone understates the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1131,10 +1131,10 @@ copy on disk, and the agents it is linked into.
 |---|---|
 | `not installed` | No copy on this machine |
 | `installed and current` | The installed version is the shipped one |
-| `out of date` | The installed copy predates this binary's; both versions are named |
+| `out of date` | The installed copy predates this binary's; both versions are named. A copy carrying no `metadata.version` — every copy installed before that marker existed — reads `installed unversioned` |
 | `newer than this build` | The installed copy is ahead — a downgraded binary, not an up-to-date skill |
 | `differs` | The versions are unequal and at least one is not semver, so no direction is claimed |
-| `unreadable` | A copy exists and its `SKILL.md` could not be read |
+| `unreadable` | A copy exists and its `SKILL.md` could not be read or parsed at all |
 
 `skills add … -g` keeps **one** copy in a global store, `~/.agents/skills/`, and
 links it into each agent's directory — so there is one row per skill, not one

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,7 @@ localhost API.
 - [`vincent status`](#vincent-status)
 - [`vincent statusline`](#vincent-statusline)
 - [`vincent update`](#vincent-update)
+- [`vincent skills`](#vincent-skills)
 - [`vincent chat`](#vincent-chat)
 - [`vincent workflow`](#vincent-workflow)
 - [`vincent github`](#vincent-github)
@@ -1105,6 +1106,69 @@ vincent update --check --json
   "release_url": "https://github.com/lezli01/vincent/releases/tag/v0.5.0"
 }
 ```
+
+## `vincent skills`
+
+vincent publishes agent skills — `skills/vincent-workflows/` today — so an agent
+you talk to **directly**, outside a vincent run, knows how to author a vincent
+workflow. Runs inside vincent do not need them: the built-in `create-workflow`
+and `update-workflows` workflows carry the same text in their own prompts.
+
+Neither subcommand talks to the daemon, so **neither can exit 2**. Detection is
+a filesystem read and works on a machine with no node installed; only `install`
+shells out.
+
+### `vincent skills ls`
+
+```sh
+vincent skills ls [--json]
+```
+
+One row per published skill: the version this binary ships, the state of the
+copy on disk, and the agents it is linked into.
+
+| State | Meaning |
+|---|---|
+| `not installed` | No copy on this machine |
+| `installed and current` | The installed version is the shipped one |
+| `out of date` | The installed copy predates this binary's; both versions are named |
+| `newer than this build` | The installed copy is ahead — a downgraded binary, not an up-to-date skill |
+| `differs` | The versions are unequal and at least one is not semver, so no direction is claimed |
+| `unreadable` | A copy exists and its `SKILL.md` could not be read |
+
+`skills add … -g` keeps **one** copy in a global store, `~/.agents/skills/`, and
+links it into each agent's directory — so there is one row per skill, not one
+per agent, and one version rather than three.
+
+The agents column is what is on disk. It can name agents vincent does not drive
+(one store serves Cline, Copilot, Zed and the rest), and it can disagree with
+`npx skills list -g`, whose agent column is that CLI's remembered *selection*
+rather than the links it left behind.
+
+### `vincent skills install`
+
+```sh
+vincent skills install [NAME...] [--agent NAME]... [--json]
+```
+
+Installs the named skills, or — with no name — every published skill that is not
+already current. It runs, once per skill:
+
+```sh
+npx skills add lezli01/vincent --skill NAME --agent claude-code,codex,cursor --yes --global
+```
+
+That is the published command with the interactive agent picker answered.
+`--agent` narrows the selection to some of `claude`, `codex`, `cursor`; the
+default is all of them. Note the `skills` CLI's slug for claude is
+`claude-code`.
+
+It needs `npx` on `PATH` and, on a first run, network — the package is
+downloaded before anything happens. Without `npx` it exits **1** with a message
+naming the dependency and printing the line to run once node is installed;
+`vincent skills ls` is unaffected either way.
+
+Exit `0` everything asked for is installed · `1` an install failed.
 
 ## `vincent chat`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,7 +78,7 @@ empty.
 vincent doctor [--json] [--fix [--force]]
 ```
 
-One report answering "why is nothing running?". Ten groups:
+One report answering "why is nothing running?". Eleven groups:
 
 | Group | Rows |
 |---|---|
@@ -89,6 +89,7 @@ One report answering "why is nothing running?". Ten groups:
 | Agents | per adapter: found, path, version, `logged_in`, whether the build is one vincent has been tested against, and whether the adapter can restrict on this OS |
 | GitHub | whether [`github.enabled`](configuration.md#github) is on, whether `gh` is installed and logged in, whether a token variable is set, and whether issues are readable |
 | Container | whether [`container.image`](configuration.md#container) names an image, which image, whether the configured runtime answered, and whether steps run in it or on this host |
+| Skills | per [published skill](#vincent-skills): the version this binary ships, the state of the copy in the global skills store, and the agents it is linked into |
 | Update | whether [`update.check`](configuration.md#update) is on, the latest stable release and when it was last seen, this binary's version, and whether the running daemon is older than it |
 | Storage | disk free under the data dir, worktree count and bytes, orphans |
 | Tasks | counts by state, so "12 blocked" is visible without opening the board, plus any task whose state and step runs contradict each other |
@@ -119,6 +120,11 @@ containerization is off by default, so a machine with no runtime — or a Window
 daemon, which cannot host one — runs every step on the host exactly as it always
 has. The runtime is probed **even when `container.image` is unset**, because
 "would this work if I turned it on" is the question the group exists to answer.
+So do the **Skills** rows: a missing, stale or unreadable skill costs you help
+in your own agent session and stops no vincent run, because the built-in
+`create-workflow` and `update-workflows` workflows carry the skill's text in
+their own prompts. The group ends with `run: vincent skills install` when
+anything is not current.
 
 An adapter row also ends with what vincent knows about the build itself:
 `untested version` and the builds it was judged against, `incompatible version`
@@ -153,8 +159,9 @@ retention window: rows are kept indefinitely, and `--fix` is the only thing that
 touches the file at all.
 
 **Without a daemon** the report is still printed in full — paths, whether the
-config parses, adapter detection, the log tail, disk free and the worktree
-count — and the database and task rows read `unknown — daemon not running`.
+config parses, adapter detection, published-skill state, the log tail, disk free
+and the worktree count — and the database and task rows read
+`unknown — daemon not running`.
 They are not read from a second process: only the daemon opens the database. The
 byte figures, the row counts and the span are unknown together, for that reason
 and no other.
@@ -1124,8 +1131,8 @@ shells out.
 vincent skills ls [--json]
 ```
 
-One row per published skill: the version this binary ships, the state of the
-copy on disk, and the agents it is linked into.
+Aliased as `vincent skills list`. One row per published skill: the version this
+binary ships, the state of the copy on disk, and the agents it is linked into.
 
 | State | Meaning |
 |---|---|

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -299,7 +299,7 @@ to pass.
 
 ## What vincent writes outside its own directories
 
-Three things, and they are recorded here rather than discovered:
+Four things, and they are recorded here rather than discovered:
 
 **A cursor step passes `--model`, and cursor persists that selection to
 `~/.cursor/cli-config.json`.** Vincent always passes one (defaulting to `auto`)
@@ -333,6 +333,23 @@ property that makes the cursor case above tolerable is held here deliberately:
 The route it posts to, `POST /v1/agents/{name}/quota`, is
 [not an MCP tool](guides/mcp.md): an agent must not be able to forge a
 daemon-level fact about the host it runs on.
+
+**[`vincent skills install`](reference/cli.md#vincent-skills) — and the daemon
+view's `S` — runs `npx skills add`, which writes into your global skills store
+(`~/.agents/skills/`) and links the result into each agent's own directory.**
+Vincent does not write those files itself; it shells out to the published CLI,
+which is why the whole install layout stays that tool's business rather than
+something vincent reimplements. It holds the same properties as `i` above: it
+happens only when you run the command or press that key, never on daemon start
+and never as a side effect of a task; the **exact `npx` command is printed
+before anything runs**; and it needs `npx` on your `PATH`, whose absence is a
+message rather than a silent no-op.
+
+Detecting whether a skill is installed writes nothing at all and runs no
+subprocess — it reads `SKILL.md` out of those directories, which are a public
+CLI's documented install locations holding a file this repository published.
+That is deliberately not the same act as reading another tool's private state
+for credentials — the `~/.claude/.credentials.json` read refused above.
 
 **[`vincent update`](reference/cli.md#vincent-update) replaces the vincent
 binary**, which is by definition outside vincent's own directories. It happens

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3660,10 +3660,10 @@ all three by construction:
 |---|---|
 | `absent` | no copy on this machine |
 | `current` | the installed version is the shipped one |
-| `older` | the installed copy predates this binary's |
+| `older` | the installed copy predates this binary's — including a copy that carries no `metadata.version` at all, which is every copy installed before the marker existed |
 | `newer` | the installed copy is ahead of it — a downgraded binary, never "up to date" |
 | `differs` | the versions are unequal and at least one is not semver, so no direction is claimed and both are printed |
-| `unreadable` | a copy exists and its `SKILL.md` could not be read or parsed |
+| `unreadable` | a copy exists and its `SKILL.md` could not be read or parsed. A manifest that reads and simply has no version is `older`, not this |
 
 Comparison uses `golang.org/x/mod/semver`. Where either side does not parse the
 row says `differs` and prints both versions; it never guesses a direction.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3672,8 +3672,12 @@ row says `differs` and prints both versions; it never guesses a direction.
 --agent <slugs> --yes --global`. That is the published command plus three
 flags, and the difference is required: `skills add` with no agent selection
 opens an interactive multi-select, which cannot be driven from a TUI takeover
-or a non-TTY CLI. The agent list defaults to the vincent adapters detected on
-the box, mapped through the table above. `npx` is a runtime dependency of the
+or a non-TTY CLI. The agent list is mapped through the table above, and the two
+surfaces answer the picker differently on purpose: the **CLI** defaults to all
+three adapters, because a person who typed the command means "put it where my
+agents look" and `--agent` is right there to narrow it, while the **TUI**
+answers with the adapters the daemon actually detected, because that offer is
+one keypress on a screen already showing which ones those are. `npx` is a runtime dependency of the
 **install action only**; its absence is a reported outcome naming the
 dependency and printing the command to run once node is available, never a
 crash. The first run downloads the package, so an install is slow and needs
@@ -7989,7 +7993,8 @@ question — is this adapter's window shut *now* — computed per §9.6's `sourc
 split.
 
 **`i` in the daemon view (task 082).** The one key in vincent that leads to a
-write outside its own data dir: it offers to make `vincent statusline` Claude
+write outside its own data dir — *amended 2026-09-10 (task 095): the first of
+two, `S` below being the other* — it offers to make `vincent statusline` Claude
 Code's `statusLine.command`, and the same key takes it back out. The exact JSON
 that will be written is shown first, as a takeover rather than a line competing
 with four other blocks — §16 asks that it be on screen, and a preview nobody
@@ -9089,6 +9094,20 @@ currently true to show (§15 view 6).
   every other subcommand discovers it instead of being written into a file
   (§13.2). Starting a daemon leaves that file untouched, and a test asserts it
   rather than assuming it.
+
+  *Amended 2026-09-10 (task 095): three, and the third is not vincent's own
+  write.* `vincent skills install`, and the daemon view's `S`, run `npx skills
+  add` (§9.8) — the published CLI puts one copy under `~/.agents/skills/` and
+  links it into each agent's directory. Vincent writes none of those files
+  itself, which is the point of shelling out: the install layout, symlink /
+  `--copy` split included, stays that tool's business. The properties above
+  hold anyway — user-initiated by a command or a keypress and never on daemon
+  start, with the **exact argv shown before it runs** — and the one property
+  that cannot is stated rather than claimed: an uninstall is that CLI's, not
+  vincent's, so `S` does not undo the way `i` does. **Detection** adds nothing
+  to this list at all: it reads `SKILL.md` out of a public CLI's documented
+  install locations and writes nothing, which is why it is not the v0 T1.7
+  refusal being reopened (§9.8).
 
 *Added 2026-08-29 (task 057).* **An agent can now create and cancel vincent
 tasks.** §13.4 serves MCP from the daemon and, by default

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3130,7 +3130,12 @@ duplicating it as a verdict would give one fact two names.
 
 None of these verdicts blocks anything except `restricted_verdict`, and none of
 them is a `vincent doctor` problem (§17, task 005 decision 7): an untested build
-is the normal state of a healthy machine. There is still **no pre-flight refusal
+is the normal state of a healthy machine. *Added 2026-09-10 (task 095):*
+the published-skill row of §9.8 is **not** a sixth facet. Task 041 closed this
+vocabulary at five, and a skill is a property of the machine's agent
+configuration rather than of an adapter binary — one store copy serves every
+agent at once, and a machine with no adapter installed can still hold it. It is
+a group beside this one in every report, and the five stay five. There is still **no pre-flight refusal
 on `logged_in: false`** (task 003 decision 4) — this re-states that decision
 rather than reopening it.
 
@@ -3594,6 +3599,117 @@ Two consequences are handled rather than assumed away:
 - A daemon crash leaves it behind, so §12.4 recovery removes a leftover one from
   every live task's worktree. An empty `.cursor` goes with it; a `.cursor` the
   user or the agent put something else in stays.
+
+### 9.8 Published skills (task 095, added 2026-09-10)
+
+This repository publishes agent **skills** — directories under `skills/`, each
+with a `SKILL.md` — so that an agent somebody is talking to *directly*, outside
+a vincent run, knows how to author a vincent workflow. A run inside vincent
+does not need them: the built-in `create-workflow` and `update-workflows`
+workflows splice the same text into their own prompts at build time (§7,
+task 024 decision 7), which is why the gap this section closes only bites where
+it is hardest to notice.
+
+**The published set is a glob, not a list.** `skills.FS` embeds `*/SKILL.md`;
+every surface below enumerates that. A second directory under `skills/` is
+reported by `vincent doctor`, listed by `vincent skills` and offered by the TUI
+with no Go change.
+
+**Versioning.** Each `SKILL.md`'s front matter carries `metadata.version`. It
+sits under `metadata:` — the format's extension point, already holding `author`
+— rather than as a bare top-level `version:`, which is not a key the skills
+format defines and which a strict validator could reject. Content hashing was
+rejected: a hash cannot tell a user's local edit from a stale copy, and cannot
+tell newer from older. A test in `skills/` hashes each published tree and fails
+when the tree changed and the version did not.
+
+**What is on disk.** `skills add … -g` keeps **one** copy in a global store,
+`~/.agents/skills/<name>/`, and links it into each selected agent's directory.
+The link is a symlink by default and a real directory under `--copy`, which is
+what Windows needs, where creating a symlink is privileged. There is no
+per-agent copy and therefore no per-agent version.
+
+| vincent adapter | `skills --agent` slug | global directory |
+|---|---|---|
+| claude | `claude-code` | `~/.claude/skills/` |
+| codex | `codex` | `~/.codex/skills/` |
+| cursor | `cursor` | `~/.cursor/skills/` |
+
+The slug is a **table, not an identity**: claude's is `claude-code`.
+
+**Detection is a filesystem read and never runs `npx`.** The store's
+`SKILL.md` answers the installed version; each `~/.<agent>/skills/<name>` that
+exists answers who it is linked into. That is what makes the report work in
+`vincent doctor`, in the TUI, and on a machine with no node installed at all.
+The agent list is discovered by scanning the home directory rather than from a
+table of paths, so it names agents vincent does not drive — one store serves
+Cline, Copilot, Zed and the rest, and hiding them would be a report that is not
+about the machine.
+
+This is **not** the v0 T1.7 "no state-file parsing" decision being reopened.
+That decision is about inferring another tool's *authentication* from its
+private state. `~/.agents/skills/` and `~/.<agent>/skills/` are a public CLI's
+documented install locations, and the file read out of them is one this
+repository published.
+
+**States a row reports**, one row per skill carrying the agent list — never one
+row per adapter per skill, which the single-store model would make identical on
+all three by construction:
+
+| state | meaning |
+|---|---|
+| `absent` | no copy on this machine |
+| `current` | the installed version is the shipped one |
+| `older` | the installed copy predates this binary's |
+| `newer` | the installed copy is ahead of it — a downgraded binary, never "up to date" |
+| `differs` | the versions are unequal and at least one is not semver, so no direction is claimed and both are printed |
+| `unreadable` | a copy exists and its `SKILL.md` could not be read or parsed |
+
+Comparison uses `golang.org/x/mod/semver`. Where either side does not parse the
+row says `differs` and prints both versions; it never guesses a direction.
+
+**Install shells out**, to `npx skills add lezli01/vincent --skill <name>
+--agent <slugs> --yes --global`. That is the published command plus three
+flags, and the difference is required: `skills add` with no agent selection
+opens an interactive multi-select, which cannot be driven from a TUI takeover
+or a non-TTY CLI. The agent list defaults to the vincent adapters detected on
+the box, mapped through the table above. `npx` is a runtime dependency of the
+**install action only**; its absence is a reported outcome naming the
+dependency and printing the command to run once node is available, never a
+crash. The first run downloads the package, so an install is slow and needs
+network.
+
+Writing the files from the embedded copy instead was rejected: `skills/embed.go`
+embeds only `SKILL.md`, so doing it would mean embedding `references/`,
+`LICENSE.txt` and `agents/openai.yaml` too and reimplementing another tool's
+install layout, symlink/copy split included.
+
+**Surfaces.** `vincent doctor` grows a `SKILLS` group *beside* the agents group
+(§9.5, §17); `vincent skills ls` / `vincent skills install` is the command
+(§12.1); the daemon view offers it under `S` (§15). All three read the same
+detection, composed server-side when a daemon answers and client-side when none
+does — identical results, because vincent's daemon is localhost and runs as the
+invoking user.
+
+**Adapter differences, stated rather than emulated.** The directory table above
+is the `skills` CLI's, and it says where that CLI *writes*. Whether **codex**
+and **cursor** read `~/.codex/skills/` and `~/.cursor/skills/` is not confirmed
+by this repository, and vincent does not claim it: the skill ships
+`agents/openai.yaml` for codex-side packaging, and beyond that vincent reports
+what is on disk and nothing about what each agent does with it. A user who
+finds the skill unused by one of them is looking at that agent's own support,
+not at a vincent fault. This is §9's standing rule applied to skills — a
+capability an adapter lacks is documented and ignored, never emulated.
+
+**vincent will disagree with `npx skills list -g`.** That command's agent
+column is the CLI's remembered selection (`lastSelectedAgents` in
+`~/.agents/.skill-lock.json`), not an on-disk fact; it can name agents that
+hold no link. vincent reports the links. The lock file also carries no version,
+which is why `metadata.version` is needed rather than reusable from it.
+
+**Nothing here moves an exit code.** A missing, stale or unreadable skill is a
+row, on the GitHub (task 035), release-check (task 055) and container (task 061)
+precedent. `vincent doctor` still exits 0 (§17, task 005 decision 7).
 
 ## 10. Worktree management
 
@@ -4092,8 +4208,9 @@ One Go binary, `vincent`:
 | `vincent gc [--dry-run] [--force] [--json]` | Reclaims data-root directories no task claims (§10); a thin API client like the rest |
 | `vincent config get [key] / set <key> <value>` | *Added 2026-08-30 (task 060).* Reads and writes `config.yaml` through `GET`/`PATCH /v1/config` (§12.3) — a thin API client like the rest, never a second editor, so the CLI and the TUI's editor are one operation with one validation. `get` with no key prints every key as `path = value` in the file's own order; with one, that key's value alone. Keys are the dotted paths the file carries. Lists and argv are whitespace-separated inside a single argument (`notify.on "blocked awaiting_gate"`), which is also why an argv element containing a space has to be edited in the file. A `set` is in force when it answers; `listen` is the exception the command says out loud. Exit 0 · 1 the daemon refused it, with the file byte-identical · 2 no daemon answered |
 | `vincent github issues / prs / pr create / status --project <id>` | *Added 2026-08-26 (task 035).* Read-only GitHub views: the project's issues newest first, and whether they can be read at all. Thin API clients like the rest — the daemon makes every GitHub call. Nothing under this command writes to GitHub. *Amended 2026-08-31 (task 069, issue #273):* the last clause stops being true for **one** subcommand. `vincent github pr create --task <id> --title <t> [--body <text>] [--draft]` drives §13.2's create route: it pushes the task's branch and opens its pull request, and it is the one thing under `vincent github` that writes to GitHub — `issues`, `prs` and `status` still write nothing. It exists for the reason every other subcommand does (the TUI holds no action the daemon does not) and because a gate script has to be able to drive that route without driving a terminal. `--body` is optional: a pull request with no description is a legal one. The fallback is **not** an error — a push that succeeded and a create that did not prints the compare URL and exits 0 |
-| `vincent doctor` | One diagnostic report: paths, daemon, log tail, database, agents, storage, task counts (§17). `--json` for scripting and bug reports; `--fix` (`--force`) reclaims orphaned worktrees and compacts the database. Exit 0 healthy · 1 problems found · 2 no daemon answered. *Amended 2026-08-26 (task 035):* it also reports the GitHub integration — the `github.enabled` toggle, `gh`'s presence, version and login state, whether a token variable is set (its **name**, never its value), and whether issues are readable. It is a **row, not a problem**: every "no" it can report leaves task creation without an issue working exactly as before, so none of it changes the exit code. *Amended 2026-08-29 (task 055):* it also reports the release check (§12.3) — whether `update.check` is on, the latest stable release and when it was last seen, this binary's version, and whether the running daemon is older than it. Rows, not problems, for the same reason: a newer release and a daemon still running the previous build both leave everything working |
+| `vincent doctor` | One diagnostic report: paths, daemon, log tail, database, agents, storage, task counts (§17). `--json` for scripting and bug reports; `--fix` (`--force`) reclaims orphaned worktrees and compacts the database. Exit 0 healthy · 1 problems found · 2 no daemon answered. *Amended 2026-08-26 (task 035):* it also reports the GitHub integration — the `github.enabled` toggle, `gh`'s presence, version and login state, whether a token variable is set (its **name**, never its value), and whether issues are readable. It is a **row, not a problem**: every "no" it can report leaves task creation without an issue working exactly as before, so none of it changes the exit code. *Amended 2026-08-29 (task 055):* it also reports the release check (§12.3) — whether `update.check` is on, the latest stable release and when it was last seen, this binary's version, and whether the running daemon is older than it. Rows, not problems, for the same reason: a newer release and a daemon still running the previous build both leave everything working. *Amended 2026-09-10 (task 095):* it also reports the published skills of §9.8 — one row per skill with the version this binary ships, the version installed in the global store and the agents it is linked into. A row and not a problem, on the same precedent: the built-in workflows carry the skill's text in their own prompts, so nothing a skill row can say stops a task from running, and `vincent doctor` still exits 0 |
 | `vincent update [--check] [--dry-run] [--require-signature] [--json]` | *Added 2026-08-29 (task 055).* Asks GitHub for the latest **stable** release and, unless `--check` is given, installs it over this binary. It queries the feed **itself** rather than through the daemon, so it works with no daemon and before the daemon's own check has polled — and so `update.check: false` (§12.3) stays a literal promise. A binary a package manager owns is never modified: the channel is detected from the resolved `os.Executable()` path and its upgrade command is printed. A binary vincent owns is verified before anything runs (§16) and swapped in place; on any failure nothing is replaced. `--check`: exit 0 up to date · 1 the check failed · 2 an update is available. Otherwise: 0 nothing to do or swapped · 1 verification or the swap failed and the binary is untouched · 2 an update exists but this install is package-managed. `--json` carries `swapped`, which separates the two 0s |
+| `vincent skills ls / install [name...]` | *Added 2026-09-10 (task 095).* Lists the agent skills this repository publishes with the version shipped, the version installed in the global skills store and the agents each is linked into, and installs them (§9.8). **It never talks to the daemon**, so it cannot exit 2: detection is a filesystem read that works with no node on the machine, and the install writes into the invoking user's own agent directories — nothing daemon-owned, which is why the write is here and not behind `doctor --fix`. `install` shells out to `npx skills add … --agent <slugs> --yes --global`; with no name it installs everything not already current, `--agent` narrows the selection. Both carry `--json`. Exit 0 fine · 1 an install failed, `npx` missing included |
 | `vincent version` | Build info |
 
 *Added 2026-08-26 (task 035).* `vincent task add --github-issue <n>` creates a
@@ -7884,6 +8001,29 @@ already run vincent, and a decline is remembered in `tui.json`
 this view opens is one somebody answers by not reading it. Once installed, the
 line says so, which is the only place the removal is discoverable.
 
+**`S` in the daemon view (task 095, added 2026-09-10).** The second key that
+leads outside vincent's own directories, and the second built on the shape
+above: a line under the adapters says how many of the skills of §9.8 are not
+installed, `S` opens a takeover listing them with the **exact `npx` command**
+each install runs, `enter` runs it, `n` is remembered in `tui.json`
+(`skills_declined`) and nothing re-asks while it is set. Once everything is
+current the line still says so, which is where `S` stays discoverable — the
+same rule the status-line line follows.
+
+It is `S` and not `i`. Both keys lead to a write outside vincent's directories,
+but they are two different operations on two different targets, and §15's key
+vocabulary lets a key be shared only where it means the same operation. `s` was
+unavailable: it is the vocabulary's "cycle a listing's scope".
+
+Two things differ from the status-line flow, and both come from what is being
+run. The state it reports comes off the `GET /v1/doctor` report this view
+already fetches rather than from a local read, so the TUI still holds no state
+the daemon does not — only the decline flag is local, exactly as the
+status-line flow already splits it. And the write is a subprocess that
+downloads a package rather than a file rewrite, so it runs off the event loop
+with the screen saying what is running: a TUI frozen on a network install is a
+TUI that cannot be quit.
+
 **Grouping (task 009, added 2026-08-16).** The task table nests its rows under
 group headers, `[project, workflow]` by default: a board with more than one
 repository on it is read project by project, and within one project the workflow
@@ -9023,6 +9163,15 @@ global cursor config is untouched.
   and orphan count** (§10). Retention above prunes transcripts and never rows,
   so unbounded growth is a real outcome; `--fix` is what reclaims it, and both
   its writes are the daemon's.
+
+  *Amended 2026-09-10 (task 095).* The report grows a `skills` group (§9.8): the
+  agent skills this repository publishes, with the version shipped, the version
+  installed in the global store and the agents each is linked into. It is a
+  **row, not a problem** — the closed unhealthy set of task 005 decision 7 does
+  not move for it, `vincent doctor` still exits 0 with every skill missing, and
+  the repair lives in `vincent skills install` rather than in `--fix` because it
+  is a client-side write into the user's own agent directories and every `--fix`
+  repair is a daemon-owned one.
 
   *Amended 2026-08-15 (task 005).* Retention is about **archived rows**: the pruner
   walks `archived_at`, so a transcript directory whose row was cascade-deleted with its

--- a/docs/tasks/095-published-skill-installation.md
+++ b/docs/tasks/095-published-skill-installation.md
@@ -1,0 +1,191 @@
+# 095 — Report whether the published skills are installed, and install them
+
+**Status:** ✅ done (10/10)
+**Issue:** #357
+**Amends:** new §9.8 "Published skills"; §9.5 (one sentence closing the facet
+set at five); §12.1 (the `vincent skills` row); §15 (the `S` offer beside the
+status-line one); §17 (the doctor group). All dated 2026-09-10, in place.
+**Keeps, without relitigating:**
+[041](041-agent-health-facets.md) — the §9.5 facet vocabulary stays at five.
+[006](006-doctor.md) decision 7 — doctor's unhealthy set stays closed.
+[082](082-reported-agent-quota.md) decision 2 — vincent may write another
+tool's configuration file when a human asks it to, on a screen that shows
+exactly what it will write.
+The v0 **T1.7 decision** ("no state-file parsing") — not reopened; see below.
+
+## The problem
+
+vincent published a skill — `skills/vincent-workflows/` — and nothing in the
+product ever looked at whether anybody had it. The only install path was a
+command a human had to find in prose (`README.md`, `docs/guides/workflows.md`)
+and run by hand. `grep -ri skill internal/` found one consumer: `builtin.go`
+splicing the embedded `SKILL.md` into two built-in prompts.
+
+So the gap bit exactly where it was hardest to notice. A run *inside* vincent
+was fine — `create-workflow` and `update-workflows` carry the skill's text in
+their own prompts — and a user talking to their own agent directly, which is
+where a workflow actually gets written, got no help and no way to learn that
+help existed. An installed copy then went stale invisibly, because the skill
+carried no version marker of any kind.
+
+## Decisions
+
+1. **Install shells out to `npx skills add`, with `-a` and `-y` added**
+   (2026-09-10). vincent runs `npx skills add lezli01/vincent --skill <name>
+   --agent <slugs> --yes --global`, not the published command verbatim, because
+   the published command opens an interactive agent multi-select and there is
+   nothing to pick with from a TUI takeover or a non-TTY CLI. The agent list
+   defaults to the vincent adapters detected on the box, mapped through the slug
+   table in §9.8.
+
+   Beat: **writing the skill files ourselves from the embedded copy.** The
+   issue rejected it partly on "vincent does not write into another tool's
+   config directory itself", which is *not true of this codebase* — task 082
+   decision 2 writes `~/.claude/settings.json` and says so in as many words. The
+   rejection stands on its other reason: `skills/embed.go` embeds only
+   `SKILL.md`, so doing it means embedding `references/`, `LICENSE.txt` and
+   `agents/openai.yaml` too and reimplementing another tool's install layout,
+   symlink/copy split included.
+
+   Consequence accepted: the command in `README.md` /
+   `docs/guides/workflows.md` and the command vincent runs are two spellings of
+   one thing and must be kept in sync. `TestInstallArgs` and
+   `TestInstallArgvReachesTheProcess` are what catch them drifting; `npx` is a
+   runtime dependency of the **install action only**.
+
+2. **Detection never uses `npx`** (2026-09-10). It is a filesystem read: the
+   store copy at `~/.agents/skills/<name>/SKILL.md` for the version, each agent
+   directory for whether it is linked. That is what makes it work in `doctor`,
+   in the TUI, and on a machine with no node at all — proved by
+   `TestDetectNeedsNoNpx` and by the CLI test that lists state with an empty
+   `PATH` right after an install failed for want of `npx`.
+
+3. **One row per skill, carrying the agent list** (2026-09-10) — not a row per
+   adapter per skill. `skills add … -g` keeps one copy in a global store and
+   links it into each agent's directory, so a per-adapter version column would
+   be the same string three times by construction. The row reads: name, shipped
+   version, store state, and the agents it is linked into.
+
+   The agent list is discovered by **scanning the home directory** rather than
+   from a table of paths. A table would have to assert install locations for
+   agents this repository cannot verify; a scan reports what is there. It names
+   agents vincent does not drive — one store serves Cline, Copilot, Zed and the
+   rest — which is honest rather than noisy.
+
+4. **The row is not a sixth §9.5 facet** (2026-09-10). Task 041 closed that
+   vocabulary at five, and a skill is a property of the machine's agent
+   configuration rather than of an adapter binary: one copy serves every agent,
+   and a machine with no adapter installed can still hold it. The skills group
+   sits beside the agents group, and §9.5 gained one sentence saying so, so the
+   closed set stays closed.
+
+5. **Nothing here moves an exit code** (2026-09-10). Task 006 decision 7's
+   unhealthy set stays closed: a missing, stale or unreadable skill is a row, on
+   the GitHub (035), release-check (055) and container (061) precedents.
+   `vincent doctor` still exits 0. `TestSkillsAreNeverAProblem` pins it with all
+   five bad states at once.
+
+6. **`metadata.version`, enforced by a test** (2026-09-10). The marker goes
+   under the `metadata:` key the front matter already uses for `author`, because
+   that is the format's extension point and a bare top-level `version:` is not a
+   key the skills format defines — a validator rejecting unknown top-level keys
+   would break the published skill. `skills/version_test.go` hashes each
+   published tree and fails with "bump `metadata.version`" when the content
+   moved and the version did not, because `references/*.md` goes stale on its
+   own and a hand bump is forgotten. The version lives inside `SKILL.md`, so
+   bumping it moves the hash too: the test cannot be satisfied by editing one of
+   the two.
+
+7. **Comparison is semver, and never a guess** (2026-09-10).
+   `golang.org/x/mod/semver` was already a direct dependency
+   (`internal/release`). Where either side does not parse, the row says the
+   versions **differ** and prints both; it claims no direction. This mirrors
+   §9.5's tri-state discipline rather than its exact-string-equality rule, which
+   cannot answer "older". `newer` is its own state, not folded into `current`: a
+   downgraded binary must not report an up-to-date skill.
+
+8. **The TUI surface is a daemon-view offer, on task 082's pattern**
+   (2026-09-10) — not a firstrun-style blocking notice. A line under the
+   adapters, a takeover showing the exact command, and a decline persisted in
+   `tui.json` beside `StatusLineDeclined`; nothing re-asks while it is set. The
+   offer is actionable only because decision 1 made the install
+   non-interactive.
+
+   **The key is `S`, not `i`** (2026-09-10). The brief left this to the diff.
+   Both keys lead to a write outside vincent's own directories, but they are two
+   different operations on two different targets, and clause 1 of §15's key
+   vocabulary lets a key be shared only where it means the same operation. `s`
+   was unavailable — it is the vocabulary's "cycle a listing's scope" — and `S`
+   carries no term. The flow is its own binding context (`ctxSkills`) for the
+   reason the config editor's keys are their own: while it is open it owns the
+   keyboard, and `n` means "not now" in there and nothing at all outside it.
+
+   One thing differs from the status-line flow, and it comes from what is being
+   run: that flow rewrites a small local file synchronously, this one spawns a
+   subprocess that downloads a package. So the install runs off the event loop
+   in a `tea.Cmd`, with the screen saying what is running. A TUI frozen on a
+   network install is a TUI that cannot be quit.
+
+9. **Detection is composed by `internal/doctor`, like every other local probe**
+   (2026-09-10). Task 006 decision 6 gives that package every probe needing no
+   database, so the group is composed server-side when a daemon answers and
+   client-side when none does — identical results, because vincent's daemon is
+   localhost and runs as the invoking user. The TUI reads the group off the
+   `GET /v1/doctor` report its daemon view already fetches; only the decline
+   flag is local, exactly as the status-line flow already splits it.
+
+10. **Enumeration is generic** (2026-09-10). `skills/embed.go` grows an
+    `embed.FS` over `*/SKILL.md`, and nothing enumerates names in Go. A second
+    directory under `skills/` appears in doctor, the command and the TUI with no
+    code change. `TestPublishEnumeratesGenerically` proves it against an
+    injected `fs.FS` rather than by adding a second real skill.
+
+## The v0 T1.7 decision is not reopened
+
+T1.7 forbids inferring another tool's **authentication** from its private state
+files. `~/.agents/skills/` and `~/.<agent>/skills/` are a public CLI's
+documented install locations, and the file read out of them is one this
+repository published. §9.8 says this out loud rather than leaving the adjacency
+for somebody to notice later and file.
+
+## Two things a reader will trip over
+
+- **vincent disagrees with `npx skills list -g`.** On the machine this was
+  probed on, that command reported vincent-workflows installed for "Claude Code,
+  Cline, Codex, Cursor, GitHub Copilot +4" while only three directories held a
+  link. That column is the CLI's *selection memory*
+  (`lastSelectedAgents` in `~/.agents/.skill-lock.json`), not an on-disk fact.
+  vincent reports the links. This is written down so the first person to notice
+  does not file it as a bug. The lock file also carries no version at all, which
+  is why decision 6's marker is needed rather than reusable from it.
+
+- **Whether codex and cursor actually read those directories is unconfirmed.**
+  The path table is the `skills` CLI's and says where that CLI *writes*. This
+  work could not confirm what each agent then does with it, so §9.8 records the
+  limitation instead of asserting the capability — the standing §9 rule that a
+  capability an adapter lacks is documented and ignored, never emulated. The
+  skill ships `agents/openai.yaml` for codex-side packaging; beyond that vincent
+  reports what is on disk and claims nothing about what reads it.
+
+## No gate script
+
+An acceptance gate drives a real daemon over curl against the fake agent. A
+skills assertion would depend on the host's home directory and on network
+access to npm, and a gate that installs into the CI runner's home is a gate that
+fails differently on three platforms. Go tests with an injected home root cover
+it, and `docs/gates/` records no manual leg — the same reason, and the same
+answer, as task 082.
+
+## Where it lives
+
+| Path | What |
+|---|---|
+| `skills/embed.go` | `//go:embed */SKILL.md` → `FS`. `VincentWorkflows` stays for `builtin.go` |
+| `skills/version_test.go` | Decision 6's drift guard |
+| `skills/vincent-workflows/SKILL.md` | `metadata.version`. Front matter is stripped by both built-in consumers, so no prompt changed |
+| `internal/skill` | The leaf: front-matter parse, the adapter→slug→directory table, `Detect` (pure filesystem), `Install` (the `npx` argv, `exec.LookPath` for the missing-dependency outcome) |
+| `internal/doctor/skills.go` | The `Skills` group on `Report`; `Evaluate` untouched |
+| `internal/apiclient/doctor.go` | `DoctorSkill` alias and the state constants |
+| `internal/cli/skills.go` | `vincent skills ls` / `install`, both `--json`, no exit 2 |
+| `internal/cli/doctor.go` | The `SKILLS` group |
+| `internal/tui/skillsflow.go`, `skills.go`, `daemon.go`, `daemonrender.go`, `bindings.go` | The `S` offer and its decline flag |

--- a/docs/tasks/095-published-skill-installation.md
+++ b/docs/tasks/095-published-skill-installation.md
@@ -104,6 +104,14 @@ carried no version marker of any kind.
    cannot answer "older". `newer` is its own state, not folded into `current`: a
    downgraded binary must not report an up-to-date skill.
 
+   *Settled in the diff:* a copy that reads perfectly and carries **no**
+   `metadata.version` is `older`, not `unreadable`. It is every copy installed
+   before this change shipped, and the marker's absence is itself the
+   direction. It was `unreadable` until the command was run against a real
+   machine, where it made the one state every existing user would see the one
+   state that sounds like a fault. `unreadable` now means only what it says: a
+   `SKILL.md` that could not be read or parsed.
+
 8. **The TUI surface is a daemon-view offer, on task 082's pattern**
    (2026-09-10) — not a firstrun-style blocking notice. A line under the
    adapters, a takeover showing the exact command, and a decline persisted in

--- a/docs/tasks/095-published-skill-installation.md
+++ b/docs/tasks/095-published-skill-installation.md
@@ -34,9 +34,20 @@ carried no version marker of any kind.
    (2026-09-10). vincent runs `npx skills add lezli01/vincent --skill <name>
    --agent <slugs> --yes --global`, not the published command verbatim, because
    the published command opens an interactive agent multi-select and there is
-   nothing to pick with from a TUI takeover or a non-TTY CLI. The agent list
-   defaults to the vincent adapters detected on the box, mapped through the slug
-   table in §9.8.
+   nothing to pick with from a TUI takeover or a non-TTY CLI. The agent list is
+   mapped through the slug table in §9.8.
+
+   *Settled in the diff (2026-09-10): the two surfaces answer the picker
+   differently.* The plan said "defaults to the adapters detected on the box"
+   for both; what shipped is the **CLI** defaulting to all three, with `--agent`
+   to narrow, and the **TUI** answering with the adapters the daemon reported.
+   The split is the right one and is why it stands: a person who typed
+   `vincent skills install` has stated an intent that a detection miss should
+   not quietly shrink — an adapter installed after vincent last looked, or one
+   `PATH` does not carry in this shell, would silently drop out of the
+   selection — and the flag is right there. The TUI offer is one keypress on a
+   screen that is already showing which adapters were found, so narrowing it
+   there costs the user nothing and asserts nothing.
 
    Beat: **writing the skill files ourselves from the embedded copy.** The
    issue rejected it partly on "vincent does not write into another tool's

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -108,6 +108,7 @@ the living engineering specification records implementation contracts.
 | [092](092-archived-boards-and-delete.md) | Archived boards for tasks and chats, with a permanent delete of an archived row | ✅ done (7/7) |
 | [093](093-tui-key-vocabulary.md) | A key vocabulary for the TUI, one operation to one key, enforced by the binding registry | ✅ done (6/6) |
 | [094](094-footer-width-and-hidden-keys.md) | The footer fills its width, and a `+N` says how many keys it is hiding | ✅ done (5/5) |
+| [095](095-published-skill-installation.md) | Report whether vincent's published skills are installed, and install them | ✅ done (10/10) |
 
 ## How to add and update a task document
 

--- a/internal/apiclient/doctor.go
+++ b/internal/apiclient/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/lezli01/vincent/internal/doctor"
+	"github.com/lezli01/vincent/internal/skill"
 )
 
 // The doctor wire types below are **aliases**, not copies (task 005
@@ -42,6 +43,9 @@ type DoctorGitHub = doctor.GitHub
 
 // DoctorContainer is the report's container-execution row (§16, task 061).
 type DoctorContainer = doctor.Container
+
+// DoctorSkill is one published skill's installation state (§9.8, task 095).
+type DoctorSkill = doctor.Skill
 
 // DoctorUpdate is the report's release-check row (task 055).
 type DoctorUpdate = doctor.Update
@@ -119,3 +123,13 @@ func (c *Client) DoctorFix(ctx context.Context, force bool) (*DoctorFixResult, e
 	}
 	return &res, nil
 }
+
+// Published-skill states a DoctorSkill.State carries (§9.8, task 095).
+const (
+	SkillAbsent     = skill.StateAbsent
+	SkillCurrent    = skill.StateCurrent
+	SkillOlder      = skill.StateOlder
+	SkillNewer      = skill.StateNewer
+	SkillDiffers    = skill.StateDiffers
+	SkillUnreadable = skill.StateUnreadable
+)

--- a/internal/apiclient/doctor_live_test.go
+++ b/internal/apiclient/doctor_live_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -219,5 +220,43 @@ func TestDoctorNeedsAuth(t *testing.T) {
 	}
 	if _, err := unauth.DoctorFix(t.Context(), false); err == nil {
 		t.Fatal("DoctorFix succeeded without a valid token")
+	}
+}
+
+// TestDoctorSkillsRoundTrip is what keeps the DoctorSkill alias honest: the
+// §9.8 group is composed by the daemon, serialized by the real handler and
+// read back by the real client (task 095 decision 9).
+//
+// It asserts the shape and not the state. Whether the skill is installed is a
+// fact about the machine running the test — this developer's has it, CI's
+// does not — and a suite that asserted either would be red on one of them.
+func TestDoctorSkillsRoundTrip(t *testing.T) {
+	c, _ := newDoctorClient(t)
+	rep, err := c.Doctor(t.Context(), true)
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if len(rep.Skills) == 0 {
+		t.Fatal("the skills group did not survive the wire; this build publishes at least one")
+	}
+	for _, s := range rep.Skills {
+		if s.Name == "" || s.State == "" || s.Shipped == "" || s.StorePath == "" {
+			t.Errorf("skill row lost fields on the wire: %+v", s)
+		}
+		switch s.State {
+		case apiclient.SkillAbsent, apiclient.SkillCurrent, apiclient.SkillOlder,
+			apiclient.SkillNewer, apiclient.SkillDiffers, apiclient.SkillUnreadable:
+		default:
+			t.Errorf("%s: state %q is not one this build defines", s.Name, s.State)
+		}
+		if s.Links == nil {
+			t.Errorf("%s: links came back null rather than an empty list", s.Name)
+		}
+	}
+	// Nothing a skill row can say is a problem (decision 5).
+	for _, p := range rep.Problems {
+		if strings.Contains(strings.ToLower(p.Message), "skill") {
+			t.Errorf("a skill produced a problem: %+v", p)
+		}
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,7 +41,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(
 		newDaemonCmd(), newVersionCmd(), newDoctorCmd(),
 		newProjectCmd(), newTaskCmd(), newChatCmd(), newWorkflowCmd(), newServiceCmd(),
-		newGCCmd(), newGitHubCmd(), newStatusCmd(), newStatusLineCmd(), newUpdateCmd(),
+		newGCCmd(), newGitHubCmd(), newSkillsCmd(), newStatusCmd(), newStatusLineCmd(), newUpdateCmd(),
 		newConfigCmd(),
 	)
 	return root

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -223,6 +223,7 @@ func doctorGroups(rep *apiclient.DoctorReport) []doctorGroup {
 		{"AGENTS", doctorAgentRows(rep.Agents)},
 		{"GITHUB", doctorGitHubRows(rep.GitHub)},
 		{"CONTAINER", doctorContainerRows(rep.Container)},
+		{"SKILLS", doctorSkillRows(rep.Skills)},
 		{"UPDATE", doctorUpdateRows(rep.Update)},
 		{"STORAGE", doctorStorageRows(rep.Storage)},
 		{"TASKS", doctorTaskRows(rep.Tasks)},
@@ -535,6 +536,43 @@ func doctorContainerRows(c apiclient.DoctorContainer) [][]string {
 			", but the task is blocked before a worktree is created"})
 	default:
 		rows = append(rows, []string{"steps", "run on this host (container.image is unset)"})
+	}
+	return rows
+}
+
+// doctorSkillRows renders the published-skill group (§9.8, task 095).
+//
+// One row per skill and not one per agent per skill: `skills add` keeps a
+// single copy in a global store and links it into each agent's directory, so
+// a per-agent version column would be the same string three times (decision
+// 3). The agents column is what is on disk — it can name agents vincent does
+// not drive, and it can disagree with `npx skills list -g`, which reports the
+// selection that CLI remembers rather than the links it left.
+//
+// It follows the GitHub and container rows' rule: nothing here is a Problem
+// and none of it changes the exit code (decision 5). A missing skill costs a
+// user help in their own agent session; it breaks no vincent run, because the
+// built-in workflows carry the skill's text in their own prompts.
+func doctorSkillRows(skills []apiclient.DoctorSkill) [][]string {
+	if len(skills) == 0 {
+		return [][]string{{"skills", "none published by this build"}}
+	}
+	rows := make([][]string, 0, len(skills)+1)
+	missing := false
+	for _, s := range skills {
+		state := skillStateWord(s)
+		if agents := s.Agents(); len(agents) > 0 {
+			state += "  ·  linked into " + strings.Join(agents, ", ")
+		} else {
+			state += "  ·  linked into nothing"
+		}
+		if s.State != apiclient.SkillCurrent {
+			missing = true
+		}
+		rows = append(rows, []string{s.Name, state})
+	}
+	if missing {
+		rows = append(rows, []string{"install", "run: vincent skills install"})
 	}
 	return rows
 }

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -175,11 +175,11 @@ func skillStateWord(s skill.Status) string {
 	case skill.StateAbsent:
 		return "not installed"
 	case skill.StateOlder:
-		return "out of date: installed " + s.Installed + ", ships " + s.Shipped
+		return "out of date: installed " + s.InstalledLabel() + ", ships " + s.Shipped
 	case skill.StateNewer:
-		return "installed " + s.Installed + " is newer than the " + s.Shipped + " this binary ships"
+		return "installed " + s.InstalledLabel() + " is newer than the " + s.Shipped + " this binary ships"
 	case skill.StateDiffers:
-		return "differs: installed " + dash(s.Installed) + ", ships " + dash(s.Shipped)
+		return "differs: installed " + s.InstalledLabel() + ", ships " + dash(s.Shipped)
 	default:
 		return s.State + ": " + s.Message
 	}

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lezli01/vincent/internal/skill"
+)
+
+// `vincent skills` (§9.8, §12.1, task 095): what this binary publishes, what
+// is on this machine, and the one command that closes the gap.
+//
+// **It never talks to the daemon**, and so it never exits 2. Installing a
+// skill writes into the invoking user's own agent directories on the client
+// machine — there is nothing daemon-owned about it, no database row and no
+// worktree — which is exactly why the write lives here and not behind
+// `doctor --fix`, where every repair is a daemon-owned write. `vincent
+// update` and `vincent daemon logs` are the same shape: 0 fine, 1 the
+// operation failed, and no third code because no request was ever made.
+func newSkillsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skills",
+		Short: "Report and install the agent skills vincent publishes",
+		Long: "Report whether the agent skills this repository publishes are installed " +
+			"for your coding agents, and install them (§9.8).\n\n" +
+			"vincent publishes skills so that an agent you are talking to directly — " +
+			"outside a vincent run — knows how to author a vincent workflow. The " +
+			"built-in create-workflow and update-workflows workflows do not need this: " +
+			"they carry the skill's text inside their own prompts.\n\n" +
+			"Nothing here needs a running daemon. Detection is a filesystem read and " +
+			"works on a machine with no node installed; only `install` shells out, to " +
+			"`npx skills add`.",
+	}
+	cmd.AddCommand(newSkillsListCmd(), newSkillsInstallCmd())
+	return cmd
+}
+
+func newSkillsListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List the published skills and whether they are installed",
+		Long: "List every skill this binary publishes with the version it ships, the " +
+			"version installed in the global skills store, and the agents it is " +
+			"linked into.\n\n" +
+			"The agent list is what is on disk. It can name agents vincent does not " +
+			"drive — one store serves every agent on the machine — and it can disagree " +
+			"with `npx skills list -g`, which reports the selection the CLI remembers " +
+			"rather than the links it left behind.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			statuses := skill.Detect(skill.Options{})
+			if wantJSON(cmd) {
+				return emitJSON(cmd.OutOrStdout(), statuses)
+			}
+			rows := make([][]string, 0, len(statuses))
+			for _, s := range statuses {
+				rows = append(rows, []string{
+					s.Name, dash(s.Shipped), skillStateWord(s), dash(strings.Join(s.Agents(), ", ")),
+				})
+			}
+			return table(cmd.OutOrStdout(), []string{"SKILL", "SHIPPED", "STATE", "AGENTS"}, rows)
+		},
+	}
+	jsonFlag(cmd)
+	return cmd
+}
+
+func newSkillsInstallCmd() *cobra.Command {
+	var adapters []string
+	cmd := &cobra.Command{
+		Use:   "install [name...]",
+		Short: "Install the published skills for your agents",
+		Long: "Install the named skills — or every published skill that is not already " +
+			"current — into the global skills store, linked into each agent's " +
+			"directory.\n\n" +
+			"This runs `npx skills add` with the agent selection supplied, because the " +
+			"published command with no selection opens an interactive picker and there " +
+			"is nothing to pick with here. It needs node on PATH and, on a first run, " +
+			"network: the package is downloaded before it does anything. Without npx " +
+			"the command exits 1 naming the dependency and printing the line to run " +
+			"once node is there — detection is unaffected either way.\n\n" +
+			"Exit codes: 0 everything asked for is installed, 1 an install failed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSkillsInstall(cmd, args, adapters)
+		},
+	}
+	cmd.Flags().StringSliceVar(&adapters, "agent", nil,
+		"Adapters to install for (repeatable, comma-separated): "+
+			strings.Join(skill.Adapters(), ", ")+". Default: all of them")
+	jsonFlag(cmd)
+	return cmd
+}
+
+// skillsInstallResult is one skill's outcome, and the --json shape.
+type skillsInstallResult struct {
+	Skill   string `json:"skill"`
+	Command string `json:"command"`
+	OK      bool   `json:"ok"`
+	Error   string `json:"error,omitempty"`
+}
+
+func runSkillsInstall(cmd *cobra.Command, args, adapters []string) error {
+	statuses := skill.Detect(skill.Options{})
+	names := args
+	if len(names) == 0 {
+		names = skill.Missing(statuses)
+	}
+	slugs := skill.Slugs(adapters)
+	out := cmd.OutOrStdout()
+	results := make([]skillsInstallResult, 0, len(names))
+	if len(names) == 0 && !wantJSON(cmd) {
+		if _, err := fmt.Fprintln(out, "every published skill is already current"); err != nil {
+			return err
+		}
+	}
+	failed := false
+	for _, name := range names {
+		res := skillsInstallResult{Skill: name, Command: skill.Command(name, slugs)}
+		// The progress line goes out before the run, not after: a first `npx`
+		// downloads the package, so a command that printed nothing would look
+		// hung for as long as that takes.
+		if !wantJSON(cmd) {
+			if _, err := fmt.Fprintf(out, "installing %s — running %s\n", name, res.Command); err != nil {
+				return err
+			}
+		}
+		// The CLI's own output is streamed only in the table mode; --json
+		// must stay a single parseable document.
+		sink := out
+		if wantJSON(cmd) {
+			sink = cmd.ErrOrStderr()
+		}
+		if err := skill.Install(cmd.Context(), name, slugs, sink); err != nil {
+			res.Error = err.Error()
+			failed = true
+		} else {
+			res.OK = true
+		}
+		results = append(results, res)
+	}
+	if wantJSON(cmd) {
+		if err := emitJSON(out, results); err != nil {
+			return err
+		}
+	} else {
+		for _, r := range results {
+			if r.OK {
+				if _, err := fmt.Fprintf(out, "installed %s\n", r.Skill); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\n", r.Skill, r.Error); err != nil {
+				return err
+			}
+		}
+	}
+	if failed {
+		// Exit 1 and not 2: no daemon was asked, so "the daemon is not
+		// running" is not a thing this command can mean.
+		return exitError{code: 1}
+	}
+	return nil
+}
+
+// skillStateWord renders one row's state for a human, carrying both versions
+// wherever the state is about a difference between them.
+func skillStateWord(s skill.Status) string {
+	switch s.State {
+	case skill.StateCurrent:
+		return "installed and current"
+	case skill.StateAbsent:
+		return "not installed"
+	case skill.StateOlder:
+		return "out of date: installed " + s.Installed + ", ships " + s.Shipped
+	case skill.StateNewer:
+		return "installed " + s.Installed + " is newer than the " + s.Shipped + " this binary ships"
+	case skill.StateDiffers:
+		return "differs: installed " + dash(s.Installed) + ", ships " + dash(s.Shipped)
+	default:
+		return s.State + ": " + s.Message
+	}
+}

--- a/internal/cli/skills_test.go
+++ b/internal/cli/skills_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/skill"
+)
+
+// fakeHome points os.UserHomeDir at a temp directory. Both variables are set
+// because the two platforms read different ones, and a test that isolated
+// only $HOME would run against the developer's real agent directories on
+// Windows.
+func fakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	return home
+}
+
+// runSkills executes one `vincent skills …` invocation in-process and returns
+// its stdout, stderr and exit code.
+func runSkills(t *testing.T, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	cmd := newSkillsCmd()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errOut.String(), asExitCode(err)
+}
+
+// TestSkillsListReportsState is the no-daemon promise: with an empty home and
+// nothing on PATH, the command still answers, and it answers "not installed"
+// rather than failing.
+func TestSkillsListReportsState(t *testing.T) {
+	fakeHome(t)
+	t.Setenv("PATH", t.TempDir())
+	out, _, code := runSkills(t, "ls", "--json")
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, out)
+	}
+	var rows []skill.Status
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("--json is not parseable: %v\n%s", err, out)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no rows; this build publishes at least one skill")
+	}
+	for _, r := range rows {
+		if r.State != skill.StateAbsent {
+			t.Errorf("%s = %q against an empty home, want %q", r.Name, r.State, skill.StateAbsent)
+		}
+		if r.Shipped == "" {
+			t.Errorf("%s reports no shipped version", r.Name)
+		}
+	}
+}
+
+// TestSkillsInstallWithoutNpx is decision 1's missing-dependency outcome, end
+// to end: exit 1 — never 2, because no daemon was asked — a message naming
+// the dependency and carrying the command, and a listing in the same test
+// that is entirely unaffected.
+func TestSkillsInstallWithoutNpx(t *testing.T) {
+	fakeHome(t)
+	t.Setenv("PATH", t.TempDir())
+
+	out, errOut, code := runSkills(t, "install")
+	if code != 1 {
+		t.Fatalf("exit %d, want 1\nstdout: %s\nstderr: %s", code, out, errOut)
+	}
+	if !strings.Contains(errOut, "npx is not installed") {
+		t.Errorf("stderr does not name the dependency: %q", errOut)
+	}
+	if !strings.Contains(errOut, "npx skills add "+skill.Repo) {
+		t.Errorf("stderr does not carry the command to run once node is there: %q", errOut)
+	}
+	if strings.Contains(errOut, "npx.cmd") {
+		t.Errorf("the message names the resolved binary rather than the dependency: %q", errOut)
+	}
+
+	// Detection's independence from npx is a test, not a claim.
+	lsOut, _, lsCode := runSkills(t, "ls")
+	if lsCode != 0 {
+		t.Fatalf("ls exited %d after a failed install", lsCode)
+	}
+	if !strings.Contains(lsOut, "not installed") {
+		t.Errorf("ls stopped reporting state: %q", lsOut)
+	}
+}
+
+// TestSkillsInstallNothingToDo: an install with everything already current
+// runs no subprocess and exits 0.
+func TestSkillsInstallNothingToDo(t *testing.T) {
+	home := fakeHome(t)
+	t.Setenv("PATH", t.TempDir())
+	for _, p := range skill.Publish(nil) {
+		dir := home + string(os.PathSeparator) + skill.StoreDir +
+			string(os.PathSeparator) + "skills" + string(os.PathSeparator) + p.Path
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "---\nname: " + p.Name + "\nmetadata:\n  version: " + p.Version + "\n---\n"
+		if err := os.WriteFile(dir+string(os.PathSeparator)+"SKILL.md", []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out, errOut, code := runSkills(t, "install")
+	if code != 0 {
+		t.Fatalf("exit %d: %s %s", code, out, errOut)
+	}
+	if !strings.Contains(out, "already current") {
+		t.Errorf("stdout = %q", out)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -75,7 +75,13 @@ type Report struct {
 	// not problems**: neither a newer release nor a stale daemon changes the
 	// exit code, because both leave everything working. A user who declines
 	// to update should not have a diagnostic that exits 1 forever.
-	Update  Update  `json:"update"`
+	Update Update `json:"update"`
+	// Skills is the published-skill row (§9.8, task 095): whether the agent
+	// skills this repository publishes are installed on this machine, and
+	// which agents they are linked into. It sits beside the agents group
+	// rather than in it (decision 4) and, like the three rows above, is a
+	// row and not a problem.
+	Skills  []Skill `json:"skills"`
 	Storage Storage `json:"storage"`
 	Tasks   Tasks   `json:"tasks"`
 	// Problems is the closed set of findings that make `vincent doctor` exit
@@ -404,6 +410,7 @@ func Compose(ctx context.Context, opts Options) *Report {
 	r.GitHub = DetectGitHub(ctx, cfg)
 	r.Container = DetectContainer(ctx, cfg)
 	r.Update = updateRow(cfg, opts.Update, r.Daemon.Version)
+	r.Skills = DetectSkills()
 	r.Storage = inspectStorage(ctx, opts)
 	r.Evaluate()
 	return r

--- a/internal/doctor/skills.go
+++ b/internal/doctor/skills.go
@@ -1,0 +1,27 @@
+package doctor
+
+import "github.com/lezli01/vincent/internal/skill"
+
+// Skill is one published skill's installation state (§9.8, task 095). It is
+// an alias rather than a copy for the reason internal/apiclient aliases the
+// whole report: internal/skill owns the vocabulary, and a second declaration
+// of it here would be a second definition of the same document.
+//
+// The group sits **beside** the agents group rather than inside it. Task 041
+// closed the §9.5 facet vocabulary at five, and a skill is a property of the
+// machine's agent configuration rather than of an adapter binary — a machine
+// with no adapter installed can still hold the skill, and one copy in the
+// store serves every agent at once (decision 4).
+//
+// Like GitHub, Container and Update it is a **row, not a problem**: a missing,
+// stale or unreadable skill leaves everything working — the built-in
+// `create-workflow` and `update-workflows` prompts carry the skill's text
+// themselves — so none of it moves `vincent doctor`'s exit code (decision 5).
+type Skill = skill.Status
+
+// DetectSkills reads the installation state off the filesystem. It runs no
+// subprocess and opens no socket, which is what lets it answer identically on
+// the daemon and in a client with no daemon (decision 9).
+func DetectSkills() []Skill {
+	return skill.Detect(skill.Options{})
+}

--- a/internal/doctor/skills_test.go
+++ b/internal/doctor/skills_test.go
@@ -1,0 +1,60 @@
+package doctor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/config"
+	"github.com/lezli01/vincent/internal/skill"
+)
+
+// TestSkillsAreNeverAProblem is decision 5: the closed unhealthy set (task
+// 005 decision 7) stays closed. Every skill missing, stale, ahead of this
+// build and unreadable at once, and `vincent doctor` still exits 0 — the
+// built-in workflows carry the skill's text in their own prompts, so nothing
+// a row here can say stops a task from running.
+func TestSkillsAreNeverAProblem(t *testing.T) {
+	r := &Report{Skills: []Skill{
+		{Name: "a", State: skill.StateAbsent},
+		{Name: "b", State: skill.StateOlder, Installed: "1.0.0", Shipped: "2.0.0"},
+		{Name: "c", State: skill.StateNewer, Installed: "3.0.0", Shipped: "2.0.0"},
+		{Name: "d", State: skill.StateUnreadable, Message: "cannot read SKILL.md"},
+		{Name: "e", State: skill.StateDiffers, Installed: "wednesday", Shipped: "2.0.0"},
+	}}
+	r.Evaluate()
+	if len(r.Problems) != 0 {
+		t.Fatalf("skills produced problems: %+v", r.Problems)
+	}
+	if !r.Healthy() {
+		t.Error("a report whose only findings are skill rows is not healthy")
+	}
+}
+
+// TestComposeFillsTheSkillsGroup proves the group is composed client-side,
+// with no daemon and no database (decision 9). What the rows *say* depends on
+// the machine the test runs on, so nothing here asserts a state — only that
+// every published skill has one.
+func TestComposeFillsTheSkillsGroup(t *testing.T) {
+	dir := t.TempDir()
+	rep := Compose(context.Background(), Options{
+		Dirs:   config.Dirs{Config: dir, Data: dir},
+		Daemon: Daemon{Status: StatusNotRunning},
+	})
+	if len(rep.Skills) == 0 {
+		t.Fatal("no skills group; this build publishes at least one skill")
+	}
+	for _, s := range rep.Skills {
+		if s.State == "" {
+			t.Errorf("%s has no state", s.Name)
+		}
+		if s.Shipped == "" {
+			t.Errorf("%s reports no shipped version", s.Name)
+		}
+		if s.StorePath == "" {
+			t.Errorf("%s reports no store path", s.Name)
+		}
+	}
+	if len(rep.Problems) != 0 {
+		t.Errorf("a local compose produced problems: %+v", rep.Problems)
+	}
+}

--- a/internal/skill/doc.go
+++ b/internal/skill/doc.go
@@ -1,0 +1,27 @@
+// Package skill answers two questions about the agent skills this repository
+// publishes (§9.8, task 095): is the one this binary ships installed on this
+// machine, and — when it is not — how does it get there.
+//
+// The two halves are deliberately unequal. **Detection is a filesystem read**
+// and nothing else: the `skills` CLI installs one copy into a global store at
+// `~/.agents/skills/<name>/` and links it into each selected agent's
+// directory, so reading `SKILL.md` out of the store answers the version and
+// stat-ing `~/.<agent>/skills/<name>` answers who it is linked into. That is
+// what makes `vincent doctor` report the truth on a machine with no node
+// installed at all. **Installation shells out** to `npx skills add`, because
+// reproducing another tool's install layout — its store, its links, its
+// symlink/copy split — is a second implementation of something already
+// published (decision 1).
+//
+// It is a leaf: it imports nothing under internal/, the way gitx and procx do
+// not, so both the daemon composing a report and a client with no daemon can
+// use it. Its one non-stdlib import inside this module is the `skills`
+// package at the repository root, which is where `go:embed` can see the
+// published tree at all.
+//
+// The v0 T1.7 decision ("no state-file parsing") is not reopened here. That
+// decision is about inferring another tool's *authentication* from its
+// private state; `~/.agents/skills/` and `~/.<agent>/skills/` are the
+// documented install locations of a public CLI, and the file read out of them
+// is one this repository published.
+package skill

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -1,0 +1,152 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Repo is the published source `skills add` fetches from. It is the same
+// string README.md and docs/guides/workflows.md print by hand, and keeping
+// the two spellings in step is what installArgvTest asserts (decision 1).
+const Repo = "lezli01/vincent"
+
+// installer is the CLI vincent shells out to. It is `npx` and not a resolved
+// path so the missing-dependency message names what a user would install;
+// exec.LookPath finds `npx.cmd` through PATHEXT on Windows without this
+// having to know that.
+const installer = "npx"
+
+// ErrNoInstaller is `npx` not being on PATH. It is a first-class outcome
+// rather than a crash: detection does not need node, so a machine without it
+// still gets a complete report and one actionable sentence (decision 1).
+var ErrNoInstaller = errors.New("npx is not installed")
+
+// agentSlug maps a vincent adapter (§9.5) to the `skills --agent` slug and to
+// the global directory that CLI links into. The mapping is a table and not an
+// identity: claude's slug is `claude-code`.
+type agentSlug struct {
+	Adapter string
+	Slug    string
+	Root    string
+}
+
+// agents is that table, in the order the argv lists them. Only vincent's
+// three adapters are here — this decides what vincent *installs for*, not
+// what it *reports*: detection scans the home directory, so an agent vincent
+// does not drive still appears in a row when it holds a link.
+var agents = []agentSlug{
+	{Adapter: "claude", Slug: "claude-code", Root: ".claude"},
+	{Adapter: "codex", Slug: "codex", Root: ".codex"},
+	{Adapter: "cursor", Slug: "cursor", Root: ".cursor"},
+}
+
+// Adapters lists the vincent adapters skills can be installed for.
+func Adapters() []string {
+	out := make([]string, 0, len(agents))
+	for _, a := range agents {
+		out = append(out, a.Adapter)
+	}
+	return out
+}
+
+// adapterForRoot names the vincent adapter a home directory belongs to, empty
+// for the agents vincent does not drive.
+func adapterForRoot(root string) string {
+	for _, a := range agents {
+		if a.Root == root {
+			return a.Adapter
+		}
+	}
+	return ""
+}
+
+// Slugs turns vincent adapter names into `--agent` slugs, in table order and
+// deduplicated. An empty or wholly unrecognized list means all three: a user
+// who asks vincent to install a skill and has no adapter detected still means
+// "put it where my agents look".
+func Slugs(adapters []string) []string {
+	want := map[string]bool{}
+	for _, a := range adapters {
+		want[strings.ToLower(strings.TrimSpace(a))] = true
+	}
+	out := make([]string, 0, len(agents))
+	for _, a := range agents {
+		if want[a.Adapter] {
+			out = append(out, a.Slug)
+		}
+	}
+	if len(out) == 0 {
+		for _, a := range agents {
+			out = append(out, a.Slug)
+		}
+	}
+	return out
+}
+
+// InstallArgs is the argv vincent hands `npx`, without the program name.
+//
+// It is the published command plus `--agent`, `--yes` and `--global`, and the
+// difference is deliberate: `skills add` with no agent selection opens an
+// interactive multi-select, which cannot be driven from a TUI takeover or a
+// non-TTY CLI. `-g` is spelled `--global` for the same reason the rest is
+// spelled out — this argv is asserted by a test, and a test that pins short
+// flags pins nothing a reader can check against the documentation.
+func InstallArgs(name string, slugs []string) []string {
+	if len(slugs) == 0 {
+		slugs = Slugs(nil)
+	}
+	return []string{
+		"skills", "add", Repo,
+		"--skill", name,
+		"--agent", strings.Join(slugs, ","),
+		"--yes",
+		"--global",
+	}
+}
+
+// Command is InstallArgs as a line a human can paste. It is what the
+// missing-`npx` outcome prints, and what the TUI shows before it runs
+// anything.
+func Command(name string, slugs []string) string {
+	return installer + " " + strings.Join(InstallArgs(name, slugs), " ")
+}
+
+// Install runs it, streaming the CLI's own output to out. One invocation per
+// skill: `--skill` takes one name in the published command, and inventing a
+// repeated or comma-joined spelling for it would be guessing at another
+// tool's parser.
+//
+// The first run downloads the package, so this is slow and needs network.
+// Callers must not block an event loop on it.
+func Install(ctx context.Context, name string, slugs []string, out io.Writer) error {
+	if _, err := exec.LookPath(installer); err != nil {
+		return fmt.Errorf("%w — install node, then run: %s", ErrNoInstaller, Command(name, slugs))
+	}
+	//nolint:gosec // G204: the program is the constant `npx` resolved on PATH, and
+	// every argument is built by InstallArgs from this package's own constants.
+	cmd := exec.CommandContext(ctx, installer, InstallArgs(name, slugs)...)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s failed: %w", Command(name, slugs), err)
+	}
+	return nil
+}
+
+// Missing is the subset of a report that is not installed and current — what
+// the TUI offers to fix and what `vincent skills install` defaults to.
+func Missing(statuses []Status) []string {
+	names := make([]string, 0, len(statuses))
+	for _, s := range statuses {
+		if s.State != StateCurrent {
+			names = append(names, s.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/skill/install_test.go
+++ b/internal/skill/install_test.go
@@ -1,0 +1,113 @@
+package skill
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubNpx builds a recorder onto a directory and puts it first on PATH. It is
+// a compiled Go program rather than a shell script for the reason
+// cmd/fakeagent is one: a `.sh` stub does not exist on Windows and a `.cmd`
+// stub mangles its own argv quoting, and the argv is the entire assertion.
+func stubNpx(t *testing.T) (record string) {
+	t.Helper()
+	dir := t.TempDir()
+	record = filepath.Join(dir, "argv.txt")
+	src := filepath.Join(dir, "main.go")
+	prog := `package main
+
+import (
+	"os"
+	"strings"
+)
+
+func main() {
+	_ = os.WriteFile(os.Getenv("VINCENT_TEST_ARGV"), []byte(strings.Join(os.Args[1:], "\n")), 0o644)
+}
+`
+	if err := os.WriteFile(src, []byte(prog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "npx")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, src)
+	build.Dir = dir
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("cannot build the npx stub: %v\n%s", err, out)
+	}
+	t.Setenv("VINCENT_TEST_ARGV", record)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return record
+}
+
+// TestInstallArgvReachesTheProcess is decision 1's guard, from the other end:
+// InstallArgs is what the child actually receives, flags and all.
+func TestInstallArgvReachesTheProcess(t *testing.T) {
+	record := stubNpx(t)
+	var out bytes.Buffer
+	if err := Install(context.Background(), "vincent-workflows", Slugs(nil), &out); err != nil {
+		t.Fatalf("install: %v (%s)", err, out.String())
+	}
+	b, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("the stub recorded nothing: %v", err)
+	}
+	got := strings.Split(string(b), "\n")
+	want := []string{
+		"skills", "add", "lezli01/vincent",
+		"--skill", "vincent-workflows",
+		"--agent", "claude-code,codex,cursor",
+		"--yes", "--global",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("argv =\n  %v\nwant\n  %v", got, want)
+	}
+}
+
+// TestInstallWithoutNpx is the missing-dependency outcome: an error naming
+// the dependency and carrying the line to run once node is there — and never
+// `npx.cmd`, which is what LookPath resolves on Windows and not what anybody
+// installs.
+func TestInstallWithoutNpx(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	err := Install(context.Background(), "vincent-workflows", nil, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("want an error with no npx on PATH")
+	}
+	if !errors.Is(err, ErrNoInstaller) {
+		t.Errorf("error %v does not wrap ErrNoInstaller", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "npx is not installed") || strings.Contains(msg, "npx.cmd") {
+		t.Errorf("message does not name the dependency plainly: %q", msg)
+	}
+	if !strings.Contains(msg, "npx skills add lezli01/vincent --skill vincent-workflows") {
+		t.Errorf("message does not carry the command to run: %q", msg)
+	}
+}
+
+// TestDetectNeedsNoNpx is decision 2 as a test rather than a claim: with
+// nothing at all on PATH, detection still answers.
+func TestDetectNeedsNoNpx(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	home := t.TempDir()
+	installAt(t, home, ".agents", "vincent-workflows", "1.0.0")
+	got := Detect(Options{Home: home})
+	if len(got) == 0 {
+		t.Fatal("no rows")
+	}
+	for _, s := range got {
+		if s.State == "" {
+			t.Errorf("%s has no state", s.Name)
+		}
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,409 @@
+package skill
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"golang.org/x/mod/semver"
+
+	"github.com/lezli01/vincent/skills"
+)
+
+// The install layout of the `skills` CLI, which is what vincent reads (§9.8).
+const (
+	// StoreDir is the single global store, relative to the user's home. One
+	// copy lives here per skill; every agent directory is a link into it,
+	// which is why there is no per-agent version to report (decision 3).
+	StoreDir = ".agents"
+	// skillsSubdir is the directory each root holds its skills under —
+	// `~/.agents/skills/<name>` in the store, `~/.claude/skills/<name>` in an
+	// agent's own root.
+	skillsSubdir = "skills"
+	// manifest is the one file a skill must have. Detection reads it and is
+	// agnostic to whether the entry holding it is a symlink into the store
+	// (the CLI's default) or a real directory (`--copy`, which is what
+	// Windows needs, where creating a symlink is privileged).
+	manifest = "SKILL.md"
+)
+
+// Store states a skill's copy can be in. They are the row's vocabulary and
+// they are reported, never acted on: nothing here moves `vincent doctor`'s
+// exit code (decision 5).
+const (
+	// StateAbsent: no copy on this machine.
+	StateAbsent = "absent"
+	// StateCurrent: the installed version is the shipped one.
+	StateCurrent = "current"
+	// StateOlder: the installed copy predates the one this binary ships.
+	StateOlder = "older"
+	// StateNewer: the installed copy is ahead of it — a downgraded binary,
+	// not an up-to-date skill, and the row must not call it one.
+	StateNewer = "newer"
+	// StateDiffers: the two versions are not equal and at least one of them
+	// is not semver, so no direction can be claimed. Both are printed
+	// (decision 7).
+	StateDiffers = "differs"
+	// StateUnreadable: a copy exists and its SKILL.md could not be read or
+	// parsed. Different from absent, and the difference is the whole point.
+	StateUnreadable = "unreadable"
+)
+
+// Published is one skill this binary ships, read from its embedded front
+// matter. Version is `metadata.version` — under `metadata:` because that is
+// the format's extension point, and a bare top-level `version:` is not a key
+// the skills format defines (decision 6).
+type Published struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	// Path is the embedded path the entry came from, which is also the
+	// directory name under `skills/` and the argument `skills add --skill`
+	// takes.
+	Path string `json:"-"`
+	// Error is a front matter that did not parse. The entry is still
+	// reported: a skill whose marker cannot be read is a fact worth showing,
+	// not one worth hiding behind an empty list.
+	Error string `json:"error,omitempty"`
+}
+
+// Link is one agent root holding this skill. Agent is the directory's name
+// without its leading dot — `claude`, `cursor`, `zed` — because that is what
+// is on disk; Adapter is the vincent adapter it corresponds to, empty for the
+// agents vincent does not drive. Reporting those is honest rather than noisy:
+// one store serves every agent on the machine.
+type Link struct {
+	Agent   string `json:"agent"`
+	Adapter string `json:"adapter,omitempty"`
+	Path    string `json:"path"`
+	// Symlink distinguishes the CLI's default from `--copy`. It changes
+	// nothing about detection and is reported because it is the difference
+	// between a copy that follows the store and one that does not.
+	Symlink bool `json:"symlink"`
+}
+
+// Status is one published skill's installation state — one row per skill, not
+// one per adapter per skill (decision 3): the store holds a single copy, so a
+// per-adapter version column would be identical on every row by construction.
+type Status struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// Shipped is `metadata.version` in the copy this binary embeds.
+	Shipped string `json:"shipped_version"`
+	// Installed is `metadata.version` in the copy on disk, empty when there
+	// is none or it could not be read.
+	Installed string `json:"installed_version,omitempty"`
+	State     string `json:"state"`
+	// StorePath is `~/.agents/skills/<name>`, reported whether or not it
+	// exists so a user knows where to look.
+	StorePath string `json:"store_path"`
+	Links     []Link `json:"links"`
+	// Message explains a state the fields alone cannot — an unreadable
+	// manifest, a front matter with no version.
+	Message string `json:"message,omitempty"`
+}
+
+// Linked reports whether any agent on this machine holds the skill.
+func (s Status) Linked() bool { return len(s.Links) > 0 }
+
+// Agents lists the agent names this skill is linked into, in the order they
+// were found (sorted).
+func (s Status) Agents() []string {
+	out := make([]string, 0, len(s.Links))
+	for _, l := range s.Links {
+		out = append(out, l.Agent)
+	}
+	return out
+}
+
+// Publish reads the published set out of fsys — `skills.FS` in every caller
+// but a test. The enumeration is a glob and not a list in Go, which is what
+// makes a second directory under `skills/` reach doctor, the command and the
+// TUI with no code change (decision 10).
+func Publish(fsys fs.FS) []Published {
+	if fsys == nil {
+		fsys = skills.FS
+	}
+	paths, err := fs.Glob(fsys, "*/"+manifest)
+	if err != nil {
+		return nil
+	}
+	sort.Strings(paths)
+	out := make([]Published, 0, len(paths))
+	for _, p := range paths {
+		dir := path0(p)
+		b, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			out = append(out, Published{Name: dir, Path: dir, Error: err.Error()})
+			continue
+		}
+		pub := parseFrontMatter(string(b))
+		pub.Path = dir
+		if pub.Name == "" {
+			// The directory name is what `skills add --skill` takes, so it
+			// is the authoritative name when the front matter has none.
+			pub.Name = dir
+		}
+		out = append(out, pub)
+	}
+	return out
+}
+
+// path0 is the first element of a slash-separated embedded path. embed always
+// uses forward slashes, whatever the host separator is.
+func path0(p string) string {
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		return p[:i]
+	}
+	return p
+}
+
+// frontMatter is the subset of the skills format vincent reads. Unknown keys
+// are ignored rather than rejected: this parses a published format vincent
+// does not own.
+type frontMatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Metadata    struct {
+		Version string `yaml:"version"`
+	} `yaml:"metadata"`
+}
+
+// parseFrontMatter reads the leading `---` block. A file with no front matter
+// at all, or one whose YAML does not parse, yields an Error rather than a
+// panic or a silent zero: the caller renders "unreadable", which is a state.
+func parseFrontMatter(text string) Published {
+	body, ok := frontMatterBlock(text)
+	if !ok {
+		return Published{Error: "no yaml front matter"}
+	}
+	var fm frontMatter
+	if err := yaml.Unmarshal([]byte(body), &fm); err != nil {
+		return Published{Error: "front matter does not parse: " + err.Error()}
+	}
+	return Published{
+		Name:        strings.TrimSpace(fm.Name),
+		Description: strings.TrimSpace(fm.Description),
+		Version:     strings.TrimSpace(fm.Metadata.Version),
+	}
+}
+
+// frontMatterBlock returns the YAML between the opening and closing `---`
+// fences. CRLF is tolerated: a SKILL.md checked out on Windows has it, and a
+// version marker that only parses on POSIX would be a cross-platform fault.
+func frontMatterBlock(text string) (string, bool) {
+	t := strings.ReplaceAll(text, "\r\n", "\n")
+	if !strings.HasPrefix(t, "---\n") {
+		return "", false
+	}
+	rest := t[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
+}
+
+// Options are Detect's inputs. The zero value is what every real caller
+// wants; a test injects both.
+type Options struct {
+	// Home is the root the store and the agent directories hang off. Empty
+	// means os.UserHomeDir(), which is what makes this work on Windows,
+	// where `~` is not a path.
+	Home string
+	// FS is where the published set is read from. Nil means skills.FS.
+	FS fs.FS
+}
+
+// Detect reports every published skill's installation state. It never runs
+// `npx` and never opens a network connection — it is a readdir and a handful
+// of file reads, which is why it answers on a machine that could not install
+// anything (decision 2).
+func Detect(opts Options) []Status {
+	published := Publish(opts.FS)
+	home := opts.Home
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			// No home is no store and no agent roots. Every row says absent
+			// with the reason, which beats an empty report.
+			out := make([]Status, 0, len(published))
+			for _, p := range published {
+				out = append(out, Status{
+					Name: p.Name, Description: p.Description, Shipped: p.Version,
+					State: StateAbsent, Message: "no home directory: " + err.Error(),
+				})
+			}
+			return out
+		}
+		home = h
+	}
+	roots := agentRoots(home)
+	out := make([]Status, 0, len(published))
+	for _, p := range published {
+		out = append(out, detectOne(home, roots, p))
+	}
+	return out
+}
+
+func detectOne(home string, roots []string, p Published) Status {
+	dir := p.Path
+	if dir == "" {
+		dir = p.Name
+	}
+	st := Status{
+		Name:        p.Name,
+		Description: p.Description,
+		Shipped:     p.Version,
+		StorePath:   filepath.Join(home, StoreDir, skillsSubdir, dir),
+		Links:       []Link{},
+	}
+	if p.Error != "" {
+		// The shipped copy is the one this binary embeds; if that cannot be
+		// read, no comparison is possible and saying so is the whole answer.
+		st.State = StateUnreadable
+		st.Message = "the shipped copy could not be read: " + p.Error
+		return st
+	}
+	for _, root := range roots {
+		entry := filepath.Join(home, root, skillsSubdir, dir)
+		info, err := os.Lstat(entry)
+		if err != nil {
+			continue
+		}
+		st.Links = append(st.Links, Link{
+			Agent:   strings.TrimPrefix(root, "."),
+			Adapter: adapterForRoot(root),
+			Path:    entry,
+			Symlink: info.Mode()&os.ModeSymlink != 0,
+		})
+	}
+	installed, found, readErr := installedVersion(st.StorePath, st.Links)
+	switch {
+	case !found:
+		st.State = StateAbsent
+		return st
+	case readErr != nil:
+		st.State = StateUnreadable
+		st.Message = readErr.Error()
+		return st
+	}
+	st.Installed = installed
+	st.State, st.Message = compare(p.Version, installed)
+	return st
+}
+
+// installedVersion reads the copy on disk. The store is the source — there is
+// one copy and every link points at it — but a link is consulted when the
+// store is missing, because an agent directory holding a real `--copy` is
+// still an installed skill and reporting it as absent would be false.
+func installedVersion(storePath string, links []Link) (version string, found bool, readErr error) {
+	paths := make([]string, 0, 1+len(links))
+	if _, err := os.Stat(storePath); err == nil {
+		paths = append(paths, storePath)
+	}
+	for _, l := range links {
+		paths = append(paths, l.Path)
+	}
+	if len(paths) == 0 {
+		return "", false, nil
+	}
+	var first error
+	for _, p := range paths {
+		// G304: the path is a documented install location under the user's own
+		// home, and the file read out of it is one this repository published.
+		b, err := os.ReadFile(filepath.Join(p, manifest)) //nolint:gosec
+		if err != nil {
+			if first == nil {
+				first = errors.New("cannot read " + filepath.Join(p, manifest))
+			}
+			continue
+		}
+		fm := parseFrontMatter(string(b))
+		if fm.Error != "" {
+			if first == nil {
+				first = errors.New(filepath.Join(p, manifest) + ": " + fm.Error)
+			}
+			continue
+		}
+		if fm.Version == "" {
+			if first == nil {
+				first = errors.New(filepath.Join(p, manifest) + ": no metadata.version")
+			}
+			continue
+		}
+		return fm.Version, true, nil
+	}
+	return "", true, first
+}
+
+// compare is decision 7: semver where both sides parse, and an explicit
+// "differs" where either does not. It never guesses a direction — a row that
+// says "older" about two strings it could not order would send somebody
+// updating a skill that is already ahead.
+func compare(shipped, installed string) (state, message string) {
+	switch shipped {
+	case installed:
+		return StateCurrent, ""
+	case "":
+		return StateDiffers, "this binary ships no metadata.version to compare against"
+	}
+	s, i := canonical(shipped), canonical(installed)
+	if s == "" || i == "" {
+		return StateDiffers, "installed " + installed + ", shipped " + shipped +
+			" — not comparable as semver, so neither is called newer"
+	}
+	switch semver.Compare(i, s) {
+	case 0:
+		return StateCurrent, ""
+	case -1:
+		return StateOlder, ""
+	default:
+		return StateNewer, "this binary ships " + shipped +
+			", which is older than the copy on disk"
+	}
+}
+
+// canonical normalizes a version for semver, which requires a leading `v`.
+// An empty answer means the string is not semver at all.
+func canonical(v string) string {
+	if v == "" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	return semver.Canonical(v)
+}
+
+// agentRoots lists the dot-directories under home that could hold a skills
+// directory, sorted. It is a scan rather than a table because the `skills`
+// CLI serves far more agents than vincent drives, and a hard-coded list would
+// either lie by omission or assert paths this repository cannot verify. The
+// store itself is excluded: `~/.agents` is where the copy lives, not an agent
+// that holds a link to it.
+func agentRoots(home string) []string {
+	entries, err := os.ReadDir(home)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, 8)
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, ".") || name == StoreDir {
+			continue
+		}
+		// A symlinked agent root is still an agent root, so this stats
+		// through the link rather than trusting the dirent's type.
+		if info, err := os.Stat(filepath.Join(home, name)); err != nil || !info.IsDir() {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -107,6 +107,20 @@ type Status struct {
 	Message string `json:"message,omitempty"`
 }
 
+// InstalledLabel is Installed for display, naming the copy that carries no
+// `metadata.version` rather than rendering it as an empty string. An installed
+// copy is never nameless in a row.
+func (s Status) InstalledLabel() string {
+	switch {
+	case s.Installed != "":
+		return s.Installed
+	case s.State == StateAbsent:
+		return ""
+	default:
+		return "unversioned"
+	}
+}
+
 // Linked reports whether any agent on this machine holds the skill.
 func (s Status) Linked() bool { return len(s.Links) > 0 }
 
@@ -291,6 +305,14 @@ func detectOne(home string, roots []string, p Published) Status {
 		st.State = StateUnreadable
 		st.Message = readErr.Error()
 		return st
+	case installed == "":
+		// A copy that reads fine and carries no `metadata.version` is not
+		// unreadable — it is a copy from before the marker existed, which is
+		// every copy installed before task 095 shipped. That is a direction
+		// this can claim rather than a comparison it cannot make.
+		st.State = StateOlder
+		st.Message = "the installed copy carries no metadata.version, so it predates the marker"
+		return st
 	}
 	st.Installed = installed
 	st.State, st.Message = compare(p.Version, installed)
@@ -301,6 +323,12 @@ func detectOne(home string, roots []string, p Published) Status {
 // one copy and every link points at it — but a link is consulted when the
 // store is missing, because an agent directory holding a real `--copy` is
 // still an installed skill and reporting it as absent would be false.
+//
+// Three answers, and the caller renders a different state for each. found is
+// false when nothing is on disk. A non-nil readErr is a copy whose SKILL.md
+// could not be read or parsed. An empty version with a nil error is the third:
+// a manifest that reads perfectly and carries no `metadata.version`, which is
+// every copy installed before that marker existed — a fact, not a failure.
 func installedVersion(storePath string, links []Link) (version string, found bool, readErr error) {
 	paths := make([]string, 0, 1+len(links))
 	if _, err := os.Stat(storePath); err == nil {
@@ -313,6 +341,7 @@ func installedVersion(storePath string, links []Link) (version string, found boo
 		return "", false, nil
 	}
 	var first error
+	unversioned := false
 	for _, p := range paths {
 		// G304: the path is a documented install location under the user's own
 		// home, and the file read out of it is one this repository published.
@@ -331,12 +360,15 @@ func installedVersion(storePath string, links []Link) (version string, found boo
 			continue
 		}
 		if fm.Version == "" {
-			if first == nil {
-				first = errors.New(filepath.Join(p, manifest) + ": no metadata.version")
-			}
+			// Keep looking: another copy may carry one, and a version is a
+			// better answer than the absence of one.
+			unversioned = true
 			continue
 		}
 		return fm.Version, true, nil
+	}
+	if unversioned {
+		return "", true, nil
 	}
 	return "", true, first
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -176,9 +176,37 @@ func TestDetect(t *testing.T) {
 			state: StateDiffers, version: "wednesday",
 		},
 		{
-			title: "store present with no readable manifest",
+			title: "store present with no manifest at all",
 			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "") },
 			state: StateUnreadable,
+		},
+		{
+			// Every copy installed before the marker existed. A manifest that
+			// reads perfectly and carries no version is not unreadable — it
+			// predates versioning, which is a direction the row can claim.
+			title: "store present with a manifest carrying no version",
+			seed: func(t *testing.T, h string) {
+				dir := installAt(t, h, ".agents", name, "")
+				if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+					[]byte("---\nname: "+name+"\ndescription: old\n---\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			state: StateOlder,
+		},
+		{
+			// A versioned copy anywhere beats an unversioned one: a version is
+			// a better answer than the absence of one.
+			title: "store unversioned, an agent holds a versioned copy",
+			seed: func(t *testing.T, h string) {
+				dir := installAt(t, h, ".agents", name, "")
+				if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+					[]byte("---\nname: "+name+"\n---\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				installAt(t, h, ".claude", name, "1.2.0")
+			},
+			state: StateCurrent, version: "1.2.0", agents: []string{"claude"},
 		},
 		{
 			title: "linked as a real copy",
@@ -233,6 +261,9 @@ func TestDetect(t *testing.T) {
 			}
 			if agents := strings.Join(row.Agents(), ","); agents != strings.Join(tc.agents, ",") {
 				t.Errorf("agents = %q, want %q", agents, strings.Join(tc.agents, ","))
+			}
+			if row.State != StateAbsent && row.InstalledLabel() == "" {
+				t.Error("an installed copy rendered as a nameless version")
 			}
 			if row.StorePath != filepath.Join(home, ".agents", "skills", name) {
 				t.Errorf("store path = %q", row.StorePath)

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,310 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/lezli01/vincent/skills"
+)
+
+// manifestFor is a minimal published SKILL.md with the given version. Written
+// out rather than templated from the real one so a test never depends on the
+// prose of the skill it is checking the marker of.
+func manifestFor(name, version string) string {
+	fm := "---\nname: " + name + "\ndescription: a test skill\n"
+	if version != "" {
+		fm += "metadata:\n  author: lezli01\n  version: " + version + "\n"
+	}
+	return fm + "---\n\n# body\n"
+}
+
+// TestPublishEnumeratesGenerically is decision 10: the published set is a
+// glob over the embedded tree, so a second directory under `skills/` reaches
+// every surface with no Go change. Proved against an injected fs.FS rather
+// than by adding a second real skill.
+func TestPublishEnumeratesGenerically(t *testing.T) {
+	fsys := fstest.MapFS{
+		"vincent-workflows/SKILL.md": {Data: []byte(manifestFor("vincent-workflows", "1.0.0"))},
+		"vincent-reviews/SKILL.md":   {Data: []byte(manifestFor("vincent-reviews", "2.3.4"))},
+		// Neither of these is a skill: one is a file at the root, the other a
+		// reference under a skill. Both must be ignored by the glob.
+		"README.md":                              {Data: []byte("nope")},
+		"vincent-workflows/references/schema.md": {Data: []byte("nope")},
+	}
+	got := Publish(fsys)
+	if len(got) != 2 {
+		t.Fatalf("published %d skills, want 2: %+v", len(got), got)
+	}
+	// Sorted by embedded path, so the second directory is first.
+	if got[0].Name != "vincent-reviews" || got[0].Version != "2.3.4" {
+		t.Errorf("first = %+v", got[0])
+	}
+	if got[1].Name != "vincent-workflows" || got[1].Version != "1.0.0" {
+		t.Errorf("second = %+v", got[1])
+	}
+	if got[1].Description != "a test skill" {
+		t.Errorf("description = %q", got[1].Description)
+	}
+}
+
+// TestPublishRealSkill reads the copy this binary actually ships. It is the
+// one assertion that the embedded front matter carries a version at all — the
+// rest of the design is answerable only because it does.
+func TestPublishRealSkill(t *testing.T) {
+	got := Publish(skills.FS)
+	if len(got) == 0 {
+		t.Fatal("this build publishes no skills")
+	}
+	for _, p := range got {
+		if p.Error != "" {
+			t.Errorf("%s: %s", p.Path, p.Error)
+		}
+		if p.Version == "" {
+			t.Errorf("%s: no metadata.version in the shipped front matter", p.Path)
+		}
+		if canonical(p.Version) == "" {
+			t.Errorf("%s: metadata.version %q is not semver", p.Path, p.Version)
+		}
+		if p.Name == "" || p.Description == "" {
+			t.Errorf("%s: name or description missing: %+v", p.Path, p)
+		}
+	}
+}
+
+func TestParseFrontMatter(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		text    string
+		version string
+		wantErr bool
+	}{
+		{name: "version", text: manifestFor("s", "1.2.3"), version: "1.2.3"},
+		{name: "no version", text: manifestFor("s", "")},
+		{name: "crlf", text: strings.ReplaceAll(manifestFor("s", "9.9.9"), "\n", "\r\n"), version: "9.9.9"},
+		{name: "no front matter", text: "# just a heading\n", wantErr: true},
+		{name: "unterminated", text: "---\nname: s\n", wantErr: true},
+		{name: "malformed yaml", text: "---\nname: [unclosed\n---\n", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseFrontMatter(tc.text)
+			if tc.wantErr {
+				if got.Error == "" {
+					t.Fatalf("want an error, got %+v", got)
+				}
+				return
+			}
+			if got.Error != "" {
+				t.Fatalf("unexpected error %q", got.Error)
+			}
+			if got.Version != tc.version {
+				t.Errorf("version = %q, want %q", got.Version, tc.version)
+			}
+		})
+	}
+}
+
+// installAt writes a skill copy under home/root/skills/name.
+func installAt(t *testing.T, home, root, name, version string) string {
+	t.Helper()
+	dir := filepath.Join(home, root, "skills", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if version != "" {
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+			[]byte(manifestFor(name, version)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// linkInto is the CLI's default: a symlink from the agent's directory into
+// the store. Windows makes creating one privileged, which is what `--copy`
+// exists for, so the test skips rather than asserting a privilege.
+func linkInto(t *testing.T, home, root, name, target string) {
+	t.Helper()
+	dir := filepath.Join(home, root, "skills")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("creating a symlink needs a privilege this runner may not have")
+		}
+		t.Fatal(err)
+	}
+}
+
+// TestDetect is the detection table (§9.8): every state a row can report,
+// over an injected home root.
+func TestDetect(t *testing.T) {
+	const name = "vincent-workflows"
+	shipped := fstest.MapFS{name + "/SKILL.md": {Data: []byte(manifestFor(name, "1.2.0"))}}
+
+	for _, tc := range []struct {
+		title   string
+		seed    func(t *testing.T, home string)
+		state   string
+		version string
+		agents  []string
+	}{
+		{title: "store absent", seed: func(*testing.T, string) {}, state: StateAbsent},
+		{
+			title: "store current",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "1.2.0") },
+			state: StateCurrent, version: "1.2.0",
+		},
+		{
+			title: "store older",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "1.1.0") },
+			state: StateOlder, version: "1.1.0",
+		},
+		{
+			// A downgraded binary. The row must not call this up to date.
+			title: "store newer",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "2.0.0") },
+			state: StateNewer, version: "2.0.0",
+		},
+		{
+			title: "version not semver",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "wednesday") },
+			state: StateDiffers, version: "wednesday",
+		},
+		{
+			title: "store present with no readable manifest",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".agents", name, "") },
+			state: StateUnreadable,
+		},
+		{
+			title: "linked as a real copy",
+			seed: func(t *testing.T, h string) {
+				installAt(t, h, ".agents", name, "1.2.0")
+				installAt(t, h, ".cursor", name, "1.2.0")
+			},
+			state: StateCurrent, version: "1.2.0", agents: []string{"cursor"},
+		},
+		{
+			title: "linked by symlink",
+			seed: func(t *testing.T, h string) {
+				store := installAt(t, h, ".agents", name, "1.2.0")
+				linkInto(t, h, ".claude", name, store)
+			},
+			state: StateCurrent, version: "1.2.0", agents: []string{"claude"},
+		},
+		{
+			// One store serves every agent on the machine, so the row names
+			// agents vincent does not drive rather than hiding them.
+			title: "linked into an agent vincent does not drive",
+			seed: func(t *testing.T, h string) {
+				store := installAt(t, h, ".agents", name, "1.2.0")
+				linkInto(t, h, ".claude", name, store)
+				linkInto(t, h, ".zed", name, store)
+			},
+			state: StateCurrent, version: "1.2.0", agents: []string{"claude", "zed"},
+		},
+		{
+			// No store, but an agent holds a real copy. Absent would be false.
+			title: "no store, agent holds a copy",
+			seed:  func(t *testing.T, h string) { installAt(t, h, ".codex", name, "1.0.0") },
+			state: StateOlder, version: "1.0.0", agents: []string{"codex"},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			home := t.TempDir()
+			tc.seed(t, home)
+			got := Detect(Options{Home: home, FS: shipped})
+			if len(got) != 1 {
+				t.Fatalf("got %d rows, want 1", len(got))
+			}
+			row := got[0]
+			if row.State != tc.state {
+				t.Errorf("state = %q (%s), want %q", row.State, row.Message, tc.state)
+			}
+			if row.Installed != tc.version {
+				t.Errorf("installed = %q, want %q", row.Installed, tc.version)
+			}
+			if row.Shipped != "1.2.0" {
+				t.Errorf("shipped = %q", row.Shipped)
+			}
+			if agents := strings.Join(row.Agents(), ","); agents != strings.Join(tc.agents, ",") {
+				t.Errorf("agents = %q, want %q", agents, strings.Join(tc.agents, ","))
+			}
+			if row.StorePath != filepath.Join(home, ".agents", "skills", name) {
+				t.Errorf("store path = %q", row.StorePath)
+			}
+		})
+	}
+}
+
+// TestDetectNamesTheAdapter proves the slug table is a table and not an
+// identity: claude's directory is `.claude`, and the row says so, while its
+// `--agent` slug is `claude-code`.
+func TestDetectNamesTheAdapter(t *testing.T) {
+	const name = "s"
+	home := t.TempDir()
+	installAt(t, home, ".claude", name, "1.0.0")
+	installAt(t, home, ".zed", name, "1.0.0")
+	got := Detect(Options{
+		Home: home,
+		FS:   fstest.MapFS{name + "/SKILL.md": {Data: []byte(manifestFor(name, "1.0.0"))}},
+	})
+	links := got[0].Links
+	if len(links) != 2 {
+		t.Fatalf("links = %+v", links)
+	}
+	if links[0].Agent != "claude" || links[0].Adapter != "claude" {
+		t.Errorf("claude link = %+v", links[0])
+	}
+	if links[1].Agent != "zed" || links[1].Adapter != "" {
+		t.Errorf("zed link = %+v; an agent vincent does not drive carries no adapter", links[1])
+	}
+}
+
+// TestSlugs pins the adapter → `skills --agent` mapping, including that
+// claude's slug is not `claude`.
+func TestSlugs(t *testing.T) {
+	for _, tc := range []struct {
+		in   []string
+		want string
+	}{
+		{in: nil, want: "claude-code,codex,cursor"},
+		{in: []string{}, want: "claude-code,codex,cursor"},
+		{in: []string{"claude"}, want: "claude-code"},
+		{in: []string{"cursor", "claude"}, want: "claude-code,cursor"},
+		{in: []string{"emacs"}, want: "claude-code,codex,cursor"},
+	} {
+		if got := strings.Join(Slugs(tc.in), ","); got != tc.want {
+			t.Errorf("Slugs(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestInstallArgs is the assertion that catches the published command and the
+// command vincent runs drifting apart (decision 1). README.md and
+// docs/guides/workflows.md print the interactive spelling of this line.
+func TestInstallArgs(t *testing.T) {
+	want := "npx skills add lezli01/vincent --skill vincent-workflows " +
+		"--agent claude-code,codex,cursor --yes --global"
+	if got := Command("vincent-workflows", nil); got != want {
+		t.Errorf("Command() = %q, want %q", got, want)
+	}
+	if got := Command("vincent-workflows", Slugs([]string{"codex"})); !strings.Contains(got, "--agent codex ") {
+		t.Errorf("a narrowed selection did not reach the argv: %q", got)
+	}
+}
+
+func TestMissing(t *testing.T) {
+	got := Missing([]Status{
+		{Name: "b", State: StateAbsent},
+		{Name: "a", State: StateCurrent},
+		{Name: "c", State: StateOlder},
+	})
+	if strings.Join(got, ",") != "b,c" {
+		t.Errorf("Missing = %v", got)
+	}
+}

--- a/internal/tui/bindings.go
+++ b/internal/tui/bindings.go
@@ -134,7 +134,13 @@ const (
 	ctxChat          bindingContext = "chat"
 	ctxNewChat       bindingContext = "new chat"
 	ctxDaemon        bindingContext = "daemon"
-	ctxForm          bindingContext = "answer form"
+	// ctxSkills is the daemon view's published-skill offer (§9.8, task 095).
+	// Its own context rather than more ctxDaemon rows for the reason the
+	// config editor's keys are their own: while it is open it owns the
+	// keyboard, and `n` means "not now" in here and nothing at all out
+	// there.
+	ctxSkills bindingContext = "agent skills"
+	ctxForm   bindingContext = "answer form"
 	// ctxRepairForm is the §6 repair popup (task 025). Its own context
 	// rather than more ctxForm rows: the two popups share a shape and
 	// nothing else — one picks from what an agent asked, the other types a
@@ -596,6 +602,18 @@ var bindings = []binding{
 	// shows the exact JSON before anything happens, and the same key takes it
 	// back out again.
 	{key: "i", label: "make vincent claude's status line, or remove it — the exact JSON is shown first", scope: scopePanel, context: ctxDaemon, hint: "i status line", priority: 6},
+	// Task 095. `S` and not `i`: both keys lead to a write outside vincent's
+	// own directories, but they are two different operations on two
+	// different targets, and clause 1 of the vocabulary lets a key be shared
+	// only when it means the same one. `s` was unavailable — it is the
+	// vocabulary's "cycle a listing's scope" — and `S` carries no term.
+	{key: "S", label: "install the agent skills vincent publishes — the exact command is shown first", scope: scopePanel, context: ctxDaemon, hint: "S skills", priority: 7},
+
+	// The §9.8 offer: it owns the keyboard while it is open and prints its
+	// own key line, so these are here to keep ? complete.
+	{key: "enter", label: "run the install (one npx per skill; the first needs network)", scope: scopePanel, context: ctxSkills, noPalette: true},
+	{key: "n", label: "not now — remembered, and S brings it back", scope: scopePanel, context: ctxSkills, noPalette: true},
+	{key: "esc", label: "close without installing anything", scope: scopePanel, context: ctxSkills, noPalette: true},
 
 	// The config editor: it owns the keyboard while it is open and prints its
 	// own key line, so these are here to keep ? complete.

--- a/internal/tui/bindings_test.go
+++ b/internal/tui/bindings_test.go
@@ -1792,6 +1792,46 @@ var panelKeyProbes = map[bindingContext]map[string]func(*testing.T){
 				t.Fatal("the status-line flow does not own the keyboard")
 			}
 		},
+		"S": func(t *testing.T) {
+			d := newTestDaemonView([]string{"a log line"}, nil)
+			d.updateKey(registryKey(t, "S"))
+			if d.skills == nil {
+				t.Fatal("S did not open the published-skill flow")
+			}
+			if !d.capturesInput() {
+				t.Fatal("the skills flow does not own the keyboard")
+			}
+		},
+	},
+
+	ctxSkills: {
+		"enter": func(t *testing.T) {
+			d := openSkillsFlow(t)
+			d.updateKey(registryKey(t, "enter"))
+			// With nothing missing, enter closes rather than shelling out —
+			// a probe must not spawn npx.
+			if d.skills != nil {
+				t.Fatal("enter did not act on the skills flow")
+			}
+		},
+		"n": func(t *testing.T) {
+			d := openSkillsFlow(t)
+			d.skills.names = []string{"vincent-workflows"}
+			d.updateKey(registryKey(t, "n"))
+			if d.skills != nil {
+				t.Fatal("n did not close the skills flow")
+			}
+			if !readSkillsDecline(d.dataDir) {
+				t.Fatal("n did not remember the decline")
+			}
+		},
+		"esc": func(t *testing.T) {
+			d := openSkillsFlow(t)
+			d.updateKey(registryKey(t, "esc"))
+			if d.skills != nil {
+				t.Fatal("esc did not close the skills flow")
+			}
+		},
 	},
 
 	ctxConfigEdit: {

--- a/internal/tui/daemon.go
+++ b/internal/tui/daemon.go
@@ -58,6 +58,13 @@ type (
 		declined bool
 		err      error
 	}
+	// skillsDeclinedMsg carries the published-skill offer's decline flag
+	// (task 095). Only the flag is local: the installation state itself
+	// rides on the doctor report this view already fetches, so the TUI holds
+	// no state the daemon does not have (decision 9).
+	skillsDeclinedMsg struct {
+		declined bool
+	}
 )
 
 // daemonView is §15's view 6. It is the only view that renders while the
@@ -115,6 +122,15 @@ type daemonView struct {
 	statusLineErr      error
 	statusLineOK       bool
 	statusLineDeclined bool
+	// skills is the open §9.8 offer, nil when it is not open. A takeover for
+	// the same reason the status-line flow is: it runs a command that leaves
+	// vincent's own directories, and the exact command belongs on a screen
+	// with nothing else on it.
+	skills *skillsFlow
+	// skillsDeclined is the persisted "not now". The state the offer is
+	// about comes off d.doctor.Skills.
+	skillsDeclined bool
+
 	// settingsPath resolves ~/.claude/settings.json and exePath this binary.
 	// They are fields so a test can point them at a temp file and a fixed
 	// path rather than at the developer's real settings and at the test
@@ -257,6 +273,16 @@ func (d *daemonView) statusLineCmd() tea.Cmd {
 	}
 }
 
+// skillsDeclineCmd re-reads the published-skill offer's decline flag. Like
+// statusLineCmd it is a read and only a read: nothing installs without a
+// keypress on the flow.
+func (d *daemonView) skillsDeclineCmd() tea.Cmd {
+	dataDir := d.dataDir
+	return func() tea.Msg {
+		return skillsDeclinedMsg{declined: readSkillsDecline(dataDir)}
+	}
+}
+
 func (d *daemonView) tickCmd() tea.Cmd {
 	return tea.Tick(logPollInterval, func(time.Time) tea.Msg { return daemonTickMsg{} })
 }
@@ -264,7 +290,8 @@ func (d *daemonView) tickCmd() tea.Cmd {
 // refreshCmd re-reads every source. It is what R does, and what activation
 // does.
 func (d *daemonView) refreshCmd() tea.Cmd {
-	return tea.Batch(d.infoCmd(), d.configCmd(), d.doctorCmd(), d.logCmd(), d.statusLineCmd())
+	return tea.Batch(d.infoCmd(), d.configCmd(), d.doctorCmd(), d.logCmd(),
+		d.statusLineCmd(), d.skillsDeclineCmd())
 }
 
 func (d *daemonView) update(msg tea.Msg) (panel, tea.Cmd) {
@@ -307,6 +334,17 @@ func (d *daemonView) update(msg tea.Msg) (panel, tea.Cmd) {
 	case statusLineStateMsg:
 		d.applyStatusLine(msg)
 		return d, nil
+	case skillsDeclinedMsg:
+		d.skillsDeclined = msg.declined
+		return d, nil
+	case skillsInstalledMsg:
+		if d.skills == nil {
+			return d, nil
+		}
+		d.skills.applyInstalled(msg)
+		// The state the row reports is a fact about the filesystem, and the
+		// install just changed it.
+		return d, d.doctorCmd()
 	case tea.KeyPressMsg:
 		return d.updateKey(msg)
 	}
@@ -406,6 +444,16 @@ func (d *daemonView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		}
 		return d, cmd
 	}
+	if d.skills != nil {
+		cmd, done := d.skills.update(msg, d.dataDir)
+		if done {
+			d.skills = nil
+			// The decline may have just been written, and the offer is drawn
+			// from a reading of it.
+			return d, tea.Batch(cmd, d.skillsDeclineCmd())
+		}
+		return d, cmd
+	}
 	if d.statusLine != nil {
 		if done := d.statusLine.update(msg, d.dataDir); done {
 			d.statusLine = nil
@@ -436,6 +484,13 @@ func (d *daemonView) updateKey(msg tea.KeyPressMsg) (panel, tea.Cmd) {
 		// whatever the file says: a documented key that silently does nothing
 		// is worse than one that opens a screen explaining why.
 		d.statusLine = newStatusLineFlow(d.statusLinePlan, d.statusLineErr)
+		return d, nil
+	case "S":
+		// Like `i`, the key works whatever the machine says: the line only
+		// advertises itself when there is something to offer, but a
+		// documented key that silently does nothing is worse than one that
+		// opens a screen saying why.
+		d.skills = newSkillsFlow(d.reportedSkills(), d.availableAdapters())
 		return d, nil
 	case "f", "G", "end":
 		d.setFollowing(true)
@@ -497,4 +552,32 @@ func (d *daemonView) syncFollowToViewport() {
 // permanently false before this view could edit anything; leaving it that way
 // would send every single-key global — R, f, g, q — into the text field on the
 // first keystroke.
-func (d *daemonView) capturesInput() bool { return d.form != nil || d.statusLine != nil }
+func (d *daemonView) capturesInput() bool {
+	return d.form != nil || d.statusLine != nil || d.skills != nil
+}
+
+// reportedSkills is the §9.8 group off the doctor report, empty when none has
+// landed yet.
+func (d *daemonView) reportedSkills() []apiclient.DoctorSkill {
+	if d.doctor == nil {
+		return nil
+	}
+	return d.doctor.Skills
+}
+
+// availableAdapters names the adapters the daemon found on this machine, in
+// §9.5 order. It decides the `--agent` selection the install is run with:
+// installing a workflow-authoring skill for an agent that is not on the box
+// would be writing into a directory nothing reads.
+func (d *daemonView) availableAdapters() []string {
+	if !d.infoOK {
+		return nil
+	}
+	out := make([]string, 0, len(d.info.Agents))
+	for _, a := range d.info.Agents {
+		if a.Available {
+			out = append(out, a.Name)
+		}
+	}
+	return out
+}

--- a/internal/tui/daemon_test.go
+++ b/internal/tui/daemon_test.go
@@ -259,25 +259,30 @@ func TestDaemonViewRefreshKeyRereadsTheLog(t *testing.T) {
 	if reads != 1 {
 		t.Fatalf("tail read %d times, want 1", reads)
 	}
-	// The two readings that need no daemon: the log, and Claude Code's
-	// settings file behind the task 082 offer. Everything else on this view
-	// comes from the API and produces nothing without a client.
-	if len(msgs) != 2 {
-		t.Fatalf("R produced %d messages, want the two local reads", len(msgs))
+	// The three readings that need no daemon: the log, Claude Code's settings
+	// file behind the task 082 offer, and the published-skill offer's decline
+	// flag (task 095 — the skill state itself rides on the doctor report, so
+	// it is not one of these). Everything else on this view comes from the API
+	// and produces nothing without a client.
+	if len(msgs) != 3 {
+		t.Fatalf("R produced %d messages, want the three local reads", len(msgs))
 	}
-	var log, statusLine bool
+	var log, statusLine, skills bool
 	for _, msg := range msgs {
 		switch msg.(type) {
 		case daemonLogMsg:
 			log = true
 		case statusLineStateMsg:
 			statusLine = true
+		case skillsDeclinedMsg:
+			skills = true
 		default:
 			t.Fatalf("R produced %T with no daemon to ask", msg)
 		}
 	}
-	if !log || !statusLine {
-		t.Fatalf("R read the log = %v, the settings file = %v; want both", log, statusLine)
+	if !log || !statusLine || !skills {
+		t.Fatalf("R read the log = %v, the settings file = %v, the skills decline = %v; want all three",
+			log, statusLine, skills)
 	}
 }
 

--- a/internal/tui/daemonrender.go
+++ b/internal/tui/daemonrender.go
@@ -40,6 +40,11 @@ func (d *daemonView) render(width, height int) string {
 		// preview competing with four other blocks is not on screen.
 		return strings.Join(d.statusLine.render(d.width), "\n")
 	}
+	if d.skills != nil {
+		// And so is the §9.8 offer, for the same reason: the command it runs
+		// leaves vincent's own directories, so it goes on screen alone.
+		return strings.Join(d.skills.render(d.width), "\n")
+	}
 	var out []string
 	out = append(out, d.identityLines()...)
 	out = append(out, "")
@@ -414,7 +419,43 @@ func (d *daemonView) adapterLines() []string {
 	if line, ok := d.statusLineLine(); ok {
 		out = append(out, line)
 	}
+	if line, ok := d.skillsLine(); ok {
+		out = append(out, line)
+	}
 	return out
+}
+
+// skillsLine is the daemon view's half of the §9.8 offer (task 095). It sits
+// beside the status-line line and follows the same three rules: the fact
+// comes from a reading rather than an assumption — here, the doctor report
+// this view already fetches — the offer stays quiet once it has been
+// declined, and the state is still stated once everything is installed, so
+// `S` is discoverable at all.
+func (d *daemonView) skillsLine() (string, bool) {
+	skills := d.reportedSkills()
+	if len(skills) == 0 {
+		return "", false
+	}
+	missing := 0
+	for _, s := range skills {
+		if s.State != apiclient.SkillCurrent {
+			missing++
+		}
+	}
+	if missing == 0 {
+		return "   " + styleDim.Render("agent skills installed and current  ") +
+			styleKey.Render("S") + styleDim.Render(" to review them"), true
+	}
+	if d.skillsDeclined {
+		return "", false
+	}
+	word := "skill"
+	if missing > 1 {
+		word = "skills"
+	}
+	return "   " + styleDim.Render(fmt.Sprintf(
+		"%d workflow-authoring %s not installed for your agents  ", missing, word)) +
+		styleKey.Render("S") + styleDim.Render(" to see what installs them"), true
 }
 
 // statusLineLine is the daemon view's half of the §16 status-line offer

--- a/internal/tui/firstrun.go
+++ b/internal/tui/firstrun.go
@@ -33,6 +33,14 @@ type tuiState struct {
 	// offer that comes back every time the daemon view opens is a nag, and
 	// `i` is still there for somebody who changes their mind.
 	StatusLineDeclined bool `json:"status_line_declined,omitempty"`
+	// SkillsDeclined remembers that the offer to install the skills this
+	// repository publishes was turned down (task 095). It sits beside
+	// StatusLineDeclined and works the same way: nothing re-asks while it is
+	// set, and `S` on the daemon view is still there for somebody who
+	// changes their mind. Two flags and not one — declining to have vincent
+	// draw claude's status line says nothing about wanting a workflow-
+	// authoring skill.
+	SkillsDeclined bool `json:"skills_declined,omitempty"`
 }
 
 func statePath(dataDir string) string { return filepath.Join(dataDir, "tui.json") }

--- a/internal/tui/skills.go
+++ b/internal/tui/skills.go
@@ -1,0 +1,14 @@
+package tui
+
+// readSkillsDecline and writeSkillsDecline are the published-skill offer's
+// memory (task 095), kept in tui.json beside the status-line offer's — a
+// preference about a prompt, which is what that file is for. A read failure
+// answers false, the way every other read of that file does: the cost of
+// being wrong is one more offer on one more view.
+func readSkillsDecline(dataDir string) bool {
+	return readTUIState(dataDir).SkillsDeclined
+}
+
+func writeSkillsDecline(dataDir string) error {
+	return mergeTUIState(dataDir, "skills_declined", true)
+}

--- a/internal/tui/skills_test.go
+++ b/internal/tui/skills_test.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+)
+
+// The daemon view's §9.8 offer (task 095). It follows task 082's shape, and
+// these assert the three things that shape promises: the offer appears when
+// there is something to install, a decline silences it, and the decline
+// outlives the process.
+
+func skillsReport(states ...string) *apiclient.DoctorReport {
+	rep := &apiclient.DoctorReport{}
+	for i, s := range states {
+		rep.Skills = append(rep.Skills, apiclient.DoctorSkill{
+			Name:      []string{"vincent-workflows", "vincent-reviews"}[i],
+			State:     s,
+			Shipped:   "1.2.0",
+			Installed: map[bool]string{true: "1.0.0", false: ""}[s == apiclient.SkillOlder],
+		})
+	}
+	return rep
+}
+
+func TestSkillsOfferAppearsWhenOneIsMissing(t *testing.T) {
+	d := newTestDaemonView(nil, nil)
+	d.doctor = skillsReport(apiclient.SkillAbsent)
+	d.doctorOK = true
+	line, ok := d.skillsLine()
+	if !ok {
+		t.Fatal("no offer with a skill missing")
+	}
+	if !strings.Contains(line, "not installed") || !strings.Contains(line, "S") {
+		t.Errorf("offer = %q", line)
+	}
+}
+
+// An installed and current set still says so. That line is the only place `S`
+// is discoverable on the view, and an install with no visible review is a key
+// nobody finds.
+func TestSkillsLineStaysWhenEverythingIsCurrent(t *testing.T) {
+	d := newTestDaemonView(nil, nil)
+	d.doctor = skillsReport(apiclient.SkillCurrent, apiclient.SkillCurrent)
+	d.doctorOK = true
+	line, ok := d.skillsLine()
+	if !ok {
+		t.Fatal("no line with everything current")
+	}
+	if !strings.Contains(line, "current") {
+		t.Errorf("line = %q", line)
+	}
+}
+
+// Before a report lands there is nothing to say, and a view that guessed
+// would be holding state the daemon does not have.
+func TestSkillsLineSilentWithoutAReport(t *testing.T) {
+	d := newTestDaemonView(nil, nil)
+	if _, ok := d.skillsLine(); ok {
+		t.Error("the view offered something before any report landed")
+	}
+}
+
+// TestSkillsDeclineSurvivesARestart is the whole point of putting the flag in
+// tui.json: `n` writes it, the offer goes away, and a second TUI over the
+// same data dir never asks again.
+func TestSkillsDeclineSurvivesARestart(t *testing.T) {
+	dataDir := t.TempDir()
+	d := newTestDaemonView(nil, nil)
+	d.dataDir = dataDir
+	d.doctor = skillsReport(apiclient.SkillAbsent)
+	d.doctorOK = true
+
+	if _, ok := d.skillsLine(); !ok {
+		t.Fatal("no offer to decline")
+	}
+	if _, cmd := d.update(key("S")); cmd != nil {
+		_ = cmd
+	}
+	if d.skills == nil {
+		t.Fatal("S did not open the flow")
+	}
+	if !d.capturesInput() {
+		t.Error("the flow does not own the keyboard while it is open")
+	}
+	if _, cmd := d.update(key("n")); cmd != nil {
+		// The close re-reads the flag; run the command the way the runtime
+		// would and feed the message back in.
+		if msg := cmd(); msg != nil {
+			d.update(msg)
+		}
+	}
+	if d.skills != nil {
+		t.Error("n left the flow open")
+	}
+	if !d.skillsDeclined {
+		t.Fatal("the decline did not reach the view")
+	}
+	if _, ok := d.skillsLine(); ok {
+		t.Error("the offer came back after being declined")
+	}
+
+	// A second process over the same data dir.
+	again := newTestDaemonView(nil, nil)
+	again.dataDir = dataDir
+	again.doctor = skillsReport(apiclient.SkillAbsent)
+	again.doctorOK = true
+	if msg := again.skillsDeclineCmd()(); msg != nil {
+		again.update(msg)
+	}
+	if !again.skillsDeclined {
+		t.Fatal("the decline did not survive the restart")
+	}
+	if _, ok := again.skillsLine(); ok {
+		t.Error("a restarted TUI asked again")
+	}
+}
+
+// The flow shows the exact command before it runs anything, the way the
+// status-line flow shows the exact JSON. It is the one screen where vincent
+// says what it is about to do outside its own directories.
+func TestSkillsFlowShowsTheCommand(t *testing.T) {
+	f := newSkillsFlow(skillsReport(apiclient.SkillAbsent).Skills, []string{"claude"})
+	body := strings.Join(f.render(80), "\n")
+	if !strings.Contains(body, "npx skills add lezli01/vincent --skill vincent-workflows --agent claude-code --yes --global") {
+		t.Errorf("the offer does not show the command it runs:\n%s", body)
+	}
+	if !strings.Contains(body, "enter") || !strings.Contains(body, "esc") {
+		t.Errorf("the offer does not print its keys:\n%s", body)
+	}
+}
+
+// Nothing to install is still a screen: `S` is documented and a documented
+// key that silently does nothing is worse than one that explains itself.
+func TestSkillsFlowWithNothingToInstall(t *testing.T) {
+	f := newSkillsFlow(skillsReport(apiclient.SkillCurrent).Skills, nil)
+	body := strings.Join(f.render(80), "\n")
+	if !strings.Contains(body, "Nothing to install") {
+		t.Errorf("body = %s", body)
+	}
+	if _, done := f.update(key("enter"), t.TempDir()); !done {
+		t.Error("enter did not close a flow with nothing to do")
+	}
+}
+
+// A failed install reports what the CLI said, and closes on any key.
+func TestSkillsFlowReportsAFailure(t *testing.T) {
+	f := newSkillsFlow(skillsReport(apiclient.SkillAbsent).Skills, nil)
+	f.running = true
+	f.applyInstalled(skillsInstalledMsg{output: "npm ERR! nope\n", err: errTestInstall})
+	if !f.reporting() || f.running {
+		t.Fatal("the flow did not land the attempt")
+	}
+	body := strings.Join(f.render(80), "\n")
+	if !strings.Contains(body, "npm ERR! nope") {
+		t.Errorf("the failure hid what the CLI said:\n%s", body)
+	}
+	if _, done := f.update(key("x"), t.TempDir()); !done {
+		t.Error("a reported flow did not close")
+	}
+}
+
+var errTestInstall = errors.New("npx skills add failed: exit status 1")
+
+// openSkillsFlow is the §9.8 takeover, open over a temp data dir so a probe
+// that declines writes into a directory the test owns.
+func openSkillsFlow(t *testing.T) *daemonView {
+	t.Helper()
+	d := newTestDaemonView([]string{"a log line"}, nil)
+	d.dataDir = t.TempDir()
+	d.doctor = skillsReport(apiclient.SkillCurrent)
+	d.doctorOK = true
+	d.skills = newSkillsFlow(d.reportedSkills(), nil)
+	return d
+}

--- a/internal/tui/skillsflow.go
+++ b/internal/tui/skillsflow.go
@@ -217,13 +217,13 @@ func skillRowLine(s apiclient.DoctorSkill) string {
 		state = styleWarn.Render("not installed") + styleDim.Render("  ships "+s.Shipped)
 	case apiclient.SkillOlder:
 		state = styleWarn.Render("out of date") +
-			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+			styleDim.Render("  installed "+s.InstalledLabel()+", ships "+s.Shipped)
 	case apiclient.SkillNewer:
 		state = styleWarn.Render("newer than this build") +
-			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+			styleDim.Render("  installed "+s.InstalledLabel()+", ships "+s.Shipped)
 	case apiclient.SkillDiffers:
 		state = styleWarn.Render("differs") +
-			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+			styleDim.Render("  installed "+s.InstalledLabel()+", ships "+s.Shipped)
 	default:
 		state = styleBad.Render(s.State) + styleDim.Render("  "+s.Message)
 	}

--- a/internal/tui/skillsflow.go
+++ b/internal/tui/skillsflow.go
@@ -1,0 +1,235 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/lezli01/vincent/internal/apiclient"
+	"github.com/lezli01/vincent/internal/skill"
+)
+
+// The daemon view's published-skill offer (§9.8, task 095), built on task
+// 082's status-line pattern rather than on the first-run notice's: a line on
+// the view that opens a takeover, a decline that persists in tui.json, and
+// nothing that re-asks while it is set. A skill that is not installed costs a
+// user help in their own agent session; it is not worth a blocking overlay.
+//
+// The offer is actionable at all only because vincent runs `skills add` with
+// an agent selection: the published command opens an interactive picker, and
+// a picker cannot be driven from here.
+
+// skillsInstallTimeout bounds the shell-out. A first `npx skills add`
+// downloads the package before it does anything, so this is generous — but it
+// is bounded, because a TUI with a child it will wait on forever is a TUI
+// that cannot be quit cleanly.
+const skillsInstallTimeout = 5 * time.Minute
+
+// skillsInstalledMsg lands one install attempt. output is the CLI's own
+// stdout and stderr, kept so a failure can show what it said rather than only
+// that it failed.
+type skillsInstalledMsg struct {
+	output string
+	err    error
+}
+
+// skillsFlow is the open takeover. Unlike the status-line flow the write here
+// is not a local file rewrite but a subprocess that downloads a package, so
+// this one has a running state and does its work in a tea.Cmd: blocking the
+// event loop on a network install would freeze the whole TUI.
+type skillsFlow struct {
+	skills []apiclient.DoctorSkill
+	// slugs is the `--agent` selection, derived from the adapters this daemon
+	// reports. It is fixed when the flow opens so that the command shown is
+	// the command run.
+	slugs   []string
+	names   []string
+	running bool
+	// outcome and err report a finished attempt; log is what the CLI printed.
+	outcome string
+	err     error
+	log     string
+}
+
+func newSkillsFlow(skills []apiclient.DoctorSkill, adapters []string) *skillsFlow {
+	return &skillsFlow{
+		skills: skills,
+		slugs:  skill.Slugs(adapters),
+		names:  skill.Missing(skills),
+	}
+}
+
+// reporting is the second screen: an install has finished, one way or the
+// other, and the flow is saying so.
+func (f *skillsFlow) reporting() bool { return f.outcome != "" || f.err != nil }
+
+// update answers one key. It returns a command to run and whether the flow is
+// finished with the keyboard — two returns rather than the status-line flow's
+// one, because this flow's work is asynchronous.
+func (f *skillsFlow) update(msg tea.KeyPressMsg, dataDir string) (tea.Cmd, bool) {
+	if f.running {
+		// Nothing but the running install may act while it is running; a
+		// second `npx` over the same store is a race with no upside.
+		return nil, false
+	}
+	if f.reporting() {
+		return nil, true
+	}
+	switch msg.String() {
+	case "esc":
+		return nil, true
+	case "n":
+		if len(f.names) == 0 {
+			return nil, true
+		}
+		if err := writeSkillsDecline(dataDir); err != nil {
+			f.err = err
+			return nil, false
+		}
+		return nil, true
+	case "enter", "y":
+		if len(f.names) == 0 {
+			return nil, true
+		}
+		f.running = true
+		return f.installCmd(), false
+	}
+	return nil, false
+}
+
+// installCmd runs every missing skill's install, one `npx` per skill, off the
+// event loop.
+func (f *skillsFlow) installCmd() tea.Cmd {
+	names, slugs := append([]string(nil), f.names...), f.slugs
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), skillsInstallTimeout)
+		defer cancel()
+		var buf bytes.Buffer
+		for _, name := range names {
+			if err := skill.Install(ctx, name, slugs, &buf); err != nil {
+				return skillsInstalledMsg{output: buf.String(), err: err}
+			}
+		}
+		return skillsInstalledMsg{output: buf.String()}
+	}
+}
+
+// applyInstalled lands the attempt.
+func (f *skillsFlow) applyInstalled(msg skillsInstalledMsg) {
+	f.running = false
+	f.log = msg.output
+	if msg.err != nil {
+		f.err = msg.err
+		return
+	}
+	f.outcome = "installed " + strings.Join(f.names, ", ")
+}
+
+func (f *skillsFlow) render(width int) []string {
+	_ = width // Hand-wrapped, like every other takeover on this view.
+	out := []string{" " + styleTitle.Render("agent skills"), ""}
+	switch {
+	case f.running:
+		return append(out,
+			"   "+styleDim.Render("running ")+skill.Command(f.names[0], f.slugs),
+			"",
+			"   "+styleDim.Render("The first run downloads the package, so this can take a minute."),
+			"   "+styleDim.Render("The TUI keeps working; this screen updates when it finishes."))
+	case f.reporting():
+		return append(out, f.reportLines()...)
+	default:
+		return append(out, f.offerLines()...)
+	}
+}
+
+// offerLines is the offer: what is on this machine, then what pressing enter
+// runs, spelled in full. The command is shown for the reason the status-line
+// flow shows its JSON — this leaves vincent's own directories, and the exact
+// thing it does belongs on screen before it happens.
+func (f *skillsFlow) offerLines() []string {
+	out := []string{
+		"   " + styleDim.Render("vincent publishes skills so an agent you talk to directly knows how"),
+		"   " + styleDim.Render("to author a vincent workflow. Runs inside vincent do not need them —"),
+		"   " + styleDim.Render("the built-in workflows carry the same text in their own prompts."),
+		"",
+	}
+	for _, s := range f.skills {
+		out = append(out, "   "+skillRowLine(s))
+	}
+	if len(f.names) == 0 {
+		return append(out, "",
+			"   "+styleDim.Render("Nothing to install."),
+			"",
+			"   "+styleKey.Render("esc")+styleDim.Render(" close"))
+	}
+	out = append(out, "", "   "+styleDim.Render("Pressing enter runs, once per skill:"), "")
+	for _, name := range f.names {
+		out = append(out, "     "+skill.Command(name, f.slugs))
+	}
+	return append(out, "",
+		"   "+styleDim.Render("That needs node on PATH, and network on its first run. It installs into"),
+		"   "+styleDim.Render("the global skills store and links it into each agent's directory."),
+		"",
+		"   "+styleKey.Render("enter")+styleDim.Render(" run it")+
+			styleDim.Render("   ")+styleKey.Render("n")+styleDim.Render(" not now (remembered — press S to come back)")+
+			styleDim.Render("   ")+styleKey.Render("esc")+styleDim.Render(" close"))
+}
+
+func (f *skillsFlow) reportLines() []string {
+	out := []string{}
+	if f.err != nil {
+		out = append(out,
+			"   "+styleBad.Render("⚠ "+errString(f.err)),
+			"")
+	} else {
+		out = append(out, "   "+styleOK.Render("✓ ")+f.outcome, "")
+	}
+	if f.log != "" {
+		for _, line := range lastLines(strings.Split(strings.TrimRight(f.log, "\n"), "\n"), 8) {
+			out = append(out, "     "+styleDim.Render(line))
+		}
+		out = append(out, "")
+	}
+	return append(out, "   "+styleKey.Render("any key")+styleDim.Render(" close"))
+}
+
+// lastLines is the tail of a slice, so a long npm log does not push the
+// outcome off the screen.
+func lastLines(lines []string, n int) []string {
+	if len(lines) <= n {
+		return lines
+	}
+	return lines[len(lines)-n:]
+}
+
+// skillRowLine renders one skill's state, naming both versions wherever the
+// state is about the difference between them.
+func skillRowLine(s apiclient.DoctorSkill) string {
+	name := s.Name
+	var state string
+	switch s.State {
+	case apiclient.SkillCurrent:
+		state = styleOK.Render("current " + s.Installed)
+	case apiclient.SkillAbsent:
+		state = styleWarn.Render("not installed") + styleDim.Render("  ships "+s.Shipped)
+	case apiclient.SkillOlder:
+		state = styleWarn.Render("out of date") +
+			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+	case apiclient.SkillNewer:
+		state = styleWarn.Render("newer than this build") +
+			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+	case apiclient.SkillDiffers:
+		state = styleWarn.Render("differs") +
+			styleDim.Render("  installed "+s.Installed+", ships "+s.Shipped)
+	default:
+		state = styleBad.Render(s.State) + styleDim.Render("  "+s.Message)
+	}
+	row := name + "  " + state
+	if agents := s.Agents(); len(agents) > 0 {
+		row += styleDim.Render("  ·  " + strings.Join(agents, ", "))
+	}
+	return row
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -14,10 +14,27 @@
 // and re-indent the text rather than assuming anything about its shape.
 package skills
 
-import _ "embed"
+import "embed"
 
 // VincentWorkflows is `skills/vincent-workflows/SKILL.md` verbatim, YAML
 // front matter included. Callers that want only the instructions strip it.
 //
 //go:embed vincent-workflows/SKILL.md
 var VincentWorkflows string
+
+// FS is every published skill's `SKILL.md`, keyed by its path inside this
+// directory (`vincent-workflows/SKILL.md`). It is the *set* of what this
+// repository publishes, which is why nothing enumerates the names in Go: a
+// second directory under `skills/` is picked up by the glob, and every
+// surface that reports installation state — `vincent doctor`, `vincent
+// skills`, the daemon view — reports it with no code change (task 095
+// decision 10).
+//
+// Only `SKILL.md` is embedded, not `references/`, `LICENSE.txt` or
+// `agents/openai.yaml`. Installation shells out to the `skills` CLI, which
+// fetches the whole published directory from git; what the binary needs from
+// the tree is the front matter — the name, the description and
+// `metadata.version` it compares an installed copy against.
+//
+//go:embed */SKILL.md
+var FS embed.FS

--- a/skills/version_test.go
+++ b/skills/version_test.go
@@ -1,0 +1,92 @@
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The version-drift guard (task 095 decision 6).
+//
+// `metadata.version` in a SKILL.md is what every "installed and current" row
+// in vincent rests on, and it is the one field nothing else forces anybody to
+// touch: `references/*.md` goes stale on its own, and a hand bump is
+// forgotten. So the content of each published skill is hashed here, and this
+// test fails when the tree moved and the version did not.
+//
+// The version lives inside SKILL.md, so bumping it changes the hash too:
+// there is no way to satisfy this test by editing one of the two. When it
+// fails, bump `metadata.version` and paste the hash the failure prints.
+var publishedTrees = map[string]string{
+	"vincent-workflows": "f8e21bdd936d676d58a2ab3775898fe8b5560ad2c0974f5dbe527780a348d387",
+}
+
+func TestPublishedSkillsAreVersioned(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		seen[name] = true
+		want, ok := publishedTrees[name]
+		if !ok {
+			t.Errorf("skills/%s/ is published but has no row in publishedTrees; "+
+				"add one with the hash below so its version cannot go stale unnoticed:\n\t%q: %q,",
+				name, name, hashTree(t, name))
+			continue
+		}
+		if got := hashTree(t, name); got != want {
+			t.Errorf("skills/%s/ changed but its recorded hash did not.\n"+
+				"Bump metadata.version in skills/%s/SKILL.md, then set:\n\t%q: %q,",
+				name, name, name, got)
+		}
+	}
+	for name := range publishedTrees {
+		if !seen[name] {
+			t.Errorf("publishedTrees names %q, which is no longer under skills/", name)
+		}
+	}
+}
+
+// hashTree digests every file under one skill, path and content. Line endings
+// are normalized and paths are slash-separated so the digest is the same on
+// all three platforms — a guard that fires only on Windows is a guard nobody
+// can act on.
+func hashTree(t *testing.T, dir string) string {
+	t.Helper()
+	var paths []string
+	if err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			paths = append(paths, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(paths)
+	h := sha256.New()
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		h.Write([]byte(filepath.ToSlash(p)))
+		h.Write([]byte{0})
+		h.Write([]byte(strings.ReplaceAll(string(b), "\r\n", "\n")))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/skills/vincent-workflows/SKILL.md
+++ b/skills/vincent-workflows/SKILL.md
@@ -4,6 +4,7 @@ description: Create, edit, review, and validate vincent workflow YAML under .vin
 license: LICENSE.txt
 metadata:
   author: lezli01
+  version: 1.0.0
 ---
 
 # vincent Workflows


### PR DESCRIPTION
## Summary

vincent publishes an agent skill — `skills/vincent-workflows/` — so that an
agent somebody is talking to **directly**, outside a vincent run, knows how to
author a vincent workflow. Nothing in the binary had ever looked at whether the
user had it: the only install path was a command a human had to find in prose
and run by hand, and `grep -ri skill internal/` found exactly one consumer,
`builtin.go` splicing the embedded text into two built-in prompts. An installed
copy then went stale invisibly, because the skill carried no version marker at
all.

This adds the missing half. New spec **§9.8 "Published skills"** describes it;
`docs/tasks/095-published-skill-installation.md` carries the ten decisions.

**Versioned.** `skills/vincent-workflows/SKILL.md` gains `metadata.version`,
under the `metadata:` key the front matter already uses for `author` — the
format's extension point, where a bare top-level `version:` is not a key the
skills format defines. `skills/version_test.go` hashes each published tree and
fails with "bump `metadata.version`" when the content moved and the version did
not; the version lives inside `SKILL.md`, so the test cannot be satisfied by
editing one of the two.

**Enumerated generically.** `skills/embed.go` grows an `embed.FS` over
`*/SKILL.md`, and nothing lists names in Go. A second directory under `skills/`
reaches doctor, the command and the TUI with no code change — proved against an
injected `fs.FS` rather than by adding a second real skill.

**Detected without `npx`.** New leaf package `internal/skill` (imports nothing
under `internal/`). `skills add … -g` keeps **one** copy in a global store,
`~/.agents/skills/<name>/`, and links it into each agent's directory, so
detection is a readdir plus a few file reads: the store's `SKILL.md` for the
version, each `~/.<agent>/skills/<name>` for who holds a link. The agent list is
discovered by scanning the home directory rather than from a table of paths —
a table would assert install locations this repository cannot verify, and the
scan honestly names agents vincent does not drive. Comparison is
`golang.org/x/mod/semver`; where either side does not parse the row says
`differs` and prints both, claiming no direction. `newer` is its own state, so a
downgraded binary never reports an up-to-date skill. A copy that reads
perfectly and carries **no** `metadata.version` — every copy installed before
this change — is `older` and not `unreadable`: the marker's absence is itself
the direction, and running the new command against a real machine is what
caught that. `unreadable` now means only what it says.

**Three surfaces, one detection.** `vincent doctor` grows a `SKILLS` group
composed by `internal/doctor` — server-side when a daemon answers, client-side
when none does; `vincent skills ls` / `vincent skills install` is the command,
never touching the daemon and therefore never exiting 2; the TUI's daemon view
offers it under `S`, showing the exact `npx` command before running anything and
persisting a decline in `tui.json`.

**Install shells out**, to `npx skills add lezli01/vincent --skill <name>
--agent <slugs> --yes --global` — the published command with the interactive
agent picker answered, because a picker cannot be driven from a TUI takeover or
a non-TTY CLI. Missing `npx` is a reported outcome naming the dependency and
printing the line to run once node is there, never a crash, and detection is
unaffected. In the TUI the install runs off the event loop: it downloads a
package, and a TUI frozen on that is a TUI that cannot be quit.

**Nothing here moves an exit code.** A missing, stale or unreadable skill is a
row, on the GitHub (035), release-check (055) and container (061) precedents.
`vincent doctor` still exits 0 with every skill missing — the built-in
workflows carry the skill's text in their own prompts, so nothing a row can say
stops a task from running.

### Three decisions worth reviewing

**The `--agent` default is per surface, and it is not what the plan said.** The
plan had the selection default to the adapters detected on the box for both
surfaces. What shipped sends **all three** from `vincent skills install`, with
`--agent` to narrow, and the **detected** ones from the TUI's `S` — confirmed
against the real argv with a stub `npx` on `PATH`. The split is deliberate and
worth keeping: a person who typed the command has stated an intent that a
detection miss should not quietly shrink (an adapter installed since vincent
last looked, or one this shell's `PATH` does not carry, would silently drop out
of the selection), and the flag is right there; the TUI offer is one keypress on
a screen already listing which adapters were found, so narrowing it there costs
nothing. The docs and task 095 decision 1 now record the split rather than the
plan's single default — **flagging it because it is a plan deviation, not
because it looks wrong.**

**The key is `S`, not `i`.** The brief left this to the diff. Both keys lead to
a write outside vincent's own directories, but they are two different operations
on two different targets, and clause 1 of §15's key vocabulary lets a key be
shared only where it means the same operation. `s` was unavailable — it is the
vocabulary's "cycle a listing's scope" — and `S` carries no term. The flow is
its own binding context, `ctxSkills`.

**Two limits are documented rather than claimed.** The directory table is the
`skills` CLI's and says where *it writes*; whether codex and cursor read those
directories could not be confirmed here, so §9.8 records the limitation instead
of asserting the capability — §9's standing rule that a capability an adapter
lacks is documented and ignored, never emulated. And vincent will disagree with
`npx skills list -g`, whose agent column is that CLI's remembered *selection*
(`lastSelectedAgents` in the lock file) rather than the links on disk. Both are
written into the task doc and the docs so the first person to notice does not
file them as bugs.

### Decisions kept, not reopened

- **Task 041** — the §9.5 facet vocabulary stays at five. The skill row is a
  group beside the agents group, not a sixth facet, and §9.5 gains one sentence
  saying so.
- **Task 006 decision 7** — doctor's unhealthy set stays closed.
- **The v0 T1.7 decision** ("no state-file parsing") is *not* reopened. It
  forbids inferring another tool's **authentication** from its private state;
  `~/.agents/skills/` is a public CLI's documented install location and the file
  read out of it is one this repository published. §9.8 says so explicitly
  rather than leaving the adjacency for somebody to find later.
- **Task 082 decision 2** is cited, and it corrects a premise the issue used:
  the issue rejected "write the skill files ourselves" partly because "vincent
  does not write into another tool's config directory itself", which is not true
  of this codebase — task 082 writes `~/.claude/settings.json`. The rejection
  stands on its surviving reason: `embed.go` embeds only `SKILL.md`, so doing it
  would mean embedding `references/`, `LICENSE.txt` and `agents/openai.yaml` too
  and reimplementing another tool's install layout.

### No gate script

An acceptance gate drives a real daemon over curl against the fake agent. A
skills assertion would depend on the host's home directory and on network access
to npm, and a gate that installs into the CI runner's home fails differently on
three platforms. Go tests with an injected home root cover it, and
`docs/gates/` records no manual leg — the same reason, and the same answer, as
task 082.

### The documentation audit found six stale claims

They are in their own `docs:` commit, separate from the implementation.

- **`docs/reference/cli.md` said the doctor report has ten groups** and listed
  them. `doctorGroups` returns eleven. Adds the Skills row, the count, the
  never-moves-the-exit-code sentence every other row-not-a-problem group has,
  and the `skills list` alias the page's own convention documents.
- **`docs/guides/tui.md`'s daemon key table had no `S`** and the view's prose
  did not mention the offer.
- **`docs/features.md` and `docs/guides/troubleshooting.md`** each enumerate what
  `vincent doctor` prints; neither listed the skills.
- **`docs/security-model.md`'s "What vincent writes outside its own directories"
  said three things.** This is a fourth — with the distinction that vincent
  shells out rather than writing, and that detection writes nothing at all.
- **§15 contradicted itself.** `i` was still "the one key in vincent that leads
  to a write outside its own data dir" eleven lines above the task 095
  amendment calling `S` "the second". Amended in place with a dated note, as
  was §16's "two places now" list.
- **The `--agent` default**, above.

Two things checked and deliberately left alone, so a reviewer does not
re-derive them:

- **No screenshot is stale.** The nine `docs/assets/tui-*.png` are the board,
  diff, grouping, multi-select, new-task, projects and the three workflow
  shots — **the daemon view is not photographed at all**, and it is the only
  view this change touches. Nothing was re-captured and nothing needs to be, so
  `scripts/screenshots.sh` was not run.
- **No spec decision-record row.** Rows 30–32 are tasks 092–094, but the direct
  precedent is task **082** — the other daemon-view offer that writes outside
  vincent's directories — which has no row, and neither do 055, 061 or 041. §9.8
  and the task doc carry the decisions.

### Found, not fixed

- **A pre-existing broken link**, unrelated to this work:
  `docs/reference/cli.md:1455` points at `workflows.md` from `docs/reference/`,
  which does not exist — it wants `../guides/workflows.md`. Introduced by
  c1165b6 (`vincent workflow render`), left out of this PR to keep the diff to
  issue #357.

## Related

Closes #357

Task [095](docs/tasks/095-published-skill-installation.md) — all ten decisions
recorded there.

## Checklist

- [x] PR title is plain language (no Conventional Commit prefix)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added/updated for behavior changes
- [x] User-visible changes noted under `## [Unreleased]` in `CHANGELOG.md` —
      audited, and the entry's `--agent` claim corrected
- [x] Affected page under `docs/` updated (config, CLI, API, TUI keys, block
      reasons) — every derivation checked one at a time; six were stale and are
      fixed in their own `docs:` commit, listed above. `configuration.md`, the
      API route table, the block-reason tables, `workflow-schema.md`,
      `task-lifecycle.md`, `agents.md` and `docs/gates/` were checked and needed
      nothing; the seven `.vincent/workflows/*.yaml` pass `workflow validate`
      and `workflow render`
